### PR TITLE
[SPARK-15076][SQL] Add ReorderAssociativeOperator optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -94,6 +94,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog, conf: CatalystConf)
       FoldablePropagation,
       OptimizeIn(conf),
       ConstantFolding,
+      ReorderAssociativeOperator,
       LikeSimplification,
       BooleanSimplification,
       SimplifyConditionals,
@@ -738,10 +739,9 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan] with PredicateHelpe
 }
 
 /**
- * Replaces [[Expression Expressions]] that can be statically evaluated with
- * equivalent [[Literal]] values.
+ * Reorder associative integral-type operators and fold all constants into one.
  */
-object ConstantFolding extends Rule[LogicalPlan] {
+object ReorderAssociativeOperator extends Rule[LogicalPlan] {
   private def isAssociativelyFoldable(e: Expression): Boolean =
     e.isInstanceOf[BinaryArithmetic] &&
       e.dataType.isInstanceOf[IntegralType] &&
@@ -761,15 +761,6 @@ object ConstantFolding extends Rule[LogicalPlan] {
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case q: LogicalPlan => q transformExpressionsDown {
-      // Skip redundant folding of literals. This rule is technically not necessary. Placing this
-      // here avoids running the next rule for Literal values, which would create a new Literal
-      // object and running eval unnecessarily.
-      case l: Literal => l
-
-      // Fold expressions that are foldable.
-      case e if e.foldable => Literal.create(e.eval(EmptyRow), e.dataType)
-
-      // Use associative property for integral type
       case e if isAssociativelyFoldable(e) =>
         val (foldables, others) = getOperandList(e).partition(_.foldable)
         if (foldables.size > 1) {
@@ -777,16 +768,34 @@ object ConstantFolding extends Rule[LogicalPlan] {
             case a: Add =>
               val foldableExpr = foldables.reduce((x, y) => Add(x, y))
               val c = Literal.create(foldableExpr.eval(EmptyRow), e.dataType)
-              Add(others.reduce((x, y) => Add(x, y)), c)
+              if (others.isEmpty) c else Add(others.reduce((x, y) => Add(x, y)), c)
             case m: Multiply =>
               val foldableExpr = foldables.reduce((x, y) => Multiply(x, y))
               val c = Literal.create(foldableExpr.eval(EmptyRow), e.dataType)
-              Multiply(others.reduce((x, y) => Multiply(x, y)), c)
+              if (others.isEmpty) c else Multiply(others.reduce((x, y) => Multiply(x, y)), c)
             case _ => e
           }
         } else {
           e
         }
+    }
+  }
+}
+
+/**
+ * Replaces [[Expression Expressions]] that can be statically evaluated with
+ * equivalent [[Literal]] values.
+ */
+object ConstantFolding extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case q: LogicalPlan => q transformExpressionsDown {
+      // Skip redundant folding of literals. This rule is technically not necessary. Placing this
+      // here avoids running the next rule for Literal values, which would create a new Literal
+      // object and running eval unnecessarily.
+      case l: Literal => l
+
+      // Fold expressions that are foldable.
+      case e if e.foldable => Literal.create(e.eval(EmptyRow), e.dataType)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -743,9 +743,8 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan] with PredicateHelpe
  */
 object ReorderAssociativeOperator extends Rule[LogicalPlan] {
   private def isAssociativelyFoldable(e: Expression): Boolean =
-    e.isInstanceOf[BinaryArithmetic] &&
-      e.dataType.isInstanceOf[IntegralType] &&
-        isSingleOperatorExpr(e)
+    e.deterministic && e.isInstanceOf[BinaryArithmetic] && e.dataType.isInstanceOf[IntegralType] &&
+      isSingleOperatorExpr(e)
 
   private def isSingleOperatorExpr(e: Expression): Boolean = e.find {
     case a: Add if a.getClass == e.getClass => false

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
@@ -33,8 +33,8 @@ class ConstantFoldingSuite extends PlanTest {
     val batches =
       Batch("AnalysisNodes", Once,
         EliminateSubqueryAliases) ::
-      Batch("ConstantFolding", Once,
-        OptimizeIn(SimpleCatalystConf(true)),
+      Batch("ConstantFolding", FixedPoint(10),
+        OptimizeIn(SimpleCatalystConf(caseSensitiveAnalysis = true)),
         ConstantFolding,
         BooleanSimplification) :: Nil
   }
@@ -104,8 +104,8 @@ class ConstantFoldingSuite extends PlanTest {
     val correctAnswer =
       testRelation
         .select(
-          Literal(5) + 'a as Symbol("c1"),
-          'a + Literal(2) + Literal(3) as Symbol("c2"),
+          'a + Literal(5) as Symbol("c1"),
+          'a + Literal(5) as Symbol("c2"),
           Literal(2) * 'a + Literal(4) as Symbol("c3"),
           'a * Literal(7) as Symbol("c4"))
         .analyze
@@ -149,7 +149,7 @@ class ConstantFoldingSuite extends PlanTest {
     val correctAnswer =
       testRelation
         .select(
-          Literal(5) + 'a as Symbol("c1"),
+          'a + 5 as Symbol("c1"),
           Literal(3) as Symbol("c2"))
         .analyze
 
@@ -260,6 +260,24 @@ class ConstantFoldingSuite extends PlanTest {
       testRelation
         .select('a)
         .where(Literal(true))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Constant folding test: associative property") {
+    val originalQuery =
+      testRelation
+        .select((Literal(3) + ((Literal(1) + 'a) + 2)) + 4, 'b * 2 * 3 * 4, 'a + 1 + 'b + 2)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer =
+      testRelation
+        .select(
+          ('a + 10).as("((3 + ((1 + a) + 2)) + 4)"),
+          ('b * 24).as("(((b * 2) * 3) * 4)"),
+          ('a + 'b + 3).as("(((a + 1) + b) + 2)"))
         .analyze
 
     comparePlans(optimized, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
@@ -40,7 +40,9 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
         .select(
           (Literal(3) + ((Literal(1) + 'a) + 2)) + 4,
           'b * 1 * 2 * 3 * 4,
+          ('b + 1) * 2 * 3 * 4,
           'a + 1 + 'b + 2 + 'c + 3,
+          'a + 1 + 'b * 2 + 'c + 3,
           Rand(0) * 1 * 2 * 3 * 4)
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -50,7 +52,9 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
         .select(
           ('a + 10).as("((3 + ((1 + a) + 2)) + 4)"),
           ('b * 24).as("((((b * 1) * 2) * 3) * 4)"),
+          (('b + 1) * 24).as("((((b + 1) * 2) * 3) * 4)"),
           ('a + 'b + 'c + 6).as("(((((a + 1) + b) + 2) + c) + 3)"),
+          ('a + 'b * 2 + 'c + 4).as("((((a + 1) + (b * 2)) + c) + 3)"),
           Rand(0) * 1 * 2 * 3 * 4)
         .analyze
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class ReorderAssociativeOperatorSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("ReorderAssociativeOperator", Once,
+        ReorderAssociativeOperator) :: Nil
+  }
+
+  val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
+
+  test("Reorder associative operators") {
+    val originalQuery =
+      testRelation
+        .select(
+          (Literal(3) + ((Literal(1) + 'a) + 2)) + 4,
+          'b * 1 * 2 * 3 * 4,
+          'a + 1 + 'b + 2 + 'c + 3)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer =
+      testRelation
+        .select(
+          ('a + 10).as("((3 + ((1 + a) + 2)) + 4)"),
+          ('b * 24).as("((((b * 1) * 2) * 3) * 4)"),
+          ('a + 'b + 'c + 6).as("(((((a + 1) + b) + 2) + c) + 3)"))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
@@ -40,7 +40,8 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
         .select(
           (Literal(3) + ((Literal(1) + 'a) + 2)) + 4,
           'b * 1 * 2 * 3 * 4,
-          'a + 1 + 'b + 2 + 'c + 3)
+          'a + 1 + 'b + 2 + 'c + 3,
+          Rand(0) * 1 * 2 * 3 * 4)
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
@@ -49,7 +50,8 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
         .select(
           ('a + 10).as("((3 + ((1 + a) + 2)) + 4)"),
           ('b * 24).as("((((b * 1) * 2) * 3) * 4)"),
-          ('a + 'b + 'c + 6).as("(((((a + 1) + b) + 2) + c) + 3)"))
+          ('a + 'b + 'c + 6).as("(((((a + 1) + b) + 2) + c) + 3)"),
+          Rand(0) * 1 * 2 * 3 * 4)
         .analyze
 
     comparePlans(optimized, correctAnswer)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This issue add a new optimizer `ReorderAssociativeOperator` by taking advantage of integral associative property. Currently, Spark works like the following.

1) Can optimize `1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + a` into `45 + a`.
2) Cannot optimize `a + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9`.

This PR can handle Case 2 for **Add/Multiply** expression whose data types are `ByteType`, `ShortType`, `IntegerType`, and `LongType`. The followings are the plan comparison between `before` and `after` this issue.

**Before**

``` scala
scala> sql("select a+1+2+3+4+5+6+7+8+9 from (select explode(array(1)) a)").explain
== Physical Plan ==
WholeStageCodegen
:  +- Project [(((((((((a#7 + 1) + 2) + 3) + 4) + 5) + 6) + 7) + 8) + 9) AS (((((((((a + 1) + 2) + 3) + 4) + 5) + 6) + 7) + 8) + 9)#8]
:     +- INPUT
+- Generate explode([1]), false, false, [a#7]
   +- Scan OneRowRelation[]
scala> sql("select a*1*2*3*4*5*6*7*8*9 from (select explode(array(1)) a)").explain
== Physical Plan ==
*Project [(((((((((a#18 * 1) * 2) * 3) * 4) * 5) * 6) * 7) * 8) * 9) AS (((((((((a * 1) * 2) * 3) * 4) * 5) * 6) * 7) * 8) * 9)#19]
+- Generate explode([1]), false, false, [a#18]
   +- Scan OneRowRelation[]
```

**After**

``` scala
scala> sql("select a+1+2+3+4+5+6+7+8+9 from (select explode(array(1)) a)").explain
== Physical Plan ==
WholeStageCodegen
:  +- Project [(a#7 + 45) AS (((((((((a + 1) + 2) + 3) + 4) + 5) + 6) + 7) + 8) + 9)#8]
:     +- INPUT
+- Generate explode([1]), false, false, [a#7]
   +- Scan OneRowRelation[]
scala> sql("select a*1*2*3*4*5*6*7*8*9 from (select explode(array(1)) a)").explain
== Physical Plan ==
*Project [(a#18 * 362880) AS (((((((((a * 1) * 2) * 3) * 4) * 5) * 6) * 7) * 8) * 9)#19]
+- Generate explode([1]), false, false, [a#18]
   +- Scan OneRowRelation[]
```

This PR is greatly generalized by @cloud-fan 's key ideas; he should be credited for the work he did.
## How was this patch tested?

Pass the Jenkins tests including new testsuite.
