### PR TITLE
[SPARK-14794][SQL] Don't pass analyze command into Hive

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveSqlParser.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveSqlParser.scala
@@ -103,7 +103,9 @@ class HiveSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder {
       ctx.identifier.getText.toLowerCase == "noscan") {
       AnalyzeTable(visitTableIdentifier(ctx.tableIdentifier).toString)
     } else {
-      throw new ParseException(s"Unsupported analyze command", ctx)
+      // Always just run the no scan analyze. We should fix this and implement full analyze
+      // command in the future.
+      AnalyzeTable(visitTableIdentifier(ctx.tableIdentifier).toString)
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveSqlParser.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveSqlParser.scala
@@ -103,7 +103,7 @@ class HiveSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder {
       ctx.identifier.getText.toLowerCase == "noscan") {
       AnalyzeTable(visitTableIdentifier(ctx.tableIdentifier).toString)
     } else {
-      HiveNativeCommand(command(ctx))
+      throw new ParseException(s"Unsupported analyze command", ctx)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -49,19 +49,19 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton {
 
     assertAnalyzeCommand(
       "ANALYZE TABLE Table1 COMPUTE STATISTICS",
-      classOf[HiveNativeCommand])
+      classOf[AnalyzeTable])
     assertAnalyzeCommand(
       "ANALYZE TABLE Table1 PARTITION(ds='2008-04-09', hr=11) COMPUTE STATISTICS",
-      classOf[HiveNativeCommand])
+      classOf[AnalyzeTable])
     assertAnalyzeCommand(
       "ANALYZE TABLE Table1 PARTITION(ds='2008-04-09', hr=11) COMPUTE STATISTICS noscan",
-      classOf[HiveNativeCommand])
+      classOf[AnalyzeTable])
     assertAnalyzeCommand(
       "ANALYZE TABLE Table1 PARTITION(ds, hr) COMPUTE STATISTICS",
-      classOf[HiveNativeCommand])
+      classOf[AnalyzeTable])
     assertAnalyzeCommand(
       "ANALYZE TABLE Table1 PARTITION(ds, hr) COMPUTE STATISTICS noscan",
-      classOf[HiveNativeCommand])
+      classOf[AnalyzeTable])
 
     assertAnalyzeCommand(
       "ANALYZE TABLE Table1 COMPUTE STATISTICS nOscAn",


### PR DESCRIPTION
## What changes were proposed in this pull request?

We shouldn't pass analyze command to Hive because some of those would require running MapReduce jobs. For now, let's just always run the no scan analyze.
## How was this patch tested?

Updated test case to reflect this change.
