### PR TITLE
[SPARK-14712][ML]spark.ml.LogisticRegressionModel.toString should sum…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -23,7 +23,7 @@ import breeze.linalg.{DenseVector => BDV}
 import breeze.optimize.{CachedDiffFunction, DiffFunction, LBFGS => BreezeLBFGS, OWLQN => BreezeOWLQN}
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkException}
+import org.apache.spark.SparkException
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.Instance

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -23,7 +23,7 @@ import breeze.linalg.{DenseVector => BDV}
 import breeze.optimize.{CachedDiffFunction, DiffFunction, LBFGS => BreezeLBFGS, OWLQN => BreezeOWLQN}
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException}
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.Instance
@@ -159,9 +159,7 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
 @Since("1.2.0")
 @Experimental
 class LogisticRegression @Since("1.2.0") (
-    @Since("1.4.0") override val uid: String,
-    @Since("2.0.0") val numFeatures: Int = 0,
-    @Since("2.0.0") val numClasses: Int = 0)
+    @Since("1.4.0") override val uid: String)
   extends ProbabilisticClassifier[Vector, LogisticRegression, LogisticRegressionModel]
   with LogisticRegressionParams with DefaultParamsWritable with Logging {
 
@@ -460,13 +458,6 @@ class LogisticRegression @Since("1.2.0") (
 
   @Since("1.4.0")
   override def copy(extra: ParamMap): LogisticRegression = defaultCopy(extra)
-
-  @Since("2.0.0")
-  override def toString: String = {
-    val td = getDefault(threshold)
-    s"${super.toString}, numClasses = ${numClasses}, " +
-      s"numFeatures = ${numFeatures} threshold = ${td.getOrElse("None")}"
-  }
 }
 
 @Since("1.6.0")
@@ -634,6 +625,13 @@ class LogisticRegressionModel private[spark] (
    */
   @Since("1.6.0")
   override def write: MLWriter = new LogisticRegressionModel.LogisticRegressionModelWriter(this)
+
+  @Since("2.0.0")
+  override def toString: String = {
+    val td = getDefault(threshold)
+    s"${super.toString}, numClasses = $numClasses, " +
+      s"numFeatures = $numFeatures threshold = ${td.getOrElse("None")}"
+  }
 }
 
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -159,7 +159,9 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
 @Since("1.2.0")
 @Experimental
 class LogisticRegression @Since("1.2.0") (
-    @Since("1.4.0") override val uid: String)
+    @Since("1.4.0") override val uid: String,
+    @Since("2.0.0") val numFeatures: Int = 0,
+    @Since("2.0.0") val numClasses: Int = 0)
   extends ProbabilisticClassifier[Vector, LogisticRegression, LogisticRegressionModel]
   with LogisticRegressionParams with DefaultParamsWritable with Logging {
 
@@ -458,6 +460,13 @@ class LogisticRegression @Since("1.2.0") (
 
   @Since("1.4.0")
   override def copy(extra: ParamMap): LogisticRegression = defaultCopy(extra)
+
+  @Since("2.0.0")
+  override def toString: String = {
+    val td = getDefault(threshold)
+    s"${super.toString}, numClasses = ${numClasses}, " +
+      s"numFeatures = ${numFeatures} threshold = ${td.getOrElse("None")}"
+  }
 }
 
 @Since("1.6.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -941,7 +941,7 @@ class LogisticRegressionSuite
       lr, isClassification = true, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients.toArray === actual.coefficients.toArray)
-    }
+      }
   }
 
   test("toString") {
@@ -950,7 +950,6 @@ class LogisticRegressionSuite
     val expected: String = "lrModeltest, numClasses = 2, numFeatures = 3 threshold = 0.5"
     assert(lrModel.toString === expected)
   }
-
 }
 
 object LogisticRegressionSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -941,8 +941,16 @@ class LogisticRegressionSuite
       lr, isClassification = true, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients.toArray === actual.coefficients.toArray)
-      }
+    }
   }
