### PR TITLE
[SPARK-15204][SQL] Nullable is not correct for Aggregator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -66,7 +66,7 @@ case class TypedAggregateExpression(
     outputExternalType: DataType,
     dataType: DataType) extends DeclarativeAggregate with NonSQLExpression {
 
-  override def nullable: Boolean = true
+  override def nullable: Boolean = false
 
   override def deterministic: Boolean = true
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
object SimpleSum extends Aggregator[Row, Int, Int] {
  def zero: Int = 0
  def reduce(b: Int, a: Row) = b + a.getInt(1)
  def merge(b1: Int, b2: Int) = b1 + b2
  def finish(b: Int) = b
  def bufferEncoder: Encoder[Int] = Encoders.scalaInt
  def outputEncoder: Encoder[Int] = Encoders.scalaInt
}

val df = List(("a", 1), ("a", 2), ("a", 3)).toDF("k", "v")
val df1 = df.groupBy("k").agg(SimpleSum.toColumn as "v1")
df1.printSchema
df1.show

root
 |-- k: string (nullable = true)
 |-- v1: integer (nullable = true)

+---+---+
|  k| v1|
+---+---+
|  a|  6|
+---+---+
```

The above example shows `v1` as `nullable=true` which is incorrect.
The aggregate fields should be non-nullable in the schema.
## How was this patch tested?

unit tests
