### PR TITLE
[SPARK-15252][CORE][WIP] add accumulator wrapper to have more control of accumulator

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.{RDD, ReliableRDDCheckpointData}
-import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, ThreadUtils, Utils}
+import org.apache.spark.util.{AccumulatorContext, AccumulatorWrapper, ThreadUtils, Utils}
 
 /**
  * Classes that represent cleaning tasks.
@@ -144,7 +144,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
     registerForCleanup(rdd, CleanRDD(rdd.id))
   }
 
-  def registerAccumulatorForCleanup(a: AccumulatorV2[_, _]): Unit = {
+  def registerAccumulatorForCleanup(a: AccumulatorWrapper[_]): Unit = {
     registerForCleanup(a, CleanAccum(a.id))
   }
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -35,7 +35,7 @@ import org.apache.spark.util._
  */
 private[spark] case class Heartbeat(
     executorId: String,
-    accumUpdates: Array[(Long, Seq[AccumulatorV2[_, _]])], // taskId -> accumulator updates
+    accumUpdates: Array[(Long, Seq[AccumulatorWrapper[_]])], // taskId -> accumulator updates
     blockManagerId: BlockManagerId)
 
 /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1292,7 +1292,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Register the given accumulator.  Note that accumulators must be registered before use, or it
    * will throw exception.
    */
