### PR TITLE
[SPARK-15096][ML]:LogisticRegression MultiClassSummarizer numClasses can fail if no valid labels are found

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -745,7 +745,13 @@ private[classification] class MultiClassSummarizer extends Serializable {
   def countInvalid: Long = totalInvalidCnt
 
   /** @return The number of distinct labels in the input dataset. */
-  def numClasses: Int = distinctMap.keySet.max + 1
+  def numClasses: Int = try {
+    distinctMap.keySet.max + 1
+  } catch {
+    case e: UnsupportedOperationException =>
+      val msg = "There are no valid labels in the input dataset."
+      throw new SparkException(msg)
+  }
 
   /** @return The weightSum of each label in the input dataset. */
   def histogram: Array[Double] = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -745,13 +745,7 @@ private[classification] class MultiClassSummarizer extends Serializable {
   def countInvalid: Long = totalInvalidCnt
 
   /** @return The number of distinct labels in the input dataset. */
-  def numClasses: Int = try {
-    distinctMap.keySet.max + 1
-  } catch {
-    case e: UnsupportedOperationException =>
-      val msg = "There are no valid labels in the input dataset."
-      throw new SparkException(msg)
-  }
+  def numClasses: Int = if (distinctMap.isEmpty) 0 else distinctMap.keySet.max + 1
 
   /** @return The weightSum of each label in the input dataset. */
   def histogram: Array[Double] = {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -257,11 +257,8 @@ class LogisticRegressionSuite
     assert(summarizer4.numClasses === 4)
 
     val summarizer5 = new MultiClassSummarizer
-    withClue("There are no valid labels in the input dataset.") {
-      intercept[org.apache.spark.SparkException] {
-        summarizer5.histogram
-      }
-    }
+    assert(summarizer5.histogram.isEmpty === true)
+    assert(summarizer5.numClasses === 0)
 
     // small map merges large one
     val summarizerA = summarizer1.merge(summarizer2)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -257,7 +257,7 @@ class LogisticRegressionSuite
     assert(summarizer4.numClasses === 4)
 
     val summarizer5 = new MultiClassSummarizer
-    assert(summarizer5.histogram.isEmpty === true)
+    assert(summarizer5.histogram.isEmpty)
     assert(summarizer5.numClasses === 0)
 
     // small map merges large one

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -256,6 +256,13 @@ class LogisticRegressionSuite
     assert(summarizer4.countInvalid === 2)
     assert(summarizer4.numClasses === 4)
 
+    val summarizer5 = new MultiClassSummarizer
+    withClue("There are no valid labels in the input dataset.") {
+      intercept[org.apache.spark.SparkException] {
+        summarizer5.histogram
+      }
+    }
+
     // small map merges large one
     val summarizerA = summarizer1.merge(summarizer2)
     assert(summarizerA.hashCode() === summarizer2.hashCode())


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Throw better exception when numClasses is empty and empty.max is thrown.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Add a new unit test, which calls histogram with empty numClasses.
