### PR TITLE
Added anchor links to Running and Completed Applications

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -114,8 +114,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                 {Utils.megabytesToString(aliveWorkers.map(_.memory).sum)} Total,
                 {Utils.megabytesToString(aliveWorkers.map(_.memoryUsed).sum)} Used</li>
               <li><strong>Applications:</strong>
-                {state.activeApps.length} Running,
-                {state.completedApps.length} Completed </li>
+                {state.activeApps.length} <a href="#running">Running</a>,
+                {state.completedApps.length} <a href="#completed">Completed</a> </li>
               <li><strong>Drivers:</strong>
                 {state.activeDrivers.length} Running,
                 {state.completedDrivers.length} Completed </li>
@@ -133,7 +133,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4> Running Applications </h4>
+            <h4 id="running"> Running Applications </h4>
             {activeAppsTable}
           </div>
         </div>
@@ -152,7 +152,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4> Completed Applications </h4>
+            <h4 id="completed"> Completed Applications </h4>
             {completedAppsTable}
           </div>
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added links to Running and Completed Applications on the Master UI in cases where there are large numbers of Workers to scroll past. Similar links are used on the Jobs and Stages pages in the Web UI.
## How was this patch tested?

Manually tested and dev/run-tests

<img width="334" alt="spark15220" src="https://cloud.githubusercontent.com/assets/13952758/15122988/705ec4ac-15d6-11e6-8f8f-d373632d116a.png">
