### PR TITLE
[SPARK-15319][SPARKR][DOCS] Fix SparkR doc layout for corr and other DataFrame stats functions

### DIFF
--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -430,19 +430,19 @@ setGeneric("coltypes<-", function(x, value) { standardGeneric("coltypes<-") })
 #' @export
 setGeneric("columns", function(x) {standardGeneric("columns") })
 
-#' @rdname statfunctions
+#' @rdname cov
 #' @export
 setGeneric("cov", function(x, ...) {standardGeneric("cov") })
 
-#' @rdname statfunctions
+#' @rdname corr
 #' @export
 setGeneric("corr", function(x, ...) {standardGeneric("corr") })
 
-#' @rdname statfunctions
+#' @rdname cov
 #' @export
 setGeneric("covar_samp", function(col1, col2) {standardGeneric("covar_samp") })
 
-#' @rdname statfunctions
+#' @rdname cov
 #' @export
 setGeneric("covar_pop", function(col1, col2) {standardGeneric("covar_pop") })
 

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -442,7 +442,7 @@ setGeneric("corr", function(x, ...) {standardGeneric("corr") })
 #' @export
 setGeneric("covar_samp", function(col1, col2) {standardGeneric("covar_samp") })
 
-#' @rdname cov
+#' @rdname covar_pop
 #' @export
 setGeneric("covar_pop", function(col1, col2) {standardGeneric("covar_pop") })
 

--- a/R/pkg/R/stats.R
+++ b/R/pkg/R/stats.R
@@ -20,6 +20,8 @@
 setOldClass("jobj")
 
 #' @title SparkDataFrame statistic functions
+
+#' @description
 #' crosstab - Computes a pair-wise frequency table of the given columns
 #'
 #' Computes a pair-wise frequency table of the given columns. Also known as a contingency

--- a/R/pkg/R/stats.R
+++ b/R/pkg/R/stats.R
@@ -19,9 +19,7 @@
 
 setOldClass("jobj")
 
-#' crosstab
-#'
-#' Computes a pair-wise frequency table of the given columns. Also known as a contingency
+#' crosstab - Computes a pair-wise frequency table of the given columns. Also known as a contingency
 #' table. The number of distinct values for each column should be less than 1e4. At most 1e6
 #' non-zero pair frequencies will be returned.
 #'
@@ -32,6 +30,7 @@ setOldClass("jobj")
 #'         of `col2`. The name of the first column will be `$col1_$col2`. Pairs that have no
 #'         occurrences will have zero as their counts.
 #'
+#' @title SparkDataFrame statistic functions
 #' @rdname statfunctions
 #' @name crosstab
 #' @export
@@ -49,9 +48,7 @@ setMethod("crosstab",
             collect(dataFrame(sct))
           })
 
-#' cov
-#'
-#' Calculate the sample covariance of two numerical columns of a SparkDataFrame.
+#' cov - Calculate the sample covariance of two numerical columns of a SparkDataFrame.
 #'
 #' @param x A SparkDataFrame
 #' @param col1 the name of the first column
@@ -75,9 +72,7 @@ setMethod("cov",
             callJMethod(statFunctions, "cov", col1, col2)
           })
 
-#' corr
-#'
-#' Calculates the correlation of two columns of a SparkDataFrame.
+#' corr - Calculates the correlation of two columns of a SparkDataFrame.
 #' Currently only supports the Pearson Correlation Coefficient.
 #' For Spearman Correlation, consider using RDD methods found in MLlib's Statistics.
 #'
@@ -106,9 +101,7 @@ setMethod("corr",
             callJMethod(statFunctions, "corr", col1, col2, method)
           })
 
-#' freqItems
-#'
-#' Finding frequent items for columns, possibly with false positives.
+#' freqItems - Finding frequent items for columns, possibly with false positives.
 #' Using the frequent element count algorithm described in
 #' \url{http://dx.doi.org/10.1145/762471.762473}, proposed by Karp, Schenker, and Papadimitriou.
 #'
@@ -134,9 +127,7 @@ setMethod("freqItems", signature(x = "SparkDataFrame", cols = "character"),
             collect(dataFrame(sct))
           })
 
-#' approxQuantile
-#'
-#' Calculates the approximate quantiles of a numerical column of a SparkDataFrame.
+#' approxQuantile - Calculates the approximate quantiles of a numerical column of a SparkDataFrame.
 #'
 #' The result of this algorithm has the following deterministic bound:
 #' If the SparkDataFrame has N elements and if we request the quantile at probability `p` up to
@@ -174,9 +165,8 @@ setMethod("approxQuantile",
                         as.list(probabilities), relativeError)
           })
 
-#' sampleBy
-#'
-#' Returns a stratified sample without replacement based on the fraction given on each stratum.
+#' sampleBy - Returns a stratified sample without replacement based on the fraction given on each
+#' stratum.
 #'
 #' @param x A SparkDataFrame
 #' @param col column that defines strata

