### PR TITLE
[SPARK-14768] [ML] [PySpark] removed expectedType from Param __init__()

### DIFF
--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -40,22 +40,15 @@ class Param(object):
     """
     A param with self-contained documentation.
 
-    Note: `expectedType` is deprecated and will be removed in 2.1. Use typeConverter instead,
-          as a keyword argument.
-
     .. versionadded:: 1.3.0
     """
 
-    def __init__(self, parent, name, doc, expectedType=None, typeConverter=None):
+    def __init__(self, parent, name, doc, typeConverter=None):
         if not isinstance(parent, Identifiable):
             raise TypeError("Parent must be an Identifiable but got type %s." % type(parent))
         self.parent = parent.uid
         self.name = str(name)
         self.doc = str(doc)
-        self.expectedType = expectedType
-        if expectedType is not None:
-            warnings.warn("expectedType is deprecated and will be removed in 2.1. " +
-                          "Use typeConverter instead, as a keyword argument.")
         self.typeConverter = TypeConverters.identity if typeConverter is None else typeConverter
 
     def _copy_new_parent(self, parent):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed expectedType arg from PySpark Param **init**, as suggested by the JIRA.
## How was this patch tested?

Manually looked through all places that use Param. Compiled and ran all ML PySpark test cases before and after the fix.
