### PR TITLE
[WIP][SPARK-14765][BUILD] Jenkins should run tests only based on the PR contents

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -82,6 +82,8 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         run_cmd(['git', 'fetch', 'origin', str(target_branch+':'+target_branch)])
     else:
         diff_target = target_ref
+    run_cmd(['git', 'config', 'user.name', '"Apache Spark"'])
+    run_cmd(['git', 'config', 'user.email', '"dev@spark.apache.org"'])
     run_cmd(['git', 'rebase', diff_target])
     raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
                                          universal_newlines=True)

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -82,10 +82,7 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         run_cmd(['git', 'fetch', 'origin', str(target_branch+':'+target_branch)])
     else:
         diff_target = target_ref
-    run_cmd(['git', 'config', 'user.name', '"Apache Spark"'])
-    run_cmd(['git', 'config', 'user.email', '"dev@spark.apache.org"'])
-    run_cmd(['git', 'rebase', diff_target])
-    raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
+    raw_output = subprocess.check_output(['git', 'diff', '--name-only', 'HEAD~2'],
                                          universal_newlines=True)
     # Remove any empty strings
     return [f for f in raw_output.split('\n') if f]

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -62,17 +62,6 @@ def determine_modules_for_files(filenames):
 
 
 def identify_changed_files_from_git_commits(patch_sha, target_branch=None, target_ref=None):
-    """
-    Given a git commit and target ref, use the set of files changed in the diff in order to
-    determine which modules' tests should be run.
-
-    >>> [x.name for x in determine_modules_for_files( \
-            identify_changed_files_from_git_commits("fc0a1475ef", target_ref="5da21f07"))]
-    ['graphx']
-    >>> 'root' in [x.name for x in determine_modules_for_files( \
-         identify_changed_files_from_git_commits("50a0496a43", target_ref="6765ef9"))]
-    True
-    """
     if target_branch is None and target_ref is None:
         raise AttributeError("must specify either target_branch or target_ref")
     elif target_branch is not None and target_ref is not None:

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -82,6 +82,7 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         run_cmd(['git', 'fetch', 'origin', str(target_branch+':'+target_branch)])
     else:
         diff_target = target_ref
+    run_cmd(['git', 'rebase', diff_target])
     raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
                                          universal_newlines=True)
     # Remove any empty strings


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Background**
Yesterday, when I exposed a function to Python/R, only Python and R module are changed. At the first successful build, it took 25 minutes, but the next one took 125 minutes.
- [25 minutes](https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/56291/consoleFull)

```
[info] Found the following changed modules: pyspark-sql, sparkr
```
- [125 minutes](https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/56298/)

```
[info] Found the following changed modules: pyspark-sql, sparkr, mllib, hive, sql, root
```

**Problem**
`identify_changed_files_from_git_commits` function in `run-tests.py` simply runs `git diff` to the master. It means **Newly updated master code** also are considered as the changed files due to the PR.

**How to fix**
Actually, the value of `patch_sha` is `HEAD`. Also, we are using Github merged commits (consisting of 2 commits), we can find the changed file like the following.

```
-    raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
+    raw_output = subprocess.check_output(['git', 'diff', '--name-only', 'HEAD~2'],
```
## How was this patch tested?

Manual.
