### PR TITLE
[SPARK-11827][SQL] Fix compilation against Java 7

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -134,7 +134,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
   def set(bigintval: BigInteger): Decimal = {
     try {
       this.decimalVal = null
-      this.longVal = bigintval.longValueExact()
+      this.longVal = bigintval.longValue()
       this._precision = DecimalType.MAX_PRECISION
       this._scale = 0
       this


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes compilation error against Java 7:

```
sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala:137: value longValueExact is not a member of java.math.BigInteger
[ERROR]       this.longVal = bigintval.longValueExact()
[ERROR]                                ^
[ERROR] one error found
```
## How was this patch tested?

Existing tests.
