### PR TITLE
[MINOR][SQL] Remove not affected settings for writing in CSV.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -65,6 +65,7 @@ private[sql] class LineCsvWriter(params: CSVOptions, headers: Seq[String]) exten
   private val format = writerSettings.getFormat
 
   format.setDelimiter(params.delimiter)
+  format.setLineSeparator(params.rowSeparator)
   format.setQuote(params.quote)
   format.setQuoteEscape(params.escape)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -65,10 +65,8 @@ private[sql] class LineCsvWriter(params: CSVOptions, headers: Seq[String]) exten
   private val format = writerSettings.getFormat
 
   format.setDelimiter(params.delimiter)
-  format.setLineSeparator(params.rowSeparator)
   format.setQuote(params.quote)
   format.setQuoteEscape(params.escape)
-  format.setComment(params.comment)
 
   writerSettings.setNullValue(params.nullValue)
   writerSettings.setEmptyValue(params.nullValue)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR removes not affected settings for writing CSV files.
- `setComment()` : It seems Univocity parser supports to write comments but only by both [commentRow()](https://github.com/uniVocity/univocity-parsers/blob/93d1fb6437bdeb1531f27156e18e8d8ca7af572f/src/main/java/com/univocity/parsers/common/AbstractWriter.java#L751-L753) and [commentRowToString()](https://github.com/uniVocity/univocity-parsers/blob/93d1fb6437bdeb1531f27156e18e8d8ca7af572f/src/main/java/com/univocity/parsers/common/AbstractWriter.java#L1392-L1394). Both methods are not used in Spark.
## How was this patch tested?

Unittests in `CSVSuite` and `./build/sbt scalastyle`
