### PR TITLE
[SPARK-14412][ML][PYSPARK] Add StorageLevel params to ALS

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -55,7 +55,6 @@ private[recommendation] trait ALSModelParams extends Params with HasPredictionCo
   /**
    * Param for the column name for user ids.
    * Default: "user"
-   *
    * @group param
    */
   val userCol = new Param[String](this, "userCol", "column name for user ids")
@@ -66,7 +65,6 @@ private[recommendation] trait ALSModelParams extends Params with HasPredictionCo
   /**
    * Param for the column name for item ids.
    * Default: "item"
-   *
    * @group param
    */
   val itemCol = new Param[String](this, "itemCol", "column name for item ids")
@@ -84,7 +82,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param for rank of the matrix factorization (>= 1).
    * Default: 10
-   *
    * @group param
    */
   val rank = new IntParam(this, "rank", "rank of the factorization", ParamValidators.gtEq(1))
@@ -95,7 +92,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param for number of user blocks (>= 1).
    * Default: 10
-   *
    * @group param
    */
   val numUserBlocks = new IntParam(this, "numUserBlocks", "number of user blocks",
@@ -107,7 +103,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param for number of item blocks (>= 1).
    * Default: 10
-   *
    * @group param
    */
   val numItemBlocks = new IntParam(this, "numItemBlocks", "number of item blocks",
@@ -119,7 +114,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param to decide whether to use implicit preference.
    * Default: false
-   *
    * @group param
    */
   val implicitPrefs = new BooleanParam(this, "implicitPrefs", "whether to use implicit preference")
@@ -130,7 +124,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param for the alpha parameter in the implicit preference formulation (>= 0).
    * Default: 1.0
-   *
    * @group param
    */
   val alpha = new DoubleParam(this, "alpha", "alpha for implicit preference",
@@ -142,7 +135,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param for the column name for ratings.
    * Default: "rating"
-   *
    * @group param
    */
   val ratingCol = new Param[String](this, "ratingCol", "column name for ratings")
@@ -153,7 +145,6 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   /**
    * Param for whether to apply nonnegativity constraints.
    * Default: false
-   *
    * @group param
    */
   val nonnegative = new BooleanParam(

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -163,29 +163,28 @@ private[recommendation] trait ALSParams extends ALSModelParams with HasMaxIter w
   def getNonnegative: Boolean = $(nonnegative)
 
   /**
-   * Param for intermediate RDD StorageLevel. Pass in a string representation of [[StorageLevel]].
-   * Cannot be "NONE".
-   * Default: "MEMORY_AND_DISK"
+   * Param for StorageLevel for intermediate RDDs. Pass in a string representation of
+   * [[StorageLevel]]. Cannot be "NONE".
+   * Default: "MEMORY_AND_DISK".
    *
    * @group expertParam
    */
-  val intermediateRDDStorageLevel = new Param[String](this,
-    "intermediateRDDStorageLevel", "intermediate RDD StorageLevel. Cannot be 'NONE'. " +
-    "Default: 'MEMORY_AND_DISK'.",
+  val intermediateRDDStorageLevel = new Param[String](this, "intermediateRDDStorageLevel",
+    "StorageLevel for intermediate RDDs. Cannot be 'NONE'. Default: 'MEMORY_AND_DISK'.",
     (s: String) => ALS.getStorageLevel(s).isInstanceOf[StorageLevel] && s != "NONE")
 
   /** @group expertGetParam */
   def getIntermediateRDDStorageLevel: String = $(intermediateRDDStorageLevel)
 
   /**
-   * Param for StorageLevel for ALS model factors. Pass in a string representation of
+   * Param for StorageLevel for ALS model factor RDDs. Pass in a string representation of
    * [[StorageLevel]].
-   * Default: "MEMORY_AND_DISK"
+   * Default: "MEMORY_AND_DISK".
    *
    * @group expertParam
    */
-  val finalRDDStorageLevel = new Param[String](this,
-    "finalRDDStorageLevel", "StorageLevel for ALS model factors. Default: 'MEMORY_AND_DISK'.",
+  val finalRDDStorageLevel = new Param[String](this, "finalRDDStorageLevel",
+    "StorageLevel for ALS model factor RDDs. Default: 'MEMORY_AND_DISK'.",
     (s: String) => ALS.getStorageLevel(s).isInstanceOf[StorageLevel])
 
   /** @group expertGetParam */

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -200,6 +200,7 @@ class ALSSuite
 
   /**
    * Generates an explicit feedback dataset for testing ALS.
+   *
    * @param numUsers number of users
    * @param numItems number of items
    * @param rank rank
@@ -240,6 +241,7 @@ class ALSSuite
 
   /**
    * Generates an implicit feedback dataset for testing ALS.
+   *
    * @param numUsers number of users
    * @param numItems number of items
    * @param rank rank
@@ -288,6 +290,7 @@ class ALSSuite
 
   /**
    * Generates random user/item factors, with i.i.d. values drawn from U(a, b).
+   *
    * @param size number of users/items
    * @param rank number of features
    * @param random random number generator
@@ -313,6 +316,7 @@ class ALSSuite
 
   /**
    * Test ALS using the given training/test splits and parameters.
+   *
    * @param training training dataset
    * @param test test dataset
    * @param rank rank of the matrix factorization
@@ -519,8 +523,7 @@ class ALSSuite
 class ALSStorageSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest with Logging {
 
-  test("storage level params") {
-    // test invalid param values
+  test("invalid storage params") {
     intercept[IllegalArgumentException] {
       new ALS().setIntermediateRDDStorageLevel("foo")
     }
@@ -530,7 +533,9 @@ class ALSStorageSuite
     intercept[IllegalArgumentException] {
       new ALS().setFinalRDDStorageLevel("foo")
     }
+  }
 
+  test("default and non-default storage params set correct RDD StorageLevels") {
     val sqlContext = this.sqlContext
     import sqlContext.implicits._
     val data = Seq(

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -119,21 +119,35 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     nonnegative = Param(Params._dummy(), "nonnegative",
                         "whether to use nonnegative constraint for least squares",
                         typeConverter=TypeConverters.toBoolean)
+    intermediateRDDStorageLevel = Param(Params._dummy(), "intermediateRDDStorageLevel",
+                                        "StorageLevel for intermediate RDDs. Cannot be 'NONE'. " +
+                                        "Default: 'MEMORY_AND_DISK'.",
+                                        typeConverter=TypeConverters.toString)
+    finalRDDStorageLevel = Param(Params._dummy(), "finalRDDStorageLevel",
+                                 "StorageLevel for ALS model factor RDDs. " +
+                                 "Default: 'MEMORY_AND_DISK'.",
+                                 typeConverter=TypeConverters.toString)
 
     @keyword_only
     def __init__(self, rank=10, maxIter=10, regParam=0.1, numUserBlocks=10, numItemBlocks=10,
                  implicitPrefs=False, alpha=1.0, userCol="user", itemCol="item", seed=None,
-                 ratingCol="rating", nonnegative=False, checkpointInterval=10):
+                 ratingCol="rating", nonnegative=False, checkpointInterval=10,
+                 intermediateRDDStorageLevel="MEMORY_AND_DISK",
+                 finalRDDStorageLevel="MEMORY_AND_DISK"):
         """
         __init__(self, rank=10, maxIter=10, regParam=0.1, numUserBlocks=10, numItemBlocks=10, \
                  implicitPrefs=false, alpha=1.0, userCol="user", itemCol="item", seed=None, \
-                 ratingCol="rating", nonnegative=false, checkpointInterval=10)
+                 ratingCol="rating", nonnegative=false, checkpointInterval=10, \
+                 intermediateRDDStorageLevel="MEMORY_AND_DISK", \
+                 finalRDDStorageLevel="MEMORY_AND_DISK")
         """
         super(ALS, self).__init__()
         self._java_obj = self._new_java_obj("org.apache.spark.ml.recommendation.ALS", self.uid)
         self._setDefault(rank=10, maxIter=10, regParam=0.1, numUserBlocks=10, numItemBlocks=10,
                          implicitPrefs=False, alpha=1.0, userCol="user", itemCol="item", seed=None,
-                         ratingCol="rating", nonnegative=False, checkpointInterval=10)
+                         ratingCol="rating", nonnegative=False, checkpointInterval=10,
+                         intermediateRDDStorageLevel="MEMORY_AND_DISK",
+                         finalRDDStorageLevel="MEMORY_AND_DISK")
         kwargs = self.__init__._input_kwargs
         self.setParams(**kwargs)
 
@@ -141,11 +155,15 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     @since("1.4.0")
     def setParams(self, rank=10, maxIter=10, regParam=0.1, numUserBlocks=10, numItemBlocks=10,
                   implicitPrefs=False, alpha=1.0, userCol="user", itemCol="item", seed=None,
-                  ratingCol="rating", nonnegative=False, checkpointInterval=10):
+                  ratingCol="rating", nonnegative=False, checkpointInterval=10,
+                  intermediateRDDStorageLevel="MEMORY_AND_DISK",
+                  finalRDDStorageLevel="MEMORY_AND_DISK"):
         """
         setParams(self, rank=10, maxIter=10, regParam=0.1, numUserBlocks=10, numItemBlocks=10, \
                  implicitPrefs=False, alpha=1.0, userCol="user", itemCol="item", seed=None, \
-                 ratingCol="rating", nonnegative=False, checkpointInterval=10)
+                 ratingCol="rating", nonnegative=False, checkpointInterval=10, \
+                 intermediateRDDStorageLevel="MEMORY_AND_DISK", \
+                 finalRDDStorageLevel="MEMORY_AND_DISK")
         Sets params for ALS.
         """
         kwargs = self.setParams._input_kwargs
@@ -296,6 +314,36 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
         Gets the value of nonnegative or its default value.
         """
         return self.getOrDefault(self.nonnegative)
+
+    @since("2.0.0")
+    def setIntermediateRDDStorageLevel(self, value):
+        """
+        Sets the value of :py:attr:`intermediateRDDStorageLevel`.
+        """
+        self._set(intermediateRDDStorageLevel=value)
+        return self
+
+    @since("2.0.0")
+    def getIntermediateRDDStorageLevel(self):
+        """
+        Gets the value of intermediateRDDStorageLevel or its default value.
+        """
+        return self.getOrDefault(self.intermediateRDDStorageLevel)
+
+    @since("2.0.0")
+    def setFinalRDDStorageLevel(self, value):
+        """
+        Sets the value of :py:attr:`finalRDDStorageLevel`.
+        """
+        self._set(finalRDDStorageLevel=value)
+        return self
+
+    @since("2.0.0")
+    def getFinalRDDStorageLevel(self):
+        """
+        Gets the value of finalRDDStorageLevel or its default value.
+        """
+        return self.getOrDefault(self.finalRDDStorageLevel)
 
 
 class ALSModel(JavaModel, JavaMLWritable, JavaMLReadable):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -962,7 +962,7 @@ class ALSTest(PySparkTestCase):
         als = ALS().setMaxIter(1)
         # test default
         als.fit(df)
-        item_factors = [(r[0], r[1]) for r in self.sc._jsc.getPersistentRDDs().iteritems()
+        item_factors = [(r[0], r[1]) for r in self.sc._jsc.getPersistentRDDs().items()
                         if r[1].name() == "itemFactors"][0][1]
         java_storage_level = item_factors.getStorageLevel()
         self.assertEqual(java_storage_level.useDisk(), True)
@@ -974,7 +974,7 @@ class ALSTest(PySparkTestCase):
         als.setIntermediateRDDStorageLevel("MEMORY_ONLY")
         als.setFinalRDDStorageLevel("MEMORY_ONLY_2")
         als.fit(df)
-        item_factors2 = [(r[0], r[1]) for r in self.sc._jsc.getPersistentRDDs().iteritems()
+        item_factors2 = [(r[0], r[1]) for r in self.sc._jsc.getPersistentRDDs().items()
                          if r[1].name() == "itemFactors" and r[0] != item_factors.id()][0][1]
         java_storage_level2 = item_factors2.getStorageLevel()
         self.assertEqual(java_storage_level2.useDisk(), False)


### PR DESCRIPTION
`mllib` `ALS` supports `setIntermediateRDDStorageLevel` and `setFinalRDDStorageLevel`. This PR adds these as Params in `ml` `ALS`. They are put in group **expertParam** since few users will need them.
## How was this patch tested?

New test cases in `ALSSuite` and `tests.py`.

cc @yanboliang @jkbradley @sethah @rishabhbhardwaj 
