### PR TITLE
Update LocalKMeans.scala

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -65,7 +65,7 @@ private[mllib] object LocalKMeans extends Logging {
       }
       if (j == 0) {
         logWarning("kMeansPlusPlus initialization ran out of distinct points for centers." +
-                   s" Using duplicate point for center k = $i.")
+          s" Using duplicate point for center k = $i.")
         centers(i) = points(0).toDense
       } else {
         centers(i) = points(j - 1).toDense

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -52,12 +52,6 @@ private[mllib] object LocalKMeans extends Logging {
     }
     
     for (i <- 1 until k) {
-
-      // Pick the next center with a probability proportional to cost under current centers
-      //      val curCenters = centers.view.take(i)
-      //      val sum = points.view.zip(weights).map { case (p, w) =>
-      //        w * KMeans.pointCost(curCenters, p)
-      //      }.sum
       val sum = costArray.view.zip(weights).map{
         case (c, w) =>
           w*c
@@ -70,8 +64,8 @@ private[mllib] object LocalKMeans extends Logging {
         j += 1
       }
       if (j == 0) {
-        //        logWarning("kMeansPlusPlus initialization ran out of distinct points for centers." +
-        //          s" Using duplicate point for center k = $i.")
+        logWarning("kMeansPlusPlus initialization ran out of distinct points for centers." +
+                   s" Using duplicate point for center k = $i.")
         centers(i) = points(0).toDense
       } else {
         centers(i) = points(j - 1).toDense

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -46,9 +46,8 @@ private[mllib] object LocalKMeans extends Logging {
 
     // Initialize centers by sampling using the k-means++ procedure.
     centers(0) = pickWeighted(rand, points, weights).toDense
-    val costArray:Array[Double] = new Array[Double](points.length)
-    for(i <- 0 to points.length-1){
-      costArray(i)=KMeans.fastSquaredDistance(points(i), centers(0))
+    val costArray = points.map { point =>
+      KMeans.fastSquaredDistance(point, centers(0))
     }
     
     for (i <- 1 until k) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -76,12 +76,6 @@ private[mllib] object LocalKMeans extends Logging {
         costArray(p)=math.min(KMeans.fastSquaredDistance(points(p), centers(i)),costArray(p))
       }
 
-      if(i%100==0){
-        val end = System.currentTimeMillis()
-        //        Utils.printLog("DEBUG", s"finish K-means++ ${i}th center in ${(end-roundStart)}ms")
-        roundStart = end
-      }
-
     }
 
     // Run up to maxIterations iterations of Lloyd's algorithm


### PR DESCRIPTION
## Proposed Change

After picking each new initial centers, it's unnecessary to compute the distances between all the points and the old ones. 
Instead this change keep the distance between all the points and their closest centers, and compare to the distance of them with the new center then update them.
## Test result

I test the KMeans++ method for a small dataset with 16k points, and the whole KMeans|| with a large one with 240k points.
The data has 4096 features and I tunes K from 100 to 500.
The test environment was on my 4 machine cluster, I also tested a 3M points data on a larger cluster with 25 machines and got similar results, which I would not draw the detail curve. The result of the first two exps are shown below
### Local KMeans++ test:

Dataset:4m_ini_center
Data_size:16234
Dimension:4096 

Lloyd's Iteration = 10
The y-axis is time in sec, the x-axis is tuning the K.

![image](https://cloud.githubusercontent.com/assets/10915169/15175831/d0c92b82-179a-11e6-8b68-4e165fc2fdff.png)

![local_total](https://cloud.githubusercontent.com/assets/10915169/15175957/6b21c3b0-179b-11e6-9741-66dfe4e23eb7.jpg)
### On a larger dataset

An improve show in the graph but not commit in this file: In this experiment I also have an improvement for calculation in normalization data (the distance is convert to the cosine distance). As if the data is normalized into (0,1), one improvement in the original vesion for util.MLUtils.fastSauaredDistance would have no effect (the precisionBound 2.0 \* EPSILON \* sumSquaredNorm / (normDiff \* normDiff + EPSILON) will never less then precision in this case). Therefore I design an early terminal method when comparing two distance (used for findClosest). But I don't include this improve in this file, you may only refer to the curves without "normalize" for comparing the results.

Dataset:4k24  
Data_size:243960
Dimension:4096

Normlize    Enlarge     Initialize  Lloyd's_Iteration
NO      1            3            5
YES             10000    3            5

Notice: the normlized data is enlarged to ensure precision

The cost time: x-for value of K, y-for time in sec
![4k24_total](https://cloud.githubusercontent.com/assets/10915169/15176635/9a54c0bc-179e-11e6-81c5-238e0c54bce2.jpg)

SE for unnormalized data between two version, to ensure the correctness
![4k24_unnorm_se](https://cloud.githubusercontent.com/assets/10915169/15176661/b85dabc8-179e-11e6-9269-fe7d2101dd48.jpg)

Here is the SE between normalized data just for reference, it's also correct.
![4k24_norm_se](https://cloud.githubusercontent.com/assets/10915169/15176742/1fbde940-179f-11e6-8290-d24b0dd4a4f7.jpg)
