### PR TITLE
[SPARK-15119] [ML] Add a validator to DecisionTreeParams.minInfoGain parameter

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -77,7 +77,8 @@ private[ml] trait DecisionTreeParams extends PredictorParams
    * @group param
    */
   final val minInfoGain: DoubleParam = new DoubleParam(this, "minInfoGain",
-    "Minimum information gain for a split to be considered at a tree node.")
+    "Minimum information gain for a split to be considered at a tree node.",
+    ParamValidators.gtEq(0))
 
   /**
    * Maximum memory in MB allocated to histogram aggregation. If too small, then 1 node will be


### PR DESCRIPTION
## What changes were proposed in this pull request?

A validator for minGainInfo was added, assuring the value is >= 0.
## How was this patch tested?

By running unit tests in org.apache.spark.ml.tree.impl.
