### PR TITLE
[SPARK-15043] [MLLIB] Fix and re-enable flaky test: mllib.stat.JavaStatisticsSuite.testCorr

### DIFF
--- a/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
@@ -66,8 +66,8 @@ public class JavaStatisticsSuite implements Serializable {
 
   @Test
   public void testCorr() {
-    JavaRDD<Double> x = sc.parallelize(Arrays.asList(1.0, 2.0, 3.0, 4.0));
-    JavaRDD<Double> y = sc.parallelize(Arrays.asList(1.1, 2.2, 3.1, 4.3));
+    JavaRDD<Double> x = sc.parallelize(Arrays.asList(1.0, 2.0, 3.0, 4.0), 1);
+    JavaRDD<Double> y = sc.parallelize(Arrays.asList(1.1, 2.2, 3.1, 4.3), 1);
 
     Double corr1 = Statistics.corr(x, y);
     Double corr2 = Statistics.corr(x, y, "pearson");

--- a/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
@@ -66,13 +66,13 @@ public class JavaStatisticsSuite implements Serializable {
 
   @Test
   public void testCorr() {
-    JavaRDD<Double> x = sc.parallelize(Arrays.asList(1.0, 2.0, 3.0, 4.0), 1);
-    JavaRDD<Double> y = sc.parallelize(Arrays.asList(1.1, 2.2, 3.1, 4.3), 1);
+    JavaRDD<Double> x = sc.parallelize(Arrays.asList(1.0, 2.0, 3.0, 4.0));
+    JavaRDD<Double> y = sc.parallelize(Arrays.asList(1.1, 2.2, 3.1, 4.3));
 
     Double corr1 = Statistics.corr(x, y);
     Double corr2 = Statistics.corr(x, y, "pearson");
     // Check default method
-    assertEquals(corr1, corr2);
+    assertEquals(corr1, corr2, 1.0e-12);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Following https://github.com/apache/spark/pull/12779 this test became flaky. The issue is that the mean, computed for a covariance calculation, is now calculated with the standard and slightly more accurate `MultivariateOnlineSummarizer`. However I think the fact that it uses `treeAggregate` internally can lead to a different order of summation and very very slightly different results on different runs.

The immediate fix for the test, which asserts equality, is to use 1 partition. We can find out if that appears to be robust.

More generally, it's an interesting question whether we want `MultivariateOnlineSummarizer` to be deterministic. I'm not sure if another aggregation method would provide more guarantees of this, in theory or practice.
## How was this patch tested?

Existing Java stats suite.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
