### PR TITLE
[SPARK-15386] [CORE] Master doesn't compile against Java 1.7 / Process.isAlive

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -144,7 +144,7 @@ public class JavaUtils {
     } catch (Exception e) {
       throw new IOException("Failed to delete: " + file.getAbsolutePath(), e);
     } finally {
-      if (process != null && process.isAlive()) {
+      if (process != null) {
         process.destroy();
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove call to Process.isAlive -- Java 8 only. Introduced in https://github.com/apache/spark/pull/13042 / SPARK-15263
## How was this patch tested?

Jenkins tests
