### PR TITLE
[Spark-14933][SQL] Failed to create view out of a parquet or orc table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -293,7 +293,10 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           fileFormat = defaultSource,
           options = options)
 
-        val created = LogicalRelation(relation)
+        val created = LogicalRelation(
+          relation,
+          metastoreTableIdentifier =
+            Some(TableIdentifier(tableIdentifier.name, Some(tableIdentifier.database))))
         cachedDataSourceTables.put(tableIdentifier, created)
         created
       }
@@ -317,7 +320,10 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
               userSpecifiedSchema = Some(metastoreRelation.schema),
               bucketSpec = bucketSpec,
               options = options,
-              className = fileType).resolveRelation())
+              className = fileType).resolveRelation(),
+              metastoreTableIdentifier =
+                Some(TableIdentifier(tableIdentifier.name, Some(tableIdentifier.database))))
+
 
         cachedDataSourceTables.put(tableIdentifier, created)
         created

--- a/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
@@ -741,4 +741,38 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
   test("filter after subquery") {
     checkHiveQl("SELECT a FROM (SELECT key + 1 AS a FROM parquet_t1) t WHERE a > 5")
   }
+
+  test("select parquet table") {
+    withTable("parquet_t") {
+      sql(
+        """
+          |create table parquet_t (c1 int, c2 string) stored as parquet
+        """.stripMargin)
+      sql(
+        """
+          |insert into parquet_t values (1, 'abc')
+        """.stripMargin)
+      checkHiveQl(
+        """
+          |select * from parquet_t
+        """.stripMargin)
+    }
+  }
+
+  test("select orc table") {
+    withTable("orc_t") {
+      sql(
+        """
+          |create table orc_t (c1 int, c2 string) stored as orc
+        """.stripMargin)
+      sql(
+        """
+          |insert into orc_t values (1, 'abc')
+        """.stripMargin)
+      checkHiveQl(
+        """
+          |select * from orc_t
+        """.stripMargin)
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
@@ -746,16 +746,11 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     withTable("parquet_t") {
       sql(
         """
-          |create table parquet_t (c1 int, c2 string) stored as parquet
+          |create table parquet_t (c1 int, c2 string)
+          |stored as parquet select 1, 'abc'
         """.stripMargin)
-      sql(
-        """
-          |insert into parquet_t values (1, 'abc')
-        """.stripMargin)
-      checkHiveQl(
-        """
-          |select * from parquet_t
-        """.stripMargin)
+
+      checkHiveQl("select * from parquet_t")
     }
   }
 
@@ -763,16 +758,11 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     withTable("orc_t") {
       sql(
         """
-          |create table orc_t (c1 int, c2 string) stored as orc
+          |create table orc_t (c1 int, c2 string)
+          |stored as orc select 1, 'abc'
         """.stripMargin)
-      sql(
-        """
-          |insert into orc_t values (1, 'abc')
-        """.stripMargin)
-      checkHiveQl(
-        """
-          |select * from orc_t
-        """.stripMargin)
+
+      checkHiveQl("select * from orc_t")
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
@@ -742,7 +742,7 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     checkHiveQl("SELECT a FROM (SELECT key + 1 AS a FROM parquet_t1) t WHERE a > 5")
   }
 
-  test("select parquet table") {
+  test("SPARK-14933 - select parquet table") {
     withTable("parquet_t") {
       sql(
         """
@@ -759,7 +759,7 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     }
   }
 
-  test("select orc table") {
+  test("SPARK-14933 - select orc table") {
     withTable("orc_t") {
       sql(
         """

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
@@ -304,4 +304,34 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       }
     }
   }
+
+  test("SPARK-14933 - create view from hive parquet tabale") {
+    withTable("t_part") {
+      withView("v_part") {
+        sqlContext.sql(
+          """create table t_part (c1 int, c2 int)
+            |stored as parquet as select 1 as a, 2 as b
+          """.stripMargin)
+        sqlContext.sql("create view v_part as select * from t_part")
+        checkAnswer(
+          sql("select * from t_part"),
+          sql("select * from v_part"))
+      }
+    }
+  }
+
+  test("SPARK-14933 - create view from hive orc tabale") {
+    withTable("t_orc") {
+      withView("v_orc") {
+        sqlContext.sql(
+          """create table t_orc (c1 int, c2 int)
+            |stored as orc as select 1 as a, 2 as b
+          """.stripMargin)
+        sqlContext.sql("create view v_orc as select * from t_orc")
+        checkAnswer(
+          sql("select * from t_orc"),
+          sql("select * from v_orc"))
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
#### Symptom

 If a table is created as parquet or ORC table with hive syntaxt DDL, such as

``` SQL
create table t1 (c1 int, c2 string) stored as parquet
```

The following command will fail

``` SQL
create view v1 as select * from t1
```
#### Root Cause

Currently, `HiveMetaStoreCatalog` converts Paruqet/Orc tables to `LogicalRelation` without giving any `tableIdentifier`. `SQLBuilder` expects the `LogicalRelation` to have an associated `tableIdentifier`. However, the `LogicalRelation` created earlier does not have such a `tableIdentifier`. Thus, `SQLBuilder.toSQL` can not recognize this logical plan and issue an exception. 

This PR is to assign a `TableIdentifier` to the `LogicalRelation` when resolving parquet or orc tables in `HiveMetaStoreCatalog`. 
## How was this patch tested?

testcases created and dev/run-tests is run.
