### PR TITLE
[SPARK-13925] [ML] [SparkR] Expose R-like summary statistics in SparkR::glm for more family and link functions

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -292,7 +292,8 @@ export("as.DataFrame",
        "tableToDF",
        "tableNames",
        "tables",
-       "uncacheTable")
+       "uncacheTable",
+       "print.summary.GeneralizedLinearRegressionModel")
 
 export("structField",
        "structField.jobj",

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -123,29 +123,30 @@ setMethod("summary", signature(object = "GeneralizedLinearRegressionModel"),
             return(ans)
           })
 
+#' Print the summary of GeneralizedLinearRegressionModel
+#'
 #' @rdname print
 #' @name print.summary.GeneralizedLinearRegressionModel
 #' @export
-print.summary.GeneralizedLinearRegressionModel <- function(x, digits = max(3L, getOption("digits") - 3L), ...) {
-    x$deviance.resid <- setNames(unlist(approxQuantile(x$deviance.resid, "devianceResiduals",
-                                 c(0.0, 0.25, 0.5, 0.75, 1.0), 0.0)),
-                                 c("Min", "1Q", "Median", "3Q", "Max"))
-    xx <- zapsmall(x$deviance.resid, digits + 1L)
-    cat("\nDeviance Residuals: \n")
-    print.default(xx, digits = digits, na.print = "", print.gap = 2L)
+print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
+  x$deviance.resid <- setNames(unlist(approxQuantile(x$deviance.resid, "devianceResiduals",
+    c(0.0, 0.25, 0.5, 0.75, 1.0), 0.0)), c("Min", "1Q", "Median", "3Q", "Max"))
+  x$deviance.resid <- zapsmall(x$deviance.resid, 5L)
+  cat("\nDeviance Residuals: \n")
+  print.default(x$deviance.resid, digits = 5L, na.print = "", print.gap = 2L)
 
-    cat("\nCoefficients:\n")
-    print.default(x$coefficients, digits = digits + 1L, na.print = "", print.gap = 2L)
+  cat("\nCoefficients:\n")
+  print.default(x$coefficients, digits = 5L, na.print = "", print.gap = 2L)
 
-    cat("\n(Dispersion parameter for ", x$family, " family taken to be ", format(x$dispersion),
-        ")\n\n", apply(cbind(paste(format(c("Null","Residual"), justify="right"), "deviance:"),
-        format(unlist(x[c("null.deviance","deviance")]), digits = max(5L, digits + 1L)),
-        " on", format(unlist(x[c("df.null","df.residual")])), " degrees of freedom\n"),
-        1L, paste, collapse = " "), sep = "")
-    cat("AIC: ", format(x$aic, digits = max(4L, digits + 1L)),"\n\n",
-        "Number of Fisher Scoring iterations: ", x$iter, "\n", sep = "")
-    cat("\n")
-    invisible(x)
+  cat("\n(Dispersion parameter for ", x$family, " family taken to be ", format(x$dispersion),
+    ")\n\n", apply(cbind(paste(format(c("Null", "Residual"), justify = "right"), "deviance:"),
+    format(unlist(x[c("null.deviance", "deviance")]), digits = 5L),
+    " on", format(unlist(x[c("df.null", "df.residual")])), " degrees of freedom\n"),
+    1L, paste, collapse = " "), sep = "")
+  cat("AIC: ", format(x$aic, digits = 4L), "\n\n",
+    "Number of Fisher Scoring iterations: ", x$iter, "\n", sep = "")
+  cat("\n")
+  invisible(x)
   }
 
 #' Make predictions from a generalized linear model

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -130,9 +130,10 @@ setMethod("summary", signature(object = "GeneralizedLinearRegressionModel"),
 #' @export
 print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
   x$deviance.resid <- setNames(unlist(approxQuantile(x$deviance.resid, "devianceResiduals",
-    c(0.0, 0.25, 0.5, 0.75, 1.0), 0.0)), c("Min", "1Q", "Median", "3Q", "Max"))
+    c(0.0, 0.25, 0.5, 0.75, 1.0), 0.01)), c("Min", "1Q", "Median", "3Q", "Max"))
   x$deviance.resid <- zapsmall(x$deviance.resid, 5L)
   cat("\nDeviance Residuals: \n")
+  cat("(Note: These are approximate quantiles with relative error <= 0.01)\n")
   print.default(x$deviance.resid, digits = 5L, na.print = "", print.gap = 2L)
 
   cat("\nCoefficients:\n")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expose R-like summary statistics in SparkR::glm for more family and link functions.
Note: Not all values in R [summary.glm](http://stat.ethz.ch/R-manual/R-patched/library/stats/html/summary.glm.html) are exposed, we only provide the most commonly used statistics in this PR. More statistics can be added in the followup work.
## How was this patch tested?

Unit tests.

SparkR Output:

```
Deviance Residuals:
(Note: These are approximate quantiles with relative error <= 0.01)
     Min        1Q    Median        3Q       Max
-0.95096  -0.16585  -0.00232   0.17410   0.72918

Coefficients:
                    Estimate  Std. Error  t value  Pr(>|t|)
(Intercept)         1.6765    0.23536     7.1231   4.4561e-11
Sepal_Length        0.34988   0.046301    7.5566   4.1873e-12
Species_versicolor  -0.98339  0.072075    -13.644  0
Species_virginica   -1.0075   0.093306    -10.798  0

(Dispersion parameter for gaussian family taken to be 0.08351462)

    Null deviance: 28.307  on 149  degrees of freedom
Residual deviance: 12.193  on 146  degrees of freedom
AIC: 59.22

Number of Fisher Scoring iterations: 1
```

R output:

```
Deviance Residuals: 
     Min        1Q    Median        3Q       Max  
-0.95096  -0.16522   0.00171   0.18416   0.72918  

Coefficients:
                  Estimate Std. Error t value Pr(>|t|)    
(Intercept)        1.67650    0.23536   7.123 4.46e-11 ***
Sepal.Length       0.34988    0.04630   7.557 4.19e-12 ***
Speciesversicolor -0.98339    0.07207 -13.644  < 2e-16 ***
Speciesvirginica  -1.00751    0.09331 -10.798  < 2e-16 ***

---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1

(Dispersion parameter for gaussian family taken to be 0.08351462)

    Null deviance: 28.307  on 149  degrees of freedom
Residual deviance: 12.193  on 146  degrees of freedom
AIC: 59.217

Number of Fisher Scoring iterations: 2
```

cc @mengxr 
