### PR TITLE
[SPARK-14903][ML][PYTHON] Revert SPARK-14071: MLWritable.write property

### DIFF
--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -53,7 +53,7 @@ from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
 from pyspark.ml.regression import LinearRegression, DecisionTreeRegressor
 from pyspark.ml.tuning import *
-from pyspark.ml.util import MLWritable, MLWriter
+from pyspark.ml.util import MLWritable, MLWriter, keyword_only
 from pyspark.ml.wrapper import JavaParams
 from pyspark.mllib.linalg import Vectors, DenseVector, SparseVector
 from pyspark.sql import DataFrame, SQLContext, Row
@@ -745,10 +745,6 @@ class PersistenceTest(PySparkTestCase):
                 rmtree(temp_path)
             except OSError:
                 pass
-
-    def test_write_property(self):
-        lr = LinearRegression(maxIter=1)
-        self.assertTrue(isinstance(lr.write, MLWriter))
 
     def test_decisiontree_classifier(self):
         dt = DecisionTreeClassifier(maxDepth=1)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -53,7 +53,6 @@ from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
 from pyspark.ml.regression import LinearRegression, DecisionTreeRegressor
 from pyspark.ml.tuning import *
-from pyspark.ml.util import MLWritable, MLWriter, keyword_only
 from pyspark.ml.wrapper import JavaParams
 from pyspark.mllib.linalg import Vectors, DenseVector, SparseVector
 from pyspark.sql import DataFrame, SQLContext, Row

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -120,14 +120,13 @@ class MLWritable(object):
     .. versionadded:: 2.0.0
     """
 
-    @property
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
         raise NotImplementedError("MLWritable is not yet implemented for type: %r" % type(self))
 
     def save(self, path):
         """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
-        self.write.save(path)
+        self.write().save(path)
 
 
 @inherit_doc
@@ -136,7 +135,6 @@ class JavaMLWritable(MLWritable):
     (Private) Mixin for ML instances that provide :py:class:`JavaMLWriter`.
     """
 
-    @property
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
         return JavaMLWriter(self)


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-14071 changed MLWritable.write to be a property.  This reverts that change since there was not a good way to make MLReadable.read appear to be a property.
## How was this patch tested?

existing unit tests
