### PR TITLE
[SPARK-15273] YarnSparkHadoopUtil#getOutOfMemoryErrorArgument should respect OnOutOfMemoryError parameter given by user

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -336,7 +336,7 @@ class CommandBuilderUtils {
   /**
    * Gets the OutOfMemoryError option for Spark if the user hasn't set it.
    */
-  static String getOutOfMemoryErrorArgument(List<String> cmd) {
+  public static String getOutOfMemoryErrorArgument(List<String> cmd) {
     for (String arg : cmd) {
       if (arg.contains("-XX:OnOutOfMemoryError=")) {
         return "";

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -339,7 +339,7 @@ public class CommandBuilderUtils {
   public static String getOutOfMemoryErrorArgument(List<String> cmd) {
     for (String arg : cmd) {
       if (arg.contains("-XX:OnOutOfMemoryError=")) {
-        return "";
+        return arg;
       }
     }
     return "-XX:OnOutOfMemoryError='kill %p'";

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -334,6 +334,18 @@ class CommandBuilderUtils {
   }
 
   /**
+   * Gets the OutOfMemoryError option for Spark if the user hasn't set it.
+   */
+  static String getOutOfMemoryErrorArgument(List<String> cmd) {
+    for (String arg : cmd) {
+      if (arg.contains("-XX:OnOutOfMemoryError=")) {
+        return "";
+      }
+    }
+    return "-XX:OnOutOfMemoryError='kill %p'";
+  }
+
+  /**
    * Get the major version of the java version string supplied. This method
    * accepts any JEP-223-compliant strings (9-ea, 9+100), as well as legacy
    * version strings such as 1.7.0_79

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -25,7 +25,7 @@ import java.util.Map;
 /**
  * Helper methods for command builders.
  */
-public class CommandBuilderUtils {
+class CommandBuilderUtils {
 
   static final String DEFAULT_MEM = "1g";
   static final String DEFAULT_PROPERTIES_FILE = "spark-defaults.conf";
@@ -331,18 +331,6 @@ public class CommandBuilderUtils {
     }
 
     cmd.add("-XX:MaxPermSize=256m");
-  }
-
-  /**
-   * Gets the OutOfMemoryError option for Spark if the user hasn't set it.
-   */
-  public static void addOutOfMemoryErrorArgument(List<String> cmd) {
-    for (String arg : cmd) {
-      if (arg.contains("-XX:OnOutOfMemoryError=")) {
-        return;
-      }
-    }
-    cmd.add("-XX:OnOutOfMemoryError='kill %p'");
   }
 
   /**

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -25,7 +25,7 @@ import java.util.Map;
 /**
  * Helper methods for command builders.
  */
-class CommandBuilderUtils {
+public class CommandBuilderUtils {
 
   static final String DEFAULT_MEM = "1g";
   static final String DEFAULT_PROPERTIES_FILE = "spark-defaults.conf";

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -336,13 +336,13 @@ public class CommandBuilderUtils {
   /**
    * Gets the OutOfMemoryError option for Spark if the user hasn't set it.
    */
-  public static String getOutOfMemoryErrorArgument(List<String> cmd) {
+  public static void addOutOfMemoryErrorArgument(List<String> cmd) {
     for (String arg : cmd) {
       if (arg.contains("-XX:OnOutOfMemoryError=")) {
-        return arg;
+        return;
       }
     }
-    return "-XX:OnOutOfMemoryError='kill %p'";
+    cmd.add("-XX:OnOutOfMemoryError='kill %p'");
   }
 
   /**

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -128,6 +128,11 @@ private[yarn] class ExecutorRunnable(
     }
   }
 
+  // Kill if OOM is raised - leverage yarn's failure handling to cause rescheduling.
+  // Not killing the task leaves various aspects of the executor and (to some extent) the jvm in
+  // an inconsistent state.
+  // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
+  // 'something' to fail job ... akin to blacklisting trackers in mapred ?
   private def prepareCommand(
       masterAddress: String,
       slaveId: String,
@@ -211,11 +216,6 @@ private[yarn] class ExecutorRunnable(
       Seq("--user-class-path", "file:" + absPath)
     }.toSeq
 
-    // Kill if OOM is raised - leverage yarn's failure handling to cause rescheduling.
-    // Not killing the task leaves various aspects of the executor and (to some extent) the jvm in
-    // an inconsistent state.
-    // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
-    // 'something' to fail job ... akin to blacklisting trackers in mapred ?
     YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
     val commands = prefixEnv ++ Seq(
       YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) + "/bin/java",

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -211,15 +211,15 @@ private[yarn] class ExecutorRunnable(
       Seq("--user-class-path", "file:" + absPath)
     }.toSeq
 
+    // Kill if OOM is raised - leverage yarn's failure handling to cause rescheduling.
+    // Not killing the task leaves various aspects of the executor and (to some extent) the jvm in
+    // an inconsistent state.
+    // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
+    // 'something' to fail job ... akin to blacklisting trackers in mapred ?
+    YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
     val commands = prefixEnv ++ Seq(
       YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) + "/bin/java",
-      "-server",
-      // Kill if OOM is raised - leverage yarn's failure handling to cause rescheduling.
-      // Not killing the task leaves various aspects of the executor and (to some extent) the jvm in
-      // an inconsistent state.
-      // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
-      // 'something' to fail job ... akin to blacklisting trackers in mapred ?
-      YarnSparkHadoopUtil.getOutOfMemoryErrorArgument(javaOpts)) ++
+      "-server") ++
       javaOpts ++
       Seq("org.apache.spark.executor.CoarseGrainedExecutorBackend",
         "--driver-url", masterAddress.toString,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -219,7 +219,7 @@ private[yarn] class ExecutorRunnable(
       // an inconsistent state.
       // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
       // 'something' to fail job ... akin to blacklisting trackers in mapred ?
-      YarnSparkHadoopUtil.getOutOfMemoryErrorArgument(sparkConf, javaOpts)) ++
+      YarnSparkHadoopUtil.getOutOfMemoryErrorArgument(javaOpts)) ++
       javaOpts ++
       Seq("org.apache.spark.executor.CoarseGrainedExecutorBackend",
         "--driver-url", masterAddress.toString,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -219,7 +219,7 @@ private[yarn] class ExecutorRunnable(
       // an inconsistent state.
       // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
       // 'something' to fail job ... akin to blacklisting trackers in mapred ?
-      YarnSparkHadoopUtil.getOutOfMemoryErrorArgument) ++
+      YarnSparkHadoopUtil.getOutOfMemoryErrorArgument(sparkConf, javaOpts)) ++
       javaOpts ++
       Seq("org.apache.spark.executor.CoarseGrainedExecutorBackend",
         "--driver-url", masterAddress.toString,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -128,11 +128,6 @@ private[yarn] class ExecutorRunnable(
     }
   }
 
-  // Kill if OOM is raised - leverage yarn's failure handling to cause rescheduling.
-  // Not killing the task leaves various aspects of the executor and (to some extent) the jvm in
-  // an inconsistent state.
-  // TODO: If the OOM is not recoverable by rescheduling it on different node, then do
-  // 'something' to fail job ... akin to blacklisting trackers in mapred ?
   private def prepareCommand(
       masterAddress: String,
       slaveId: String,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -24,6 +24,7 @@ import java.security.PrivilegedExceptionAction
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.{HashMap, ListBuffer}
 import scala.reflect.runtime._
 import scala.util.Try

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -422,7 +422,7 @@ object YarnSparkHadoopUtil {
     if (Utils.isWindows) {
       escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
-      val = onOOME = javaOpts.find(x => x.contains("-XX:OnOutOfMemoryError"))
+      val onOOME = javaOpts.find(x => x.contains("-XX:OnOutOfMemoryError"))
       if (onOOME == None) {
         "-XX:OnOutOfMemoryError='kill %p'"
       } else {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -418,7 +418,7 @@ object YarnSparkHadoopUtil {
    * variable. Windows .cmd files escape a '%' by '%%'. Thus, the correct way of writing
    * '%%p' in an escaped way is '%%%%p'.
    */
-  def addOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): Unit = {
+  private[yarn] def addOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): Unit = {
     if (Utils.isWindows) {
       javaOpts += escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -24,7 +24,7 @@ import java.security.PrivilegedExceptionAction
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{HashMap, ListBuffer}
 import scala.reflect.runtime._
 import scala.util.Try
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -417,14 +417,12 @@ object YarnSparkHadoopUtil {
    * the behavior of '%' in a .cmd file: it gets interpreted as an incomplete environment
    * variable. Windows .cmd files escape a '%' by '%%'. Thus, the correct way of writing
    * '%%p' in an escaped way is '%%%%p'.
-   *
-   * @return The correct OOM Error handler JVM option, platform dependent.
    */
-  def getOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): String = {
+  def addOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): Unit = {
     if (Utils.isWindows) {
-      escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
+      javaOpts += escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
-      CommandBuilderUtils.getOutOfMemoryErrorArgument(javaOpts.asJava)
+      CommandBuilderUtils.addOutOfMemoryErrorArgument(javaOpts.asJava)
     }
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -47,7 +47,6 @@ import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.config._
-import org.apache.spark.launcher.CommandBuilderUtils
 import org.apache.spark.launcher.YarnCommandBuilderUtils
 import org.apache.spark.util.Utils
 
@@ -422,7 +421,9 @@ object YarnSparkHadoopUtil {
     if (Utils.isWindows) {
       javaOpts += escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
-      CommandBuilderUtils.addOutOfMemoryErrorArgument(javaOpts.asJava)
+      if (!javaOpts.exists(_.contains("-XX:OnOutOfMemoryError"))) {
+        javaOpts.add("-XX:OnOutOfMemoryError='kill %p'")
+      }
     }
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -420,7 +420,7 @@ object YarnSparkHadoopUtil {
    *
    * @return The correct OOM Error handler JVM option, platform dependent.
    */
-  def getOutOfMemoryErrorArgument(sparkConf: SparkConf, javaOpts: ListBuffer[String]): String = {
+  def getOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): String = {
     if (Utils.isWindows) {
       escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -422,12 +422,7 @@ object YarnSparkHadoopUtil {
     if (Utils.isWindows) {
       escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
-      val onOOME = javaOpts.find(x => x.contains("-XX:OnOutOfMemoryError"))
-      if (onOOME == None) {
-        "-XX:OnOutOfMemoryError='kill %p'"
-      } else {
-        ""
-      }
+      CommandBuilderUtils.getOutOfMemoryErrorArgument(javaOpts.asJava)
     }
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -418,11 +418,16 @@ object YarnSparkHadoopUtil {
    *
    * @return The correct OOM Error handler JVM option, platform dependent.
    */
-  def getOutOfMemoryErrorArgument: String = {
+  def getOutOfMemoryErrorArgument(sparkConf: SparkConf, javaOpts: ListBuffer[String]): String = {
     if (Utils.isWindows) {
       escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
-      "-XX:OnOutOfMemoryError='kill %p'"
+      val = onOOME = javaOpts.find(x => x.contains("-XX:OnOutOfMemoryError"))
+      if (onOOME == None) {
+        "-XX:OnOutOfMemoryError='kill %p'"
+      } else {
+        ""
+      }
     }
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -422,7 +422,7 @@ object YarnSparkHadoopUtil {
       javaOpts += escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
       if (!javaOpts.exists(_.contains("-XX:OnOutOfMemoryError"))) {
-        javaOpts.add("-XX:OnOutOfMemoryError='kill %p'")
+        javaOpts += "-XX:OnOutOfMemoryError='kill %p'"
       }
     }
   }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -46,6 +46,7 @@ import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.config._
+import org.apache.spark.launcher.CommandBuilderUtils
 import org.apache.spark.launcher.YarnCommandBuilderUtils
 import org.apache.spark.util.Utils
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -424,12 +424,10 @@ object YarnSparkHadoopUtil {
    * '%%p' in an escaped way is '%%%%p'.
    */
   private[yarn] def addOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): Unit = {
-    if (Utils.isWindows) {
-      if (!javaOpts.exists(_.contains("-XX:OnOutOfMemoryError"))) {
+    if (!javaOpts.exists(_.contains("-XX:OnOutOfMemoryError"))) {
+      if (Utils.isWindows) {
         javaOpts += escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
-      }
-    } else {
-      if (!javaOpts.exists(_.contains("-XX:OnOutOfMemoryError"))) {
+      } else {
         javaOpts += "-XX:OnOutOfMemoryError='kill %p'"
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As Nirav reported in this thread:
http://search-hadoop.com/m/q3RTtdF3yNLMd7u

YarnSparkHadoopUtil#getOutOfMemoryErrorArgument previously specified 'kill %p' unconditionally.
We should respect the parameter given by user.
## How was this patch tested?

Existing tests
