### PR TITLE
[SPARK-15145][ML]:port binary classification evaluator to spark.ml

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -136,6 +136,12 @@ class BinaryClassificationMetrics @Since("1.3.0") (
   def precisionByThreshold(): RDD[(Double, Double)] = createCurve(Precision)
 
   /**
+   * Returns the (threshold, accuracy) curve.
+   */
+  @Since("2.0.0")
+  def accuracyByThreshold(): RDD[(Double, Double)] = createCurve(Accuracy)
+
+  /**
    * Returns the (threshold, recall) curve.
    */
   @Since("1.0.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/binary/BinaryClassificationMetricComputers.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/binary/BinaryClassificationMetricComputers.scala
@@ -24,14 +24,14 @@ private[evaluation] trait BinaryClassificationMetricComputer extends Serializabl
   def apply(c: BinaryConfusionMatrix): Double
 }
 
-/** Accuracy. Defined as 1.0 where there are zero no positive and negative examples. */
+/** Accuracy. Defined as 1.0 where there are no positive and negative examples. */
 private[evaluation] object Accuracy extends BinaryClassificationMetricComputer {
-  override  def apply(c: BinaryConfusionMatrix): Double = {
+  override def apply(c: BinaryConfusionMatrix): Double = {
     val totalCounts = c.numNegatives + c.numPositives
-    val totalTrue = c.numTruePositives + c.numTrueNegatives
     if (totalCounts == 0) {
       1.0
     } else {
+      val totalTrue = c.numTruePositives + c.numTrueNegatives
       totalTrue.toDouble / totalCounts
     }
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/binary/BinaryClassificationMetricComputers.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/binary/BinaryClassificationMetricComputers.scala
@@ -24,6 +24,19 @@ private[evaluation] trait BinaryClassificationMetricComputer extends Serializabl
   def apply(c: BinaryConfusionMatrix): Double
 }
 
+/** Accuracy. Defined as 1.0 where there are zero no positive and negative examples. */
+private[evaluation] object Accuracy extends BinaryClassificationMetricComputer {
+  override  def apply(c: BinaryConfusionMatrix): Double = {
+    val totalCounts = c.numNegatives + c.numPositives
+    val totalTrue = c.numTruePositives + c.numTrueNegatives
+    if (totalCounts == 0) {
+      1.0
+    } else {
+      totalTrue.toDouble / totalCounts
+    }
+  }
+}
+
 /** Precision. Defined as 1.0 when there are no positive examples. */
 private[evaluation] object Precision extends BinaryClassificationMetricComputer {
   override def apply(c: BinaryConfusionMatrix): Double = {

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
@@ -85,7 +85,7 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     val prCurve = Seq((0.0, 1.0)) ++ pr
     val f1 = pr.map { case (r, p) => 2.0 * (p * r) / (p + r)}
     val f2 = pr.map { case (r, p) => 5.0 * (p * r) / (4.0 * p + r)}
-    val accuracies = numTruePosNeg.map (t => t.toDouble / numAllCounts)
+    val accuracies = numTruePosNeg.map(t => t.toDouble / numAllCounts)
 
     validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls, accuracies)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add accuracy into binary classification metrics.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Add new scala unit test and all tests passed
