### PR TITLE
[SPARK-14937][ML][Document]spark.ml LogisticRegression sqlCtx in scala is inconsistent with java and python

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/LinearRegressionWithElasticNetExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LinearRegressionWithElasticNetExample.scala
@@ -29,11 +29,11 @@ object LinearRegressionWithElasticNetExample {
   def main(args: Array[String]): Unit = {
     val conf = new SparkConf().setAppName("LinearRegressionWithElasticNetExample")
     val sc = new SparkContext(conf)
-    val sqlCtx = new SQLContext(sc)
+    val sqlContext = new SQLContext(sc)
 
     // $example on$
     // Load training data
-    val training = sqlCtx.read.format("libsvm")
+    val training = sqlContext.read.format("libsvm")
       .load("data/mllib/sample_linear_regression_data.txt")
 
     val lr = new LinearRegression()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionSummaryExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionSummaryExample.scala
@@ -30,11 +30,11 @@ object LogisticRegressionSummaryExample {
   def main(args: Array[String]): Unit = {
     val conf = new SparkConf().setAppName("LogisticRegressionSummaryExample")
     val sc = new SparkContext(conf)
-    val sqlCtx = new SQLContext(sc)
-    import sqlCtx.implicits._
+    val sqlContext = new SQLContext(sc)
+    import sqlContext.implicits._
 
     // Load training data
-    val training = sqlCtx.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
+    val training = sqlContext.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
 
     val lr = new LogisticRegression()
       .setMaxIter(10)

--- a/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionWithElasticNetExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionWithElasticNetExample.scala
@@ -29,11 +29,11 @@ object LogisticRegressionWithElasticNetExample {
   def main(args: Array[String]): Unit = {
     val conf = new SparkConf().setAppName("LogisticRegressionWithElasticNetExample")
     val sc = new SparkContext(conf)
-    val sqlCtx = new SQLContext(sc)
+    val sqlContext = new SQLContext(sc)
 
     // $example on$
     // Load training data
-    val training = sqlCtx.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
+    val training = sqlContext.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
 
     val lr = new LogisticRegression()
       .setMaxIter(10)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In spark.ml document, the LogisticRegression scala example uses sqlCtx. It is inconsistent with java and python examples which use sqlContext. In addition, a user can't copy & paste to run the example in spark-shell as sqlCtx doesn't exist in spark-shell while sqlContext exists.

Change the scala example referred by the spark.ml example.
## How was this patch tested?

Compile the example scala file and it passes compilation.
