### PR TITLE
[SPARK-15058][MLLIB][TEST] Enable Java DecisionTree Save/Load test codes.

### DIFF
--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +35,7 @@ import org.apache.spark.mllib.regression.LabeledPoint;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.util.Utils;
 
 public class JavaDecisionTreeClassifierSuite implements Serializable {
 
@@ -55,7 +58,7 @@ public class JavaDecisionTreeClassifierSuite implements Serializable {
   }
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -85,18 +88,14 @@ public class JavaDecisionTreeClassifierSuite implements Serializable {
     model.depth();
     model.toDebugString();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = tempDir.toURI().toString() + "/JavaDecisionTreeClassifierSuite";
     try {
-      model3.save(sc.sc(), path);
-      DecisionTreeClassificationModel sameModel =
-        DecisionTreeClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+      model.save(path);
+      DecisionTreeClassificationModel sameModel = DecisionTreeClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
@@ -17,10 +17,13 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +59,7 @@ public class JavaGBTClassifierSuite implements Serializable {
   }
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -91,17 +94,14 @@ public class JavaGBTClassifierSuite implements Serializable {
     model.trees();
     model.treeWeights();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = tempDir.toURI().toString() + "/JavaGBTClassifierSuite";
     try {
-      model3.save(sc.sc(), path);
-      GBTClassificationModel sameModel = GBTClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+      model.save(path);
+      GBTClassificationModel sameModel = GBTClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -17,10 +17,13 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,7 +61,7 @@ public class JavaRandomForestClassifierSuite implements Serializable {
   }
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -114,18 +117,14 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     model.treeWeights();
     Vector importances = model.featureImportances();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = tempDir.toURI().toString() + "/JavaRandomForestClassifierSuite";
     try {
-      model3.save(sc.sc(), path);
-      RandomForestClassificationModel sameModel =
-          RandomForestClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+      model.save(path);
+      RandomForestClassificationModel sameModel = RandomForestClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
@@ -17,10 +17,13 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +59,7 @@ public class JavaDecisionTreeRegressorSuite implements Serializable {
   }
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -86,17 +89,14 @@ public class JavaDecisionTreeRegressorSuite implements Serializable {
     model.depth();
     model.toDebugString();
 
-    /*
-    // TODO: Add test once save/load are implemented.   SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = tempDir.toURI().toString() + "/JavaDecisionTreeRegressorSuite";
     try {
-      model2.save(sc.sc(), path);
-      DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
@@ -17,10 +17,13 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +59,7 @@ public class JavaGBTRegressorSuite implements Serializable {
   }
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -90,17 +93,14 @@ public class JavaGBTRegressorSuite implements Serializable {
     model.trees();
     model.treeWeights();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = tempDir.toURI().toString() + "/JavaGBTRegressorSuite";
     try {
-      model2.save(sc.sc(), path);
-      GBTRegressionModel sameModel = GBTRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      GBTRegressionModel sameModel = GBTRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -17,10 +17,13 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,7 +61,7 @@ public class JavaRandomForestRegressorSuite implements Serializable {
   }
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -114,17 +117,14 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     model.treeWeights();
     Vector importances = model.featureImportances();
 
-    /*
-    // TODO: Add test once save/load are implemented.   SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = tempDir.toURI().toString() + "/JavaRandomForestRegressorSuite";
     try {
-      model2.save(sc.sc(), path);
-      RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR enables six Java DecisionTree save/load tests since the feature is implemented in SPARK-6725. The test code already exist as comments. This issue just removes comments and amends very little. This PR also removes all TODO about SPARK-6725.
- JavaDecisionTreeClassifierSuite.java
- JavaGBTClassifierSuite.java
- JavaRandomForestClassifierSuite.java
- JavaDecisionTreeRegressorSuite.java
- JavaGBTRegressorSuite.java
- JavaRandomForestRegressorSuite.java
## How was this patch tested?

Pass the Jenkins tests.
