### PR TITLE
[MINOR] Follow-up to #12625

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -360,10 +360,10 @@ private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasM
  */
 @Since("1.6.0")
 @Experimental
-sealed abstract class LDAModel protected[ml] (
+sealed abstract class LDAModel private[ml] (
     @Since("1.6.0") override val uid: String,
     @Since("1.6.0") val vocabSize: Int,
-    @Since("1.6.0") @transient protected[ml] val sparkSession: SparkSession)
+    @Since("1.6.0") @transient private[ml] val sparkSession: SparkSession)
   extends Model[LDAModel] with LDAParams with Logging with MLWritable {
 
   // NOTE to developers:
@@ -512,7 +512,7 @@ sealed abstract class LDAModel protected[ml] (
  */
 @Since("1.6.0")
 @Experimental
-class LocalLDAModel protected[ml] (
+class LocalLDAModel private[ml] (
     uid: String,
     vocabSize: Int,
     @Since("1.6.0") override protected val oldLocalModel: OldLocalLDAModel,
@@ -604,7 +604,7 @@ object LocalLDAModel extends MLReadable[LocalLDAModel] {
  */
 @Since("1.6.0")
 @Experimental
-class DistributedLDAModel protected[ml] (
+class DistributedLDAModel private[ml] (
     uid: String,
     vocabSize: Int,
     private val oldDistributedModel: OldDistributedLDAModel,

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -673,8 +673,18 @@ object MimaExcludes {
         ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.executor.OutputMetrics.this")
       ) ++ Seq(
         // SPARK-14861: Replace internal usages of SQLContext with SparkSession
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.apache.spark.ml.clustering.LocalLDAModel.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.apache.spark.ml.clustering.DistributedLDAModel.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.apache.spark.ml.clustering.LDAModel.this"),
         ProblemFilters.exclude[DirectMissingMethodProblem](
-          "org.apache.spark.ml.clustering.LDAModel.sqlContext")
+          "org.apache.spark.ml.clustering.LDAModel.sqlContext"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.apache.spark.sql.Dataset.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.apache.spark.sql.DataFrameReader.this")
       ) ++ Seq(
         // [SPARK-4452][Core]Shuffle data structures can starve others on the same thread for memory
         ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.util.collection.Spillable")

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -673,18 +673,8 @@ object MimaExcludes {
         ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.executor.OutputMetrics.this")
       ) ++ Seq(
         // SPARK-14861: Replace internal usages of SQLContext with SparkSession
-        ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.apache.spark.ml.clustering.LocalLDAModel.this"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.apache.spark.ml.clustering.DistributedLDAModel.this"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.apache.spark.ml.clustering.LDAModel.this"),
         ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.apache.spark.ml.clustering.LDAModel.sqlContext"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.apache.spark.sql.Dataset.this"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.apache.spark.sql.DataFrameReader.this")
       ) ++ Seq(
         // [SPARK-4452][Core]Shuffle data structures can starve others on the same thread for memory
         ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.util.collection.Spillable")

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -674,7 +674,7 @@ object MimaExcludes {
       ) ++ Seq(
         // SPARK-14861: Replace internal usages of SQLContext with SparkSession
         ProblemFilters.exclude[DirectMissingMethodProblem](
-          "org.apache.spark.ml.clustering.LDAModel.sqlContext"),
+          "org.apache.spark.ml.clustering.LDAModel.sqlContext")
       ) ++ Seq(
         // [SPARK-4452][Core]Shuffle data structures can starve others on the same thread for memory
         ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.util.collection.Spillable")

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.types.StructType
  * @since 1.4.0
  */
 @Experimental
-class DataFrameReader protected[sql](sparkSession: SparkSession) extends Logging {
+class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
 
   /**
    * Specifies the input data source format.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -151,7 +151,7 @@ private[sql] object Dataset {
  *
  * @since 1.6.0
  */
-class Dataset[T] protected[sql](
+class Dataset[T] private[sql](
     @transient val sparkSession: SparkSession,
     @DeveloperApi @transient val queryExecution: QueryExecution,
     encoder: Encoder[T])


### PR DESCRIPTION
## What changes were proposed in this pull request?

That patch mistakenly widened the visibility from `private[x]` to `protected[x]`. This patch reverts those changes.
