### PR TITLE
[MINOR][DOCS] Remove remaining sqlContext in documentation at examples

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSparkSQL.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSparkSQL.java
@@ -133,7 +133,7 @@ public class JavaSparkSQL {
     // Register this DataFrame as a table.
     peopleFromJsonFile.registerTempTable("people");
 
-    // SQL statements can be run by using the sql methods provided by sqlContext.
+    // SQL statements can be run by using the sql methods provided by spark (SparkSession object).
     Dataset<Row> teenagers3 = spark.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19");
 
     // The results of SQL queries are DataFrame and support all the normal RDD operations.

--- a/examples/src/main/python/sql.py
+++ b/examples/src/main/python/sql.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     # Register this DataFrame as a temporary table.
     people.registerTempTable("people")
 
-    # SQL statements can be run by using the sql methods provided by sqlContext
+    # SQL statements can be run by using the sql methods provided by spark (SparkSession object)
     teenagers = spark.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19")
 
     for each in teenagers.collect():

--- a/examples/src/main/python/sql.py
+++ b/examples/src/main/python/sql.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     # Register this DataFrame as a temporary table.
     people.registerTempTable("people")
 
-    # SQL statements can be run by using the sql methods provided by spark (SparkSession object)
+    # SQL statements can be run by using the sql methods provided by spark (SparkSession object).
     teenagers = spark.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19")
 
     for each in teenagers.collect():


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR removes `sqlContext` in examples. Actual usage was all replaced in https://github.com/apache/spark/pull/12809 but there are some in comments.
## How was this patch tested?

Manual style checking.
