### PR TITLE
[SPARK-14752][SQL] LazilyGenerateOrdering throws NullPointerException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -154,12 +154,14 @@ class LazilyGeneratedOrdering(val ordering: Seq[SortOrder]) extends Ordering[Int
   private[this] var generatedOrdering = GenerateOrdering.generate(ordering)
 
   def compare(a: InternalRow, b: InternalRow): Int = {
+    if (generatedOrdering == null) {
+      generatedOrdering = GenerateOrdering.generate(ordering)
+    }
     generatedOrdering.compare(a, b)
   }
 
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
-    generatedOrdering = GenerateOrdering.generate(ordering)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

LazilyGenerateOrdering throws NullPointerException when clubbed with TakeOrderedAndProjectExec. This causes simple queries like "select i_item_id from item order by i_item_id limit 10;" would fail in spark-sql. Detailed explain plan and stack traces are available in [SPARK-14752](https://issues.apache.org/jira/browse/SPARK-14752). When deserializing in DirectTaskResult, it goes through nested structure in Kryo causing NPE for generatedOrdering.
## How was this patch tested?

Manual testing by running multiple SQL queries in multi node cluster.
