### PR TITLE
[SPARK-14433][PySpark][ML]:PySpark ml GaussianMixture

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -24,12 +24,15 @@ import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.param.{IntParam, ParamMap, Params}
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
+import org.apache.spark.mllib.api.python.SerDe
 import org.apache.spark.mllib.clustering.{GaussianMixture => MLlibGM, GaussianMixtureModel => MLlibGMModel}
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.stat.distribution.MultivariateGaussian
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.{IntegerType, StructType}
+
+import scala.collection.JavaConverters
 
 
 /**
@@ -103,6 +106,15 @@ class GaussianMixtureModel private[ml] (
 
   @Since("2.0.0")
   def gaussians: Array[MultivariateGaussian] = parentModel.gaussians
+
+  @Since("2.0.0")
+  def gaussiansPyDump: Array[Byte] = {
+    val tmp_gaussians = parentModel.gaussians
+    val modelGaussians = tmp_gaussians.map { gaussian =>
+      Array[Any](gaussian.mu, gaussian.sigma)
+    }
+    SerDe.dumps(JavaConverters.seqAsJavaListConverter(modelGaussians).asJava)
+  }
 
   @Since("2.0.0")
   override def write: MLWriter = new GaussianMixtureModel.GaussianMixtureModelWriter(this)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.clustering
 
+import scala.collection.JavaConverters
+
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.{Experimental, Since}
@@ -31,8 +33,6 @@ import org.apache.spark.mllib.stat.distribution.MultivariateGaussian
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.{IntegerType, StructType}
-
-import scala.collection.JavaConverters
 
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -106,15 +106,17 @@ class GaussianMixtureModel private[ml] (
   def gaussians: Array[MultivariateGaussian] = parentModel.gaussians
 
   /**
-   * Helper method used in Python.
    * Retrieve Gaussian distributions as a DataFrame.
    * Each row represents a Gaussian Distribution.
    * Two columns are defined: mean and cov.
    * Schema:
+   * {{{
    * root
    * |-- mean: vector (nullable = true)
    * |-- cov: matrix (nullable = true)
+   * }}}
    */
