### PR TITLE
[SPARK-15360][Spark-Submit]Should print spark-submit usage when no arguments is specified

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/Main.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/Main.java
@@ -83,16 +83,8 @@ class Main {
     }
 
     Map<String, String> env = new HashMap<>();
-    List<String> cmd = new ArrayList<>();
-    try {
-      cmd = builder.buildCommand(env);
-    } catch (IllegalArgumentException e) {
-      if (argsArray.length == 1) {
-        printUsage();
-      } else {
-        System.err.println(e.getMessage());
-      }
-    }
+    List<String> cmd = builder.buildCommand(env);
+
     if (printLaunchCommand) {
       System.err.println("Spark Command: " + join(" ", cmd));
       System.err.println("========================================");
@@ -108,80 +100,6 @@ class Main {
         System.out.print('\0');
       }
     }
-  }
-
-  private static void printUsage() {
-    String usage = "Usage: spark-submit [options] <app jar | python file> [app arguments]\n" +
-    "Usage: spark-submit --kill [submission ID] --master [spark://...]\n" +
-    "Usage: spark-submit --status [submission ID] --master [spark://...]\n" +
-    "Usage: spark-submit run-example [options] example-class [example args]\n";
-    System.err.println(usage);
-    String mem = CommandBuilderUtils.DEFAULT_MEM;
-    String options =
-    "Options:\n"+
-    "  --master MASTER_URL         spark://host:port, mesos://host:port, yarn, or local.\n" +
-    "  --deploy-mode DEPLOY_MODE   Whether to launch the driver program locally (\"client\") or\n" +
-    "                              on one of the worker machines inside the cluster (\"cluster\")\n" +
-    "                              (Default: client).\n" +
-    "  --class CLASS_NAME          Your application's main class (for Java / Scala apps).\n" +
-    "  --name NAME                 A name of your application.\n" +
-    "  --jars JARS                 Comma-separated list of local jars to include on the driver\n" +
-    "                              and executor classpaths.\n" +
-    "  --packages                  Comma-separated list of maven coordinates of jars to include\n" +
-    "                              on the driver and executor classpaths. Will search the local\n" +
-    "                              maven repo, then maven central and any additional remote\n" +
-    "                              repositories given by --repositories. The format for the\n" +
-    "                              coordinates should be groupId:artifactId:version.\n" +
-    "  --exclude-packages          Comma-separated list of groupId:artifactId, to exclude while\n" +
-    "                              resolving the dependencies provided in --packages to avoid\n" +
-    "                              dependency conflicts.\n" +
-    "  --repositories              Comma-separated list of additional remote repositories to\n" +
-    "                              search for the maven coordinates given with --packages.\n" +
-    "  --py-files PY_FILES         Comma-separated list of .zip, .egg, or .py files to place\n" +
-    "                              on the PYTHONPATH for Python apps.\n" +
-    "  --files FILES               Comma-separated list of files to be placed in the working\n" +
-    "                              directory of each executor.\n\n" +
-    "  --conf PROP=VALUE           Arbitrary Spark configuration property.\n" +
-    "  --properties-file FILE      Path to a file from which to load extra properties. If not\n" +
-    "                              specified, this will look for conf/spark-defaults.conf.\n\n" +
-    "  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: " + mem + ").\n" +
-    "  --driver-java-options       Extra Java options to pass to the driver.\n" +
-    "  --driver-library-path       Extra library path entries to pass to the driver.\n" +
-    "  --driver-class-path         Extra class path entries to pass to the driver. Note that\n" +
-    "                              jars added with --jars are automatically included in the\n" +
-    "                              classpath.\n\n" +
-    "  --executor-memory MEM       Memory per executor (e.g. 1000M, 2G) (Default: 1G).\n\n" +
-    "  --proxy-user NAME           User to impersonate when submitting the application.\n" +
-    "                              This argument does not work with --principal / --keytab.\n\n" +
-    "  --help, -h                  Show this help message and exit.\n" +
-    "  --verbose, -v               Print additional debug output.\n" +
-    "  --version,                  Print the version of current Spark.\n\n" +
-    " Spark standalone with cluster deploy mode only:\n" +
-    "  --driver-cores NUM          Cores for driver (Default: 1).\n\n" +
-    " Spark standalone or Mesos with cluster deploy mode only:\n" +
-    "  --supervise                 If given, restarts the driver on failure.\n" +
-    "  --kill SUBMISSION_ID        If given, kills the driver specified.\n" +
-    "  --status SUBMISSION_ID      If given, requests the status of the driver specified.\n\n"+
-    " Spark standalone and Mesos only:\n" +
-    "  --total-executor-cores      NUM Total cores for all executors.\n\n" +
-    " Spark standalone and YARN only:\n" +
-    "  --executor-cores NUM        Number of cores per executor. (Default: 1 in YARN mode,\n" +
-    "                              or all available cores on the worker in standalone mode)\n\n" +
-    " YARN-only:\n" +
-    "  --driver-cores NUM          Number of cores used by the driver, only in cluster mode\n" +
-    "                              (Default: 1).\n" +
-    "  --queue QUEUE_NAME          The YARN queue to submit to (Default: \"default\").\n" +
-    "  --num-executors NUM         Number of executors to launch (Default: 2).\n" +
-    "  --archives ARCHIVES         Comma separated list of archives to be extracted into the\n" +
-    "                              working directory of each executor.\n" +
-    "  --principal PRINCIPAL       Principal to be used to login to KDC, while running on\n" +
-    "                              secure HDFS.\n" +
-    "  --keytab KEYTAB             The full path to the file that contains the keytab for the\n" +
-    "                              principal specified above. This keytab will be copied to\n" +
-    "                              the node running the Application Master via the Secure\n" +
-    "                              Distributed Cache, for renewing the login tickets and the\n" +
-    "                              delegation tokens periodically.\n";
-    System.err.println(options);
   }
 
   /**

--- a/launcher/src/main/java/org/apache/spark/launcher/Main.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/Main.java
@@ -83,7 +83,16 @@ class Main {
     }
 
     Map<String, String> env = new HashMap<>();
-    List<String> cmd = builder.buildCommand(env);
+    List<String> cmd = new ArrayList<>();
+    try {
+      cmd = builder.buildCommand(env);
+    } catch (IllegalArgumentException e) {
+      if (argsArray.length == 1) {
+        printUsage();
+      } else {
+        System.err.println(e.getMessage());
+      }
+    }
     if (printLaunchCommand) {
       System.err.println("Spark Command: " + join(" ", cmd));
       System.err.println("========================================");
@@ -99,6 +108,80 @@ class Main {
         System.out.print('\0');
       }
     }
+  }
+
+  private static void printUsage() {
+    String usage = "Usage: spark-submit [options] <app jar | python file> [app arguments]\n" +
+    "Usage: spark-submit --kill [submission ID] --master [spark://...]\n" +
+    "Usage: spark-submit --status [submission ID] --master [spark://...]\n" +
+    "Usage: spark-submit run-example [options] example-class [example args]\n";
+    System.err.println(usage);
+    String mem = CommandBuilderUtils.DEFAULT_MEM;
+    String options =
+    "Options:\n"+
+    "  --master MASTER_URL         spark://host:port, mesos://host:port, yarn, or local.\n" +
+    "  --deploy-mode DEPLOY_MODE   Whether to launch the driver program locally (\"client\") or\n" +
+    "                              on one of the worker machines inside the cluster (\"cluster\")\n" +
+    "                              (Default: client).\n" +
+    "  --class CLASS_NAME          Your application's main class (for Java / Scala apps).\n" +
+    "  --name NAME                 A name of your application.\n" +
+    "  --jars JARS                 Comma-separated list of local jars to include on the driver\n" +
+    "                              and executor classpaths.\n" +
+    "  --packages                  Comma-separated list of maven coordinates of jars to include\n" +
+    "                              on the driver and executor classpaths. Will search the local\n" +
+    "                              maven repo, then maven central and any additional remote\n" +
+    "                              repositories given by --repositories. The format for the\n" +
+    "                              coordinates should be groupId:artifactId:version.\n" +
+    "  --exclude-packages          Comma-separated list of groupId:artifactId, to exclude while\n" +
+    "                              resolving the dependencies provided in --packages to avoid\n" +
+    "                              dependency conflicts.\n" +
+    "  --repositories              Comma-separated list of additional remote repositories to\n" +
+    "                              search for the maven coordinates given with --packages.\n" +
+    "  --py-files PY_FILES         Comma-separated list of .zip, .egg, or .py files to place\n" +
+    "                              on the PYTHONPATH for Python apps.\n" +
+    "  --files FILES               Comma-separated list of files to be placed in the working\n" +
+    "                              directory of each executor.\n\n" +
+    "  --conf PROP=VALUE           Arbitrary Spark configuration property.\n" +
+    "  --properties-file FILE      Path to a file from which to load extra properties. If not\n" +
+    "                              specified, this will look for conf/spark-defaults.conf.\n\n" +
+    "  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: " + mem + ").\n" +
+    "  --driver-java-options       Extra Java options to pass to the driver.\n" +
+    "  --driver-library-path       Extra library path entries to pass to the driver.\n" +
+    "  --driver-class-path         Extra class path entries to pass to the driver. Note that\n" +
+    "                              jars added with --jars are automatically included in the\n" +
+    "                              classpath.\n\n" +
+    "  --executor-memory MEM       Memory per executor (e.g. 1000M, 2G) (Default: 1G).\n\n" +
+    "  --proxy-user NAME           User to impersonate when submitting the application.\n" +
+    "                              This argument does not work with --principal / --keytab.\n\n" +
+    "  --help, -h                  Show this help message and exit.\n" +
+    "  --verbose, -v               Print additional debug output.\n" +
+    "  --version,                  Print the version of current Spark.\n\n" +
+    " Spark standalone with cluster deploy mode only:\n" +
+    "  --driver-cores NUM          Cores for driver (Default: 1).\n\n" +
+    " Spark standalone or Mesos with cluster deploy mode only:\n" +
+    "  --supervise                 If given, restarts the driver on failure.\n" +
+    "  --kill SUBMISSION_ID        If given, kills the driver specified.\n" +
+    "  --status SUBMISSION_ID      If given, requests the status of the driver specified.\n\n"+
+    " Spark standalone and Mesos only:\n" +
+    "  --total-executor-cores      NUM Total cores for all executors.\n\n" +
+    " Spark standalone and YARN only:\n" +
+    "  --executor-cores NUM        Number of cores per executor. (Default: 1 in YARN mode,\n" +
+    "                              or all available cores on the worker in standalone mode)\n\n" +
+    " YARN-only:\n" +
+    "  --driver-cores NUM          Number of cores used by the driver, only in cluster mode\n" +
+    "                              (Default: 1).\n" +
+    "  --queue QUEUE_NAME          The YARN queue to submit to (Default: \"default\").\n" +
+    "  --num-executors NUM         Number of executors to launch (Default: 2).\n" +
+    "  --archives ARCHIVES         Comma separated list of archives to be extracted into the\n" +
+    "                              working directory of each executor.\n" +
+    "  --principal PRINCIPAL       Principal to be used to login to KDC, while running on\n" +
+    "                              secure HDFS.\n" +
+    "  --keytab KEYTAB             The full path to the file that contains the keytab for the\n" +
+    "                              principal specified above. This keytab will be copied to\n" +
+    "                              the node running the Application Master via the Secure\n" +
+    "                              Distributed Cache, for renewing the login tickets and the\n" +
+    "                              delegation tokens periodically.\n";
+    System.err.println(options);
   }
 
   /**

--- a/launcher/src/main/java/org/apache/spark/launcher/Main.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/Main.java
@@ -249,7 +249,6 @@ class Main {
     protected void handleExtraArgs(List<String> extra) {
 
     }
-
   }
 
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/Main.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/Main.java
@@ -249,6 +249,7 @@ class Main {
     protected void handleExtraArgs(List<String> extra) {
 
     }
+
   }
 
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/Main.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/Main.java
@@ -84,7 +84,6 @@ class Main {
 
     Map<String, String> env = new HashMap<>();
     List<String> cmd = builder.buildCommand(env);
-
     if (printLaunchCommand) {
       System.err.println("Spark Command: " + join(" ", cmd));
       System.err.println("========================================");

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -107,28 +107,36 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
   SparkSubmitCommandBuilder(List<String> args) {
     this.allowsMixedArguments = false;
-
+    this.sparkArgs = new ArrayList<>();
     boolean isExample = false;
     List<String> submitArgs = args;
-    if (args.size() > 0 && args.get(0).equals(PYSPARK_SHELL)) {
-      this.allowsMixedArguments = true;
-      appResource = PYSPARK_SHELL;
-      submitArgs = args.subList(1, args.size());
-    } else if (args.size() > 0 && args.get(0).equals(SPARKR_SHELL)) {
-      this.allowsMixedArguments = true;
-      appResource = SPARKR_SHELL;
-      submitArgs = args.subList(1, args.size());
-    } else if (args.size() > 0 && args.get(0).equals(RUN_EXAMPLE)) {
-      isExample = true;
-      submitArgs = args.subList(1, args.size());
+
+    if (args.size() > 0) {
+      switch (args.get(0)) {
+        case PYSPARK_SHELL:
+          this.allowsMixedArguments = true;
+          appResource = PYSPARK_SHELL;
+          submitArgs = args.subList(1, args.size());
+          break;
+
+        case SPARKR_SHELL:
+          this.allowsMixedArguments = true;
+          appResource = SPARKR_SHELL;
+          submitArgs = args.subList(1, args.size());
+          break;
+
+        case RUN_EXAMPLE:
+          isExample = true;
+          submitArgs = args.subList(1, args.size());
+      }
+
+      OptionParser parser = new OptionParser();
+      parser.parse(submitArgs);
+      this.printInfo = parser.infoRequested;
+    }  else {
+      this.printInfo = true;
     }
-
-    this.sparkArgs = new ArrayList<>();
     this.isExample = isExample;
-
-    OptionParser parser = new OptionParser();
-    parser.parse(submitArgs);
-    this.printInfo = parser.infoRequested;
   }
 
   @Override
@@ -147,7 +155,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     List<String> args = new ArrayList<>();
     SparkSubmitOptionParser parser = new SparkSubmitOptionParser();
 
-    if (!allowsMixedArguments) {
+    if (!allowsMixedArguments &!printInfo) {
       checkArgument(appResource != null, "Missing application resource.");
     }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -156,7 +156,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     List<String> args = new ArrayList<>();
     SparkSubmitOptionParser parser = new SparkSubmitOptionParser();
 
-    if (!allowsMixedArguments &!printInfo) {
+    if (!allowsMixedArguments && !printInfo) {
       checkArgument(appResource != null, "Missing application resource.");
     }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -130,13 +130,14 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
           submitArgs = args.subList(1, args.size());
       }
 
+      this.isExample = isExample;
       OptionParser parser = new OptionParser();
       parser.parse(submitArgs);
       this.printInfo = parser.infoRequested;
     }  else {
+      this.isExample = isExample;
       this.printInfo = true;
     }
-    this.isExample = isExample;
   }
 
   @Override

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -66,7 +66,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     List<String> sparkEmptyArgs = Arrays.asList("");
     cmd = buildCommand(sparkSubmitArgs, env);
-    assertTrue("--help should be contained in the final cmd", cmd.contains(parser.HELP));
+    assertTrue("--help should be contained in the final cmd.", cmd.contains(parser.HELP));
   }
 
   @Test

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -59,6 +59,16 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   }
 
   @Test
+  public void testCliHelpAndNoArg() throws Exception {
+    List<String> sparkSubmitArgs = Arrays.asList(parser.HELP);
+    Map<String, String> env = new HashMap<>();
+    List<String> cmd = buildCommand(sparkSubmitArgs, env);
+
+    List<String> sparkEmptyArgs = Arrays.asList("");
+    cmd = buildCommand(sparkSubmitArgs, env);
+  }
+
+  @Test
   public void testCliParser() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
       parser.MASTER,

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -63,10 +63,11 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     List<String> sparkSubmitArgs = Arrays.asList(parser.HELP);
     Map<String, String> env = new HashMap<>();
     List<String> cmd = buildCommand(sparkSubmitArgs, env);
+    assertTrue("--help should be contained in the final cmd.", cmd.contains(parser.HELP));
 
     List<String> sparkEmptyArgs = Arrays.asList("");
     cmd = buildCommand(sparkSubmitArgs, env);
-    assertTrue("--help should be contained in the final cmd.", cmd.contains(parser.HELP));
+    assertTrue("--help should be contained in the final cmd of empty input.", cmd.contains(parser.HELP));
   }
 
   @Test

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -66,6 +66,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     List<String> sparkEmptyArgs = Arrays.asList("");
     cmd = buildCommand(sparkSubmitArgs, env);
+    assertTrue("--help should be contained in the final cmd", cmd.contains(parser.HELP));
   }
 
   @Test

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -60,14 +60,15 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
   @Test
   public void testCliHelpAndNoArg() throws Exception {
-    List<String> sparkSubmitArgs = Arrays.asList(parser.HELP);
+    List<String> helpArgs = Arrays.asList(parser.HELP);
     Map<String, String> env = new HashMap<>();
-    List<String> cmd = buildCommand(sparkSubmitArgs, env);
+    List<String> cmd = buildCommand(helpArgs, env);
     assertTrue("--help should be contained in the final cmd.", cmd.contains(parser.HELP));
 
-    List<String> sparkEmptyArgs = Arrays.asList("");
-    cmd = buildCommand(sparkSubmitArgs, env);
-    assertTrue("--help should be contained in the final cmd of empty input.", cmd.contains(parser.HELP));
+    List<String> sparkEmptyArgs = Collections.emptyList();
+    cmd = buildCommand(sparkEmptyArgs, env);
+    assertTrue("org.apache.spark.deploy.SparkSubmit should be contained in the final cmd of empty input.",
+              cmd.contains("org.apache.spark.deploy.SparkSubmit"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
In 2.0, ./bin/spark-submit doesn't print out usage, but it raises an exception.
In this PR, an exception handling is added in the Main.java when the exception is thrown. In the handling code, if there is no additional argument, it prints out usage.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Manually tested.
./bin/spark-submit 
Usage: spark-submit [options] <app jar | python file> [app arguments]
Usage: spark-submit --kill [submission ID] --master [spark://...]
Usage: spark-submit --status [submission ID] --master [spark://...]
Usage: spark-submit run-example [options] example-class [example args]

Options:
  --master MASTER_URL         spark://host:port, mesos://host:port, yarn, or local.
  --deploy-mode DEPLOY_MODE   Whether to launch the driver program locally ("client") or
                              on one of the worker machines inside the cluster ("cluster")
                              (Default: client).
  --class CLASS_NAME          Your application's main class (for Java / Scala apps).
  --name NAME                 A name of your application.
  --jars JARS                 Comma-separated list of local jars to include on the driver
                              and executor classpaths.
  --packages                  Comma-separated list of maven coordinates of jars to include
                              on the driver and executor classpaths. Will search the local
                              maven repo, then maven central and any additional remote
                              repositories given by --repositories. The format for the
                              coordinates should be groupId:artifactId:version.
