### PR TITLE
[MINOR][ML][PYTHON][DOC] Remove use of JavaMLWriter/Reader in public Python API docs

### DIFF
--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -137,7 +137,7 @@ class MLWritable(object):
 
     @property
     def write(self):
-        """Returns an JavaMLWriter instance for this ML instance."""
+        """Returns an MLWriter instance for this ML instance."""
         raise NotImplementedError("MLWritable is not yet implemented for type: %r" % type(self))
 
     def save(self, path):
@@ -153,7 +153,7 @@ class JavaMLWritable(MLWritable):
 
     @property
     def write(self):
-        """Returns an JavaMLWriter instance for this ML instance."""
+        """Returns an MLWriter instance for this ML instance."""
         return JavaMLWriter(self)
 
 
@@ -236,7 +236,7 @@ class MLReadable(object):
 
     @classmethod
     def read(cls):
-        """Returns an JavaMLReader instance for this class."""
+        """Returns an MLReader instance for this class."""
         raise NotImplementedError("MLReadable.read() not implemented for type: %r" % cls)
 
     @classmethod
@@ -253,5 +253,5 @@ class JavaMLReadable(MLReadable):
 
     @classmethod
     def read(cls):
-        """Returns an JavaMLReader instance for this class."""
+        """Returns an MLReader instance for this class."""
         return JavaMLReader(cls)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed instances of JavaMLWriter, JavaMLReader appearing in public Python API docs
## How was this patch tested?

n/a
