### PR TITLE
[SPARK-14899] [ML] [PySpark] Remove spark.ml HashingTF hashingAlg option

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -31,9 +31,11 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
 /**
  * :: Experimental ::
  * Maps a sequence of terms to their term frequencies using the hashing trick.
- * Currently we support one hash algorithms "murmur3" which is also the default option.
- * "murmur3" calculates a hash code value for the term object using
- * Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32).
+ * Currently we use Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32)
+ * to calculate the hash code value for the term object.
+ * Since a simple modulo is used to transform the hash function to a column index,
+ * it is advisable to use a power of two as the numFeatures parameter;
+ * otherwise the features will not be mapped evenly to the columns.
  */
 @Experimental
 class HashingTF(override val uid: String)
@@ -66,19 +68,7 @@ class HashingTF(override val uid: String)
     "This is useful for discrete probabilistic models that model binary events rather " +
     "than integer counts")
 
-  /**
-   * The hash algorithm used when mapping term to integer.
-   * Supported options: "murmur3".
-   * (Default = "murmur3")
-   * @group expertParam
-   */
-  val hashAlgorithm = new Param[String](this, "hashAlgorithm", "The hash algorithm used when " +
-    "mapping term to integer. Supported options: " +
-    s"${feature.HashingTF.supportedHashAlgorithms.mkString(",")}.",
-    ParamValidators.inArray[String](feature.HashingTF.supportedHashAlgorithms))
-
-  setDefault(numFeatures -> (1 << 18), binary -> false,
-    hashAlgorithm -> feature.HashingTF.Murmur3)
+  setDefault(numFeatures -> (1 << 18), binary -> false)
 
   /** @group getParam */
   def getNumFeatures: Int = $(numFeatures)
@@ -92,18 +82,10 @@ class HashingTF(override val uid: String)
   /** @group setParam */
   def setBinary(value: Boolean): this.type = set(binary, value)
 
-  /** @group expertGetParam */
-  def getHashAlgorithm: String = $(hashAlgorithm)
-
-  /** @group expertSetParam */
-  def setHashAlgorithm(value: String): this.type = set(hashAlgorithm, value)
-
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema)
-    val hashingTF = new feature.HashingTF($(numFeatures))
-      .setBinary($(binary))
-      .setHashAlgorithm($(hashAlgorithm))
+    val hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
     val t = udf { terms: Seq[_] => hashingTF.transform(terms) }
     val metadata = outputSchema($(outputCol)).metadata
     dataset.select(col("*"), t(col($(inputCol))).as($(outputCol), metadata))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -31,12 +31,9 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
 /**
  * :: Experimental ::
  * Maps a sequence of terms to their term frequencies using the hashing trick.
- * Currently we support two hash algorithms: "murmur3" (default) and "native".
+ * Currently we support one hash algorithms "murmur3" which is also the default option.
  * "murmur3" calculates a hash code value for the term object using
- * Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32);
- * "native" calculates the hash code value using the native Scala implementation.
- * In Spark 1.6 and earlier, "native" is the default hash algorithm;
- * after Spark 2.0, we use "murmur3" as the default one.
+ * Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32).
  */
 @Experimental
 class HashingTF(override val uid: String)
