### PR TITLE
[SPARK-15216] [SQL] Add a new Dataset API explainCodegen

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -407,6 +407,21 @@ class Dataset[T] private[sql](
   // scalastyle:on println
 
   /**
+   * Prints the codegen to the console for debugging purposes.
+   *
+   * @group basic
+   * @since 2.0.0
+   */
+  def explainCodegen(): Unit = {
+    val explain = ExplainCommand(queryExecution.logical, codegen = true)
+    sparkSession.executePlan(explain).executedPlan.executeCollect().foreach {
+      // scalastyle:off println
+      r => println(r.getString(0))
+      // scalastyle:on println
+    }
+  }
+
+  /**
    * Prints the plans (logical and physical) to the console for debugging purposes.
    *
    * @group basic


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Reading codegen output is important for developers to debug. So far, outputting codegen results is available in the SQL interface by `EXPLAIN CODEGEN`. However, in the Dataset/DataFrame APIs, we face the same issue. 

This PR is to add a new Dataset API `explainCodegen` for achieving the same purpose. 

BTW, I also tried another way, i.e., adding a new boolean parameter into the existing `explain` API. However, if users set both `extended` and `codegen` to `true`, we only output the `codegen` results to the console. Basically, that is not allowed. We need to issue an exception in that case? Or change the behavior? Output both results in this case? Anyway, I am also fine if this is preferred. 
#### How was this patch tested?

Since `explainCodegen` is writing the result to the console, I only do the manual testing in my local environment. For example, the test case:

``` scala
  test("explainCodegen") {
    val ds = Seq("a" -> 1, "a" -> 3, "b" -> 3).toDS().groupByKey(_._1).agg(
      expr("avg(_2)").as[Double],
      ComplexResultAgg.toColumn)
    ds.explainCodegen()
  }
```
