### PR TITLE
[SPARK-14908] [YARN] Provide support HDFS-located resources for spark…

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable.HashMap
 import scala.util.control.NonFatal
 
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.{FileContext, FileSystem, Path}
 import org.apache.hadoop.yarn.api._
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.conf.YarnConfiguration
@@ -37,6 +37,7 @@ import org.apache.spark.deploy.history.HistoryServer
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
+import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rpc._
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, YarnSchedulerBackend}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
@@ -125,8 +126,8 @@ private[spark] class ApplicationMaster(
   // Load the list of localized files set by the client. This is used when launching executors,
   // and is loaded here so that these configs don't pollute the Web UI's environment page in
   // cluster mode.
-  private val localResources = {
-    logInfo("Preparing Local resources")
+  private val executorLocalResources = {
+    logDebug("Preparing Local resources for executor launch context")
     val resources = HashMap[String, LocalResource]()
 
     def setupDistributedCache(
@@ -173,8 +174,65 @@ private[spark] class ApplicationMaster(
       sys.props.remove(e.key)
     }
 
-    logInfo("Prepared Local resources " + resources)
+    if (sparkConf.contains(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH)
+      && sparkConf.get(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH).contains("hdfs://")) {
+      logDebug("Spark hdfs-located executor extra classpath detected")
+      prepareHdfsExtraClasspath(resources)
+    }
+
+    logInfo(s"Prepared Local resources for executor launch context $resources")
     resources.toMap
+  }
+
+  /**
+   *
+   * What this method do:
+   * 1. Iterate over hdfs paths specified by "spark.executor.extraClassPath"
+   * 2. Resolve each path and get information about resource
+   * 3. Create link based on resource URI
+   * 4. Add local resource using link as key to container launch context resources
+   *
+   * The method does not change the "spark.executor.extraClasspath" value,
+   * which then puts to executor CLASSPATH as is, whereas for HDFS-located resources,
+   * it generates links, which used as key for container launch context local resources.
+   *
+   * All generated links puts to executor CLASSPATH {@see ExecutorRunnable.prepareEnvironment}
+   * Then node manager resolve these links and download needed resources to application cache.
+   *
+   * @param localResources container launch context local resources
+   */
+  private def prepareHdfsExtraClasspath (localResources: HashMap[String, LocalResource]): Unit = {
+    try {
+      val hdfs = FileSystem.get( yarnConf )
+
+      def addResource (path: String): Unit = {
+        val qualified = hdfs.makeQualified( new Path( Utils.resolveURI( path.trim ) ) )
+        val fileContext = FileContext.getFileContext( qualified.toUri( ), yarnConf )
+        val resolvedPath = fileContext.resolvePath( qualified )
+        val fileStatus = hdfs.getFileStatus( resolvedPath )
+
+        def buildLink (name: String): String = {
+          "__extra_classpath_link__" + name.replaceAll( "[/\\\\:.-]", "_" ).trim
+        }
+
+        val link: String = buildLink( resolvedPath.toUri.getPath )
+
+        localResources( link ) = LocalResource.newInstance(
+          ConverterUtils.getYarnUrlFromPath( resolvedPath ),
+          LocalResourceType.FILE,
+          LocalResourceVisibility.PRIVATE,
+          fileStatus.getLen,
+          fileStatus.getModificationTime )
+      }
+
+      val extraResources = sparkConf.get( SparkLauncher.EXECUTOR_EXTRA_CLASSPATH ).split( "," )
+      extraResources.filter( _.startsWith( "hdfs://" ) ).foreach( path => addResource( path ) )
+
+    } catch {
+      case err: Throwable =>
+        logError( s"Failed to prepare links for executor extra classpath hdfs:// resources $err" )
+        throw err
+    }
   }
 
   def getAttemptId(): ApplicationAttemptId = {
@@ -350,7 +408,7 @@ private[spark] class ApplicationMaster(
       uiAddress,
       historyAddress,
       securityMgr,
-      localResources)
+      executorLocalResources)
 
     allocator.allocateResources()
     reporterThread = launchReporterThread()

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1268,12 +1268,17 @@ private object Client extends Logging {
       conf: Configuration,
       sparkConf: SparkConf,
       env: HashMap[String, String],
-      extraClassPath: Option[String] = None): Unit = {
+      extraClassPath: Option[String] = None,
+      extraClassPathLinks: Option[Set[String]] = None): Unit = {
     extraClassPath.foreach { cp =>
       addClasspathEntry(getClusterPath(sparkConf, cp), env)
     }
 
     addClasspathEntry(YarnSparkHadoopUtil.expandEnvironment(Environment.PWD), env)
+
+    if (extraClassPathLinks.isDefined) {
+      extraClassPathLinks.get.foreach { link => addClasspathEntry(link, env) }
+    }
 
     addClasspathEntry(
       YarnSparkHadoopUtil.expandEnvironment(Environment.PWD) + Path.SEPARATOR +

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -40,6 +40,7 @@ import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
+import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.launcher.YarnCommandBuilderUtils
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
@@ -93,6 +94,10 @@ private[yarn] class ExecutorRunnable(
       |YARN executor launch context:
       |  env:
       |${env.map { case (k, v) => s"    $k -> $v\n" }.mkString}
+      |
+      |  local resources:
+      |${localResources.map { case (k, v) => s"    $k -> $v\n" }.mkString}
+      |
       |  command:
       |    ${commands.mkString(" ")}
       |===============================================================================
@@ -238,7 +243,8 @@ private[yarn] class ExecutorRunnable(
 
   private def prepareEnvironment(container: Container): HashMap[String, String] = {
     val env = new HashMap[String, String]()
-    Client.populateClasspath(null, yarnConf, sparkConf, env, sparkConf.get(EXECUTOR_CLASS_PATH))
+    val extraClassPath: Option[String] = sparkConf.get(EXECUTOR_CLASS_PATH)
+    Client.populateClasspath(null, yarnConf, sparkConf, env, extraClassPath, getExtraLinks())
 
     sparkConf.getExecutorEnv.foreach { case (key, value) =>
       // This assumes each executor environment variable set here is a path
@@ -271,5 +277,22 @@ private[yarn] class ExecutorRunnable(
     System.getenv().asScala.filterKeys(_.startsWith("SPARK"))
       .foreach { case (k, v) => env(k) = v }
     env
+  }
+
+  /**
+   *
+   * Get all extra classpath links prepared by {@see org.apache.spark.deploy.yarn.ApplicationMaster}
+   * These links will be added to executor CLASSPATH,
+   * which provides possibility to use hdfs-located resources for executor extra classpath
+   *
+   * @return executor extra classpath links which points to hdfs resources
+   */
+  private def getExtraLinks(): Option[Set[String]] = {
+    if (sparkConf.contains(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH)
+      && sparkConf.get(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH).contains("hdfs://")) {
+      Some(localResources.filterKeys(_.startsWith("__extra_classpath_link__")).keySet)
+    } else {
+      None
+    }
   }
 }


### PR DESCRIPTION
The main goal behind these changes are provide support to use HDFS resources for "spark.executor.extraClassPath", when Hadoop/YARN deployments used.
 This can be helpful when you want to use custom SparkSerializer implementation (our project case).

How it works with these changes:
1. Value of "spark.executor.extraClassPath" splits by comma
2. Iterate over all paths and filter those which started with "hdfs;//"
3. Generate link for each path and add LocalResource to executor launch context local resources
4. Add generated links to executor CLASSPATH
5. NodeManager loads the specified local resources to application cache

After that, you do not need deploy extra resources to each Hadoop node manually, it will be automatically.

The changes fully backward compatible and does not break any existing "spark.executor.extraClassPath" usages.

This patch was tested manually on our Hadoop cluster (4-nodes).
