### PR TITLE
[MINOR] More than 100 chars in line in SparkSubmitCommandBuilderSuite

### DIFF
--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -67,7 +67,8 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     List<String> sparkEmptyArgs = Collections.emptyList();
     cmd = buildCommand(sparkEmptyArgs, env);
-    assertTrue("org.apache.spark.deploy.SparkSubmit should be contained in the final cmd of empty input.",
+    assertTrue(
+      "org.apache.spark.deploy.SparkSubmit should be contained in the final cmd of empty input.",
       cmd.contains("org.apache.spark.deploy.SparkSubmit"));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

More than 100 chars in line.
## How was this patch tested?
