### PR TITLE
[SPARK-14696][SQL] Add implicit encoders for boxed primitive types

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/ExceptionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/internal/ExceptionUtils.scala
@@ -1,5 +1,0 @@
-package org.apache.spark.internal
-
-class ExceptionUtils {
-
-}

--- a/core/src/main/scala/org/apache/spark/internal/ExceptionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/internal/ExceptionUtils.scala
@@ -1,0 +1,5 @@
+package org.apache.spark.internal
+
+class ExceptionUtils {
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -72,6 +72,29 @@ abstract class SQLImplicits {
   /** @since 1.6.0 */
   implicit def newStringEncoder: Encoder[String] = Encoders.STRING
 
+  // Boxed primitives
+
+  /** @since 2.0.0 */
+  implicit def newBoxedIntEncoder: Encoder[java.lang.Integer] = Encoders.INT
+
+  /** @since 2.0.0 */
+  implicit def newBoxedLongEncoder: Encoder[java.lang.Long] = Encoders.LONG
+
+  /** @since 2.0.0 */
+  implicit def newBoxedDoubleEncoder: Encoder[java.lang.Double] = Encoders.DOUBLE
+
+  /** @since 2.0.0 */
+  implicit def newBoxedFloatEncoder: Encoder[java.lang.Float] = Encoders.FLOAT
+
+  /** @since 2.0.0 */
+  implicit def newBoxedByteEncoder: Encoder[java.lang.Byte] = Encoders.BYTE
+
+  /** @since 2.0.0 */
+  implicit def newBoxedShortEncoder: Encoder[java.lang.Short] = Encoders.SHORT
+
+  /** @since 2.0.0 */
+  implicit def newBoxedBooleanEncoder: Encoder[java.lang.Boolean] = Encoders.BOOLEAN
+
   // Seqs
 
   /** @since 1.6.1 */

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -471,6 +471,10 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
         (JavaData(2), JavaData(2))))
   }
 
+  test("SPARK-14696: implicit encoders for boxed types") {
+    assert(sqlContext.range(1).map { i => i : java.lang.Long }.head == 0L)
+  }
+
   test("SPARK-11894: Incorrect results are returned when using null") {
     val nullInt = null.asInstanceOf[java.lang.Integer]
     val ds1 = Seq((nullInt, "1"), (new java.lang.Integer(22), "2")).toDS()


### PR DESCRIPTION
## What changes were proposed in this pull request?

We currently only have implicit encoders for scala primitive types. We should also add implicit encoders for boxed primitives. Otherwise, the following code would not have an encoder:

``` scala
sqlContext.range(1000).map { i => i }
```
## How was this patch tested?

Added a unit test case for this.
