### PR TITLE
[SPARK-13590] [ML] [Doc] Document spark.ml LiR, LoR and AFTSurvivalRegression behavior difference 

### DIFF
--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -62,6 +62,8 @@ For more background and more details about the implementation, refer to the docu
 
   > The current implementation of logistic regression in `spark.ml` only supports binary classes. Support for multiclass regression will be added in the future.
 
+  > When fitting LogisticRegressionModel without intercept on dataset with constant nonzero column, Spark ML produce same model as R glmnet but different from LIBSVM.
+
 **Example**
 
 The following example shows how to train a logistic regression model
@@ -344,6 +346,8 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classificat
 The interface for working with linear regression models and model
 summaries is similar to the logistic regression case.
 
+  > When fitting LinearRegressionModel without intercept on dataset with constant nonzero column by "l-bfgs" solver, Spark ML produce same model as R glmnet but different from LIBSVM. 
+
 **Example**
 
 The following
@@ -526,6 +530,8 @@ that depends coefficients vector $\beta$ and the log of scale parameter $\log\si
 The optimization algorithm underlying the implementation is L-BFGS.
 The implementation matches the result from R's survival function 
 [survreg](https://stat.ethz.ch/R-manual/R-devel/library/survival/html/survreg.html)
+
+  > When fitting AFTSurvivalRegressionModel without intercept on dataset with constant nonzero column, Spark ML will produce different model compared with R survival::survreg. 
 
 **Example**
 

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -62,7 +62,7 @@ For more background and more details about the implementation, refer to the docu
 
   > The current implementation of logistic regression in `spark.ml` only supports binary classes. Support for multiclass regression will be added in the future.
 
-  > When fitting LogisticRegressionModel without intercept on dataset with constant nonzero column, Spark ML outputs zero coefficients for constant nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.
+  > When fitting LogisticRegressionModel without intercept on dataset with constant nonzero column, Spark MLlib outputs zero coefficients for constant nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.
 
 **Example**
 
@@ -346,7 +346,7 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classificat
 The interface for working with linear regression models and model
 summaries is similar to the logistic regression case.
 
-  > When fitting LinearRegressionModel without intercept on dataset with constant nonzero column by "l-bfgs" solver, Spark ML outputs zero coefficients for constant nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.
+  > When fitting LinearRegressionModel without intercept on dataset with constant nonzero column by "l-bfgs" solver, Spark MLlib outputs zero coefficients for constant nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.
 
 **Example**
 
@@ -531,7 +531,7 @@ The optimization algorithm underlying the implementation is L-BFGS.
 The implementation matches the result from R's survival function 
 [survreg](https://stat.ethz.ch/R-manual/R-devel/library/survival/html/survreg.html)
 
-  > When fitting AFTSurvivalRegressionModel without intercept on dataset with constant nonzero column, Spark ML outputs zero coefficients for constant nonzero columns. This behavior is different from R survival::survreg.
+  > When fitting AFTSurvivalRegressionModel without intercept on dataset with constant nonzero column, Spark MLlib outputs zero coefficients for constant nonzero columns. This behavior is different from R survival::survreg.
 
 **Example**
 

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -62,7 +62,7 @@ For more background and more details about the implementation, refer to the docu
 
   > The current implementation of logistic regression in `spark.ml` only supports binary classes. Support for multiclass regression will be added in the future.
 
-  > When fitting LogisticRegressionModel without intercept on dataset with constant nonzero column, Spark ML produce same model as R glmnet but different from LIBSVM.
+  > When fitting LogisticRegressionModel without intercept on dataset with constant nonzero column, Spark ML outputs zero coefficients for constant nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.
 
 **Example**
 
@@ -346,7 +346,7 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classificat
 The interface for working with linear regression models and model
 summaries is similar to the logistic regression case.
 
-  > When fitting LinearRegressionModel without intercept on dataset with constant nonzero column by "l-bfgs" solver, Spark ML produce same model as R glmnet but different from LIBSVM. 
+  > When fitting LinearRegressionModel without intercept on dataset with constant nonzero column by "l-bfgs" solver, Spark ML outputs zero coefficients for constant nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.
 
 **Example**
 
@@ -531,7 +531,7 @@ The optimization algorithm underlying the implementation is L-BFGS.
 The implementation matches the result from R's survival function 
 [survreg](https://stat.ethz.ch/R-manual/R-devel/library/survival/html/survreg.html)
 
-  > When fitting AFTSurvivalRegressionModel without intercept on dataset with constant nonzero column, Spark ML will produce different model compared with R survival::survreg. 
+  > When fitting AFTSurvivalRegressionModel without intercept on dataset with constant nonzero column, Spark ML outputs zero coefficients for constant nonzero columns. This behavior is different from R survival::survreg.
 
 **Example**
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -333,7 +333,7 @@ class LogisticRegression @Since("1.2.0") (
         val featuresMean = summarizer.mean.toArray
         val featuresStd = summarizer.variance.toArray.map(math.sqrt)
 
-        if (!$(fitIntercept) && (0 to numFeatures).exists { i =>
+        if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
           featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
           logWarning("Fitting LogisticRegressionModel without intercept on dataset with " +
             "constant nonzero column, Spark ML produce same model as R glmnet but " +

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -333,6 +333,13 @@ class LogisticRegression @Since("1.2.0") (
         val featuresMean = summarizer.mean.toArray
         val featuresStd = summarizer.variance.toArray.map(math.sqrt)
 
+        if (!$(fitIntercept) && (0 to numFeatures).exists { i =>
+          featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
+          logWarning("Fitting LogisticRegressionModel without intercept on dataset with " +
+            "constant nonzero column, Spark ML produce same model as R glmnet but " +
+            "different from LIBSVM.")
+        }
+
         val regParamL1 = $(elasticNetParam) * $(regParam)
         val regParamL2 = (1.0 - $(elasticNetParam)) * $(regParam)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -336,8 +336,8 @@ class LogisticRegression @Since("1.2.0") (
         if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
           featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
           logWarning("Fitting LogisticRegressionModel without intercept on dataset with " +
-            "constant nonzero column, Spark ML outputs zero coefficients for constant nonzero " +
-            "columns. This behavior is the same as R glmnet but different from LIBSVM.")
+            "constant nonzero column, Spark MLlib outputs zero coefficients for constant " +
+            "nonzero columns. This behavior is the same as R glmnet but different from LIBSVM.")
         }
 
         val regParamL1 = $(elasticNetParam) * $(regParam)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -336,8 +336,8 @@ class LogisticRegression @Since("1.2.0") (
         if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
           featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
           logWarning("Fitting LogisticRegressionModel without intercept on dataset with " +
-            "constant nonzero column, Spark ML produce same model as R glmnet but " +
-            "different from LIBSVM.")
+            "constant nonzero column, Spark ML outputs zero coefficients for constant nonzero " +
+            "columns. This behavior is the same as R glmnet but different from LIBSVM.")
         }
 
         val regParamL1 = $(elasticNetParam) * $(regParam)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -210,7 +210,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
     val numFeatures = featuresStd.size
 
-    if (!$(fitIntercept) && (0 to numFeatures).exists { i =>
+    if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
         featuresStd(i) == 0.0 && featuresSummarizer.mean(i) != 0.0 }) {
       logWarning("Fitting AFTSurvivalRegressionModel without intercept on dataset with " +
         "constant nonzero column, Spark ML will produce different model compared with " +

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -208,11 +208,18 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
     }
 
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
+    val numFeatures = featuresStd.size
+
+    if (!$(fitIntercept) && (0 to numFeatures).exists { i =>
+        featuresStd(i) == 0.0 && featuresSummarizer.mean(i) != 0.0 }) {
+      logWarning("Fitting AFTSurvivalRegressionModel without intercept on dataset with " +
+        "constant nonzero column, Spark ML will produce different model compared with " +
+        "R survival::survreg.")
+    }
 
     val costFun = new AFTCostFun(instances, $(fitIntercept), featuresStd)
     val optimizer = new BreezeLBFGS[BDV[Double]]($(maxIter), 10, $(tol))
 
-    val numFeatures = featuresStd.size
     /*
        The parameters vector has three parts:
        the first element: Double, log(sigma), the log of scale parameter

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -213,7 +213,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
     if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
         featuresStd(i) == 0.0 && featuresSummarizer.mean(i) != 0.0 }) {
       logWarning("Fitting AFTSurvivalRegressionModel without intercept on dataset with " +
-        "constant nonzero column, Spark ML outputs zero coefficients for constant nonzero " +
+        "constant nonzero column, Spark MLlib outputs zero coefficients for constant nonzero " +
         "columns. This behavior is different from R survival::survreg.")
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -213,8 +213,8 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
     if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
         featuresStd(i) == 0.0 && featuresSummarizer.mean(i) != 0.0 }) {
       logWarning("Fitting AFTSurvivalRegressionModel without intercept on dataset with " +
-        "constant nonzero column, Spark ML will produce different model compared with " +
-        "R survival::survreg.")
+        "constant nonzero column, Spark ML outputs zero coefficients for constant nonzero " +
+        "columns. This behavior is different from R survival::survreg.")
     }
 
     val costFun = new AFTCostFun(instances, $(fitIntercept), featuresStd)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -268,7 +268,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     val featuresMean = featuresSummarizer.mean.toArray
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
 
-    if (!$(fitIntercept) && (0 to numFeatures).exists { i =>
+    if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
       featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
       logWarning("Fitting LinearRegressionModel without intercept on dataset with " +
         "constant nonzero column, Spark ML produce same model as R glmnet but " +

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -268,6 +268,13 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     val featuresMean = featuresSummarizer.mean.toArray
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
 
+    if (!$(fitIntercept) && (0 to numFeatures).exists { i =>
+      featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
+      logWarning("Fitting LinearRegressionModel without intercept on dataset with " +
+        "constant nonzero column, Spark ML produce same model as R glmnet but " +
+        "different from LIBSVM.")
+    }
+
     // Since we implicitly do the feature scaling when we compute the cost function
     // to improve the convergence, the effective regParam will be changed.
     val effectiveRegParam = $(regParam) / yStd

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -271,7 +271,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
       featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
       logWarning("Fitting LinearRegressionModel without intercept on dataset with " +
-        "constant nonzero column, Spark ML outputs zero coefficients for constant nonzero " +
+        "constant nonzero column, Spark MLlib outputs zero coefficients for constant nonzero " +
         "columns. This behavior is the same as R glmnet but different from LIBSVM.")
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -271,8 +271,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
       featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {
       logWarning("Fitting LinearRegressionModel without intercept on dataset with " +
-        "constant nonzero column, Spark ML produce same model as R glmnet but " +
-        "different from LIBSVM.")
+        "constant nonzero column, Spark ML outputs zero coefficients for constant nonzero " +
+        "columns. This behavior is the same as R glmnet but different from LIBSVM.")
     }
 
     // Since we implicitly do the feature scaling when we compute the cost function


### PR DESCRIPTION
## What changes were proposed in this pull request?

When fitting `LinearRegressionModel`(by "l-bfgs" solver) and `LogisticRegressionModel` w/o intercept on dataset with constant nonzero column, spark.ml produce same model as R glmnet but different from LIBSVM.

When fitting `AFTSurvivalRegressionModel` w/o intercept on dataset with constant nonzero column, spark.ml produce different model compared with R survival::survreg.

We should output a warning message and clarify in document for this condition.
## How was this patch tested?

Document change, no unit test.

cc @mengxr 
