### PR TITLE
[SPARK-10001][Core] Don't short-circuit actions in signal handlers

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/SignalUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SignalUtils.scala
@@ -92,9 +92,11 @@ private[spark] object SignalUtils extends Logging {
       // register old handler, will receive incoming signals while this handler is running
       Signal.handle(signal, prevHandler)
 
-      // run all actions, escalate to parent handler if no action catches the signal
-      // (i.e. all actions return false)
-      val escalate = actions.asScala.forall { action => !action() }
+      // Run all actions, escalate to parent handler if no action catches the signal
+      // (i.e. all actions return false). Note that calling `map` is to ensure that
+      // all actions are run, `forall` is short-circuited and will stop evaluating
+      // after reaching a first false predicate.
+      val escalate = actions.asScala.map(action => action()).forall(_ == false)
       if (escalate) {
         prevHandler.handle(sig)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current signal handlers have a subtle bug that stops evaluating registered actions as soon as one of them returns true, this is because `forall` is short-circuited.
This PR adds a strict mapping stage before evaluating returned result.
There are no known occurrences of the bug and this is a preemptive fix.
## How was this patch tested?

As with the original introduction of signal handlers, this was tested manually (unit testing with signals is not straightforward).
