### PR TITLE
[SPARK-11834][ML] Ignore Thresholds in LogisticRegression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -247,10 +247,7 @@ class LogisticRegression @Since("1.2.0") (
   setDefault(weightCol -> "")
 
   @Since("1.5.0")
-  override def setThresholds(value: Array[Double]): this.type = {
-    logWarning("Ignoring setThresholds(), use setThreshold() for binary Logistic Regression.")
-    this
-  }
+  override def setThresholds(value: Array[Double]): this.type = super.setThresholds(value)
 
   @Since("1.5.0")
   override def getThresholds: Array[Double] = super.getThresholds
@@ -487,10 +484,7 @@ class LogisticRegressionModel private[spark] (
   override def getThreshold: Double = super.getThreshold
 
   @Since("1.5.0")
-  override def setThresholds(value: Array[Double]): this.type = {
-    logWarning("Ignoring setThresholds(), use setThreshold() for binary Logistic Regression.")
-    this
-  }
+  override def setThresholds(value: Array[Double]): this.type = super.setThresholds(value)
 
   @Since("1.5.0")
   override def getThresholds: Array[Double] = super.getThresholds

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -92,6 +92,9 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
   }
 
   /**
+   * This functionality is currently disabled. It will be re-enabled once multi-class logistic
+   * regression is included in ML.
+   *
    * Set thresholds in multiclass (or binary) classification to adjust the probability of
    * predicting each class. Array must have length equal to the number of classes, with values >= 0.
    * The class with largest value p/t is predicted, where p is the original probability of that
@@ -104,14 +107,14 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
    * @group setParam
    */
   def setThresholds(value: Array[Double]): this.type = {
-    if (isSet(threshold)) clear(threshold)
-    set(thresholds, value)
+    logWarning("Ignoring setThresholds(), use setThreshold() for binary Logistic Regression.")
+    this
   }
 
   /**
    * Get thresholds for binary or multiclass classification.
    *
-   * If [[thresholds]] is set, return its value.
+   * If [[thresholds]] is x, return its value.
    * Otherwise, if [[threshold]] is set, return the equivalent thresholds for binary
    * classification: (1-threshold, threshold).
    * If neither are set, throw an exception.

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -92,7 +92,8 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
   }
 
   /**
-   * This functionality is currently disabled.
+   * This functionality is currently disabled. It will be re-enabled once multi-class logistic
+   * regression is included in ML.
    *
    * Set thresholds in multiclass (or binary) classification to adjust the probability of
    * predicting each class. Array must have length equal to the number of classes, with values >= 0.

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -92,18 +92,12 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
   }
 
   /**
-   * This functionality is currently disabled. It will be re-enabled once multi-class logistic
-   * regression is included in ML.
+   * This functionality is currently disabled.
    *
    * Set thresholds in multiclass (or binary) classification to adjust the probability of
    * predicting each class. Array must have length equal to the number of classes, with values >= 0.
    * The class with largest value p/t is predicted, where p is the original probability of that
    * class and t is the class' threshold.
-   *
-   * Note: After being re-enabled once multi-class logistic regression is included, when
-   *      [[setThresholds()]] is called any user-set value for [[threshold]] will be cleared.
-   *       If both [[threshold]] and [[thresholds]] are set in a ParamMap, then they must be
-   *       equivalent.
    *
    * @group setParam
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -100,7 +100,8 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
    * The class with largest value p/t is predicted, where p is the original probability of that
    * class and t is the class' threshold.
    *
-   * Note: When [[setThresholds()]] is called, any user-set value for [[threshold]] will be cleared.
+   * Note: After being re-enabled once multi-class logistic regression is included, when
+   *      [[setThresholds()]] is called any user-set value for [[threshold]] will be cleared.
    *       If both [[threshold]] and [[thresholds]] are set in a ParamMap, then they must be
    *       equivalent.
    *

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -114,7 +114,7 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
   /**
    * Get thresholds for binary or multiclass classification.
    *
-   * If [[thresholds]] is x, return its value.
+   * If [[thresholds]] is set, return its value.
    * Otherwise, if [[threshold]] is set, return the equivalent thresholds for binary
    * classification: (1-threshold, threshold).
    * If neither are set, throw an exception.

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -245,7 +245,7 @@ class LogisticRegression @Since("1.2.0") (
 
   @Since("1.5.0")
   override def setThresholds(value: Array[Double]): this.type = {
-    logWarning("Ignoring setThresholds, use setThreshold() for binary Logistic Regression.")
+    logWarning("Ignoring setThresholds(), use setThreshold() for binary Logistic Regression.")
     this
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -46,7 +46,7 @@ import org.apache.spark.storage.StorageLevel
  */
 private[classification] trait LogisticRegressionParams extends ProbabilisticClassifierParams
   with HasRegParam with HasElasticNetParam with HasMaxIter with HasFitIntercept with HasTol
-  with HasStandardization with HasWeightCol with HasThreshold {
+  with HasStandardization with HasWeightCol with HasThreshold with Logging {
 
   /**
    * Set threshold in binary classification, in range [0, 1].

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -244,7 +244,10 @@ class LogisticRegression @Since("1.2.0") (
   setDefault(weightCol -> "")
 
   @Since("1.5.0")
-  override def setThresholds(value: Array[Double]): this.type = super.setThresholds(value)
+  override def setThresholds(value: Array[Double]): this.type = {
+    logWarning("Ignoring setThresholds, use setThreshold() for binary Logistic Regression.")
+    this
+  }
 
   @Since("1.5.0")
   override def getThresholds: Array[Double] = super.getThresholds
@@ -481,7 +484,10 @@ class LogisticRegressionModel private[spark] (
   override def getThreshold: Double = super.getThreshold
 
   @Since("1.5.0")
-  override def setThresholds(value: Array[Double]): this.type = super.setThresholds(value)
+  override def setThresholds(value: Array[Double]): this.type = {
+    logWarning("Ignoring setThresholds(), use setThreshold() for binary Logistic Regression.")
+    this
+  }
 
   @Since("1.5.0")
   override def getThresholds: Array[Double] = super.getThresholds


### PR DESCRIPTION
## What changes were proposed in this pull request?

See [SPARK-11834 ](https://issues.apache.org/jira/browse/SPARK-11834)for details of this issue. 
Ignore the setThresholds call in ML's LogisticRegression. It currently clears any user defined threshold, but it should be disabled until multi-class Logistic Regression is added.
## How was this patch tested?

I have built and run setThresholds() with the classes LogisticRegression and LogisticRegressionModel, both return the appropriate warning messages. Spark ml tests were run and passed successfully.

![screen shot 2016-04-14 at 11 39 33 am](https://cloud.githubusercontent.com/assets/4738024/14539574/d274c9c0-0235-11e6-943c-d4a40d1c06af.png)