--- a/R/pkg/R/stats.R
+++ b/R/pkg/R/stats.R
@@ -22,9 +22,7 @@ setOldClass("jobj")
 #' @title SparkDataFrame statistic functions
 
 #' @description
-#' crosstab - Computes a pair-wise frequency table of the given columns
-#'
-#' Computes a pair-wise frequency table of the given columns. Also known as a contingency
+#' crosstab - Computes a pair-wise frequency table of the given columns. Also known as a contingency
 #' table. The number of distinct values for each column should be less than 1e4. At most 1e6
 #' non-zero pair frequencies will be returned.
 #'

--- a/R/pkg/R/stats.R
+++ b/R/pkg/R/stats.R
@@ -19,7 +19,10 @@
 
 setOldClass("jobj")
 
-#' crosstab - Computes a pair-wise frequency table of the given columns. Also known as a contingency
+#' @title SparkDataFrame statistic functions
+#' crosstab - Computes a pair-wise frequency table of the given columns
+#'
+#' Computes a pair-wise frequency table of the given columns. Also known as a contingency
 #' table. The number of distinct values for each column should be less than 1e4. At most 1e6
 #' non-zero pair frequencies will be returned.
 #'
@@ -30,7 +33,6 @@ setOldClass("jobj")
 #'         of `col2`. The name of the first column will be `$col1_$col2`. Pairs that have no
 #'         occurrences will have zero as their counts.
 #'
-#' @title SparkDataFrame statistic functions
 #' @rdname statfunctions
 #' @name crosstab
 #' @export
@@ -48,14 +50,14 @@ setMethod("crosstab",
             collect(dataFrame(sct))
           })
 
-#' cov - Calculate the sample covariance of two numerical columns of a SparkDataFrame.
+#' Calculate the sample covariance of two numerical columns of a SparkDataFrame.
 #'
 #' @param x A SparkDataFrame
 #' @param col1 the name of the first column
 #' @param col2 the name of the second column
 #' @return the covariance of the two columns.
 #'
-#' @rdname statfunctions
+#' @rdname cov
 #' @name cov
 #' @export
 #' @examples
@@ -72,7 +74,7 @@ setMethod("cov",
             callJMethod(statFunctions, "cov", col1, col2)
           })
 
-#' corr - Calculates the correlation of two columns of a SparkDataFrame.
+#' Calculates the correlation of two columns of a SparkDataFrame.
 #' Currently only supports the Pearson Correlation Coefficient.
 #' For Spearman Correlation, consider using RDD methods found in MLlib's Statistics.
 #'
@@ -83,7 +85,7 @@ setMethod("cov",
 #'               only "pearson" is allowed now.
 #' @return The Pearson Correlation Coefficient as a Double.
 #'
-#' @rdname statfunctions
+#' @rdname corr
 #' @name corr
 #' @export
 #' @examples

--- a/R/pkg/R/stats.R
+++ b/R/pkg/R/stats.R
@@ -103,6 +103,7 @@ setMethod("corr",
             callJMethod(statFunctions, "corr", col1, col2, method)
           })
 
+#' @description
 #' freqItems - Finding frequent items for columns, possibly with false positives.
 #' Using the frequent element count algorithm described in
 #' \url{http://dx.doi.org/10.1145/762471.762473}, proposed by Karp, Schenker, and Papadimitriou.
@@ -129,8 +130,8 @@ setMethod("freqItems", signature(x = "SparkDataFrame", cols = "character"),
             collect(dataFrame(sct))
           })
 
+#' @description
 #' approxQuantile - Calculates the approximate quantiles of a numerical column of a SparkDataFrame.
-#'
 #' The result of this algorithm has the following deterministic bound:
 #' If the SparkDataFrame has N elements and if we request the quantile at probability `p` up to
 #' error `err`, then the algorithm will return a sample `x` from the SparkDataFrame so that the
@@ -167,6 +168,7 @@ setMethod("approxQuantile",
                         as.list(probabilities), relativeError)
           })
 
+#' @description
 #' sampleBy - Returns a stratified sample without replacement based on the fraction given on each
 #' stratum.
 #'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Doc only changes. Please see screenshots.

Before:
http://spark.apache.org/docs/latest/api/R/statfunctions.html
![image](https://cloud.githubusercontent.com/assets/8969467/15264110/cd458826-1924-11e6-85bd-8ee2e2e1a85f.png)

After
![image](https://cloud.githubusercontent.com/assets/8969467/16218452/b9e89f08-3732-11e6-969d-a3a1796e7ad0.png)
(please ignore the style differences - this is due to not having the css in my local copy)

This is still a bit weird. As discussed in SPARK-15237, I think the better approach is to separate out the DataFrame stats function instead of putting everything on one page. At least now it is clearer which description is on which function.
## How was this patch tested?

Build doc
