### PR TITLE
[SPARK-14835][SQL] Remove MetastoreRelation dependency from SQLBuilder

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -21,7 +21,8 @@ import javax.annotation.Nullable
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.parser.DataTypeParser
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
 
 
@@ -301,6 +302,7 @@ object ExternalCatalog {
  */
 trait CatalogRelation {
   def catalogTable: CatalogTable
+  def output: Seq[Attribute]
 }
 
 
@@ -315,10 +317,20 @@ case class SimpleCatalogRelation(
     alias: Option[String] = None)
   extends LeafNode with CatalogRelation {
 
-  // TODO: implement this
-  override def output: Seq[Attribute] = Seq.empty
-
   override def catalogTable: CatalogTable = metadata
+
+  override val output: Seq[Attribute] = {
+    val cols = catalogTable.schema
+      .filter { c => !catalogTable.partitionColumnNames.contains(c.name) }
+    (cols ++ catalogTable.partitionColumns).map { f =>
+      AttributeReference(
+        f.name,
+        DataTypeParser.parse(f.dataType),
+        // Since data can be dumped in randomly with no validation, everything is nullable.
+        nullable = true
+      )(qualifier = Some(alias.getOrElse(metadata.identifier.table)))
+    }
+  }
 
   require(metadata.identifier.database == Some(databaseName),
     "provided database does not match the one specified in the table definition")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch removes SQLBuilder's dependency on MetastoreRelation. We should be able to move SQLBuilder into the sql/core package after this change.
## How was this patch tested?

N/A - covered by existing tests.
