### PR TITLE
[SPARK-14989][BUILD] Upgrade Jackson from 2.5.3 to 2.7.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -81,13 +81,14 @@ hadoop-yarn-server-web-proxy-2.2.0.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar
-jackson-annotations-2.5.3.jar
-jackson-core-2.5.3.jar
+jackson-annotations-2.7.3.jar
+jackson-core-2.7.3.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.5.3.jar
+jackson-databind-2.7.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
+jackson-module-paranamer-2.7.3.jar
+jackson-module-scala_2.11-2.7.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 javax.inject-1.jar
@@ -142,7 +143,7 @@ netty-all-4.0.29.Final.jar
 objenesis-2.1.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -76,13 +76,14 @@ hadoop-yarn-server-web-proxy-2.3.0.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar
-jackson-annotations-2.5.3.jar
-jackson-core-2.5.3.jar
+jackson-annotations-2.7.3.jar
+jackson-core-2.7.3.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.5.3.jar
+jackson-databind-2.7.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
+jackson-module-paranamer-2.7.3.jar
+jackson-module-scala_2.11-2.7.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -133,7 +134,7 @@ netty-all-4.0.29.Final.jar
 objenesis-2.1.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -76,13 +76,14 @@ hadoop-yarn-server-web-proxy-2.4.0.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar
-jackson-annotations-2.5.3.jar
-jackson-core-2.5.3.jar
+jackson-annotations-2.7.3.jar
+jackson-core-2.7.3.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.5.3.jar
+jackson-databind-2.7.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
+jackson-module-paranamer-2.7.3.jar
+jackson-module-scala_2.11-2.7.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -134,7 +135,7 @@ netty-all-4.0.29.Final.jar
 objenesis-2.1.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -82,13 +82,14 @@ htrace-core-3.0.4.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar
-jackson-annotations-2.5.3.jar
-jackson-core-2.5.3.jar
+jackson-annotations-2.7.3.jar
+jackson-core-2.7.3.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.5.3.jar
+jackson-databind-2.7.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
+jackson-module-paranamer-2.7.3.jar
+jackson-module-scala_2.11-2.7.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -140,7 +141,7 @@ netty-all-4.0.29.Final.jar
 objenesis-2.1.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -82,13 +82,14 @@ htrace-core-3.1.0-incubating.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar
-jackson-annotations-2.5.3.jar
-jackson-core-2.5.3.jar
+jackson-annotations-2.7.3.jar
+jackson-core-2.7.3.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.5.3.jar
+jackson-databind-2.7.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
+jackson-module-paranamer-2.7.3.jar
+jackson-module-scala_2.11-2.7.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -141,7 +142,7 @@ netty-all-4.0.29.Final.jar
 objenesis-2.1.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <jline.version>${scala.version}</jline.version>
     <jline.groupid>org.scala-lang</jline.groupid>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.5.3</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.7.3</fasterxml.jackson.version>
     <snappy.version>1.1.2.4</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>


### PR DESCRIPTION
This patch upgrades Jackson from 2.5.3 to 2.7.3. I'd like to upgrade now in order to take advantage of new performance improvements and features, as well as to be better-prepared for when we'll want to upgrade for Scala 2.12 support.
