### PR TITLE
[SPARK-14960][WIP] treeAggregate should fall back to regular aggregate in local mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1073,6 +1073,8 @@ abstract class RDD[T: ClassTag](
     require(depth >= 1, s"Depth must be greater than or equal to 1 but got $depth.")
     if (partitions.length == 0) {
       Utils.clone(zeroValue, context.env.closureSerializer.newInstance())
+    } else if (sparkContext.isLocal) {
+      aggregate(zeroValue)(seqOp, combOp)
     } else {
       val cleanSeqOp = context.clean(seqOp)
       val cleanCombOp = context.clean(combOp)


### PR DESCRIPTION
I don't think that `treeAggregate` will help performance in local mode and based on measurement of some unit tests it looks like it actually severely harms performance in certain cases. Therefore, I think that `treeAggregate` should fall back to plain `aggregate` when running in `local` mode.

This is WIP because I think we'll need to refactor the tests to make sure that this patch doesn't lead to a loss of test coverage in `treeAggregate`. I'm opening now in order to run tests and measure performance.
