### PR TITLE
[SPARK-14422][SQL] Improve handling of optional configs in SQLConf

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -284,7 +284,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
         new Path(userSpecified).toUri.toString
       }.orElse {
         val checkpointConfig: Option[String] =
-          df.sparkSession.conf.getOption(SQLConf.CHECKPOINT_LOCATION)
+          df.sparkSession.conf.get(SQLConf.CHECKPOINT_LOCATION)
 
         checkpointConfig.map { location =>
           new Path(location, queryName).toUri.toString

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -322,9 +322,10 @@ final class DataFrameWriter private[sql](df: DataFrame) {
           partitionColumns = normalizedParCols.getOrElse(Nil))
 
       val queryName = extraOptions.getOrElse("queryName", StreamExecution.nextName)
-      val checkpointLocation = extraOptions.getOrElse("checkpointLocation", {
-        new Path(df.sparkSession.sessionState.conf.checkpointLocation, queryName).toUri.toString
-      })
+      val checkpointLocation = extraOptions.getOrElse("checkpointLocation",
+        new Path(df.sparkSession.sessionState.conf.checkpointLocation.get, queryName).toUri.toString
+      )
+
       df.sparkSession.sessionState.continuousQueryManager.startQuery(
         queryName,
         checkpointLocation,

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -284,7 +284,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
         new Path(userSpecified).toUri.toString
       }.orElse {
         val checkpointConfig: Option[String] =
-          df.sparkSession.conf.get(SQLConf.CHECKPOINT_LOCATION, None)
+          df.sparkSession.conf.getOption(SQLConf.CHECKPOINT_LOCATION)
 
         checkpointConfig.map { location =>
           new Path(location, queryName).toUri.toString

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -86,7 +86,7 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
     sqlConf.getConf(entry)
   }
 
-  protected[sql] def getOption[T](entry: OptionalConfigEntry[T]): Option[T] = {
+  protected[sql] def get[T](entry: OptionalConfigEntry[T]): Option[T] = {
     sqlConf.getOptionalConf(entry)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.internal.config.ConfigEntry
+import org.apache.spark.internal.config.{ConfigEntry, OptionalConfigEntry}
 import org.apache.spark.sql.internal.SQLConf
 
 
@@ -84,6 +84,10 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
   @throws[NoSuchElementException]("if the key is not set")
   protected[sql] def get[T](entry: ConfigEntry[T]): T = {
     sqlConf.getConf(entry)
+  }
+
+  protected[sql] def getOption[T](entry: OptionalConfigEntry[T]): Option[T] = {
+    sqlConf.getOptionalConf(entry)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -87,7 +87,7 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
   }
 
   protected[sql] def get[T](entry: OptionalConfigEntry[T]): Option[T] = {
-    sqlConf.getOptionalConf(entry)
+    sqlConf.getConf(entry)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -726,6 +726,14 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   }
 
   /**
+    * Return the value of an optional Spark SQL configuration property for the given key. If the key
+    * is not set yet, returns None.
+    */
+  def getOptionalConf[T](entry: OptionalConfigEntry[T]): Option[T] = {
+    Option(settings.get(entry.key)).map(entry.rawValueConverter)
+  }
+
+  /**
    * Return the `string` value of Spark SQL configuration property for the given key. If the key is
    * not set yet, return `defaultValue`.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -546,7 +546,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
 
   def optimizerInSetConversionThreshold: Int = getConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD)
 
-  def checkpointLocation: String = getConf(CHECKPOINT_LOCATION)
+  def checkpointLocation: Option[String] = getConf(CHECKPOINT_LOCATION)
 
   def filesMaxPartitionBytes: Long = getConf(FILES_MAX_PARTITION_BYTES)
 
@@ -712,16 +712,6 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def getConf[T](entry: ConfigEntry[T]): T = {
     require(sqlConfEntries.get(entry.key) == entry, s"$entry is not registered")
     Option(settings.get(entry.key)).map(entry.valueConverter).orElse(entry.defaultValue).
-      getOrElse(throw new NoSuchElementException(entry.key))
-  }
-
-  /**
-   * Return the value of an optional Spark SQL configuration property for the given key. If the key
-   * is not set yet, throw an exception.
-   */
-  def getConf[T](entry: OptionalConfigEntry[T]): T = {
-    require(sqlConfEntries.get(entry.key) == entry, s"$entry is not registered")
-    Option(settings.get(entry.key)).map(entry.rawValueConverter).
       getOrElse(throw new NoSuchElementException(entry.key))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -726,9 +726,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   }
 
   /**
-    * Return the value of an optional Spark SQL configuration property for the given key. If the key
-    * is not set yet, returns None.
-    */
+   * Return the value of an optional Spark SQL configuration property for the given key. If the key
+   * is not set yet, returns None.
+   */
   def getOptionalConf[T](entry: OptionalConfigEntry[T]): Option[T] = {
     Option(settings.get(entry.key)).map(entry.rawValueConverter)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -719,7 +719,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
    * Return the value of an optional Spark SQL configuration property for the given key. If the key
    * is not set yet, returns None.
    */
-  def getOptionalConf[T](entry: OptionalConfigEntry[T]): Option[T] = {
+  def getConf[T](entry: OptionalConfigEntry[T]): Option[T] = {
     require(sqlConfEntries.get(entry.key) == entry, s"$entry is not registered")
     Option(settings.get(entry.key)).map(entry.rawValueConverter)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -730,6 +730,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
    * is not set yet, returns None.
    */
   def getOptionalConf[T](entry: OptionalConfigEntry[T]): Option[T] = {
+    require(sqlConfEntries.get(entry.key) == entry, s"$entry is not registered")
     Option(settings.get(entry.key)).map(entry.rawValueConverter)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
@@ -159,9 +159,9 @@ class SQLConfEntrySuite extends SparkFunSuite {
       .stringConf
       .createOptional
 
-    assert(conf.getOptionalConf(confEntry) === None)
+    assert(conf.getConf(confEntry) === None)
     conf.setConfString(key, "a")
-    assert(conf.getOptionalConf(confEntry) === Some("a"))
+    assert(conf.getConf(confEntry) === Some("a"))
   }
 
   test("duplicate entry") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
@@ -153,6 +153,17 @@ class SQLConfEntrySuite extends SparkFunSuite {
     assert(conf.getConf(confEntry, Seq("a", "b", "c")) === Seq("a", "b", "c", "d", "e"))
   }
 
+  test("optionalConf") {
+    val key = "spark.sql.SQLConfEntrySuite.optional"
+    val confEntry = SQLConfigBuilder(key)
+      .stringConf
+      .createOptional
+
+    assert(conf.getOptionalConf(confEntry) === None)
+    conf.setConfString(key, "a")
+    assert(conf.getOptionalConf(confEntry) === Some("a"))
+  }
+
   test("duplicate entry") {
     val key = "spark.sql.SQLConfEntrySuite.duplicate"
     SQLConfigBuilder(key).stringConf.createOptional


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create a new API for handling Optional Configs in SQLConf.
Right now `getConf` for `OptionalConfigEntry[T]` returns value of type `T`, if doesn't exist throws an exception. Add new method `getOptionalConf`(suggestions on naming) which will now returns value of type `Option[T]`(so if doesn't exist it returns `None`).
## How was this patch tested?

Add test and ran tests locally.
