### PR TITLE
[SPARK-15312] [SQL] Detect Duplicate Key in Partition Spec and Table Properties

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -127,10 +127,8 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
       }
 
       // Check for duplicate names.
-      ctes.groupBy(_._1).filter(_._2.size > 1).foreach {
-        case (name, _) =>
-          throw new ParseException(
-            s"Name '$name' is used for multiple common table expressions", ctx)
+      ctes.groupBy(_._1).filter(_._2.size > 1).foreach { case (name, _) =>
+        throw new ParseException(s"Name '$name' is used for multiple common table expressions", ctx)
       }
 
       With(query, ctes.toMap)
@@ -226,10 +224,8 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
       name -> value
     }
     // Check for duplicate partition columns in one spec.
-    parts.groupBy(_._1).filter(_._2.size > 1).foreach {
-      case (name, _) =>
-        throw new ParseException(
-          s"The partition spec has duplicate partition columns '$name'.", ctx)
+    parts.groupBy(_._1).filter(_._2.size > 1).foreach { case (name, _) =>
+      throw new ParseException(s"The partition spec has duplicate partition columns '$name'.", ctx)
     }
     parts.toMap
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -125,12 +125,8 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
           val namedQuery = visitNamedQuery(nCtx)
           (namedQuery.alias, namedQuery)
       }
-
       // Check for duplicate names.
-      ctes.groupBy(_._1).filter(_._2.size > 1).foreach { case (name, _) =>
-        throw new ParseException(s"Name '$name' is used for multiple common table expressions", ctx)
-      }
-
+      checkDuplicateKeys(ctes, ctx)
       With(query, ctes.toMap)
     }
   }
@@ -224,9 +220,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
       name -> value
     }
     // Check for duplicate partition columns in one spec.
-    parts.groupBy(_._1).filter(_._2.size > 1).foreach { case (name, _) =>
-      throw new ParseException(s"The partition spec has duplicate partition columns '$name'.", ctx)
-    }
+    checkDuplicateKeys(parts, ctx)
     parts.toMap
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.catalyst.parser
 
+import scala.collection.mutable
 import scala.collection.mutable.StringBuilder
 
 import org.antlr.v4.runtime.{CharStream, ParserRuleContext, Token}
@@ -41,6 +42,14 @@ object ParserUtils {
 
   def operationNotAllowed(message: String, ctx: ParserRuleContext): ParseException = {
     new ParseException(s"Operation not allowed: $message", ctx)
+  }
+
+  /** Check if duplicate keys exist in a set of key-value pairs. */
+  def checkDuplicateKeys(
+      keyPairs: mutable.Buffer[_ <: (String, Any)], ctx: ParserRuleContext): Unit = {
+    keyPairs.groupBy(_._1).filter(_._2.size > 1).foreach { case (key, _) =>
+      throw new ParseException(s"Found duplicate keys '$key'.", ctx)
+    }
   }
 
   /** Get the code that creates the given node. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.catalyst.parser
 
-import scala.collection.mutable
 import scala.collection.mutable.StringBuilder
 
 import org.antlr.v4.runtime.{CharStream, ParserRuleContext, Token}
@@ -45,8 +44,7 @@ object ParserUtils {
   }
 
   /** Check if duplicate keys exist in a set of key-value pairs. */
-  def checkDuplicateKeys(
-      keyPairs: mutable.Buffer[_ <: (String, Any)], ctx: ParserRuleContext): Unit = {
+  def checkDuplicateKeys[T](keyPairs: Seq[(String, T)], ctx: ParserRuleContext): Unit = {
     keyPairs.groupBy(_._1).filter(_._2.size > 1).foreach { case (key, _) =>
       throw new ParseException(s"Found duplicate keys '$key'.", ctx)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -108,7 +108,7 @@ class PlanParserSuite extends PlanTest {
         "cte2" -> table("cte1").select(star())))
     intercept(
       "with cte1 (select 1), cte1 as (select 1 from cte1) select * from cte1",
-      "Name 'cte1' is used for multiple common table expressions")
+      "Found duplicate keys 'cte1'")
   }
 
   test("simple select query") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -345,9 +345,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
       key -> value
     }
     // Check for duplicate property names.
