### PR TITLE
[SPARK-14754][SPARK CORE] Metrics as logs are not coming through slf4j

### DIFF
--- a/conf/log4j.properties.template
+++ b/conf/log4j.properties.template
@@ -38,3 +38,14 @@ log4j.logger.parquet=ERROR
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
 log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+# SPARK-14754: Metrics as logs are not coming through slf4j.
+#log4j.logger.org.apache.spark.metrics=INFO, metricFileAppender
+#log4j.additivity.org.apache.spark.metrics=true
+
+#log4j.appender.metricFileAppender=org.apache.log4j.RollingFileAppender
+#log4j.appender.metricFileAppender.File=${logFilePath}
+#log4j.appender.metricFileAppender.MaxFileSize=10MB
+#log4j.appender.metricFileAppender.MaxBackupIndex=10
+#log4j.appender.metricFileAppender.layout=org.apache.log4j.PatternLayout
+#log4j.appender.metricFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/core/src/main/scala/org/apache/spark/metrics/sink/Slf4jSink.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/Slf4jSink.scala
@@ -22,11 +22,11 @@ import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.{MetricRegistry, Slf4jReporter}
 
-import org.apache.spark.SecurityManager
-import org.apache.spark.metrics.MetricsSystem
-
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+
+import org.apache.spark.SecurityManager
+import org.apache.spark.metrics.MetricsSystem
 
 private[spark] class Slf4jSink(
     val property: Properties,

--- a/core/src/main/scala/org/apache/spark/metrics/sink/Slf4jSink.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/Slf4jSink.scala
@@ -25,6 +25,9 @@ import com.codahale.metrics.{MetricRegistry, Slf4jReporter}
 import org.apache.spark.SecurityManager
 import org.apache.spark.metrics.MetricsSystem
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 private[spark] class Slf4jSink(
     val property: Properties,
     val registry: MetricRegistry,
@@ -49,6 +52,7 @@ private[spark] class Slf4jSink(
   MetricsSystem.checkMinimalPollingPeriod(pollUnit, pollPeriod)
 
   val reporter: Slf4jReporter = Slf4jReporter.forRegistry(registry)
+    .outputTo(LoggerFactory.getLogger("org.apache.spark.metrics"))
     .convertDurationsTo(TimeUnit.MILLISECONDS)
     .convertRatesTo(TimeUnit.SECONDS)
     .build()

--- a/core/src/main/scala/org/apache/spark/metrics/sink/Slf4jSink.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/Slf4jSink.scala
@@ -52,7 +52,7 @@ private[spark] class Slf4jSink(
   MetricsSystem.checkMinimalPollingPeriod(pollUnit, pollPeriod)
 
   val reporter: Slf4jReporter = Slf4jReporter.forRegistry(registry)
-    .outputTo(LoggerFactory.getLogger("org.apache.spark.metrics"))
+    .outputTo(LoggerFactory.getLogger("org.apache.spark.metrics.sink.Slf4jSink"))
     .convertDurationsTo(TimeUnit.MILLISECONDS)
     .convertRatesTo(TimeUnit.SECONDS)
     .build()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two changes need to be done : 
1) Slf4jsink.scala 
        Added class name for logging. (Reference : https://dropwizard.github.io/metrics/3.1.0/manual/core/#man-core-reporters-slf4j )

2) log4j.properties.template
        Added log configuration in log4j.properties.template for in support of above changes.
## How was this patch tested?

It is tested with manual testing. I build spark with make-distribution.sh and then tried few example job to print Metrics in log files.
