### PR TITLE
[SPARK-15206][SQL] add testcases for distinct aggregate in having clause

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -958,6 +958,69 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
         Row(11) :: Nil)
     }
   }
+
+  test("SPARK-15206: two distinct aggregation with having clause of one distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(distinct value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3),
+        Row(2, 2, 1)
+      )
+    )
+  }
+
+  test("SPARK-15206: one distinct aggregration with having clause of one distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1)
+          |from agg2 group by key
+          |having count(distinct value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3),
+        Row(1, 2),
+        Row(2, 2)
+      )
+    )
+  }
+
+  test("SPARK-15206: two distinct aggregration with having clause of two distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(distinct value1) > 0 and count(distinct value2) = 3
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3)
+      )
+    )
+  }
+
+  test("SPARK-15206: two distinct aggregration with having clause of non-distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3),
+        Row(2, 2, 1)
+      )
+    )
+  }
 }
 
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -958,69 +958,6 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
         Row(11) :: Nil)
     }
   }
-
-  test("SPARK-15206: two distinct aggregation with having clause of one distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(distinct value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3),
-        Row(2, 2, 1)
-      )
-    )
-  }
-
-  test("SPARK-15206: one distinct aggregration with having clause of one distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1)
-          |from agg2 group by key
-          |having count(distinct value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3),
-        Row(1, 2),
-        Row(2, 2)
-      )
-    )
-  }
-
-  test("SPARK-15206: two distinct aggregration with having clause of two distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(distinct value1) > 0 and count(distinct value2) = 3
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3)
-      )
-    )
-  }
-
-  test("SPARK-15206: two distinct aggregration with having clause of non-distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3),
-        Row(2, 2, 1)
-      )
-    )
-  }
 }
 
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -959,22 +959,6 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
     }
   }
 
-  test("SPARK-15206: two distinct aggregation with having clause of one distinct aggregation") {
-    checkAnswer(
-      sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(distinct value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3),
-        Row(2, 2, 1)
-      )
-    )
-  }
-
   test("SPARK-15206: single distinct aggregate in having clause") {
     checkAnswer(
       sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -958,6 +958,53 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
         Row(11) :: Nil)
     }
   }
+
+  test("SPARK-15206: two distinct aggregation with having clause of one distinct aggregation") {
+    checkAnswer(
+      sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(distinct value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3),
+        Row(2, 2, 1)
+      )
+    )
+  }
+
+  test("SPARK-15206: single distinct aggregate in having clause") {
+    checkAnswer(
+      sql(
+        """
+          |select key, count(distinct value1)
+          |from agg2 group by key
+          |having count(distinct value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3),
+        Row(1, 2),
+        Row(2, 2)
+      )
+    )
+  }
+
+  test("SPARK-15206: multiple distinct aggregates in having clause") {
+    checkAnswer(
+      sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(distinct value1) > 0 and count(distinct value2) = 3
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3)
+      )
+    )
+  }
 }
 
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -959,7 +959,7 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
     }
   }
 
-  test("SPARK-15206: single distinct aggregate in having clause") {
+  test("SPARK-15206: single distinct aggregate function in having clause") {
     checkAnswer(
       sql(
         """
@@ -975,7 +975,7 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
     )
   }
 
-  test("SPARK-15206: multiple distinct aggregates in having clause") {
+  test("SPARK-15206: multiple distinct aggregate function in having clause") {
     checkAnswer(
       sql(
         """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add new test cases for including distinct aggregate in having clause in 2.0 branch.
This is a followup PR for [#12974](https://github.com/apache/spark/pull/12974), which is for 1.6 branch.
