### PR TITLE
[WIP][SPARK-14629][SPARK-14630][Build] Add support for custom scala style rules & Add rule PublicAbstractMethodsHaveTypeChecker

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -98,3 +98,4 @@ LZ4BlockInputStream.java
 spark-deps-.*
 .*csv
 .*tsv
+reference.conf

--- a/dev/spark_scala_style_checker/src/main/resources/reference.conf
+++ b/dev/spark_scala_style_checker/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+public.abstract.methods.have.type.message = "Public abstract methods must have explicit return types"
+public.abstract.methods.have.type.label = "PulicAbstractMethod"
+public.abstract.methods.have.type.description = "Check that a pulic abstract method has an explicit return type, it is not inferred"

--- a/dev/spark_scala_style_checker/src/main/scala/org/apache/spark/scala_style/PublicAbstractMethodsHaveTypeChecker.scala
+++ b/dev/spark_scala_style_checker/src/main/scala/org/apache/spark/scala_style/PublicAbstractMethodsHaveTypeChecker.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scala_style
+
+import org.scalastyle.scalariform.AbstractSingleMethodChecker
+
+import scalariform.parser.ProcFunBody
+
+class PublicAbstractMethodsHaveTypeChecker extends AbstractSingleMethodChecker[Unit] {
+
+  val errorKey = "public.abstract.methods.have.type"
+
+  protected def matchParameters() = Unit
+
+  protected def matches(t: FullDefOrDclVisit, p: Unit) = {
+
+    t.funDefOrDcl.funBodyOpt match {
+      case Some(ProcFunBody(newlineOpt, bodyBlock)) => false
+      case _ => // None or Some(ExprFunBody)
+        t.funDefOrDcl.returnTypeOpt.isEmpty &&
+        !isConstructor(t.fullDefOrDcl.defOrDcl) &&
+        !privateOrProtected(t.fullDefOrDcl.modifiers) &&
+        !t.insideDefOrValOrVar &&
+        !t.funDefOrDcl.nameToken.text.equals("main") // public static void main(...) is OK
+    }
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2237,6 +2237,13 @@
           <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
           <outputEncoding>${project.reporting.outputEncoding}</outputEncoding>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>scala_style_checker</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -114,6 +114,8 @@ This file is divided into 3 sections:
 
   <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
 
+  <check level="error" class="org.apache.spark.scala_style.PublicAbstractMethodsHaveTypeChecker" enabled="true"></check>
+
   <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
 
   <check customId="nonascii" level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true"></check>


### PR DESCRIPTION
## What changes were proposed in this pull request?
- [ ] automatically build and install custom rules
- [x] added a custom rule `PublicAbstractMethodsHaveTypeChecker` implementation, which would ensure public abstract methods have explicit return types
## How was this patch tested?

the list of changes-to-make found by this `PublicAbstractMethodsHaveTypeChecker` rule is here: https://github.com/apache/spark/pull/12389/files