-  def register(acc: AccumulatorV2[_, _]): Unit = {
+  def register(acc: AccumulatorWrapper[_]): Unit = {
     acc.register(this)
   }
 
@@ -1300,15 +1300,15 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Register the given accumulator with given name.  Note that accumulators must be registered
    * before use, or it will throw exception.
    */
-  def register(acc: AccumulatorV2[_, _], name: String): Unit = {
+  def register(acc: AccumulatorWrapper[_], name: String): Unit = {
     acc.register(this, name = Some(name))
   }
 
   /**
    * Create and register a long accumulator, which starts with 0 and accumulates inputs by `+=`.
    */
-  def longAccumulator: LongAccumulator = {
-    val acc = new LongAccumulator
+  def longAccumulator: AccumulatorWrapper[LongAccumulator] = {
+    val acc = new AccumulatorWrapper(new LongAccumulator)
     register(acc)
     acc
   }
@@ -1316,8 +1316,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   /**
    * Create and register a long accumulator, which starts with 0 and accumulates inputs by `+=`.
    */
-  def longAccumulator(name: String): LongAccumulator = {
-    val acc = new LongAccumulator
+  def longAccumulator(name: String): AccumulatorWrapper[LongAccumulator] = {
+    val acc = new AccumulatorWrapper(new LongAccumulator)
     register(acc, name)
     acc
   }
@@ -1325,8 +1325,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   /**
    * Create and register a double accumulator, which starts with 0 and accumulates inputs by `+=`.
    */
-  def doubleAccumulator: DoubleAccumulator = {
-    val acc = new DoubleAccumulator
+  def doubleAccumulator: AccumulatorWrapper[DoubleAccumulator] = {
+    val acc = new AccumulatorWrapper(new DoubleAccumulator)
     register(acc)
     acc
   }
@@ -1334,8 +1334,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   /**
    * Create and register a double accumulator, which starts with 0 and accumulates inputs by `+=`.
    */
-  def doubleAccumulator(name: String): DoubleAccumulator = {
-    val acc = new DoubleAccumulator
+  def doubleAccumulator(name: String): AccumulatorWrapper[DoubleAccumulator] = {
+    val acc = new AccumulatorWrapper(new DoubleAccumulator)
     register(acc, name)
     acc
   }
@@ -1344,8 +1344,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Create and register a list accumulator, which starts with empty list and accumulates inputs
    * by adding them into the inner list.
    */
-  def listAccumulator[T]: ListAccumulator[T] = {
-    val acc = new ListAccumulator[T]
+  def listAccumulator[T]: AccumulatorWrapper[ListAccumulator[T]] = {
+    val acc = new AccumulatorWrapper(new ListAccumulator[T])
     register(acc)
     acc
   }
@@ -1354,8 +1354,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Create and register a list accumulator, which starts with empty list and accumulates inputs
    * by adding them into the inner list.
    */
-  def listAccumulator[T](name: String): ListAccumulator[T] = {
-    val acc = new ListAccumulator[T]
+  def listAccumulator[T](name: String): AccumulatorWrapper[ListAccumulator[T]] = {
+    val acc = new AccumulatorWrapper(new ListAccumulator[T])
     register(acc, name)
     acc
   }

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -24,7 +24,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.metrics.source.Source
-import org.apache.spark.util.{AccumulatorV2, TaskCompletionListener, TaskFailureListener}
+import org.apache.spark.util.{AccumulatorWrapper, TaskCompletionListener, TaskFailureListener}
 
 
 object TaskContext {
@@ -188,6 +188,6 @@ abstract class TaskContext extends Serializable {
    * Register an accumulator that belongs to this task. Accumulators must call this method when
    * deserializing in executors.
    */
-  private[spark] def registerAccumulator(a: AccumulatorV2[_, _]): Unit
+  private[spark] def registerAccumulator(a: AccumulatorWrapper[_]): Unit
 
 }

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -122,7 +122,7 @@ private[spark] class TaskContextImpl(
   override def getMetricsSources(sourceName: String): Seq[Source] =
     metricsSystem.getSourcesByName(sourceName)
 
-  private[spark] override def registerAccumulator(a: AccumulatorV2[_, _]): Unit = {
+  private[spark] override def registerAccumulator(a: AccumulatorWrapper[_]): Unit = {
     taskMetrics.registerAccumulator(a)
   }
 

--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.{AccumulatorV2, Utils}
+import org.apache.spark.util.{AccumulatorWrapper, Utils}
 
 // ==============================================================================================
 // NOTE: new task end reasons MUST be accompanied with serialization logic in util.JsonProtocol!
@@ -118,7 +118,7 @@ case class ExceptionFailure(
     fullStackTrace: String,
     private val exceptionWrapper: Option[ThrowableSerializationWrapper],
     accumUpdates: Seq[AccumulableInfo] = Seq.empty,
-    private[spark] var accums: Seq[AccumulatorV2[_, _]] = Nil)
+    private[spark] var accums: Seq[AccumulatorWrapper[_]] = Nil)
   extends TaskFailedReason {
 
   /**
@@ -138,7 +138,7 @@ case class ExceptionFailure(
     this(e, accumUpdates, preserveCause = true)
   }
 
-  private[spark] def withAccums(accums: Seq[AccumulatorV2[_, _]]): ExceptionFailure = {
+  private[spark] def withAccums(accums: Seq[AccumulatorWrapper[_]]): ExceptionFailure = {
     this.accums = accums
     this
   }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -376,7 +376,7 @@ private[spark] class Executor(
           logError(s"Exception in $taskName (TID $taskId)", t)
 
           // Collect latest accumulator values to report back to the driver
-          val accums: Seq[AccumulatorV2[_, _]] =
+          val accums: Seq[AccumulatorWrapper[_]] =
             if (task != null) {
               task.metrics.setExecutorRunTime(System.currentTimeMillis() - taskStart)
               task.metrics.setJvmGCTime(computeTotalGcTime() - startGCTime)
@@ -385,7 +385,7 @@ private[spark] class Executor(
               Seq.empty
             }
 
-          val accUpdates = accums.map(acc => acc.toInfo(Some(acc.value), None))
+          val accUpdates = accums.map(acc => acc.toInfo(Some(acc.genericAcc.value), None))
 
           val serializedTaskEndReason = {
             try {
@@ -502,7 +502,7 @@ private[spark] class Executor(
   /** Reports heartbeat and metrics for active tasks to the driver. */
   private def reportHeartBeat(): Unit = {
     // list of (task id, accumUpdates) to send back to the driver
-    val accumUpdates = new ArrayBuffer[(Long, Seq[AccumulatorV2[_, _]])]()
+    val accumUpdates = new ArrayBuffer[(Long, Seq[AccumulatorWrapper[_]])]()
     val curGCTime = computeTotalGcTime()
 
     for (taskRunner <- runningTasks.values().asScala) {

--- a/core/src/main/scala/org/apache/spark/executor/InputMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/InputMetrics.scala
@@ -40,20 +40,22 @@ object DataReadMethod extends Enumeration with Serializable {
  */
 @DeveloperApi
 class InputMetrics private[spark] () extends Serializable {
-  private[executor] val _bytesRead = new LongAccumulator
-  private[executor] val _recordsRead = new LongAccumulator
+  import TaskMetrics.newLongAccum
+
+  private[executor] val _bytesRead = newLongAccum
+  private[executor] val _recordsRead = newLongAccum
 
   /**
    * Total number of bytes read.
    */
-  def bytesRead: Long = _bytesRead.sum
+  def bytesRead: Long = _bytesRead.acc.sum
 
   /**
    * Total number of records read.
    */
-  def recordsRead: Long = _recordsRead.sum
+  def recordsRead: Long = _recordsRead.acc.sum
 
-  private[spark] def incBytesRead(v: Long): Unit = _bytesRead.add(v)
-  private[spark] def incRecordsRead(v: Long): Unit = _recordsRead.add(v)
-  private[spark] def setBytesRead(v: Long): Unit = _bytesRead.setValue(v)
+  private[spark] def incBytesRead(v: Long): Unit = _bytesRead.acc.add(v)
+  private[spark] def incRecordsRead(v: Long): Unit = _recordsRead.acc.add(v)
+  private[spark] def setBytesRead(v: Long): Unit = _bytesRead.acc.setValue(v)
 }

--- a/core/src/main/scala/org/apache/spark/executor/OutputMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/OutputMetrics.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.executor
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.util.LongAccumulator
 
 
 /**
@@ -39,19 +38,21 @@ object DataWriteMethod extends Enumeration with Serializable {
  */
 @DeveloperApi
 class OutputMetrics private[spark] () extends Serializable {
-  private[executor] val _bytesWritten = new LongAccumulator
-  private[executor] val _recordsWritten = new LongAccumulator
+  import TaskMetrics.newLongAccum
+
+  private[executor] val _bytesWritten = newLongAccum
+  private[executor] val _recordsWritten = newLongAccum
 
   /**
    * Total number of bytes written.
    */
-  def bytesWritten: Long = _bytesWritten.sum
+  def bytesWritten: Long = _bytesWritten.acc.sum
 
   /**
    * Total number of records written.
    */
-  def recordsWritten: Long = _recordsWritten.sum
+  def recordsWritten: Long = _recordsWritten.acc.sum
 
-  private[spark] def setBytesWritten(v: Long): Unit = _bytesWritten.setValue(v)
-  private[spark] def setRecordsWritten(v: Long): Unit = _recordsWritten.setValue(v)
+  private[spark] def setBytesWritten(v: Long): Unit = _bytesWritten.acc.setValue(v)
+  private[spark] def setRecordsWritten(v: Long): Unit = _recordsWritten.acc.setValue(v)
 }

--- a/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
@@ -28,34 +28,33 @@ import org.apache.spark.util.LongAccumulator
  */
 @DeveloperApi
 class ShuffleWriteMetrics private[spark] () extends Serializable {
-  private[executor] val _bytesWritten = new LongAccumulator
-  private[executor] val _recordsWritten = new LongAccumulator
-  private[executor] val _writeTime = new LongAccumulator
+  import TaskMetrics.newLongAccum
+
+  private[executor] val _bytesWritten = newLongAccum
+  private[executor] val _recordsWritten = newLongAccum
+  private[executor] val _writeTime = newLongAccum
 
   /**
    * Number of bytes written for the shuffle by this task.
    */
-  def bytesWritten: Long = _bytesWritten.sum
+  def bytesWritten: Long = _bytesWritten.acc.sum
 
   /**
    * Total number of records written to the shuffle by this task.
    */
-  def recordsWritten: Long = _recordsWritten.sum
+  def recordsWritten: Long = _recordsWritten.acc.sum
 
   /**
    * Time the task spent blocking on writes to disk or buffer cache, in nanoseconds.
    */
-  def writeTime: Long = _writeTime.sum
+  def writeTime: Long = _writeTime.acc.sum
 
-  private[spark] def incBytesWritten(v: Long): Unit = _bytesWritten.add(v)
-  private[spark] def incRecordsWritten(v: Long): Unit = _recordsWritten.add(v)
-  private[spark] def incWriteTime(v: Long): Unit = _writeTime.add(v)
-  private[spark] def decBytesWritten(v: Long): Unit = {
-    _bytesWritten.setValue(bytesWritten - v)
-  }
-  private[spark] def decRecordsWritten(v: Long): Unit = {
-    _recordsWritten.setValue(recordsWritten - v)
-  }
+  private[spark] def incBytesWritten(v: Long): Unit = _bytesWritten.acc.add(v)
+  private[spark] def incRecordsWritten(v: Long): Unit = _recordsWritten.acc.add(v)
+  private[spark] def incWriteTime(v: Long): Unit = _writeTime.acc.add(v)
+  private[spark] def decBytesWritten(v: Long): Unit = _bytesWritten.acc.setValue(bytesWritten - v)
+  private[spark] def decRecordsWritten(v: Long): Unit =
+    _recordsWritten.acc.setValue(recordsWritten - v)
 
   // Legacy methods for backward compatibility.
   // TODO: remove these once we make this class private.

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -209,7 +209,7 @@ class DAGScheduler(
       task: Task[_],
       reason: TaskEndReason,
       result: Any,
-      accumUpdates: Seq[AccumulatorV2[_, _]],
+      accumUpdates: Seq[AccumulatorWrapper[_]],
       taskInfo: TaskInfo): Unit = {
     eventProcessLoop.post(
       CompletionEvent(task, reason, result, accumUpdates, taskInfo))
@@ -1091,16 +1091,17 @@ class DAGScheduler(
       event.accumUpdates.foreach { updates =>
         val id = updates.id
         // Find the corresponding accumulator on the driver and update it
-        val acc: AccumulatorV2[Any, Any] = AccumulatorContext.get(id) match {
-          case Some(accum) => accum.asInstanceOf[AccumulatorV2[Any, Any]]
+        val acc: AccumulatorWrapper[_] = AccumulatorContext.get(id) match {
+          case Some(accum) => accum.asInstanceOf[AccumulatorWrapper[_]]
           case None =>
             throw new SparkException(s"attempted to access non-existent accumulator $id")
         }
-        acc.merge(updates.asInstanceOf[AccumulatorV2[Any, Any]])
+        acc.genericAcc.merge(updates.genericAcc)
         // To avoid UI cruft, ignore cases where value wasn't updated
-        if (acc.name.isDefined && !updates.isZero) {
-          stage.latestInfo.accumulables(id) = acc.toInfo(None, Some(acc.value))
-          event.taskInfo.accumulables += acc.toInfo(Some(updates.value), Some(acc.value))
+        if (acc.name.isDefined && !updates.genericAcc.isZero) {
+          stage.latestInfo.accumulables(id) = acc.toInfo(None, Some(acc.genericAcc.value))
+          event.taskInfo.accumulables +=
+            acc.toInfo(Some(updates.genericAcc.value), Some(acc.genericAcc.value))
         }
       }
     } catch {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -23,7 +23,7 @@ import scala.language.existentials
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.util.{AccumulatorV2, CallSite}
+import org.apache.spark.util.{AccumulatorWrapper, CallSite}
 
 /**
  * Types of events that can be handled by the DAGScheduler. The DAGScheduler uses an event queue
@@ -71,7 +71,7 @@ private[scheduler] case class CompletionEvent(
     task: Task[_],
     reason: TaskEndReason,
     result: Any,
-    accumUpdates: Seq[AccumulatorV2[_, _]],
+    accumUpdates: Seq[AccumulatorWrapper[_]],
     taskInfo: TaskInfo)
   extends DAGSchedulerEvent
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -28,7 +28,7 @@ import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.{MemoryMode, TaskMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.serializer.SerializerInstance
-import org.apache.spark.util.{AccumulatorV2, ByteBufferInputStream, ByteBufferOutputStream, Utils}
+import org.apache.spark.util.{AccumulatorWrapper, ByteBufferInputStream, ByteBufferOutputStream, Utils}
 
 /**
  * A unit of execution. We have two kinds of Task's in Spark:
@@ -153,7 +153,7 @@ private[spark] abstract class Task[T](
    * Collect the latest values of accumulators used in this task. If the task failed,
    * filter out the accumulators whose values should not be included on failures.
    */
-  def collectAccumulatorUpdates(taskFailed: Boolean = false): Seq[AccumulatorV2[_, _]] = {
+  def collectAccumulatorUpdates(taskFailed: Boolean = false): Seq[AccumulatorWrapper[_]] = {
     if (context != null) {
       context.taskMetrics.accumulators().filter { a => !taskFailed || a.countFailedValues }
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResult.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.storage.BlockId
-import org.apache.spark.util.{AccumulatorV2, Utils}
+import org.apache.spark.util.{AccumulatorWrapper, Utils}
 
 // Task result. Also contains updates to accumulator variables.
 private[spark] sealed trait TaskResult[T]
@@ -36,7 +36,7 @@ private[spark] case class IndirectTaskResult[T](blockId: BlockId, size: Int)
 /** A TaskResult that contains the task's return value and accumulator updates. */
 private[spark] class DirectTaskResult[T](
     var valueBytes: ByteBuffer,
-    var accumUpdates: Seq[AccumulatorV2[_, _]])
+    var accumUpdates: Seq[AccumulatorWrapper[_]])
   extends TaskResult[T] with Externalizable {
 
   private var valueObjectDeserialized = false
@@ -61,9 +61,9 @@ private[spark] class DirectTaskResult[T](
     if (numUpdates == 0) {
       accumUpdates = null
     } else {
-      val _accumUpdates = new ArrayBuffer[AccumulatorV2[_, _]]
+      val _accumUpdates = new ArrayBuffer[AccumulatorWrapper[_]]
       for (i <- 0 until numUpdates) {
-        _accumUpdates += in.readObject.asInstanceOf[AccumulatorV2[_, _]]
+        _accumUpdates += in.readObject.asInstanceOf[AccumulatorWrapper[_]]
       }
       accumUpdates = _accumUpdates
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -27,7 +27,7 @@ import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.SerializerInstance
-import org.apache.spark.util.{LongAccumulator, ThreadUtils, Utils}
+import org.apache.spark.util.{AccumulatorWrapper, LongAccumulator, ThreadUtils, Utils}
 
 /**
  * Runs a thread pool that deserializes and remotely fetches (if necessary) task results.
@@ -93,9 +93,10 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
           // we would have to serialize the result again after updating the size.
           result.accumUpdates = result.accumUpdates.map { a =>
             if (a.name == Some(InternalAccumulator.RESULT_SIZE)) {
-              val acc = a.asInstanceOf[LongAccumulator]
-              assert(acc.sum == 0L, "task result size should not have been set on the executors")
-              acc.setValue(size.toLong)
+              val acc = a.asInstanceOf[AccumulatorWrapper[LongAccumulator]]
+              assert(acc.accumulator.value == 0L,
+                "task result size should not have been set on the executors")
+              acc.acc.setValue(size.toLong)
               acc
             } else {
               a

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -19,7 +19,7 @@ package org.apache.spark.scheduler
 
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.AccumulatorV2
+import org.apache.spark.util.AccumulatorWrapper
 
 /**
  * Low-level task scheduler interface, currently implemented exclusively by
@@ -67,7 +67,7 @@ private[spark] trait TaskScheduler {
    */
   def executorHeartbeatReceived(
       execId: String,
-      accumUpdates: Array[(Long, Seq[AccumulatorV2[_, _]])],
+      accumUpdates: Array[(Long, Seq[AccumulatorWrapper[_]])],
       blockManagerId: BlockManagerId): Boolean
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -32,7 +32,7 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.TaskState.TaskState
-import org.apache.spark.util.{AccumulatorV2, Clock, SystemClock, Utils}
+import org.apache.spark.util.{AccumulatorWrapper, Clock, SystemClock, Utils}
 
 /**
  * Schedules the tasks within a single TaskSet in the TaskSchedulerImpl. This class keeps track of
@@ -647,7 +647,7 @@ private[spark] class TaskSetManager(
     info.markFailed()
     val index = info.index
     copiesRunning(index) -= 1
-    var accumUpdates: Seq[AccumulatorV2[_, _]] = Seq.empty
+    var accumUpdates: Seq[AccumulatorWrapper[_]] = Seq.empty
     val failureReason = s"Lost task ${info.id} in stage ${taskSet.id} (TID $tid, ${info.host}): " +
       reason.asInstanceOf[TaskFailedReason].toErrorString
     val failureException: Option[Throwable] = reason match {

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -841,7 +841,7 @@ private[spark] object JsonProtocol {
         val accumUpdates = Utils.jsonOption(json \ "Accumulator Updates")
           .map(_.extract[List[JValue]].map(accumulableInfoFromJson))
           .getOrElse(taskMetricsFromJson(json \ "Metrics").accumulators().map(acc => {
-            acc.toInfo(Some(acc.value), None)
+            acc.toInfo(Some(acc.genericAcc.value), None)
           }))
         ExceptionFailure(className, description, stackTrace, fullStackTrace, None, accumUpdates)
       case `taskResultLost` => TaskResultLost

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.scheduler
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.AccumulatorV2
+import org.apache.spark.util.AccumulatorWrapper
 
 class ExternalClusterManagerSuite extends SparkFunSuite with LocalSparkContext {
   test("launch of backend and scheduler") {
@@ -68,6 +68,6 @@ private class DummyTaskScheduler extends TaskScheduler {
   override def applicationAttemptId(): Option[String] = None
   def executorHeartbeatReceived(
       execId: String,
-      accumUpdates: Array[(Long, Seq[AccumulatorV2[_, _]])],
+      accumUpdates: Array[(Long, Seq[AccumulatorWrapper[_]])],
       blockManagerId: BlockManagerId): Boolean = true
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -162,8 +162,8 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
     }.count()
     // The one that counts failed values should be 4x the one that didn't,
     // since we ran each task 4 times
-    assert(AccumulatorContext.get(acc1.id).get.value === 40L)
-    assert(AccumulatorContext.get(acc2.id).get.value === 10L)
+    assert(AccumulatorContext.get(acc1.id).get.genericAcc.value === 40L)
+    assert(AccumulatorContext.get(acc2.id).get.genericAcc.value === 10L)
   }
 
   test("failed tasks collect only accumulators whose values count during failures") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -241,8 +241,10 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
     assert(resultGetter.taskResults.size === 1)
     val resBefore = resultGetter.taskResults.head
     val resAfter = captor.getValue
-    val resSizeBefore = resBefore.accumUpdates.find(_.name == Some(RESULT_SIZE)).map(_.value)
-    val resSizeAfter = resAfter.accumUpdates.find(_.name == Some(RESULT_SIZE)).map(_.value)
+    val resSizeBefore =
+      resBefore.accumUpdates.find(_.name == Some(RESULT_SIZE)).map(_.genericAcc.value)
+    val resSizeAfter =
+      resAfter.accumUpdates.find(_.name == Some(RESULT_SIZE)).map(_.genericAcc.value)
     assert(resSizeBefore.exists(_ == 0L))
     assert(resSizeAfter.exists(_.toString.toLong > 0L))
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark._
 import org.apache.spark.internal.Logging
-import org.apache.spark.util.{AccumulatorV2, ManualClock}
+import org.apache.spark.util.{AccumulatorWrapper, ManualClock}
 
 class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
   extends DAGScheduler(sc) {
@@ -37,7 +37,7 @@ class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
       task: Task[_],
       reason: TaskEndReason,
       result: Any,
-      accumUpdates: Seq[AccumulatorV2[_, _]],
+      accumUpdates: Seq[AccumulatorWrapper[_]],
       taskInfo: TaskInfo) {
     taskScheduler.endedTasks(taskInfo.index) = reason
   }
@@ -184,7 +184,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     val sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
     val taskSet = FakeTask.createTaskSet(3)
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
-    val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>
+    val accumUpdatesByTask: Array[Seq[AccumulatorWrapper[_]]] = taskSet.tasks.map { task =>
       task.metrics.internalAccums
     }
 
@@ -791,7 +791,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
 
   private def createTaskResult(
       id: Int,
-      accumUpdates: Seq[AccumulatorV2[_, _]] = Seq.empty): DirectTaskResult[Int] = {
+      accumUpdates: Seq[AccumulatorWrapper[_]] = Seq.empty): DirectTaskResult[Int] = {
     val valueSer = SparkEnv.get.serializer.newInstance()
     new DirectTaskResult[Int](valueSer.serialize(id), accumUpdates)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -113,7 +113,7 @@ private[sql] case class RDDScanExec(
     rdd.mapPartitionsInternal { iter =>
       val proj = UnsafeProjection.create(schema)
       iter.map { r =>
-        numOutputRows += 1
+        numOutputRows.acc += 1
         proj(r)
       }
     }
@@ -168,7 +168,7 @@ private[sql] case class RowDataSourceScanExec(
 
     val numOutputRows = longMetric("numOutputRows")
     unsafeRow.map { r =>
-      numOutputRows += 1
+      numOutputRows.acc += 1
       r
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -78,7 +78,7 @@ case class ExpandExec(
             idx = 0
           }
 
-          numOutputRows += 1
+          numOutputRows.acc += 1
           result
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -94,7 +94,7 @@ case class GenerateExec(
     rows.mapPartitionsInternal { iter =>
       val proj = UnsafeProjection.create(output, output)
       iter.map { r =>
-        numOutputRows += 1
+        numOutputRows.acc += 1
         proj(r)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
@@ -43,7 +43,7 @@ private[sql] case class LocalTableScanExec(
   protected override def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     rdd.map { r =>
-      numOutputRows += 1
+      numOutputRows.acc += 1
       r
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -101,9 +101,9 @@ case class SortExec(
 
       val sortedIterator = sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
 
-      sortTime += (System.nanoTime() - beforeSort) / 1000000
-      peakMemory += sorter.getPeakMemoryUsage
-      spillSize += metrics.memoryBytesSpilled - spillSizeBefore
+      sortTime.acc += (System.nanoTime() - beforeSort) / 1000000
+      peakMemory.acc += sorter.getPeakMemoryUsage
+      spillSize.acc += metrics.memoryBytesSpilled - spillSizeBefore
       metrics.incPeakExecutionMemory(sorter.getPeakMemoryUsage)
 
       sortedIterator

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.util.AccumulatorWrapper
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -77,19 +78,19 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   /**
    * Return all metrics containing metrics of this SparkPlan.
    */
-  private[sql] def metrics: Map[String, SQLMetric] = Map.empty
+  private[sql] def metrics: Map[String, AccumulatorWrapper[SQLMetric]] = Map.empty
 
   /**
    * Reset all the metrics.
    */
   private[sql] def resetMetrics(): Unit = {
-    metrics.valuesIterator.foreach(_.reset())
+    metrics.valuesIterator.foreach(_.acc.reset())
   }
 
   /**
    * Return a LongSQLMetric according to the name.
    */
-  private[sql] def longMetric(name: String): SQLMetric = metrics(name)
+  private[sql] def longMetric(name: String): AccumulatorWrapper[SQLMetric] = metrics(name)
 
   // TODO: Move to `DistributedPlan`
   /** Specifies how data is partitioned across different nodes in the cluster. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
@@ -55,7 +55,7 @@ private[sql] object SparkPlanInfo {
       case _ => plan.children ++ plan.subqueries
     }
     val metrics = plan.metrics.toSeq.map { case (key, metric) =>
-      new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.metricType)
+      new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.acc.metricType)
     }
 
     new SparkPlanInfo(plan.nodeName, plan.simpleString, children.map(fromSparkPlan),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -52,7 +52,8 @@ trait CodegenSupport extends SparkPlan {
    * @return name of the variable representing the metric
    */
   def metricTerm(ctx: CodegenContext, name: String): String = {
-    ctx.addReferenceObj(name, longMetric(name))
+    val sqlMetric = ctx.addReferenceObj(name, longMetric(name))
+    s"((org.apache.spark.sql.execution.metric.SQLMetric) $sqlMetric.accumulator())"
   }
 
   /**
@@ -355,7 +356,7 @@ case class WholeStageCodegenExec(child: SparkPlan) extends UnaryExecNode with Co
         new Iterator[InternalRow] {
           override def hasNext: Boolean = {
             val v = buffer.hasNext
-            if (!v) durationMs += buffer.durationMs()
+            if (!v) durationMs.acc += buffer.durationMs()
             v
           }
           override def next: InternalRow = buffer.next()
@@ -371,7 +372,7 @@ case class WholeStageCodegenExec(child: SparkPlan) extends UnaryExecNode with Co
         new Iterator[InternalRow] {
           override def hasNext: Boolean = {
             val v = buffer.hasNext
-            if (!v) durationMs += buffer.durationMs()
+            if (!v) durationMs.acc += buffer.durationMs()
             v
           }
           override def next: InternalRow = buffer.next()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregateExec.scala
@@ -91,7 +91,7 @@ case class SortBasedAggregateExec(
         if (!hasInput && groupingExpressions.isEmpty) {
           // There is no input and there is no grouping expressions.
           // We need to output a single row as the output.
-          numOutputRows += 1
+          numOutputRows.acc += 1
           Iterator[UnsafeRow](outputIter.outputForEmptyGroupingKeyWithoutInput())
         } else {
           outputIter

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregationIterator.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction}
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.util.AccumulatorWrapper
 
 /**
  * An iterator used to evaluate [[AggregateFunction]]. It assumes the input rows have been
@@ -35,7 +36,7 @@ class SortBasedAggregationIterator(
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     newMutableProjection: (Seq[Expression], Seq[Attribute]) => MutableProjection,
-    numOutputRows: SQLMetric)
+    numOutputRows: AccumulatorWrapper[SQLMetric])
   extends AggregationIterator(
     groupingExpressions,
     valueAttributes,
@@ -152,7 +153,7 @@ class SortBasedAggregationIterator(
       val outputRow = generateOutput(currentGroupingKey, sortBasedAggregationBuffer)
       // Initialize buffer values for the next group.
       initializeBuffer(sortBasedAggregationBuffer)
-      numOutputRows += 1
+      numOutputRows.acc += 1
       outputRow
     } else {
       // no more result

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -111,7 +111,7 @@ case class TungstenAggregate(
             peakMemory,
             spillSize)
         if (!hasInput && groupingExpressions.isEmpty) {
-          numOutputRows += 1
+          numOutputRows.acc += 1
           Iterator.single[UnsafeRow](aggregationIterator.outputForEmptyGroupingKeyWithoutInput())
         } else {
           aggregationIterator

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -201,7 +201,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
       val predicate = newPredicate(condition, child.output)
       iter.filter { row =>
         val r = predicate(row)
-        if (r) numOutputRows += 1
+        if (r) numOutputRows.acc += 1
         r
       }
     }
@@ -451,7 +451,7 @@ case class RangeExec(
               overflow = true
             }
 
-            numOutputRows += 1
+            numOutputRows.acc += 1
             unsafeRow.setLong(0, ret)
             unsafeRow
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -341,7 +341,7 @@ private[sql] case class InMemoryTableScanExec(
 
       // update SQL metrics
       val withMetrics = cachedBatchesToScan.map { batch =>
-        numOutputRows += batch.numRows
+        numOutputRows.acc += batch.numRows
         batch
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -73,16 +73,16 @@ case class BroadcastExchangeExec(
         // Note that we use .executeCollect() because we don't want to convert data to Scala types
         val input: Array[InternalRow] = child.executeCollect()
         val beforeBuild = System.nanoTime()
-        longMetric("collectTime") += (beforeBuild - beforeCollect) / 1000000
-        longMetric("dataSize") += input.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
+        longMetric("collectTime").acc += (beforeBuild - beforeCollect) / 1000000
+        longMetric("dataSize").acc += input.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
 
         // Construct and broadcast the relation.
         val relation = mode.transform(input)
         val beforeBroadcast = System.nanoTime()
-        longMetric("buildTime") += (beforeBroadcast - beforeBuild) / 1000000
+        longMetric("buildTime").acc += (beforeBroadcast - beforeBuild) / 1000000
 
         val broadcasted = sparkContext.broadcast(relation)
-        longMetric("broadcastTime") += (System.nanoTime() - beforeBroadcast) / 1000000
+        longMetric("broadcastTime").acc += (System.nanoTime() - beforeBroadcast) / 1000000
         broadcasted
       }
     }(BroadcastExchangeExec.executionContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
@@ -367,7 +367,7 @@ case class BroadcastNestedLoopJoinExec(
     resultRdd.mapPartitionsInternal { iter =>
       val resultProj = genResultProjection
       iter.map { r =>
-        numOutputRows += 1
+        numOutputRows.acc += 1
         resultProj(r)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/CartesianProductExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/CartesianProductExec.scala
@@ -109,7 +109,7 @@ case class CartesianProductExec(
         iter
       }
       filtered.map { r =>
-        numOutputRows += 1
+        numOutputRows.acc += 1
         joiner.join(r._1, r._2)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{RowIterator, SparkPlan}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.{IntegralType, LongType}
+import org.apache.spark.util.AccumulatorWrapper
 
 trait HashJoin {
   self: SparkPlan =>
@@ -222,7 +223,7 @@ trait HashJoin {
   protected def join(
       streamedIter: Iterator[InternalRow],
       hashed: HashedRelation,
-      numOutputRows: SQLMetric): Iterator[InternalRow] = {
+      numOutputRows: AccumulatorWrapper[SQLMetric]): Iterator[InternalRow] = {
 
     val joinedIter = joinType match {
       case Inner =>
@@ -242,7 +243,7 @@ trait HashJoin {
 
     val resultProj = createResultProjection
     joinedIter.map { r =>
-      numOutputRows += 1
+      numOutputRows.acc += 1
       resultProj(r)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -53,8 +53,8 @@ case class ShuffledHashJoinExec(
     val start = System.nanoTime()
     val context = TaskContext.get()
     val relation = HashedRelation(iter, buildKeys, taskMemoryManager = context.taskMemoryManager())
-    buildTime += (System.nanoTime() - start) / 1000000
-    buildDataSize += relation.estimatedSize
+    buildTime.acc += (System.nanoTime() - start) / 1000000
+    buildDataSize.acc += relation.estimatedSize
     // This relation is usually used until the end of task.
     context.addTaskCompletionListener(_ => relation.close())
     relation

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -164,7 +164,7 @@ private[sql] class SQLListener(conf: SparkConf) extends SparkListener with Loggi
         taskEnd.taskInfo.taskId,
         taskEnd.stageId,
         taskEnd.stageAttemptId,
-        taskEnd.taskMetrics.accumulators().map(a => a.toInfo(Some(a.value), None)),
+        taskEnd.taskMetrics.accumulators().map(a => a.toInfo(Some(a.genericAcc.value), None)),
         finishTask = true)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -38,7 +38,7 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
   import testImplicits._
 
   test("SQLMetric should not box Long") {
-    val l = SQLMetrics.createMetric(sparkContext, "long")
+    val l = SQLMetrics.createMetric(sparkContext, "long").acc
     val f = () => {
       l += 1L
       l.add(1L)
@@ -301,8 +301,8 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
 
   test("metrics can be loaded by history server") {
     val metric = SQLMetrics.createMetric(sparkContext, "zanzibar")
-    metric += 10L
-    val metricInfo = metric.toInfo(Some(metric.value), None)
+    metric.acc += 10L
+    val metricInfo = metric.toInfo(Some(metric.acc.value), None)
     metricInfo.update match {
       case Some(v: Long) => assert(v === 10L)
       case Some(v) => fail(s"metric value was not a Long: ${v.getClass.getName}")

--- a/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
@@ -96,7 +96,7 @@ class DataFrameCallbackSuite extends QueryTest with SharedSQLContext {
           case w: WholeStageCodegenExec => w.child.longMetric("numOutputRows")
           case other => other.longMetric("numOutputRows")
         }
-        metrics += metric.value
+        metrics += metric.acc.value
       }
     }
     sqlContext.listenerManager.register(listener)
@@ -126,9 +126,9 @@ class DataFrameCallbackSuite extends QueryTest with SharedSQLContext {
       override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {}
 
       override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
-        metrics += qe.executedPlan.longMetric("dataSize").value
+        metrics += qe.executedPlan.longMetric("dataSize").acc.value
         val bottomAgg = qe.executedPlan.children(0).children(0)
-        metrics += bottomAgg.longMetric("dataSize").value
+        metrics += bottomAgg.longMetric("dataSize").acc.value
       }
     }
     sqlContext.listenerManager.register(listener)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -155,7 +155,7 @@ case class HiveTableScanExec(
     rdd.mapPartitionsInternal { iter =>
       val proj = UnsafeProjection.create(schema)
       iter.map { r =>
-        numOutputRows += 1
+        numOutputRows.acc += 1
         proj(r)
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the `AccumulatorV2` is kind of messy as it mixes the logic of how to accumulate inputs and how to control the metadata. This PR adds an `AccumulatorWrapper` to take care of the metadata management and make our accumulator framework more flexible.

One drawback is, this makes the API a little harder to use. e.g. now users have to use `wrapper.accumulator.add` in RDD closure instead of `acc1.add`.

This PR is a prototype.
## How was this patch tested?

existing tests.
