### PR TITLE
[SPARK-14928] [SQL] support substitution in SET key=value

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -22,7 +22,7 @@ import java.util.NoSuchElementException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 
@@ -129,8 +129,10 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
     // Configures a single property.
     case Some((key, Some(value))) =>
       val runFunc = (sparkSession: SparkSession) => {
-        sparkSession.setConf(key, value)
-        Seq(Row(key, value))
+        val substitutedValue =
+          new VariableSubstitution(sparkSession.sessionState.conf).substitute(value)
+        sparkSession.sessionState.setConf(key, substitutedValue)
+        Seq(Row(key, substitutedValue))
       }
       (keyValueOutput, runFunc)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1082,6 +1082,16 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql(s"SET $nonexistentKey"),
       Row(nonexistentKey, "<undefined>")
     )
+
+    // substitution
+    sql("SET xxx=5")
+    sql("SET spark.sql.variable.substitute=false")
+    sql("SET yyy=${xxx}")
+    checkAnswer(sql("SET yyy"), Row("yyy", "${xxx}"))
+    sql("SET spark.sql.variable.substitute=true")
+    sql("SET zzz=${xxx}")
+    checkAnswer(sql("SET zzz"), Row("zzz", "5"))
+
     sqlContext.conf.clear()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the `SET key=value` command, value can be defined as a variable and replaced by substitution.
Since we have `VARIABLE_SUBSTITUTE_ENABLED` and `VARIABLE_SUBSTITUTE_DEPTH` defined in the SQLConf, it is nice to use them in the SET command.
## How was this patch tested?

New test case was added to test this function.
