### PR TITLE
[SPARK-14683][Documentation] Configure external links in ScalaDoc

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,8 @@ addSbtPlugin("com.alpinenow" % "junit_xml_listener" % "0.5.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "0.2.2")
+
 addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")


### PR DESCRIPTION
Right now Spark's Scaladoc does not link to Scala standard library and other dependencies. This would bother Spark starters because they may be not experienced Scala programmers.

This patch fixes these links in ScalaDoc.
