### PR TITLE
[SPARK-15305][ML][DOC]:spark.ml document Bisectiong k-means has the incorrect format

### DIFF
--- a/docs/ml-clustering.md
+++ b/docs/ml-clustering.md
@@ -116,6 +116,8 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.
 {% include_example python/ml/lda_example.py %}
 </div>
 </div>
+
+
 ## Bisecting k-means
 
 

--- a/docs/ml-clustering.md
+++ b/docs/ml-clustering.md
@@ -86,7 +86,6 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.
 </div>
 </div>
 
-
 ## Latent Dirichlet allocation (LDA)
 
 `LDA` is implemented as an `Estimator` that supports both `EMLDAOptimizer` and `OnlineLDAOptimizer`,
@@ -117,9 +116,7 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.
 </div>
 </div>
 
-
 ## Bisecting k-means
-
 
 Bisecting k-means is a kind of [hierarchical clustering](https://en.wikipedia.org/wiki/Hierarchical_clustering) using a
 divisive (or "top-down") approach: all observations start in one cluster, and splits are performed recursively as one
@@ -150,5 +147,4 @@ Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.
 
 {% include_example python/ml/bisecting_k_means_example.py %}
 </div>
-
 </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
The generated document has the incorrect format for biseckmeans.

![bug](https://cloud.githubusercontent.com/assets/5033592/15233120/d910098a-185a-11e6-901d-44aeafc8a011.jpg)
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Fix the formatting.
![fix](https://cloud.githubusercontent.com/assets/5033592/15233136/fce2ccd0-185a-11e6-9ded-14d71da4bdab.jpg)
