### PR TITLE
[Spark-15155][Mesos] Optionally ignore default role resources

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -429,6 +429,13 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.mesos.ignoreDefaultRoleResources</code></td>
+  <td>false</td>
+  <td>
+    Only if `spark.mesos.role` has been set, ignore mesos resources with the role `*`.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.constraints</code></td>
   <td>(none)</td>
   <td>

--- a/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosDriverDescription.scala
+++ b/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosDriverDescription.scala
@@ -41,7 +41,7 @@ private[spark] class MesosDriverDescription(
     val cores: Double,
     val supervise: Boolean,
     val command: Command,
-    schedulerProperties: Map[String, String],
+    val schedulerProperties: Map[String, String],
     val submissionId: String,
     val submissionDate: Date,
     val retryState: Option[MesosClusterRetryState] = None)

--- a/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -382,6 +382,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     val remainingResources = mutable.Map(offers.map(offer =>
       (offer.getId.getValue, offer.getResourcesList)): _*)
 
+    val acceptedResourceRoles = getAcceptedResourceRoles(sc.conf)
+
     var launchTasks = true
 
     // TODO(mgummelt): combine offers for a single slave
@@ -393,15 +395,19 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       for (offer <- offers) {
         val slaveId = offer.getSlaveId.getValue
         val offerId = offer.getId.getValue
-        val resources = remainingResources(offerId)
+        val resources =
+          remainingResources(offerId).asScala
+            .filter((r: Resource) => acceptedResourceRoles(r.getRole))
+            .asJava
 
-        if (canLaunchTask(slaveId, resources)) {
+        if (canLaunchTask(slaveId, resources, acceptedResourceRoles)) {
           // Create a task
           launchTasks = true
           val taskId = newMesosTaskId()
           val offerCPUs = getResource(resources, "cpus").toInt
           val taskGPUs = Math.min(
-            Math.max(0, maxGpus - totalGpusAcquired), getResource(resources, "gpus").toInt)
+            Math.max(0, maxGpus - totalGpusAcquired),
+            getResource(resources, "gpus").toInt)
 
           val taskCPUs = executorCores(offerCPUs)
           val taskMemory = executorMemory(sc)
@@ -466,7 +472,10 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       cpuResourcesToUse ++ memResourcesToUse ++ portResourcesToUse ++ gpuResourcesToUse)
   }
 
-  private def canLaunchTask(slaveId: String, resources: JList[Resource]): Boolean = {
+  private def canLaunchTask(
+      slaveId: String,
+      resources: JList[Resource],
+      acceptedResourceRoles: Set[String]): Boolean = {
     val offerMem = getResource(resources, "mem")
     val offerCPUs = getResource(resources, "cpus").toInt
     val cpus = executorCores(offerCPUs)

--- a/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -249,10 +249,15 @@ private[spark] class MesosFineGrainedSchedulerBackend(
           .setRefuseSeconds(rejectOfferDurationForUnmetConstraints).build())
       }
 
+      val acceptedResourceRoles = getAcceptedResourceRoles(sc.conf)
+
       // Of the matching constraints, see which ones give us enough memory and cores
       val (usableOffers, unUsableOffers) = offersMatchingConstraints.partition { o =>
-        val mem = getResource(o.getResourcesList, "mem")
-        val cpus = getResource(o.getResourcesList, "cpus")
+        val acceptableResources = o.getResourcesList.asScala
+          .filter((r: Resource) => acceptedResourceRoles(r.getRole))
+          .asJava
+        val mem = getResource(acceptableResources, "mem")
+        val cpus = getResource(acceptableResources, "cpus")
         val slaveId = o.getSlaveId.getValue
         val offerAttributes = toAttributeMap(o.getAttributesList)
 

--- a/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
+++ b/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
@@ -291,7 +291,7 @@ class MesosFineGrainedSchedulerBackendSuite
     verify(driver, times(1)).declineOffer(mesosOffers2.get(0).getId)
   }
 
-  test("can handle multiple roles") {
+  test("accept all roles by default") {
     val driver = mock[SchedulerDriver]
     val taskScheduler = mock[TaskSchedulerImpl]
 
@@ -299,11 +299,14 @@ class MesosFineGrainedSchedulerBackendSuite
     listenerBus.post(
       SparkListenerExecutorAdded(anyLong, "s1", new ExecutorInfo("host1", 2, Map.empty)))
 
+    val conf = new SparkConf
+    conf.set("spark.mesos.role", "dev")
+
     val sc = mock[SparkContext]
     when(sc.executorMemory).thenReturn(100)
     when(sc.getSparkHome()).thenReturn(Option("/path"))
     when(sc.executorEnvs).thenReturn(new mutable.HashMap[String, String])
-    when(sc.conf).thenReturn(new SparkConf)
+    when(sc.conf).thenReturn(conf)
     when(sc.listenerBus).thenReturn(listenerBus)
 
     val id = 1
@@ -311,11 +314,11 @@ class MesosFineGrainedSchedulerBackendSuite
     builder.addResourcesBuilder()
       .setName("mem")
       .setType(Value.Type.SCALAR)
-      .setRole("prod")
+      .setRole("*")
       .setScalar(Scalar.newBuilder().setValue(500))
     builder.addResourcesBuilder()
       .setName("cpus")
-      .setRole("prod")
+      .setRole("*")
       .setType(Value.Type.SCALAR)
       .setScalar(Scalar.newBuilder().setValue(1))
     builder.addResourcesBuilder()
@@ -339,11 +342,11 @@ class MesosFineGrainedSchedulerBackendSuite
     val backend = new MesosFineGrainedSchedulerBackend(taskScheduler, sc, "master")
 
     val expectedWorkerOffers = new ArrayBuffer[WorkerOffer](1)
-    expectedWorkerOffers += new WorkerOffer(
+    expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(0).getSlaveId.getValue,
       mesosOffers.get(0).getHostname,
       2 // Deducting 1 for executor
-    )
+    ))
 
     val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
     when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))
