### PR TITLE
[SPARK-14677][SQL] follow up: make max iter num config internal

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -52,6 +52,7 @@ object SQLConf {
   }
 
   val OPTIMIZER_MAX_ITERATIONS = SQLConfigBuilder("spark.sql.optimizer.maxIterations")
+    .internal()
     .doc("The max number of iterations the optimizer and analyzer runs")
     .intConf
     .createWithDefault(100)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up to make the max iteration number an internal config.
## How was this patch tested?

N/A
