### PR TITLE
[SPARK-14742] [DOCS] Redirect spark-ec2 doc to new location

### DIFF
--- a/docs/ec2-scripts.md
+++ b/docs/ec2-scripts.md
@@ -1,0 +1,7 @@
+---		
+layout: global
+title: Running Spark on EC2
+redirect: https://github.com/amplab/spark-ec2#readme
+---
+
+This document has been superseded and replaced by documentation at https://github.com/amplab/spark-ec2#readme


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restore `ec2-scripts.md` as a redirect to amplab/spark-ec2 docs
## How was this patch tested?

`jekyll build` and checked with the browser
