### PR TITLE
[SPARK-14990][SQL] Fix checkForSameTypeInputExpr (ignore nullability)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -42,13 +42,14 @@ object TypeUtils {
   }
 
   def checkForSameTypeInputExpr(types: Seq[DataType], caller: String): TypeCheckResult = {
-    if (types.distinct.size > 1) {
-      TypeCheckResult.TypeCheckFailure(
-        s"input to $caller should all be the same type, but it's " +
-          types.map(_.simpleString).mkString("[", ", ", "]"))
-    } else {
-      TypeCheckResult.TypeCheckSuccess
-    }
+    types.foreach ( t =>
+      if (!t.sameType(types.head)) {
+        return TypeCheckResult.TypeCheckFailure(
+          s"input to $caller should all be the same type, but it's " +
+            types.map(_.simpleString).mkString("[", ", ", "]"))
+      }
+    )
+    TypeCheckResult.TypeCheckSuccess
   }
 
   def getNumeric(t: DataType): Numeric[Any] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -42,14 +42,19 @@ object TypeUtils {
   }
 
   def checkForSameTypeInputExpr(types: Seq[DataType], caller: String): TypeCheckResult = {
-    types.foreach ( t =>
-      if (!t.sameType(types.head)) {
-        return TypeCheckResult.TypeCheckFailure(
-          s"input to $caller should all be the same type, but it's " +
-            types.map(_.simpleString).mkString("[", ", ", "]"))
+    if (types.size <= 1) {
+      TypeCheckResult.TypeCheckSuccess
+    } else {
+      val firstType = types.head
+      types.foreach { t =>
+        if (!t.sameType(firstType)) {
+          return TypeCheckResult.TypeCheckFailure(
+            s"input to $caller should all be the same type, but it's " +
+              types.map(_.simpleString).mkString("[", ", ", "]"))
+        }
       }
-    )
-    TypeCheckResult.TypeCheckSuccess
+      TypeCheckResult.TypeCheckSuccess
+    }
   }
 
   def getNumeric(t: DataType): Numeric[Any] =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TypeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TypeUtilsSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
+import org.apache.spark.sql.types._
+
+class TypeUtilsSuite extends SparkFunSuite {
+
+  private def typeCheckPass(types: Seq[DataType]): Unit = {
+    assert(TypeUtils.checkForSameTypeInputExpr(types, "a") == TypeCheckSuccess)
+  }
+
+  private def typeCheckFail(types: Seq[DataType]): Unit = {
+    assert(TypeUtils.checkForSameTypeInputExpr(types, "a").isInstanceOf[TypeCheckFailure])
+  }
+
+  test("checkForSameTypeInputExpr") {
+    typeCheckPass(Nil)
+    typeCheckPass(StringType :: Nil)
+    typeCheckPass(StringType :: StringType :: Nil)
+
+    typeCheckFail(StringType :: IntegerType :: Nil)
+    typeCheckFail(StringType :: IntegerType :: Nil)
+
+    // Should also work on arrays. See SPARK-14990
+    typeCheckPass(ArrayType(StringType, containsNull = true) ::
+      ArrayType(StringType, containsNull = false) :: Nil)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes a bug in TypeUtils.checkForSameTypeInputExpr. Previously the code was testing on strict equality, which does not taking nullability into account.

This is based on https://github.com/apache/spark/pull/12768. This patch fixed a bug there (with empty expression) and added a test case.
## How was this patch tested?

Added a new test suite and test case.

Closes #12768.
