### PR TITLE
[Spark 14653][WIP][Mllib]

### DIFF
--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -63,6 +63,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib-local_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/udt/MatricesUDT.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/udt/MatricesUDT.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types.udt
+
+import scala.collection.mutable.{ArrayBuilder => MArrayBuilder}
+
+import breeze.linalg.{CSCMatrix => BSM, DenseMatrix => BDM, Matrix => BM}
+
+import org.apache.spark.ml.linalg._
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.types.{ArrayType, DataType, DoubleType, UserDefinedType}
+
+ /**
+  * User Defined Transformations for Matrix
+  *
+  */
+
+class MatricesUDT extends UserDefinedType[Matrix] {
+  /** Underlying storage type for this UDT */
+  override def sqlType: DataType = {
+    ArrayType(ArrayType(DoubleType, containsNull = false), containsNull = false)
+  }
+
+  /**
+    * Convert the user type to a SQL datum
+    */
+  override def serialize(matrix: Matrix): Any = {
+    new GenericArrayData(matrix.toArray)
+  }
+
+  /**
+    * Class object for the UserType
+    */
+  override def userClass: Class[Matrix] = classOf[Matrix]
+
+  /** Convert a SQL datum to the user type */
+  override def deserialize(datum: Any): Matrix = {
+    datum match {
+      case (numRows: Int, numCols: Int, entries: Iterable[(Int, Int, Double)]) =>
+        toMatrix(numRows, numCols, entries)
+      case (breeze: BM[Double]) => toMatrix(breeze)
+    }
+  }
+
+    /**
+     * Creates a Matrix instance from a breeze matrix.
+     * @param breeze a breeze matrix
+     * @return a Matrix instance
+     */
+  private def toMatrix(breeze: BM[Double]): Matrix = breeze match {
+    case dm: BDM[Double] =>
+      new DenseMatrix(dm.rows, dm.cols, dm.data, dm.isTranspose)
+    case sm: BSM[Double] =>
+      // Spark-11507. work around breeze issue 479.
+      val mat = if (sm.colPtrs.last != sm.data.length) {
+        val matCopy = sm.copy
+        matCopy.compact()
+        matCopy
+      } else {
+        sm
+      }
+      // There is no isTranspose flag for sparse matrices in Breeze
+      new SparseMatrix(mat.rows, mat.cols, mat.colPtrs, mat.rowIndices, mat.data)
+    case _ =>
+      throw new UnsupportedOperationException(
+        s"Do not support conversion from type ${breeze.getClass.getName}.")
+  }
+
+   /**
+     * Generate a `SparseMatrix` from Coordinate List (COO) format. Input must be an array of
+     * (i, j, value) tuples. Entries that have duplicate values of i and j are
+     * added together. Tuples where value is equal to zero will be omitted.
+     * @param numRows number of rows of the matrix
+     * @param numCols number of columns of the matrix
+     * @param entries Array of (i, j, value) tuples
+     * @return The corresponding `SparseMatrix`
+     */
+  private def toMatrix(numRows: Int,
+                       numCols: Int,
+                       entries: Iterable[(Int, Int, Double)]): Matrix = {
+    val sortedEntries = entries.toSeq.sortBy(v => (v._2, v._1))
+    val numEntries = sortedEntries.size
+    if (sortedEntries.nonEmpty) {
+      // Since the entries are sorted by column index, we only need to check the first and the last.
+      for (col <- Seq(sortedEntries.head._2, sortedEntries.last._2)) {
+        require(col >= 0 && col < numCols, s"Column index out of range [0, $numCols): $col.")
+      }
+    }
+    val colPtrs = new Array[Int](numCols + 1)
+    val rowIndices = MArrayBuilder.make[Int]
+    rowIndices.sizeHint(numEntries)
+    val values = MArrayBuilder.make[Double]
+    values.sizeHint(numEntries)
+    var nnz = 0
+    var prevCol = 0
+    var prevRow = -1
+    var prevVal = 0.0
+    // Append a dummy entry to include the last one at the end of the loop.
+    (sortedEntries.view :+(numRows, numCols, 1.0)).foreach { case (i, j, v) =>
+      if (v != 0) {
+        if (i == prevRow && j == prevCol) {
+          prevVal += v
+        } else {
+          if (prevVal != 0) {
+            require(prevRow >= 0 && prevRow < numRows,
+              s"Row index out of range [0, $numRows): $prevRow.")
+            nnz += 1
+            rowIndices += prevRow
+            values += prevVal
+          }
+          prevRow = i
+          prevVal = v
+          while (prevCol < j) {
+            colPtrs(prevCol + 1) = nnz
+            prevCol += 1
+          }
+        }
+      }
+    }
+    new SparseMatrix(numRows, numCols, colPtrs, rowIndices.result(), values.result())
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/udt/VectorUDT.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/udt/VectorUDT.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types.udt
+
+import breeze.linalg.{DenseVector => BDV, SparseVector => BSV, Vector => BV}
+import org.json4s.{DefaultFormats, JValue}
+
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
+import org.apache.spark.sql.types._
+
+/**
+ * User Defined Transformations for Vectors
+ *
+ * Note: Currently Supports deserialization of Json and BEEze.
+ */
+class VectorUDT extends UserDefinedType[Vector] {
+  /** Underlying storage type for this UDT */
+  override def sqlType: DataType = ArrayType(DoubleType, containsNull = false)
+
+  /**
+   * Convert the user type to a SQL datum
+   */
+  override def serialize(vector: Vector): ArrayData = {
+    new GenericArrayData(vector match {
+      case denseVector: DenseVector => denseVector.values
+      case sparseVector: SparseVector => sparseVector.toDense.values
+    })
+  }
+
+  /**
+   * Class object for the UserType
+   */
+  override def userClass: Class[Vector] = classOf[Vector]
+
+  /** Convert a SQL datum to the user type */
+  override def deserialize(datum: Any): Vector = {
+    implicit val formats = DefaultFormats
+    datum match {
+      case jValue: JValue => (jValue \ "type").extract[Int] match {
+        case 0 => // sparse
+          val size = (jValue \ "size").extract[Int]
+          val indices = (jValue \ "indices").extract[Seq[Int]].toArray
+          val values = (jValue \ "values").extract[Seq[Double]].toArray
+          Vectors.sparse(size, indices, values)
+        case 1 => // dense
+          val values = (jValue \ "values").extract[Seq[Double]].toArray
+          Vectors.dense(values)
+        case _ =>
+          throw new IllegalArgumentException(s"Cannot parse $json into a vector.")
+      }
+
+      case breezeVector: BV[Double] => breezeVector match {
+        case v: BDV[Double] =>
+          if (v.offset == 0 && v.stride == 1 && v.length == v.data.length) {
+            new DenseVector(v.data)
+          } else {
+            new DenseVector(v.toArray) // Can't use underlying array directly, so make a new one
+          }
+        case v: BSV[Double] =>
+          if (v.index.length == v.used) {
+            new SparseVector(v.length, v.index, v.data)
+          } else {
+            new SparseVector(v.length, v.index.slice(0, v.used), v.data.slice(0, v.used))
+          }
+        case _ =>
+          sys.error("Unsupported Breeze vector type: " + datum.getClass.getName)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Inorder to remove Jackson and numeric parser from the mllib-local's dependencies. I've added two UserDefined Transformations. `org.apache.spark.sql.types.udt.VectorUDT` and `org.apache.spark.sql.types.udt.MatricesUDT`. I'm not sure if i'm doing it right needed some inputs on how to proceed.
## How was this patch tested?

Its up for review and not been tested yet.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
