### PR TITLE
[SPARK-11962] WIP: Added `attempt` and `getOption`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .ensime_cache/
 .ensime_lucene
 .generated-mima*
+.history
 .idea/
 .idea_modules/
 .project
@@ -39,6 +40,7 @@ dependency-reduced-pom.xml
 derby.log
 dev/create-release/*final
 dev/create-release/*txt
+dev/pr-deps/
 dist/
 docs/_site
 docs/api

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 import scala.util.hashing.MurmurHash3
 
 import org.apache.spark.sql.catalyst.expressions.GenericRow
@@ -324,6 +325,28 @@ trait Row extends Serializable {
   def getAs[T](i: Int): T = get(i).asInstanceOf[T]
 
   /**
+   * Returns the value at position i as a scala.util.Try object.
+   */
+  def attempt[T](i: Int): Try[T] = {
+    // TODO: Check why this code is failing to return a Failure when there should be a
+    // ClassCastException. Removing the nested Try and replacing the code block with a
+    // Try(getAs[T](i)) also does not seem to make a difference.
+    Try(isNullAt(i)) match {
+      case Success(isNull) =>
+        if (isNull) Failure(new NullPointerException(s"Value at index $i is null."))
+        else Try(getAs[T](i))
+      case Failure(exception) => Failure[T](exception)
+    }
+  }
+
+  /**
+   * Returns the Optional value at position i.
+   * If the value is null or if it cannot be cast to the requested type, None is returned. None is
+   * also returned if i greater then the number of fields in the row.
+   */
+  def getOption[T](i: Int): Option[T] = attempt[T](i).toOption
+
+  /**
    * Returns the value of a given fieldName.
    * For primitive types if value is null it returns 'zero value' specific for primitive
    * ie. 0 for Int - use isNullAt to ensure that value is not null
@@ -333,6 +356,19 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    */
   def getAs[T](fieldName: String): T = getAs[T](fieldIndex(fieldName))
