### PR TITLE
[SPARK-14856] Correct message in assertion for 'returning batch for wide table'

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -609,7 +609,7 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
         val df3 = df2.selectExpr(columns : _*)
         assert(
           df3.queryExecution.sparkPlan.find(_.isInstanceOf[BatchedDataSourceScanExec]).isDefined,
-          "Should not return batch")
+          "Should return batch")
         checkAnswer(df3, df.selectExpr(columns : _*))
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There was a typo in the message for second assertion in "returning batch for wide table" test
## How was this patch tested?

Existing tests.
