### PR TITLE
[SPARK-14997]Files in subdirectories are incorrectly considered in sqlContext.read.json()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -376,14 +376,10 @@ class HDFSFileCatalog(
         HadoopFsRelation.shouldFilterOut(name)
       }
 
-      val (dirs, files) = statuses.partition(_.isDirectory)
+      val (_, files) = statuses.partition(_.isDirectory)
 
       // It uses [[LinkedHashSet]] since the order of files can affect the results. (SPARK-11500)
-      if (dirs.isEmpty) {
-        mutable.LinkedHashSet(files: _*)
-      } else {
-        mutable.LinkedHashSet(files: _*) ++ listLeafFiles(dirs.map(_.getPath))
-      }
+      mutable.LinkedHashSet(files: _*)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the issue of "Files in subdirectories are incorrectly considered in sqlContext.read.json()".

An example,

```
xyz/file0.json
xyz/subdir1/file1.json
xyz/subdir2/file2.json
xyz/subdir1/subsubdir1/file3.json


sqlContext.read.json("xyz") should read only file0.json according to behavior in Spark 1.6.1. However in current master, all the 4 files are read.
```
## How was this patch tested?

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
