### PR TITLE
[SPARK-15446][build][sql] modify catalyst using longValueExact not supporting java 7

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -132,17 +132,11 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * Set this Decimal to the given BigInteger value. Will have precision 38 and scale 0.
    */
   def set(bigintval: BigInteger): Decimal = {
-    try {
       this.decimalVal = null
-      this.longVal = bigintval.longValueExact()
+      this.longVal = bigintval.longValue()
       this._precision = DecimalType.MAX_PRECISION
       this._scale = 0
       this
-    }
-    catch {
-      case e: ArithmeticException =>
-        throw new IllegalArgumentException(s"BigInteger ${bigintval} too large for decimal")
-     }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

change into BigInteger.longValue supporting java 7
## How was this patch tested?
