### PR TITLE
[SPARK-15114][SQL] Column name generated by typed aggregate is super verbose

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -185,8 +185,7 @@ class Analyzer(
               case c @ Cast(ne: NamedExpression, _) => Alias(c, ne.name)()
               case e: ExtractValue => Alias(e, toPrettySQL(e))()
               case e if optGenAliasFunc.isDefined =>
-                val v: String = optGenAliasFunc.get.apply(e)
-                Alias(child, s"${v}_c${i + 1}")()
+                Alias(child, s"${optGenAliasFunc.get.apply(e, i + 1)}")()
               case e => Alias(e, toPrettySQL(e))()
             }
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -185,7 +185,7 @@ class Analyzer(
               case c @ Cast(ne: NamedExpression, _) => Alias(c, ne.name)()
               case e: ExtractValue => Alias(e, toPrettySQL(e))()
               case e if optGenAliasFunc.isDefined =>
-                Alias(child, s"${optGenAliasFunc.get.apply(e, i + 1)}")()
+                Alias(child, optGenAliasFunc.get.apply(e))()
               case e => Alias(e, toPrettySQL(e))()
             }
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -177,8 +177,11 @@ class Analyzer(
     private def assignAliases(exprs: Seq[NamedExpression]) = {
       exprs.zipWithIndex.map {
         case (expr, i) =>
-          expr.transformUp { case u @ UnresolvedAlias(child, optionalAliasName) =>
+          expr.transformUp { case u @ UnresolvedAlias(child, optionalAliasName, optGenAliasFunc) =>
             child match {
+              case e if optGenAliasFunc.isDefined =>
+                val v: String = optGenAliasFunc.get.apply(e)
+                Alias(child, s"${v}_c${i + 1}")()
               case ne: NamedExpression => ne
               case e if !e.resolved => u
               case g: Generator => MultiAlias(g, Nil)
@@ -656,7 +659,7 @@ class Analyzer(
         // Using Dataframe/Dataset API: testData2.groupBy($"a", $"b").agg($"*")
         case s: Star => s.expand(child, resolver)
         // Using SQL API without running ResolveAlias: SELECT * FROM testData2 group by a, b
-        case UnresolvedAlias(s: Star, _) => s.expand(child, resolver)
+        case UnresolvedAlias(s: Star, _, _) => s.expand(child, resolver)
         case o if containsStar(o :: Nil) => expandStarExpression(o, child) :: Nil
         case o => o :: Nil
       }.map(_.asInstanceOf[NamedExpression])
@@ -1335,14 +1338,14 @@ class Analyzer(
     }
 
     private def hasNestedGenerator(expr: NamedExpression): Boolean = expr match {
-      case UnresolvedAlias(_: Generator, _) => false
+      case UnresolvedAlias(_: Generator, _, _) => false
       case Alias(_: Generator, _) => false
       case MultiAlias(_: Generator, _) => false
       case other => hasGenerator(other)
     }
 
     private def trimAlias(expr: NamedExpression): Expression = expr match {
-      case UnresolvedAlias(child, _) => child
+      case UnresolvedAlias(child, _, _) => child
       case Alias(child, _) => child
       case MultiAlias(child, _) => child
       case _ => expr

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -325,14 +325,12 @@ case class UnresolvedExtractValue(child: Expression, extraction: Expression)
  * Holds the expression that has yet to be aliased.
  *
  * @param child The computation that is needs to be resolved during analysis.
- * @param aliasName The name if specified to be associated with the result of computing [[child]]
  * @param aliasFunc The function if specified to be called to generate an alias to associate
  *                  with the result of computing [[child]]
  *
  */
 case class UnresolvedAlias(
     child: Expression,
-    aliasName: Option[String] = None,
     aliasFunc: Option[Expression => String] = None)
   extends UnaryExpression with NamedExpression with Unevaluable {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -331,7 +331,7 @@ case class UnresolvedExtractValue(child: Expression, extraction: Expression)
  */
 case class UnresolvedAlias(
     child: Expression,
-    aliasFunc: Option[Expression => String] = None)
+    aliasFunc: Option[(Expression, Int) => String] = None)
   extends UnaryExpression with NamedExpression with Unevaluable {
 
   override def toAttribute: Attribute = throw new UnresolvedException(this, "toAttribute")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -326,9 +326,14 @@ case class UnresolvedExtractValue(child: Expression, extraction: Expression)
  *
  * @param child The computation that is needs to be resolved during analysis.
  * @param aliasName The name if specified to be associated with the result of computing [[child]]
+ * @param aliasFunc The function if specified to be called to generate an alias to associate
+ *                  with the result of computing [[child]]
  *
  */
-case class UnresolvedAlias(child: Expression, aliasName: Option[String] = None)
+case class UnresolvedAlias(
+     child: Expression,
+     aliasName: Option[String] = None,
+     aliasFunc: Option[Expression => String] = None)
   extends UnaryExpression with NamedExpression with Unevaluable {
 
   override def toAttribute: Attribute = throw new UnresolvedException(this, "toAttribute")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -331,9 +331,9 @@ case class UnresolvedExtractValue(child: Expression, extraction: Expression)
  *
  */
 case class UnresolvedAlias(
-     child: Expression,
-     aliasName: Option[String] = None,
-     aliasFunc: Option[Expression => String] = None)
+    child: Expression,
+    aliasName: Option[String] = None,
+    aliasFunc: Option[Expression => String] = None)
   extends UnaryExpression with NamedExpression with Unevaluable {
 
   override def toAttribute: Attribute = throw new UnresolvedException(this, "toAttribute")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -331,7 +331,7 @@ case class UnresolvedExtractValue(child: Expression, extraction: Expression)
  */
 case class UnresolvedAlias(
     child: Expression,
-    aliasFunc: Option[(Expression, Int) => String] = None)
+    aliasFunc: Option[Expression => String] = None)
   extends UnaryExpression with NamedExpression with Unevaluable {
 
   override def toAttribute: Attribute = throw new UnresolvedException(this, "toAttribute")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -154,7 +154,7 @@ class Column(protected[sql] val expr: Expression) extends Logging {
 
     case jt: JsonTuple => MultiAlias(jt, Nil)
 
-    case func: UnresolvedFunction => UnresolvedAlias(func, Some(usePrettyExpression(func).sql))
+    case func: UnresolvedFunction => UnresolvedAlias(func, Some(Column.generateAlias))
 
     // If we have a top level Cast, there is a chance to give it a better alias, if there is a
     // NamedExpression under this Cast.
@@ -166,7 +166,7 @@ class Column(protected[sql] val expr: Expression) extends Logging {
     }
 
     case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
-      UnresolvedAlias(a, None, Some(Column.generateAlias))
+      UnresolvedAlias(a, Some(Column.generateAlias))
 
     case expr: Expression => Alias(expr, usePrettyExpression(expr).sql)()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -40,12 +40,12 @@ private[sql] object Column {
   def unapply(col: Column): Option[Expression] = Some(col.expr)
 
    def generateAlias(e: Expression): String = {
-    e match {
-      case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
-        s"${a.aggregateFunction.prettyName}"
-      case expr => usePrettyExpression(expr).sql
-    }
-  }
+     e match {
+       case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
+         s"${a.aggregateFunction.prettyName}"
+       case expr => usePrettyExpression(expr).sql
+     }
+   }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -39,10 +39,10 @@ private[sql] object Column {
 
   def unapply(col: Column): Option[Expression] = Some(col.expr)
 
-  private[sql] def generateAlias(e: Expression, index: Int): String = {
+  private[sql] def generateAlias(e: Expression): String = {
     e match {
       case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
-        s"${a.aggregateFunction.prettyName}_c${index}"
+        a.aggregateFunction.toString
       case expr => usePrettyExpression(expr).sql
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -39,13 +39,13 @@ private[sql] object Column {
 
   def unapply(col: Column): Option[Expression] = Some(col.expr)
 
-   def generateAlias(e: Expression): String = {
-     e match {
-       case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
-         s"${a.aggregateFunction.prettyName}"
-       case expr => usePrettyExpression(expr).sql
-     }
-   }
+  private[sql] def generateAlias(e: Expression): String = {
+    e match {
+      case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
+        s"${a.aggregateFunction.prettyName}"
+      case expr => usePrettyExpression(expr).sql
+    }
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -24,6 +24,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.encoders.{encoderFor, ExpressionEncoder}
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.usePrettyExpression
 import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
@@ -155,6 +156,9 @@ class Column(protected[sql] val expr: Expression) extends Logging {
       case ne: NamedExpression => ne
       case other => Alias(expr, usePrettyExpression(expr).sql)()
     }
+
+    case a: AggregateExpression if (a.aggregateFunction.isInstanceOf[TypedAggregateExpression]) =>
+      Alias(a, s"${a.aggregateFunction.prettyName}")()
 
     case expr: Expression => Alias(expr, usePrettyExpression(expr).sql)()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -39,10 +39,10 @@ private[sql] object Column {
 
   def unapply(col: Column): Option[Expression] = Some(col.expr)
 
-  private[sql] def generateAlias(e: Expression): String = {
+  private[sql] def generateAlias(e: Expression, index: Int): String = {
     e match {
       case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
-        s"${a.aggregateFunction.prettyName}"
+        s"${a.aggregateFunction.prettyName}_c${index}"
       case expr => usePrettyExpression(expr).sql
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Pivot}
 import org.apache.spark.sql.catalyst.util.usePrettyExpression
+import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.NumericType
 
@@ -73,6 +74,8 @@ class RelationalGroupedDataset protected[sql](
   private[this] def alias(expr: Expression): NamedExpression = expr match {
     case u: UnresolvedAttribute => UnresolvedAlias(u)
     case expr: NamedExpression => expr
+    case a: AggregateExpression if (a.aggregateFunction.isInstanceOf[TypedAggregateExpression]) =>
+      Alias(a, s"${a.aggregateFunction.prettyName}")()
     case expr: Expression => Alias(expr, usePrettyExpression(expr).sql)()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -75,7 +75,7 @@ class RelationalGroupedDataset protected[sql](
     case u: UnresolvedAttribute => UnresolvedAlias(u)
     case expr: NamedExpression => expr
     case a: AggregateExpression if (a.aggregateFunction.isInstanceOf[TypedAggregateExpression]) =>
-      UnresolvedAlias(a, None, Some(Column.generateAlias))
+      UnresolvedAlias(a, Some(Column.generateAlias))
     case expr: Expression => Alias(expr, usePrettyExpression(expr).sql)()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -75,7 +75,7 @@ class RelationalGroupedDataset protected[sql](
     case u: UnresolvedAttribute => UnresolvedAlias(u)
     case expr: NamedExpression => expr
     case a: AggregateExpression if (a.aggregateFunction.isInstanceOf[TypedAggregateExpression]) =>
-      Alias(a, s"${a.aggregateFunction.prettyName}")()
+      UnresolvedAlias(a, None, Some(Column.generateAlias))
     case expr: Expression => Alias(expr, usePrettyExpression(expr).sql)()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -240,4 +240,15 @@ class DatasetAggregatorSuite extends QueryTest with SharedSQLContext {
     val df2 = Seq(1 -> "a", 2 -> "b", 3 -> "b").toDF("i", "j")
     checkAnswer(df2.agg(RowAgg.toColumn as "b").select("b"), Row(6) :: Nil)
   }
+
+  test("spark-15114 shorter system generated alias names") {
+    val ds = Seq(1, 3, 2, 5).toDS()
+    assert(ds.select(typed.sum((i: Int) => i)).columns.head === "typedsumdouble")
+    val ds2 = ds.select(typed.sum((i: Int) => i), typed.avg((i: Int) => i))
+    assert(ds2.columns.head === "typedsumdouble")
+    assert(ds2.columns.last === "typedaverage")
+    val df = Seq(1 -> "a", 2 -> "b", 3 -> "b").toDF("i", "j")
+    assert(df.groupBy($"j").agg(RowAgg.toColumn).columns.last == "rowagg")
+    assert(df.groupBy($"j").agg(RowAgg.toColumn as "agg1").columns.last == "agg1")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -243,12 +243,12 @@ class DatasetAggregatorSuite extends QueryTest with SharedSQLContext {
 
   test("spark-15114 shorter system generated alias names") {
     val ds = Seq(1, 3, 2, 5).toDS()
-    assert(ds.select(typed.sum((i: Int) => i)).columns.head === "typedsumdouble")
+    assert(ds.select(typed.sum((i: Int) => i)).columns.head === "typedsumdouble_c1")
     val ds2 = ds.select(typed.sum((i: Int) => i), typed.avg((i: Int) => i))
-    assert(ds2.columns.head === "typedsumdouble")
-    assert(ds2.columns.last === "typedaverage")
+    assert(ds2.columns.head === "typedsumdouble_c1")
+    assert(ds2.columns.last === "typedaverage_c2")
     val df = Seq(1 -> "a", 2 -> "b", 3 -> "b").toDF("i", "j")
-    assert(df.groupBy($"j").agg(RowAgg.toColumn).columns.last == "rowagg")
+    assert(df.groupBy($"j").agg(RowAgg.toColumn).columns.last == "rowagg_c2")
     assert(df.groupBy($"j").agg(RowAgg.toColumn as "agg1").columns.last == "agg1")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -243,12 +243,13 @@ class DatasetAggregatorSuite extends QueryTest with SharedSQLContext {
 
   test("spark-15114 shorter system generated alias names") {
     val ds = Seq(1, 3, 2, 5).toDS()
-    assert(ds.select(typed.sum((i: Int) => i)).columns.head === "typedsumdouble_c1")
+    assert(ds.select(typed.sum((i: Int) => i)).columns.head === "TypedSumDouble(int)")
     val ds2 = ds.select(typed.sum((i: Int) => i), typed.avg((i: Int) => i))
-    assert(ds2.columns.head === "typedsumdouble_c1")
-    assert(ds2.columns.last === "typedaverage_c2")
+    assert(ds2.columns.head === "TypedSumDouble(int)")
+    assert(ds2.columns.last === "TypedAverage(int)")
     val df = Seq(1 -> "a", 2 -> "b", 3 -> "b").toDF("i", "j")
-    assert(df.groupBy($"j").agg(RowAgg.toColumn).columns.last == "rowagg_c2")
+    assert(df.groupBy($"j").agg(RowAgg.toColumn).columns.last ==
+      "RowAgg(org.apache.spark.sql.Row)")
     assert(df.groupBy($"j").agg(RowAgg.toColumn as "agg1").columns.last == "agg1")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Generate a shorter default alias for `AggregateExpression`, In this PR, aggregate function name along with a index is used for generating the alias name.

``` SQL
val ds = Seq(1, 3, 2, 5).toDS()
ds.select(typed.sum((i: Int) => i), typed.avg((i: Int) => i)).show()
```

Output before change.

``` SQL
+-----------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
|typedsumdouble(unresolveddeserializer(upcast(input[0, int], IntegerType, - root class: "scala.Int"), value#1), upcast(value))|typedaverage(unresolveddeserializer(upcast(input[0, int], IntegerType, - root class: "scala.Int"), value#1), newInstance(class scala.Tuple2))|
+-----------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
|                                                                                                                         11.0|                                                                                                                                         2.75|
+-----------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```

Output after change:

``` SQL
+-----------------+---------------+
|typedsumdouble_c1|typedaverage_c2|
+-----------------+---------------+
|             11.0|           2.75|
+-----------------+---------------+
```

Note: There is one test in ParquetSuites.scala which shows that that the system picked alias
name is not usable and is rejected.  [test](https://github.com/apache/spark/blob/master/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala#L672-#L687)
## How was this patch tested?

A new test was added in DataSetAggregatorSuite. 
