### PR TITLE
[SPARK-13370][SQL] Require whitespace between expression and alias

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -438,7 +438,11 @@ tableIdentifier
     ;
 
 namedExpression
-    : expression (AS? (identifier | identifierList))?
+    : expression (ws (AS ws)? (identifier | identifierList))?
+    ;
+
+ws
+    : {_input.get(_input.index() - 1).getType() == WS}?
     ;
 
 namedExpressionSeq

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -438,11 +438,7 @@ tableIdentifier
     ;
 
 namedExpression
-    : expression (ws (AS ws)? (identifier | identifierList))?
-    ;
-
-ws
-    : {_input.get(_input.index() - 1).getType() == WS}?
+    : expression (AS? (identifier | identifierList))?
     ;
 
 namedExpressionSeq
@@ -627,6 +623,7 @@ number
     | SMALLINT_LITERAL         #smallIntLiteral
     | TINYINT_LITERAL          #tinyIntLiteral
     | DOUBLE_LITERAL           #doubleLiteral
+    | BIG_DECIMAL_LITERAL      #bigDecimalLiteral
     ;
 
 nonReserved
@@ -908,9 +905,12 @@ SCIENTIFIC_DECIMAL_VALUE
     | '.' DIGIT+ EXPONENT
     ;
 
+BIG_DECIMAL_LITERAL
+    : (INTEGER_VALUE | DECIMAL_VALUE | SCIENTIFIC_DECIMAL_VALUE) 'B' 'D'
+    ;
+
 DOUBLE_LITERAL
-    :
-    (INTEGER_VALUE | DECIMAL_VALUE | SCIENTIFIC_DECIMAL_VALUE) 'D'
+    : (INTEGER_VALUE | DECIMAL_VALUE | SCIENTIFIC_DECIMAL_VALUE) 'D'
     ;
 
 IDENTIFIER

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -71,7 +71,7 @@ object ParserUtils {
   }
 
   /** Assert if a condition holds. If it doesn't throw a parse exception. */
-  def assert(f: => Boolean, message: String, ctx: ParserRuleContext): Unit = {
+  def assert(f: => Boolean, message: => String, ctx: ParserRuleContext): Unit = {
     if (!f) {
       throw new ParseException(message, ctx)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -76,8 +76,8 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("1SL", Symbol("1SL"))
     assertEqual("1 asL", Literal(1).as("asL"))
     assertEqual("1as L", Symbol("1as").as("L"))
-    intercept("1.0L", "no viable alternative at input")
-    intercept("(1.0 + 1)L", "no viable alternative at input")
+    assertEqual("(1E0 + 1)L", (Literal(1.0) + Literal(1)).as("L"))
+    intercept("1.0L", "Ambiguous alias 'L' encountered")
 
     // Aliased star is allowed.
     assertEqual("a.* b", UnresolvedStar(Option(Seq("a"))) as 'b)
@@ -392,6 +392,11 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("10.0D", Literal(10.0D))
     // TODO we need to figure out if we should throw an exception here!
     assertEqual("1E309", Literal(Double.PositiveInfinity))
+
+    // Big Decimal Literal
+    assertEqual("1BD", Literal(BigDecimal("1").underlying()))
+    assertEqual("7873247234798249279371.2334BD",
+      Literal(BigDecimal("7873247234798249279371.2334").underlying()))
   }
 
   test("strings") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -73,8 +73,11 @@ class ExpressionParserSuite extends PlanTest {
 
     // Numeric literals without a space between the literal qualifier and the alias, should not be
     // interpreted as such. An unresolved reference should be returned instead.
-    // TODO add the JIRA-ticket number.
     assertEqual("1SL", Symbol("1SL"))
+    assertEqual("1 asL", Literal(1).as("asL"))
+    assertEqual("1as L", Symbol("1as").as("L"))
+    intercept("1.0L", "no viable alternative at input")
+    intercept("(1.0 + 1)L", "no viable alternative at input")
 
     // Aliased star is allowed.
     assertEqual("a.* b", UnresolvedStar(Option(Seq("a"))) as 'b)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The parser currently interprets `1.0L` as `Alias(Literal(BigDecimal(1.0)), "L")`. This violates the principle of least surprise. This PR changes this behavior and throws an exception when the an expression has an ambiguous alias (an alias without a space).

I also added support for Hive's BigDecimal literal since this missing feature caused a test failure.
## How was this patch tested?

Added tests to `ExpressionParserSuite`.
