### PR TITLE
[SPARK-14914] Fix Command too long for windows. Especially for test cases. 

### DIFF
--- a/bin/spark-submit.cmd
+++ b/bin/spark-submit.cmd
@@ -20,4 +20,4 @@ rem
 rem This is the entry point for running Spark submit. To avoid polluting the
 rem environment, it just launches a new cmd to do the real work.
 
-cmd /V /E /C "%~dp0spark-submit2.cmd" %*
+cmd /V /E /C ""%~dp0spark-submit2.cmd" %*"

--- a/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
@@ -181,6 +181,11 @@ private[deploy] class DriverRunner(
       Files.append(header, stderr, StandardCharsets.UTF_8)
       CommandUtils.redirectStream(process.getErrorStream, stderr)
     }
+
+    if (Utils.isWindows) {
+      Utils.shortenClasspath(builder)
+    }
+
     runCommandWithRetry(ProcessBuilderLike(builder), initialize, supervise)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -145,6 +145,11 @@ private[deploy] class ExecutorRunner(
       val builder = CommandUtils.buildProcessBuilder(appDesc.command, new SecurityManager(conf),
         memory, sparkHome.getAbsolutePath, substituteVariables)
       val command = builder.command()
+
+      if (Utils.isWindows) {
+        Utils.shortenClasspath(builder)
+      }
+
       val formattedCommand = command.asScala.mkString("\"", "\" \"", "\"")
       logInfo(s"Launch command: $formattedCommand")
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1099,16 +1099,15 @@ private[spark] object Utils extends Logging {
   def createShortClassPath(tempDir: File, classPath: String) : String = {
     if (isWindows) {
       val env = new util.HashMap[String, String](System.getenv())
-      val javaCp = FileUtil
+      val javaCps = FileUtil
         .createJarWithClassPath(classPath, new Path(tempDir.getAbsolutePath), env)
-        .mkString(File.pathSeparator)
-      logInfo("Shorten the class path to: " + javaCp)
-      javaCp
+      val javaCpStr = javaCps(0) + javaCps(1)
+      logInfo("Shorten the class path to: " + javaCpStr)
+      javaCpStr
     } else {
       classPath
     }
   }
-
 
   def createShortClassPath(classPath: String) : String = {
     val tempDir = createTempDir("classpaths")

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -110,7 +110,7 @@ private[spark] object Utils extends Logging {
   }
 
   /** Deserialize a Long value (used for [[org.apache.spark.api.python.PythonPartitioner]]) */
-  def deserializeLongValue(bytes: Array[Byte]) : Long = {
+  def deserializeLongValue(bytes: Array[Byte]): Long = {
     // Note: we assume that we are given a Long value encoded in network (big-endian) byte order
     var result = bytes(7) & 0xFFL
     result = result + ((bytes(6) & 0xFFL) << 8)
@@ -1096,7 +1096,7 @@ private[spark] object Utils extends Logging {
    * Create a jar file at the given path, containing a manifest with a classpath
    * that references all specified entries.
    */
-  def createShortClassPath(tempDir: File, classPath: String) : String = {
+  def createShortClassPath(tempDir: File, classPath: String): String = {
     if (isWindows) {
       val env = new util.HashMap[String, String](System.getenv())
       val javaCps = FileUtil
@@ -1109,7 +1109,7 @@ private[spark] object Utils extends Logging {
     }
   }
 
-  def createShortClassPath(classPath: String) : String = {
+  def createShortClassPath(classPath: String): String = {
     val tempDir = createTempDir("classpaths")
     createShortClassPath(tempDir, classPath)
   }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1137,23 +1137,6 @@ private[spark] object Utils extends Logging {
 
 
   /**
-   * Normalize the local path for windows. If the path is absolute (starts with drive label)
-   * it will append a leading slash. The back slashes will be replaced with slash
-   * @param path the path to be normalized
-   * @return the normalized path
-   */
-  def normalizePath(path: String): String = {
-    if (isWindows) {
-      if (path.matches("""^[A-Za-z]:[/\\].*$""")) {
-        "/" + path.replace("\\", "/")
-      } else {
-        path.replace("\\", "/")
-      }
-    } else {
-      path
-    }
-  }
-  /**
    * Execute a command and return the process running the command.
    */
   def executeCommand(

--- a/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
+++ b/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
@@ -23,12 +23,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang.SystemUtils;
-import org.apache.spark.util.Utils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import static org.junit.Assert.*;
+
+import org.apache.spark.util.Utils;
 
 /**
  * These tests require the Spark assembly to be built before they can be run.

--- a/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
+++ b/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
@@ -105,7 +105,8 @@ public class SparkLauncherSuite {
       .addSparkArg(opts.CLASS, "ShouldBeOverriddenBelow")
       .setMainClass(SparkLauncherTestApp.class.getName())
       .addAppArgs("proc");
-        File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
+
+    File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     try {
       if (SystemUtils.IS_OS_WINDOWS) {
         launcher.setConf(SparkLauncher.DRIVER_EXTRA_CLASSPATH,
@@ -122,7 +123,8 @@ public class SparkLauncherSuite {
       if(tempDir.exists()) {
         Utils.deleteRecursively(tempDir);
       }
-    }  }
+    }
+  }
 
   public static class SparkLauncherTestApp {
 

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -217,10 +217,12 @@ abstract class AbstractCommandBuilder {
         boolean foundWildCardJar = false;
         // Append all jars that match the wildcard
         File[] files = new File(classPathEntry.substring(0, classPathEntry.length() - 2)).listFiles();
-        for(File f: files) {
-          if (f.getName().toLowerCase().endsWith("jar")) {
-            foundWildCardJar = true;
-            classPathEntryList.add(f.getAbsoluteFile().toURI().toURL().toExternalForm());
+        if (files != null) {
+          for (File f : files) {
+            if (f.getName().toLowerCase().endsWith("jar")) {
+              foundWildCardJar = true;
+              classPathEntryList.add(f.getAbsoluteFile().toURI().toURL().toExternalForm());
+            }
           }
         }
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -23,8 +23,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
+import com.sun.javafx.util.Utils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -66,7 +70,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
       parser.DRIVER_MEMORY,
       "42g",
       parser.DRIVER_CLASS_PATH,
-      "/driverCp",
+      Utils.isWindows() ? "D:/driverCp" : "/driverCp",
       parser.DRIVER_JAVA_OPTIONS,
       "extraJavaOpt",
       parser.CONF,
@@ -78,7 +82,25 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     assertTrue(findInStringList(env.get(CommandBuilderUtils.getLibPathEnvName()),
         File.pathSeparator, "/driverLibPath"));
-    assertTrue(findInStringList(findArgValue(cmd, "-cp"), File.pathSeparator, "/driverCp"));
+    if (!Utils.isWindows())
+    {
+      assertTrue(findInStringList(findArgValue(cmd, "-cp"), File.pathSeparator, "/driverCp"));
+    } else {
+      String[] cp = findArgValue(cmd, "-cp").split(File.pathSeparator);
+      JarFile jarFile = null;
+      try {
+        jarFile = new JarFile(cp[0]);
+        Manifest jarManifest = jarFile.getManifest();
+        Attributes attrs = jarManifest.getMainAttributes();
+        String classPath = attrs.getValue(Attributes.Name.CLASS_PATH);
+        assertTrue(contains("file:/D:/driverCp", classPath.split(" ")));
+      } finally {
+        if (jarFile != null) {
+          jarFile.close();
+        }
+
+      }
+    }
     assertTrue("Driver -Xmx should be configured.", cmd.contains("-Xmx42g"));
     assertTrue("Command should contain user-defined conf.",
       Collections.indexOfSubList(cmd, Arrays.asList(parser.CONF, "spark.randomOption=foo")) > 0);
@@ -187,7 +209,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     if (!useDefaultPropertyFile) {
       launcher.setPropertiesFile(dummyPropsFile.getAbsolutePath());
       launcher.conf.put(SparkLauncher.DRIVER_MEMORY, "1g");
-      launcher.conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, "/driver");
+      launcher.conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, Utils.isWindows() ? "D:/driver": "/driver");
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, "-Ddriver -XX:MaxPermSize=256m");
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_LIBRARY_PATH, "/native");
     } else {
@@ -220,10 +242,30 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     }
 
     String[] cp = findArgValue(cmd, "-cp").split(Pattern.quote(File.pathSeparator));
-    if (isDriver) {
-      assertTrue("Driver classpath should contain provided entry.", contains("/driver", cp));
+    if (!Utils.isWindows()) {
+      if (isDriver) {
+        assertTrue("Driver classpath should contain provided entry.", contains("/driver", cp));
+      } else {
+        assertFalse("Driver classpath should not be in command.", contains("/driver", cp));
+      }
     } else {
-      assertFalse("Driver classpath should not be in command.", contains("/driver", cp));
+      JarFile jarFile = null;
+      try {
+        jarFile = new JarFile(cp[0]);
+        Manifest jarManifest = jarFile.getManifest();
+        Attributes attrs = jarManifest.getMainAttributes();
+        String classPath = attrs.getValue(Attributes.Name.CLASS_PATH);
+        if (isDriver) {
+          assertTrue(contains("file:/D:/driver", classPath.split(" ")));
+        } else {
+          assertFalse(contains("file:/D:/driver", classPath.split(" ")));
+        }
+      } finally {
+        if (jarFile != null) {
+          jarFile.close();
+        }
+
+      }
     }
 
     String libPath = env.get(CommandBuilderUtils.getLibPathEnvName());

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -28,7 +28,6 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
-import com.sun.javafx.util.Utils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -70,7 +69,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
       parser.DRIVER_MEMORY,
       "42g",
       parser.DRIVER_CLASS_PATH,
-      Utils.isWindows() ? "D:/driverCp" : "/driverCp",
+      CommandBuilderUtils.isWindows() ? "D:/driverCp" : "/driverCp",
       parser.DRIVER_JAVA_OPTIONS,
       "extraJavaOpt",
       parser.CONF,
@@ -82,7 +81,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     assertTrue(findInStringList(env.get(CommandBuilderUtils.getLibPathEnvName()),
         File.pathSeparator, "/driverLibPath"));
-    if (!Utils.isWindows())
+    if (!CommandBuilderUtils.isWindows())
     {
       assertTrue(findInStringList(findArgValue(cmd, "-cp"), File.pathSeparator, "/driverCp"));
     } else {
@@ -209,7 +208,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     if (!useDefaultPropertyFile) {
       launcher.setPropertiesFile(dummyPropsFile.getAbsolutePath());
       launcher.conf.put(SparkLauncher.DRIVER_MEMORY, "1g");
-      launcher.conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, Utils.isWindows() ? "D:/driver": "/driver");
+      launcher.conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, CommandBuilderUtils.isWindows() ? "D:/driver": "/driver");
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, "-Ddriver -XX:MaxPermSize=256m");
       launcher.conf.put(SparkLauncher.DRIVER_EXTRA_LIBRARY_PATH, "/native");
     } else {
@@ -242,7 +241,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     }
 
     String[] cp = findArgValue(cmd, "-cp").split(Pattern.quote(File.pathSeparator));
-    if (!Utils.isWindows()) {
+    if (!CommandBuilderUtils.isWindows()) {
       if (isDriver) {
         assertTrue("Driver classpath should contain provided entry.", contains("/driver", cp));
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Windows has a limitation of 8192 characters on command line. This limitation will fail the test cases related to command builder in some test cases. This pull request adopt the method in Hadoop, which create a Jar that ref all the dependencies in the manifest to shorten the class path passing to the command line. 
## How was this patch tested?

Unit tests on windows and Linux. Note that this commit can't fix all the unit test errors on windows. 
