### PR TITLE
[SPARK-14852][ML] refactored GLM summary into training, non-training summaries

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -876,8 +876,8 @@ class GeneralizedLinearRegressionSummary private[regression] (
   /** predictions output by the model's `transform` method */
   @Since("2.0.0") @transient val predictions: DataFrame = model.transform(dataset)
 
-  private[regression] val family: Family = Family.fromName(model.getFamily)
-  private[regression] val link: Link = if (model.isDefined(model.link)) {
+  private[regression] lazy val family: Family = Family.fromName(model.getFamily)
+  private[regression] lazy val link: Link = if (model.isDefined(model.link)) {
     Link.fromName(model.getLink)
   } else {
     family.defaultLink

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -82,7 +82,7 @@ private[regression] trait GeneralizedLinearRegressionBase extends PredictorParam
   /**
    * Param for link prediction (linear predictor) column name.
    * Default is empty, which means we do not output link prediction.
- *
+   *
    * @group param
    */
   @Since("2.0.0")
@@ -146,7 +146,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the value of param [[family]].
    * Default is "gaussian".
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -155,7 +155,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
 
   /**
    * Sets the value of param [[link]].
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -164,7 +164,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets if we should fit the intercept.
    * Default is true.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -173,7 +173,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the maximum number of iterations.
    * Default is 25 if the solver algorithm is "irls".
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -183,7 +183,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -197,7 +197,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    *   0.5 * regParam * L2norm(coefficients)^2
    * }}}
    * Default is 0.0.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -208,7 +208,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
    * Default is empty, so all instances have weight one.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -218,7 +218,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the solver algorithm used for optimization.
    * Currently only support "irls" which is also the default solver.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -227,7 +227,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
 
   /**
    * Sets the link prediction (linear predictor) column name.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -372,7 +372,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
   /**
    * A description of the error distribution to be used in the model.
- *
+   *
    * @param name the name of the family.
    */
   private[ml] abstract class Family(val name: String) extends Serializable {
@@ -391,7 +391,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Akaike's 'An Information Criterion'(AIC) value of the family for a given dataset.
- *
+     *
      * @param predictions an RDD of (y, mu, weight) of instances in evaluation dataset
      * @param deviance the deviance for the fitted model in evaluation dataset
      * @param numInstances number of instances in evaluation dataset
@@ -411,7 +411,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Gets the [[Family]] object from its name.
- *
+     *
      * @param name family name: "gaussian", "binomial", "poisson" or "gamma".
      */
     def fromName(name: String): Family = {
@@ -591,7 +591,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
    * A description of the link function to be used in the model.
    * The link function provides the relationship between the linear predictor
    * and the mean of the distribution function.
- *
+   *
    * @param name the name of link function.
    */
   private[ml] abstract class Link(val name: String) extends Serializable {
@@ -610,7 +610,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Gets the [[Link]] object from its name.
- *
+     *
      * @param name link name: "identity", "logit", "log",
      *             "inverse", "probit", "cloglog" or "sqrt".
      */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -772,7 +772,8 @@ class GeneralizedLinearRegressionModel private[ml] (
   @Since("2.0.0")
   def hasSummary: Boolean = trainingSummary.nonEmpty
 
-  private[regression] def setSummary(summary: GeneralizedLinearRegressionTrainingSummary): this.type = {
+  private[regression]
+  def setSummary(summary: GeneralizedLinearRegressionTrainingSummary): this.type = {
     this.trainingSummary = Some(summary)
     this
   }
@@ -888,19 +889,19 @@ class GeneralizedLinearRegressionSummary private[regression] (
   private val weightCol: String = model.getWeightCol
   private val labelCol: String = model.getLabelCol
 
-  protected val familyName: String = model.getFamily
-  protected val family: Family = Family.fromName(familyName)
-  protected val link: Link = if (model.isDefined(model.link)) {
+  private[regression] val familyName: String = model.getFamily
+  private[regression] val family: Family = Family.fromName(familyName)
+  private[regression] val link: Link = if (model.isDefined(model.link)) {
     Link.fromName(model.getLink)
   } else {
     family.defaultLink
   }
-  protected val fitIntercept: Boolean = model.getFitIntercept
-  protected val intercept: Double = model.intercept
-  protected val coefficients: Vector = model.coefficients
+  private[regression] val fitIntercept: Boolean = model.getFitIntercept
+  private[regression] val intercept: Double = model.intercept
+  private[regression] val coefficients: Vector = model.coefficients
 
   /** Number of instances in DataFrame predictions */
-  protected lazy val numInstances: Long = predictions.count()
+  private[regression] lazy val numInstances: Long = predictions.count()
 
   /** The numeric rank of the fitted linear model */
   @Since("2.0.0")
@@ -928,7 +929,7 @@ class GeneralizedLinearRegressionSummary private[regression] (
     numInstances
   }
 
-  protected lazy val devianceResiduals: DataFrame = {
+  private[regression] lazy val devianceResiduals: DataFrame = {
     val drUDF = udf { (y: Double, mu: Double, weight: Double) =>
       val r = math.sqrt(math.max(family.deviance(y, mu, weight), 0.0))
       if (y > mu) r else -1.0 * r
@@ -938,19 +939,19 @@ class GeneralizedLinearRegressionSummary private[regression] (
       drUDF(col(labelCol), col(predictionCol), w).as("devianceResiduals"))
   }
 
-  protected lazy val pearsonResiduals: DataFrame = {
+  private[regression] lazy val pearsonResiduals: DataFrame = {
     val prUDF = udf { mu: Double => family.variance(mu) }
     val w = if (weightCol.isEmpty) lit(1.0) else col(weightCol)
     predictions.select(col(labelCol).minus(col(predictionCol))
       .multiply(sqrt(w)).divide(sqrt(prUDF(col(predictionCol)))).as("pearsonResiduals"))
   }
 
-  protected lazy val workingResiduals: DataFrame = {
+  private[regression] lazy val workingResiduals: DataFrame = {
     val wrUDF = udf { (y: Double, mu: Double) => (y - mu) * link.deriv(mu) }
     predictions.select(wrUDF(col(labelCol), col(predictionCol)).as("workingResiduals"))
   }
 
-  protected lazy val responseResiduals: DataFrame = {
+  private[regression] lazy val responseResiduals: DataFrame = {
     predictions.select(col(labelCol).minus(col(predictionCol)).as("responseResiduals"))
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -603,7 +603,9 @@ class GeneralizedLinearRegressionSuite
     val residualDegreeOfFreedomR = 1
     val aicR = 18.783
 
+    assert(model.hasSummary)
     val summary = model.summary
+    assert(summary.isInstanceOf[GeneralizedLinearRegressionTrainingSummary])
 
     val devianceResiduals = summary.residuals()
       .select(col("devianceResiduals"))
@@ -643,6 +645,18 @@ class GeneralizedLinearRegressionSuite
     assert(summary.residualDegreeOfFreedomNull === residualDegreeOfFreedomNullR)
     assert(summary.aic ~== aicR absTol 1E-3)
     assert(summary.solver === "irls")
+
+    val summary2: GeneralizedLinearRegressionSummary = model.evaluate(datasetWithWeight)
+    assert(summary.predictions.columns.toSet === summary2.predictions.columns.toSet)
+    assert(summary.predictionCol === summary2.predictionCol)
+    assert(summary.rank === summary2.rank)
+    assert(summary.degreesOfFreedom === summary2.degreesOfFreedom)
+    assert(summary.residualDegreeOfFreedom === summary2.residualDegreeOfFreedom)
+    assert(summary.residualDegreeOfFreedomNull === summary2.residualDegreeOfFreedomNull)
+    assert(summary.nullDeviance === summary2.nullDeviance)
+    assert(summary.deviance === summary2.deviance)
+    assert(summary.dispersion === summary2.dispersion)
+    assert(summary.aic === summary2.aic)
   }
 
   test("glm summary: binomial family with weight") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This splits GeneralizedLinearRegressionSummary into 2 summary types:
- GeneralizedLinearRegressionSummary, which does not store info from fitting (diagInvAtWA)
- GeneralizedLinearRegressionTrainingSummary, which is a subclass of GeneralizedLinearRegressionSummary and stores info from fitting

This also add a method evaluate() which can produce a GeneralizedLinearRegressionSummary on a new dataset.

The summary no longer provides the model itself as a public val.

Also:
- Fixes bug where GeneralizedLinearRegressionTrainingSummary was created with model, not summaryModel.
- Adds hasSummary method.
- Renames findSummaryModelAndPredictionCol -> getSummaryModel and simplifies that method.
- In summary, extract values from model immediately in case user later changes those (e.g., predictionCol).
- Pardon the style fixes; that is IntelliJ being obnoxious.
## How was this patch tested?

Existing unit tests + updated test for evaluate and hasSummary
