### PR TITLE
[SPARK-15210][SQL] Add missing @DeveloperApi annotation in sql.types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.types
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{runtimeMirror, TypeTag}
 
+import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.catalyst.ScalaReflectionLock
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.util.Utils
@@ -141,6 +142,7 @@ protected[sql] abstract class AtomicType extends DataType {
  * :: DeveloperApi ::
  * Numeric data types.
  */
+@DeveloperApi
 abstract class NumericType extends AtomicType {
   // Unfortunately we can't get this implicitly as that breaks Spark Serialization. In order for
   // implicitly[Numeric[JvmType]] to be valid, we have to change JvmType from a type variable to a

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.types
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
+import org.apache.spark.annotation.DeveloperApi
 
 /**
  * :: DeveloperApi ::
@@ -31,6 +32,7 @@ import org.json4s.JsonDSL._
  * @param valueType The data type of map values.
  * @param valueContainsNull Indicates if map values have `null` values.
  */
+@DeveloperApi
 case class MapType(
   keyType: DataType,
   valueType: DataType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -40,6 +40,7 @@ import org.apache.spark.annotation.DeveloperApi
  * Note: This was previously a developer API in Spark 1.x. We are making this private in Spark 2.0
  * because we will very likely create a new version of this that works better with Datasets.
  */
+@DeveloperApi
 private[spark]
 abstract class UserDefinedType[UserType >: Null] extends DataType with Serializable {
 
@@ -101,6 +102,7 @@ abstract class UserDefinedType[UserType >: Null] extends DataType with Serializa
  *
  * Note: This can only be accessed via Python UDF, or accessed as serialized object.
  */
+@DeveloperApi
 private[sql] class PythonUserDefinedType(
     val sqlType: DataType,
     override val pyUDT: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -40,7 +40,6 @@ import org.apache.spark.annotation.DeveloperApi
  * Note: This was previously a developer API in Spark 1.x. We are making this private in Spark 2.0
  * because we will very likely create a new version of this that works better with Datasets.
  */
-@DeveloperApi
 private[spark]
 abstract class UserDefinedType[UserType >: Null] extends DataType with Serializable {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

add @DeveloperApi annotation for `AbstractDataType` `MapType` `UserDefinedType`
## How was this patch tested?

local build
