### PR TITLE
[SPARK-15186][ML][DOCS] Add user guide for generalized linear regression

### DIFF
--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -378,9 +378,9 @@ regression model and extracting model summary statistics.
 
 When working with data that has a relatively small number of features (< 4096), Spark's GeneralizedLinearRegression interface
 allows for flexible specification of [generalized linear models](https://en.wikipedia.org/wiki/Generalized_linear_model) (GLMs) which can be used for various types of
-problems including linear regression, Poisson regression, logistic regression, and others.
+prediction problems including linear regression, Poisson regression, logistic regression, and others.
 
-Contrasted with linear regression where the output is assumed to have a Gaussian
+Contrasted with linear regression where the output is assumed to follow a Gaussian
 distribution, GLMs are specifications of linear models where the response variable $Y_i$ may take on _any_
 distribution from the [exponential family of distributions](https://en.wikipedia.org/wiki/Exponential_family). 
 
@@ -435,7 +435,7 @@ Spark's generalized linear regression interface also provides summary statistics
 fit of GLM models, including residuals, p-values, deviances, the Akaike information criterion, and
 others.
 
-###  Available Families
+###  Available families
 
 <table class="table">
   <thead>

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -374,6 +374,78 @@ regression model and extracting model summary statistics.
 
 </div>
 
+## Generalized linear regression
+
+When working with data that has a relatively small number of features (< 4096), Spark's GeneralizedLinearRegression interface
+allows for flexible specification of [generalized linear models](https://en.wikipedia.org/wiki/Generalized_linear_model) (GLMs) which can be used for various types of
+problems including linear regression, Poisson regression, logistic regression, and others.
+
+Contrasted with linear regression where the output is assumed to have a Gaussian
+distribution, GLMs are specifications of linear models where the output may take on _any_
+distribution from the [exponential family of distributions](https://en.wikipedia.org/wiki/Exponential_family). An exponential family distribution is any
+probability distribution of the form
+
+$$
+f\left(y|\theta, \phi, w\right) = e^{\frac{y\theta - b(\theta)}{\phi/w} - c(y, \phi)}\\
+Y_i \sim f\left(\cdot|\theta_i, \phi, w_i\right)
+$$
+
+where the parameter of interest $\theta_i$ is related to the expected value of the response variable
+$\mu_i$ by
+
+$$
+\theta_i = h(\mu_i)
+$$
+
+A GLM finds the regression coefficients $\vec{\beta}$ which maximize the joint probability density
+of the data, also known as the likelihood.
+
+$$
+\min_{\vec{\beta}} \mathcal{L}(\vec{\theta}|\vec{y},X) =
+\prod_{i=1}^{N} e^{\frac{y_i\theta_i - b(\theta_i)}{\phi/w_i} - c(y_i, \phi)}
+$$
+
+where the parameter of interest $\theta_i$ is related to the regression coefficients $\vec{\beta}$
+by
+
+$$
+\theta_i = h(g^{-1}(\vec{x_i} \cdot \vec{\beta}))
+$$
+
+Spark's generalized linear regression interface also provides summary statistics for diagnosing the
+fit of GLM models, including residuals, p-values, deviances, the Akaike information criterion, and
+others.
+
+
+**Example**
+
+The following example demonstrates training a GLM with a Gaussian response and identity link
+function and extracting model summary statistics.
+
+<div class="codetabs">
+
+<div data-lang="scala" markdown="1">
+<!--- TODO -->
+</div>
+
+<div data-lang="java" markdown="1">
+<!--- TODO -->
+</div>
+
+<div data-lang="python" markdown="1">
+<!--- TODO -->
+</div>
+
+</div>
+
+### Implementation (developer)
+
+The `spark.ml` GLM implements the method of iteratively reweighted least squares (IRLS) for finding
+the optimal regression coefficients. GLMs seek to find a maximum likelihood estimate of the
+regression coefficients by finding zeros of the score equation. In practice, a first-order Taylor
+approximation of the score equation is cast to a weighted least squares regression and solved
+iteratively until convergence.
+
 
 ## Decision tree regression
 

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -479,16 +479,16 @@ others.
 The `spark.ml` GLM implements the method of 
 [iteratively reweighted least squares](https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares) (IRLS) for finding
 the optimal regression coefficients. GLMs seek to find a maximum likelihood estimate of the
-regression coefficients by finding zeros of the [score equation](https://en.wikipedia.org/wiki/Score_(statistics)). The
-The method of IRLS uses a first-order approximation of the score equation in the vicinity of an initial guess for the 
- $\vec{\mu}$ vector. This approximation can be manipulated to the form of a weighted least squares regression which can
- be solved easily using a normal equation solver. Solving this weighted least squares problem yields a (likely poor) approximation
- to the regression coefficients $\vec{\beta}$. However, this approximation can be used to find an improved guess for $\vec{\mu}$
- using the fact that $\vec{\mu} = g^{-1}(X\vec{\beta})$, which can, in turn, generate a better approximation to $\vec{\beta}$ by
- solving the weighted least squares problem again. The true value of $\vec{\beta}$ is found by repeatedly solving weighted least
+regression coefficients by finding zeros of the [score equation](https://en.wikipedia.org/wiki/Score_(statistics)).
+The method of IRLS uses a first-order Taylor approximation of the score equation in the vicinity of an initial guess for the expected response
+ $\vec{\mu}$. This approximation can be manipulated to the form of a simple weighted least squares regression, which is straightforward
+ to solve using a normal equation solver. Solving this initial weighted least squares problem yields a (likely poor) approximation
+ to the regression coefficients $\vec{\beta}$. This approximation of $\vec{\beta}$ generates an improved approximation for $\vec{\mu}$
+ using the fact that $\vec{\mu} = g^{-1}(X\vec{\beta})$. In turn, an even more improved approximation to $\vec{\beta}$ can be found
+ solving the weighted least squares problem again. The true value of $\vec{\beta}$ is converged upon by repeatedly solving weighted least
  squares problems in this manner (hence the name, iteratively weighted least squares).
 
- Solving the normal equations for a linear system $A\vec{x} = \vec{b}$ involves 
+ Note that solving the normal equations, as in a weighted least squares, for a linear system $A\vec{x} = \vec{b}$ involves 
  inverting the covariance matrix $A^TA$. If $A$ is an $MxN$ matrix, then $A^TA$ has dimension $NxN$. When N is relatively
  small (<4096) then the covariance matrix can (generally) fit into main memory on the driver node and the linear system can
  then be solved using well-established linear subroutines like the Cholesky decomposition. For this reason, it is important

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -390,27 +390,25 @@ interface, and will throw an exception if this constraint is exceeded. See the [
  Still, for linear and logistic regression, models with an increased number of features can be trained 
  using the `LinearRegression` and `LogisticRegression` estimators.
 
-An exponential family distribution is any probability distribution of the form
+The canonical form of an exponential family distribution is given as:
 
 $$
-f\left(y|\theta, \phi, w\right) = \exp{\left(\frac{y\theta - b(\theta)}{\phi/w} - c(y, \phi)\right)}
+f_Y(y|\theta, \tau) = h(y, \tau)\exp{\left( \frac{\theta \cdot T(y) - A(\theta)}{d(\tau)} \right)}
 $$
 
-where $\theta$ and $\phi$ are location and scale parameters, and $w_i$ is known as a _prior weight_ and
-is usually equal to one. In a GLM the response variable $Y_i$ is assumed to be drawn from an exponential family distribution:
+where $\theta$ is the parameter of interest and $\tau$ is a dispersion parameter. In a GLM the response variable $Y_i$ is assumed to be drawn from an exponential family distribution:
 
 $$
-Y_i \sim f\left(\cdot|\theta_i, \phi, w_i\right)
+Y_i \sim f\left(\cdot|\theta_i, \tau \right)
 $$
 
-where the parameter of interest $\theta_i$ is related to the expected value of the response variable
-$\mu_i$ by
+where the parameter of interest $\theta_i$ is related to the expected value of the response variable $\mu_i$ by
 
 $$
-\theta_i = h(\mu_i)
+\mu_i = A'(\theta_i)
 $$
 
-Here, $h(\mu_i)$ is defined by the form of the exponential family distribution used. GLMs also allow specification
+Here, $A'(\theta_i)$ is defined by the form of the exponential family distribution used. GLMs also allow specification
 of a link function, which defines the relationship between the expected value of the response variable $\mu_i$
 and the so called _linear predictor_ $\eta_i$:
 
@@ -418,26 +416,26 @@ $$
 g(\mu_i) = \eta_i = \vec{x_i}^T \cdot \vec{\beta}
 $$
 
-Often, the link function is chosen such that $h(\mu) = g(\mu)$, which yields a simplified relationship
+Often, the link function is chosen such that $A' = g^{-1}$, which yields a simplified relationship
 between the parameter of interest $\theta$ and the linear predictor $\eta$. In this case, the link
 function $g(\mu)$ is said to be the "canonical" link function.
 
 $$
-\theta_i = h(g^{-1}(\eta_i)) = \eta_i
+\theta_i = A'^{-1}(\mu_i) = g(g^{-1}(\eta_i)) = \eta_i
 $$
 
 A GLM finds the regression coefficients $\vec{\beta}$ which maximize the likelihood function.
 
 $$
 \min_{\vec{\beta}} \mathcal{L}(\vec{\theta}|\vec{y},X) =
-\prod_{i=1}^{N} \exp{\left(\frac{y_i\theta_i - b(\theta_i)}{\phi/w_i} - c(y_i, \phi)\right)}
+\prod_{i=1}^{N} h(y_i, \tau) \exp{\left(\frac{y_i\theta_i - A(\theta_i)}{d(\tau)}\right)}
 $$
 
 where the parameter of interest $\theta_i$ is related to the regression coefficients $\vec{\beta}$
 by
 
 $$
-\theta_i = h(g^{-1}(\vec{x_i} \cdot \vec{\beta}))
+\theta_i = A'(g^{-1}(\vec{x_i} \cdot \vec{\beta}))
 $$
 
 Spark's generalized linear regression interface also provides summary statistics for diagnosing the

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -479,9 +479,20 @@ others.
 The `spark.ml` GLM implements the method of 
 [iteratively reweighted least squares](https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares) (IRLS) for finding
 the optimal regression coefficients. GLMs seek to find a maximum likelihood estimate of the
-regression coefficients by finding zeros of the [score equation](https://en.wikipedia.org/wiki/Score_(statistics)). 
-The IRLS solver casts a first-order Taylor approximation of the score equation to a weighted least squares regression and solves it
-iteratively until convergence.
+regression coefficients by finding zeros of the [score equation](https://en.wikipedia.org/wiki/Score_(statistics)). The
+The method of IRLS uses a first-order approximation of the score equation in the vicinity of an initial guess for the 
+ $\vec{\mu}$ vector. This approximation can be manipulated to the form of a weighted least squares regression which can
+ be solved easily using a normal equation solver. Solving this weighted least squares problem yields a (likely poor) approximation
+ to the regression coefficients $\vec{\beta}$. However, this approximation can be used to find an improved guess for $\vec{\mu}$
+ using the fact that $\vec{\mu} = g^{-1}(X\vec{\beta})$, which can, in turn, generate a better approximation to $\vec{\beta}$ by
+ solving the weighted least squares problem again. The true value of $\vec{\beta}$ is found by repeatedly solving weighted least
+ squares problems in this manner (hence the name, iteratively weighted least squares).
+
+ Solving the normal equations for a linear system $A\vec{x} = \vec{b}$ involves 
+ inverting the covariance matrix $A^TA$. If $A$ is an $MxN$ matrix, then $A^TA$ has dimension $NxN$. When N is relatively
+ small (<4096) then the covariance matrix can (generally) fit into main memory on the driver node and the linear system can
+ then be solved using well-established linear subroutines like the Cholesky decomposition. For this reason, it is important
+ to note that the `spark.ml` generalized linear regression module currently does not accept more than 4096 feature columns.
 
 ### Input Columns
 

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -377,7 +377,7 @@ regression model and extracting model summary statistics.
 ## Generalized linear regression
 
 Contrasted with linear regression where the output is assumed to follow a Gaussian
-distribution, [generalized linear models](https://en.wikipedia.org/wiki/Generalized_linear_model) (GLMs) are specifications of linear models where the response variable $Y_i$ may take on _any_
+distribution, [generalized linear models](https://en.wikipedia.org/wiki/Generalized_linear_model) (GLMs) are specifications of linear models where the response variable $Y_i$ follows some
 distribution from the [exponential family of distributions](https://en.wikipedia.org/wiki/Exponential_family).
 Spark's `GeneralizedLinearRegression` interface
 allows for flexible specification of GLMs which can be used for various types of
@@ -390,9 +390,8 @@ interface, and will throw an exception if this constraint is exceeded. See the [
  Still, for linear and logistic regression, models with an increased number of features can be trained 
  using the `LinearRegression` and `LogisticRegression` estimators.
 
-Though GLMs may be used with general exponential family distributions, it is common to work only with exponential families that are 
-in their _natural_ or _canonical_ forms. Any distribution can be converted to its canonical form via a simple transform, and this
-assumption simplifies the notation. The form of a [natural exponential family distribution](https://en.wikipedia.org/wiki/Natural_exponential_family) is given as:
+GLMs require exponential family distributions that can be written in their "canonical" or "natural" form, aka
+[natural exponential family distributions](https://en.wikipedia.org/wiki/Natural_exponential_family). The form of a natural exponential family distribution is given as:
 
 $$
 f_Y(y|\theta, \tau) = h(y, \tau)\exp{\left( \frac{\theta \cdot y - A(\theta)}{d(\tau)} \right)}

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -440,33 +440,28 @@ others.
 <table class="table">
   <thead>
     <tr>
-      <th></th>
-      <th>PDF</th>
+      <th>Family</th>
       <th>Response Type</th>
       <th>Supported Links</th></tr>
   </thead>
   <tbody>
     <tr>
       <td>Gaussian</td>
-      <td>$\frac{1}{\sigma \sqrt{2\pi}} \exp \left( -\frac{(x - \mu)^2}{2\sigma^2}\right)$</td>
       <td>Continuous</td>
       <td>Identity*, Log, Inverse</td>
     </tr>
     <tr>
       <td>Binomial</td>
-      <td>$\binom{n}{k}p^k (1-p)^{n-k}$</td>
       <td>Binary</td>
       <td>Logit*, Probit, CLogLog</td>
     </tr>
     <tr>
       <td>Poisson</td>
-      <td>$\frac{\lambda^k e^{-\lambda}}{k!}$</td>
       <td>Count</td>
       <td>Log*, Identity, Sqrt</td>
     </tr>
     <tr>
       <td>Gamma</td>
-      <td>$\frac{\beta^{\alpha}}{\Gamma(\alpha)} x^{\alpha - 1} e^{-\beta x}$</td>
       <td>Continuous</td>
       <td>Inverse*, Idenity, Log</td>
     </tr>
@@ -483,77 +478,16 @@ regression coefficients by finding zeros of the [score equation](https://en.wiki
 The method of IRLS uses a first-order Taylor approximation of the score equation in the vicinity of an initial guess for the expected response
  $\vec{\mu}$. This approximation can be manipulated to the form of a simple weighted least squares regression, which is straightforward
  to solve using a normal equation solver. Solving this initial weighted least squares problem yields a (likely poor) approximation
- to the regression coefficients $\vec{\beta}$. This approximation of $\vec{\beta}$ generates an improved approximation for $\vec{\mu}$
+ to the regression coefficients $\vec{\beta}$. However, this approximation of $\vec{\beta}$ generates an improved approximation for $\vec{\mu}$
  using the fact that $\vec{\mu} = g^{-1}(X\vec{\beta})$. In turn, an even more improved approximation to $\vec{\beta}$ can be found
  solving the weighted least squares problem again. The true value of $\vec{\beta}$ is converged upon by repeatedly solving weighted least
  squares problems in this manner (hence the name, iteratively weighted least squares).
 
  Note that solving the normal equations, as in a weighted least squares, for a linear system $A\vec{x} = \vec{b}$ involves 
  inverting the covariance matrix $A^TA$. If $A$ is an $MxN$ matrix, then $A^TA$ has dimension $NxN$. When N is relatively
- small (<4096) then the covariance matrix can (generally) fit into main memory on the driver node and the linear system can
+ small (< 4096) then the covariance matrix can (generally) fit into main memory on the driver node and the linear system can
  then be solved using well-established linear subroutines like the Cholesky decomposition. For this reason, it is important
  to note that the `spark.ml` generalized linear regression module currently does not accept more than 4096 feature columns.
-
-### Input Columns
-
-<table class="table">
-  <thead>
-    <tr>
-      <th align="left">Param name</th>
-      <th align="left">Type(s)</th>
-      <th align="left">Default</th>
-      <th align="left">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>labelCol</td>
-      <td>Double</td>
-      <td>"label"</td>
-      <td>Label to predict</td>
-    </tr>
-    <tr>
-      <td>featuresCol</td>
-      <td>Vector</td>
-      <td>"features"</td>
-      <td>Feature vector</td>
-    </tr>
-    <tr>
-      <td>weightCol</td>
-      <td>Double</td>
-      <td>""</td>
-      <td>Sample weights</td>
-    </tr>
-  </tbody>
-</table>
-
-### Output Columns
-
-<table class="table">
-  <thead>
-    <tr>
-      <th align="left">Param name</th>
-      <th align="left">Type(s)</th>
-      <th align="left">Default</th>
-      <th align="left">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>predictionCol</td>
-      <td>Double</td>
-      <td>"prediction"</td>
-      <td>Predicted label</td>
-    </tr>
-    <tr>
-      <td>linkPredictionCol</td>
-      <td>Double</td>
-      <td>""</td>
-      <td>Linear predicted response</td>
-    </tr>
-  </tbody>
-</table>
-
 
 **Example**
 
@@ -563,14 +497,20 @@ function and extracting model summary statistics.
 <div class="codetabs">
 
 <div data-lang="scala" markdown="1">
+Refer to the [Scala API docs](api/scala/index.html#org.apache.spark.ml.regression.GeneralizedLinearRegression) for more details.
+
 {% include_example scala/org/apache/spark/examples/ml/GeneralizedLinearRegressionExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
+Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/GeneralizedLinearRegression.html) for more details.
+
 {% include_example java/org/apache/spark/examples/ml/JavaGeneralizedLinearRegressionExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
+Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.regression.GeneralizedLinearRegression) for more details.
+
 {% include_example python/ml/generalized_linear_regression_example.py %}
 </div>
 

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -376,13 +376,19 @@ regression model and extracting model summary statistics.
 
 ## Generalized linear regression
 
-When working with data that has a relatively small number of features (< 4096), Spark's GeneralizedLinearRegression interface
-allows for flexible specification of [generalized linear models](https://en.wikipedia.org/wiki/Generalized_linear_model) (GLMs) which can be used for various types of
-prediction problems including linear regression, Poisson regression, logistic regression, and others.
-
 Contrasted with linear regression where the output is assumed to follow a Gaussian
-distribution, GLMs are specifications of linear models where the response variable $Y_i$ may take on _any_
-distribution from the [exponential family of distributions](https://en.wikipedia.org/wiki/Exponential_family). 
+distribution, [generalized linear models](https://en.wikipedia.org/wiki/Generalized_linear_model) (GLMs) are specifications of linear models where the response variable $Y_i$ may take on _any_
+distribution from the [exponential family of distributions](https://en.wikipedia.org/wiki/Exponential_family).
+Spark's `GeneralizedLinearRegression` interface
+allows for flexible specification of GLMs which can be used for various types of
+prediction problems including linear regression, Poisson regression, logistic regression, and others.
+Currently in `spark.ml`, only a subset of the exponential family distributions are supported and they are listed
+[below](#available-families).
+
+**NOTE**: Spark currently only supports up to 4096 features for GLM models, and will throw an exception if this 
+constraint is exceeded. See the [optimization section](#optimization) for more details.
+
+In a GLM the resonse variable $Y_i$ is assumed to be drawn from an exponential family distribution:
 
 $$
 Y_i \sim f\left(\cdot|\theta_i, \phi, w_i\right)
@@ -472,7 +478,7 @@ others.
 ### Optimization
 
 The `spark.ml` GLM implements the method of 
-[iteratively reweighted least squares](https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares) (IRLS) for finding
+[iteratively re-weighted least squares](https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares) (IRLS) for finding
 the optimal regression coefficients. GLMs seek to find a maximum likelihood estimate of the
 regression coefficients by finding zeros of the [score equation](https://en.wikipedia.org/wiki/Score_(statistics)).
 The method of IRLS uses a first-order Taylor approximation of the score equation in the vicinity of an initial guess for the expected response
@@ -481,10 +487,10 @@ The method of IRLS uses a first-order Taylor approximation of the score equation
  to the regression coefficients $\vec{\beta}$. However, this approximation of $\vec{\beta}$ generates an improved approximation for $\vec{\mu}$
  using the fact that $\vec{\mu} = g^{-1}(X\vec{\beta})$. In turn, an even more improved approximation to $\vec{\beta}$ can be found
  solving the weighted least squares problem again. The true value of $\vec{\beta}$ is converged upon by repeatedly solving weighted least
- squares problems in this manner (hence the name, iteratively weighted least squares).
+ squares problems in this manner (hence the name, iteratively re-weighted least squares).
 
  Note that solving the normal equations, as in a weighted least squares, for a linear system $A\vec{x} = \vec{b}$ involves 
- inverting the covariance matrix $A^TA$. If $A$ is an $MxN$ matrix, then $A^TA$ has dimension $NxN$. When N is relatively
+ inverting the covariance matrix $A^TA$. If $A$ is an $M \times N$ matrix, then $A^TA$ has dimension $N \times N$. When N is relatively
  small (< 4096) then the covariance matrix can (generally) fit into main memory on the driver node and the linear system can
  then be solved using well-established linear subroutines like the Cholesky decomposition. For this reason, it is important
  to note that the `spark.ml` generalized linear regression module currently does not accept more than 4096 feature columns.

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -390,13 +390,15 @@ interface, and will throw an exception if this constraint is exceeded. See the [
  Still, for linear and logistic regression, models with an increased number of features can be trained 
  using the `LinearRegression` and `LogisticRegression` estimators.
 
-The canonical form of an exponential family distribution is given as:
+Though GLMs may be used with general exponential family distributions, it is common to work only with exponential families that are 
+in their _natural_ or _canonical_ forms. Any distribution can be converted to its canonical form via a simple transform, and this
+assumption simplifies the notation. The form of a [natural exponential family distribution](https://en.wikipedia.org/wiki/Natural_exponential_family) is given as:
 
 $$
-f_Y(y|\theta, \tau) = h(y, \tau)\exp{\left( \frac{\theta \cdot T(y) - A(\theta)}{d(\tau)} \right)}
+f_Y(y|\theta, \tau) = h(y, \tau)\exp{\left( \frac{\theta \cdot y - A(\theta)}{d(\tau)} \right)}
 $$
 
-where $\theta$ is the parameter of interest and $\tau$ is a dispersion parameter. In a GLM the response variable $Y_i$ is assumed to be drawn from an exponential family distribution:
+where $\theta$ is the parameter of interest and $\tau$ is a dispersion parameter. In a GLM the response variable $Y_i$ is assumed to be drawn from a natural exponential family distribution:
 
 $$
 Y_i \sim f\left(\cdot|\theta_i, \tau \right)
@@ -408,7 +410,7 @@ $$
 \mu_i = A'(\theta_i)
 $$
 
-Here, $A'(\theta_i)$ is defined by the form of the exponential family distribution used. GLMs also allow specification
+Here, $A'(\theta_i)$ is defined by the form of the distribution selected. GLMs also allow specification
 of a link function, which defines the relationship between the expected value of the response variable $\mu_i$
 and the so called _linear predictor_ $\eta_i$:
 
@@ -427,7 +429,7 @@ $$
 A GLM finds the regression coefficients $\vec{\beta}$ which maximize the likelihood function.
 
 $$
-\min_{\vec{\beta}} \mathcal{L}(\vec{\theta}|\vec{y},X) =
+\max_{\vec{\beta}} \mathcal{L}(\vec{\theta}|\vec{y},X) =
 \prod_{i=1}^{N} h(y_i, \tau) \exp{\left(\frac{y_i\theta_i - A(\theta_i)}{d(\tau)}\right)}
 $$
 
@@ -435,7 +437,7 @@ where the parameter of interest $\theta_i$ is related to the regression coeffici
 by
 
 $$
-\theta_i = A'(g^{-1}(\vec{x_i} \cdot \vec{\beta}))
+\theta_i = A'^{-1}(g^{-1}(\vec{x_i} \cdot \vec{\beta}))
 $$
 
 Spark's generalized linear regression interface also provides summary statistics for diagnosing the


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds a user guide section for generalized linear regression and includes the examples from [#12754](https://github.com/apache/spark/pull/12754).
## How was this patch tested?

Documentation only, no tests required.
## Approach

In general, it is a bit unclear what level of detail ought to be included in the user guide since there is a lot of variability within the current user guide. I tried to give a fairly brief mathematical introduction to GLMs, and cover what types of problems they could be used for. Additionally, I included a brief blurb on the IRLS solver. The input/output columns are given in a table as is found elsewhere in the docs (though, again, these appear rather intermittently in the current docs), as well as a table providing the supported families and their link functions.
