### PR TITLE
[SPARK-14757][SQL] Corrected doGenCode() in EqualNullSafe predicate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -467,7 +467,7 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
     val equalCode = ctx.genEqual(left.dataType, eval1.value, eval2.value)
     ev.copy(code = eval1.code + eval2.code + s"""
         boolean ${ev.value} = (${eval1.isNull} && ${eval2.isNull}) ||
-           (!${eval1.isNull} && $equalCode);""", isNull = "false")
+           (!${eval1.isNull} && !${eval2.isNull} && $equalCode);""", isNull = "false")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the doGenCode() function for the EqualNullSafe predicate, in determining whether the two operands are equal, check that the right operand is not null, in addition to checking the left operand. This is because if only one of the operands is null, then the two operands are guaranteed not to be equal. Therefore, in order to have a valid comparison using `==`, both operands have to be non-null.
## How was this patch tested?

This patch was tested using the example given in the JIRA for this issue.
