### PR TITLE
[SPARK-14752] [SQL] fix kryo ordering serialization

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -151,7 +151,7 @@ class LazilyGeneratedOrdering(val ordering: Seq[SortOrder]) extends Ordering[Int
     this(ordering.map(BindReferences.bindReference(_, inputSchema)))
 
   @transient
-  private[this] var generatedOrdering = GenerateOrdering.generate(ordering)
+  private[this] lazy val generatedOrdering = GenerateOrdering.generate(ordering)
 
   def compare(a: InternalRow, b: InternalRow): Int = {
     generatedOrdering.compare(a, b)
@@ -159,7 +159,6 @@ class LazilyGeneratedOrdering(val ordering: Seq[SortOrder]) extends Ordering[Int
 
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
-    generatedOrdering = GenerateOrdering.generate(ordering)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using Kryo as serializer and we will get `NullPointerException` exception for query with `ORDER BY`.
## How was this patch tested?

I've added a new test cases to HashedRelationSuite.scala, since this issue is kind of related to Spark-14521.
