### PR TITLE
[SPARK-15176][Core] Add maxShares setting to Pools

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -32,6 +32,7 @@ private[spark] class Pool(
     val poolName: String,
     val schedulingMode: SchedulingMode,
     initMinShare: Int,
+    val initMaxRunningTasks: Int,
     initWeight: Int)
   extends Schedulable with Logging {
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
@@ -34,10 +34,23 @@ private[spark] trait Schedulable {
   def schedulingMode: SchedulingMode
   def weight: Int
   def minShare: Int
+  val initMaxRunningTasks: Int
   def runningTasks: Int
   def priority: Int
   def stageId: Int
   def name: String
+
+  /**
+   * How much space for new tasks is there in this Schedulable?
+   */
+  def maxRunningTasks: Int = {
+    val myMaxRunningTasks = math.max(0, initMaxRunningTasks - runningTasks)
+    if (parent == null) {
+      myMaxRunningTasks
+    } else {
+      math.min(myMaxRunningTasks, parent.maxRunningTasks)
+    }
+  }
 
   def addSchedulable(schedulable: Schedulable): Unit
   def removeSchedulable(schedulable: Schedulable): Unit

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -135,7 +135,7 @@ private[spark] class TaskSchedulerImpl(
   def initialize(backend: SchedulerBackend) {
     this.backend = backend
     // temporarily set rootPool name to empty
-    rootPool = new Pool("", schedulingMode, 0, 0)
+    rootPool = new Pool("", schedulingMode, 0, Int.MaxValue, 0)
     schedulableBuilder = {
       schedulingMode match {
         case SchedulingMode.FIFO =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -97,6 +97,7 @@ private[spark] class TaskSetManager(
   var parent: Pool = null
   var totalResultSize = 0L
   var calculatedTasks = 0
+  val initMaxRunningTasks = Int.MaxValue
 
   val runningTasksSet = new HashSet[Long]
 
@@ -421,7 +422,7 @@ private[spark] class TaskSetManager(
       maxLocality: TaskLocality.TaskLocality)
     : Option[TaskDescription] =
   {
-    if (!isZombie) {
+    if (!isZombie && maxRunningTasks > 0) {
       val curTime = clock.getTimeMillis()
 
       var allowedLocality = maxLocality

--- a/core/src/test/resources/nestedpool.xml
+++ b/core/src/test/resources/nestedpool.xml
@@ -17,18 +17,44 @@
   -->
 
 <allocations>
+<pool name="0">
+    <minShare>3</minShare>
+    <maxRunningTasks>1024</maxRunningTasks>
+    <weight>1</weight>
+    <schedulingMode>FAIR</schedulingMode>
+</pool>
 <pool name="1">
+    <minShare>4</minShare>
+    <maxRunningTasks>128</maxRunningTasks>
+    <weight>1</weight>
+    <schedulingMode>FAIR</schedulingMode>
+</pool>
+<pool name="00">
+    <parent>0</parent>
     <minShare>2</minShare>
     <maxRunningTasks>512</maxRunningTasks>
-    <weight>1</weight>
-    <schedulingMode>FIFO</schedulingMode>
+    <weight>2</weight>
+    <schedulingMode>FAIR</schedulingMode>
 </pool>
-<pool name="2">
-    <minShare>3</minShare>
+<pool name="01">
+    <parent>0</parent>
+    <minShare>1</minShare>
+    <maxRunningTasks>128</maxRunningTasks>
+    <weight>1</weight>
+    <schedulingMode>FAIR</schedulingMode>
+</pool>
+<pool name="10">
+    <parent>1</parent>
+    <minShare>2</minShare>
     <maxRunningTasks>256</maxRunningTasks>
-    <weight>1</weight>
-    <schedulingMode>FIFO</schedulingMode>
+    <weight>2</weight>
+    <schedulingMode>FAIR</schedulingMode>
 </pool>
-<pool name="3">
+<pool name="11">
+    <parent>1</parent>
+    <minShare>2</minShare>
+    <maxRunningTasks>64</maxRunningTasks>
+    <weight>1</weight>
+    <schedulingMode>FAIR</schedulingMode>
 </pool>
 </allocations>

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -318,6 +318,129 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     assert(manager.resourceOffer("exec2", "host2", ANY).get.index === 3)
   }
 
+  test("Scheduler respects maxRunningTasks setting of its pool") {
+    sc = new SparkContext("local", "test")
+    val sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val clock = new ManualClock
+
+    // set up three pools to contend for three resources
+    val parent = new Pool("parent", SchedulingMode.FAIR, 0, 3, 0)
+    val child0 = new Pool("child0", SchedulingMode.FAIR, 0, 2, 0)
+    val child1 = new Pool("child1", SchedulingMode.FAIR, 0, 2, 0)
+    child0.parent = parent
+    child1.parent = parent
+
+    // add a taskset for each pool
+    val parentManager = new TaskSetManager(
+      sched, FakeTask.createTaskSet(5), MAX_TASK_FAILURES, clock)
+    val child0Manager = new TaskSetManager(
+      sched, FakeTask.createTaskSet(3), MAX_TASK_FAILURES, clock)
+    val child1Manager = new TaskSetManager(
+      sched, FakeTask.createTaskSet(3), MAX_TASK_FAILURES, clock)
+    parentManager.parent = parent
+    child0Manager.parent = child0
+    child1Manager.parent = child1
+
+    // child pool has two tasks...
+    val c0t0 = child0Manager.resourceOffer("exec1", "host1", ANY).get
+    assert(c0t0.index === 0)
+    val c0t1 = child0Manager.resourceOffer("exec1", "host1", ANY).get
+    assert(c0t1.index === 1)
+
+    // but not three!
+    assert(child0Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    assert(child0.maxRunningTasks === 0)
+    assert(child1.maxRunningTasks === 1)
+    assert(parent.maxRunningTasks === 1)
+
+    // ...until one of the others finishes
+    child0Manager.handleSuccessfulTask(c0t0.taskId, createTaskResult())
+    val c0t2 = child0Manager.resourceOffer("exec1", "host1", ANY).get
+    assert(c0t2.index === 2)
+    assert(child0Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // meanwhile, we can add a task to the other child pool
+    val c1t0 = child1Manager.resourceOffer("exec1", "host1", ANY).get
+    assert(c1t0.index === 0)
+    assert(child1Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // as three are in use, we can't add any to the other pools
+    assert(parentManager.resourceOffer("exec1", "host1", ANY).isEmpty)
+    assert(child0Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    assert(child0.maxRunningTasks === 0)
+    assert(child1.maxRunningTasks === 0)
+    assert(parent.maxRunningTasks === 0)
+
+    // finish another child task, and add a task to the parent
+    child0Manager.handleSuccessfulTask(c0t1.taskId, createTaskResult())
+    val pt0 = parentManager.resourceOffer("exec1", "host1", ANY).get
+    assert(pt0.index === 0)
+    assert(parentManager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // three tasks are running, so we can't add things to the other pool
+    assert(child0Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+    assert(child1Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // finish the parent task. We now have one running in each child pool...
+    parentManager.handleSuccessfulTask(pt0.taskId, createTaskResult())
+
+    // so add another to the first child
+    val c1t1 = child1Manager.resourceOffer("exec1", "host1", ANY).get
+    assert(c1t1.index === 1)
+    assert(child1Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // check we still can't add tasks to the other pools
+    assert(parentManager.resourceOffer("exec1", "host1", ANY).isEmpty)
+    assert(child0Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // finish the last task of the child pool. It shouldn't schedule any more!
+    child0Manager.handleSuccessfulTask(c0t2.taskId, createTaskResult())
+    assert(child0Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // the child 1 pool is already running two tasks, so even if we offer it
+    // more resources it can't accept:
+    assert(child1Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    assert(child0.maxRunningTasks === 1) // limited by parent, otherwise would be 2
+    assert(child0Manager.runningTasks === 0)
+    assert(child1.maxRunningTasks === 0)
+    assert(child1Manager.runningTasks === 2)
+    assert(parent.maxRunningTasks === 1)
+    assert(parentManager.runningTasks === 0)
+
+    // ...so give it to the parent
+    val pt1 = parentManager.resourceOffer("exec1", "host1", ANY).get
+    assert(pt1.index === 1)
+    assert(parentManager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // now, finish all the tasks in the child ppols, and fill up the parent pool
+    child0Manager.handleSuccessfulTask(c0t2.taskId, createTaskResult())
+    child1Manager.handleSuccessfulTask(c1t0.taskId, createTaskResult())
+    child1Manager.handleSuccessfulTask(c1t1.taskId, createTaskResult())
+    val pt2 = parentManager.resourceOffer("exec1", "host1", ANY).get
+    val pt3 = parentManager.resourceOffer("exec1", "host1", ANY).get
+    assert(parentManager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    assert(child0.maxRunningTasks === 0)
+    assert(child0Manager.runningTasks === 0)
+    assert(child1.maxRunningTasks === 0)
+    assert(child1Manager.runningTasks === 0)
+    assert(parent.maxRunningTasks === 0)
+    assert(parentManager.runningTasks === 3)
+
+    // as the parent's used all three slots in the pool, the child pool can't
+    // run its tasks:
+    assert(child1Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+
+    // at least, until a parent finished
+    parentManager.handleSuccessfulTask(pt1.taskId, createTaskResult())
+    val c1t2 = child1Manager.resourceOffer("exec1", "host1", ANY).get
+    assert(c1t2.index === 2)
+    assert(child1Manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+  }
+
   test("delay scheduling with failed hosts") {
     sc = new SparkContext("local", "test")
     val sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"),
@@ -840,7 +963,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   }
 
   private def createTaskResult(
-      id: Int,
+      id: Int = 0xDEADBEEF, // default to a meaningless, yet obvious result value
       accumUpdates: Seq[AccumulatorV2[_, _]] = Seq.empty): DirectTaskResult[Int] = {
     val valueSer = SparkEnv.get.serializer.newInstance()
     new DirectTaskResult[Int](valueSer.serialize(id), accumUpdates)

--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -244,6 +244,11 @@ properties:
   The `minShare` property can therefore be another way to ensure that a pool can always get up to a
   certain number of resources (e.g. 10 cores) quickly without giving it a high priority for the rest
   of the cluster. By default, each pool's `minShare` is 0.
+* `maxRunningTasks`: Limit the number of tasks this pool can run concurrently. This includes all the
+  tasks run by nested pools.
+* `parent`: Make this pool a child of the pool named in the `parent` element. The parent pool must be
+  declared before the child in the configuration file; if not (or if the parent isn't declared at all)
+  the pool becomes a top-level pool.
 
 The pool properties can be set by creating an XML file, similar to `conf/fairscheduler.xml.template`,
 and setting a `spark.scheduler.allocation.file` property in your
@@ -274,4 +279,4 @@ within it for the various settings. For example:
 
 A full example is also available in `conf/fairscheduler.xml.template`. Note that any pools not
 configured in the XML file will simply get default values for all settings (scheduling mode FIFO,
-weight 1, and minShare 0).
+weight 1, no limit on running tasks and minShare 0).


### PR DESCRIPTION
## What changes were proposed in this pull request?

Help guarantee resource availablity by (hierarchically) limiting the amount of tasks a given pool can run. The maximum number of tasks for a given pool can be configured by the allocation XML file, and child pools are limited to at most the number of tasks of their parent.
## How was this patch tested?

Unit tests run and new unit tests added for functionality.
