### PR TITLE
[MINOR][BUILD] Enable RAT checking on `LZ4BlockInputStream.java`.

### DIFF
--- a/core/src/main/java/org/apache/spark/io/LZ4BlockInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/LZ4BlockInputStream.java
@@ -1,5 +1,3 @@
-package org.apache.spark.io;
-
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +11,7 @@ package org.apache.spark.io;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.io;
 
 import java.io.EOFException;
 import java.io.FilterInputStream;

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -94,7 +94,6 @@ gen-java.*
 org.apache.spark.sql.sources.DataSourceRegister
 org.apache.spark.scheduler.SparkHistoryListenerFactory
 .*parquet
-LZ4BlockInputStream.java
 spark-deps-.*
 .*csv
 .*tsv


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since `LZ4BlockInputStream.java` is not licensed to Apache Software Foundation (ASF), the Apache License header of that file is not monitored until now.
This PR aims to enable RAT checking on `LZ4BlockInputStream.java` by excluding from `dev/.rat-excludes`.
This will prevent accidental removal of Apache License header from that file.
## How was this patch tested?

Pass the Jenkins tests (Specifically, RAT check stage).
