### PR TITLE
[SPARK-14894][Pyspark] Add result summary API to Gaussian Mixture

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+   * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.r
+
+import org.apache.hadoop.fs.Path
+import org.json4s.DefaultFormats
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.SparkException
+import org.apache.spark.ml.util.MLReader
+
+/**
+ * This is the Scala stub of SparkR ml.load. It will dispatch the call to corresponding
+ * model wrapper according to the class name extracted from rMetadata.
+ */
+
+  private[r] object RWrappers extends MLReader[Object] {
+
+      override def load(path: String): Object = {
+        implicit val format = DefaultFormats
+        val rMetadataPath = new Path(path, "rMetadata").toString
+        val rMetadataStr = sc.textFile(rMetadataPath, 1).first()
+        val rMetadata = parse(rMetadataStr)
+        val className = (rMetadata \ "class").extract[String]
+        className match {
+          case "org.apache.spark.ml.r.KMeansWrapper" => KMeansWrapper.load(path)
+          case "org.apache.spark.ml.r.GeneralizedLinearRegressionWrapepr" =>
+            GeneralizedLinearRegressionWrapper.load(path)
+          case _ =>
+            throw new SparkException(s"SparkR ml.load does not support load $className")
+        }
+      }
+  }

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -237,7 +237,6 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     +--------------------+--------------------+
     ...
 
-
     .. versionadded:: 2.0.0
     """
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -878,7 +878,7 @@ class TrainingSummaryTest(PySparkTestCase):
         self.assertTrue(isinstance(s.cluster, DataFrame))
         self.assertTrue(isinstance(s.probability, DataFrame))
         self.assertEqual(isinstance(cluster_sizes[0], long))
-        # test evaluation (with training dataset) produces a summary with same values
+        # test evaluation (with a training dataset) produces a summary with same values
         # one check is enough to verify a summary is returned, Scala version runs full test
         sameSummary = model.evaluate(df)
         self.assertAlmostEqual(sameSummary.cluster, s.cluster)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -46,7 +46,7 @@ from pyspark import keyword_only
 from pyspark.ml import Estimator, Model, Pipeline, PipelineModel, Transformer
 from pyspark.ml.classification import (
     LogisticRegression, DecisionTreeClassifier, OneVsRest, OneVsRestModel)
-from pyspark.ml.clustering import KMeans
+from pyspark.ml.clustering import KMeans, GaussianMixture
 from pyspark.ml.evaluation import BinaryClassificationEvaluator, RegressionEvaluator
 from pyspark.ml.feature import *
 from pyspark.ml.param import Param, Params, TypeConverters
@@ -856,6 +856,32 @@ class TrainingSummaryTest(PySparkTestCase):
         # one check is enough to verify a summary is returned, Scala version runs full test
         sameSummary = model.evaluate(df)
         self.assertAlmostEqual(sameSummary.areaUnderROC, s.areaUnderROC)
+
+    def test_gaussian_mixture_summary(self):
+        from pyspark.mllib.linalg import Vectors
+        sqlContext = SQLContext(self.sc)
+        df = sqlContext.createDataFrame([(1.0, 2.0, Vectors.dense(1.0)),
+                                         (0.0, 2.0, Vectors.sparse(1, [], []))],
+                                        ["features"])
+        gm = GaussianMixture(k=3, tol=0.0001, maxIter=10, seed=10)
+        model = gm.fit(df)
+        self.assertTrue(model.hasSummary)
+        s = model.summary
+        # test that api is callable and returns expected types
+        self.assertGreater(s.totalIterations, 0)
+        self.assertTrue(isinstance(s.predictions, DataFrame))
+        self.assertEqual(s.predictionCol, "prediction")
+        self.assertEqual(s.featuresCol, "features")
+        objHist = s.objectiveHistory
+        cluster_sizes = s.clusterSizes
+        self.assertTrue(isinstance(objHist, list) and isinstance(objHist[0], float))
+        self.assertTrue(isinstance(s.cluster, DataFrame))
+        self.assertTrue(isinstance(s.probability, DataFrame))
+        self.assertEqual(isinstance(cluster_sizes[0], long))
+        # test evaluation (with training dataset) produces a summary with same values
+        # one check is enough to verify a summary is returned, Scala version runs full test
+        sameSummary = model.evaluate(df)
+        self.assertAlmostEqual(sameSummary.cluster, s.cluster)
 
 
 class OneVsRestTests(PySparkTestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add summary API to Gaussian Mixture in Pyspark
## How was this patch tested?

Added unit testcases to verify summary information
