### PR TITLE
[SPARK-15269][SQL] Set provided path to CatalogTable.storage.locationURI when creating external non-hive compatible table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -480,15 +480,13 @@ object CreateDataSourceTableUtils extends Logging {
               s"Could not persist $qualifiedTableName in a Hive compatible way. Persisting " +
                 s"it into Hive metastore in Spark SQL specific format."
             logWarning(warningMessage, e)
-            val table =
-              newSparkSQLSpecificMetastoreTable()
+            val table = newSparkSQLSpecificMetastoreTable()
             sparkSession.sessionState.catalog.createTable(table, ignoreIfExists = false)
         }
 
       case (None, message) =>
         logWarning(message)
-        val table =
-          newSparkSQLSpecificMetastoreTable()
+        val table = newSparkSQLSpecificMetastoreTable()
         sparkSession.sessionState.catalog.createTable(table, ignoreIfExists = false)
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1104,4 +1104,18 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
       }
     }
   }
+
+  test("SPARK-15269: non-hive compative table") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.json(path)
+
+      withTable("ddl_test1") {
+        sql(s"CREATE TABLE ddl_test1 USING json OPTIONS (PATH '$path')")
+        sql("DROP TABLE ddl_test1")
+        sql(s"CREATE TABLE ddl_test1 USING json AS SELECT 10 AS a")
+        checkAnswer(sql("select * from ddl_test1"), Seq(Row(10)))
+      }
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -958,6 +958,69 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
         Row(11) :: Nil)
     }
   }
+
+  test("SPARK-15206: two distinct aggregation with having clause of one distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(distinct value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3),
+        Row(2, 2, 1)
+      )
+    )
+  }
+
+  test("SPARK-15206: one distinct aggregration with having clause of one distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1)
+          |from agg2 group by key
+          |having count(distinct value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3),
+        Row(1, 2),
+        Row(2, 2)
+      )
+    )
+  }
+
+  test("SPARK-15206: two distinct aggregration with having clause of two distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(distinct value1) > 0 and count(distinct value2) = 3
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3)
+      )
+    )
+  }
+
+  test("SPARK-15206: two distinct aggregration with having clause of non-distinct aggregation") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |select key, count(distinct value1), count(distinct value2)
+          |from agg2 group by key
+          |having count(value1) > 0
+        """.stripMargin),
+      Seq(
+        Row(null, 3, 3),
+        Row(1, 2, 3),
+        Row(2, 2, 1)
+      )
+    )
+  }
 }
 
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -958,69 +958,6 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
         Row(11) :: Nil)
     }
   }
-
-  test("SPARK-15206: two distinct aggregation with having clause of one distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(distinct value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3),
-        Row(2, 2, 1)
-      )
-    )
-  }
-
-  test("SPARK-15206: one distinct aggregration with having clause of one distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1)
-          |from agg2 group by key
-          |having count(distinct value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3),
-        Row(1, 2),
-        Row(2, 2)
-      )
-    )
-  }
-
-  test("SPARK-15206: two distinct aggregration with having clause of two distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(distinct value1) > 0 and count(distinct value2) = 3
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3)
-      )
-    )
-  }
-
-  test("SPARK-15206: two distinct aggregration with having clause of non-distinct aggregation") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |select key, count(distinct value1), count(distinct value2)
-          |from agg2 group by key
-          |having count(value1) > 0
-        """.stripMargin),
-      Seq(
-        Row(null, 3, 3),
-        Row(1, 2, 3),
-        Row(2, 2, 1)
-      )
-    )
-  }
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Symptom

```
scala> spark.range(1).write.json("/home/xwu0226/spark-test/data/spark-15269")
Datasource.write -> Path: file:/home/xwu0226/spark-test/data/spark-15269

scala> spark.sql("create table spark_15269 using json options(PATH '/home/xwu0226/spark-test/data/spark-15269')")
16/05/11 14:51:00 WARN CreateDataSourceTableUtils: Couldn't find corresponding Hive SerDe for data source provider json. Persisting data source relation `spark_15269` into Hive metastore in Spark SQL specific format, which is NOT compatible with Hive.
going through newSparkSQLSpecificMetastoreTable()
res1: org.apache.spark.sql.DataFrame = []

scala> spark.sql("drop table spark_15269")
res2: org.apache.spark.sql.DataFrame = []

scala> spark.sql("create table spark_15269 using json as select 1 as a")
org.apache.spark.sql.AnalysisException: path file:/user/hive/warehouse/spark_15269 already exists.;
  at org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelation.run(InsertIntoHadoopFsRelation.scala:88)
  at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:62)
  at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:60)
  at org.apache.spark.sql.execution.command.ExecutedCommandExec.doExecute(commands.scala:74)
...
```

The 2nd creation of the table fails complaining about the path exists. 
### Root cause:

When the first table is created as external table with the data source path, but as json, `createDataSourceTables`considers it as non-hive compatible table because `json`is not a Hive SerDe. Then, `newSparkSQLSpecificMetastoreTable`is invoked to create the `CatalogTable`before asking HiveClient to create the metastore table. In this call, `locationURI`is not set. So when we convert `CatalogTable` to HiveTable before passing to Hive Metastore, hive table's data location is not set. Then, Hive metastore implicitly creates a data location as <hive warehouse>/tableName, which is, `file:/user/hive/warehouse/spark_15269` in the above case. 

When dropping the table, hive does not delete this implicitly created path because the table is external.

when we create the 2nd table with select and without a path, the table is created as managed table, provided a default path in the options as following:

```
val optionsWithPath =
      if (!new CaseInsensitiveMap(options).contains("path")) {
        isExternal = false
        options + ("path" -> sessionState.catalog.defaultTablePath(tableIdent))
      } else {
        options
      }
```

This default path happens to be the hive's warehouse directory + the table name, which is the same as the one hive metastore implicitly created earlier for the 1st table.  So when trying to write the provided data to this data source table by `InsertIntoHadoopFsRelation`, which complains about the path existence since the SaveMode is SaveMode.ErrorIfExists.
### Solution:

When creating an external datasource table that is non-hive compatible, make sure we set the provided path to `CatalogTable.storage.locationURI`, so we avoid hive metastore from implicitly creating a data location for the table.
## How was this patch tested?

Testcase is added. And run regtest. 
