### PR TITLE
[SPARK-15055] Remove setValue method on accumulators

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -296,7 +296,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
         // final write as bytes spilled (instead, it's accounted as shuffle write). The merge needs
         // to be counted as shuffle write, but this will lead to double-counting of the final
         // SpillInfo's bytes.
-        writeMetrics.decBytesWritten(spills[spills.length - 1].file.length());
+        writeMetrics.incBytesWritten(0L - spills[spills.length - 1].file.length());
         writeMetrics.incBytesWritten(outputFile.length());
         return partitionLengths;
       }

--- a/core/src/main/scala/org/apache/spark/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/AccumulatorV2.scala
@@ -276,8 +276,6 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
       s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
   }
 
-  private[spark] def setValue(newValue: Long): Unit = _sum = newValue
-
   override def localValue: jl.Long = _sum
 }
 
@@ -300,8 +298,6 @@ class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
     case _ => throw new UnsupportedOperationException(
       s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
   }
-
-  private[spark] def setValue(newValue: Double): Unit = _sum = newValue
 
   override def localValue: jl.Double = _sum
 }
@@ -361,11 +357,6 @@ class ListAccumulator[T] extends AccumulatorV2[T, java.util.List[T]] {
   }
 
   override def localValue: java.util.List[T] = java.util.Collections.unmodifiableList(_list)
-
-  private[spark] def setValue(newValue: java.util.List[T]): Unit = {
-    _list.clear()
-    _list.addAll(newValue)
-  }
 }
 
 

--- a/core/src/main/scala/org/apache/spark/executor/InputMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/InputMetrics.scala
@@ -55,5 +55,4 @@ class InputMetrics private[spark] () extends Serializable {
 
   private[spark] def incBytesRead(v: Long): Unit = _bytesRead.add(v)
   private[spark] def incRecordsRead(v: Long): Unit = _recordsRead.add(v)
-  private[spark] def setBytesRead(v: Long): Unit = _bytesRead.setValue(v)
 }

--- a/core/src/main/scala/org/apache/spark/executor/OutputMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/OutputMetrics.scala
@@ -52,6 +52,6 @@ class OutputMetrics private[spark] () extends Serializable {
    */
   def recordsWritten: Long = _recordsWritten.sum
 
-  private[spark] def setBytesWritten(v: Long): Unit = _bytesWritten.setValue(v)
-  private[spark] def setRecordsWritten(v: Long): Unit = _recordsWritten.setValue(v)
+  private[spark] def incBytesWritten(v: Long): Unit = _bytesWritten.add(v)
+  private[spark] def incRecordsWritten(v: Long): Unit = _recordsWritten.add(v)
 }

