### PR TITLE
[SPARK-14920] [SQL] Location should not be Specified in Creating Non-external Table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -149,6 +149,11 @@ class SessionCatalog(
     val db = tableDefinition.identifier.database.getOrElse(currentDb)
     val table = formatTableName(tableDefinition.identifier.table)
     val newTableDefinition = tableDefinition.copy(identifier = TableIdentifier(table, Some(db)))
+    if (tableDefinition.storage.locationUri.isDefined &&
+        tableDefinition.tableType != CatalogTableType.EXTERNAL_TABLE) {
+      logWarning(s"Location: ${tableDefinition.storage.locationUri.get} specified for " +
+        s"non-external table:${tableDefinition.identifier}")
+    }
     externalCatalog.createTable(db, newTableDefinition, ignoreIfExists)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -106,7 +106,7 @@ case class CreateDataSourceTableCommand(
       partitionColumns = Array.empty[String],
       bucketSpec = None,
       provider = provider,
-      options = optionsWithPath,
+      options = if (isExternal) optionsWithPath else options,
       isExternal = isExternal)
 
     Seq.empty[Row]
@@ -234,7 +234,7 @@ case class CreateDataSourceTableAsSelectCommand(
         partitionColumns = partitionColumns,
         bucketSpec = bucketSpec,
         provider = provider,
-        options = optionsWithPath,
+        options = if (isExternal) optionsWithPath else options,
         isExternal = isExternal)
     }
 


### PR DESCRIPTION
#### What changes were proposed in this pull request?

When creating non-external tables, we should not specify the location. Below is the warning message we got.

```
09:58:00.952 WARN org.apache.hadoop.hive.metastore.HiveMetaStore: Location: file:/private/var/folders/4b/sgmfldk15js406vk7lw5llzw0000gn/T/spark-4bca5aef-13b6-4c58-96aa-6cf76d8d9131/metastore/testdb8156.db/ttt3 specified for non-external table:ttt3
```

This PR is to avoid setting the default location when the path is not specified. 
#### How was this patch tested?

The existing test cases
