### PR TITLE
[SPARK-15452][SQL] Mark aggregator API as experimental

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
@@ -17,12 +17,14 @@
 
 package org.apache.spark.sql.expressions
 
+import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.{Dataset, Encoder, TypedColumn}
 import org.apache.spark.sql.catalyst.encoders.encoderFor
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete}
 import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
 
 /**
+ * :: Experimental ::
  * A base class for user-defined aggregations, which can be used in [[Dataset]] operations to take
  * all of the elements of a group and reduce them to a single value.
  *
@@ -48,6 +50,7 @@ import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
  * @tparam OUT The type of the final output result.
  * @since 1.6.0
  */
+@Experimental
 abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Aggregator API was introduced in 2.0 for Dataset. All typed Dataset APIs should still be marked as experimental in 2.0.
## How was this patch tested?

N/A - annotation only change.
