### PR TITLE
[SPARK-14656][Core] Fix Benchmark.getPorcessorName() always return "Unknown processor" on Linux

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Benchmark.scala
+++ b/core/src/main/scala/org/apache/spark/util/Benchmark.scala
@@ -98,7 +98,7 @@ private[spark] object Benchmark {
       Try {
         val grepPath = Utils.executeAndGetOutput(Seq("which", "grep")).stripLineEnd
         Utils.executeAndGetOutput(Seq(grepPath, "-m", "1", "model name", "/proc/cpuinfo"))
-        .replaceFirst("model name[\\s*]:[\\s*]", "")
+        .stripLineEnd.replaceFirst("model name[\\s*]:[\\s*]", "")
       }.getOrElse("Unknown processor")
     } else {
       System.getenv("PROCESSOR_IDENTIFIER")

--- a/core/src/main/scala/org/apache/spark/util/Benchmark.scala
+++ b/core/src/main/scala/org/apache/spark/util/Benchmark.scala
@@ -96,7 +96,7 @@ private[spark] object Benchmark {
       Utils.executeAndGetOutput(Seq("/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"))
     } else if (SystemUtils.IS_OS_LINUX) {
       Try {
-        val grepPath = Utils.executeAndGetOutput(Seq("which", "grep"))
+        val grepPath = Utils.executeAndGetOutput(Seq("which", "grep")).stripLineEnd
         Utils.executeAndGetOutput(Seq(grepPath, "-m", "1", "model name", "/proc/cpuinfo"))
         .replaceFirst("model name[\\s*]:[\\s*]", "")
       }.getOrElse("Unknown processor")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR returns correct processor name in `/proc/cpuinfo` on Linux from  `Benchmark.getPorcessorName()`. Now, this return `Unknown processor`.
Since `Utils.executeAndGetOutput(Seq("which", "grep"))` return `/bin/grep\n`, it is failed to execute `/bin/grep\n`. This PR strips `\n` at the end of the line of a result of `Utils.executeAndGetOutput()`

Before applying this PR

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_66-b17 on Linux 2.6.32-504.el6.x86_64
Unknown processor
back-to-back filter:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Dataset                                   472 /  503         21.2          47.2       1.0X
DataFrame                                  51 /   58        198.0           5.1       9.3X
RDD                                       189 /  211         52.8          18.9       2.5X
```

After applying this PR

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_66-b17 on Linux 2.6.32-504.el6.x86_64
Intel(R) Xeon(R) CPU E5-2667 v2 @ 3.30GHz
back-to-back filter:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Dataset                                   490 /  502         20.4          49.0       1.0X
DataFrame                                  55 /   61        183.4           5.5       9.0X
RDD                                       210 /  237         47.7          21.0       2.3X
```
## How was this patch tested?

Run Benchmark programs on Linux by hand
