### PR TITLE
[MINOR][DOCS] Update license header of LZ4BlockInputStream.java and remove it from RAT exclusion list.

### DIFF
--- a/core/src/main/java/org/apache/spark/io/LZ4BlockInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/LZ4BlockInputStream.java
@@ -1,11 +1,12 @@
-package org.apache.spark.io;
-
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +14,8 @@ package org.apache.spark.io;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.spark.io;
 
 import java.io.EOFException;
 import java.io.FilterInputStream;
@@ -35,8 +38,6 @@ import net.jpountz.xxhash.XXHashFactory;
  * This is based on net.jpountz.lz4.LZ4BlockInputStream
  *
  * changes: https://github.com/davies/lz4-java/commit/cc1fa940ac57cc66a0b937300f805d37e2bf8411
- *
- * TODO: merge this into upstream
  */
 public final class LZ4BlockInputStream extends FilterInputStream {
 

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -94,7 +94,6 @@ gen-java.*
 org.apache.spark.sql.sources.DataSourceRegister
 org.apache.spark.scheduler.SparkHistoryListenerFactory
 .*parquet
-LZ4BlockInputStream.java
 spark-deps-.*
 .*csv
 .*tsv


### PR DESCRIPTION
## What changes were proposed in this pull request?

`LZ4BlockInputStream.java` seems to be excluded RAT check due to its literally-different Apache license header and java package line order.
This PR updates the license header and moves it to the top of the file. Also, this removes `LZ4BlockInputStream.java` from `dev/.rat-excludes`.
## How was this patch tested?

Manual.