+
+  test("toString") {
+    val lrModel = new LogisticRegressionModel(uid = "lrModeltest",
+      coefficients = Vectors.dense(0.1, 0.2, 0.3), intercept = 0.5)
+    val expected: String = "lrModeltest, numClasses = 2, numFeatures = 3 threshold = 0.5"
+    assert(lrModel.toString === expected)
+  }
+
 }
 
 object LogisticRegressionSuite {

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -123,8 +123,7 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
     def setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction",
                   maxIter=100, regParam=0.0, elasticNetParam=0.0, tol=1e-6, fitIntercept=True,
                   threshold=0.5, thresholds=None, probabilityCol="probability",
-                  rawPredictionCol="rawPrediction", standardization=True, weightCol=None,
-                  numFeatures=0, numClasses=0):
+                  rawPredictionCol="rawPrediction", standardization=True, weightCol=None):
         """
         setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
                   maxIter=100, regParam=0.0, elasticNetParam=0.0, tol=1e-6, fitIntercept=True, \
@@ -136,8 +135,6 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
         kwargs = self.setParams._input_kwargs
         self._set(**kwargs)
         self._checkThresholdConsistency()
-        self._numFeatures = int(numFeatures)
-        self._numClasses = int(numClasses)
         return self
 
     def _create_model(self, java_model):
@@ -207,9 +204,6 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
                 raise ValueError("Logistic Regression getThreshold found inconsistent values for" +
                                  " threshold (%g) and thresholds (equivalent to %g)" % (t2, t))
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class LogisticRegressionModel(JavaModel, JavaMLWritable, JavaMLReadable):
     """
@@ -278,6 +272,10 @@ class LogisticRegressionModel(JavaModel, JavaMLWritable, JavaMLReadable):
             raise ValueError("dataset must be a DataFrame but got %s." % type(dataset))
         java_blr_summary = self._call_java("evaluate", dataset)
         return BinaryLogisticRegressionSummary(java_blr_summary)
+
+    @since("2.0.0")
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class LogisticRegressionSummary(JavaWrapper):

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -123,7 +123,8 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
     def setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction",
                   maxIter=100, regParam=0.0, elasticNetParam=0.0, tol=1e-6, fitIntercept=True,
                   threshold=0.5, thresholds=None, probabilityCol="probability",
-                  rawPredictionCol="rawPrediction", standardization=True, weightCol=None):
+                  rawPredictionCol="rawPrediction", standardization=True, weightCol=None,
+                  numFeatures=0, numClasses=0):
         """
         setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
                   maxIter=100, regParam=0.0, elasticNetParam=0.0, tol=1e-6, fitIntercept=True, \
@@ -135,6 +136,8 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
         kwargs = self.setParams._input_kwargs
         self._set(**kwargs)
         self._checkThresholdConsistency()
+        self._numFeatures = int(numFeatures)
+        self._numClasses = int(numClasses)
         return self
 
     def _create_model(self, java_model):
@@ -203,6 +206,9 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
             if abs(t2 - t) >= 1E-5:
                 raise ValueError("Logistic Regression getThreshold found inconsistent values for" +
                                  " threshold (%g) and thresholds (equivalent to %g)" % (t2, t))
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class LogisticRegressionModel(JavaModel, JavaMLWritable, JavaMLReadable):

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -262,6 +262,7 @@ class LogisticRegressionModel(LinearClassificationModel):
         model.setThreshold(threshold)
         return model
 
+    @since("2.0.0")
     def __repr__(self):
         return self._call_java("toString")
 

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -265,6 +265,7 @@ class LogisticRegressionModel(LinearClassificationModel):
     def __repr__(self):
         return self._call_java("toString")
 
+
 class LogisticRegressionWithSGD(object):
     """
     .. versionadded:: 0.9.0

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -262,6 +262,8 @@ class LogisticRegressionModel(LinearClassificationModel):
         model.setThreshold(threshold)
         return model
 
+    def __repr__(self):
+        return self._call_java("toString")
 
 class LogisticRegressionWithSGD(object):
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?

[SPARK-14712](https://issues.apache.org/jira/browse/SPARK-14712)
spark.mllib LogisticRegressionModel overrides toString to print a little model info. We should do the same in spark.ml and override _repr_ in pyspark.
## How was this patch tested?

LogisticRegressionSuite.scala
