### PR TITLE
[SPARK-14661] [MLlib] trim PCAModel by required explained variance

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -37,6 +37,7 @@ private[feature] trait PCAParams extends Params with HasInputCol with HasOutputC
 
   /**
    * The number of principal components.
+   *
    * @group param
    */
   final val k: IntParam = new IntParam(this, "k", "the number of principal components")
@@ -150,6 +151,12 @@ class PCAModel private[ml] (
 
   @Since("1.6.0")
   override def write: MLWriter = new PCAModelWriter(this)
+
+  def trimByVarianceRetained(requiredVariance: Double): PCAModel = {
+    feature.PCAModel.trimByVarianceRetained(requiredVariance, pc, explainedVariance)
+      .map(model => new PCAModel(uid, model.pc, model.explainedVariance))
+      .getOrElse(this)
+  }
 }
 
 @Since("1.6.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
@@ -85,14 +85,12 @@ class PCASuite extends SparkFunSuite with MLlibTestSparkContext with DefaultRead
     // given
     val df = sqlContext.createDataFrame(dataRDD.zipWithIndex()).toDF("features", "index")
 
-    val pca = new PCA()
+    // when
+    val trimmed = new PCA()
       .setInputCol("features")
       .setOutputCol("pca_features")
-      .setK(4)
+      .setRequiredVariance(0.9)
       .fit(df)
-
-    // when
-    val trimmed = pca.trimByVarianceRetained(0.90)
 
     // then
     val pcaWithExpectedK = new PCA()

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
@@ -51,7 +51,7 @@ class PCASuite extends SparkFunSuite with MLlibTestSparkContext {
     val pca = new PCA(4).fit(dataRDD)
 
     // when
-    val trimmed = pca.minimalByVarianceExplained(0.90)
+    val trimmed = pca.trimByVarianceRetained(0.90)
 
     // then
     val pcaWithExpectedK = new PCA(2).fit(dataRDD)

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
@@ -45,4 +45,18 @@ class PCASuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(pca_transform.toSet === mat_multiply.toSet)
     assert(pca.explainedVariance === explainedVariance)
   }
+
+  test("should return model with minimal number of features that retain given level of variance") {
+    // given
+    val pca = new PCA(4).fit(dataRDD)
+
+    // when
+    val trimmed = pca.minimalByVarianceExplained(0.90)
+
+    // then
+    val pcaWithExpectedK = new PCA(2).fit(dataRDD)
+    assert(trimmed.k === pcaWithExpectedK.k)
+    assert(trimmed.explainedVariance === pcaWithExpectedK.explainedVariance)
+    assert(trimmed.pc === pcaWithExpectedK.pc)
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
@@ -37,7 +37,7 @@ class PCASuite extends SparkFunSuite with MLlibTestSparkContext {
     val pca = new PCA(k).fit(dataRDD)
 
     val mat = new RowMatrix(dataRDD)
-    val (pc, explainedVariance) = mat.computePrincipalComponentsAndExplainedVariance(k)
+    val (pc, explainedVariance) = mat.computePrincipalComponentsAndExplainedVariance(Left(k))
 
     val pca_transform = pca.transform(dataRDD).collect()
     val mat_multiply = mat.multiply(pc).rows.collect()
@@ -47,14 +47,11 @@ class PCASuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should return model with minimal number of features that retain given level of variance") {
-    // given
-    val pca = new PCA(4).fit(dataRDD)
-
     // when
-    val trimmed = pca.trimByVarianceRetained(0.90)
+    val trimmed = new PCA(requiredVariance = 0.90).fit(dataRDD)
 
     // then
-    val pcaWithExpectedK = new PCA(2).fit(dataRDD)
+    val pcaWithExpectedK = new PCA(k = 2).fit(dataRDD)
     assert(trimmed.k === pcaWithExpectedK.k)
     assert(trimmed.explainedVariance === pcaWithExpectedK.explainedVariance)
     assert(trimmed.pc === pcaWithExpectedK.pc)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/RowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/RowMatrixSuite.scala
@@ -204,7 +204,7 @@ class RowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("pca") {
     for (mat <- Seq(denseMat, sparseMat); k <- 1 to n) {
-      val (pc, expVariance) = mat.computePrincipalComponentsAndExplainedVariance(k)
+      val (pc, expVariance) = mat.computePrincipalComponentsAndExplainedVariance(Left(k))
       assert(pc.numRows === n)
       assert(pc.numCols === k)
       assertColumnEqualUpToSign(pc.toBreeze.asInstanceOf[BDM[Double]], principalComponents, k)


### PR DESCRIPTION
## What changes were proposed in this pull request?

New method in PCAModel for auto-trimming the model to minimal number of features calculated from required variance retained by those features
## How was this patch tested?

unit tests
