### PR TITLE
[SPARK-14749][SQL, Tests] PlannerSuite failed when it run individually

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -51,7 +51,10 @@ class QueryExecution(val sqlContext: SQLContext, val logical: LogicalPlan) {
     }
   }
 
-  lazy val analyzed: LogicalPlan = sqlContext.sessionState.analyzer.execute(logical)
+  lazy val analyzed: LogicalPlan = {
+    SQLContext.setActive(sqlContext)
+    sqlContext.sessionState.analyzer.execute(logical)
+  }
 
   lazy val withCachedData: LogicalPlan = {
     assertAnalyzed()


### PR DESCRIPTION
## What changes were proposed in this pull request?

3 testcases namely, 

```
"count is partially aggregated"
"count distinct is partially aggregated"
"mixed aggregates are partially aggregated"
```

were failing when running PlannerSuite individually. 
The PR provides a fix for this.
## How was this patch tested?

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