@@ -376,10 +379,106 @@ class MesosFineGrainedSchedulerBackendSuite
     assert(cpusDev.getRole.equals("dev"))
     val executorResources = taskInfo.getExecutor.getResourcesList.asScala
     assert(executorResources.exists { r =>
-      r.getName.equals("mem") && r.getScalar.getValue.equals(484.0) && r.getRole.equals("prod")
+      r.getName.equals("mem") && r.getScalar.getValue.equals(484.0) && r.getRole.equals("*")
     })
     assert(executorResources.exists { r =>
-      r.getName.equals("cpus") && r.getScalar.getValue.equals(1.0) && r.getRole.equals("prod")
+      r.getName.equals("cpus") && r.getScalar.getValue.equals(1.0) && r.getRole.equals("*")
+    })
+  }
+
+  test("can ignore default role") {
+    val driver = mock[SchedulerDriver]
+    val taskScheduler = mock[TaskSchedulerImpl]
+
+    val listenerBus = mock[LiveListenerBus]
+    listenerBus.post(
+      SparkListenerExecutorAdded(anyLong, "s1", new ExecutorInfo("host1", 2, Map.empty)))
+
+    val conf = new SparkConf
+    conf.set("spark.mesos.role", "dev")
+    conf.set("spark.mesos.ignoreDefaultRoleResources", "true")
+
+    val sc = mock[SparkContext]
+    when(sc.executorMemory).thenReturn(100)
+    when(sc.getSparkHome()).thenReturn(Option("/path"))
+    when(sc.executorEnvs).thenReturn(new mutable.HashMap[String, String])
+    when(sc.conf).thenReturn(conf)
+    when(sc.listenerBus).thenReturn(listenerBus)
+
+    val id = 1
+    val builder = Offer.newBuilder()
+    builder.addResourcesBuilder()
+      .setName("mem")
+      .setType(Value.Type.SCALAR)
+      .setRole("*")
+      .setScalar(Scalar.newBuilder().setValue(500))
+    builder.addResourcesBuilder()
+      .setName("cpus")
+      .setRole("*")
+      .setType(Value.Type.SCALAR)
+      .setScalar(Scalar.newBuilder().setValue(1))
+    builder.addResourcesBuilder()
+      .setName("mem")
+      .setRole("dev")
+      .setType(Value.Type.SCALAR)
+      .setScalar(Scalar.newBuilder().setValue(600))
+    builder.addResourcesBuilder()
+      .setName("cpus")
+      .setRole("dev")
+      .setType(Value.Type.SCALAR)
+      .setScalar(Scalar.newBuilder().setValue(2))
+    val offer = builder.setId(OfferID.newBuilder().setValue(s"o${id.toString}").build())
+      .setFrameworkId(FrameworkID.newBuilder().setValue("f1"))
+      .setSlaveId(SlaveID.newBuilder().setValue(s"s${id.toString}"))
+      .setHostname(s"host${id.toString}").build()
+
+    val mesosOffers = new java.util.ArrayList[Offer]
+    mesosOffers.add(offer)
+
+    val backend = new MesosFineGrainedSchedulerBackend(taskScheduler, sc, "master")
+
+    val expectedWorkerOffers = new ArrayBuffer[WorkerOffer](1)
+    expectedWorkerOffers.append(new WorkerOffer(
+      mesosOffers.get(0).getSlaveId.getValue,
+      mesosOffers.get(0).getHostname,
+      2 // Deducting 1 for executor
+    ))
+
+    val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
+    when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))
+    when(taskScheduler.CPUS_PER_TASK).thenReturn(1)
+
+    val capture = ArgumentCaptor.forClass(classOf[Collection[TaskInfo]])
+    when(
+      driver.launchTasks(
+        Matchers.eq(Collections.singleton(mesosOffers.get(0).getId)),
+        capture.capture(),
+        any(classOf[Filters])
+      )
+    ).thenReturn(Status.valueOf(1))
+
+    backend.resourceOffers(driver, mesosOffers)
+
+    verify(driver, times(1)).launchTasks(
+      Matchers.eq(Collections.singleton(mesosOffers.get(0).getId)),
+      capture.capture(),
+      any(classOf[Filters])
+    )
+
+    assert(capture.getValue.size() === 1)
+    val taskInfo = capture.getValue.iterator().next()
+    assert(taskInfo.getName.equals("n1"))
+    assert(taskInfo.getResourcesCount === 1)
+    val cpusDev = taskInfo.getResourcesList.get(0)
+    assert(cpusDev.getName.equals("cpus"))
+    assert(cpusDev.getScalar.getValue.equals(1.0))
+    assert(cpusDev.getRole.equals("dev"))
+    val executorResources = taskInfo.getExecutor.getResourcesList.asScala
+    assert(executorResources.exists { r =>
+      r.getName.equals("mem") && r.getScalar.getValue.equals(484.0) && r.getRole.equals("*")
+    })
+    assert(executorResources.exists { r =>
+      r.getName.equals("cpus") && r.getScalar.getValue.equals(1.0) && r.getRole.equals("*")
     })
   }
 }


### PR DESCRIPTION
Add new boolean property: `spark.mesos.ignoreDefaultRoleResources`. When this property is set Spark will only accept resources from the role passed in the `spark.mesos.role` property. If `spark.mesos.role` has not been set, `spark.mesos.ignoreDefaultRoleResources` has no effect.

Additional unit tests added to `MesosSchedulerBackendSuite`, extending the original multi-role test suite.
