### PR TITLE
[SPARK-14631][SQL]drop database cascade should drop functions for HiveExternalCatalog

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -778,6 +778,24 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       "db2", "tbl1", Seq(part1.spec), ignoreIfNotExists = false, purge = false, retainData = false)
     assert(fs.exists(partPath))
   }
+
+  test("drop database cascade with function defined") {
+    import org.apache.spark.sql.catalyst.expressions.Lower
+
+    val catalog = newEmptyCatalog()
+    val dbName = "dbCascade"
+    val path = newUriForDatabase()
+    catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
+    // create a permanent function in catalog
+    catalog.createFunction(dbName, CatalogFunction(
+      FunctionIdentifier("func1", Some(dbName)), classOf[Lower].getName, Nil))
+    assert(catalog.functionExists(dbName, "func1"))
+    catalog.dropDatabase(dbName, ignoreIfNotExists = false, cascade = true)
+    // create the db again because `functionExists` requires db to exist
+    catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
+    assert(!catalog.functionExists(dbName, "func1"))
+    catalog.dropDatabase(dbName, ignoreIfNotExists = true, cascade = true)
+  }
 }
 
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -143,6 +143,14 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       db: String,
       ignoreIfNotExists: Boolean,
       cascade: Boolean): Unit = withClient {
+    // Unregister the functions as well.
+    // Note: This is a bug for Hive's API design, so we only do this explicit dropping for
+    // HiveExternalCatalog only. See HIVE-12304.
+    if (cascade) {
+      client.listFunctions(db, "*").foreach {
+        case functionName => client.dropFunction(db, functionName)
+      }
+    }
     client.dropDatabase(db, ignoreIfNotExists, cascade)
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.hive
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -69,23 +69,5 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     val rawTable = externalCatalog.client.getTable("db1", "hive_tbl")
     assert(!rawTable.properties.contains(HiveExternalCatalog.DATASOURCE_PROVIDER))
     assert(externalCatalog.getTable("db1", "hive_tbl").provider == Some(DDLUtils.HIVE_PROVIDER))
-  }
-
-  test("drop database cascade with function defined") {
-    import org.apache.spark.sql.catalyst.expressions.Lower
-
-    val catalog = newEmptyCatalog()
-    val dbName = "dbCascade"
-    val path = newUriForDatabase()
-    catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
-    // create a permanent function in catalog
-    catalog.createFunction(dbName, CatalogFunction(
-      FunctionIdentifier("func1", Some(dbName)), classOf[Lower].getName, Nil))
-    assert(catalog.functionExists(dbName, "func1"))
-    catalog.dropDatabase(dbName, ignoreIfNotExists = false, cascade = true)
-    // create the db again because `functionExists` requires db to exist
-    catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
-    assert(!catalog.functionExists(dbName, "func1"))
-    catalog.dropDatabase(dbName, ignoreIfNotExists = true, cascade = true)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.hive
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -69,5 +69,23 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     val rawTable = externalCatalog.client.getTable("db1", "hive_tbl")
     assert(!rawTable.properties.contains(HiveExternalCatalog.DATASOURCE_PROVIDER))
     assert(externalCatalog.getTable("db1", "hive_tbl").provider == Some(DDLUtils.HIVE_PROVIDER))
+  }
+
+  test("drop database cascade with function defined") {
+    import org.apache.spark.sql.catalyst.expressions.Lower
+
+    val catalog = newEmptyCatalog()
+    val dbName = "dbCascade"
+    val path = newUriForDatabase()
+    catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
+    // create a permanent function in catalog
+    catalog.createFunction(dbName, CatalogFunction(
+      FunctionIdentifier("func1", Some(dbName)), Lower.getClass.getName, Nil))
+    assert(catalog.functionExists(dbName, "func1"))
+    catalog.dropDatabase(dbName, ignoreIfNotExists = false, cascade = true)
+    // create the db again because `functionExists` requires db to exist
+    catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
+    assert(!catalog.functionExists(dbName, "func1"))
+    catalog.dropDatabase(dbName, ignoreIfNotExists = true, cascade = true)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -80,7 +80,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     catalog.createDatabase(CatalogDatabase(dbName, "", path, Map.empty), ignoreIfExists = false)
     // create a permanent function in catalog
     catalog.createFunction(dbName, CatalogFunction(
-      FunctionIdentifier("func1", Some(dbName)), Lower.getClass.getName, Nil))
+      FunctionIdentifier("func1", Some(dbName)), classOf[Lower].getName, Nil))
     assert(catalog.functionExists(dbName, "func1"))
     catalog.dropDatabase(dbName, ignoreIfNotExists = false, cascade = true)
     // create the db again because `functionExists` requires db to exist


### PR DESCRIPTION
## What changes were proposed in this pull request?

as HIVE-12304, drop database cascade of hive did not drop functions as well (even after the fix, by call `client.dropDatabase` would still not drop functions). We need to fix this when call `dropDatabase` in `HiveExternalCatalog`.

Jira: https://issues.apache.org/jira/browse/SPARK-14631
See also: https://issues.apache.org/jira/browse/HIVE-12304
## How was this patch tested?

unit test in HiveExternalCatalogSuite.
