### PR TITLE
[SPARK-15037][HOTFIX] Don't create 2 SparkSessions in constructor

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -31,17 +31,7 @@ private[sql] class TestSparkSession(sc: SparkContext) extends SparkSession(sc) {
   }
 
   def this() {
-    this {
-      val conf = new SparkConf()
-      conf.set("spark.sql.testkey", "true")
-
-      val spark = SparkSession.builder
-        .master("local[2]")
-        .appName("test-sql-context")
-        .config(conf)
-        .getOrCreate()
-      spark.sparkContext
-    }
+    this(new SparkConf)
   }
 
   @transient


### PR DESCRIPTION
## What changes were proposed in this pull request?

After #12907 `TestSparkSession` creates a spark session in one of the constructors just to get the `SparkContext` from it. This ends up creating 2 `SparkSession`s from one call, which is definitely not what we want.
## How was this patch tested?

Jenkins.
