### PR TITLE
[spark-15212][SQL]CSV file reader when read file with first line schema do not filter blank in schema column name

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/DefaultSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/DefaultSource.scala
@@ -61,7 +61,7 @@ class DefaultSource extends FileFormat with DataSourceRegister {
     val firstRow = new LineCsvReader(csvOptions).parseLine(firstLine)
 
     val header = if (csvOptions.headerFlag) {
-      firstRow
+      firstRow.map{_.trim}
     } else {
       firstRow.zipWithIndex.map { case (value, index) => s"C$index" }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When load csv file with schema, add schema column name string trim to avoid blank problem.
## How was this patch tested?

construct csv data file contains schema definition with column blank such as:
## csv data file contains：

col1, col2,col3,col4,col5
1997,Ford,E350,"ac, abs, moon",3000.00
## ....

notice there is a blank before col2,
test command:
val sqlContext = new org.apache.spark.sql.SQLContext(sc);
var reader = sqlContext.read
reader.option("header", true)
var df = reader.csv("path/to/csvfile")
df.select("col2");//check if OK
df.registerTempTable("tab1");
sqlContext.sql("select col2 from tab1"); //check if OK.
