### PR TITLE
[SPARK-14678][SQL]Add a file sink log to support versioning and compaction

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -52,7 +52,14 @@ class FileStreamSink(
       logInfo(s"Skipping already committed batch $batchId")
     } else {
       val files = fs.listStatus(writeFiles(data)).map { f =>
-        SinkFileStatus(f.getPath.toUri.toString, f.getLen, FileStreamSinkLog.ADD_ACTION)
+        SinkFileStatus(
+          path = f.getPath.toUri.toString,
+          size = f.getLen,
+          isDir = f.isDirectory,
+          modificationTime = f.getModificationTime,
+          blockReplication = f.getReplication,
+          blockSize = f.getBlockSize,
+          action = FileStreamSinkLog.ADD_ACTION)
       }
       if (fileLog.add(batchId, files)) {
         logInfo(s"Committed batch $batchId")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -52,7 +52,7 @@ class FileStreamSink(
       logInfo(s"Skipping already committed batch $batchId")
     } else {
       val files = fs.listStatus(writeFiles(data)).map { f =>
-        FileLog(f.getPath.toUri.toString, f.getLen, FileStreamSinkLog.ADD_ACTION)
+        SinkFileStatus(f.getPath.toUri.toString, f.getLen, FileStreamSinkLog.ADD_ACTION)
       }
       if (fileLog.add(batchId, files)) {
         logInfo(s"Committed batch $batchId")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -44,28 +44,26 @@ class FileStreamSink(
 
   private val basePath = new Path(path)
   private val logPath = new Path(basePath, FileStreamSink.metadataDir)
-  private val fileLog = new HDFSMetadataLog[Seq[String]](sqlContext, logPath.toUri.toString)
+  private val fileLog = new FileStreamSinkLog(sqlContext, logPath.toUri.toString)
+  private val fs = basePath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
 
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
-    if (fileLog.get(batchId).isDefined) {
+    if (batchId <= fileLog.getLatest().map(_._1).getOrElse(-1L)) {
       logInfo(s"Skipping already committed batch $batchId")
     } else {
-      val files = writeFiles(data)
+      val files = fs.listStatus(writeFiles(data)).map { f =>
+        FileLog(f.getPath.toUri.toString, f.getLen, FileStreamSinkLog.ADD_ACTION)
+      }
       if (fileLog.add(batchId, files)) {
         logInfo(s"Committed batch $batchId")
       } else {
-        logWarning(s"Race while writing batch $batchId")
+        throw new IllegalStateException(s"Race while writing batch $batchId")
       }
     }
   }
 
   /** Writes the [[DataFrame]] to a UUID-named dir, returning the list of files paths. */
-  private def writeFiles(data: DataFrame): Seq[String] = {
-    val ctx = sqlContext
-    val outputDir = path
-    val format = fileFormat
-    val schema = data.schema
-
+  private def writeFiles(data: DataFrame): Array[Path] = {
     val file = new Path(basePath, UUID.randomUUID().toString).toUri.toString
     data.write.parquet(file)
     sqlContext.read
@@ -74,7 +72,6 @@ class FileStreamSink(
         .inputFiles
         .map(new Path(_))
         .filterNot(_.getName.startsWith("_"))
-        .map(_.toUri.toString)
   }
 
   override def toString: String = s"FileSink[$path]"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLog.scala
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.io.IOException
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.apache.hadoop.fs.{Path, PathFilter}
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.{read, write}
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * @param path the file path
+ * @param size the file size
+ * @param action the file action. Must be either "add" or "delete".
+ */
+case class FileLog(path: String, size: Long, action: String)
+
+/**
+ * A special log for [[FileStreamSink]]. It will write one log file for each batch. The first line
+ * of the log file is the version number, and there are multiple JSON lines following. Each JSON
+ * line is a JSON format of [[FileLog]].
+ *
+ * As reading from many small files is usually pretty slow, [[FileStreamSinkLog]] will compact log
+ * files every "spark.sql.sink.file.log.compactLen" batches into a big file. When doing a compact,
+ * it will read all history logs and merge them with the new batch. During the compaction, it will
+ * also delete the files that are deleted (marked by [[FileLog.action]]). When the reader uses
+ * `allLogs` to list all files, this method only returns the visible files (drops the deleted
+ * files).
+ */
+class FileStreamSinkLog(sqlContext: SQLContext, path: String)
+  extends HDFSMetadataLog[Seq[FileLog]](sqlContext, path) {
+
+  import FileStreamSinkLog._
+
+  private implicit val formats = Serialization.formats(NoTypeHints)
+
+  /**
+   * If we delete the old files after compaction at once, there is a race condition in S3: other
+   * processes may see the old files are deleted but still cannot see the compaction file. The user
+   * should set a reasonable `fileExpiredTimeMS`. We will wait until then so that the compaction
+   * file is guaranteed to be visible for all readers
+   */
+  private val fileExpiredTimeMS = sqlContext.getConf(SQLConf.FILE_STREAM_SINK_LOG_EXPIRED_TIME)
+
+  private val isDeletingExpiredLog = sqlContext.getConf(SQLConf.FILE_STREAM_SINK_LOG_DELETE)
+
+  private val compactLength = sqlContext.getConf(SQLConf.FILE_STREAM_SINK_LOG_COMPACT_LEN)
+
+  override def batchIdToPath(batchId: Long): Path = {
+    if (isCompactionBatch(batchId, compactLength)) {
+      new Path(metadataPath, s"$batchId$COMPACT_FILE_SUFFIX")
+    } else {
+      new Path(metadataPath, batchId.toString)
+    }
+  }
+
+  override def pathToBatchId(path: Path): Long = {
+    getBatchIdFromFileName(path.getName)
+  }
+
+  override def isBatchFile(path: Path): Boolean = {
+    try {
+      getBatchIdFromFileName(path.getName)
+      true
+    } catch {
+      case _: NumberFormatException => false
+    }
+  }
+
+  override def serialize(logs: Seq[FileLog]): Array[Byte] = {
+    (VERSION +: logs.map(write(_))).mkString("\n").getBytes(UTF_8)
+  }
+
+  override def deserialize(bytes: Array[Byte]): Seq[FileLog] = {
+    val lines = new String(bytes, UTF_8).split("\n")
+    if (lines.length == 0) {
+      throw new IllegalStateException("Incomplete log file")
+    }
+    val version = lines(0)
+    if (version != VERSION) {
+      throw new IllegalStateException(s"Unknown log version: ${version}")
+    }
+    lines.toSeq.slice(1, lines.length).map(read[FileLog](_))
+  }
+
+  override def add(batchId: Long, logs: Seq[FileLog]): Boolean = {
+    if (isCompactionBatch(batchId, compactLength)) {
+      compact(batchId, logs)
+    } else {
+      super.add(batchId, logs)
+    }
+  }
+
+  /**
+   * Compacts all logs before `batchId` plus the provided `logs`, and writes them into the
+   * corresponding `batchId` file.
+   */
+  private def compact(batchId: Long, logs: Seq[FileLog]): Boolean = {
+    val validBatches = getValidBatchesBeforeCompactionBatch(batchId, compactLength)
+    val allLogs = validBatches.flatMap(batchId => get(batchId)).flatten ++ logs
+    if (super.add(batchId, compactLogs(allLogs))) {
+      if (isDeletingExpiredLog) {
+        deleteExpiredLog(batchId)
+      }
+      true
+    } else {
+      // Return false as there is another writer.
+      false
+    }
+  }
+
+  /**
+   * Returns all file logs except the deleted files.
+   */
+  def allLogs(): Array[FileLog] = {
+    var latestId = getLatest().map(_._1).getOrElse(-1L)
+    while (true) {
+      if (latestId >= 0) {
+        val startId = getAllValidBatches(latestId, compactLength)(0)
+        try {
+          val logs = get(Some(startId), Some(latestId)).flatMap(_._2)
+          return compactLogs(logs).toArray
+        } catch {
+          case e: IOException =>
+            // Another process may delete the batch files when we are reading. However, it only
+            // happens when there is a compaction done. If so, we should retry to read the batches.
+            // Otherwise, this is a real IO issue and we should throw it.
+            val preLatestId = latestId
+            latestId = getLatest().map(_._1).getOrElse(-1L)
+            if (preLatestId == latestId) {
+              throw e
+            }
+        }
+      } else {
+        return Array.empty
+      }
+    }
+    Array.empty
+  }
+
+  /**
+   * Since all logs before `compactionBatchId` are compacted and written into the
+   * `compactionBatchId` log file, they can be removed. However, due to the eventual consistency of
+   * S3, the compaction file may not be seen by other processes at once. So we only delete files
+   * created `fileExpiredTimeMS` milliseconds ago.
+   */
+  private def deleteExpiredLog(compactionBatchId: Long): Unit = {
+    val expiredTime = System.currentTimeMillis() - fileExpiredTimeMS
+    fileManager.list(metadataPath, new PathFilter {
+      override def accept(path: Path): Boolean = {
+        try {
+          val batchId = getBatchIdFromFileName(path.getName)
+          batchId < compactionBatchId
+        } catch {
+          case _: NumberFormatException =>
+            false
+        }
+      }
+    }).foreach { f =>
+      if (f.getModificationTime <= expiredTime) {
+        fileManager.delete(f.getPath)
+      }
+    }
+  }
+}
+
+object FileStreamSinkLog {
+  val VERSION = "v1"
+  val COMPACT_FILE_SUFFIX = ".compact"
+  val DELETE_ACTION = "delete"
+  val ADD_ACTION = "add"
+
+  def getBatchIdFromFileName(fileName: String): Long = {
+    fileName.stripSuffix(COMPACT_FILE_SUFFIX).toLong
+  }
+
+  /**
+   * Returns if this is a compaction batch. FileStreamSinkLog will compact old logs every
+   * `compactLength` commits.
+   *
+   * E.g., if `compactLength` is 3, then 2, 5, 8, ... are all compaction batches.
+   */
+  def isCompactionBatch(batchId: Long, compactLength: Int): Boolean = {
+    (batchId + 1) % compactLength == 0
+  }
+
+  /**
+   * Returns all valid batches before the specified `compactionBatchId`. They contain all logs we
+   * need to do a new compaction.
+   */
+  def getValidBatchesBeforeCompactionBatch(
+      compactionBatchId: Long, compactLength: Int): Seq[Long] = {
+    assert(isCompactionBatch(compactionBatchId, compactLength),
+      s"$compactionBatchId is not a compaction batch")
+    (math.max(0, compactionBatchId - compactLength)) until compactionBatchId
+  }
+
+  /**
+   * Returns all necessary logs before `batchId` (inclusive). If `batchId` is a compaction, just
+   * return itself. Otherwise, it will find the previous compaction batch and return all batches
+   * between it and `batchId`.
+   */
+  def getAllValidBatches(batchId: Long, compactLength: Long): Seq[Long] = {
+    assert(batchId >= 0)
+    val start = math.max(0, (batchId + 1) / compactLength * compactLength - 1)
+    start to batchId
+  }
+
+  /**
+   * Removes all deleted files from logs. It assumes once one file is deleted, it won't be added to
+   * the log in future.
+   */
+  def compactLogs(logs: Seq[FileLog]): Seq[FileLog] = {
+    val deletedFiles = logs.filter(_.action == DELETE_ACTION).map(_.path).toSet
+    if (deletedFiles.isEmpty) {
+      logs
+    } else {
+      logs.filter(f => !deletedFiles.contains(f.path))
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLog.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.streaming
 import java.io.IOException
 import java.nio.charset.StandardCharsets.UTF_8
 
-import org.apache.hadoop.fs.{Path, PathFilter}
+import org.apache.hadoop.fs.{FileStatus, Path, PathFilter}
 import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
 import org.json4s.jackson.Serialization.{read, write}
@@ -32,11 +32,27 @@ import org.apache.spark.sql.internal.SQLConf
  * The status of a file outputted by [[FileStreamSink]]. A file is visible only if it appears in
  * the sink log and its action is not "delete".
  *
- * @param path the file path
- * @param size the file size
+ * @param path the file path.
+ * @param size the file size.
+ * @param isDir whether this file is a directory.
+ * @param modificationTime the file last modification time.
+ * @param blockReplication the block replication.
+ * @param blockSize the block size.
  * @param action the file action. Must be either "add" or "delete".
  */
-case class SinkFileStatus(path: String, size: Long, action: String)
+case class SinkFileStatus(
+    path: String,
+    size: Long,
+    isDir: Boolean,
+    modificationTime: Long,
+    blockReplication: Int,
+    blockSize: Long,
+    action: String) {
+
+  def toFileStatus: FileStatus = {
+    new FileStatus(size, isDir, blockReplication, blockSize, modificationTime, new Path(path))
+  }
+}
 
 /**
  * A special log for [[FileStreamSink]]. It will write one log file for each batch. The first line

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamFileCatalog.scala
@@ -54,6 +54,6 @@ class StreamFileCatalog(sqlContext: SQLContext, path: Path) extends FileCatalog 
   override def refresh(): Unit = {}
 
   override def allFiles(): Seq[FileStatus] = {
-    fs.listStatus(metadataLog.allLogs().map(f => new Path(f.path)))
+    fs.listStatus(metadataLog.allFiles().map(f => new Path(f.path)))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamFileCatalog.scala
@@ -54,6 +54,6 @@ class StreamFileCatalog(sqlContext: SQLContext, path: Path) extends FileCatalog 
   override def refresh(): Unit = {}
 
   override def allFiles(): Seq[FileStatus] = {
-    fs.listStatus(metadataLog.allFiles().map(f => new Path(f.path)))
+    metadataLog.allFiles().map(_.toFileStatus)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamFileCatalog.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType
 class StreamFileCatalog(sqlContext: SQLContext, path: Path) extends FileCatalog with Logging {
   val metadataDirectory = new Path(path, FileStreamSink.metadataDir)
   logInfo(s"Reading streaming file log from $metadataDirectory")
-  val metadataLog = new HDFSMetadataLog[Seq[String]](sqlContext, metadataDirectory.toUri.toString)
+  val metadataLog = new FileStreamSinkLog(sqlContext, metadataDirectory.toUri.toString)
   val fs = path.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
 
   override def paths: Seq[Path] = path :: Nil
@@ -54,6 +54,6 @@ class StreamFileCatalog(sqlContext: SQLContext, path: Path) extends FileCatalog 
   override def refresh(): Unit = {}
 
   override def allFiles(): Seq[FileStatus] = {
-    fs.listStatus(metadataLog.get(None, None).flatMap(_._2).map(new Path(_)))
+    fs.listStatus(metadataLog.allLogs().map(f => new Path(f.path)))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -463,7 +463,7 @@ object SQLConf {
       .internal()
       .doc("How long in milliseconds a file is guaranteed to be visible for all readers.")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefault(3600 * 1000L) // 1 hour
+      .createWithDefault(60 * 1000L) // 10 minutes
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -443,23 +443,25 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val FILE_STREAM_SINK_LOG_DELETE = SQLConfigBuilder("spark.sql.sink.file.log.delete")
+  val FILE_STREAM_SINK_LOG_DELETE = SQLConfigBuilder("spark.sql.streaming.fileSink.log.deletion")
     .internal()
-    .doc("Whether deleting the expired log files for FileStreamSink.")
+    .doc("Whether to delete the expired log files in file stream sink.")
     .booleanConf
     .createWithDefault(true)
 
-  val FILE_STREAM_SINK_LOG_COMPACT_LEN = SQLConfigBuilder("spark.sql.sink.file.log.compactLen")
-    .internal()
-    .doc("The frequency to compact the file sink logs.")
-    .intConf
-    .createWithDefault(10)
+  val FILE_STREAM_SINK_LOG_COMPACT_LEN =
+    SQLConfigBuilder("spark.sql.streaming.fileSink.log.compactLen")
+      .internal()
+      .doc("Every how many log files is a compaction triggered.")
+      .intConf
+      .createWithDefault(10)
 
-  val FILE_STREAM_SINK_LOG_EXPIRED_TIME = SQLConfigBuilder("spark.sql.sink.file.log.expired")
-    .internal()
-    .doc("How long in milliseconds a file is guaranteed to be visible for all readers.")
-    .longConf
-    .createWithDefault(3600 * 1000L) // 1 hour
+  val FILE_STREAM_SINK_LOG_EXPIRED_TIME =
+    SQLConfigBuilder("spark.sql.streaming.fileSink.log.expired")
+      .internal()
+      .doc("How long in milliseconds a file is guaranteed to be visible for all readers.")
+      .longConf
+      .createWithDefault(3600 * 1000L) // 1 hour
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.internal
 
 import java.util.{NoSuchElementException, Properties}
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -443,24 +444,25 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val FILE_STREAM_SINK_LOG_DELETE = SQLConfigBuilder("spark.sql.streaming.fileSink.log.deletion")
+  val FILE_SINK_LOG_DELETION = SQLConfigBuilder("spark.sql.streaming.fileSink.log.deletion")
     .internal()
     .doc("Whether to delete the expired log files in file stream sink.")
     .booleanConf
     .createWithDefault(true)
 
-  val FILE_STREAM_SINK_LOG_COMPACT_LEN =
-    SQLConfigBuilder("spark.sql.streaming.fileSink.log.compactLen")
+  val FILE_SINK_LOG_COMPACT_INTERVAL =
+    SQLConfigBuilder("spark.sql.streaming.fileSink.log.compactInterval")
       .internal()
-      .doc("Every how many log files is a compaction triggered.")
+      .doc("Number of log files after which all the previous files " +
+        "are compacted into the next log file.")
       .intConf
       .createWithDefault(10)
 
-  val FILE_STREAM_SINK_LOG_EXPIRED_TIME =
-    SQLConfigBuilder("spark.sql.streaming.fileSink.log.expired")
+  val FILE_SINK_LOG_CLEANUP_DELAY =
+    SQLConfigBuilder("spark.sql.streaming.fileSink.log.cleanupDelay")
       .internal()
       .doc("How long in milliseconds a file is guaranteed to be visible for all readers.")
-      .longConf
+      .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(3600 * 1000L) // 1 hour
 
   object Deprecated {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -443,6 +443,24 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val FILE_STREAM_SINK_LOG_DELETE = SQLConfigBuilder("spark.sql.sink.file.log.delete")
+    .internal()
+    .doc("Whether deleting the expired log files for FileStreamSink.")
+    .booleanConf
+    .createWithDefault(true)
+
+  val FILE_STREAM_SINK_LOG_COMPACT_LEN = SQLConfigBuilder("spark.sql.sink.file.log.compactLen")
+    .internal()
+    .doc("The frequency to compact the file sink logs.")
+    .intConf
+    .createWithDefault(10)
+
+  val FILE_STREAM_SINK_LOG_EXPIRED_TIME = SQLConfigBuilder("spark.sql.sink.file.log.expired")
+    .internal()
+    .doc("How long in milliseconds a file is guaranteed to be visible for all readers.")
+    .longConf
+    .createWithDefault(3600 * 1000L) // 1 hour
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
     val EXTERNAL_SORT = "spark.sql.planner.externalSort"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSQLContext
+
+class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
+
+  import FileStreamSinkLog._
+
+  test("getBatchIdFromFileName") {
+    assert(1234L === getBatchIdFromFileName("1234"))
+    assert(1234L === getBatchIdFromFileName("1234.compact"))
+    intercept[NumberFormatException] {
+      FileStreamSinkLog.getBatchIdFromFileName("1234a")
+    }
+  }
+
+  test("isCompactionBatch") {
+    assert(false === isCompactionBatch(0, compactLength = 3))
+    assert(false === isCompactionBatch(1, compactLength = 3))
+    assert(true === isCompactionBatch(2, compactLength = 3))
+    assert(false === isCompactionBatch(3, compactLength = 3))
+    assert(false === isCompactionBatch(4, compactLength = 3))
+    assert(true === isCompactionBatch(5, compactLength = 3))
+  }
+
+  test("getValidBatchesBeforeCompactionBatch") {
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(0, compactLength = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(1, compactLength = 3)
+    }
+    assert(Seq(0, 1) === getValidBatchesBeforeCompactionBatch(2, compactLength = 3))
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(3, compactLength = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(4, compactLength = 3)
+    }
+    assert(Seq(2, 3, 4) === getValidBatchesBeforeCompactionBatch(5, compactLength = 3))
+  }
+
+  test("getAllValidBatches") {
+    assert(Seq(0) === getAllValidBatches(0, compactLength = 3))
+    assert(Seq(0, 1) === getAllValidBatches(1, compactLength = 3))
+    assert(Seq(2) === getAllValidBatches(2, compactLength = 3))
+    assert(Seq(2, 3) === getAllValidBatches(3, compactLength = 3))
+    assert(Seq(2, 3, 4) === getAllValidBatches(4, compactLength = 3))
+    assert(Seq(5) === getAllValidBatches(5, compactLength = 3))
+    assert(Seq(5, 6) === getAllValidBatches(6, compactLength = 3))
+    assert(Seq(5, 6, 7) === getAllValidBatches(7, compactLength = 3))
+    assert(Seq(8) === getAllValidBatches(8, compactLength = 3))
+  }
+
+  test("compactLogs") {
+    val logs = Seq(
+      FileLog("/a/b/x", 100L, FileStreamSinkLog.ADD_ACTION),
+      FileLog("/a/b/y", 200L, FileStreamSinkLog.ADD_ACTION),
+      FileLog("/a/b/z", 300L, FileStreamSinkLog.ADD_ACTION))
+    assert(logs === compactLogs(logs))
+
+    val logs2 = Seq(
+      FileLog("/a/b/m", 100L, FileStreamSinkLog.ADD_ACTION),
+      FileLog("/a/b/n", 200L, FileStreamSinkLog.ADD_ACTION),
+      FileLog("/a/b/z", 300L, FileStreamSinkLog.DELETE_ACTION))
+    assert(logs.dropRight(1) ++ logs2.dropRight(1) === compactLogs(logs ++ logs2))
+  }
+
+  test("serialize") {
+    withSQLConf(SQLConf.FILE_STREAM_SINK_LOG_COMPACT_LEN.key -> "3") {
+      withFileStreamSinkLog { sinkLog =>
+        val logs = Seq(
+          FileLog("/a/b/x", 100L, FileStreamSinkLog.ADD_ACTION),
+          FileLog("/a/b/y", 200L, FileStreamSinkLog.DELETE_ACTION),
+          FileLog("/a/b/z", 300L, FileStreamSinkLog.ADD_ACTION))
+
+        val expected = s"""${FileStreamSinkLog.VERSION}
+            |{"path":"/a/b/x","size":100,"action":"add"}
+            |{"path":"/a/b/y","size":200,"action":"delete"}
+            |{"path":"/a/b/z","size":300,"action":"add"}""".stripMargin
+        assert(expected === new String(sinkLog.serialize(logs), UTF_8))
+
+        assert(FileStreamSinkLog.VERSION === new String(sinkLog.serialize(Nil), UTF_8))
+      }
+    }
+  }
+
+  test("deserialize") {
+    withSQLConf(SQLConf.FILE_STREAM_SINK_LOG_COMPACT_LEN.key -> "3") {
+      withFileStreamSinkLog { sinkLog =>
+        val logs = s"""${FileStreamSinkLog.VERSION}
+            |{"path":"/a/b/x","size":100,"action":"add"}
+            |{"path":"/a/b/y","size":200,"action":"delete"}
+            |{"path":"/a/b/z","size":300,"action":"add"}""".stripMargin
+
+        val expected = Seq(
+          FileLog("/a/b/x", 100L, FileStreamSinkLog.ADD_ACTION),
+          FileLog("/a/b/y", 200L, FileStreamSinkLog.DELETE_ACTION),
+          FileLog("/a/b/z", 300L, FileStreamSinkLog.ADD_ACTION))
+
+        assert(expected === sinkLog.deserialize(logs.getBytes(UTF_8)))
+
+        assert(Nil === sinkLog.deserialize(FileStreamSinkLog.VERSION.getBytes(UTF_8)))
+      }
+    }
+  }
+
+  test("batchIdToPath") {
+    withSQLConf(SQLConf.FILE_STREAM_SINK_LOG_COMPACT_LEN.key -> "3") {
+      withFileStreamSinkLog { sinkLog =>
+        assert("0" === sinkLog.batchIdToPath(0).getName)
+        assert("1" === sinkLog.batchIdToPath(1).getName)
+        assert("2.compact" === sinkLog.batchIdToPath(2).getName)
+        assert("3" === sinkLog.batchIdToPath(3).getName)
+        assert("4" === sinkLog.batchIdToPath(4).getName)
+        assert("5.compact" === sinkLog.batchIdToPath(5).getName)
+      }
+    }
+  }
+
+  test("compact") {
+    withSQLConf(SQLConf.FILE_STREAM_SINK_LOG_COMPACT_LEN.key -> "3") {
+      withFileStreamSinkLog { sinkLog =>
+        for (batchId <- 0 to 10) {
+          sinkLog.add(batchId, Seq(FileLog("/a/b/" + batchId, 100L, FileStreamSinkLog.ADD_ACTION)))
+          assert(sinkLog.allLogs() === (0 to batchId).map {
+            id => FileLog("/a/b/" + id, 100L, FileStreamSinkLog.ADD_ACTION)
+          })
+        }
+      }
+    }
+  }
+
+  test("delete expired file") {
+    withSQLConf(SQLConf.FILE_STREAM_SINK_LOG_COMPACT_LEN.key -> "3",
+      // Set it to 0 so that we can detect the deleting behaviour deterministically
+      SQLConf.FILE_STREAM_SINK_LOG_EXPIRED_TIME.key -> "0"
+    ) {
+      withFileStreamSinkLog { sinkLog =>
+        val metadataPath = new File(sinkLog.metadataPath.toUri.toString)
+
+        def listBatchFiles(): Set[String] = {
+          metadataPath.listFiles().map(_.getName).filter { fileName =>
+            try {
+              getBatchIdFromFileName(fileName)
+              true
+            } catch {
+              case _: NumberFormatException => false
+            }
+          }.toSet
+        }
+
+        sinkLog.add(0, Seq(FileLog("/a/b/0", 100L, FileStreamSinkLog.ADD_ACTION)))
+        assert(Set("0") === listBatchFiles())
+        sinkLog.add(1, Seq(FileLog("/a/b/1", 100L, FileStreamSinkLog.ADD_ACTION)))
+        assert(Set("0", "1") === listBatchFiles())
+        sinkLog.add(2, Seq(FileLog("/a/b/2", 100L, FileStreamSinkLog.ADD_ACTION)))
+        assert(Set("2.compact") === listBatchFiles())
+        sinkLog.add(3, Seq(FileLog("/a/b/3", 100L, FileStreamSinkLog.ADD_ACTION)))
+        assert(Set("2.compact", "3") === listBatchFiles())
+        sinkLog.add(4, Seq(FileLog("/a/b/4", 100L, FileStreamSinkLog.ADD_ACTION)))
+        assert(Set("2.compact", "3", "4") === listBatchFiles())
+        sinkLog.add(5, Seq(FileLog("/a/b/5", 100L, FileStreamSinkLog.ADD_ACTION)))
+        assert(Set("5.compact") === listBatchFiles())
+      }
+    }
+  }
+
+  def withFileStreamSinkLog(f: FileStreamSinkLog => Unit): Unit = {
+    withTempDir { file =>
+      val sinkLog = new FileStreamSinkLog(sqlContext, file.getCanonicalPath)
+      f(sinkLog)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -45,6 +45,15 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
     assert(true === isCompactionBatch(5, compactInterval = 3))
   }
 
+  test("nextCompactionBatchId") {
+    assert(2 === nextCompactionBatchId(0, compactInterval = 3))
+    assert(2 === nextCompactionBatchId(1, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(2, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(3, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(4, compactInterval = 3))
+    assert(8 === nextCompactionBatchId(5, compactInterval = 3))
+  }
+
   test("getValidBatchesBeforeCompactionBatch") {
     intercept[AssertionError] {
       getValidBatchesBeforeCompactionBatch(0, compactInterval = 3)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.spark.SparkFunSuite
@@ -218,10 +217,10 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
       SQLConf.FILE_SINK_LOG_COMPACT_INTERVAL.key -> "3",
       SQLConf.FILE_SINK_LOG_CLEANUP_DELAY.key -> "0") {
       withFileStreamSinkLog { sinkLog =>
-        val metadataPath = new File(sinkLog.metadataPath.toUri.toString)
+        val fs = sinkLog.metadataPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
 
         def listBatchFiles(): Set[String] = {
-          metadataPath.listFiles().map(_.getName).filter { fileName =>
+          fs.listStatus(sinkLog.metadataPath).map(_.getPath.getName).filter { fileName =>
             try {
               getBatchIdFromFileName(fileName)
               true


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a special log for FileStreamSink for two purposes:
- Versioning. A future Spark version should be able to read the metadata of an old FileStreamSink.
- Compaction. As reading from many small files is usually pretty slow, we should compact small metadata files into big files.

FileStreamSinkLog has a new log format instead of Java serialization format. It will write one log file for each batch. The first line of the log file is the version number, and there are multiple JSON lines following. Each JSON line is a JSON format of FileLog.

FileStreamSinkLog will compact log files every "spark.sql.sink.file.log.compactLen" batches into a big file. When doing a compact, it will read all history logs and merge them with the new batch. During the compaction, it will also delete the files that are deleted (marked by FileLog.action). When the reader uses allLogs to list all files, this method only returns the visible files (drops the deleted files).
## How was this patch tested?

FileStreamSinkLogSuite
