### PR TITLE
[SPARK-14772][ML,PySpark]Python ML Params.copy treats uid, paramMaps …

### DIFF
--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -366,14 +366,15 @@ class Params(Identifiable):
         user-supplied values < extra.
 
         :param extra: extra param values
+        :param default: if just copy the default param map
         :return: merged param map
         """
-        if extra is None:
+        if extra is None and not default:
             extra = dict()
         paramMap = self._defaultParamMap.copy()
         if not default:
             paramMap.update(self._paramMap)
-        paramMap.update(extra)
+            paramMap.update(extra)
         return paramMap
 
     @since("1.4.0")
@@ -471,6 +472,7 @@ class Params(Identifiable):
 
         :param to: the target instance
         :param extra: extra params to be copied
+        :param default: if just copy the default param map
         :return: the target instance with param values copied
         """
         if extra is None:
@@ -479,7 +481,6 @@ class Params(Identifiable):
         for p in self.params:
             if p in paramMap and to.hasParam(p.name):
                 to._set(**{p.name: paramMap[p]})
-        to.set(**{'uid': self.uid})
         return to
 
     def _resetUid(self, newUid):

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -357,7 +357,7 @@ class Params(Identifiable):
             return self._defaultParamMap[param]
 
     @since("1.4.0")
-    def extractParamMap(self, extra=None):
+    def extractParamMap(self, extra=None, default=False):
         """
         Extracts the embedded default param values and user-supplied
         values, and then merges them with extra values from input into
@@ -371,7 +371,8 @@ class Params(Identifiable):
         if extra is None:
             extra = dict()
         paramMap = self._defaultParamMap.copy()
-        paramMap.update(self._paramMap)
+        if not default:
+            paramMap.update(self._paramMap)
         paramMap.update(extra)
         return paramMap
 
@@ -463,7 +464,7 @@ class Params(Identifiable):
             self._defaultParamMap[p] = value
         return self
 
-    def _copyValues(self, to, extra=None):
+    def _copyValues(self, to, extra=None, default=False):
         """
         Copies param values from this instance to another instance for
         params shared by them.
@@ -474,10 +475,11 @@ class Params(Identifiable):
         """
         if extra is None:
             extra = dict()
-        paramMap = self.extractParamMap(extra)
+        paramMap = self.extractParamMap(extra, default)
         for p in self.params:
             if p in paramMap and to.hasParam(p.name):
                 to._set(**{p.name: paramMap[p]})
+        to.set(**{'uid': self.uid})
         return to
 
     def _resetUid(self, newUid):

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -378,7 +378,7 @@ class Params(Identifiable):
         return paramMap
 
     @since("1.4.0")
-    def copy(self, extra=None):
+    def copy(self, extra=None, default=False):
         """
         Creates a copy of this instance with the same uid and some
         extra params. The default implementation creates a
@@ -388,13 +388,14 @@ class Params(Identifiable):
         is not sufficient.
 
         :param extra: Extra parameters to copy to the new instance
+        :param default: if just copy the default param map
         :return: Copy of this instance
         """
         if extra is None:
             extra = dict()
         that = copy.copy(self)
         that._paramMap = {}
-        return self._copyValues(that, extra)
+        return self._copyValues(that, extra, default)
 
     def _shouldOwn(self, param):
         """


### PR DESCRIPTION
## What changes were proposed in this pull request?

The patch referenced [SPARK-14772](https://issues.apache.org/jira/browse/SPARK-14772#)
After apply this patch, user can choose to just copy the default param map or the param map.
## How was this patch tested?

Unit test, test locally.
