### PR TITLE
[SPARK-14748][SQL] BoundReference should not set ExprCode.code to empty string

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BoundAttribute.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BoundAttribute.scala
@@ -62,12 +62,7 @@ case class BoundReference(ordinal: Int, dataType: DataType, nullable: Boolean)
     val javaType = ctx.javaType(dataType)
     val value = ctx.getValue(ctx.INPUT_ROW, dataType, ordinal.toString)
     if (ctx.currentVars != null && ctx.currentVars(ordinal) != null) {
-      val oev = ctx.currentVars(ordinal)
-      ev.isNull = oev.isNull
-      ev.value = oev.value
-      val code = oev.code
-      oev.code = ""
-      ev.copy(code = code)
+      ctx.currentVars(ordinal)
     } else if (nullable) {
       ev.copy(code = s"""
         boolean ${ev.isNull} = ${ctx.INPUT_ROW}.isNullAt($ordinal);


### PR DESCRIPTION
## What changes were proposed in this pull request?

While generating code for `BoundReference`, for variables that have already been evaluated we should not set `ExprCode.code` to empty string and should just return the original `ExprCode`.
## How was this patch tested?

Existing test should catch any issues. In particular, we should fix the generated code for any operator should it now start failing.
