### PR TITLE
[SPARK-14702] [Core] Expose SparkLauncher's ProcessBuilder for user flexibility

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -360,7 +360,7 @@ public class SparkLauncher {
    * @return A process handle for the Spark app.
    */
   public Process launch() throws IOException {
-    return createBuilder().start();
+    return createProcessBuilder().start();
   }
 
   /**
@@ -413,7 +413,7 @@ public class SparkLauncher {
 
     String loggerPrefix = getClass().getPackage().getName();
     String loggerName = String.format("%s.app.%s", loggerPrefix, appName);
-    ProcessBuilder pb = createBuilder().redirectErrorStream(true);
+    ProcessBuilder pb = createProcessBuilder().redirectErrorStream(true);
     pb.environment().put(LauncherProtocol.ENV_LAUNCHER_PORT,
       String.valueOf(LauncherServer.getServerInstance().getPort()));
     pb.environment().put(LauncherProtocol.ENV_LAUNCHER_SECRET, handle.getSecret());
@@ -427,7 +427,7 @@ public class SparkLauncher {
     return handle;
   }
 
-  private ProcessBuilder createBuilder() {
+  public ProcessBuilder createProcessBuilder() {
     List<String> cmd = new ArrayList<>();
     String script = isWindows() ? "spark-submit.cmd" : "spark-submit";
     cmd.add(join(File.separator, builder.getSparkHome(), "bin", script));


### PR DESCRIPTION
## What changes were proposed in this pull request?

making public the ProcessBuilder that SparkLauncher uses to construct the process used in SparkLauncher.launch()
## How was this patch tested?

tests not needed, just exposed/rename a private method
