### PR TITLE
[SPARK-3190][GraphX] fix VertexRDD.count exceed on large graph

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -179,8 +179,8 @@ class BitSet(numBits: Int) extends Serializable {
 
 
   /** Return the number of bits set to true in this BitSet. */
-  def cardinality(): Int = {
-    var sum = 0
+  def cardinality(): Long = {
+    var sum = 0L
     var i = 0
     while (i < numWords) {
       sum += java.lang.Long.bitCount(words(i))

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
@@ -68,7 +68,7 @@ private[graphx] abstract class VertexPartitionBase[@specialized(Long, Int, Doubl
 
   val capacity: Int = index.capacity
 
-  def size: Int = mask.cardinality()
+  def size: Long = mask.cardinality()
 
   /** Return the vertex attribute for the given vertex ID. */
   def apply(vid: VertexId): VD = values(index.getPos(vid))


### PR DESCRIPTION
As [SPARK-3190] and https://github.com/apache/spark/pull/2106 described, VertexRDDs  with more than 4 billion elements are counted incorrectly due to integer overflow when summing partition sizes. 
And the PR above expected to fix the issue by converting partition sizes to Longs before summing them. But when the number of vertices in specific partition exceed Integer.MAX_VALUE also can repreduce this issue.
The fundamental cause of this problem is the variable “size” is defined as type Int in class VertexPartitionBase. 
def size: Int = mask.cardinality()
