### PR TITLE
[SPARK-15458][SQL][STREAMING] Disable schema inference for streaming datasets on file streams

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -192,9 +192,10 @@ case class DataSource(
         // If the schema inference is disabled, only text sources require schema to be specified
         if (!isSchemaInferenceEnabled && !isTextSource && userSpecifiedSchema.isEmpty) {
           throw new IllegalArgumentException(
-            "Schema must be specified for creating a streaming source DataFrame. " +
-              "If some input data already exists in the directory, you can create " +
-              "a static DataFrame with spark.read.load(path) and infer schema from it.")
+            "Schema must be specified when creating a streaming source DataFrame. " +
+              "If some files already exist in the directory, then depending on the file format " +
+              "you may be able to create a static DataFrame on that directory with " +
+              "'spark.read.load(directory)' and infer schema from it.")
         }
         SourceInfo(s"FileSource[$path]", inferFileFormatSchema(format))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -187,9 +187,10 @@ case class DataSource(
         val path = caseInsensitiveOptions.getOrElse("path", {
           throw new IllegalArgumentException("'path' is not specified")
         })
-        if (!sparkSession.conf.get(SQLConf.STREAMING_SCHEMA_INFERENCE) &&
-            userSpecifiedSchema.isEmpty &&
-            providingClass != classOf[text.DefaultSource]) {
+        val isSchemaInferenceEnabled = sparkSession.conf.get(SQLConf.STREAMING_SCHEMA_INFERENCE)
+        val isTextSource = providingClass == classOf[text.DefaultSource]
+        // If the schema inference is disabled, only text sources require schema to be specified
+        if (!isSchemaInferenceEnabled && !isTextSource && userSpecifiedSchema.isEmpty) {
           throw new IllegalArgumentException(
             "Schema must be specified for creating a streaming source DataFrame. " +
               "If some input data already exists in the directory, you can create " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -522,7 +522,7 @@ object SQLConf {
       .createWithDefault(60 * 1000L) // 10 minutes
 
   val STREAMING_SCHEMA_INFERENCE =
-    SQLConfigBuilder("spark.sql.streaming.allowSchemaInference")
+    SQLConfigBuilder("spark.sql.streaming.schemaInference")
       .internal()
       .doc("Whether file-based streaming sources will infer its own schema")
       .booleanConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -521,6 +521,13 @@ object SQLConf {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(60 * 1000L) // 10 minutes
 
+  val STREAMING_SCHEMA_INFERENCE =
+    SQLConfigBuilder("spark.sql.streaming.allowSchemaInference")
+      .internal()
+      .doc("Whether file-based streaming sources will infer its own schema")
+      .booleanConf
+      .createWithDefault(false)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -141,11 +141,11 @@ class FileStreamSourceSuite extends FileStreamSourceTest with SharedSQLContext {
   import testImplicits._
 
   private def withSchemaInference(f: => Unit): Unit = {
-    withSQLConf("spark.sql.streaming.allowSchemaInference" -> "true")(f)
+    withSQLConf("spark.sql.streaming.schemaInference" -> "true")(f)
   }
 
   private def withoutSchemaInference(f: => Unit): Unit = {
-    withSQLConf("spark.sql.streaming.allowSchemaInference" -> "false")(f)
+    withSQLConf("spark.sql.streaming.schemaInference" -> "false")(f)
   }
 
   private def testWithSchemaInference(testName: String)(f: => Unit): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the user relies on the schema to be inferred in file streams can break easily for multiple reasons
- accidentally running on a directory which has no data
- schema changing underneath
- on restart, the query will infer schema again, and may unexpectedly infer incorrect schema, as the file in the directory may be different at the time of the restart.

To avoid these complicated scenarios, for Spark 2.0, we are going to disable schema inferencing by default with a config, so that user is forced to consider explicitly what is the schema it wants, rather than the system trying to infer it and run into weird corner cases.

In this PR, I introduce a SQLConf that determines whether schema inference for file streams is allowed or not. It is disabled by default. 
## How was this patch tested?

Updated unit tests that test error behavior with and without schema inference enabled.
