### PR TITLE
[SPARK-14662] LinearRegressionModel use default parameters if yStd is 0

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -241,7 +241,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
         val coefficients = Vectors.sparse(numFeatures, Seq())
         val intercept = yMean
 
-        val model = new LinearRegressionModel(uid, coefficients, intercept)
+        val model = copyValues(new LinearRegressionModel(uid, coefficients, intercept))
         // Handle possible missing or invalid prediction columns
         val (summaryModel, predictionColName) = model.findSummaryModelAndPredictionCol()
 
@@ -253,7 +253,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
           model,
           Array(0D),
           Array(0D))
-        return copyValues(model.setSummary(trainingSummary))
+        return model.setSummary(trainingSummary)
       } else {
         require($(regParam) == 0.0, "The standard deviation of the label is zero. " +
           "Model cannot be regularized.")


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the (rare) case where yStd is 0 in LinearRegression, parameters are not copied immediately to the created LinearRegressionModel instance, but they should (as in all other cases), because now the default column names are used in and returned by model.findSummaryModelAndPredictionCol(), which leads to schema validation errors.
## How was this patch tested?

some simple manual tests