+  @Since("2.0.0")
   def gaussiansDF: DataFrame = {
     val modelGaussians = gaussians.map { gaussian =>
       (gaussian.mu, gaussian.sigma)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -100,10 +100,10 @@ class GaussianMixtureModel private[ml] (
   }
 
   @Since("2.0.0")
-  def gaussians: Array[MultivariateGaussian] = parentModel.gaussians
+  def weights: Array[Double] = parentModel.weights
 
   @Since("2.0.0")
-  def weights: Array[Double] = parentModel.weights
+  def gaussians: Array[MultivariateGaussian] = parentModel.gaussians
 
   /**
    * Helper method used in Python

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -107,7 +107,9 @@ class GaussianMixtureModel private[ml] (
 
   /**
    * Helper method used in Python.
-   * Retrieve gaussians as a DataFrame.
+   * Retrieve Gaussian distributions as a DataFrame.
+   * Each row represents a Gaussian Distribution.
+   * Two columns are defined: mean and cov.
    * Schema:
    * root
    * |-- mean: vector (nullable = true)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -108,7 +108,6 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext
   test("read/write") {
     def checkModelData(model: GaussianMixtureModel, model2: GaussianMixtureModel): Unit = {
       assert(model.weights === model2.weights)
-      val gaussians = model.gaussians
       assert(model.gaussians.map(_.mu) === model2.gaussians.map(_.mu))
       assert(model.gaussians.map(_.sigma) === model2.gaussians.map(_.sigma))
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions._
 
 
-
 class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext
   with DefaultReadWriteTest {
 
@@ -81,7 +80,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext
     val model = gm.fit(dataset)
     assert(model.hasParent)
     assert(model.weights.length === k)
-    assert(model.gaussians.collect.size === k)
+    assert(model.gaussians.length === k)
 
     val transformed = model.transform(dataset)
     val expectedColumns = Array("features", predictionColName, probabilityColName)
@@ -112,13 +111,8 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext
     def checkModelData(model: GaussianMixtureModel, model2: GaussianMixtureModel): Unit = {
       assert(model.weights === model2.weights)
       val gaussians = model.gaussians
-      val mus = gaussians.select(col("mu")).collect().map{_.getAs[Vector]("mu")}
-      val sigmas = gaussians.select(col("sigma")).collect().map{_.getAs[Matrix]("sigma")}
-      val gaussians2 = model2.gaussians
-      val mus2 = gaussians2.select(col("mu")).collect().map{_.getAs[Vector]("mu")}
-      val sigmas2 = gaussians2.select(col("sigma")).collect().map{_.getAs[Matrix]("sigma")}
-      assert(mus === mus2)
-      assert(sigmas === sigmas2)
+      assert(model.gaussians.map(_.mu) === model2.gaussians.map(_.mu))
+      assert(model.gaussians.map(_.sigma) === model2.gaussians.map(_.sigma))
     }
     val gm = new GaussianMixture()
     testEstimatorAndModelReadWrite(gm, dataset,

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -19,10 +19,8 @@ package org.apache.spark.ml.clustering
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.util.DefaultReadWriteTest
-import org.apache.spark.mllib.linalg.{Matrix, Vector}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.{DataFrame, Dataset}
-import org.apache.spark.sql.functions._
 
 
 class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -28,6 +28,7 @@ __all__ = ['BisectingKMeans', 'BisectingKMeansModel',
 class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
     """
     .. note:: Experimental
+
     Model fitted by GaussianMixtureModel.
 
     .. versionadded:: 2.0.0

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -60,10 +60,7 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
 
     Learning algorithm for Gaussian Mixtures using the expectation-maximization algorithm.
 
-    >>> from pyspark.mllib.linalg import Vectors, DenseMatrix
-    >>> from numpy.testing import assert_equal
-    >>> from shutil import rmtree
-    >>> import os, tempfile
+    >>> from pyspark.mllib.linalg import Vectors
 
     >>> data1 = [(Vectors.dense([-0.1, -0.05 ]),),
     ...         (Vectors.dense([-0.01, -0.1]),),
@@ -83,8 +80,6 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     3
     >>> transformed = model.transform(df1).select("features", "prediction")
     >>> rows = transformed.collect()
-    >>> len(rows)
-    6
     >>> rows[0].prediction == rows[2].prediction
     False
     >>> rows[4].prediction == rows[5].prediction
@@ -104,6 +99,21 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> model2.weights == model.weights
     True
     >>> model2.gaussians == model.gaussians
+    True
+    >>> data2 = [(Vectors.dense([-5.1971, -2.5359, -3.8220]),),
+    ...          (Vectors.dense([-5.2211, -5.0602,  4.7118]),),
+    ...          (Vectors.dense([6.8989, 3.4592,  4.6322]),),
+    ...          (Vectors.dense([5.7048,  4.6567, 5.5026]),),
+    ...          (Vectors.dense([4.5605,  5.2043,  6.2734]),)]
+    >>> df2 = sqlContext.createDataFrame(data2, ["features"])
+    >>> gaussianmixture3 = GaussianMixture(k=2, tol=0.0001,
+    ...                                     maxIter=150, seed=10)
+    >>> model3 = gaussianmixture3.fit(df2)
+    >>> transformed2 = model3.transform(df2).select("features", "prediction")
+    >>> rows2 = transformed2.collect()
+    >>> rows2[0].prediction == rows2[1].prediction
+    True
+    >>> rows2[2].prediction == rows2[3].prediction == rows2[4].prediction
     True
 
     .. versionadded:: 2.0.0

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -66,15 +66,15 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> from pyspark.mllib.linalg import Vectors
 
     >>> data = [(Vectors.dense([-0.1, -0.05 ]),),
-    ...          (Vectors.dense([-0.01, -0.1]),),
-    ...          (Vectors.dense([0.9, 0.8]),),
-    ...          (Vectors.dense([0.75, 0.935]),),
-    ...          (Vectors.dense([-0.83, -0.68]),),
-    ...          (Vectors.dense([-0.91, -0.76]),)]
+    ...         (Vectors.dense([-0.01, -0.1]),),
+    ...         (Vectors.dense([0.9, 0.8]),),
+    ...         (Vectors.dense([0.75, 0.935]),),
+    ...         (Vectors.dense([-0.83, -0.68]),),
+    ...         (Vectors.dense([-0.91, -0.76]),)]
     >>> df = sqlContext.createDataFrame(data, ["features"])
-    >>> gaussianmixture = GaussianMixture(k=3, tol=0.0001,
-    ...                                    maxIter=50, seed=10)
-    >>> model = gaussianmixture.fit(df)
+    >>> gm = GaussianMixture(k=3, tol=0.0001,
+    ...                                    maxIter=10, seed=10)
+    >>> model = gm.fit(df)
     >>> weights = model.weights
     >>> len(weights)
     3
@@ -95,9 +95,9 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> rows[2].prediction == rows[3].prediction
     True
     >>> gmm_path = temp_path + "/gmm"
-    >>> gaussianmixture.save(gmm_path)
-    >>> gaussianmixture2 = GaussianMixture.load(gmm_path)
-    >>> gaussianmixture2.getK()
+    >>> gm.save(gmm_path)
+    >>> gm2 = GaussianMixture.load(gmm_path)
+    >>> gm2.getK()
     3
     >>> model_path = temp_path + "/gmm_model"
     >>> model.save(model_path)
@@ -155,7 +155,7 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
         """
         Sets the value of :py:attr:`k`.
         """
-        self._paramMap[self.k] = value
+        self._set(k=value)
         return self
 
     @since("2.0.0")

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -20,7 +20,6 @@ from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaEstimator, JavaModel
 from pyspark.ml.param.shared import *
 from pyspark.mllib.common import inherit_doc
-from pyspark.mllib.stat.distribution import MultivariateGaussian
 
 __all__ = ['BisectingKMeans', 'BisectingKMeansModel',
            'KMeans', 'KMeansModel',
@@ -47,10 +46,13 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
 
     @property
     @since("2.0.0")
-    def gaussians(self):
+    def gaussiansDF(self):
         """
-        Array of MultivariateGaussian where gaussians[i] represents
-        the Multivariate Gaussian (Normal) Distribution for Gaussian i.
+        Retrieve gaussians as a DataFrame.
+        Schema:
+        root
+        |-- mean: vector (nullable = true)
+        |-- cov: matrix (nullable = true)
         """
         return self._call_java("gaussiansDF")
 
@@ -73,15 +75,15 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     ...         (Vectors.dense([-0.91, -0.76]),)]
     >>> df = sqlContext.createDataFrame(data, ["features"])
     >>> gm = GaussianMixture(k=3, tol=0.0001,
-    ...                                    maxIter=10, seed=10)
+    ...                      maxIter=10, seed=10)
     >>> model = gm.fit(df)
     >>> weights = model.weights
     >>> len(weights)
     3
-    >>> gaussians = model.gaussians
+    >>> gaussians = model.gaussiansDF
     >>> gaussians.show()
     +--------------------+--------------------+
-    |                  mu|               sigma|
+    |                mean|                 cov|
     +--------------------+--------------------+
     |[-0.0550000000000...|0.002025000000000...|
     |[0.82499999999999...|0.005625000000000...|
@@ -104,9 +106,9 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> model2 = GaussianMixtureModel.load(model_path)
     >>> model2.weights == model.weights
     True
-    >>> model2.gaussians.show()
+    >>> model2.gaussiansDF.show()
     +--------------------+--------------------+
-    |                  mu|               sigma|
+    |                mean|                 cov|
     +--------------------+--------------------+
     |[-0.0550000000000...|0.002025000000000...|
     |[0.82499999999999...|0.005625000000000...|

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -51,8 +51,8 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
         Retrieve gaussians as a DataFrame.
         Schema:
         root
-        |-- mean: vector (nullable = true)
-        |-- cov: matrix (nullable = true)
+         -- mean: vector (nullable = true)
+         -- cov: matrix (nullable = true)
         """
         return self._call_java("gaussiansDF")
 

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -48,7 +48,9 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
     @since("2.0.0")
     def gaussiansDF(self):
         """
-        Retrieve gaussians as a DataFrame.
+        Retrieve Gaussian distributions as a DataFrame.
+        Each row represents a Gaussian Distribution.
+        Two columns are defined: mean and cov.
         Schema:
         root
         -- mean: vector (nullable = true)

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -51,8 +51,8 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
         Retrieve gaussians as a DataFrame.
         Schema:
         root
-         -- mean: vector (nullable = true)
-         -- cov: matrix (nullable = true)
+        -- mean: vector (nullable = true)
+        -- cov: matrix (nullable = true)
         """
         return self._call_java("gaussiansDF")
 

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -80,8 +80,7 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> weights = model.weights
     >>> len(weights)
     3
-    >>> gaussians = model.gaussiansDF
-    >>> gaussians.show()
+    >>> model.gaussiansDF.show()
     +--------------------+--------------------+
     |                mean|                 cov|
     +--------------------+--------------------+

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -52,7 +52,7 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
         Array of MultivariateGaussian where gaussians[i] represents
         the Multivariate Gaussian (Normal) Distribution for Gaussian i.
         """
-        return self._call_java("gaussians")
+        return self._call_java("gaussiansDF")
 
 
 @inherit_doc


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Python API in ML for GaussianMixture
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Add doctest and test cases are the same as mllib Python tests
./dev/lint-python 
PEP8 checks passed.
rm -rf _build/*
pydoc checks passed.

./python/run-tests --python-executables=python2.7 --modules=pyspark-ml
Running PySpark tests. Output is in /Users/mwang/spark_ws_0904/python/unit-tests.log
Will test against the following Python executables: ['python2.7']
Will test the following Python modules: ['pyspark-ml']
Finished test(python2.7): pyspark.ml.evaluation (18s)
Finished test(python2.7): pyspark.ml.clustering (40s)
Finished test(python2.7): pyspark.ml.classification (49s)
Finished test(python2.7): pyspark.ml.recommendation (44s)
Finished test(python2.7): pyspark.ml.feature (64s)
Finished test(python2.7): pyspark.ml.regression (45s)
Finished test(python2.7): pyspark.ml.tuning (30s)
Finished test(python2.7): pyspark.ml.tests (56s)
Tests passed in 106 seconds
