### PR TITLE
[SPARK-14780][R] Add `setLogLevel` to SparkR

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -25,8 +25,7 @@ export("setJobGroup",
        "cancelJobGroup")
 
 # Export Utility methods
-export("version",
-       "setLogLevel")
+export("setLogLevel")
 
 exportClasses("DataFrame")
 

--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -24,6 +24,10 @@ export("setJobGroup",
        "clearJobGroup",
        "cancelJobGroup")
 
+# Export Utility methods
+export("version",
+       "setLogLevel")
+
 exportClasses("DataFrame")
 
 exportMethods("arrange",

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -229,8 +229,11 @@ setCheckpointDir <- function(sc, dirName) {
 #' Set new log level
 #'
 #' Set new log level: "ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"
+#'
+#' @rdname setLogLevel
 #' @param sc Spark Context to use
 #' @param level New log level
+#' @export
 #' @examples
 #'\dontrun{
 #' setLogLevel(sc, "ERROR")

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -226,19 +226,6 @@ setCheckpointDir <- function(sc, dirName) {
   invisible(callJMethod(sc, "setCheckpointDir", suppressWarnings(normalizePath(dirName))))
 }
 
-#' Get Spark Version
-#'
-#' Get Spark Version
-#' @param sc existing spark context
-#' @examples
-#'\dontrun{
-#' version(sc)
-#'}
-
-version <- function(sc) {
-  callJMethod(sc, "version")
-}
-
 #' Set new log level
 #'
 #' Set new log level: "ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -229,8 +229,8 @@ setCheckpointDir <- function(sc, dirName) {
 #' Set new log level
 #'
 #' Set new log level: "ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"
-#' @param sc existing spark context
-#' @param level a string value specifying new log level
+#' @param sc Spark Context to use
+#' @param level New log level
 #' @examples
 #'\dontrun{
 #' setLogLevel(sc, "ERROR")

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -225,3 +225,30 @@ broadcast <- function(sc, object) {
 setCheckpointDir <- function(sc, dirName) {
   invisible(callJMethod(sc, "setCheckpointDir", suppressWarnings(normalizePath(dirName))))
 }
+
+#' Get Spark Version
+#'
+#' Get Spark Version
+#' @param sc existing spark context
+#' @examples
+#'\dontrun{
+#' version(sc)
+#'}
+
+version <- function(sc) {
+  callJMethod(sc, "version")
+}
+
+#' Set new log level
+#'
+#' Set new log level: "ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"
+#' @param sc existing spark context
+#' @param level a string value specifying new log level
+#' @examples
+#'\dontrun{
+#' setLogLevel(sc, "ERROR")
+#'}
+
+setLogLevel <- function(sc, level) {
+  callJMethod(sc, "setLogLevel", level)
+}

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -90,9 +90,8 @@ test_that("job group functions can be called", {
   clearJobGroup(sc)
 })
 
-test_that("utility can be called", {
+test_that("utility functions can be called", {
   sc <- sparkR.init()
-  version(sc)
   setLogLevel(sc, "ERROR")
 })
 

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -90,7 +90,7 @@ test_that("job group functions can be called", {
   clearJobGroup(sc)
 })
 
-test_that("utility functions can be called", {
+test_that("utility function can be called", {
   sc <- sparkR.init()
   setLogLevel(sc, "ERROR")
 })

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -90,6 +90,12 @@ test_that("job group functions can be called", {
   clearJobGroup(sc)
 })
 
+test_that("utility can be called", {
+  sc <- sparkR.init()
+  version(sc)
+  setLogLevel(sc, "ERROR")
+})
+
 test_that("getClientModeSparkSubmitOpts() returns spark-submit args from whitelist", {
   e <- new.env()
   e[["spark.driver.memory"]] <- "512m"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to add `setLogLevel` function to SparkR shell.

**Spark Shell**

``` scala
scala> sc.setLogLevel("ERROR")
```

**PySpark**

``` python
>>> sc.setLogLevel("ERROR")
```

**SparkR (this PR)**

``` r
> setLogLevel(sc, "ERROR")
NULL
```
## How was this patch tested?

Pass the Jenkins tests including a new R testcase.
