### PR TITLE
[Minor] [ML] [PySpark] Fix omissive param setters which should use _set method

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -340,7 +340,7 @@ class CountVectorizer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, 
         """
         Sets the value of :py:attr:`binary`.
         """
-        self._paramMap[self.binary] = value
+        self._set(binary=value)
         return self
 
     @since("2.0.0")
@@ -569,7 +569,7 @@ class HashingTF(JavaTransformer, HasInputCol, HasOutputCol, HasNumFeatures, Java
         """
         Sets the value of :py:attr:`binary`.
         """
-        self._paramMap[self.binary] = value
+        self._set(binary=value)
         return self
 
     @since("2.0.0")


### PR DESCRIPTION
## What changes were proposed in this pull request?
#11939 make Python param setters use the `_set` method. This PR fix omissive ones.
## How was this patch tested?

Existing tests.

cc @jkbradley @sethah 
