### PR TITLE
[SPARK-15417][SQL][Python] PySpark shell always uses in-memory catalog

### DIFF
--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -35,12 +35,11 @@ from pyspark.storagelevel import StorageLevel
 if os.environ.get("SPARK_EXECUTOR_URI"):
     SparkContext.setSystemProperty("spark.executor.uri", os.environ["SPARK_EXECUTOR_URI"])
 
-sc = SparkContext()
-atexit.register(lambda: sc.stop())
+SparkContext._ensure_initialized()
 
 try:
     # Try to access HiveConf, it will raise exception if Hive is not added
-    sc._jvm.org.apache.hadoop.hive.conf.HiveConf()
+    SparkContext._jvm.org.apache.hadoop.hive.conf.HiveConf()
     spark = SparkSession.builder\
         .enableHiveSupport()\
         .getOrCreate()
@@ -48,6 +47,9 @@ except py4j.protocol.Py4JError:
     spark = SparkSession(sc)
 except TypeError:
     spark = SparkSession(sc)
+
+sc = spark.sparkContext
+atexit.register(lambda: sc.stop())
 
 # for compatibility
 sqlContext = spark._wrapped

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -193,6 +193,12 @@ class SparkSession(object):
 
     @property
     @since(2.0)
+    def sparkContext(self):
+        """Returns the underlying :class:`SparkContext`."""
+        return self._sc
+
+    @property
+    @since(2.0)
     def conf(self):
         """Runtime configuration interface for Spark.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is no way to use the Hive catalog in `pyspark-shell`. This is because we used to create a `SparkContext` before calling `SparkSession.enableHiveSupport().getOrCreate()`, which just gets the existing `SparkContext` instead of creating a new one. As a result, `spark.sql.catalogImplementation` was never propagated.
## How was this patch tested?

Manual.