+
+  /**
+   * Returns the value of a given fieldName as a scala.util.Try object.
+   */
+  def attempt[T](fieldName: String): Try[T] = Try(getAs[T](fieldIndex(fieldName)))
+
+  /**
+   * Returns the Optional value of a given fieldName.
+   * If the value is null or if it cannot be cast to the requested type, None is returned. None is
+   * also returned if either the schema is not defined or else the given fieldName does not exist
+   * in the schema.
+   */
+  def getOption[T](fieldName: String): Option[T] = attempt[T](fieldName).toOption
 
   /**
    * Returns the index of a given field name.
@@ -474,3 +510,4 @@ trait Row extends Serializable {
     if (isNullAt(i)) throw new NullPointerException(s"Value at index $i in null")
     else getAs[T](i)
 }
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import scala.util.{Failure, Success, Try}
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
@@ -211,6 +213,15 @@ class GenericRowWithSchema(values: Array[Any], override val schema: StructType)
   protected def this() = this(null, null)
 
   override def fieldIndex(name: String): Int = schema.fieldIndex(name)
+
+  override def attempt[T](fieldName: String): Try[T] = {
+    Try(fieldIndex(fieldName)) match {
+      case Success(i) => attempt[T](i)
+      case Failure(exception) => Failure[T](exception)
+    }
+  }
+
+  override def getOption[T](fieldName: String): Option[T] = attempt[T](fieldName).toOption
 }
 
 /**
@@ -251,3 +262,4 @@ class GenericMutableRow(values: Array[Any]) extends MutableRow with BaseGenericI
 
   override def copy(): InternalRow = new GenericInternalRow(values.clone())
 }
+

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import scala.util.{Failure, Success, Try}
+
 import org.scalatest.{FunSpec, Matchers}
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -27,17 +29,18 @@ class RowTest extends FunSpec with Matchers {
 
   val schema = StructType(
     StructField("col1", StringType) ::
-    StructField("col2", StringType) ::
-    StructField("col3", IntegerType) :: Nil)
-  val values = Array("value1", "value2", 1)
-  val valuesWithoutCol3 = Array[Any](null, "value2", null)
+    StructField("col2", DoubleType) ::
+    StructField("col3", IntegerType) ::
+    Nil)
+  val values = Array("value1", 1.0, 1)
+  val valuesWithoutCol3 = Array[Any]("value1", 1.0, null)
 
   val sampleRow: Row = new GenericRowWithSchema(values, schema)
   val sampleRowWithoutCol3: Row = new GenericRowWithSchema(valuesWithoutCol3, schema)
   val noSchemaRow: Row = new GenericRow(values)
 
   describe("Row (without schema)") {
-    it("throws an exception when accessing by fieldName") {
+    it("throws an exception when accessing by field name") {
       intercept[UnsupportedOperationException] {
         noSchemaRow.fieldIndex("col1")
       }
@@ -45,17 +48,148 @@ class RowTest extends FunSpec with Matchers {
         noSchemaRow.getAs("col1")
       }
     }
+
+    it("getAs[T]() should throw ClassCastException when casting fails.") {
+      intercept[ClassCastException] {
+        noSchemaRow.getAs[Int](0)
+      }
+    }
+
+    it("attempt[T]() returns Success for valid indices.") {
+      noSchemaRow.attempt[String](0) should be (Success("value1"))
+      noSchemaRow.attempt[Double](1) should be (Success(1.0))
+      noSchemaRow.attempt[Int](2) should be (Success(1))
+    }
+
+    it("attempt[T]() returns Failure for an invalid index.") {
+      val value = noSchemaRow.attempt[String](3)
+      value.getClass should be (classOf[Failure[String]])
+      intercept[IndexOutOfBoundsException] { value.get }
+    }
+
+    // TODO: Check why the commented out test works when it should behave the same.
+    it("attempt[T]() returns Failure for invalid casts.") {
+      val value = noSchemaRow.attempt[Int](0)
+      // val value = Try(noSchemaRow.getAs[Int](0))
+      value.getClass should be (classOf[Failure[Int]])
+      intercept[ClassCastException] { value.get }
+    }
+
+    it("attempt[T]() cannot get values using field names.") {
+      val value = noSchemaRow.attempt[String]("col1")
+      value.getClass should be (classOf[Failure[String]])
+      intercept[UnsupportedOperationException] { value.get }
+    }
+
+    it("getOption[T]() can get values for valid indices.") {
+      noSchemaRow.getOption[String](0) should be (Some("value1"))
+      noSchemaRow.getOption[Double](1) should be (Some(1.0))
+      noSchemaRow.getOption[Int](2) should be (Some(1))
+    }
+
+    it("getOption[T]() returns None for an invalid index.") {
+      noSchemaRow.getOption[String](3) should be (None)
+    }
+
+    it("getOption[T]() retrieves values for valid casts.") {
+      noSchemaRow.getOption[Int](1) should be (Some(1))
+      noSchemaRow.getOption[Long](1) should be (Some(1L))
+    }
+
+    // TODO: Check why the commented out test works when it should behave the same.
+    it("getOption[T]() returns None for invalid casts.") {
+      sampleRow.getOption[Int](0) should be (None)
+      // noSchemaRow.getOption[Int](0) should be (Some("value1"))
+      sampleRow.getOption[String](1) should be (None)
+      // noSchemaRow.getOption[String](1) should be (Some(1.0))
+    }
+
+    it("getOption[T]() cannot get values using field names.") {
+      noSchemaRow.getOption[String]("col1") should be (None)
+      noSchemaRow.getOption[Double]("col2") should be (None)
+      noSchemaRow.getOption[Int]("col3") should be (None)
+    }
   }
 
   describe("Row (with schema)") {
     it("fieldIndex(name) returns field index") {
-      sampleRow.fieldIndex("col1") shouldBe 0
-      sampleRow.fieldIndex("col3") shouldBe 2
+      sampleRow.fieldIndex("col1") should be (0)
+      sampleRow.fieldIndex("col3") should be (2)
     }
 
-    it("getAs[T] retrieves a value by fieldname") {
-      sampleRow.getAs[String]("col1") shouldBe "value1"
-      sampleRow.getAs[Int]("col3") shouldBe 1
+    it("getAs[T] retrieves a value by field name") {
+      sampleRow.getAs[String]("col1") should be ("value1")
+      sampleRow.getAs[Int]("col3") should be (1)
+    }
+
+    it("attempt[T]() returns Success for valid indices.") {
+      sampleRow.attempt[String](0) should be (Success("value1"))
+      sampleRow.attempt[Double](1) should be (Success(1.0))
+      sampleRow.attempt[Int](2) should be (Success(1))
+    }
+
+    it("attempt[T]() returns Failure for an invalid index.") {
+      val value = sampleRow.attempt[String](3)
+      value.getClass should be (classOf[Failure[String]])
+      intercept[IndexOutOfBoundsException] { value.get }
+    }
+
+    it("attempt[T]() can get values using field names.") {
+      sampleRow.attempt[String]("col1") should be (Success("value1"))
+      sampleRow.attempt[Double]("col2") should be (Success(1.0))
+      sampleRow.attempt[Int]("col3") should be (Success(1))
+    }
+
+    it("attempt[T]() returns Failure for an invalid field name.") {
+      val value = sampleRow.attempt[String]("col4")
+      value.getClass should be (classOf[Failure[String]])
+      intercept[IllegalArgumentException] { value.get }
+    }
+
+    it("attempt[T]() returns Success for valid casts.") {
+      sampleRow.attempt[Int]("col2") should be (Success(1))
+      sampleRow.attempt[Long]("col2") should be (Success(1L))
+    }
+
+    // TODO: Check why the commented out test works when it should behave the same.
+    it("attempt[T]() returns Failure for invalid casts.") {
+      val value = sampleRow.attempt[Int]("col1")
+      // val value = Try(sampleRow.getAs[Int]("col1"))
+      value.getClass should be (classOf[Failure[Int]])
+      intercept[ClassCastException] { value.get }
+    }
+
+    it("getOption[T]() can get values for valid indices.") {
+      sampleRow.getOption[String](0) should be (Some("value1"))
+      sampleRow.getOption[Double](1) should be (Some(1.0))
+      sampleRow.getOption[Int](2) should be (Some(1))
+    }
+
+    it("getOption[T]() returns None for an invalid index.") {
+      sampleRow.getOption[String](3) should be (None)
+    }
+
+    it("getOption[T]() can get values using field names.") {
+      sampleRow.getOption[String]("col1") should be (Some("value1"))
+      sampleRow.getOption[Double]("col2") should be (Some(1.0))
+      sampleRow.getOption[Int]("col3") should be (Some(1))
+    }
+
+    it("getOption[T]() returns None for an invalid field name.") {
+      sampleRow.getOption[String]("col4") should be (None)
+    }
+
+    it("getOption[T]() retrieves values for valid casts.") {
+      sampleRow.getOption[Int]("col2") should be (Some(1))
+      sampleRow.getOption[Long]("col2") should be (Some(1L))
+    }
+
+    // TODO: Check why the commented out test works when it should behave the same.
+    it("getOption[T]() returns None for invalid casts.") {
+      sampleRow.getOption[Int]("col1") should be (None)
+      // sampleRow.getOption[Int]("col1") should be (Some("value1"))
+      sampleRow.getOption[String]("col2") should be (None)
+      // sampleRow.getOption[String]("col2") should be (Some(1.0))
     }
 
     it("Accessing non existent field throws an exception") {
@@ -67,17 +201,19 @@ class RowTest extends FunSpec with Matchers {
     it("getValuesMap() retrieves values of multiple fields as a Map(field -> value)") {
       val expected = Map(
         "col1" -> "value1",
-        "col2" -> "value2"
+        "col2" -> 1.0,
+        "col3" -> 1
       )
-      sampleRow.getValuesMap(List("col1", "col2")) shouldBe expected
+      sampleRow.getValuesMap(List("col1", "col2", "col3")) should be (expected)
     }
 
     it("getValuesMap() retrieves null value on non AnyVal Type") {
       val expected = Map(
-        "col1" -> null,
-        "col2" -> "value2"
+        "col1" -> "value1",
+        "col2" -> 1.0,
+        "col3" -> null
       )
-      sampleRowWithoutCol3.getValuesMap[String](List("col1", "col2")) shouldBe expected
+      sampleRowWithoutCol3.getValuesMap[String](List("col1", "col2", "col3")) should be (expected)
     }
 
     it("getAs() on type extending AnyVal throws an exception when accessing field that is null") {
@@ -87,7 +223,7 @@ class RowTest extends FunSpec with Matchers {
     }
 
     it("getAs() on type extending AnyVal does not throw exception when value is null") {
-      sampleRowWithoutCol3.getAs[String](sampleRowWithoutCol3.fieldIndex("col1")) shouldBe null
+      sampleRowWithoutCol3.getAs[String](sampleRowWithoutCol3.fieldIndex("col3")) should be (null)
     }
   }
 
@@ -136,3 +272,4 @@ class RowTest extends FunSpec with Matchers {
     }
   }
 }
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds two major methods to Row, `attempt` and `getOption`. The former returns a `Try` while the latter returns an `Option`. The end use case for both `attempt` and `getOption` is to get values out of a row object without throwing an exception. However, in one of my previous PRs, #10247 (which didn't have an `attempt` method), it was pointed out by @marmbrus that the `getOption` method caught exceptions and converted them to `None`s. His point of view was that exceptions should not be automatically handled internally as that hid important information. But since the whole reason of `getOption` was to _not_ throw exceptions, I introduced the `attempt` method which returns `Success` and `Failure` objects, which do not lose information and `getOption`, which does and returns a `Some` or `None` but loses the information.
## How was this patch tested?

I've written extensive unit tests to test the features. The tests testing for `ClassCastException` do not pass though looking at the code, I cannot tell why. Would appreciate some feedback if anyone has insights. Also I think `attempt` might not be the best method name. So I am open to suggestions. Also, I am closing PR #12587 and creating this because it was pointing to `master` and not inconvenient to work with.
