### PR TITLE
[SPARK-12457] Fixed the Wrong Description and Missing Example in Collection Functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -49,7 +49,7 @@ case class Size(child: Expression) extends UnaryExpression with ExpectsInputType
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(array(array, ascendingOrder)) - Sorts the input array in ascending order according to the natural ordering of the array elements.",
+  usage = "_FUNC_(array(obj1, obj2, ...), ascendingOrder) - Sorts the input array in ascending order according to the natural ordering of the array elements.",
   extended = " > SELECT _FUNC_(array('b', 'd', 'c', 'a'), true);\n 'a', 'b', 'c', 'd'")
 // scalastyle:on line.size.limit
 case class SortArray(base: Expression, ascendingOrder: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.types._
  * Given an array or map, returns its size.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the size of an array or a map.")
+  usage = "_FUNC_(expr) - Returns the size of an array or a map.",
+  extended = " > SELECT _FUNC_(array('b', 'd', 'c', 'a'));\n 4")
 case class Size(child: Expression) extends UnaryExpression with ExpectsInputTypes {
   override def dataType: DataType = IntegerType
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(ArrayType, MapType))
@@ -48,8 +49,8 @@ case class Size(child: Expression) extends UnaryExpression with ExpectsInputType
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(array(obj1, obj2,...)) - Sorts the input array in ascending order according to the natural ordering of the array elements.",
-  extended = " > SELECT _FUNC_(array('b', 'd', 'c', 'a'));\n 'a', 'b', 'c', 'd'")
+  usage = "_FUNC_(array(array, ascendingOrder)) - Sorts the input array in ascending order according to the natural ordering of the array elements.",
+  extended = " > SELECT _FUNC_(array('b', 'd', 'c', 'a'), true);\n 'a', 'b', 'c', 'd'")
 // scalastyle:on line.size.limit
 case class SortArray(base: Expression, ascendingOrder: Expression)
   extends BinaryExpression with ExpectsInputTypes with CodegenFallback {
@@ -133,7 +134,7 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
  * Checks if the array (left) has the element (right)
  */
 @ExpressionDescription(
-  usage = "_FUNC_(array, value) - Returns TRUE if the array contains value.",
+  usage = "_FUNC_(array, value) - Returns TRUE if the array contains the value.",
   extended = " > SELECT _FUNC_(array(1, 2, 3), 2);\n true")
 case class ArrayContains(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -28,9 +28,10 @@ import org.apache.spark.sql.types.StringType
 trait Command
 
 /**
- * Returned for the "DESCRIBE [EXTENDED] FUNCTION functionName" command.
- * @param functionName The function to be described.
- * @param isExtended True if "DESCRIBE EXTENDED" is used. Otherwise, false.
+  * Returned for the "DESCRIBE FUNCTION [EXTENDED] functionName" command.
+  *
+  * @param functionName The function to be described.
+  * @param isExtended   True if "DESCRIBE FUNCTION EXTENDED" is used. Otherwise, false.
  */
 private[sql] case class DescribeFunction(
     functionName: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -30,7 +30,7 @@ trait Command
 /**
  * Returned for the "DESCRIBE FUNCTION [EXTENDED] functionName" command.
  * @param functionName The function to be described.
- * @param isExtended   True if "DESCRIBE FUNCTION EXTENDED" is used. Otherwise, false.
+ * @param isExtended True if "DESCRIBE FUNCTION EXTENDED" is used. Otherwise, false.
  */
 private[sql] case class DescribeFunction(
     functionName: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -28,10 +28,9 @@ import org.apache.spark.sql.types.StringType
 trait Command
 
 /**
-  * Returned for the "DESCRIBE FUNCTION [EXTENDED] functionName" command.
-  *
-  * @param functionName The function to be described.
-  * @param isExtended   True if "DESCRIBE FUNCTION EXTENDED" is used. Otherwise, false.
+ * Returned for the "DESCRIBE FUNCTION [EXTENDED] functionName" command.
+ * @param functionName The function to be described.
+ * @param isExtended   True if "DESCRIBE FUNCTION EXTENDED" is used. Otherwise, false.
  */
 private[sql] case class DescribeFunction(
     functionName: String,


### PR DESCRIPTION
#### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/12185 contains the original PR I submitted in https://github.com/apache/spark/pull/10418

However, it misses one of the extended example, a wrong description and a few typos for collection functions. This PR is fix all these issues. 
#### How was this patch tested?

The existing test cases already cover it. 
