### PR TITLE
[SPARK-15291][GraphX] Remove redundant operations in SVD++

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/SVDPlusPlus.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/SVDPlusPlus.scala
@@ -196,9 +196,7 @@ object SVDPlusPlus {
     g.unpersist()
     g = gJoinT3
 
-    // Convert DoubleMatrix to Array[Double]:
-    val newVertices = g.vertices.mapValues(v => (v._1.toArray, v._2.toArray, v._3, v._4))
-    (Graph(newVertices, g.edges), u)
+    (g, u)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
val newVertices = g.vertices.mapValues(v => (v._1.toArray, v._2.toArray, v._3, v._4))
(Graph(newVertices, g.edges), u)
```

`g` is of type `Graph[(Array[Double], Array[Double], Double, Double), Double]`,
and the return value seems just equal to `(g, u)`
## How was this patch tested?

unit test