@@ -71,8 +68,7 @@ class HashingTF(override val uid: String)
 
   /**
    * The hash algorithm used when mapping term to integer.
-   * Supported options: "murmur3" and "native". We use "native" as default hash algorithm
-   * in Spark 1.6 and earlier. After Spark 2.0, we use "murmur3" as default one.
+   * Supported options: "murmur3".
    * (Default = "murmur3")
    * @group expertParam
    */

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -135,8 +135,6 @@ object HashingTF {
 
   private[spark] val Murmur3: String = "murmur3"
 
-  private[spark] val supportedHashAlgorithms: Array[String] = Array(Murmur3)
-
   private val seed = 42
 
   /**
@@ -148,7 +146,7 @@ object HashingTF {
   /**
    * Calculate a hash code value for the term object using
    * Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32).
-   * This is the default hash algorithm used after Spark 2.0.
+   * This is the default hash algorithm used from Spark 2.0 onwards.
    */
   private[spark] def murmur3Hash(term: Any): Int = {
     term match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -135,18 +135,20 @@ object HashingTF {
 
   private[spark] val Murmur3: String = "murmur3"
 
-  private[spark] val supportedHashAlgorithms: Array[String] = Array(Native, Murmur3)
+  private[spark] val supportedHashAlgorithms: Array[String] = Array(Murmur3)
 
   private val seed = 42
 
   /**
    * Calculate a hash code value for the term object using the native Scala implementation.
+   * This is the default hash algorithm used in Spark 1.6 and earlier.
    */
   private[spark] def nativeHash(term: Any): Int = term.##
 
   /**
    * Calculate a hash code value for the term object using
    * Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32).
+   * This is the default hash algorithm used after Spark 2.0.
    */
   private[spark] def murmur3Hash(term: Any): Int = {
     term match {

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -544,8 +544,8 @@ class HashingTF(JavaTransformer, HasInputCol, HasOutputCol, HasNumFeatures, Java
                    typeConverter=TypeConverters.toBoolean)
 
     hashAlgorithm = Param(Params._dummy(), "hashAlgorithm", "The hash algorithm used when " +
-                          "mapping term to integer. Supported options: murmur3(default) " +
-                          "and native.", typeConverter=TypeConverters.toString)
+                          "mapping term to integer. Supported options: murmur3 (default).",
+                          typeConverter=TypeConverters.toString)
 
     @keyword_only
     def __init__(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None,

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -517,8 +517,12 @@ class HashingTF(JavaTransformer, HasInputCol, HasOutputCol, HasNumFeatures, Java
     """
     .. note:: Experimental
 
-    Maps a sequence of terms to their term frequencies using the
-    hashing trick.
+    Maps a sequence of terms to their term frequencies using the hashing trick.
+    Currently we use Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32)
+    to calculate the hash code value for the term object.
+    Since a simple modulo is used to transform the hash function to a column index,
+    it is advisable to use a power of two as the numFeatures parameter;
+    otherwise the features will not be mapped evenly to the columns.
 
     >>> df = sqlContext.createDataFrame([(["a", "b", "c"],)], ["words"])
     >>> hashingTF = HashingTF(numFeatures=10, inputCol="words", outputCol="features")
@@ -543,30 +547,22 @@ class HashingTF(JavaTransformer, HasInputCol, HasOutputCol, HasNumFeatures, Java
                    "rather than integer counts. Default False.",
                    typeConverter=TypeConverters.toBoolean)
 
-    hashAlgorithm = Param(Params._dummy(), "hashAlgorithm", "The hash algorithm used when " +
-                          "mapping term to integer. Supported options: murmur3 (default).",
-                          typeConverter=TypeConverters.toString)
-
     @keyword_only
-    def __init__(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None,
-                 hashAlgorithm="murmur3"):
+    def __init__(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None):
         """
-        __init__(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None, \
-                 hashAlgorithm="murmur3")
+        __init__(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None)
         """
         super(HashingTF, self).__init__()
         self._java_obj = self._new_java_obj("org.apache.spark.ml.feature.HashingTF", self.uid)
-        self._setDefault(numFeatures=1 << 18, binary=False, hashAlgorithm="murmur3")
+        self._setDefault(numFeatures=1 << 18, binary=False)
         kwargs = self.__init__._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
     @since("1.3.0")
-    def setParams(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None,
-                  hashAlgorithm="murmur3"):
+    def setParams(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None):
         """
-        setParams(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None, \
-                  hashAlgorithm="murmur3")
+        setParams(self, numFeatures=1 << 18, binary=False, inputCol=None, outputCol=None)
         Sets params for this HashingTF.
         """
         kwargs = self.setParams._input_kwargs
@@ -586,21 +582,6 @@ class HashingTF(JavaTransformer, HasInputCol, HasOutputCol, HasNumFeatures, Java
         Gets the value of binary or its default value.
         """
         return self.getOrDefault(self.binary)
-
-    @since("2.0.0")
-    def setHashAlgorithm(self, value):
-        """
-        Sets the value of :py:attr:`hashAlgorithm`.
-        """
-        self._set(hashAlgorithm=value)
-        return self
-
-    @since("2.0.0")
-    def getHashAlgorithm(self):
-        """
-        Gets the value of hashAlgorithm or its default value.
-        """
-        return self.getOrDefault(self.hashAlgorithm)
 
 
 @inherit_doc

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -916,15 +916,12 @@ class HashingTFTest(PySparkTestCase):
         sqlContext = SQLContext(self.sc)
 
         df = sqlContext.createDataFrame([(0, ["a", "a", "b", "c", "c", "c"])], ["id", "words"])
-        n = 100
+        n = 10
         hashingTF = HashingTF()
-        hashingTF.setInputCol("words").setOutputCol("features").setNumFeatures(n)\
-            .setBinary(True).setHashAlgorithm("native")
+        hashingTF.setInputCol("words").setOutputCol("features").setNumFeatures(n).setBinary(True)
         output = hashingTF.transform(df)
         features = output.select("features").first().features.toArray()
-        expected = Vectors.sparse(n, {(ord("a") % n): 1.0,
-                                      (ord("b") % n): 1.0,
-                                      (ord("c") % n): 1.0}).toArray()
+        expected = Vectors.dense([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).toArray()
         for i in range(0, n):
             self.assertAlmostEqual(features[i], expected[i], 14, "Error at " + str(i) +
                                    ": expected " + str(expected[i]) + ", got " + str(features[i]))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since [SPARK-10574](https://issues.apache.org/jira/browse/SPARK-10574) breaks behavior of `HashingTF`, we should try to enforce good practice by removing the "native" hashAlgorithm option in spark.ml and pyspark.ml. We can leave spark.mllib and pyspark.mllib alone.
## How was this patch tested?

Unit tests.

cc @jkbradley 
