### PR TITLE
[SPARK-14871][SQL] Disable StatsReportListener to declutter output

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -23,7 +23,6 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.StatsReportListener
 import org.apache.spark.sql.hive.{HiveContext, HiveUtils}
 import org.apache.spark.util.Utils
 
@@ -55,7 +54,6 @@ private[hive] object SparkSQLEnv extends Logging {
           maybeKryoReferenceTracking.getOrElse("false"))
 
       sparkContext = new SparkContext(sparkConf)
-      sparkContext.addSparkListener(new StatsReportListener())
       hiveContext = new HiveContext(sparkContext)
 
       hiveContext.sessionState.metadataHive.setOut(new PrintStream(System.out, true, "UTF-8"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark SQL inherited from Shark to use the StatsReportListener. Unfortunately this clutters the spark-sql CLI output and makes it very difficult to read the actual query results.
## How was this patch tested?

Built and tested in spark-sql CLI.
