### PR TITLE
[SPARK-15024] NoClassDefFoundError in spark-examples due to Guava relocation

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -388,6 +388,37 @@
   </build>
   <profiles>
     <profile>
+      <id>bigtop-dist</id>
+      <dependencies>
+        <!-- Promote guava to compiled scope for the purpose of shading it -->
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <outputFile>${project.build.directory}/scala-${scala.binary.version}/spark-examples-${project.version}-hadoop${hadoop.version}.jar</outputFile>
+              <artifactSet>
+                <includes>
+                  <!-- At a minimum we must include this to force effective pom generation -->
+                  <include>org.spark-project.spark:unused</include>
+                  <!-- Examples are not included in the classpath -->
+                  <include>com.google.guava:guava</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>kinesis-asl</id>
       <dependencies>
         <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change will only shade and relocate Guava in the spark-examples JAR used by the Apache Bigtop distribution (as of writing the Bigtop distribution uses the unshaded JAR).  Since only Guava and Jetty are relocated, and since there are 0 references to Jetty in the spark-examples codebase, only Guava needs to be shaded.  The shaded spark-assembly JAR provides the rest of the dependencies needed to get the spark-examples to run without any NoClassDefFoundErrors
## How was this patch tested?

mvn package -DrecompileMode=all -Pbigtop-dist -Pyarn -Phadoop-2.6 -Phive -Phive-thriftserver -Dprotobuf.version=2.5.0

$ unzip -l target/scala-2.10/spark-examples-1.6.1-hadoop2.6.0.jar | grep org.spark-project.guava | wc -l
1602
