### PR TITLE
[SPARK-14680][SQL]Support all datatypes to use VectorizedHashmap in TungstenAggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -280,7 +280,7 @@ class CodegenContext {
       case _ if isPrimitiveType(jt) =>
         s"$batch.column($ordinal).put${primitiveTypeName(jt)}($row, $value);"
       case t: DecimalType => s"$batch.column($ordinal).putDecimal($row, $value, ${t.precision});"
-      case udt: UserDefinedType[_] => setColumnarBatch(batch, row, udt.sqlType, ordinal, value)
+      case t: StringType => s"$batch.column($ordinal).putByteArray($row, $value.getBytes());"
       case _ => throw new IllegalArgumentException("cannot generate code for unsupported type")
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -298,24 +298,13 @@ class CodegenContext {
       ev: ExprCode,
       nullable: Boolean): String = {
     if (nullable) {
-      // Can't call setNullAt on DecimalType, because we need to keep the offset
-      if (dataType.isInstanceOf[DecimalType]) {
-        s"""
-           if (!${ev.isNull}) {
-             ${setValue(batch, row, dataType, ordinal, ev.value)}
-           } else {
-             ${setValue(batch, row, dataType, ordinal, "null")}
-           }
-         """
-      } else {
-        s"""
-           if (!${ev.isNull}) {
-             ${setValue(batch, row, dataType, ordinal, ev.value)}
-           } else {
-             $batch.column($ordinal).putNull($row);
-           }
-         """
-      }
+      s"""
+         if (!${ev.isNull}) {
+           ${setValue(batch, row, dataType, ordinal, ev.value)}
+         } else {
+           $batch.column($ordinal).putNull($row);
+         }
+       """
     } else {
       s"""${setValue(batch, row, dataType, ordinal, ev.value)};"""
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -569,9 +569,9 @@ public abstract class ColumnVector implements AutoCloseable {
 
   public final void putDecimal(int rowId, Decimal value, int precision) {
     if (precision <= Decimal.MAX_INT_DIGITS()) {
-      putInt(rowId, value.toInt());
+      putInt(rowId, (int) value.toUnscaledLong());
     } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
-      putLong(rowId, value.toLong());
+      putLong(rowId, value.toUnscaledLong());
     } else {
       BigInteger bigInteger = value.toJavaBigDecimal().unscaledValue();
       putByteArray(rowId, bigInteger.toByteArray());

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -265,11 +265,7 @@ case class TungstenAggregate(
 
   // The name for Vectorized HashMap
   private var vectorizedHashMapTerm: String = _
-
-  // We currently only enable vectorized hashmap for long key/value types and partial aggregates
-  private val isVectorizedHashMapEnabled: Boolean = sqlContext.conf.columnarAggregateMapEnabled &&
-    (groupingKeySchema ++ bufferSchema).forall(_.dataType == LongType) &&
-    modes.forall(mode => mode == Partial || mode == PartialMerge)
+  private var isVectorizedHashMapEnabled: Boolean = _
 
   // The name for UnsafeRow HashMap
   private var hashMapTerm: String = _
@@ -447,6 +443,10 @@ case class TungstenAggregate(
     val initAgg = ctx.freshName("initAgg")
     ctx.addMutableState("boolean", initAgg, s"$initAgg = false;")
 
+    // Enable vectorized hash map for all primitive data types during partial aggregation
+    isVectorizedHashMapEnabled = sqlContext.conf.columnarAggregateMapEnabled &&
+      (groupingKeySchema ++ bufferSchema).forall(f => ctx.isPrimitiveType(f.dataType)) &&
+      modes.forall(mode => mode == Partial || mode == PartialMerge)
     vectorizedHashMapTerm = ctx.freshName("vectorizedHashMap")
     val vectorizedHashMapClassName = ctx.freshName("VectorizedHashMap")
     val vectorizedHashMapGenerator = new VectorizedHashMapGenerator(ctx, vectorizedHashMapClassName,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -447,12 +447,12 @@ case class TungstenAggregate(
     isVectorizedHashMapEnabled = sqlContext.conf.columnarAggregateMapEnabled &&
       (groupingKeySchema ++ bufferSchema).forall(f => ctx.isPrimitiveType(f.dataType) ||
         f.dataType.isInstanceOf[DecimalType] || f.dataType.isInstanceOf[StringType]) &&
-      bufferSchema.forall(!_.dataType.isInstanceOf[StringType]) &&
+      bufferSchema.forall(!_.dataType.isInstanceOf[StringType]) && bufferSchema.nonEmpty &&
       modes.forall(mode => mode == Partial || mode == PartialMerge)
     vectorizedHashMapTerm = ctx.freshName("vectorizedHashMap")
     val vectorizedHashMapClassName = ctx.freshName("VectorizedHashMap")
-    val vectorizedHashMapGenerator = new VectorizedHashMapGenerator(ctx, vectorizedHashMapClassName,
-      groupingKeySchema, bufferSchema)
+    val vectorizedHashMapGenerator = new VectorizedHashMapGenerator(ctx, aggregateExpressions,
+      vectorizedHashMapClassName, groupingKeySchema, bufferSchema)
     // Create a name for iterator from vectorized HashMap
     val iterTermForVectorizedHashMap = ctx.freshName("vectorizedHashMapIter")
     if (isVectorizedHashMapEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -186,8 +186,8 @@ class VectorizedHashMapGenerator(
     s"""
        |private boolean equals(int idx, $groupingKeySignature) {
        |  return ${groupingKeys.zipWithIndex.map { case (key: Buffer, ordinal: Int) =>
-            s"""${ctx.genEqual(key.dataType,
-              ctx.getValue("batch", "buckets[idx]", key.dataType, ordinal), key.name)}"""
+            s"""(${ctx.genEqual(key.dataType,
+              ctx.getValue("batch", "buckets[idx]", key.dataType, ordinal), key.name)})"""
           }.mkString(" && ")};
        |}
      """.stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.execution.aggregate
 
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, DeclarativeAggregate}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.types._
 
 /**
@@ -40,15 +41,32 @@ import org.apache.spark.sql.types._
  */
 class VectorizedHashMapGenerator(
     ctx: CodegenContext,
+    aggregateExpressions: Seq[AggregateExpression],
     generatedClassName: String,
     groupingKeySchema: StructType,
     bufferSchema: StructType) {
-
   case class Buffer(dataType: DataType, name: String)
   val groupingKeys = groupingKeySchema.map(k => Buffer(k.dataType, ctx.freshName("key")))
   val bufferValues = bufferSchema.map(k => Buffer(k.dataType, ctx.freshName("value")))
   val groupingKeySignature = groupingKeys.map(key => (ctx.javaType(key.dataType), key.name))
     .map(_.productIterator.toList.mkString(" ")).mkString(", ")
+  val buffVars: Seq[ExprCode] = {
+    val functions = aggregateExpressions.map(_.aggregateFunction.asInstanceOf[DeclarativeAggregate])
+    val initExpr = functions.flatMap(f => f.initialValues)
+    initExpr.map { e =>
+      val isNull = ctx.freshName("bufIsNull")
+      val value = ctx.freshName("bufValue")
+      ctx.addMutableState("boolean", isNull, "")
+      ctx.addMutableState(ctx.javaType(e.dataType), value, "")
+      val ev = e.genCode(ctx)
+      val initVars =
+        s"""
+           | $isNull = ${ev.isNull};
+           | $value = ${ev.value};
+       """.stripMargin
+      ExprCode(ev.code + initVars, isNull, value)
+    }
+  }
 
   def generate(): String = {
     s"""
@@ -72,17 +90,29 @@ class VectorizedHashMapGenerator(
     val generatedSchema: String =
       s"""
          |new org.apache.spark.sql.types.StructType()
-         |${(groupingKeySchema ++ bufferSchema).map(key =>
-          s""".add("${key.name}", org.apache.spark.sql.types.DataTypes.${key.dataType})""")
-          .mkString("\n")};
+         |${(groupingKeySchema ++ bufferSchema).map { key =>
+            key.dataType match {
+              case d: DecimalType =>
+                s""".add("${key.name}", org.apache.spark.sql.types.DataTypes.createDecimalType(
+                   |${d.precision}, ${d.scale}))""".stripMargin
+              case _ =>
+                s""".add("${key.name}", org.apache.spark.sql.types.DataTypes.${key.dataType})"""
+            }
+          }.mkString("\n")};
       """.stripMargin
 
     val generatedAggBufferSchema: String =
       s"""
          |new org.apache.spark.sql.types.StructType()
-         |${bufferSchema.map(key =>
-        s""".add("${key.name}", org.apache.spark.sql.types.DataTypes.${key.dataType})""")
-        .mkString("\n")};
+         |${bufferSchema.map { key =>
+            key.dataType match {
+              case d: DecimalType =>
+                s""".add("${key.name}", org.apache.spark.sql.types.DataTypes.createDecimalType(
+                    |${d.precision}, ${d.scale}))""".stripMargin
+              case _ =>
+                s""".add("${key.name}", org.apache.spark.sql.types.DataTypes.${key.dataType})"""
+            }
+          }.mkString("\n")};
       """.stripMargin
 
     s"""
@@ -156,7 +186,8 @@ class VectorizedHashMapGenerator(
     s"""
        |private boolean equals(int idx, $groupingKeySignature) {
        |  return ${groupingKeys.zipWithIndex.map { case (key: Buffer, ordinal: Int) =>
-            s"""${ctx.getValue("batch", "buckets[idx]", key.dataType, ordinal)} == ${key.name}"""
+            s"""${ctx.genEqual(key.dataType,
+              ctx.getValue("batch", "buckets[idx]", key.dataType, ordinal), key.name)}"""
           }.mkString(" && ")};
        |}
      """.stripMargin
@@ -209,8 +240,10 @@ class VectorizedHashMapGenerator(
        |        ${groupingKeys.zipWithIndex.map { case (key: Buffer, ordinal: Int) =>
                   ctx.setValue("batch", "numRows", key.dataType, ordinal, key.name)
                 }.mkString("\n")}
+       |        ${buffVars.map(_.code).mkString("\n")}
        |        ${bufferValues.zipWithIndex.map { case (key: Buffer, ordinal: Int) =>
-                  s"batch.column(${groupingKeys.length + ordinal}).putNull(numRows);"
+                  ctx.updateColumn("batch", "numRows", key.dataType, groupingKeys.length + ordinal,
+                    buffVars(ordinal), nullable = true)
                 }.mkString("\n")}
        |        buckets[idx] = numRows++;
        |        batch.setNumRows(numRows);
@@ -257,13 +290,11 @@ class VectorizedHashMapGenerator(
     def hashInt(i: String): String = s"int $result = $i;"
     def hashLong(l: String): String = s"long $result = $l;"
     def hashBytes(b: String): String = {
-      val bytes = ctx.freshName("bytes")
       val hash = ctx.freshName("hash")
       s"""
          |int $result = 0;
-         |byte[] $bytes = $b.getBytes();
-         |for (int i = 0; i < $bytes.length; i++) {
-         |  ${computeHash(s"$bytes[i]", ByteType, hash, ctx)}
+         |for (int i = 0; i < $b.length; i++) {
+         |  ${computeHash(s"$b[i]", ByteType, hash, ctx)}
          |  $result = ($result ^ (0x9e3779b9)) + $hash + ($result << 6) + ($result >>> 2);
          |}
        """.stripMargin
@@ -285,7 +316,7 @@ class VectorizedHashMapGenerator(
             ${hashBytes(bytes)}
           """
         }
-      case StringType => hashBytes(input)
+      case StringType => hashBytes(s"$input.getBytes()")
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -461,7 +461,7 @@ object SQLConf {
     .internal()
     .doc("When true, aggregate with keys use an in-memory columnar map to speed up execution.")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
@@ -224,6 +224,127 @@ class BenchmarkWholeStageCodegen extends SparkFunSuite {
     */
   }
 
+  ignore("aggregate with string key") {
+    val N = 20 << 20
+
+    val benchmark = new Benchmark("Aggregate w string key", N)
+    def f(): Unit = sqlContext.range(N).selectExpr("id", "cast(id & 1023 as string) as k")
+      .groupBy("k").count().collect()
+
+    benchmark.addCase(s"codegen = F") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "false")
+      f()
+    }
+
+    benchmark.addCase(s"codegen = T hashmap = F") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "true")
+      sqlContext.setConf("spark.sql.codegen.aggregate.map.enabled", "false")
+      f()
+    }
+
+    benchmark.addCase(s"codegen = T hashmap = T") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "true")
+      sqlContext.setConf("spark.sql.codegen.aggregate.map.enabled", "true")
+      f()
+    }
+
+    benchmark.run()
+
+    /*
+    Java HotSpot(TM) 64-Bit Server VM 1.8.0_73-b02 on Mac OS X 10.11.4
+    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
+    Aggregate w string key:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    -------------------------------------------------------------------------------------------
+    codegen = F                              3307 / 3376          6.3         157.7       1.0X
+    codegen = T hashmap = F                  2364 / 2471          8.9         112.7       1.4X
+    codegen = T hashmap = T                  1740 / 1841         12.0          83.0       1.9X
+    */
+  }
+
+  ignore("aggregate with decimal key") {
+    val N = 20 << 20
+
+    val benchmark = new Benchmark("Aggregate w decimal key", N)
+    def f(): Unit = sqlContext.range(N).selectExpr("id", "cast(id & 65535 as decimal) as k")
+      .groupBy("k").count().collect()
+
+    benchmark.addCase(s"codegen = F") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "false")
+      f()
+    }
+
+    benchmark.addCase(s"codegen = T hashmap = F") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "true")
+      sqlContext.setConf("spark.sql.codegen.aggregate.map.enabled", "false")
+      f()
+    }
+
+    benchmark.addCase(s"codegen = T hashmap = T") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "true")
+      sqlContext.setConf("spark.sql.codegen.aggregate.map.enabled", "true")
+      f()
+    }
+
+    benchmark.run()
+
+    /*
+    Java HotSpot(TM) 64-Bit Server VM 1.8.0_73-b02 on Mac OS X 10.11.4
+    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
+    Aggregate w decimal key:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    -------------------------------------------------------------------------------------------
+    codegen = F                              2756 / 2817          7.6         131.4       1.0X
+    codegen = T hashmap = F                  1580 / 1647         13.3          75.4       1.7X
+    codegen = T hashmap = T                   641 /  662         32.7          30.6       4.3X
+    */
+  }
+
+  ignore("aggregate with multiple key types") {
+    val N = 20 << 20
+
+    val benchmark = new Benchmark("Aggregate w multiple keys", N)
+    def f(): Unit = sqlContext.range(N)
+      .selectExpr(
+        "id",
+        "(id & 1023) as k1",
+        "cast(id & 1023 as string) as k2",
+        "cast(id & 1023 as int) as k3",
+        "cast(id & 1023 as double) as k4",
+        "cast(id & 1023 as float) as k5",
+        "id > 1023 as k6")
+      .groupBy("k1", "k2", "k3", "k4", "k5", "k6")
+      .sum()
+      .collect()
+
+    benchmark.addCase(s"codegen = F") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "false")
+      f()
+    }
+
+    benchmark.addCase(s"codegen = T hashmap = F") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "true")
+      sqlContext.setConf("spark.sql.codegen.aggregate.map.enabled", "false")
+      f()
+    }
+
+    benchmark.addCase(s"codegen = T hashmap = T") { iter =>
+      sqlContext.setConf("spark.sql.codegen.wholeStage", "true")
+      sqlContext.setConf("spark.sql.codegen.aggregate.map.enabled", "true")
+      f()
+    }
+
+    benchmark.run()
+
+    /*
+    Java HotSpot(TM) 64-Bit Server VM 1.8.0_73-b02 on Mac OS X 10.11.4
+    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
+    Aggregate w decimal key:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    -------------------------------------------------------------------------------------------
+    codegen = F                              6876 / 7216          3.1         327.8       1.0X
+    codegen = T hashmap = F                  5297 / 5478          4.0         252.6       1.3X
+    codegen = T hashmap = T                  5395 / 5668          3.9         257.2       1.3X
+    */
+  }
+
   ignore("broadcast hash join") {
     val N = 20 << 20
     val M = 1 << 16

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
@@ -339,9 +339,9 @@ class BenchmarkWholeStageCodegen extends SparkFunSuite {
     Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
     Aggregate w decimal key:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     -------------------------------------------------------------------------------------------
-    codegen = F                              6876 / 7216          3.1         327.8       1.0X
-    codegen = T hashmap = F                  5297 / 5478          4.0         252.6       1.3X
-    codegen = T hashmap = T                  5395 / 5668          3.9         257.2       1.3X
+    codegen = F                              5885 / 6091          3.6         280.6       1.0X
+    codegen = T hashmap = F                  3625 / 4009          5.8         172.8       1.6X
+    codegen = T hashmap = T                  3204 / 3271          6.5         152.8       1.8X
     */
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds support for all primitive datatypes, decimal types and stringtypes in the VectorizedHashmap during aggregation.
## How was this patch tested?

Existing tests for group-by aggregates should already test for all these datatypes. Additionally, manually inspected the generated code for all supported datatypes (details below).
