### PR TITLE
[SPARK-15234][SQL] spark.catalog.listDatabases.show() is not formatted correctly

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.DefinedByConstructorParams
 // Note: all classes here are expected to be wrapped in Datasets and so must extend
 // DefinedByConstructorParams for the catalog to be able to create encoders for them.
 
-class Database(
+case class Database(
     val name: String,
     @Nullable val description: String,
     val locationUri: String)
@@ -41,7 +41,7 @@ class Database(
 }
 
 
-class Table(
+case class Table(
     val name: String,
     @Nullable val database: String,
     @Nullable val description: String,
@@ -61,7 +61,7 @@ class Table(
 }
 
 
-class Column(
+case class Column(
     val name: String,
     @Nullable val description: String,
     val dataType: String,
@@ -84,7 +84,7 @@ class Column(
 
 
 // TODO(andrew): should we include the database here?
-class Function(
+case class Function(
     val name: String,
     @Nullable val description: String,
     val className: String,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `Database`, `Table`, `Column`, `Function` classes, case classes so that `listDatabases`, `listTables`, `listFunctions` and `listColumns` are formatted properly.

Before:

```
scala> spark.catalog.listDatabases.show()
+--------------------+-----------+-----------+
|                name|description|locationUri|
+--------------------+-----------+-----------+
|Database[name='de...|
+--------------------+-----------+-----------+
```

After the Change:

```
scala> spark.catalog.listDatabases.show()
+-------+----------------+--------------------+
|   name|     description|         locationUri|
+-------+----------------+--------------------+
|default|default database|file:/Users/pichu...|
+-------+----------------+--------------------+
```
## How was this patch tested?

Existing Tests
