### PR TITLE
[SPARK-13178] RRDD faces with concurrency issue in case of rdd.zip(rdd).count().

### DIFF
--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -131,8 +131,6 @@ test_that("kmeans", {
   newIris$Species <- NULL
   training <- suppressWarnings(createDataFrame(sqlContext, newIris))
 
-  # Cache the DataFrame here to work around the bug SPARK-13178.
-  cache(training)
   take(training, 1)
 
   model <- kmeans(x = training, centers = 2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The concurrency issue reported in SPARK-13178 was fixed by the PR https://github.com/apache/spark/pull/10947 for SPARK-12792. 
This PR just removes a workaround not needed anymore.
## How was this patch tested?

SparkR unit tests.
