### PR TITLE
[DOCS] [MINOR] Fixed scaladoc java example syntax in DataSet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -136,9 +136,9 @@ private[sql] object Dataset {
  *   Dataset<Row> people = spark.read().parquet("...");
  *   Dataset<Row> department = spark.read().parquet("...");
  *
- *   people.filter("age".gt(30))
+ *   people.filter(people.col("age").gt(30))
  *     .join(department, people.col("deptId").equalTo(department("id")))
- *     .groupBy(department.col("name"), "gender")
+ *     .groupBy("name", "gender")
  *     .agg(avg(people.col("salary")), max(people.col("age")));
  * }}}
  *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed scaladoc java example syntax in DataSet.scala
## How was this patch tested?

No new tests required as this is a doc example change
Existing tests passed (using ./dev/run-tests)
