### PR TITLE
[SPARK-15430][SQL] Fix potential ConcurrentModificationException for ListAccumulator

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 
 import java.{lang => jl}
 import java.io.ObjectInputStream
+import java.util.ArrayList
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -415,7 +416,7 @@ class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
 
 
 class ListAccumulator[T] extends AccumulatorV2[T, java.util.List[T]] {
-  private val _list: java.util.List[T] = new java.util.ArrayList[T]
+  private val _list: java.util.List[T] = new ArrayList[T]
 
   override def isZero: Boolean = _list.isEmpty
 
@@ -438,9 +439,7 @@ class ListAccumulator[T] extends AccumulatorV2[T, java.util.List[T]] {
   }
 
   override def value: java.util.List[T] = _list.synchronized {
-    val newList = new java.util.ArrayList[T]
-    newList.addAll(_list)
-    java.util.Collections.unmodifiableList(newList)
+    java.util.Collections.unmodifiableList(new ArrayList[T](_list))
   }
 
   private[spark] def setValue(newValue: java.util.List[T]): Unit = {

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -437,7 +437,11 @@ class ListAccumulator[T] extends AccumulatorV2[T, java.util.List[T]] {
       s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
   }
 
-  override def value: java.util.List[T] = java.util.Collections.unmodifiableList(_list)
+  override def value: java.util.List[T] = _list.synchronized {
+    val newList = new java.util.ArrayList[T]
+    newList.addAll(_list)
+    java.util.Collections.unmodifiableList(newList)
+  }
 
   private[spark] def setValue(newValue: java.util.List[T]): Unit = {
     _list.clear()


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `ListAccumulator` we create an unmodifiable view for underlying list. However, it doesn't prevent the underlying to be modified further. So as we access the unmodifiable list, the underlying list can be modified in the same time. It could cause `java.util.ConcurrentModificationException`. We can observe such exception in recent tests.

To fix it, we can copy a list of the underlying list and then create the unmodifiable view of this list instead.
## How was this patch tested?

The exception might be difficult to test. Existing tests should be passed.
