### PR TITLE
[SPARK-15245][SQL] Stream API throws an exception for non-directory path with incorrect message.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -179,6 +179,12 @@ case class DataSource(
           throw new IllegalArgumentException("'path' is not specified")
         })
 
+        val hdfsPath = new Path(path)
+        val fs = hdfsPath.getFileSystem(sparkSession.sessionState.newHadoopConf())
+        if (!fs.isDirectory(hdfsPath)) {
+          throw new IllegalArgumentException("'path' must be a directory")
+        }
+
         def dataFrameBuilder(files: Array[String]): DataFrame = {
           val newOptions = options.filterKeys(_ != "path") + ("basePath" -> path)
           val newDataSource =

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.streaming
 
 import java.io.File
-import java.util.UUID
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.util._
@@ -441,6 +440,18 @@ class FileStreamSourceSuite extends FileStreamSourceTest with SharedSQLContext {
       intercept[AnalysisException] {
         createFileStream("parquet", src.getCanonicalPath)
       }
+    }
+  }
+
+  test("throws an exception when the given path is not a directory.") {
+    withTempDir { src =>
+      val e = intercept[IllegalArgumentException] {
+        val fileName = s"${src.getCanonicalPath}/tmp1.txt"
+        stringToFile(new File(fileName), "a\nb\nc")
+        val textStream = createFileStream("text", fileName)
+        testStream(textStream.toDF())(StopStream)
+      }
+      assert("'path' must be a directory" === e.getMessage)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-15245

When `stream()` takes a non-direcotry path, this throws an exception during execution with a message `Option 'basePath' must be a directory`.

In `DataSource`, this can be checked before. This PR prevents to give a non-directory path for `stream()`. 
## How was this patch tested?

Unittest in `FileStreamSourceSuite` and `./build/sbt scalastyle`
