### PR TITLE
[SPARK-15470] [SQL] Unify the Configuration Interface in SQLContext

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -64,7 +64,7 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    *
    * @since 2.0.0
    */
-  def set[T](entry: ConfigEntry[T], value: T): Unit = {
+  protected[sql] def set[T](entry: ConfigEntry[T], value: T): Unit = {
     sqlConf.setConf(entry, value)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -146,6 +146,15 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
   }
 
   /**
+   * Resets all the configuration properties.
+   *
+   * @since 2.0.0
+   */
+  def clear(): Unit = {
+    sqlConf.clear()
+  }
+
+  /**
    * Returns whether a particular key is set.
    */
   protected[sql] def contains(key: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import java.util.Properties
+
 import org.apache.spark.internal.config.{ConfigEntry, OptionalConfigEntry}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -55,6 +57,24 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    */
   def set(key: String, value: Long): Unit = {
     set(key, value.toString)
+  }
+
+  /**
+   * Set the given Spark runtime configuration property.
+   *
+   * @since 2.0.0
+   */
+  def set[T](entry: ConfigEntry[T], value: T): Unit = {
+    sqlConf.setConf(entry, value)
+  }
+
+  /**
+   * Set the given Spark runtime configuration properties.
+   *
+   * @since 2.0.0
+   */
+  def set(props: Properties): Unit = {
+    sqlConf.setConf(props)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -85,7 +85,6 @@ class SQLContext private[sql](
 
   protected[sql] def sessionState: SessionState = sparkSession.sessionState
   protected[sql] def sharedState: SharedState = sparkSession.sharedState
-  protected[sql] def conf: SQLConf = sessionState.conf
   protected[sql] def runtimeConf: RuntimeConfig = sparkSession.conf
   protected[sql] def cacheManager: CacheManager = sparkSession.cacheManager
   protected[sql] def externalCatalog: ExternalCatalog = sparkSession.externalCatalog

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -115,14 +115,14 @@ class SQLContext private[sql](
    * @since 1.0.0
    */
   def setConf(props: Properties): Unit = {
-    sessionState.conf.setConf(props)
+    runtimeConf.set(props)
   }
 
   /**
    * Set the given Spark SQL configuration property.
    */
   private[sql] def setConf[T](entry: ConfigEntry[T], value: T): Unit = {
-    sessionState.conf.setConf(entry, value)
+    runtimeConf.set(entry, value)
   }
 
   /**
@@ -132,7 +132,7 @@ class SQLContext private[sql](
    * @since 1.0.0
    */
   def setConf(key: String, value: String): Unit = {
-    sparkSession.conf.set(key, value)
+    runtimeConf.set(key, value)
   }
 
   /**
@@ -142,7 +142,7 @@ class SQLContext private[sql](
    * @since 1.0.0
    */
   def getConf(key: String): String = {
-    sparkSession.conf.get(key)
+    runtimeConf.get(key)
   }
 
   /**
@@ -153,7 +153,7 @@ class SQLContext private[sql](
    * @since 1.0.0
    */
   def getConf(key: String, defaultValue: String): String = {
-    sparkSession.conf.get(key, defaultValue)
+    runtimeConf.get(key, defaultValue)
   }
 
   /**
@@ -164,7 +164,7 @@ class SQLContext private[sql](
    * @since 1.0.0
    */
   def getAllConfs: immutable.Map[String, String] = {
-    sparkSession.conf.getAll
+    runtimeConf.getAll
   }
 
   protected[sql] def parseSql(sql: String): LogicalPlan = sparkSession.parseSql(sql)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -50,7 +50,7 @@ case class SortExec(
   override def requiredChildDistribution: Seq[Distribution] =
     if (global) OrderedDistribution(sortOrder) :: Nil else UnspecifiedDistribution :: Nil
 
-  private val enableRadixSort = sqlContext.conf.enableRadixSort
+  private val enableRadixSort = sqlContext.sessionState.conf.enableRadixSort
 
   override private[sql] lazy val metrics = Map(
     "sortTime" -> SQLMetrics.createTimingMetric(sparkContext, "sort time"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -58,7 +58,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   // the value of subexpressionEliminationEnabled will be set by the deserializer after the
   // constructor has run.
   val subexpressionEliminationEnabled: Boolean = if (sqlContext != null) {
-    sqlContext.conf.subexpressionEliminationEnabled
+    sqlContext.sessionState.conf.subexpressionEliminationEnabled
   } else {
     false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -478,7 +478,7 @@ case class TungstenAggregate(
       .forall(!DecimalType.isByteArrayDecimalType(_))
 
     isSupported  && isNotByteArrayDecimalType &&
-      schemaLength <= sqlContext.conf.vectorizedAggregateMapMaxColumns
+      schemaLength <= sqlContext.sessionState.conf.vectorizedAggregateMapMaxColumns
   }
 
   private def doProduceWithKeys(ctx: CodegenContext): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -105,7 +105,7 @@ private[sql] case class InMemoryRelation(
       if (batchStats.value.isEmpty) {
         // Underlying columnar RDD hasn't been materialized, no useful statistics information
         // available, return the default statistics.
-        Statistics(sizeInBytes = child.sqlContext.conf.defaultSizeInBytes)
+        Statistics(sizeInBytes = child.sqlContext.sessionState.conf.defaultSizeInBytes)
       } else {
         // Underlying columnar RDD has been materialized, required information has also been
         // collected via the `batchStats` accumulator, compute the final statistics,
@@ -292,7 +292,8 @@ private[sql] case class InMemoryTableScanExec(
   lazy val readPartitions: Accumulator[Int] = sparkContext.accumulator(0)
   lazy val readBatches: Accumulator[Int] = sparkContext.accumulator(0)
 
-  private val inMemoryPartitionPruningEnabled = sqlContext.conf.inMemoryPartitionPruning
+  private val inMemoryPartitionPruningEnabled =
+    sqlContext.sessionState.conf.inMemoryPartitionPruning
 
   protected override def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -392,7 +392,7 @@ private[sql] class DefaultSource
       dataSchema: StructType,
       options: Map[String, String]): OutputWriterFactory = {
     new ParquetOutputWriterFactory(
-      sqlContext.conf,
+      sqlContext.sessionState.conf,
       dataSchema,
       sqlContext.sparkContext.hadoopConfiguration,
       options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -53,7 +53,7 @@ case class BroadcastExchangeExec(
 
   @transient
   private val timeout: Duration = {
-    val timeoutValue = sqlContext.conf.broadcastTimeout
+    val timeoutValue = sqlContext.sessionState.conf.broadcastTimeout
     if (timeoutValue < 0) {
       Duration.Inf
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -92,7 +92,7 @@ class FileStreamSinkWriter(
     options: Map[String, String]) extends Serializable with Logging {
 
   PartitioningUtils.validatePartitionColumnDataTypes(
-    data.schema, partitionColumnNames, data.sqlContext.conf.caseSensitiveAnalysis)
+    data.schema, partitionColumnNames, data.sqlContext.sessionState.conf.caseSensitiveAnalysis)
 
   private val serializableConf = new SerializableConfiguration(hadoopConf)
   private val dataSchema = data.schema

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -196,7 +196,7 @@ abstract class BaseRelation {
    *
    * @since 1.3.0
    */
-  def sizeInBytes: Long = sqlContext.conf.defaultSizeInBytes
+  def sizeInBytes: Long = sqlContext.sessionState.conf.defaultSizeInBytes
 
   /**
    * Whether does it need to convert the objects in Row to internal representation, for example:

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1042,7 +1042,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   }
 
   test("SET commands semantics using sql()") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     val testKey = "test.key.0"
     val testVal = "test.val.0"
     val nonexistentKey = "nonexistent"
@@ -1083,17 +1083,17 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql(s"SET $nonexistentKey"),
       Row(nonexistentKey, "<undefined>")
     )
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
   }
 
   test("SET commands with illegal or inappropriate argument") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     // Set negative mapred.reduce.tasks for automatically determining
     // the number of reducers is not supported
     intercept[IllegalArgumentException](sql(s"SET mapred.reduce.tasks=-1"))
     intercept[IllegalArgumentException](sql(s"SET mapred.reduce.tasks=-01"))
     intercept[IllegalArgumentException](sql(s"SET mapred.reduce.tasks=-2"))
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
   }
 
   test("apply schema") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -17,12 +17,14 @@
 
 package org.apache.spark.sql
 
+import org.scalatest.BeforeAndAfterEach
+
 import org.apache.spark.{SparkContext, SparkFunSuite}
 
 /**
  * Test cases for the builder pattern of [[SparkSession]].
  */
-class SparkSessionBuilderSuite extends SparkFunSuite {
+class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   private var initialSession: SparkSession = _
 
@@ -35,9 +37,13 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     initialSession.sparkContext
   }
 
-  test("create with config options and propagate them to SparkContext and SparkSession") {
+  override def beforeEach() {
+    super.beforeEach()
     // Creating a new session with config - this works by just calling the lazy val
     sparkContext
+  }
+
+  test("create with config options and propagate them to SparkContext and SparkSession") {
     assert(initialSession.sparkContext.conf.get("some-config") == "v2")
     assert(initialSession.conf.get("some-config") == "v2")
     SparkSession.clearDefaultSession()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -129,7 +129,7 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
         sql(s"CREATE DATABASE db2")
         val pathInCatalog = new Path(catalog.getDatabaseMetadata("db2").locationUri).toUri
         assert("file" === pathInCatalog.getScheme)
-        val expectedPath = appendTrailingSlash(sqlContext.conf.warehousePath) + "db2.db"
+        val expectedPath = appendTrailingSlash(spark.conf.get(SQLConf.WAREHOUSE_PATH)) + "db2.db"
         assert(expectedPath === pathInCatalog.getPath)
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -129,7 +129,8 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
         sql(s"CREATE DATABASE db2")
         val pathInCatalog = new Path(catalog.getDatabaseMetadata("db2").locationUri).toUri
         assert("file" === pathInCatalog.getScheme)
-        val expectedPath = appendTrailingSlash(spark.conf.get(SQLConf.WAREHOUSE_PATH)) + "db2.db"
+        val expectedPath =
+          appendTrailingSlash(sqlContext.sessionState.conf.warehousePath) + "db2.db"
         assert(expectedPath === pathInCatalog.getPath)
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -35,7 +35,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     // Set a conf first.
     spark.conf.set(testKey, testVal)
     // Clear the conf.
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     // After clear, only overrideConfs used by unit test should be in the SQLConf.
     assert(spark.conf.getAll === TestSQLContext.overrideConfs)
 
@@ -50,11 +50,11 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     assert(spark.conf.get(testKey, testVal + "_") === testVal)
     assert(spark.conf.getAll.contains(testKey))
 
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
   }
 
   test("parse SQL set commands") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     sql(s"set $testKey=$testVal")
     assert(spark.conf.get(testKey, testVal + "_") === testVal)
     assert(spark.conf.get(testKey, testVal + "_") === testVal)
@@ -72,7 +72,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     sql(s"set $key=")
     assert(spark.conf.get(key, "0") === "")
 
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
   }
 
   test("set command for display") {
@@ -97,7 +97,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("deprecated property") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     val original = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS)
     try{
       sql(s"set ${SQLConf.Deprecated.MAPRED_REDUCE_TASKS}=10")
@@ -108,7 +108,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("invalid conf value") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     val e = intercept[IllegalArgumentException] {
       sql(s"set ${SQLConf.CASE_SENSITIVE.key}=10")
     }
@@ -116,7 +116,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("Test SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE's method") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
 
     spark.conf.set(SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key, "100")
     assert(spark.conf.get(SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE) === 100)
@@ -144,7 +144,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
       spark.conf.set(SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key, "-90000000000g")
     }
 
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
   }
 
   test("SparkSession can access configs set in SparkConf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -108,7 +108,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("reset - public conf") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
     try {
       assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
@@ -124,7 +124,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("reset - internal conf") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     val original = spark.conf.get(SQLConf.NATIVE_VIEW)
     try {
       assert(spark.conf.get(SQLConf.NATIVE_VIEW) === true)
@@ -140,7 +140,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("reset - user-defined conf") {
-    spark.sqlContext.conf.clear()
+    spark.conf.clear()
     val userDefinedConf = "x.y.z.reset"
     try {
       assert(spark.conf.getOption(userDefinedConf).isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/FilteredScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/FilteredScanSuite.scala
@@ -310,7 +310,7 @@ class FilteredScanSuite extends DataSourceTest with SharedSQLContext with Predic
 
     test(s"PushDown Returns $expectedCount: $sqlString") {
       // These tests check a particular plan, disable whole stage codegen.
-      caseInsensitiveContext.conf.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED, false)
+      caseInsensitiveContext.runtimeConf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED, false)
       try {
         val queryExecution = sql(sqlString).queryExecution
         val rawPlan = queryExecution.executedPlan.collect {
@@ -337,7 +337,7 @@ class FilteredScanSuite extends DataSourceTest with SharedSQLContext with Predic
               queryExecution)
         }
       } finally {
-        caseInsensitiveContext.conf.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED,
+        caseInsensitiveContext.runtimeConf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED,
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.defaultValue.get)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PrunedScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PrunedScanSuite.scala
@@ -122,7 +122,7 @@ class PrunedScanSuite extends DataSourceTest with SharedSQLContext {
     test(s"Columns output ${expectedColumns.mkString(",")}: $sqlString") {
 
       // These tests check a particular plan, disable whole stage codegen.
-      caseInsensitiveContext.conf.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED, false)
+      caseInsensitiveContext.runtimeConf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED, false)
       try {
         val queryExecution = sql(sqlString).queryExecution
         val rawPlan = queryExecution.executedPlan.collect {
@@ -145,7 +145,7 @@ class PrunedScanSuite extends DataSourceTest with SharedSQLContext {
           fail(s"Wrong output row. Got $rawOutput\n$queryExecution")
         }
       } finally {
-        caseInsensitiveContext.conf.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED,
+        caseInsensitiveContext.runtimeConf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED,
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.defaultValue.get)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
@@ -35,7 +35,7 @@ class SaveLoadSuite extends DataSourceTest with SharedSQLContext with BeforeAndA
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    originalDefaultSource = caseInsensitiveContext.conf.defaultDataSourceName
+    originalDefaultSource = caseInsensitiveContext.sessionState.conf.defaultDataSourceName
 
     path = Utils.createTempDir()
     path.delete()

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
@@ -47,7 +47,8 @@ class SaveLoadSuite extends DataSourceTest with SharedSQLContext with BeforeAndA
 
   override def afterAll(): Unit = {
     try {
-      caseInsensitiveContext.conf.setConf(SQLConf.DEFAULT_DATA_SOURCE_NAME, originalDefaultSource)
+      caseInsensitiveContext.runtimeConf.set(
+        SQLConf.DEFAULT_DATA_SOURCE_NAME, originalDefaultSource)
     } finally {
       super.afterAll()
     }
@@ -58,12 +59,12 @@ class SaveLoadSuite extends DataSourceTest with SharedSQLContext with BeforeAndA
   }
 
   def checkLoad(expectedDF: DataFrame = df, tbl: String = "jsonTable"): Unit = {
-    caseInsensitiveContext.conf.setConf(
+    caseInsensitiveContext.runtimeConf.set(
       SQLConf.DEFAULT_DATA_SOURCE_NAME, "org.apache.spark.sql.json")
     checkAnswer(caseInsensitiveContext.read.load(path.toString), expectedDF.collect())
 
     // Test if we can pick up the data source name passed in load.
-    caseInsensitiveContext.conf.setConf(SQLConf.DEFAULT_DATA_SOURCE_NAME, "not a source name")
+    caseInsensitiveContext.runtimeConf.set(SQLConf.DEFAULT_DATA_SOURCE_NAME, "not a source name")
     checkAnswer(caseInsensitiveContext.read.format("json").load(path.toString),
       expectedDF.collect())
     checkAnswer(caseInsensitiveContext.read.format("json").load(path.toString),
@@ -75,14 +76,14 @@ class SaveLoadSuite extends DataSourceTest with SharedSQLContext with BeforeAndA
   }
 
   test("save with path and load") {
-    caseInsensitiveContext.conf.setConf(
+    caseInsensitiveContext.runtimeConf.set(
       SQLConf.DEFAULT_DATA_SOURCE_NAME, "org.apache.spark.sql.json")
     df.write.save(path.toString)
     checkLoad()
   }
 
   test("save with string mode and path, and load") {
-    caseInsensitiveContext.conf.setConf(
+    caseInsensitiveContext.runtimeConf.set(
       SQLConf.DEFAULT_DATA_SOURCE_NAME, "org.apache.spark.sql.json")
     path.createNewFile()
     df.write.mode("overwrite").save(path.toString)
@@ -90,13 +91,13 @@ class SaveLoadSuite extends DataSourceTest with SharedSQLContext with BeforeAndA
   }
 
   test("save with path and datasource, and load") {
-    caseInsensitiveContext.conf.setConf(SQLConf.DEFAULT_DATA_SOURCE_NAME, "not a source name")
+    caseInsensitiveContext.runtimeConf.set(SQLConf.DEFAULT_DATA_SOURCE_NAME, "not a source name")
     df.write.json(path.toString)
     checkLoad()
   }
 
   test("save with data source and options, and load") {
-    caseInsensitiveContext.conf.setConf(SQLConf.DEFAULT_DATA_SOURCE_NAME, "not a source name")
+    caseInsensitiveContext.runtimeConf.set(SQLConf.DEFAULT_DATA_SOURCE_NAME, "not a source name")
     df.write.mode(SaveMode.ErrorIfExists).json(path.toString)
     checkLoad()
   }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -63,7 +63,7 @@ object HiveThriftServer2 extends Logging {
 
     server.init(executionHive.conf)
     server.start()
-    listener = new HiveThriftServer2Listener(server, sqlContext.conf)
+    listener = new HiveThriftServer2Listener(server, sqlContext.sessionState.conf)
     sqlContext.sparkContext.addSparkListener(listener)
     uiTab = if (sqlContext.sparkContext.getConf.getBoolean("spark.ui.enabled", true)) {
       Some(new ThriftServerTab(sqlContext.sparkContext))
@@ -94,7 +94,7 @@ object HiveThriftServer2 extends Logging {
       server.init(executionHive.conf)
       server.start()
       logInfo("HiveThriftServer2 started")
-      listener = new HiveThriftServer2Listener(server, SparkSQLEnv.sqlContext.conf)
+      listener = new HiveThriftServer2Listener(server, SparkSQLEnv.sqlContext.sessionState.conf)
       SparkSQLEnv.sparkContext.addSparkListener(listener)
       uiTab = if (SparkSQLEnv.sparkContext.getConf.getBoolean("spark.ui.enabled", true)) {
         Some(new ThriftServerTab(SparkSQLEnv.sparkContext))

--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -37,8 +37,8 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
 
   private val originalTimeZone = TimeZone.getDefault
   private val originalLocale = Locale.getDefault
-  private val originalColumnBatchSize = TestHive.conf.columnBatchSize
-  private val originalInMemoryPartitionPruning = TestHive.conf.inMemoryPartitionPruning
+  private val originalColumnBatchSize = TestHive.sessionState.conf.columnBatchSize
+  private val originalInMemoryPartitionPruning = TestHive.sessionState.conf.inMemoryPartitionPruning
   private val originalConvertMetastoreOrc = TestHive.sessionState.convertMetastoreOrc
 
   def testCases: Seq[(String, File)] = {


### PR DESCRIPTION
#### What changes were proposed in this pull request?

We introduced `RuntimeConfig` in `SQLContext` in the PR https://github.com/apache/spark/pull/12669. Now, `SQLContext` has both `conf` and `runtimeConf`. `SQLContext` is being replaced by `SparkSession`. Like `SparkSession`, we should not have two configuration interfaces. That means, we should not expose `conf` to external users.

This PR contains three major parts:
1. removed `conf` from `SQLContext`. 
2. added the missing functions into `RuntimeConfig`, including two `set` functions and one `clear` function.
3. fixed the test cases in `SparkSessionBuilderSuite.scala`. Without this fix, we are unable to individually run the test cases. All the test cases require `initialSession`.  

@rxin @andrewor14 @yhuai @cloud-fan  Do you think this PR is valid? Thanks!
#### How was this patch tested?

Existing test cases cover it.
