### PR TITLE
[SPARK-15092][PySpark][ML] Add toDebugString to DecisionTreeModel

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -510,6 +510,8 @@ class DecisionTreeClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPred
     1
     >>> model.featureImportances
     SparseVector(1, {0: 1.0})
+    >>> print(model.toDebugString)
+    DecisionTreeClassificationModel (uid=...) of depth 1 with 3 nodes...
     >>> test0 = sqlContext.createDataFrame([(Vectors.dense(-1.0),)], ["features"])
     >>> result = model.transform(test0).head()
     >>> result.prediction

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -726,6 +726,12 @@ class DecisionTreeModel(JavaModel):
         """Return depth of the decision tree."""
         return self._call_java("depth")
 
+    @property
+    @since("2.0.0")
+    def toDebugString(self):
+        """Full description of model."""
+        return self._call_java("toDebugString")
+
     def __repr__(self):
         return self._call_java("toString")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add toDebugString to DecisionTreeModel. This is related to https://github.com/apache/spark/pull/12919 but different base class.
## How was this patch tested?

DocTests
