### PR TITLE
[SPARK-14867][BUILD] Remove `--force` option in `build/mvn`

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -124,6 +124,11 @@ install_scala() {
 # the environment
 ZINC_PORT=${ZINC_PORT:-"3030"}
 
+# Remove `--force` for backward compatability.
+if [ "$1" == "--force" ]; then
+  shift
+fi
+
 # Install the proper version of Scala, Zinc and Maven for the build
 install_zinc
 install_scala

--- a/build/mvn
+++ b/build/mvn
@@ -70,8 +70,7 @@ install_app() {
 # Determine the Maven version from the root pom.xml file and
 # install maven under the build/ folder if needed.
 install_mvn() {
-  local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | \
-                     head -1 | cut -f2 -d'>' | cut -f1 -d'<'`
+  local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
   MVN_BIN="$(command -v mvn)"
   if [ "$MVN_BIN" ]; then
     local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
@@ -108,8 +107,7 @@ install_zinc() {
 # the build/ folder
 install_scala() {
   # determine the Scala version used in Spark
-  local scala_version=`grep "scala.version" "${_DIR}/../pom.xml" | \
-                       head -1 | cut -f2 -d'>' | cut -f1 -d'<'`
+  local scala_version=`grep "scala.version" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
   local scala_bin="${_DIR}/scala-${scala_version}/bin/scala"
   local TYPESAFE_MIRROR=${TYPESAFE_MIRROR:-https://downloads.typesafe.com}
 

--- a/build/mvn
+++ b/build/mvn
@@ -67,9 +67,11 @@ install_app() {
   fi
 }
 
-# Install maven under the build/ folder
+# Determine the Maven version from the root pom.xml file and
+# install maven under the build/ folder if needed.
 install_mvn() {
-  local MVN_VERSION="3.3.9"
+  local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | \
+                     head -1 | cut -f2 -d'>' | cut -f1 -d'<'`
   MVN_BIN="$(command -v mvn)"
   if [ "$MVN_BIN" ]; then
     local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
@@ -124,7 +126,7 @@ install_scala() {
 # the environment
 ZINC_PORT=${ZINC_PORT:-"3030"}
 
-# Remove `--force` for backward compatability.
+# Remove `--force` for backward compatibility.
 if [ "$1" == "--force" ]; then
   shift
 fi

--- a/build/mvn
+++ b/build/mvn
@@ -69,7 +69,6 @@ install_app() {
 
 # Install maven under the build/ folder
 install_mvn() {
-  local MVN_VERSION="3.3.9"
   local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua?action=download&filename='}
 
   install_app \
@@ -124,10 +123,13 @@ if [ "$1" == "--force" ]; then
 fi
 
 # Install Maven if necessary
+MVN_VERSION="3.3.9"
 MVN_BIN="$(command -v mvn)"
 
 if [ ! "$MVN_BIN" -o -n "$FORCE_MVN" ]; then
   install_mvn
+elif [ -f "${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn" ]; then # Try to use downloaded mvn first.
+  MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
 fi
 
 # Install the proper version of Scala and Zinc for the build

--- a/build/mvn
+++ b/build/mvn
@@ -69,14 +69,23 @@ install_app() {
 
 # Install maven under the build/ folder
 install_mvn() {
-  local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua?action=download&filename='}
+  MVN_VERSION="3.3.9"
+  MVN_BIN="$(command -v mvn)"
+  if [ "$MVN_BIN" ]; then
+    MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
+  fi
+  # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
+  function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
+  if [ $(version $MVN_DETECTED_VERSION) -lt $(version $MVN_VERSION) ]; then
+    local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua?action=download&filename='}
 
-  install_app \
-    "${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries" \
-    "apache-maven-${MVN_VERSION}-bin.tar.gz" \
-    "apache-maven-${MVN_VERSION}/bin/mvn"
+    install_app \
+      "${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries" \
+      "apache-maven-${MVN_VERSION}-bin.tar.gz" \
+      "apache-maven-${MVN_VERSION}/bin/mvn"
 
-  MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+    MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+  fi
 }
 
 # Install zinc under the build/ folder
@@ -115,26 +124,10 @@ install_scala() {
 # the environment
 ZINC_PORT=${ZINC_PORT:-"3030"}
 
-# Check for the `--force` flag dictating that `mvn` should be downloaded
-# regardless of whether the system already has a `mvn` install
-if [ "$1" == "--force" ]; then
-  FORCE_MVN=1
-  shift
-fi
-
-# Install Maven if necessary
-MVN_VERSION="3.3.9"
-MVN_BIN="$(command -v mvn)"
-
-if [ ! "$MVN_BIN" -o -n "$FORCE_MVN" ]; then
-  install_mvn
-elif [ -f "${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn" ]; then # Try to use downloaded mvn first.
-  MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
-fi
-
-# Install the proper version of Scala and Zinc for the build
+# Install the proper version of Scala, Zinc and Maven for the build
 install_zinc
 install_scala
+install_mvn
 
 # Reset the current working directory
 cd "${_CALLING_DIR}"

--- a/build/mvn
+++ b/build/mvn
@@ -128,6 +128,7 @@ ZINC_PORT=${ZINC_PORT:-"3030"}
 
 # Remove `--force` for backward compatibility.
 if [ "$1" == "--force" ]; then
+  echo "WARNING: '--force' is deprecated and ignored."
   shift
 fi
 

--- a/build/mvn
+++ b/build/mvn
@@ -69,10 +69,10 @@ install_app() {
 
 # Install maven under the build/ folder
 install_mvn() {
-  MVN_VERSION="3.3.9"
+  local MVN_VERSION="3.3.9"
   MVN_BIN="$(command -v mvn)"
   if [ "$MVN_BIN" ]; then
-    MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
+    local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
   fi
   # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
   function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -30,7 +30,7 @@ export LC_ALL=C
 
 # NOTE: These should match those in the release publishing script
 HADOOP2_MODULE_PROFILES="-Phive-thriftserver -Pyarn -Phive"
-MVN="build/mvn --force"
+MVN="build/mvn"
 HADOOP_PROFILES=(
     hadoop-2.2
     hadoop-2.3


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `build/mvn` provides a convenient option, `--force`, in order to use the recommended version of maven without changing PATH environment variable. However, there were two problems.
- `dev/lint-java` does not use the newly installed maven.
  
  ``` bash
  $ ./build/mvn --force clean
  $ ./dev/lint-java 
  Using `mvn` from path: /usr/local/bin/mvn
  ```
- It's not easy to type `--force` option always.

If '--force' option is used once, we had better prefer the installed maven recommended by Spark.
This PR makes `build/mvn` check the existence of maven installed by `--force` option first.

According to the comments, this PR aims to the followings:
- Detect the maven version from `pom.xml`.
- Install maven if there is no or old maven.
- Remove `--force` option.
## How was this patch tested?

Manual.

``` bash
$ ./build/mvn --force clean
$ ./dev/lint-java 
Using `mvn` from path: /Users/dongjoon/spark/build/apache-maven-3.3.9/bin/mvn
...
$ rm -rf ./build/apache-maven-3.3.9/
$ ./dev/lint-java 
Using `mvn` from path: /usr/local/bin/mvn
```
