### PR TITLE
[SPARK-14594][SPARKR] check execution return status code

### DIFF
--- a/R/pkg/R/backend.R
+++ b/R/pkg/R/backend.R
@@ -110,6 +110,9 @@ invokeJava <- function(isStatic, objId, methodName, ...) {
 
   # TODO: check the status code to output error information
   returnStatus <- readInt(conn)
+  if (length(returnStatus) == 0) {
+    stop("No status is returned. Java SparkR backend might have failed.")
+  }
   if (returnStatus != 0) {
     stop(readString(conn))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When JVM backend fails without going proper error handling (eg. process crashed), the R error message could be ambiguous.

```
Error in if (returnStatus != 0) { : argument is of length zero
```

This change attempts to make it more clear (however, one would still need to investigate why JVM fails)
## How was this patch tested?

manually
