### PR TITLE
[SPARK-14734][ML][MLLIB] Added asML, fromML methods for all spark.mllib Vector, Matrix types

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -164,8 +164,7 @@ sealed trait Matrix extends Serializable {
    * Convert this matrix to the new mllib-local representation.
    * This does NOT copy the data; it copies references.
    */
-  private[spark]
-  def asML: newlinalg.Matrix
+  private[spark] def asML: newlinalg.Matrix
 }
 
 private[spark] class MatrixUDT extends UserDefinedType[Matrix] {
@@ -428,8 +427,7 @@ class DenseMatrix @Since("1.3.0") (
     }
   }
 
-  private[spark]
-  override def asML: newlinalg.DenseMatrix = {
+  private[spark] override def asML: newlinalg.DenseMatrix = {
     new newlinalg.DenseMatrix(numRows, numCols, values, isTransposed)
   }
 }
@@ -530,8 +528,7 @@ object DenseMatrix {
   }
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
-  private[spark]
-  def fromML(m: newlinalg.DenseMatrix): DenseMatrix = {
+  private[spark] def fromML(m: newlinalg.DenseMatrix): DenseMatrix = {
     new DenseMatrix(m.numRows, m.numCols, m.values, m.isTransposed)
   }
 }
@@ -741,8 +738,7 @@ class SparseMatrix @Since("1.3.0") (
     }
   }
 
-  private[spark]
-  override def asML: newlinalg.SparseMatrix = {
+  private[spark] override def asML: newlinalg.SparseMatrix = {
     new newlinalg.SparseMatrix(numRows, numCols, colPtrs, rowIndices, values, isTransposed)
   }
 }
@@ -921,8 +917,7 @@ object SparseMatrix {
   }
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
-  private[spark]
-  def fromML(m: newlinalg.SparseMatrix): SparseMatrix = {
+  private[spark] def fromML(m: newlinalg.SparseMatrix): SparseMatrix = {
     new SparseMatrix(m.numRows, m.numCols, m.colPtrs, m.rowIndices, m.values, m.isTransposed)
   }
 }
