### PR TITLE
[SPARK-14933][HOTFIX] Replace `sqlContext` with `spark`.

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaLDAExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaLDAExample.java
@@ -53,7 +53,7 @@ public class JavaLDAExample {
     double lp = model.logPerplexity(dataset);
     System.out.println("The lower bound on the log likelihood of the entire corpus: " + ll);
     System.out.println("The upper bound bound on perplexity: " + lp);
-    
+
     // Describe topics.
     Dataset<Row> topics = model.describeTopics(3);
     System.out.println("The topics described by their top-weighted terms:");

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
@@ -308,11 +308,11 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("SPARK-14933 - create view from hive parquet tabale") {
     withTable("t_part") {
       withView("v_part") {
-        sqlContext.sql(
+        spark.sql(
           """create table t_part (c1 int, c2 int)
             |stored as parquet as select 1 as a, 2 as b
           """.stripMargin)
-        sqlContext.sql("create view v_part as select * from t_part")
+        spark.sql("create view v_part as select * from t_part")
         checkAnswer(
           sql("select * from t_part"),
           sql("select * from v_part"))
@@ -323,11 +323,11 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("SPARK-14933 - create view from hive orc tabale") {
     withTable("t_orc") {
       withView("v_orc") {
-        sqlContext.sql(
+        spark.sql(
           """create table t_orc (c1 int, c2 int)
             |stored as orc as select 1 as a, 2 as b
           """.stripMargin)
-        sqlContext.sql("create view v_orc as select * from t_orc")
+        spark.sql("create view v_orc as select * from t_orc")
         checkAnswer(
           sql("select * from t_orc"),
           sql("select * from v_orc"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fixes compile errors.
## How was this patch tested?

Pass the Jenkins tests.
