### PR TITLE
[SPARK-15167][SQL] Expose catalog implementation in SparkSession

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -28,6 +28,14 @@ import org.apache.spark.sql.types.StructType
 abstract class Catalog {
 
   /**
+   * Return an identifier for the underlying catalog implementation, currently must be
+   * either 'hive' or 'in-memory'.
+   *
+   * @since 2.0.0
+   */
+  def implementation: String
+
+  /**
    * Returns the current default database in this session.
    *
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.annotation.Experimental
+import org.apache.spark.internal.config.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.catalog.{Catalog, Column, Database, Function, Table}
 import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, TableIdentifier}
@@ -57,6 +58,12 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
     val queryExecution = sparkSession.executePlan(plan)
     new Dataset[T](sparkSession, queryExecution, enc)
   }
+
+  /**
+   * Return an identifier for the underlying catalog implementation, currently must be
+   * either 'hive' or 'in-memory'.
+   */
+  override val implementation: String = sparkSession.sparkContext.conf.get(CATALOG_IMPLEMENTATION)
 
   /**
    * Returns the current default database in this session.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now there's no way to check whether a given `SparkSession` has Hive support. You can do `spark.conf.get("spark.sql.catalogImplementation")` but that's supposed to be hidden from the user.

After this patch, the user can run the following to find out whether this `SparkSession` has Hive support.

```
scala> spark.catalog.implementation
res0: String = in-memory
```
## How was this patch tested?

Jenkins.
