### PR TITLE
[SPARK-15207][BUILD] Use Travis CI for Java Linter and JDK7/8 compilation test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sudo: required
+# Travis CI Guide
+# - Environment Setup: https://docs.travis-ci.com/user/trusty-ci-environment
+# - Buidling Java Project: https://docs.travis-ci.com/user/languages/java
+# - Caching: https://docs.travis-ci.com/user/caching
 
+# 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit, ~2 CORE, 7.5GB RAM)
+sudo: required
 dist: trusty
 
+# 2. Choose language and target JDKs for parallel builds.
 language: java
-
 jdk:
   - oraclejdk7
   - oraclejdk8
 
-addons:
-  apt:
-    packages:
-    - python-numpy
-    - python-sphinx
-
+# 3. Setup cache directory for SBT and Maven.
 cache:
   directories:
   - $HOME/.sbt
   - $HOME/.m2
 
+# 4. Turn off notifications.
 notifications:
   email: false
 
+# 5. Run maven install before running lint-java.
 install:
   - export MAVEN_SKIP_RC=1
   - build/mvn -T 4 -q -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver install
 
+# 6. Run lint-java.
 script:
   - dev/lint-java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo: required
+
+dist: trusty
+
+language: java
+
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+
+addons:
+  apt:
+    packages:
+    - python-numpy
+    - python-sphinx
+
+cache:
+  directories:
+  - $HOME/.sbt
+  - $HOME/.m2
+
+notifications:
+  email: false
+
+install: true
+
+script:
+  - export MAVEN_SKIP_RC=1
+  - dev/check-license &&
+    dev/lint-python &&
+    dev/lint-scala &&
+    dev/lint-java &&
+    (build/mvn -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver compile | grep -v 'org/maven2/')

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,5 @@ script:
   - dev/check-license &&
     dev/lint-python &&
     dev/lint-scala &&
-    dev/lint-java &&
-    (build/mvn -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver compile test-compile | grep -v 'org/maven2/')
+    (build/mvn -T 2 -DskipTests -Ddoc-jar.skip=true -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver install | grep -v 'org/maven2/' | grep -v 'from the shaded jar') &&
+    dev/lint-java

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
     dev/lint-python &&
     dev/lint-scala &&
     dev/lint-java &&
-    (build/mvn -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver compile | grep -v 'org/maven2/')
+    (build/mvn -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver compile test-compile | grep -v 'org/maven2/')

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,9 @@ cache:
 notifications:
   email: false
 
-install: true
+install:
+  - export MAVEN_SKIP_RC=1
+  - build/mvn -T 4 -q -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver install
 
 script:
-  - export MAVEN_SKIP_RC=1
-  - dev/check-license &&
-    dev/lint-python &&
-    dev/lint-scala &&
-    (build/mvn -T 2 -DskipTests -Ddoc-jar.skip=true -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver install | grep -v 'org/maven2/' | grep -v 'from the shaded jar') &&
-    dev/lint-java
+  - dev/lint-java

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Travis CI Guide
-# - Environment Setup: https://docs.travis-ci.com/user/trusty-ci-environment
-# - Buidling Java Project: https://docs.travis-ci.com/user/languages/java
-# - Caching: https://docs.travis-ci.com/user/caching
+# Spark provides this Travis CI configuration file to help contributors
+# check Scala/Java style conformance and JDK7/8 compilation easily
+# during their preparing pull requests.
+#   - Scalastyle is executed during `maven install` implicitly.
+#   - Java Checkstyle is executed by `lint-java`.
+# See the related discussion here.
+# https://github.com/apache/spark/pull/12980
 
 # 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit, ~2 CORE, 7.5GB RAM)
 sudo: required


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Java Linter is disabled in Jenkins tests.

https://github.com/apache/spark/blob/master/dev/run-tests.py#L554

However, as of today, Spark has 721 java files with 97362 code (without blank/comments). It's about 1/3 of Scala.

```
--------------------------------------------------------------------------------
Language                      files          blank        comment           code
--------------------------------------------------------------------------------
Scala                          2353          62819         124060         318747
Java                            721          18617          23314          97362
```

This PR aims to take advantage of Travis CI to handle the following static analysis by adding a single file, `.travis.yml` without any additional burden on the existing servers.
- Java Linter
- JDK7/JDK8 maven compile

Note that this PR does not propose to remove some of the above work items from the Jenkins. It's possible, but we need to observe the Travis CI stability for a while. The main goal of this issue is to remove committer's overhead on linter-related PRs (the original PR and the fixation PR).
## How was this patch tested?

Pass the Travis CI tests. Please see the following link.

https://travis-ci.org/dongjoon-hyun/spark/builds/128595350
https://travis-ci.org/dongjoon-hyun/spark/builds/128708372
