### PR TITLE
[SPARK-15456][PYSPARK] Fixed PySpark shell context initialization when HiveConf not present

### DIFF
--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -44,9 +44,9 @@ try:
         .enableHiveSupport()\
         .getOrCreate()
 except py4j.protocol.Py4JError:
-    spark = SparkSession(sc)
+    spark = SparkSession(SparkContext.getOrCreate())
 except TypeError:
-    spark = SparkSession(sc)
+    spark = SparkSession(SparkContext.getOrCreate())
 
 sc = spark.sparkContext
 atexit.register(lambda: sc.stop())

--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -44,9 +44,9 @@ try:
         .enableHiveSupport()\
         .getOrCreate()
 except py4j.protocol.Py4JError:
-    spark = SparkSession(SparkContext.getOrCreate())
+    spark = SparkSession.builder.getOrCreate()
 except TypeError:
-    spark = SparkSession(SparkContext.getOrCreate())
+    spark = SparkSession.builder.getOrCreate()
 
 sc = spark.sparkContext
 atexit.register(lambda: sc.stop())


### PR DESCRIPTION
## What changes were proposed in this pull request?

When PySpark shell cannot find HiveConf, it will fallback to create a SparkSession from a SparkContext.  This fixes a bug caused by using a variable to SparkContext before it was initialized.
## How was this patch tested?

Manually starting PySpark shell and using the SparkContext
