### PR TITLE
[SPARK-15275] [SQL] CatalogTable should store sort ordering for sorted columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -21,7 +21,7 @@ import javax.annotation.Nullable
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, SortDirection}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
 
@@ -64,6 +64,13 @@ case class CatalogColumn(
 
 
 /**
+ * Sort ordering of a table.
+ */
+case class CatalogSortOrder(
+    column: CatalogColumn,
+    direction: SortDirection)
+
+/**
  * A partition (Hive style) defined in the catalog.
  *
  * @param spec partition spec values indexed by column name
@@ -86,7 +93,7 @@ case class CatalogTable(
     storage: CatalogStorageFormat,
     schema: Seq[CatalogColumn],
     partitionColumnNames: Seq[String] = Seq.empty,
-    sortColumnNames: Seq[String] = Seq.empty,
+    sortColumns: Seq[CatalogSortOrder] = Seq.empty,
     bucketColumnNames: Seq[String] = Seq.empty,
     numBuckets: Int = -1,
     owner: String = "",
@@ -104,7 +111,7 @@ case class CatalogTable(
       s"must be a subset of schema (${colNames.mkString(", ")}) in table '$identifier'")
   }
   requireSubsetOfSchema(partitionColumnNames, "partition")
-  requireSubsetOfSchema(sortColumnNames, "sort")
+  requireSubsetOfSchema(sortColumns.map(_.column.name), "sort")
   requireSubsetOfSchema(bucketColumnNames, "bucket")
 
   /** Columns this table is partitioned by. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -392,7 +392,7 @@ case class DescribeTableCommand(table: TableIdentifier, isExtended: Boolean, isF
     } else {
       append(buffer, "Num Buckets:", metadata.numBuckets.toString, "")
       append(buffer, "Bucket Columns:", metadata.bucketColumnNames.mkString("[", ", ", "]"), "")
-      append(buffer, "Sort Columns:", metadata.sortColumnNames.mkString("[", ", ", "]"), "")
+      append(buffer, "Sort Columns:", metadata.sortColumns.mkString("[", ", ", "]"), "")
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
@@ -91,6 +91,16 @@ private[hive] case class MetastoreRelation(
       catalogTable.partitionColumnNames.contains(c.getName)
     }
     sd.setCols(schema.asJava)
+
+    if (catalogTable.bucketColumnNames.nonEmpty) {
+      sd.setBucketCols(catalogTable.bucketColumnNames.toList.asJava)
+      sd.setNumBuckets(catalogTable.numBuckets)
+
+      if (catalogTable.sortColumnNames.nonEmpty) {
+        sd.setSortCols(catalogTable.sortColumnNames.toList.asJava)
+      }
+    }
+
     tTable.setPartitionKeys(partCols.asJava)
 
     catalogTable.storage.locationUri.foreach(sd.setLocation)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Jira link : https://issues.apache.org/jira/browse/SPARK-15275

For bucketed tables in Hive, one can also add constraint about column sortedness along with ordering.
As per the spec in [0], CREATE TABLE statement can allow SORT ordering as well:

  [CLUSTERED BY (col_name, col_name, ...) [SORTED BY (col_name [ASC|DESC], ...)] INTO num_buckets BUCKETS]

[0] : https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-CreateTable

Currently CatalogTable does not store any information about the sort ordering and just has the names of the sorted columns. This PR adds `CatalogSortOrder` to hold the sorted column name and the sorted order. Currently this information is _not_ used in query execution but can be used as more support for bucketing is added. Possible advantage is ability to skip rows while performing predicate matching.
## How was this patch tested?

Currently trunk does support creating bucketed hive tables. I am relying on existing tests. 
