### PR TITLE
[HOTFIX][SQL] sparkSession can't be private.

### DIFF
--- a/sql/hivecontext-compatibility/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hivecontext-compatibility/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{SparkSession, SQLContext}
  */
 @deprecated("Use SparkSession.withHiveSupport instead", "2.0.0")
 class HiveContext private[hive](
-    @transient private val sparkSession: SparkSession,
+    @transient override val sparkSession: SparkSession,
     isRootContext: Boolean)
   extends SQLContext(sparkSession, isRootContext) with Logging {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fixes the following errors.

```
-    @transient private val sparkSession: SparkSession,
+    @transient override val sparkSession: SparkSession,
```

**Build Error**

```
[error]  value sparkSession has weaker access privileges; it should not be private
[error]     @transient private val sparkSession: SparkSession,
[error]                            ^
[error] one error found
[error] (hivecontext-compatibility/compile:compileIncremental) Compilation failed
```
## How was this patch tested?

Pass the Jenkins build.