-    properties.groupBy(_._1).filter(_._2.size > 1).foreach { case (name, _) =>
-      throw new ParseException(s"The property list contains duplicate keys '$name'.", ctx)
-    }
+    checkDuplicateKeys(properties, ctx)
     properties.toMap
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -345,10 +345,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
       key -> value
     }
     // Check for duplicate property names.
-    properties.groupBy(_._1).filter(_._2.size > 1).foreach {
-      case (name, _) =>
-        throw new ParseException(
-          s"The property list contains duplicate keys '$name'.", ctx)
+    properties.groupBy(_._1).filter(_._2.size > 1).foreach { case (name, _) =>
+      throw new ParseException(s"The property list contains duplicate keys '$name'.", ctx)
     }
     properties.toMap
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -544,6 +544,21 @@ class DDLCommandSuite extends PlanTest {
     assert(parsed.isInstanceOf[Project])
   }
 
+  test("duplicate keys in table properties") {
+    val e = intercept[ParseException] {
+      parser.parsePlan("ALTER TABLE dbx.tab1 SET TBLPROPERTIES ('key1' = '1', 'key1' = '2')")
+    }.getMessage
+    assert(e.contains("Found duplicate keys 'key1'"))
+  }
+
+  test("duplicate columns in partition specs") {
+    val e = intercept[ParseException] {
+      parser.parsePlan(
+        "ALTER TABLE dbx.tab1 PARTITION (a='1', a='2') RENAME TO PARTITION (a='100', a='200')")
+    }.getMessage
+    assert(e.contains("Found duplicate keys 'a'"))
+  }
+
   test("drop table") {
     val tableName1 = "db.tab"
     val tableName2 = "tab"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -471,6 +471,13 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     assert(e.getMessage.contains("datasource"))
   }
 
+  test("duplicate keys in table properties") {
+    val e = intercept[AnalysisException] {
+      sql("ALTER TABLE dbx.tab1 SET TBLPROPERTIES ('key1' = '1', 'key1' = '2')")
+    }.getMessage
+    assert(e.contains("The property list contains duplicate keys 'key1'"))
+  }
+
   test("alter table: unset properties") {
     val catalog = spark.sessionState.catalog
     val tableIdent = TableIdentifier("tab1", Some("dbx"))
@@ -590,6 +597,13 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     intercept[AnalysisException] {
       sql("ALTER TABLE tab1 PARTITION (x='300') RENAME TO PARTITION (x='333')")
     }
+  }
+
+  test("duplicate columns in partition specs") {
+    val e = intercept[AnalysisException] {
+      sql("ALTER TABLE dbx.tab1 PARTITION (a='1', a='2') RENAME TO PARTITION (a='100', a='200')")
+    }.getMessage
+    assert(e.contains("The partition spec has duplicate partition columns 'a'"))
   }
 
   test("show tables") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -471,13 +471,6 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     assert(e.getMessage.contains("datasource"))
   }
 
-  test("duplicate keys in table properties") {
-    val e = intercept[AnalysisException] {
-      sql("ALTER TABLE dbx.tab1 SET TBLPROPERTIES ('key1' = '1', 'key1' = '2')")
-    }.getMessage
-    assert(e.contains("The property list contains duplicate keys 'key1'"))
-  }
-
   test("alter table: unset properties") {
     val catalog = spark.sessionState.catalog
     val tableIdent = TableIdentifier("tab1", Some("dbx"))
@@ -597,13 +590,6 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     intercept[AnalysisException] {
       sql("ALTER TABLE tab1 PARTITION (x='300') RENAME TO PARTITION (x='333')")
     }
-  }
-
-  test("duplicate columns in partition specs") {
-    val e = intercept[AnalysisException] {
-      sql("ALTER TABLE dbx.tab1 PARTITION (a='1', a='2') RENAME TO PARTITION (a='100', a='200')")
-    }.getMessage
-    assert(e.contains("The partition spec has duplicate partition columns 'a'"))
   }
 
   test("show tables") {


### PR DESCRIPTION
#### What changes were proposed in this pull request?

When there are duplicate keys in the partition specs or table properties, we always use the last value and ignore all the previous values. This is caused by the function call `toMap`. 

partition specs or table properties are widely used in multiple DDL statements.

This PR is to detect the duplicates and issue an exception if found.
#### How was this patch tested?

Added test cases in DDLSuite