@@ -1209,8 +1204,7 @@ object Matrices {
   }
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
-  private[spark]
-  def fromML(m: newlinalg.Matrix): Matrix = m match {
+  private[spark] def fromML(m: newlinalg.Matrix): Matrix = m match {
     case dm: newlinalg.DenseMatrix =>
       DenseMatrix.fromML(dm)
     case sm: newlinalg.SparseMatrix =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -165,7 +165,7 @@ sealed trait Matrix extends Serializable {
    * This does NOT copy the data; it copies references.
    */
   private[spark]
-  def toNew: newlinalg.Matrix
+  def asML: newlinalg.Matrix
 }
 
 private[spark] class MatrixUDT extends UserDefinedType[Matrix] {
@@ -429,7 +429,7 @@ class DenseMatrix @Since("1.3.0") (
   }
 
   private[spark]
-  override def toNew: newlinalg.DenseMatrix = {
+  override def asML: newlinalg.DenseMatrix = {
     new newlinalg.DenseMatrix(numRows, numCols, values, isTransposed)
   }
 }
@@ -531,7 +531,7 @@ object DenseMatrix {
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
   private[spark]
-  def fromNew(m: newlinalg.DenseMatrix): DenseMatrix = {
+  def fromML(m: newlinalg.DenseMatrix): DenseMatrix = {
     new DenseMatrix(m.numRows, m.numCols, m.values, m.isTransposed)
   }
 }
@@ -742,7 +742,7 @@ class SparseMatrix @Since("1.3.0") (
   }
 
   private[spark]
-  override def toNew: newlinalg.SparseMatrix = {
+  override def asML: newlinalg.SparseMatrix = {
     new newlinalg.SparseMatrix(numRows, numCols, colPtrs, rowIndices, values, isTransposed)
   }
 }
@@ -922,7 +922,7 @@ object SparseMatrix {
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
   private[spark]
-  def fromNew(m: newlinalg.SparseMatrix): SparseMatrix = {
+  def fromML(m: newlinalg.SparseMatrix): SparseMatrix = {
     new SparseMatrix(m.numRows, m.numCols, m.colPtrs, m.rowIndices, m.values, m.isTransposed)
   }
 }
@@ -1210,10 +1210,10 @@ object Matrices {
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
   private[spark]
-  def fromNew(m: newlinalg.Matrix): Matrix = m match {
+  def fromML(m: newlinalg.Matrix): Matrix = m match {
     case dm: newlinalg.DenseMatrix =>
-      DenseMatrix.fromNew(dm)
+      DenseMatrix.fromML(dm)
     case sm: newlinalg.SparseMatrix =>
-      SparseMatrix.fromNew(sm)
+      SparseMatrix.fromML(sm)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -186,8 +186,7 @@ sealed trait Vector extends Serializable {
    * Convert this vector to the new mllib-local representation.
    * This does NOT copy the data; it copies references.
    */
-  private[spark]
-  def asML: newlinalg.Vector
+  private[spark] def asML: newlinalg.Vector
 }
 
 /**
@@ -583,8 +582,7 @@ object Vectors {
   private[linalg] val MAX_HASH_NNZ = 128
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
-  private[spark]
-  def fromML(v: newlinalg.Vector): Vector = v match {
+  private[spark] def fromML(v: newlinalg.Vector): Vector = v match {
     case dv: newlinalg.DenseVector =>
       DenseVector.fromML(dv)
     case sv: newlinalg.SparseVector =>
@@ -704,8 +702,7 @@ class DenseVector @Since("1.0.0") (
     compact(render(jValue))
   }
 
-  private[spark]
-  override def asML: newlinalg.DenseVector = {
+  private[spark] override def asML: newlinalg.DenseVector = {
     new newlinalg.DenseVector(values)
   }
 }
@@ -718,8 +715,7 @@ object DenseVector {
   def unapply(dv: DenseVector): Option[Array[Double]] = Some(dv.values)
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
-  private[spark]
-  def fromML(v: newlinalg.DenseVector): DenseVector = {
+  private[spark] def fromML(v: newlinalg.DenseVector): DenseVector = {
     new DenseVector(v.values)
   }
 }
@@ -911,8 +907,7 @@ class SparseVector @Since("1.0.0") (
     compact(render(jValue))
   }
 
-  private[spark]
-  override def asML: newlinalg.SparseVector = {
+  private[spark] override def asML: newlinalg.SparseVector = {
     new newlinalg.SparseVector(size, indices, values)
   }
 }
@@ -924,8 +919,7 @@ object SparseVector {
     Some((sv.size, sv.indices, sv.values))
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
-  private[spark]
-  def fromML(v: newlinalg.SparseVector): SparseVector = {
+  private[spark] def fromML(v: newlinalg.SparseVector): SparseVector = {
     new SparseVector(v.size, v.indices, v.values)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -187,7 +187,7 @@ sealed trait Vector extends Serializable {
    * This does NOT copy the data; it copies references.
    */
   private[spark]
-  def toNew: newlinalg.Vector
+  def asML: newlinalg.Vector
 }
 
 /**
@@ -584,11 +584,11 @@ object Vectors {
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
   private[spark]
-  def fromNew(v: newlinalg.Vector): Vector = v match {
+  def fromML(v: newlinalg.Vector): Vector = v match {
     case dv: newlinalg.DenseVector =>
-      DenseVector.fromNew(dv)
+      DenseVector.fromML(dv)
     case sv: newlinalg.SparseVector =>
-      SparseVector.fromNew(sv)
+      SparseVector.fromML(sv)
   }
 }
 
@@ -705,7 +705,7 @@ class DenseVector @Since("1.0.0") (
   }
 
   private[spark]
-  override def toNew: newlinalg.DenseVector = {
+  override def asML: newlinalg.DenseVector = {
     new newlinalg.DenseVector(values)
   }
 }
@@ -719,7 +719,7 @@ object DenseVector {
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
   private[spark]
-  def fromNew(v: newlinalg.DenseVector): DenseVector = {
+  def fromML(v: newlinalg.DenseVector): DenseVector = {
     new DenseVector(v.values)
   }
 }
@@ -912,7 +912,7 @@ class SparseVector @Since("1.0.0") (
   }
 
   private[spark]
-  override def toNew: newlinalg.SparseVector = {
+  override def asML: newlinalg.SparseVector = {
     new newlinalg.SparseVector(size, indices, values)
   }
 }
@@ -925,7 +925,7 @@ object SparseVector {
 
   /** Convert new linalg type to spark.mllib type.  Light copy; only copies references */
   private[spark]
-  def fromNew(v: newlinalg.SparseVector): SparseVector = {
+  def fromML(v: newlinalg.SparseVector): SparseVector = {
     new SparseVector(v.size, v.indices, v.values)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -538,10 +538,10 @@ class MatricesSuite extends SparkFunSuite {
       assert(oldM.numRows === newM.numRows)
     }
 
-    val newSM: newlinalg.SparseMatrix = sm.toNew
-    val newDM: newlinalg.DenseMatrix = dm.toNew
-    val newSM0: newlinalg.Matrix = sm0.toNew
-    val newDM0: newlinalg.Matrix = dm0.toNew
+    val newSM: newlinalg.SparseMatrix = sm.asML
+    val newDM: newlinalg.DenseMatrix = dm.asML
+    val newSM0: newlinalg.Matrix = sm0.asML
+    val newDM0: newlinalg.Matrix = dm0.asML
     assert(newSM0.isInstanceOf[newlinalg.SparseMatrix])
     assert(newDM0.isInstanceOf[newlinalg.DenseMatrix])
     compare(sm, newSM)
@@ -549,10 +549,10 @@ class MatricesSuite extends SparkFunSuite {
     compare(sm0, newSM0)
     compare(dm0, newDM0)
 
-    val oldSM: SparseMatrix = SparseMatrix.fromNew(newSM)
-    val oldDM: DenseMatrix = DenseMatrix.fromNew(newDM)
-    val oldSM0: Matrix = Matrices.fromNew(newSM0)
-    val oldDM0: Matrix = Matrices.fromNew(newDM0)
+    val oldSM: SparseMatrix = SparseMatrix.fromML(newSM)
+    val oldDM: DenseMatrix = DenseMatrix.fromML(newDM)
+    val oldSM0: Matrix = Matrices.fromML(newSM0)
+    val oldDM0: Matrix = Matrices.fromML(newDM0)
     assert(oldSM0.isInstanceOf[SparseMatrix])
     assert(oldDM0.isInstanceOf[DenseMatrix])
     compare(oldSM, newSM)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -19,12 +19,14 @@ package org.apache.spark.mllib.linalg
 
 import java.util.Random
 
+import scala.collection.mutable.{Map => MutableMap}
+
 import breeze.linalg.{CSCMatrix, Matrix => BM}
 import org.mockito.Mockito.when
 import org.scalatest.mock.MockitoSugar._
-import scala.collection.mutable.{Map => MutableMap}
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.{linalg => newlinalg}
 import org.apache.spark.mllib.util.TestingUtils._
 
 class MatricesSuite extends SparkFunSuite {
@@ -522,5 +524,40 @@ class MatricesSuite extends SparkFunSuite {
       assert(m.transpose.rowIter.toSeq === cols)
       assert(m.transpose.colIter.toSeq === rows)
     }
+  }
+
+  test("conversions between new local linalg and mllib linalg") {
+    val dm: DenseMatrix = new DenseMatrix(3, 2, Array(0.0, 0.0, 1.0, 0.0, 2.0, 3.5))
+    val sm: SparseMatrix = dm.toSparse
+    val sm0: Matrix = sm.asInstanceOf[Matrix]
+    val dm0: Matrix = dm.asInstanceOf[Matrix]
+
+    def compare(oldM: Matrix, newM: newlinalg.Matrix): Unit = {
+      assert(oldM.toArray === newM.toArray)
+      assert(oldM.numCols === newM.numCols)
+      assert(oldM.numRows === newM.numRows)
+    }
+
+    val newSM: newlinalg.SparseMatrix = sm.toNew
+    val newDM: newlinalg.DenseMatrix = dm.toNew
+    val newSM0: newlinalg.Matrix = sm0.toNew
+    val newDM0: newlinalg.Matrix = dm0.toNew
+    assert(newSM0.isInstanceOf[newlinalg.SparseMatrix])
+    assert(newDM0.isInstanceOf[newlinalg.DenseMatrix])
+    compare(sm, newSM)
+    compare(dm, newDM)
+    compare(sm0, newSM0)
+    compare(dm0, newDM0)
+
+    val oldSM: SparseMatrix = SparseMatrix.fromNew(newSM)
+    val oldDM: DenseMatrix = DenseMatrix.fromNew(newDM)
+    val oldSM0: Matrix = Matrices.fromNew(newSM0)
+    val oldDM0: Matrix = Matrices.fromNew(newDM0)
+    assert(oldSM0.isInstanceOf[SparseMatrix])
+    assert(oldDM0.isInstanceOf[DenseMatrix])
+    compare(oldSM, newSM)
+    compare(oldDM, newDM)
+    compare(oldSM0, newSM0)
+    compare(oldDM0, newDM0)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -400,10 +400,10 @@ class VectorsSuite extends SparkFunSuite with Logging {
     val sv0: Vector = sv.asInstanceOf[Vector]
     val dv0: Vector = dv.asInstanceOf[Vector]
 
-    val newSV: newlinalg.SparseVector = sv.toNew
-    val newDV: newlinalg.DenseVector = dv.toNew
-    val newSV0: newlinalg.Vector = sv0.toNew
-    val newDV0: newlinalg.Vector = dv0.toNew
+    val newSV: newlinalg.SparseVector = sv.asML
+    val newDV: newlinalg.DenseVector = dv.asML
+    val newSV0: newlinalg.Vector = sv0.asML
+    val newDV0: newlinalg.Vector = dv0.asML
     assert(newSV0.isInstanceOf[newlinalg.SparseVector])
     assert(newDV0.isInstanceOf[newlinalg.DenseVector])
     assert(sv.toArray === newSV.toArray)
@@ -411,10 +411,10 @@ class VectorsSuite extends SparkFunSuite with Logging {
     assert(sv0.toArray === newSV0.toArray)
     assert(dv0.toArray === newDV0.toArray)
 
-    val oldSV: SparseVector = SparseVector.fromNew(newSV)
-    val oldDV: DenseVector = DenseVector.fromNew(newDV)
-    val oldSV0: Vector = Vectors.fromNew(newSV0)
-    val oldDV0: Vector = Vectors.fromNew(newDV0)
+    val oldSV: SparseVector = SparseVector.fromML(newSV)
+    val oldDV: DenseVector = DenseVector.fromML(newDV)
+    val oldSV0: Vector = Vectors.fromML(newSV0)
+    val oldDV0: Vector = Vectors.fromML(newDV0)
     assert(oldSV0.isInstanceOf[SparseVector])
     assert(oldDV0.isInstanceOf[DenseVector])
     assert(oldSV.toArray === newSV.toArray)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -24,6 +24,7 @@ import org.json4s.jackson.JsonMethods.{parse => parseJson}
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.internal.Logging
+import org.apache.spark.ml.{linalg => newlinalg}
 import org.apache.spark.mllib.util.TestingUtils._
 
 class VectorsSuite extends SparkFunSuite with Logging {
@@ -391,5 +392,34 @@ class VectorsSuite extends SparkFunSuite with Logging {
       assert(u.getClass === v.getClass, "toJson/fromJson should preserve vector types.")
       assert(u === v, "toJson/fromJson should preserve vector values.")
     }
+  }
+
+  test("conversions between new local linalg and mllib linalg") {
+    val dv: DenseVector = new DenseVector(Array(1.0, 2.0, 3.5))
+    val sv: SparseVector = new SparseVector(5, Array(1, 2, 4), Array(1.1, 2.2, 4.4))
+    val sv0: Vector = sv.asInstanceOf[Vector]
+    val dv0: Vector = dv.asInstanceOf[Vector]
+
+    val newSV: newlinalg.SparseVector = sv.toNew
+    val newDV: newlinalg.DenseVector = dv.toNew
+    val newSV0: newlinalg.Vector = sv0.toNew
+    val newDV0: newlinalg.Vector = dv0.toNew
+    assert(newSV0.isInstanceOf[newlinalg.SparseVector])
+    assert(newDV0.isInstanceOf[newlinalg.DenseVector])
+    assert(sv.toArray === newSV.toArray)
+    assert(dv.toArray === newDV.toArray)
+    assert(sv0.toArray === newSV0.toArray)
+    assert(dv0.toArray === newDV0.toArray)
+
+    val oldSV: SparseVector = SparseVector.fromNew(newSV)
+    val oldDV: DenseVector = DenseVector.fromNew(newDV)
+    val oldSV0: Vector = Vectors.fromNew(newSV0)
+    val oldDV0: Vector = Vectors.fromNew(newDV0)
+    assert(oldSV0.isInstanceOf[SparseVector])
+    assert(oldDV0.isInstanceOf[DenseVector])
+    assert(oldSV.toArray === newSV.toArray)
+    assert(oldDV.toArray === newDV.toArray)
+    assert(oldSV0.toArray === newSV0.toArray)
+    assert(oldDV0.toArray === newDV0.toArray)
   }
 }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -657,6 +657,10 @@ object MimaExcludes {
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.sources.OutputWriter"),
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.sources.OutputWriterFactory")
       ) ++ Seq(
+        // SPARK-14734: Add conversions between mllib and ml Vector, Matrix types
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.mllib.linalg.Vector.asML"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.mllib.linalg.Matrix.asML")
+      ) ++ Seq(
         // SPARK-14704: Create accumulators in TaskMetrics
         ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.executor.InputMetrics.this"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.executor.OutputMetrics.this")


### PR DESCRIPTION
## What changes were proposed in this pull request?

For maintaining wrappers around spark.mllib algorithms in spark.ml, it will be useful to have `private[spark]` methods for converting from one linear algebra representation to another.
This PR adds toNew, fromNew methods for all spark.mllib Vector and Matrix types.
## How was this patch tested?

Unit tests for all conversions
