### PR TITLE
[SPARK-15020][SQL] GROUP-BY should support Aliases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -514,6 +514,13 @@ class Analyzer(
         } else {
           a.copy(aggregateExpressions = buildExpandedProjectList(a.aggregateExpressions, a.child))
         }
+
+      // When resolve grouping expressions in Aggregate, we need to consider aliases in
+      // aggregationExprs; e.g. SELECT 1 a GROUP BY a
+      case a @ Aggregate(ge, ae, child) if child.resolved && ae.forall(_.resolved) && !a.resolved =>
+         val newGroupingExprs = ge.map(expandGroupingExpr(_, ae))
+         a.copy(groupingExpressions = newGroupingExprs)
+
       // If the script transformation input contains Stars, expand it.
       case t: ScriptTransformation if containsStar(t.input) =>
         t.copy(
@@ -633,6 +640,17 @@ class Analyzer(
           failAnalysis(s"Invalid usage of '*' in expression '${o.prettyName}'")
       }
     }
+
+    /**
+     * Expands the matching attribute in aggregation expression aliases.
+     */
+    private def expandGroupingExpr(expr: Expression, aggregationExprs: Seq[NamedExpression]) =
+      if (!expr.resolved && expr.isInstanceOf[UnresolvedAttribute]) {
+        val name = expr.asInstanceOf[UnresolvedAttribute].name
+        aggregationExprs.filter(x => x.resolved && x.name == name).headOption.getOrElse(expr)
+      } else {
+        expr
+      }
   }
 
   private def containsDeserializer(exprs: Seq[Expression]): Boolean = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -346,4 +346,10 @@ class AnalysisSuite extends AnalysisTest {
 
     assertAnalysisSuccess(query)
   }
+
+  test("SPARK-15020: GROUP-BY should support Aliases") {
+    val input = LocalRelation('a.int)
+    val query = input.groupBy('x)('a.as('x))
+    assertAnalysisSuccess(query)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`GROUP-BY` clauses raise **AnalysisException** for aliases while `ORDER-BY` clauses support them correctly. This PR aims to support aliases in `GROUP-BY` clause. This is one of frequently-used syntax to avoid unnecessary repetition.

```
scala> sql("select 1 a group by a").head
org.apache.spark.sql.AnalysisException: cannot resolve '`a`' given input columns: []; line 1 pos 20
scala> sql("select 1 a order by a").head
res1: org.apache.spark.sql.Row = [1]
```
## How was this patch tested?

Pass the Jenkins tests (including a new testcase)
