### PR TITLE
[SPARK-14885] [SQL] When creating a CatalogColumn, we should use the catalogString of a DataType object.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1073,7 +1073,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         // just convert the whole type string to lower case, otherwise the struct field names
         // will no longer be case sensitive. Instead, we rely on our parser to get the proper
         // case before passing it to Hive.
-        CatalystSqlParser.parseDataType(col.dataType.getText).simpleString,
+        CatalystSqlParser.parseDataType(col.dataType.getText).catalogString,
         nullable = true,
         Option(col.STRING).map(string))
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -144,11 +144,11 @@ case class CreateViewCommand(
     val viewSchema: Seq[CatalogColumn] = {
       if (tableDesc.schema.isEmpty) {
         analyzedPlan.output.map { a =>
-          CatalogColumn(a.name, a.dataType.simpleString)
+          CatalogColumn(a.name, a.dataType.catalogString)
         }
       } else {
         analyzedPlan.output.zip(tableDesc.schema).map { case (a, col) =>
-          CatalogColumn(col.name, a.dataType.simpleString, nullable = true, col.comment)
+          CatalogColumn(col.name, a.dataType.catalogString, nullable = true, col.comment)
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now, the data type field of a CatalogColumn is using the string representation. When we create this string from a DataType object, there are places where we use simpleString instead of catalogString. Although catalogString is the same as simpleString right now, it is still good to use catalogString. So, we will not silently introduce issues when we change the semantic of simpleString or the implementation of catalogString.
## How was this patch tested?

Existing tests.
