### PR TITLE
[SPARK-15003] Use ConcurrentHashMap in place of HashMap for NewAccumulator.originals

### DIFF
--- a/core/src/main/scala/org/apache/spark/NewAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/NewAccumulator.scala
@@ -19,6 +19,7 @@ package org.apache.spark
 
 import java.{lang => jl}
 import java.io.ObjectInputStream
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import javax.annotation.concurrent.GuardedBy
 
@@ -198,9 +199,7 @@ private[spark] object AccumulatorContext {
    * once the RDDs and user-code that reference them are cleaned up.
    * TODO: Don't use a global map; these should be tied to a SparkContext (SPARK-13051).
    */
-  @GuardedBy("AccumulatorContext")
-  private val originals =
-    new java.util.concurrent.ConcurrentHashMap[Long, jl.ref.WeakReference[NewAccumulator[_, _]]]
+  private val originals = new ConcurrentHashMap[Long, jl.ref.WeakReference[NewAccumulator[_, _]]]
 
   private[this] val nextId = new AtomicLong(0L)
 

--- a/core/src/main/scala/org/apache/spark/NewAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/NewAccumulator.scala
@@ -199,7 +199,8 @@ private[spark] object AccumulatorContext {
    * TODO: Don't use a global map; these should be tied to a SparkContext (SPARK-13051).
    */
   @GuardedBy("AccumulatorContext")
-  private val originals = new java.util.HashMap[Long, jl.ref.WeakReference[NewAccumulator[_, _]]]
+  private val originals =
+    new java.util.concurrent.ConcurrentHashMap[Long, jl.ref.WeakReference[NewAccumulator[_, _]]]
 
   private[this] val nextId = new AtomicLong(0L)
 
@@ -209,9 +210,9 @@ private[spark] object AccumulatorContext {
    */
   def newId(): Long = nextId.getAndIncrement
 
-  def numAccums: Int = synchronized(originals.size)
+  def numAccums: Int = originals.size
 
-  def accumIds: Set[Long] = synchronized(originals.keySet().asScala.toSet)
+  def accumIds: Set[Long] = originals.keySet().asScala.toSet
 
   /**
    * Register an [[Accumulator]] created on the driver such that it can be used on the executors.
@@ -224,23 +225,21 @@ private[spark] object AccumulatorContext {
    * If an [[Accumulator]] with the same ID was already registered, this does nothing instead
    * of overwriting it. We will never register same accumulator twice, this is just a sanity check.
    */
-  def register(a: NewAccumulator[_, _]): Unit = synchronized {
-    if (!originals.containsKey(a.id)) {
-      originals.put(a.id, new jl.ref.WeakReference[NewAccumulator[_, _]](a))
-    }
+  def register(a: NewAccumulator[_, _]): Unit = {
+    originals.putIfAbsent(a.id, new jl.ref.WeakReference[NewAccumulator[_, _]](a))
   }
 
   /**
    * Unregister the [[Accumulator]] with the given ID, if any.
    */
-  def remove(id: Long): Unit = synchronized {
+  def remove(id: Long): Unit = {
     originals.remove(id)
   }
 
   /**
    * Return the [[Accumulator]] registered with the given ID, if any.
    */
-  def get(id: Long): Option[NewAccumulator[_, _]] = synchronized {
+  def get(id: Long): Option[NewAccumulator[_, _]] = {
     Option(originals.get(id)).map { ref =>
       // Since we are storing weak references, we must check whether the underlying data is valid.
       val acc = ref.get
@@ -254,7 +253,7 @@ private[spark] object AccumulatorContext {
   /**
    * Clear all registered [[Accumulator]]s. For testing only.
    */
-  def clear(): Unit = synchronized {
+  def clear(): Unit = {
     originals.clear()
   }
 }

--- a/core/src/main/scala/org/apache/spark/NewAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/NewAccumulator.scala
@@ -211,8 +211,6 @@ private[spark] object AccumulatorContext {
 
   def numAccums: Int = originals.size
 
-  def accumIds: Set[Long] = originals.keySet().asScala.toSet
-
   /**
    * Register an [[Accumulator]] created on the driver such that it can be used on the executors.
    *

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -188,7 +188,7 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
     val numInternalAccums = TaskMetrics.empty.internalAccums.length
     // We ran 2 stages, so we should have 2 sets of internal accumulators, 1 for each stage
     assert(AccumulatorContext.numAccums === numInternalAccums * 2)
-    val cnt = 0
+    var cnt = 0
     val accumsRegistered = sc.cleaner match {
       case Some(cleaner: SaveAccumContextCleaner) => {
         for (id <- cleaner.accumsRegisteredForCleanup) {

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -194,7 +194,7 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
     }
     // Make sure the same set of accumulators is registered for cleanup
     assert(accumsRegistered.size === numInternalAccums * 2)
-    assert(accumsRegistered.size === AccumulatorContext.numAccums)
+    assert(accumsRegistered.toSet.size === AccumulatorContext.numAccums)
     accumsRegistered.foreach(id => assert(AccumulatorContext.get(id) != None))
   }
 

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -188,13 +188,18 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
     val numInternalAccums = TaskMetrics.empty.internalAccums.length
     // We ran 2 stages, so we should have 2 sets of internal accumulators, 1 for each stage
     assert(AccumulatorContext.numAccums === numInternalAccums * 2)
+    val cnt = 0
     val accumsRegistered = sc.cleaner match {
-      case Some(cleaner: SaveAccumContextCleaner) => cleaner.accumsRegisteredForCleanup
+      case Some(cleaner: SaveAccumContextCleaner) => {
+        for (id <- cleaner.accumsRegisteredForCleanup) {
+          assert(AccumulatorContext.get(id) != None)
+          cnt = cnt + 1
+        }
+      }
       case _ => Seq.empty[Long]
     }
     // Make sure the same set of accumulators is registered for cleanup
-    assert(accumsRegistered.size === numInternalAccums * 2)
-    assert(accumsRegistered.toSet === AccumulatorContext.accumIds)
+    assert(cnt === numInternalAccums * 2)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -188,18 +188,14 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
     val numInternalAccums = TaskMetrics.empty.internalAccums.length
     // We ran 2 stages, so we should have 2 sets of internal accumulators, 1 for each stage
     assert(AccumulatorContext.numAccums === numInternalAccums * 2)
-    var cnt = 0
     val accumsRegistered = sc.cleaner match {
-      case Some(cleaner: SaveAccumContextCleaner) =>
-        for (id <- cleaner.accumsRegisteredForCleanup) {
-          assert(AccumulatorContext.get(id) != None)
-          cnt = cnt + 1
-        }
+      case Some(cleaner: SaveAccumContextCleaner) => cleaner.accumsRegisteredForCleanup
       case _ => Seq.empty[Long]
     }
     // Make sure the same set of accumulators is registered for cleanup
-    assert(cnt === numInternalAccums * 2)
-    assert(cnt == AccumulatorContext.numAccums)
+    assert(accumsRegistered.size === numInternalAccums * 2)
+    assert(accumsRegistered.size === AccumulatorContext.numAccums)
+    accumsRegistered.foreach(id => assert(AccumulatorContext.get(id) != None))
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -190,16 +190,16 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
     assert(AccumulatorContext.numAccums === numInternalAccums * 2)
     var cnt = 0
     val accumsRegistered = sc.cleaner match {
-      case Some(cleaner: SaveAccumContextCleaner) => {
+      case Some(cleaner: SaveAccumContextCleaner) =>
         for (id <- cleaner.accumsRegisteredForCleanup) {
           assert(AccumulatorContext.get(id) != None)
           cnt = cnt + 1
         }
-      }
       case _ => Seq.empty[Long]
     }
     // Make sure the same set of accumulators is registered for cleanup
     assert(cnt === numInternalAccums * 2)
+    assert(cnt == AccumulatorContext.numAccums)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to use ConcurrentHashMap in place of HashMap for NewAccumulator.originals

This should result in better performance.
## How was this patch tested?

Existing unit test suite

@cloud-fan
