### PR TITLE
[SPARK-15184] [SQL] Fix Silent Removal of An Existent Temp Table by Rename Table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -301,6 +301,15 @@ class SessionCatalog(
     if (oldName.database.isDefined || !tempTables.contains(oldTableName)) {
       externalCatalog.renameTable(db, oldTableName, newTableName)
     } else {
+      if (newName.database.isDefined) {
+        throw new AnalysisException(
+          s"RENAME TEMPORARY TABLE from '$oldName' to '$newName': destination database '$newDb' " +
+            s"is not empty")
+      }
+      if (tempTables.contains(oldTableName)) {
+        throw new AnalysisException(
+          s"RENAME TEMPORARY TABLE from '$oldName' to '$newName': destination table already exists")
+      }
       val table = tempTables(oldTableName)
       tempTables.remove(oldTableName)
       tempTables.put(newTableName, table)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -303,8 +303,8 @@ class SessionCatalog(
     } else {
       if (newName.database.isDefined) {
         throw new AnalysisException(
-          s"RENAME TEMPORARY TABLE from '$oldName' to '$newName': destination database '$newDb' " +
-            s"is not empty")
+          s"RENAME TEMPORARY TABLE from '$oldName' to '$newName': cannot specify database " +
+            s"name '${newName.database.get}' in the destination table")
       }
       if (tempTables.contains(newTableName)) {
         throw new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -306,7 +306,7 @@ class SessionCatalog(
           s"RENAME TEMPORARY TABLE from '$oldName' to '$newName': destination database '$newDb' " +
             s"is not empty")
       }
-      if (tempTables.contains(oldTableName)) {
+      if (tempTables.contains(newTableName)) {
         throw new AnalysisException(
           s"RENAME TEMPORARY TABLE from '$oldName' to '$newName': destination table already exists")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -396,7 +396,7 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     }
   }
 
-  test("rename temporary table - negative case 1") {
+  test("rename temporary table - destination table with database name") {
     withTempTable("tab1") {
       sql(
         """
@@ -414,14 +414,14 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
       }
       assert(e.getMessage.contains(
         "RENAME TEMPORARY TABLE from '`tab1`' to '`default`.`tab2`': " +
-          "destination database 'default' is not empty"))
+          "cannot specify database name 'default' in the destination table"))
 
       val catalog = sqlContext.sessionState.catalog
       assert(catalog.listTables("default") == Seq(TableIdentifier("tab1")))
     }
   }
 
-  test("rename temporary table - negative case 2") {
+  test("rename temporary table - destination table already exists") {
     withTempTable("tab1", "tab2") {
       sql(
         """


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Currently, if we rename a temp table `Tab1` to another existent temp table `Tab2`. `Tab2` will be silently removed. This PR is to detect it and issue an exception message. 

In addition, this PR also detects another issue in the rename table command. When the destination table identifier does have database name, we should not ignore them. That might mean users could rename a regular table. 
#### How was this patch tested?

Added two related test cases
