### PR TITLE
[SPARK-14875][SQL] Makes OutputWriterFactory.newInstance public

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -59,7 +59,7 @@ abstract class OutputWriterFactory extends Serializable {
    * @param context The Hadoop MapReduce task context.
    * @since 1.4.0
    */
-  private[sql] def newInstance(
+  def newInstance(
       path: String,
       bucketId: Option[Int], // TODO: This doesn't belong here...
       dataSchema: StructType,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
@@ -48,7 +48,7 @@ class SimpleTextSource extends FileFormat with DataSourceRegister {
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = new OutputWriterFactory {
-    override private[sql] def newInstance(
+    override def newInstance(
         path: String,
         bucketId: Option[Int],
         dataSchema: StructType,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This method was accidentally made `private[sql]` in Spark 2.0. This PR makes it public again, since 3rd party data sources like spark-avro depend on it.
## How was this patch tested?

N/A
