### PR TITLE
[SPARK-15123] upgrade org.json4s to 3.2.11 version

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -110,9 +110,9 @@ joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar
-json4s-ast_2.11-3.2.10.jar
-json4s-core_2.11-3.2.10.jar
-json4s-jackson_2.11-3.2.10.jar
+json4s-ast_2.11-3.2.11.jar
+json4s-core_2.11-3.2.11.jar
+json4s-jackson_2.11-3.2.11.jar
 jsr305-1.3.9.jar
 jta-1.1.jar
 jtransforms-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -101,9 +101,9 @@ joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar
-json4s-ast_2.11-3.2.10.jar
-json4s-core_2.11-3.2.10.jar
-json4s-jackson_2.11-3.2.10.jar
+json4s-ast_2.11-3.2.11.jar
+json4s-core_2.11-3.2.11.jar
+json4s-jackson_2.11-3.2.11.jar
 jsr305-1.3.9.jar
 jta-1.1.jar
 jtransforms-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -102,9 +102,9 @@ joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar
-json4s-ast_2.11-3.2.10.jar
-json4s-core_2.11-3.2.10.jar
-json4s-jackson_2.11-3.2.10.jar
+json4s-ast_2.11-3.2.11.jar
+json4s-core_2.11-3.2.11.jar
+json4s-jackson_2.11-3.2.11.jar
 jsr305-1.3.9.jar
 jta-1.1.jar
 jtransforms-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -108,9 +108,9 @@ joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar
-json4s-ast_2.11-3.2.10.jar
-json4s-core_2.11-3.2.10.jar
-json4s-jackson_2.11-3.2.10.jar
+json4s-ast_2.11-3.2.11.jar
+json4s-core_2.11-3.2.11.jar
+json4s-jackson_2.11-3.2.11.jar
 jsr305-1.3.9.jar
 jta-1.1.jar
 jtransforms-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -108,9 +108,9 @@ joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar
-json4s-ast_2.11-3.2.10.jar
-json4s-core_2.11-3.2.10.jar
-json4s-jackson_2.11-3.2.10.jar
+json4s-ast_2.11-3.2.11.jar
+json4s-core_2.11-3.2.11.jar
+json4s-jackson_2.11-3.2.11.jar
 jsp-api-2.1.jar
 jsr305-1.3.9.jar
 jta-1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -619,7 +619,7 @@
       <dependency>
         <groupId>org.json4s</groupId>
         <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-        <version>3.2.10</version>
+        <version>3.2.11</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We had the issue when using snowplow in our Spark applications. Snowplow requires json4s version 3.2.11 while Spark still use a few years old version 3.2.10. The change is to upgrade json4s jar to 3.2.11.
## How was this patch tested?

We built Spark jar and successfully ran our applications in local and cluster modes.
