### PR TITLE
[SPARK-15247][SQL] Set the default number of partitions for reading parquet schemas

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -797,7 +797,7 @@ private[sql] object ParquetFileFormat extends Logging {
 
     // Set the number of partitions to prevent following schema reads from generating many tasks
     // in case of a small number of parquet files.
-    val numParallelism = Math.min(partialFileStatusInfo.size,
+    val numParallelism = Math.min(partialFileStatusInfo.size + 1,
       sparkSession.sparkContext.defaultParallelism)
 
     // Issues a Spark job to read Parquet schema in parallel.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -797,7 +797,8 @@ private[sql] object ParquetFileFormat extends Logging {
 
     // Set the number of partitions to prevent following schema reads from generating many tasks
     // in case of a small number of parquet files.
-    val numParallelism = Math.min(partialFileStatusInfo.size + 1, 10000)
+    val numParallelism = Math.min(partialFileStatusInfo.size + 1,
+      sparkSession.sparkContext.defaultParallelism)
 
     // Issues a Spark job to read Parquet schema in parallel.
     val partiallyMergedSchemas =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -797,7 +797,7 @@ private[sql] object ParquetFileFormat extends Logging {
 
     // Set the number of partitions to prevent following schema reads from generating many tasks
     // in case of a small number of parquet files.
-    val numParallelism = Math.min(partialFileStatusInfo.size + 1,
+    val numParallelism = Math.min(Math.max(partialFileStatusInfo.size, 1),
       sparkSession.sparkContext.defaultParallelism)
 
     // Issues a Spark job to read Parquet schema in parallel.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -795,11 +795,16 @@ private[sql] object ParquetFileFormat extends Logging {
     // side, and resemble fake `FileStatus`es there.
     val partialFileStatusInfo = filesToTouch.map(f => (f.getPath.toString, f.getLen))
 
+    // Set the number of partitions to prevent following schema reads from generating many tasks
+    // in case of a small number of parquet files.
+    val numParallelism = Math.min(partialFileStatusInfo.size,
+      sparkSession.sparkContext.defaultParallelism)
+
     // Issues a Spark job to read Parquet schema in parallel.
     val partiallyMergedSchemas =
       sparkSession
         .sparkContext
-        .parallelize(partialFileStatusInfo)
+        .parallelize(partialFileStatusInfo, numParallelism)
         .mapPartitions { iterator =>
           // Resembles fake `FileStatus`es with serialized path and length information.
           val fakeFileStatuses = iterator.map { case (path, length) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -797,8 +797,7 @@ private[sql] object ParquetFileFormat extends Logging {
 
     // Set the number of partitions to prevent following schema reads from generating many tasks
     // in case of a small number of parquet files.
-    val numParallelism = Math.min(partialFileStatusInfo.size + 1,
-      sparkSession.sparkContext.defaultParallelism)
+    val numParallelism = Math.min(partialFileStatusInfo.size + 1, 10000)
 
     // Issues a Spark job to read Parquet schema in parallel.
     val partiallyMergedSchemas =


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr sets the default number of partitions when reading parquet schemas.
SQLContext#read#parquet currently yields at least n_executors \* n_cores tasks even if parquet data consist of a  single small file. This issue could increase the latency for small jobs.
## How was this patch tested?

Manually tested and checked.
