### PR TITLE
[SPARK-14807] Create a compatibility module

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -110,7 +110,7 @@ def determine_modules_to_test(changed_modules):
     ['graphx', 'examples']
     >>> x = [x.name for x in determine_modules_to_test([modules.sql])]
     >>> x # doctest: +NORMALIZE_WHITESPACE
-    ['sql', 'hive', 'mllib', 'examples', 'hive-1-x-compatibility', 'hive-thriftserver',
+    ['sql', 'hive', 'mllib', 'examples', 'hive-thriftserver', 'hivecontext-compatibility',
      'pyspark-sql', 'sparkr', 'pyspark-mllib', 'pyspark-ml']
     """
     modules_to_test = set()

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -110,8 +110,8 @@ def determine_modules_to_test(changed_modules):
     ['graphx', 'examples']
     >>> x = [x.name for x in determine_modules_to_test([modules.sql])]
     >>> x # doctest: +NORMALIZE_WHITESPACE
-    ['sql', 'hive', 'mllib', 'examples', 'hive-thriftserver', 'pyspark-sql', 'sparkr',
-     'pyspark-mllib', 'pyspark-ml']
+    ['sql', 'hive', 'mllib', 'examples', 'hive-1-x-compatibility', 'hive-thriftserver',
+     'pyspark-sql', 'sparkr', 'pyspark-mllib', 'pyspark-ml']
     """
     modules_to_test = set()
     for module in changed_modules:

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -151,14 +151,14 @@ hive_thriftserver = Module(
 )
 
 
-hive_1_x_compatibility = Module(
-    name="hive-1-x-compatibility",
+hivecontext_compatibility = Module(
+    name="hivecontext-compatibility",
     dependencies=[hive],
     source_file_regexes=[
-        "sql/hive-1-x-compatibility/",
+        "sql/hivecontext-compatibility/",
     ],
     sbt_test_goals=[
-        "hive-1-x-compatibility/test"
+        "hivecontext-compatibility/test"
     ]
 )
 

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -151,6 +151,18 @@ hive_thriftserver = Module(
 )
 
 
+hive_1_x_compatibility = Module(
+    name="hive-1-x-compatibility",
+    dependencies=[hive],
+    source_file_regexes=[
+        "sql/hive-1-x-compatibility/",
+    ],
+    sbt_test_goals=[
+        "hive-1-x-compatibility/test"
+    ]
+)
+
+
 sketch = Module(
     name="sketch",
     dependencies=[],

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <module>sql/catalyst</module>
     <module>sql/core</module>
     <module>sql/hive</module>
-    <module>sql/hive-1-x-compatibility</module>
+    <module>sql/hivecontext-compatibility</module>
     <module>external/docker-integration-tests</module>
     <module>assembly</module>
     <module>external/flume</module>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <module>sql/catalyst</module>
     <module>sql/core</module>
     <module>sql/hive</module>
+    <module>sql/hive-1-x-compatibility</module>
     <module>external/docker-integration-tests</module>
     <module>assembly</module>
     <module>external/flume</module>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -36,8 +36,8 @@ object BuildCommons {
 
   private val buildLocation = file(".").getAbsoluteFile.getParentFile
 
-  val sqlProjects@Seq(catalyst, sql, hive, hiveThriftServer) = Seq(
-    "catalyst", "sql", "hive", "hive-thriftserver"
+  val sqlProjects@Seq(catalyst, sql, hive, hiveThriftServer, hiveCompatibility) = Seq(
+    "catalyst", "sql", "hive", "hive-thriftserver", "hive-1-x-compatibility"
   ).map(ProjectRef(buildLocation, _))
 
   val streamingProjects@Seq(
@@ -253,7 +253,7 @@ object SparkBuild extends PomBuild {
 
   val mimaProjects = allProjects.filterNot { x =>
     Seq(
-      spark, hive, hiveThriftServer, catalyst, repl, networkCommon, networkShuffle, networkYarn,
+      spark, hive, hiveThriftServer, hiveCompatibility, catalyst, repl, networkCommon, networkShuffle, networkYarn,
       unsafe, testTags, sketch, mllibLocal
     ).contains(x)
   }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -37,7 +37,7 @@ object BuildCommons {
   private val buildLocation = file(".").getAbsoluteFile.getParentFile
 
   val sqlProjects@Seq(catalyst, sql, hive, hiveThriftServer, hiveCompatibility) = Seq(
-    "catalyst", "sql", "hive", "hive-thriftserver", "hive-1-x-compatibility"
+    "catalyst", "sql", "hive", "hive-thriftserver", "hivecontext-compatibility"
   ).map(ProjectRef(buildLocation, _))
 
   val streamingProjects@Seq(

--- a/sql/hive-1-x-compatibility/pom.xml
+++ b/sql/hive-1-x-compatibility/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-parent_2.11</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-hive-1-x-compatibility_2.11</artifactId>
+    <packaging>jar</packaging>
+    <name>Spark Project Hive 1.x Compatibility</name>
+    <url>http://spark.apache.org/</url>
+    <properties>
+        <sbt.project.name>hive-1-x-compatibility</sbt.project.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+        <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <configuration>
+                        <javacArgs combine.children="append">
+                            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
+                            <javacArg>-XDignore.symbol.file</javacArg>
+                        </javacArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs combine.children="append">
+                            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
+                            <arg>-XDignore.symbol.file</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/sql/hivecontext-compatibility/pom.xml
+++ b/sql/hivecontext-compatibility/pom.xml
@@ -27,12 +27,12 @@
     </parent>
 
     <groupId>org.apache.spark</groupId>
-    <artifactId>spark-hive-1-x-compatibility_2.11</artifactId>
+    <artifactId>spark-hivecontext-compatibility_2.11</artifactId>
     <packaging>jar</packaging>
-    <name>Spark Project Hive 1.x Compatibility</name>
+    <name>Spark Project HiveContext Compatibility</name>
     <url>http://spark.apache.org/</url>
     <properties>
-        <sbt.project.name>hive-1-x-compatibility</sbt.project.name>
+        <sbt.project.name>hivecontext-compatibility</sbt.project.name>
     </properties>
 
     <dependencies>
@@ -46,29 +46,5 @@
     <build>
         <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
         <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>net.alchim31.maven</groupId>
-                    <artifactId>scala-maven-plugin</artifactId>
-                    <configuration>
-                        <javacArgs combine.children="append">
-                            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
-                            <javacArg>-XDignore.symbol.file</javacArg>
-                        </javacArgs>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <compilerArgs combine.children="append">
-                            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
-                            <arg>-XDignore.symbol.file</arg>
-                        </compilerArgs>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR creates a compatibility module in sql (called `hive-1-x-compatibility`), which will host HiveContext in Spark 2.0 (moving HiveContext to here will be done separately). This module is not included in assembly because only users who still want to access HiveContext need it.
## How was this patch tested?

I manually tested `sbt/sbt -Phive package` and `mvn -Phive package -DskipTests`.
