### PR TITLE
[SPARK-15240][SQL][WIP] Use buffer variables to improve buffer serialization/deserialization in TungstenAggregate

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -172,6 +172,20 @@ public final class UnsafeRow extends MutableRow implements Externalizable, KryoS
   }
 
   /**
+   * Update this UnsafeRow to point to another UnsafeRow.
+   *
+   * @param other the other UnsafeRow
+   */
+  public void pointTo(UnsafeRow other) {
+    assert numFields >= 0 : "numFields (" + numFields + ") should >= 0";
+    assert numFields == other.numFields : "point to another UnsafeRow with different numFields (" +
+      numFields + ")" ;
+    this.baseObject = other.baseObject;
+    this.baseOffset = other.baseOffset;
+    this.sizeInBytes = other.sizeInBytes;
+  }
+
+  /**
    * Update this UnsafeRow to point to the underlying byte array.
    *
    * @param buf byte array to point to

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -700,7 +700,7 @@ case class TungstenAggregate(
     val updateRowInVectorizedHashMap: Option[String] = {
       if (isVectorizedHashMapEnabled) {
         // We use currentVars that contains bufferVars and input
-        ctx.INPUT_ROW = null // vectorizedRowBuffer
+        ctx.INPUT_ROW = null
         val boundUpdateExpr = updateExpr.map(BindReferences.bindReference(_, inputAttr))
         val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(boundUpdateExpr)
         val effectiveCodes = subExprs.codes.mkString("\n")
@@ -769,7 +769,7 @@ case class TungstenAggregate(
 
     val updateRowInUnsafeRowMap: String = {
       // We use currentVars that contains bufferVars and input
-      ctx.INPUT_ROW = null // unsafeRowBuffer
+      ctx.INPUT_ROW = null
       val boundUpdateExpr = updateExpr.map(BindReferences.bindReference(_, inputAttr))
       val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(boundUpdateExpr)
       val effectiveCodes = subExprs.codes.mkString("\n")


### PR DESCRIPTION
## What changes were proposed in this pull request?

We do serialization/deserialization on aggregation buffer in `TungstenAggregate` for each aggregation function. It wastes time on duplicate serde for the same grouping keys.

Instead of deserializing elements from aggregation buffer, updating the variables then serializing it back, we can use the same variables for the same grouping keys and only serializing it back when it is needed to change grouping keys.
## How was this patch tested?

Existing tests.
