### PR TITLE
[SPARK-12492] Using spark-sql commond to run query, write the event of SparkListenerJobStart

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -110,24 +110,29 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
    */
   def hiveResultString(): Seq[String] = executedPlan match {
     case ExecutedCommandExec(desc: DescribeTableCommand) =>
-      // If it is a describe command for a Hive table, we want to have the output format
-      // be similar with Hive.
-      desc.run(sparkSession).map {
-        case Row(name: String, dataType: String, comment) =>
-          Seq(name, dataType,
-            Option(comment.asInstanceOf[String]).getOrElse(""))
-            .map(s => String.format(s"%-20s", s))
-            .mkString("\t")
+      SQLExecution.withNewExecutionId(self, this) {
+        // If it is a describe command for a Hive table, we want to have the output format
+        // be similar with Hive.
+        desc.run(sparkSession).map {
+          case Row(name: String, dataType: String, comment) =>
+            Seq(name, dataType,
+              Option(comment.asInstanceOf[String]).getOrElse(""))
+              .map(s => String.format(s"%-20s", s))
+              .mkString("\t")
+        }
       }
     case command: ExecutedCommandExec =>
-      command.executeCollect().map(_.getString(0))
-
+      SQLExecution.withNewExecutionId(self, this) {
+        command.executeCollect().map(_.getString(0))
+      }
     case other =>
-      val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
-      // We need the types so we can output struct field names
-      val types = analyzed.output.map(_.dataType)
-      // Reformat to match hive tab delimited output.
-      result.map(_.zip(types).map(toHiveString)).map(_.mkString("\t")).toSeq
+      SQLExecution.withNewExecutionId(self, this) {
+        val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
+        // We need the types so we can output struct field names
+        val types = analyzed.output.map(_.dataType)
+        // Reformat to match hive tab delimited output.
+        result.map(_.zip(types).map(toHiveString)).map(_.mkString("\t")).toSeq
+      }
   }
 
   /** Formats a datum (based on the given data type) and returns the string representation. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -110,7 +110,7 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
    */
   def hiveResultString(): Seq[String] = executedPlan match {
     case ExecutedCommandExec(desc: DescribeTableCommand) =>
-      SQLExecution.withNewExecutionId(self, this) {
+      SQLExecution.withNewExecutionId(sparkSession, this) {
         // If it is a describe command for a Hive table, we want to have the output format
         // be similar with Hive.
         desc.run(sparkSession).map {
@@ -122,11 +122,11 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
         }
       }
     case command: ExecutedCommandExec =>
-      SQLExecution.withNewExecutionId(self, this) {
+      SQLExecution.withNewExecutionId(sparkSession, this) {
         command.executeCollect().map(_.getString(0))
       }
     case other =>
-      SQLExecution.withNewExecutionId(self, this) {
+      SQLExecution.withNewExecutionId(sparkSession, this) {
         val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
         // We need the types so we can output struct field names
         val types = analyzed.output.map(_.dataType)


### PR DESCRIPTION
Using spark-sql commond to run query, the sqlPage is blank, e.g.
![sqlpage is blank](https://cloud.githubusercontent.com/assets/9440626/12570121/ce441cfc-c40f-11e5-88e6-618abc1ed4d9.png)

Because, running query, the event of SparkListenerJobStart  is not written. So now I change the code, when run job, the event will be written, then the sqlPage will be not blank.

See https://github.com/apache/spark/pull/10900
