### PR TITLE
[SPARK-15218][DEPLOY] replace any occurence of ':' in SPARK_HOME with…

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -21,6 +21,17 @@ if [ -z "${SPARK_HOME}" ]; then
   export SPARK_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 fi
 
+# [SPARK-15218] replace ':' in SPARK_HOME to '_'
+SPARK_HOME_WITHOUT_COLON=$SPARK_HOME                                                          
+SPARK_HOME=${SPARK_HOME//:/_}
+if [ "$SPARK_HOME_WITHOUT_COLON" != "$SPARK_HOME"  ] && [ ! -d "$SPARK_HOME" ]; then
+  echo "replace ':' in SPARK_HOME with '_'."
+  PARENT_SPARK_HOME="$(dirname "$SPARK_HOME")"
+  mkdir -p $PARENT_SPARK_HOME
+  echo "SPARK_HOME=$SPARK_HOME"
+  ln -s $SPARK_HOME_WITHOUT_COLON  $PARENT_SPARK_HOME
+fi
+
 . "${SPARK_HOME}"/bin/load-spark-env.sh
 
 # Find the java binary


### PR DESCRIPTION
## What changes were proposed in this pull request?

Java could not find or load main org.apache.spark.launcher.Main when run from a directory containing colon ':'. Mesos used to use ':' in path generation.

This PR is proposed to create symlink with '_' instead of ':'.
## How was this patch tested?

manual tests
