### PR TITLE
[SPARK-14981][SQL] Throws exception if DESC is specified for sorting columns

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -758,9 +758,15 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     BucketSpec(
       ctx.INTEGER_VALUE.getText.toInt,
       visitIdentifierList(ctx.identifierList),
-      Option(ctx.orderedIdentifierList).toSeq
+      Option(ctx.orderedIdentifierList)
+        .toSeq
         .flatMap(_.orderedIdentifier.asScala)
-        .map(_.identifier.getText))
+        .map { orderedIdCtx =>
+          if (orderedIdCtx.ordering.getText.toLowerCase != "asc") {
+            throw parseException("Only ASC ordering is supported for sorting columns", ctx)
+          }
+          orderedIdCtx.identifier.getText
+        })
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -762,9 +762,12 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         .toSeq
         .flatMap(_.orderedIdentifier.asScala)
         .map { orderedIdCtx =>
-          if (orderedIdCtx.ordering.getText.toLowerCase != "asc") {
-            throw parseException("Only ASC ordering is supported for sorting columns", ctx)
+          Option(orderedIdCtx.ordering).map(_.getText).foreach { dir =>
+            if (dir.toLowerCase != "asc") {
+              throw parseException("Only ASC ordering is supported for sorting columns", ctx)
+            }
           }
+
           orderedIdCtx.identifier.getText
         })
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -948,9 +948,9 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
 
         sql(
           s"""CREATE TABLE t USING PARQUET
-              |OPTIONS (PATH '$path')
-              |PARTITIONED BY (a)
-              |AS SELECT 1 AS a, 2 AS b
+             |OPTIONS (PATH '$path')
+             |PARTITIONED BY (a)
+             |AS SELECT 1 AS a, 2 AS b
            """.stripMargin
         )
 
@@ -972,9 +972,9 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
 
         sql(
           s"""CREATE TABLE t USING PARQUET
-              |OPTIONS (PATH '$path')
-              |CLUSTERED BY (a) SORTED BY (b) INTO 2 BUCKETS
-              |AS SELECT 1 AS a, 2 AS b
+             |OPTIONS (PATH '$path')
+             |CLUSTERED BY (a) SORTED BY (b) INTO 2 BUCKETS
+             |AS SELECT 1 AS a, 2 AS b
            """.stripMargin
         )
 
@@ -992,9 +992,9 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
 
         sql(
           s"""CREATE TABLE t USING PARQUET
-              |OPTIONS (PATH '$path')
-              |CLUSTERED BY (a) INTO 2 BUCKETS
-              |AS SELECT 1 AS a, 2 AS b
+             |OPTIONS (PATH '$path')
+             |CLUSTERED BY (a) INTO 2 BUCKETS
+             |AS SELECT 1 AS a, 2 AS b
            """.stripMargin
         )
 
@@ -1016,10 +1016,10 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
 
         sql(
           s"""CREATE TABLE t USING PARQUET
-              |OPTIONS (PATH '$path')
-              |PARTITIONED BY (a)
-              |CLUSTERED BY (b) SORTED BY (c) INTO 2 BUCKETS
-              |AS SELECT 1 AS a, 2 AS b, 3 AS c
+             |OPTIONS (PATH '$path')
+             |PARTITIONED BY (a)
+             |CLUSTERED BY (b) SORTED BY (c) INTO 2 BUCKETS
+             |AS SELECT 1 AS a, 2 AS b, 3 AS c
            """.stripMargin
         )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Spark SQL doesn't support sorting columns in descending order. However, the parser accepts the syntax and silently drops sorting directions. This PR fixes this by throwing an exception if `DESC` is specified as sorting direction of a sorting column.
## How was this patch tested?

A test case is added to test the invalid sorting order by checking exception message.
