### PR TITLE
[SPARK-14803][SQL][Optimizer] A bug in EliminateSerialization rule in Catalyst Optimizer.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -157,7 +157,8 @@ object SamplePushDown extends Rule[LogicalPlan] {
 object EliminateSerialization extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case d @ DeserializeToObject(_, _, s: SerializeFromObject)
-        if d.outputObjectType == s.inputObjectType =>
+        if ((d.outputObjectType == s.inputObjectType) &&
+            !d.outputObjectType.isInstanceOf[ObjectType]) =>
       // Adds an extra Project here, to preserve the output expr id of `DeserializeToObject`.
       val objAttr = Alias(s.child.output.head, "obj")(exprId = d.output.head.exprId)
       Project(objAttr :: Nil, s.child)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes a bug in EliminateSerialization rule in Catalyst Optimizer. When there is a SerializeFromObject and DeserializeToObject pair with equal inputObjectType and outputObjectType, the pair will be eliminated and replaced by a Project operator. However, when the involved object type is Row, there will be a codegen compilation error, because UnsafeProjection does not support Row.
## How was this patch tested?

Unit tests.
