### PR TITLE
[SPARK-15046] When running hive-thriftserver with yarn on a secure cluster it errors out due to the config 'spark.yarn.token.renewal.interval' is expected to be a Long but it is stored as Time.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -286,7 +286,7 @@ class SparkHadoopUtil extends Logging {
     val now = System.currentTimeMillis()
 
     val renewalInterval =
-      sparkConf.getLong("spark.yarn.token.renewal.interval", (24 hours).toMillis)
+      sparkConf.getTimeAsMs("spark.yarn.token.renewal.interval", (24 hours).toMillis.toString)
 
     credentials.getAllTokens.asScala
       .filter(_.getKind == DelegationTokenIdentifier.HDFS_DELEGATION_KIND)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed it so when you ask for the variable
"spark.yarn.token.renewal.interval" from sparkConf you get it as Time
instead of Long as thats how its stored.
## How was this patch tested?

Built from source and ran Hive-thriftserver against a secure cluster.
