### PR TITLE
[SPARK-14700] [Python] adding SQL Row equality and inequality overrides

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -658,7 +658,7 @@ class SQLTests(ReusedPySparkTestCase):
         df = self.df
         g = df.groupBy()
         self.assertEqual([99, 100], sorted(g.agg({'key': 'max', 'value': 'count'}).collect()[0]))
-        self.assertEqual([Row(**{"AVG(key#0)": 49.5})], g.mean().collect())
+        self.assertEqual([Row(**{"avg(key)": 49.5})], g.mean().collect())
 
         from pyspark.sql import functions
         self.assertEqual((0, u'99'),
@@ -1200,10 +1200,11 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(df.schema.simpleString(), "struct<key:string,value:string>")
         self.assertEqual(df.collect(), [Row(key=str(i), value=str(i)) for i in range(100)])
 
-        # field names can differ.
+        # field names can be changed.
         df = rdd.toDF(" a: int, b: string ")
+        renamed_data = [Row(a=row['key'], b=row['value']) for row in data]
         self.assertEqual(df.schema.simpleString(), "struct<a:int,b:string>")
-        self.assertEqual(df.collect(), data)
+        self.assertEqual(df.collect(), renamed_data)
 
         # number of fields must match.
         self.assertRaisesRegexp(Exception, "Length of object",
@@ -1216,12 +1217,12 @@ class SQLTests(ReusedPySparkTestCase):
         # flat schema values will be wrapped into row.
         df = rdd.map(lambda row: row.key).toDF("int")
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
-        self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
+        self.assertEqual(df.collect(), [Row(value=i) for i in range(100)])
 
         # users can use DataType directly instead of data type string.
         df = rdd.map(lambda row: row.key).toDF(IntegerType())
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
-        self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
+        self.assertEqual(df.collect(), [Row(value=i) for i in range(100)])
 
 
 class HiveContextSQLTests(ReusedPySparkTestCase):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1448,6 +1448,54 @@ class Row(tuple):
         else:
             return "<Row(%s)>" % ", ".join(self)
 
+    def __eq__(self, other):
+        """
+        Test for equality with `other`.
+
+        :param other: other Row for comparison
+
+        >>> Row(name="Alice", age=11) == Row(age=11, name="Alice")
+        True
+        >>> R1 = Row('a', 'b')
+        >>> R2 = Row('b', 'a')
+        >>> R1(1, 2) == R2(2, 1)
+        True
+        >>> Row('a', 'b') == Row('b', 'a')
+        False
+        >>> R3 = Row('a', 'c')
+        >>> R1(1, 2) == R3(1, 2)
+        False
+        """
+        if isinstance(other, Row) and not (hasattr(self, "__fields__") ^ hasattr(other, "__fields__")):
+            if hasattr(self, "__fields__"):
+                return len(self.__fields__) == len(other.__fields__) and \
+                    set(self.__fields__).intersection(other.__fields__) == set(self.__fields__) and \
+                    all([self[k] == other[k] for k in self.__fields__])
+            else:
+                return super(Row, self).__eq__(other)
+        else:
+            return False
+
+    def __ne__(self, other):
+        """
+        Test for inequality with `other`.
+
+        :param other: other Row for comparison
+
+        >>> Row(name="Alice", age=11) != Row(age=11, name="Alice")
+        False
+        >>> R1 = Row('a', 'b')
+        >>> R2 = Row('b', 'a')
+        >>> R1(1, 2) != R2(2, 1)
+        False
+        >>> Row('a', 'b') != Row('b', 'a')
+        True
+        >>> R3 = Row('a', 'c')
+        >>> R1(1, 2) != R3(1, 2)
+        True
+        """
+        return not self.__eq__(other)
+
 
 class DateConverter(object):
     def can_convert(self, obj):


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds equality and inequality overrides to `pyspark.sql.Row`. Without this override, `Row` simply uses the equality operator of `tuple`, which doesn't consider the private member `__fields__` of Row to determine the implicit ordering needed to compare the tuples correctly.

Without this PR, we get seemingly illogical equality checks like:

```
Row(a=1) == Row(b=1) # True
r1 = Row('b', 'a')(2, 1) # Row(b=2, a=1)
r1 == Row(b=2, a=1) # False
r1 == Row(a=2, b=1) # True
```
## How was this patch tested?

Unit tests were added to `pyspark/sql/types.py` in the `Row` docstring. A handful of newly failing tests in `pyspark/sql/tests.py` were fixed.

This PR is my original work and I license the work to the project under the project's open source license.

@davies @rxin Mind having a look?
