### PR TITLE
[SPARK-15217] [SQL] Always Case Insensitive in HiveSessionState

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
@@ -17,14 +17,12 @@
 
 package org.apache.spark.sql.hive
 
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.execution.SparkPlanner
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.hive.client.HiveClient
-import org.apache.spark.sql.internal.SessionState
+import org.apache.spark.sql.internal.{SessionState, SQLConf}
 
 
 /**
@@ -56,6 +54,11 @@ private[hive] class HiveSessionState(sparkSession: SparkSession)
       functionRegistry,
       conf,
       newHadoopConf())
+  }
+
+  override lazy val conf: SQLConf = new SQLConf {
+    // Hive-backed catalog is case incensitive
+    override def caseSensitiveAnalysis: Boolean = false
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -519,7 +519,8 @@ private[hive] class TestHiveSessionState(
   override lazy val conf: SQLConf = {
     new SQLConf {
       clear()
-      override def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE, false)
+      // Hive-backed catalog is case incensitive
+      override def caseSensitiveAnalysis: Boolean = false
       override def clear(): Unit = {
         super.clear()
         TestHiveContext.overrideConfs.foreach { case (k, v) => setConfString(k, v) }


### PR DESCRIPTION
#### What changes were proposed in this pull request?

In a `HiveSessionState`, which is a given `SparkSession` backed by Hive, the analysis should not be case sensitive because the underlying Hive Metastore is case insensitive. 

For example, 

``` SQL
CREATE TABLE tab1 (C1 int);
SELECT C1 FROM tab1
```

In the current implementation, we will get the following error because the column name is always stored in lower case. 

```
cannot resolve '`C1`' given input columns: [c1]; line 1 pos 7
org.apache.spark.sql.AnalysisException: cannot resolve '`C1`' given input columns: [c1]; line 1 pos 7
```

This PR is to always use case insensitive analysis in `HiveSessionState`, no matter whether users set `spark.sql.caseSensitive` to true or false. 
#### How was this patch tested?

Added the related  test cases. 
