### PR TITLE
[Minor][SQL] Enhance the exception message if checkpointLocation is not set

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -334,9 +334,11 @@ final class DataFrameWriter private[sql](df: DataFrame) {
           partitionColumns = normalizedParCols.getOrElse(Nil))
 
       val queryName = extraOptions.getOrElse("queryName", StreamExecution.nextName)
-      val checkpointLocation = extraOptions.getOrElse("checkpointLocation",
-        new Path(df.sparkSession.sessionState.conf.checkpointLocation.get, queryName).toUri.toString
-      )
+      val checkpointLocation = extraOptions.get("checkpointLocation")
+        .orElse(df.sparkSession.sessionState.conf.checkpointLocation)
+        .map(new Path(_, queryName).toUri.toString)
+        .getOrElse(throw new AnalysisException("checkpointLocation must be specified either " +
+          "through option() or SQLConf"))
 
       df.sparkSession.sessionState.continuousQueryManager.startQuery(
         queryName,

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -335,9 +335,9 @@ final class DataFrameWriter private[sql](df: DataFrame) {
 
       val queryName = extraOptions.getOrElse("queryName", StreamExecution.nextName)
       val checkpointLocation = extraOptions.get("checkpointLocation")
-        .orElse(df.sparkSession.sessionState.conf.checkpointLocation)
-        .map(new Path(_, queryName).toUri.toString)
-        .getOrElse(throw new AnalysisException("checkpointLocation must be specified either " +
+        .orElse { df.sparkSession.sessionState.conf.checkpointLocation
+            .map(new Path(_, queryName).toUri.toString)
+        }.getOrElse(throw new AnalysisException("checkpointLocation must be specified either " +
           "through option() or SQLConf"))
 
       df.sparkSession.sessionState.continuousQueryManager.startQuery(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enhance the exception message when `checkpointLocation` is not set, previously the message is:

```
java.util.NoSuchElementException: None.get
  at scala.None$.get(Option.scala:347)
  at scala.None$.get(Option.scala:345)
  at org.apache.spark.sql.DataFrameWriter$$anonfun$8.apply(DataFrameWriter.scala:338)
  at org.apache.spark.sql.DataFrameWriter$$anonfun$8.apply(DataFrameWriter.scala:338)
  at scala.collection.MapLike$class.getOrElse(MapLike.scala:128)
  at scala.collection.AbstractMap.getOrElse(Map.scala:59)
  at org.apache.spark.sql.DataFrameWriter.startStream(DataFrameWriter.scala:337)
  at org.apache.spark.sql.DataFrameWriter.startStream(DataFrameWriter.scala:277)
  ... 48 elided
```

This is not so meaningful, so changing to make it more specific.
## How was this patch tested?

Local verified.
