### PR TITLE
[SPARK-14978][PySpark] PySpark TrainValidationSplitModel should support validationMetrics

### DIFF
--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -608,7 +608,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(0.0, bestModelMetric, "Best model has RMSE of 0")
         self.assertEqual(len(grid), len(validationMetrics),
                          "validationMetrics has the same size of grid parameter")
-        self.assertEqual(bestModelMetric, min(validationMetrics))
+        self.assertEqual(0.0, min(validationMetrics))
 
     def test_fit_maximize_metric(self):
         dataset = self.spark.createDataFrame([
@@ -635,7 +635,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
         self.assertEqual(len(grid), len(validationMetrics),
                          "validationMetrics has the same size of grid parameter")
-        self.assertEqual(bestModelMetric, max(validationMetrics))
+        self.assertEqual(1.0, max(validationMetrics))
 
     def test_save_load(self):
         # This tests saving and loading the trained model only.

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -594,9 +594,9 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         iee = InducedErrorEstimator()
         evaluator = RegressionEvaluator(metricName="rmse")
 
-        grid = (ParamGridBuilder()
-                .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])
-                .build())
+        grid = ParamGridBuilder() \
+            .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])\
+            .build()
         tvs = TrainValidationSplit(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
         tvsModel = tvs.fit(dataset)
         bestModel = tvsModel.bestModel
@@ -608,7 +608,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(0.0, bestModelMetric, "Best model has RMSE of 0")
         self.assertEqual(len(grid), len(validationMetrics),
                          "validationMetrics has the same size of grid parameter")
-        self.assertIn(bestModelMetric, validationMetrics)
+        self.assertEqual(bestModelMetric, min(validationMetrics))
 
     def test_fit_maximize_metric(self):
         dataset = self.spark.createDataFrame([
@@ -621,9 +621,9 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         iee = InducedErrorEstimator()
         evaluator = RegressionEvaluator(metricName="r2")
 
-        grid = (ParamGridBuilder()
-                .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])
-                .build())
+        grid = ParamGridBuilder() \
+            .addGrid(iee.inducedError, [100.0, 0.0, 10000.0]) \
+            .build()
         tvs = TrainValidationSplit(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
         tvsModel = tvs.fit(dataset)
         bestModel = tvsModel.bestModel
@@ -635,6 +635,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
         self.assertEqual(len(grid), len(validationMetrics),
                          "validationMetrics has the same size of grid parameter")
+        self.assertEqual(bestModelMetric, max(validationMetrics))
 
     def test_save_load(self):
         # This tests saving and loading the trained model only.
@@ -672,9 +673,9 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         iee = InducedErrorEstimator()
         evaluator = RegressionEvaluator(metricName="r2")
 
-        grid = (ParamGridBuilder()
-                .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])
-                .build())
+        grid = ParamGridBuilder() \
+            .addGrid(iee.inducedError, [100.0, 0.0, 10000.0]) \
+            .build()
         tvs = TrainValidationSplit(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
         tvsModel = tvs.fit(dataset)
         tvsCopied = tvs.copy()

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -601,10 +601,13 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         tvsModel = tvs.fit(dataset)
         bestModel = tvsModel.bestModel
         bestModelMetric = evaluator.evaluate(bestModel.transform(dataset))
+        validationMetrics = tvsModel.validationMetrics
 
         self.assertEqual(0.0, bestModel.getOrDefault('inducedError'),
                          "Best model should have zero induced error")
         self.assertEqual(0.0, bestModelMetric, "Best model has RMSE of 0")
+        self.assertEqual(len(grid), len(validationMetrics),
+                         "validationMetrics has the same size of grid parameter")
 
     def test_fit_maximize_metric(self):
         dataset = self.spark.createDataFrame([
@@ -624,10 +627,13 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         tvsModel = tvs.fit(dataset)
         bestModel = tvsModel.bestModel
         bestModelMetric = evaluator.evaluate(bestModel.transform(dataset))
+        validationMetrics = tvsModel.validationMetrics
 
         self.assertEqual(0.0, bestModel.getOrDefault('inducedError'),
                          "Best model should have zero induced error")
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
+        self.assertEqual(len(grid), len(validationMetrics),
+                         "validationMetrics has the same size of grid parameter")
 
     def test_save_load(self):
         # This tests saving and loading the trained model only.
@@ -652,6 +658,36 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         loadedLrModel = LogisticRegressionModel.load(tvsModelPath)
         self.assertEqual(loadedLrModel.uid, lrModel.uid)
         self.assertEqual(loadedLrModel.intercept, lrModel.intercept)
+
+    def test_copy(self):
+        sqlContext = SQLContext(self.sc)
+        dataset = sqlContext.createDataFrame([
+            (10, 10.0),
+            (50, 50.0),
+            (100, 100.0),
+            (500, 500.0)] * 10,
+            ["feature", "label"])
+
+        iee = InducedErrorEstimator()
+        evaluator = RegressionEvaluator(metricName="r2")
+
+        grid = (ParamGridBuilder()
+                .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])
+                .build())
+        tvs = TrainValidationSplit(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
+        tvsModel = tvs.fit(dataset)
+        tvsCopied = tvs.copy()
+        tvsModelCopied = tvsModel.copy()
+
+        self.assertEqual(tvs.getEstimator().uid, tvsCopied.getEstimator().uid,
+                         "Copied TrainValidationSplit has the same uid of Estimator")
+
+        self.assertEqual(len(tvsModel.validationMetrics),
+                         len(tvsModelCopied.validationMetrics),
+                         "Copied validationMetrics has the same size of the original")
+        for index in range(len(tvsModel.validationMetrics)):
+            self.assertEqual(tvsModel.validationMetrics[index],
+                             tvsModelCopied.validationMetrics[index])
 
 
 class PersistenceTest(SparkSessionTestCase):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -595,7 +595,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         evaluator = RegressionEvaluator(metricName="rmse")
 
         grid = ParamGridBuilder() \
-            .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])\
+            .addGrid(iee.inducedError, [100.0, 0.0, 10000.0]) \
             .build()
         tvs = TrainValidationSplit(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
         tvsModel = tvs.fit(dataset)
@@ -662,8 +662,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(loadedLrModel.intercept, lrModel.intercept)
 
     def test_copy(self):
-        sqlContext = SQLContext(self.sc)
-        dataset = sqlContext.createDataFrame([
+        dataset = self.spark.createDataFrame([
             (10, 10.0),
             (50, 50.0),
             (100, 100.0),

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -659,6 +659,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(loadedLrModel.uid, lrModel.uid)
         self.assertEqual(loadedLrModel.intercept, lrModel.intercept)
 
+
     def test_copy(self):
         sqlContext = SQLContext(self.sc)
         dataset = sqlContext.createDataFrame([

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -608,6 +608,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(0.0, bestModelMetric, "Best model has RMSE of 0")
         self.assertEqual(len(grid), len(validationMetrics),
                          "validationMetrics has the same size of grid parameter")
+        self.assertIn(bestModelMetric, validationMetrics)
 
     def test_fit_maximize_metric(self):
         dataset = self.spark.createDataFrame([
@@ -659,7 +660,6 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(loadedLrModel.uid, lrModel.uid)
         self.assertEqual(loadedLrModel.intercept, lrModel.intercept)
 
-
     def test_copy(self):
         sqlContext = SQLContext(self.sc)
         dataset = sqlContext.createDataFrame([
@@ -683,6 +683,7 @@ class TrainValidationSplitTests(SparkSessionTestCase):
         self.assertEqual(tvs.getEstimator().uid, tvsCopied.getEstimator().uid,
                          "Copied TrainValidationSplit has the same uid of Estimator")
 
+        self.assertEqual(tvsModel.bestModel.uid, tvsModelCopied.bestModel.uid)
         self.assertEqual(len(tvsModel.validationMetrics),
                          len(tvsModelCopied.validationMetrics),
                          "Copied validationMetrics has the same size of the original")

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -441,6 +441,7 @@ class TrainValidationSplitModel(Model, ValidatorParams):
         and some extra params. This copies the underlying bestModel,
         creates a deep copy of the embedded paramMap, and
         copies the embedded and extra parameters over.
+        And, this creates a shallow copy of the validationMetrics.
 
         :param extra: Extra parameters to copy to the new instance
         :return: Copy of this instance

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -448,7 +448,7 @@ class TrainValidationSplitModel(Model, ValidatorParams):
         if extra is None:
             extra = dict()
         bestModel = self.bestModel.copy(extra)
-        validationMetrics = self.validationMetrics
+        validationMetrics = list(self.validationMetrics)
         return TrainValidationSplitModel(bestModel, validationMetrics)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request includes supporting validationMetrics for TrainValidationSplitModel with Python and test for it.
## How was this patch tested?

test in `python/pyspark/ml/tests.py`
