### PR TITLE
[SPARK-14521][SQL] StackOverflowError in Kryo when executing TPC-DS 

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -52,7 +52,7 @@ private[hive] object SparkSQLEnv extends Logging {
           maybeSerializer.getOrElse("org.apache.spark.serializer.KryoSerializer"))
         .set(
           "spark.kryo.referenceTracking",
-          maybeKryoReferenceTracking.getOrElse("false"))
+          maybeKryoReferenceTracking.getOrElse("true"))
 
       sparkContext = new SparkContext(sparkConf)
       sparkContext.addSparkListener(new StatsReportListener())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Observed stackOverflowError in Kryo when executing TPC-DS Query27. Spark thrift server disables kryo reference tracking (if not specified in conf). When "spark.kryo.referenceTracking" is set to true explicitly in spark-defaults.conf, query executes successfully. Recent changes HashedRelation could have introduced loops which would need "spark.kryo.referenceTracking=true" in spark-thrift server.  This PR addresses this by setting referenceTracking to true in SparkSQLEnv
## How was this patch tested?

Manually running TPC-DS queries at 200 GB scale in multi node cluster.  Also ran org.apache.spark.sql.hive.execution.HiveCompatibilitySuite,org.apache.spark.sql.hive.execution.HiveQuerySuite,org.apache.spark.sql.hive.execution.PruningSuite,org.apache.spark.sql.hive/CachedTableSuite
