### PR TITLE
[SPARK-14671][ML] Pipeline setStages should handle subclasses of PipelineStage

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
@@ -297,7 +297,7 @@ class PipelineModel private[ml] (
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    stages.foldLeft(dataset.toDF())((cur, transformer) => transformer.transform(cur))
+    stages.foldLeft(dataset.toDF)((cur, transformer) => transformer.transform(cur))
   }
 
   @Since("1.2.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
@@ -103,7 +103,10 @@ class Pipeline @Since("1.4.0") (
 
   /** @group setParam */
   @Since("1.2.0")
-  def setStages(value: Array[PipelineStage]): this.type = { set(stages, value); this }
+  def setStages(value: Array[_ <: PipelineStage]): this.type = {
+    set(stages, value.asInstanceOf[Array[PipelineStage]])
+    this
+  }
 
   // Below, we clone stages so that modifications to the list of stages will not change
   // the Param value in the Pipeline.
@@ -294,7 +297,7 @@ class PipelineModel private[ml] (
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    stages.foldLeft(dataset.toDF)((cur, transformer) => transformer.transform(cur))
+    stages.foldLeft(dataset.toDF())((cur, transformer) => transformer.transform(cur))
   }
 
   @Since("1.2.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -79,7 +79,7 @@ class Param[T](val parent: String, val name: String, val doc: String, val isVali
   }
 
   /** Creates a param pair with the given value (for Java). */
-  def w(value: T): ParamPair[T] = this -> value
+  def w[U <: T](value: U): ParamPair[T] = this -> value
 
   /** Creates a param pair with the given value (for Scala). */
   // scalastyle:off
@@ -242,7 +242,7 @@ class DoubleParam(parent: String, name: String, doc: String, isValid: Double => 
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w(value: Double): ParamPair[Double] = super.w(value)
+  override def w[U <: Double](value: U): ParamPair[Double] = super.w(value)
 
   override def jsonEncode(value: Double): String = {
     compact(render(DoubleParam.jValueEncode(value)))
@@ -302,7 +302,7 @@ class IntParam(parent: String, name: String, doc: String, isValid: Int => Boolea
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w(value: Int): ParamPair[Int] = super.w(value)
+  override def w[U <: Int](value: U): ParamPair[Int] = super.w(value)
 
   override def jsonEncode(value: Int): String = {
     compact(render(JInt(value)))
@@ -331,7 +331,7 @@ class FloatParam(parent: String, name: String, doc: String, isValid: Float => Bo
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w(value: Float): ParamPair[Float] = super.w(value)
+  override def w[U <: Float](value: U): ParamPair[Float] = super.w(value)
 
   override def jsonEncode(value: Float): String = {
     compact(render(FloatParam.jValueEncode(value)))
@@ -392,7 +392,7 @@ class LongParam(parent: String, name: String, doc: String, isValid: Long => Bool
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w(value: Long): ParamPair[Long] = super.w(value)
+  override def w[U <: Long](value: U): ParamPair[Long] = super.w(value)
 
   override def jsonEncode(value: Long): String = {
     compact(render(JInt(value)))
@@ -415,7 +415,7 @@ class BooleanParam(parent: String, name: String, doc: String) // No need for isV
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w(value: Boolean): ParamPair[Boolean] = super.w(value)
+  override def w[U <: Boolean](value: U): ParamPair[Boolean] = super.w(value)
 
   override def jsonEncode(value: Boolean): String = {
     compact(render(JBool(value)))

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -79,7 +79,7 @@ class Param[T](val parent: String, val name: String, val doc: String, val isVali
   }
 
   /** Creates a param pair with the given value (for Java). */
-  def w[U <: T](value: U): ParamPair[T] = this -> value
+  def w(value: T): ParamPair[T] = this -> value
 
   /** Creates a param pair with the given value (for Scala). */
   // scalastyle:off
@@ -242,7 +242,7 @@ class DoubleParam(parent: String, name: String, doc: String, isValid: Double => 
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w[U <: Double](value: U): ParamPair[Double] = super.w(value)
+  override def w(value: Double): ParamPair[Double] = super.w(value)
 
   override def jsonEncode(value: Double): String = {
     compact(render(DoubleParam.jValueEncode(value)))
@@ -302,7 +302,7 @@ class IntParam(parent: String, name: String, doc: String, isValid: Int => Boolea
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w[U <: Int](value: U): ParamPair[Int] = super.w(value)
+  override def w(value: Int): ParamPair[Int] = super.w(value)
 
   override def jsonEncode(value: Int): String = {
     compact(render(JInt(value)))
@@ -331,7 +331,7 @@ class FloatParam(parent: String, name: String, doc: String, isValid: Float => Bo
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w[U <: Float](value: U): ParamPair[Float] = super.w(value)
+  override def w(value: Float): ParamPair[Float] = super.w(value)
 
   override def jsonEncode(value: Float): String = {
     compact(render(FloatParam.jValueEncode(value)))
@@ -392,7 +392,7 @@ class LongParam(parent: String, name: String, doc: String, isValid: Long => Bool
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w[U <: Long](value: U): ParamPair[Long] = super.w(value)
+  override def w(value: Long): ParamPair[Long] = super.w(value)
 
   override def jsonEncode(value: Long): String = {
     compact(render(JInt(value)))
@@ -415,7 +415,7 @@ class BooleanParam(parent: String, name: String, doc: String) // No need for isV
   def this(parent: Identifiable, name: String, doc: String) = this(parent.uid, name, doc)
 
   /** Creates a param pair with the given value (for Java). */
-  override def w[U <: Boolean](value: U): ParamPair[Boolean] = super.w(value)
+  override def w(value: Boolean): ParamPair[Boolean] = super.w(value)
 
   override def jsonEncode(value: Boolean): String = {
     compact(render(JBool(value)))

--- a/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
@@ -51,11 +51,11 @@ class PipelineSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     val dataset3 = mock[DataFrame]
     val dataset4 = mock[DataFrame]
 
-    when(dataset0.toDF()).thenReturn(dataset0)
-    when(dataset1.toDF()).thenReturn(dataset1)
-    when(dataset2.toDF()).thenReturn(dataset2)
-    when(dataset3.toDF()).thenReturn(dataset3)
-    when(dataset4.toDF()).thenReturn(dataset4)
+    when(dataset0.toDF).thenReturn(dataset0)
+    when(dataset1.toDF).thenReturn(dataset1)
+    when(dataset2.toDF).thenReturn(dataset2)
+    when(dataset3.toDF).thenReturn(dataset3)
+    when(dataset4.toDF).thenReturn(dataset4)
 
     when(estimator0.copy(any[ParamMap])).thenReturn(estimator0)
     when(model0.copy(any[ParamMap])).thenReturn(model0)
@@ -229,7 +229,7 @@ class WritableStage(override val uid: String) extends Transformer with MLWritabl
 
   override def write: MLWriter = new DefaultParamsWriter(this)
 
-  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
+  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF
 
   override def transformSchema(schema: StructType): StructType = schema
 }
@@ -250,7 +250,7 @@ class UnWritableStage(override val uid: String) extends Transformer {
 
   override def copy(extra: ParamMap): UnWritableStage = defaultCopy(extra)
 
-  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
+  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF
 
   override def transformSchema(schema: StructType): StructType = schema
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
@@ -207,9 +207,6 @@ class PipelineSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     val stages1 = Array(new WritableStage("a"))
     val steps = stages0 ++ stages1
     val p = new Pipeline().setStages(steps)
-
-    p.stages.w(steps)
-    new ParamPair(p.stages, steps)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
@@ -192,13 +192,13 @@ class PipelineSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     ).toDF("id", "features", "label")
 
     intercept[IllegalArgumentException] {
-      val scaler = new MinMaxScaler()
-        .setInputCol("features")
-        .setOutputCol("features_scaled")
-        .setMin(10)
-        .setMax(0)
-      val pipeline = new Pipeline().setStages(Array(scaler))
-      pipeline.fit(df)
+       val scaler = new MinMaxScaler()
+         .setInputCol("features")
+         .setOutputCol("features_scaled")
+         .setMin(10)
+         .setMax(0)
+       val pipeline = new Pipeline().setStages(Array(scaler))
+       pipeline.fit(df)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/PipelineSuite.scala
@@ -210,9 +210,6 @@ class PipelineSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
 
     p.stages.w(steps)
     new ParamPair(p.stages, steps)
-    // These
-    //val pp: ParamPair[Array[PipelineStage]] = p.stages -> steps
-    //p.set(p.stages -> steps)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pipeline.setStages failed for some code examples which worked in 1.5 but fail in 1.6.  This tends to occur when using a mix of transformers from ml.feature. It is because Java Arrays are non-covariant and the addition of MLWritable to some transformers means the stages0/1 arrays above are not of type Array[PipelineStage].  This PR modifies the following to accept subclasses of PipelineStage:
- Pipeline.setStages()
- Params.w()
## How was this patch tested?

Unit test which fails to compile before this fix.