--- a/core/src/main/scala/org/apache/spark/executor/ShuffleReadMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ShuffleReadMetrics.scala
@@ -77,31 +77,11 @@ class ShuffleReadMetrics private[spark] () extends Serializable {
    */
   def totalBlocksFetched: Long = remoteBlocksFetched + localBlocksFetched
 
-  private[spark] def incRemoteBlocksFetched(v: Long): Unit = _remoteBlocksFetched.add(v)
-  private[spark] def incLocalBlocksFetched(v: Long): Unit = _localBlocksFetched.add(v)
-  private[spark] def incRemoteBytesRead(v: Long): Unit = _remoteBytesRead.add(v)
-  private[spark] def incLocalBytesRead(v: Long): Unit = _localBytesRead.add(v)
-  private[spark] def incFetchWaitTime(v: Long): Unit = _fetchWaitTime.add(v)
-  private[spark] def incRecordsRead(v: Long): Unit = _recordsRead.add(v)
-
-  private[spark] def setRemoteBlocksFetched(v: Int): Unit = _remoteBlocksFetched.setValue(v)
-  private[spark] def setLocalBlocksFetched(v: Int): Unit = _localBlocksFetched.setValue(v)
-  private[spark] def setRemoteBytesRead(v: Long): Unit = _remoteBytesRead.setValue(v)
-  private[spark] def setLocalBytesRead(v: Long): Unit = _localBytesRead.setValue(v)
-  private[spark] def setFetchWaitTime(v: Long): Unit = _fetchWaitTime.setValue(v)
-  private[spark] def setRecordsRead(v: Long): Unit = _recordsRead.setValue(v)
-
   /**
    * Resets the value of the current metrics (`this`) and and merges all the independent
    * [[TempShuffleReadMetrics]] into `this`.
    */
-  private[spark] def setMergeValues(metrics: Seq[TempShuffleReadMetrics]): Unit = {
-    _remoteBlocksFetched.setValue(0)
-    _localBlocksFetched.setValue(0)
-    _remoteBytesRead.setValue(0)
-    _localBytesRead.setValue(0)
-    _fetchWaitTime.setValue(0)
-    _recordsRead.setValue(0)
+  private[spark] def mergeWithTempMetrics(metrics: Seq[TempShuffleReadMetrics]): Unit = {
     metrics.foreach { metric =>
       _remoteBlocksFetched.add(metric.remoteBlocksFetched)
       _localBlocksFetched.add(metric.localBlocksFetched)

--- a/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
@@ -50,12 +50,6 @@ class ShuffleWriteMetrics private[spark] () extends Serializable {
   private[spark] def incBytesWritten(v: Long): Unit = _bytesWritten.add(v)
   private[spark] def incRecordsWritten(v: Long): Unit = _recordsWritten.add(v)
   private[spark] def incWriteTime(v: Long): Unit = _writeTime.add(v)
-  private[spark] def decBytesWritten(v: Long): Unit = {
-    _bytesWritten.setValue(bytesWritten - v)
-  }
-  private[spark] def decRecordsWritten(v: Long): Unit = {
-    _recordsWritten.setValue(recordsWritten - v)
-  }
 
   // Legacy methods for backward compatibility.
   // TODO: remove these once we make this class private.

--- a/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
@@ -101,19 +101,19 @@ class TaskMetrics private[spark] () extends Serializable {
   def updatedBlockStatuses: Seq[(BlockId, BlockStatus)] = _updatedBlockStatuses.localValue
 
   // Setters and increment-ers
-  private[spark] def setExecutorDeserializeTime(v: Long): Unit =
+  private[spark] def incExecutorDeserializeTime(v: Long): Unit =
     _executorDeserializeTime.add(v)
-  private[spark] def setExecutorRunTime(v: Long): Unit = _executorRunTime.add(v)
-  private[spark] def setResultSize(v: Long): Unit = _resultSize.add(v)
-  private[spark] def setJvmGCTime(v: Long): Unit = _jvmGCTime.add(v)
-  private[spark] def setResultSerializationTime(v: Long): Unit =
+  private[spark] def incExecutorRunTime(v: Long): Unit = _executorRunTime.add(v)
+  private[spark] def incResultSize(v: Long): Unit = _resultSize.add(v)
+  private[spark] def incJvmGCTime(v: Long): Unit = _jvmGCTime.add(v)
+  private[spark] def incResultSerializationTime(v: Long): Unit =
     _resultSerializationTime.add(v)
   private[spark] def incMemoryBytesSpilled(v: Long): Unit = _memoryBytesSpilled.add(v)
   private[spark] def incDiskBytesSpilled(v: Long): Unit = _diskBytesSpilled.add(v)
   private[spark] def incPeakExecutionMemory(v: Long): Unit = _peakExecutionMemory.add(v)
   private[spark] def incUpdatedBlockStatuses(v: (BlockId, BlockStatus)): Unit =
     _updatedBlockStatuses.add(v)
-  private[spark] def setUpdatedBlockStatuses(v: Seq[(BlockId, BlockStatus)]): Unit = {
+  private[spark] def incUpdatedBlockStatuses(v: Seq[(BlockId, BlockStatus)]): Unit = {
     v.foreach(incUpdatedBlockStatuses)
   }
 
@@ -259,7 +259,7 @@ private[spark] object TaskMetrics extends Logging {
       val name = info.name.get
       val value = info.update.get
       if (name == UPDATED_BLOCK_STATUSES) {
-        tm.setUpdatedBlockStatuses(value.asInstanceOf[Seq[(BlockId, BlockStatus)]])
+        tm.incUpdatedBlockStatuses(value.asInstanceOf[Seq[(BlockId, BlockStatus)]])
       } else {
         tm.nameToAccums.get(name).foreach(
           _.asInstanceOf[LongAccumulator].add(value.asInstanceOf[Long])

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -236,7 +236,7 @@ class HadoopRDD[K, V](
       // previous partitions (SPARK-13071).
       def updateBytesRead(): Unit = {
         getBytesReadCallback.foreach { getBytesRead =>
-          inputMetrics.setBytesRead(existingBytesRead + getBytesRead())
+          inputMetrics.incBytesRead(existingBytesRead + getBytesRead() - inputMetrics.bytesRead)
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
@@ -150,7 +150,7 @@ class NewHadoopRDD[K, V](
       // previous partitions (SPARK-13071).
       def updateBytesRead(): Unit = {
         getBytesReadCallback.foreach { getBytesRead =>
-          inputMetrics.setBytesRead(existingBytesRead + getBytesRead())
+          inputMetrics.incBytesRead(existingBytesRead + getBytesRead() - - inputMetrics.bytesRead)
         }
       }
 
@@ -170,7 +170,6 @@ class NewHadoopRDD[K, V](
       context.addTaskCompletionListener(context => close())
       var havePair = false
       var finished = false
-      var recordsSinceMetricsUpdate = 0
 
       override def hasNext: Boolean = {
         if (!finished && !havePair) {

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -1114,8 +1114,8 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       }(finallyBlock = writer.close(hadoopContext))
       committer.commitTask(hadoopContext)
       outputMetricsAndBytesWrittenCallback.foreach { case (om, callback) =>
-        om.setBytesWritten(callback())
-        om.setRecordsWritten(recordsWritten)
+        om.incBytesWritten(callback() - om.bytesWritten)
+        om.incRecordsWritten(recordsWritten - om.recordsWritten)
       }
       1
     } : Int
@@ -1201,8 +1201,8 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       }(finallyBlock = writer.close())
       writer.commit()
       outputMetricsAndBytesWrittenCallback.foreach { case (om, callback) =>
-        om.setBytesWritten(callback())
-        om.setRecordsWritten(recordsWritten)
+        om.incBytesWritten(callback() - om.bytesWritten)
+        om.incRecordsWritten(recordsWritten - om.recordsWritten)
       }
     }
 
@@ -1227,8 +1227,8 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       recordsWritten: Long): Unit = {
     if (recordsWritten % PairRDDFunctions.RECORDS_BETWEEN_BYTES_WRITTEN_METRIC_UPDATES == 0) {
       outputMetricsAndBytesWrittenCallback.foreach { case (om, callback) =>
-        om.setBytesWritten(callback())
-        om.setRecordsWritten(recordsWritten)
+        om.incBytesWritten(callback() - om.bytesWritten)
+        om.incRecordsWritten(recordsWritten - om.recordsWritten)
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -95,7 +95,7 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
             if (a.name == Some(InternalAccumulator.RESULT_SIZE)) {
               val acc = a.asInstanceOf[LongAccumulator]
               assert(acc.sum == 0L, "task result size should not have been set on the executors")
-              acc.setValue(size.toLong)
+              acc.add(size.toLong)
               acc
             } else {
               a

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -152,8 +152,8 @@ private[spark] class DiskBlockObjectWriter(
     // truncating the file to its initial position.
     try {
       if (initialized) {
-        writeMetrics.decBytesWritten(reportedPosition - initialPosition)
-        writeMetrics.decRecordsWritten(numRecordsWritten)
+        writeMetrics.incBytesWritten(-(reportedPosition - initialPosition))
+        writeMetrics.incRecordsWritten(-numRecordsWritten)
         objOut.flush()
         bs.flush()
         close()

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -754,11 +754,11 @@ private[spark] object JsonProtocol {
     if (json == JNothing) {
       return metrics
     }
-    metrics.setExecutorDeserializeTime((json \ "Executor Deserialize Time").extract[Long])
-    metrics.setExecutorRunTime((json \ "Executor Run Time").extract[Long])
-    metrics.setResultSize((json \ "Result Size").extract[Long])
-    metrics.setJvmGCTime((json \ "JVM GC Time").extract[Long])
-    metrics.setResultSerializationTime((json \ "Result Serialization Time").extract[Long])
+    metrics.incExecutorDeserializeTime((json \ "Executor Deserialize Time").extract[Long])
+    metrics.incExecutorRunTime((json \ "Executor Run Time").extract[Long])
+    metrics.incResultSize((json \ "Result Size").extract[Long])
+    metrics.incJvmGCTime((json \ "JVM GC Time").extract[Long])
+    metrics.incResultSerializationTime((json \ "Result Serialization Time").extract[Long])
     metrics.incMemoryBytesSpilled((json \ "Memory Bytes Spilled").extract[Long])
     metrics.incDiskBytesSpilled((json \ "Disk Bytes Spilled").extract[Long])
 
@@ -800,7 +800,7 @@ private[spark] object JsonProtocol {
 
     // Updated blocks
     Utils.jsonOption(json \ "Updated Blocks").foreach { blocksJson =>
-      metrics.setUpdatedBlockStatuses(blocksJson.extract[List[JValue]].map { blockJson =>
+      metrics.incUpdatedBlockStatuses(blocksJson.extract[List[JValue]].map { blockJson =>
         val id = BlockId((blockJson \ "Block ID").extract[String])
         val status = blockStatusFromJson(blockJson \ "Status")
         (id, status)

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -787,8 +787,8 @@ private[spark] object JsonProtocol {
     // Output metrics
     Utils.jsonOption(json \ "Output Metrics").foreach { outJson =>
       val outputMetrics = metrics.outputMetrics
-      outputMetrics.setBytesWritten((outJson \ "Bytes Written").extract[Long])
-      outputMetrics.setRecordsWritten((outJson \ "Records Written").extractOpt[Long].getOrElse(0L))
+      outputMetrics.incBytesWritten((outJson \ "Bytes Written").extract[Long])
+      outputMetrics.incRecordsWritten((outJson \ "Records Written").extractOpt[Long].getOrElse(0L))
     }
 
     // Input metrics

--- a/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
@@ -260,10 +260,8 @@ private[spark] object AccumulatorSuite {
   def createLongAccum(
       name: String,
       countFailedValues: Boolean = false,
-      initValue: Long = 0,
       id: Long = AccumulatorContext.newId()): LongAccumulator = {
     val acc = new LongAccumulator
-    acc.setValue(initValue)
     acc.metadata = AccumulatorMetadata(id, Some(name), countFailedValues)
     AccumulatorContext.register(acc)
     acc

--- a/core/src/test/scala/org/apache/spark/executor/TaskMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/TaskMetricsSuite.scala
@@ -38,16 +38,16 @@ class TaskMetricsSuite extends SparkFunSuite {
     assert(tm.peakExecutionMemory == 0L)
     assert(tm.updatedBlockStatuses.isEmpty)
     // set or increment values
-    tm.setExecutorDeserializeTime(100L)
-    tm.setExecutorDeserializeTime(1L) // overwrite
-    tm.setExecutorRunTime(200L)
-    tm.setExecutorRunTime(2L)
-    tm.setResultSize(300L)
-    tm.setResultSize(3L)
-    tm.setJvmGCTime(400L)
-    tm.setJvmGCTime(4L)
-    tm.setResultSerializationTime(500L)
-    tm.setResultSerializationTime(5L)
+    tm.incExecutorDeserializeTime(100L)
+    tm.incExecutorDeserializeTime(1L) // overwrite
+    tm.incExecutorRunTime(200L)
+    tm.incExecutorRunTime(2L)
+    tm.incResultSize(300L)
+    tm.incResultSize(3L)
+    tm.incJvmGCTime(400L)
+    tm.incJvmGCTime(4L)
+    tm.incResultSerializationTime(500L)
+    tm.incResultSerializationTime(5L)
     tm.incMemoryBytesSpilled(600L)
     tm.incMemoryBytesSpilled(6L) // add
     tm.incDiskBytesSpilled(700L)

--- a/core/src/test/scala/org/apache/spark/executor/TaskMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/TaskMetricsSuite.scala
@@ -38,15 +38,10 @@ class TaskMetricsSuite extends SparkFunSuite {
     assert(tm.peakExecutionMemory == 0L)
     assert(tm.updatedBlockStatuses.isEmpty)
     // set or increment values
-    tm.incExecutorDeserializeTime(100L)
     tm.incExecutorDeserializeTime(1L) // overwrite
-    tm.incExecutorRunTime(200L)
     tm.incExecutorRunTime(2L)
-    tm.incResultSize(300L)
     tm.incResultSize(3L)
-    tm.incJvmGCTime(400L)
     tm.incJvmGCTime(4L)
-    tm.incResultSerializationTime(500L)
     tm.incResultSerializationTime(5L)
     tm.incMemoryBytesSpilled(600L)
     tm.incMemoryBytesSpilled(6L) // add

--- a/core/src/test/scala/org/apache/spark/executor/TaskMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/TaskMetricsSuite.scala
@@ -70,50 +70,6 @@ class TaskMetricsSuite extends SparkFunSuite {
     assert(tm.updatedBlockStatuses == Seq(block1, block2))
   }
 
-  test("mutating shuffle read metrics values") {
-    val tm = new TaskMetrics
-    val sr = tm.shuffleReadMetrics
-    // initial values
-    assert(sr.remoteBlocksFetched == 0)
-    assert(sr.localBlocksFetched == 0)
-    assert(sr.remoteBytesRead == 0L)
-    assert(sr.localBytesRead == 0L)
-    assert(sr.fetchWaitTime == 0L)
-    assert(sr.recordsRead == 0L)
-    // set and increment values
-    sr.setRemoteBlocksFetched(100)
-    sr.setRemoteBlocksFetched(10)
-    sr.incRemoteBlocksFetched(1) // 10 + 1
-    sr.incRemoteBlocksFetched(1) // 10 + 1 + 1
-    sr.setLocalBlocksFetched(200)
-    sr.setLocalBlocksFetched(20)
-    sr.incLocalBlocksFetched(2)
-    sr.incLocalBlocksFetched(2)
-    sr.setRemoteBytesRead(300L)
-    sr.setRemoteBytesRead(30L)
-    sr.incRemoteBytesRead(3L)
-    sr.incRemoteBytesRead(3L)
-    sr.setLocalBytesRead(400L)
-    sr.setLocalBytesRead(40L)
-    sr.incLocalBytesRead(4L)
-    sr.incLocalBytesRead(4L)
-    sr.setFetchWaitTime(500L)
-    sr.setFetchWaitTime(50L)
-    sr.incFetchWaitTime(5L)
-    sr.incFetchWaitTime(5L)
-    sr.setRecordsRead(600L)
-    sr.setRecordsRead(60L)
-    sr.incRecordsRead(6L)
-    sr.incRecordsRead(6L)
-    // assert new values exist
-    assert(sr.remoteBlocksFetched == 12)
-    assert(sr.localBlocksFetched == 24)
-    assert(sr.remoteBytesRead == 36L)
-    assert(sr.localBytesRead == 48L)
-    assert(sr.fetchWaitTime == 60L)
-    assert(sr.recordsRead == 72L)
-  }
-
   test("mutating shuffle write metrics values") {
     val tm = new TaskMetrics
     val sw = tm.shuffleWriteMetrics
@@ -124,12 +80,12 @@ class TaskMetricsSuite extends SparkFunSuite {
     // increment and decrement values
     sw.incBytesWritten(100L)
     sw.incBytesWritten(10L) // 100 + 10
-    sw.decBytesWritten(1L) // 100 + 10 - 1
-    sw.decBytesWritten(1L) // 100 + 10 - 1 - 1
+    sw.incBytesWritten(-1L) // 100 + 10 - 1
+    sw.incBytesWritten(-1L) // 100 + 10 - 1 - 1
     sw.incRecordsWritten(200L)
     sw.incRecordsWritten(20L)
-    sw.decRecordsWritten(2L)
-    sw.decRecordsWritten(2L)
+    sw.incRecordsWritten(-2L)
+    sw.incRecordsWritten(-2L)
     sw.incWriteTime(300L)
     sw.incWriteTime(30L)
     // assert new values exist
@@ -145,8 +101,7 @@ class TaskMetricsSuite extends SparkFunSuite {
     assert(in.bytesRead == 0L)
     assert(in.recordsRead == 0L)
     // set and increment values
-    in.setBytesRead(1L)
-    in.setBytesRead(2L)
+    in.incBytesRead(2L)
     in.incRecordsRead(1L)
     in.incRecordsRead(2L)
     // assert new values exist
@@ -161,10 +116,8 @@ class TaskMetricsSuite extends SparkFunSuite {
     assert(out.bytesWritten == 0L)
     assert(out.recordsWritten == 0L)
     // set values
-    out.setBytesWritten(1L)
-    out.setBytesWritten(2L)
-    out.setRecordsWritten(3L)
-    out.setRecordsWritten(4L)
+    out.incBytesWritten(2L)
+    out.incRecordsWritten(4L)
     // assert new values exist
     assert(out.bytesWritten == 2L)
     assert(out.recordsWritten == 4L)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -270,14 +270,16 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
       accumId: Long,
       taskSet: TaskSet,
       results: Seq[(TaskEndReason, Any)]) {
-    assert(taskSet.tasks.size >= results.size)
+    assert(taskSet.tasks.length >= results.size)
     for ((result, i) <- results.zipWithIndex) {
-      if (i < taskSet.tasks.size) {
+      if (i < taskSet.tasks.length) {
+        val acc = AccumulatorSuite.createLongAccum("", id = accumId)
+        acc.add(1)
         runEvent(makeCompletionEvent(
           taskSet.tasks(i),
           result._1,
           result._2,
-          Seq(AccumulatorSuite.createLongAccum("", initValue = 1, id = accumId))))
+          Seq(acc)))
       }
     }
   }
@@ -1632,13 +1634,13 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
     assert(AccumulatorContext.get(acc3.id).isDefined)
     val accUpdate1 = new LongAccumulator
     accUpdate1.metadata = acc1.metadata
-    accUpdate1.setValue(15)
+    accUpdate1.add(15)
     val accUpdate2 = new LongAccumulator
     accUpdate2.metadata = acc2.metadata
-    accUpdate2.setValue(13)
+    accUpdate2.add(13)
     val accUpdate3 = new LongAccumulator
     accUpdate3.metadata = acc3.metadata
-    accUpdate3.setValue(18)
+    accUpdate3.add(18)
     val accumUpdates = Seq(accUpdate1, accUpdate2, accUpdate3)
     val accumInfo = accumUpdates.map(AccumulatorSuite.makeInfo)
     val exceptionFailure = new ExceptionFailure(

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -243,7 +243,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
 
     sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
     listener.stageInfos.size should be (4)
-    listener.stageInfos.foreach { case (stageInfo, taskInfoMetrics) =>
+    listener.stageInfos.foreach { case (stageInfo, taskInfoMetrics: Seq[(TaskInfo, TaskMetrics)]) =>
       /**
        * Small test, so some tasks might take less than 1 millisecond, but average should be greater
        * than 0 ms.

--- a/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
@@ -282,8 +282,8 @@ class JobProgressListenerSuite extends SparkFunSuite with LocalSparkContext with
       taskMetrics.setExecutorRunTime(base + 4)
       taskMetrics.incDiskBytesSpilled(base + 5)
       taskMetrics.incMemoryBytesSpilled(base + 6)
-      inputMetrics.setBytesRead(base + 7)
-      outputMetrics.setBytesWritten(base + 8)
+      inputMetrics.incBytesRead(base + 7)
+      outputMetrics.incBytesWritten(base + 8)
       taskMetrics
     }
 

--- a/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
@@ -279,7 +279,7 @@ class JobProgressListenerSuite extends SparkFunSuite with LocalSparkContext with
       shuffleReadMetrics.incRemoteBlocksFetched(base + 2)
       taskMetrics.mergeShuffleReadMetrics()
       shuffleWriteMetrics.incBytesWritten(base + 3)
-      taskMetrics.setExecutorRunTime(base + 4)
+      taskMetrics.incExecutorRunTime(base + 4)
       taskMetrics.incDiskBytesSpilled(base + 5)
       taskMetrics.incMemoryBytesSpilled(base + 6)
       inputMetrics.incBytesRead(base + 7)

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -815,11 +815,11 @@ private[spark] object JsonProtocolSuite extends Assertions {
       hasOutput: Boolean,
       hasRecords: Boolean = true) = {
     val t = TaskMetrics.empty
-    t.setExecutorDeserializeTime(a)
-    t.setExecutorRunTime(b)
-    t.setResultSize(c)
-    t.setJvmGCTime(d)
-    t.setResultSerializationTime(a + b)
+    t.incExecutorDeserializeTime(a)
+    t.incExecutorRunTime(b)
+    t.incResultSize(c)
+    t.incJvmGCTime(d)
+    t.incResultSerializationTime(a + b)
     t.incMemoryBytesSpilled(a + c)
 
     if (hasHadoopInput) {
@@ -846,7 +846,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       sw.incRecordsWritten(if (hasRecords) (a + b + c) / 100 else -1)
     }
     // Make at most 6 blocks
-    t.setUpdatedBlockStatuses((1 to (e % 5 + 1)).map { i =>
+    t.incUpdatedBlockStatuses((1 to (e % 5 + 1)).map { i =>
       (RDDBlockId(e % i, f % i), BlockStatus(StorageLevel.MEMORY_AND_DISK_SER_2, a % i, b % i))
     }.toSeq)
     t

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -824,7 +824,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
 
     if (hasHadoopInput) {
       val inputMetrics = t.inputMetrics
-      inputMetrics.setBytesRead(d + e + f)
+      inputMetrics.incBytesRead(d + e + f)
       inputMetrics.incRecordsRead(if (hasRecords) (d + e + f) / 100 else -1)
     } else {
       val sr = t.createTempShuffleReadMetrics()
@@ -837,8 +837,8 @@ private[spark] object JsonProtocolSuite extends Assertions {
       t.mergeShuffleReadMetrics()
     }
     if (hasOutput) {
-      t.outputMetrics.setBytesWritten(a + b + c)
-      t.outputMetrics.setRecordsWritten(if (hasRecords) (a + b + c) / 100 else -1)
+      t.outputMetrics.incBytesWritten(a + b + c)
+      t.outputMetrics.incRecordsWritten(if (hasRecords) (a + b + c) / 100 else -1)
     } else {
       val sw = t.shuffleWriteMetrics
       sw.incBytesWritten(a + b + c)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -72,7 +72,7 @@ class FileScanRDD(
       // previous partitions (SPARK-13071).
       private def updateBytesRead(): Unit = {
         getBytesReadCallback.foreach { getBytesRead =>
-          inputMetrics.setBytesRead(existingBytesRead + getBytesRead())
+          inputMetrics.incBytesRead(existingBytesRead + getBytesRead() - inputMetrics.bytesRead)
         }
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLListenerSuite.scala
@@ -76,7 +76,7 @@ class SQLListenerSuite extends SparkFunSuite with SharedSQLContext {
     when(metrics.accumulators()).thenReturn(accumulatorUpdates.map { case (id, update) =>
       val acc = new LongAccumulator
       acc.metadata = AccumulatorMetadata(id, Some(""), true)
-      acc.setValue(update)
+      acc.add(update)
       acc
     }.toSeq)
     metrics


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch removes setValue methods on the new accumulator API. Even though they were defined as private[spark], they can still be accessed in Java.
## How was this patch tested?

Updated test cases to reflect this.
