### PR TITLE
[SPARK-15443][SQL][Streaming] Properly explain continuous query

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQuery.scala
@@ -61,6 +61,9 @@ trait ContinuousQuery {
   /** Returns current status of the sink. */
   def sinkStatus: SinkStatus
 
+  /** Return the current plan tree of ContinuousQuery */
+  def explain(extended: Boolean = false, codegen: Boolean = false): String
+
   /**
    * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
    * If the query has terminated with an exception, then the exception will be thrown.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -201,7 +201,7 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
 
   def simpleString: String = {
     s"""== Physical Plan ==
-       |${stringOrError(executedPlan)}
+       |${ if (logical.isStreaming) "N/A" else stringOrError(executedPlan) }
       """.stripMargin.trim
   }
 
@@ -216,9 +216,9 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
        |== Analyzed Logical Plan ==
        |$analyzedPlan
        |== Optimized Logical Plan ==
-       |${stringOrError(optimizedPlan)}
+       |${ if (logical.isStreaming) "N/A" else stringOrError(optimizedPlan) }
        |== Physical Plan ==
-       |${stringOrError(executedPlan)}
+       |${ if (logical.isStreaming) "N/A" else stringOrError(executedPlan) }
     """.stripMargin.trim
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ContinuousQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ContinuousQuerySuite.scala
@@ -85,6 +85,18 @@ class ContinuousQuerySuite extends StreamTest with SharedSQLContext {
     )
   }
 
+  testQuietly("explain continuous query") {
+    val inputData = MemoryStream[Int]
+    val mapped = inputData.toDS().map(6 / _)
+
+    testStream(mapped)(
+      AssertOnQuery(_.explain() === "N/A"),
+      AddData(inputData, 1, 2),
+      CheckAnswer(6, 3),
+      AssertOnQuery(_.explain() !== "N/A")
+    )
+  }
+
   /**
    * A [[StreamAction]] to test the behavior of `ContinuousQuery.awaitTermination()`.
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently directly call `explain` on streaming Dataset will get exception for optimized logical plan and physical plan:

```
scala> res0.explain(true)
== Parsed Logical Plan ==
FileSource[file:///tmp/input]
== Analyzed Logical Plan ==
value: string
FileSource[file:///tmp/input]
== Optimized Logical Plan ==
org.apache.spark.sql.AnalysisException: Queries with streaming sources must be executed with write.startStream();
== Physical Plan ==
org.apache.spark.sql.AnalysisException: Queries with streaming sources must be executed with write.startStream();
```

Inside `StreamExecution`, logical plan still needs to tranform to finally materialize in the run-time. Also in the future optimized logical plan and physical plan may be changed according the different batch. So here propose a way to get an explained plan in the run-time for continuous query.

User could use like:

```
val query = spark.read.format("text").stream("file:///tmp/input")
  .write
  .format("console")
  .option("checkpointLocation", "file:///tmp/checkpoint1")
  .trigger(ProcessingTime("2 seconds"))
  .startStream()

// This could be called in the runtime
query.explain()
```
## How was this patch tested?

Add unit test.

Propose one possible solution, please help to review, thanks lot for your time.
