### PR TITLE
[SPARK-15337] [SPARK-15338] [SQL] Enable Run-time Changes on Hive-related Conf

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -65,7 +65,9 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
     // Configures a single property.
     case Some((key, Some(value))) =>
       val runFunc = (sparkSession: SparkSession) => {
-        sparkSession.conf.set(key, value)
+        // Use sessionState.setConfString for ensuring all the hive-related conf changes
+        // are sent to Hive Metastore too.
+        sparkSession.sessionState.setConfString(key, value)
         Seq(Row(key, value))
       }
       (keyValueOutput, runFunc)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -170,6 +170,10 @@ private[sql] class SessionState(sparkSession: SparkSession) {
     catalog.invalidateTable(sqlParser.parseTableIdentifier(tableName))
   }
 
+  def setConfString(key: String, value: String): Unit = {
+    conf.setConfString(key, value)
+  }
+
   def addJar(path: String): Unit = {
     sparkSession.sparkContext.addJar(path)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -126,6 +126,17 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     spark.wrapped.conf.clear()
   }
 
+  test("Change warehouse path at runtime") {
+    spark.wrapped.conf.clear()
+    val original = spark.conf.get(SQLConf.WAREHOUSE_PATH)
+    try{
+      sql(s"set ${SQLConf.WAREHOUSE_PATH.key}=/x/y/z/spark-warehouse")
+      assert(spark.conf.get(SQLConf.WAREHOUSE_PATH) === "/x/y/z/spark-warehouse")
+    } finally {
+      sql(s"set ${SQLConf.WAREHOUSE_PATH.key}=$original")
+    }
+  }
+
   test("SparkSession can access configs set in SparkConf") {
     try {
       sparkContext.conf.set("spark.to.be.or.not.to.be", "my love")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
@@ -113,7 +113,7 @@ private[hive] class HiveSessionState(sparkSession: SparkSession)
       conf.setConfString(SQLConf.WAREHOUSE_PATH.key, value)
       conf.setConfString("hive.metastore.warehouse.dir", value)
       logInfo(s"Changing Hive metastore warehouse path to '$value'")
-    } else if (key.toLowerCase.startsWith("hive.")) {
+    } else if (!key.toLowerCase.startsWith("spark.")) {
       // Need to use the sql command to pass the hive-related conf changes to Hive metastore
       metadataHive.runSqlHive(s"set $key=$value")
       conf.setConfString(key, value)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -502,6 +502,9 @@ private[hive] class TestHiveSharedState(
     metastoreTemporaryConf: Map[String, String])
   extends HiveSharedState(sc) {
 
+  // The value set by HiveSharedState is the default value of SQLConf.WAREHOUSE_PATH
+  sc.conf.set("hive.metastore.warehouse.dir", warehousePath.toURI.toString)
+
   override lazy val metadataHive: HiveClient = {
     TestHiveContext.newClientForMetadata(
       sc.conf, sc.hadoopConfiguration, warehousePath, scratchDirPath, metastoreTemporaryConf)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -522,6 +522,7 @@ private[hive] class TestHiveSessionState(
         super.clear()
         TestHiveContext.overrideConfs.foreach { case (k, v) => setConfString(k, v) }
         setConfString("hive.metastore.warehouse.dir", self.warehousePath.toURI.toString)
+        setConfString("spark.sql.warehouse.dir", self.warehousePath.toURI.toString)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -27,8 +27,9 @@ import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, Functio
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.hive.{HiveUtils, MetastoreRelation}
+import org.apache.spark.sql.hive.{HiveSessionState, HiveUtils, MetastoreRelation}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -997,6 +998,34 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       case Some(throwable) =>
         fail("CREATE TEMPORARY FUNCTION should not fail.", throwable)
       case None => // OK
+    }
+  }
+
+  test("Change hive warehouse path at runtime") {
+    spark.wrapped.conf.clear()
+    val original = spark.conf.get(SQLConf.WAREHOUSE_PATH)
+    val sessionState = spark.sessionState.asInstanceOf[HiveSessionState]
+    assert(sessionState.metadataHive.getConf("hive.metastore.warehouse.dir", null)
+      != "/x/y/z/spark-warehouse")
+    try{
+      sql(s"set ${SQLConf.WAREHOUSE_PATH.key}=/x/y/z/spark-warehouse")
+      assert(spark.conf.get(SQLConf.WAREHOUSE_PATH) == "/x/y/z/spark-warehouse")
+      assert(spark.conf.get("hive.metastore.warehouse.dir") == "/x/y/z/spark-warehouse")
+      assert(sessionState.metadataHive.getConf("hive.metastore.warehouse.dir", null)
+        == "/x/y/z/spark-warehouse")
+    } finally {
+      sql(s"set ${SQLConf.WAREHOUSE_PATH.key}=$original")
+      sql(s"set hive.metastore.warehouse.dir=$original")
+    }
+    try{
+      sql(s"set hive.metastore.warehouse.dir=/x/y/z/spark-warehouse")
+      assert(spark.conf.get(SQLConf.WAREHOUSE_PATH) == "/x/y/z/spark-warehouse")
+      assert(spark.conf.get("hive.metastore.warehouse.dir") == "/x/y/z/spark-warehouse")
+      assert(sessionState.metadataHive.getConf("hive.metastore.warehouse.dir", null)
+        == "/x/y/z/spark-warehouse")
+    } finally {
+      sql(s"set ${SQLConf.WAREHOUSE_PATH.key}=$original")
+      sql(s"set hive.metastore.warehouse.dir=$original")
     }
   }
 


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Currently, we are facing two issues when using the Set Command. 
1. When changing a Hive-related conf at runtime, we are not passing the change to the underlying Hive metastore. For example, `SET hive.metastore.warehouse.dir=/x/y/z` The following link contains the possible conf: https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties
2. When changing the warehouse path conf `spark.sql.warehouse.dir`, we are not changing the corresponding Hive metastore default warehouse path conf: `hive.metastore.warehouse.dir`. Thus, this change does not take effect if the underlying catalog is Hive metastore.

This PR is to fix the above two issues by using the native Hive SQL interface, if necessary. 
#### How was this patch tested?

Added two test cases to verify if the run-time configuration works in either Hive metastore or In-Memory Catalog
