### PR TITLE
[SPARK-14489][SPARK-14153][ML][PYSPARK] Support dropping NaN predicted values in RegressionEvaluator

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/RegressionEvaluatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/RegressionEvaluatorSuite.scala
@@ -76,6 +76,19 @@ class RegressionEvaluatorSuite
     assert(evaluator.evaluate(predictions) ~== 0.08399089 absTol 0.01)
   }
 
+  test("support dropping NaNs from prediction column") {
+    val local = this.sqlContext
+    import local.implicits._
+    val dataset = Seq(
+      (5.0, 4.0), (1.0, 4.0), (2.0, Double.NaN), (3.0, 1.0), (4.0, Double.NaN)
+    ).toDF("label", "prediction")
+
+    val evaluator = new RegressionEvaluator()
+    assert(evaluator.evaluate(dataset).isNaN)
+    evaluator.setDropNaN(true)
+    assert(evaluator.evaluate(dataset) ~== 2.16024 absTol 1e-2)
+  }
+
   test("read/write") {
     val evaluator = new RegressionEvaluator()
       .setPredictionCol("myPrediction")

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -187,6 +187,13 @@ class RegressionEvaluator(JavaEvaluator, HasLabelCol, HasPredictionCol):
     0.993...
     >>> evaluator.evaluate(dataset, {evaluator.metricName: "mae"})
     2.649...
+    >>> scoreAndLabels = [(4.0, 5.0), (4.0, 1.0), (float('nan'), 2.0),
+    ...   (1.0, 3.0), (float('nan'), 4.0)]
+    >>> dataset = sqlContext.createDataFrame(scoreAndLabels, ["raw", "label"])
+    ...
+    >>> evaluator = RegressionEvaluator(predictionCol="raw").setDropNaN(True)
+    >>> evaluator.evaluate(dataset)
+    2.160...
 
     .. versionadded:: 1.4.0
     """
@@ -197,18 +204,24 @@ class RegressionEvaluator(JavaEvaluator, HasLabelCol, HasPredictionCol):
                        "metric name in evaluation (mse|rmse|r2|mae)",
                        typeConverter=TypeConverters.toString)
 
+    dropNaN = Param(Params._dummy(), "dropNaN",
+                    "whether to drop rows where 'predictionCol' is NaN. NOTE - only set this to " +
+                    "True if you are certain that NaN predictions should be ignored! " +
+                    "(default: False)",
+                    typeConverter=TypeConverters.toBoolean)
+
     @keyword_only
     def __init__(self, predictionCol="prediction", labelCol="label",
-                 metricName="rmse"):
+                 metricName="rmse", dropNaN=False):
         """
         __init__(self, predictionCol="prediction", labelCol="label", \
-                 metricName="rmse")
+                 metricName="rmse", dropNaN=False)
         """
         super(RegressionEvaluator, self).__init__()
         self._java_obj = self._new_java_obj(
             "org.apache.spark.ml.evaluation.RegressionEvaluator", self.uid)
         self._setDefault(predictionCol="prediction", labelCol="label",
-                         metricName="rmse")
+                         metricName="rmse", dropNaN=False)
         kwargs = self.__init__._input_kwargs
         self._set(**kwargs)
 
@@ -227,13 +240,28 @@ class RegressionEvaluator(JavaEvaluator, HasLabelCol, HasPredictionCol):
         """
         return self.getOrDefault(self.metricName)
 
+    @since("2.0.0")
+    def setDropNaN(self, value):
+        """
+        Sets the value of :py:attr:`dropNaN`.
+        """
+        self._set(dropNaN=value)
+        return self
+
+    @since("2.0.0")
+    def getDropNaN(self):
+        """
+        Gets the value of dropNaN or its default value.
+        """
+        return self.getOrDefault(self.dropNaN)
+
     @keyword_only
     @since("1.4.0")
     def setParams(self, predictionCol="prediction", labelCol="label",
-                  metricName="rmse"):
+                  metricName="rmse", dropNaN=False):
         """
         setParams(self, predictionCol="prediction", labelCol="label", \
-                  metricName="rmse")
+                  metricName="rmse", dropNaN=False)
         Sets params for regression evaluator.
         """
         kwargs = self.setParams._input_kwargs


### PR DESCRIPTION
As discussed in [SPARK-14489](https://issues.apache.org/jira/browse/SPARK-14489), when using `ALSModel` to predict on a test set, the model returns `NaN` when the user/item is in the test set but not the training set, since the model has not computed factor(s) for that user and/or item. 

This PR adds support to `RegressionEvaluator` to drop rows where the value of `predictionCol` is `NaN`. This should not be used in the general case (since a bad regression model may produce a lot of `NaN`s and one would not want to ignore those but rather fix the underlying issue), but allows ALS to be used in cross-validation settings even when this situation occurs (which may be quite common on larger, sparser datasets). Thus it is an `expertParam` and the default is `false`. 
## How was this patch tested?

New unit tests in `RegressionEvaluatorSuite` and doc string tests in `evaluation.py`.

cc @srowen @sethah @jkbradley 
