### PR TITLE
[SPARK-15472][SQL][Streaming] Add support for partitioned `text` format in FileStreamSink

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -218,12 +218,15 @@ case class DataSource(
     providingClass.newInstance() match {
       case s: StreamSinkProvider => s.createSink(sparkSession.sqlContext, options, partitionColumns)
 
-      case parquet: parquet.DefaultSource =>
+      // TODO: Remove the `isInstanceOf` check when other formats have been ported
+      case fileFormat: FileFormat
+          if fileFormat.isInstanceOf[parquet.DefaultSource]
+          || fileFormat.isInstanceOf[text.DefaultSource] =>
         val caseInsensitiveOptions = new CaseInsensitiveMap(options)
         val path = caseInsensitiveOptions.getOrElse("path", {
           throw new IllegalArgumentException("'path' is not specified")
         })
-        new FileStreamSink(sparkSession, path, parquet, partitionColumns, options)
+        new FileStreamSink(sparkSession, path, fileFormat, partitionColumns, options)
 
       case _ =>
         throw new UnsupportedOperationException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -494,8 +494,8 @@ private[sql] class ParquetOutputWriterFactory(
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
     throw new UnsupportedOperationException(
-      "this verison of newInstance not supported for " +
-        "ParquetOutputWriterFactory")
+      "this version of newInstance is not supported for " +
+        classOf[ParquetOutputWriterFactory].getSimpleName)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/DefaultSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/DefaultSource.scala
@@ -20,14 +20,16 @@ package org.apache.spark.sql.execution.datasources.text
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.io.{NullWritable, Text}
-import org.apache.hadoop.mapreduce.{Job, RecordWriter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 
-import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{BufferHolder, UnsafeRowWriter}
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.SerializableConfiguration
@@ -38,6 +40,8 @@ import org.apache.spark.util.SerializableConfiguration
 class DefaultSource extends FileFormat with DataSourceRegister {
 
   override def shortName(): String = "text"
+
+  override def toString: String = "Text"
 
   private def verifySchema(schema: StructType): Unit = {
     if (schema.size != 1) {
@@ -108,6 +112,17 @@ class DefaultSource extends FileFormat with DataSourceRegister {
       }
     }
   }
+
+  override def buildWriter(
+      sqlContext: SQLContext,
+      dataSchema: StructType,
+      options: Map[String, String]): OutputWriterFactory = {
+    new TextOutputWriterFactory(
+      sqlContext.conf,
+      dataSchema,
+      sqlContext.sparkContext.hadoopConfiguration,
+      options)
+  }
 }
 
 class TextOutputWriter(path: String, dataSchema: StructType, context: TaskAttemptContext)
@@ -137,5 +152,72 @@ class TextOutputWriter(path: String, dataSchema: StructType, context: TaskAttemp
 
   override def close(): Unit = {
     recordWriter.close(context)
+  }
+}
+
+/**
+ * A factory for generating [[OutputWriter]]s for writing text files. This implemented is different
+ * from the [[TextOutputWriter]] as this does not use any [[OutputCommitter]]. It simply
+ * writes the data to the path used to generate the output writer. Callers of this factory
+ * has to ensure which files are to be considered as committed.
+ */
+private[sql] class TextOutputWriterFactory(
+    sqlConf: SQLConf,
+    dataSchema: StructType,
+    hadoopConf: Configuration,
+    options: Map[String, String]) extends OutputWriterFactory {
+
+  private val serializableConf =
+    new SerializableConfiguration(Job.getInstance(hadoopConf).getConfiguration)
+
+  /**
+   * Returns a [[OutputWriter]] that writes data to the give path without using an
+   * [[OutputCommitter]].
+   */
+  override private[sql] def newWriter(path: String): OutputWriter = new OutputWriter {
+
+    private val hadoopTaskAttempId = new TaskAttemptID(new TaskID(new JobID, TaskType.MAP, 0), 0)
+    private val hadoopAttemptContext =
+      new TaskAttemptContextImpl(serializableConf.value, hadoopTaskAttempId)
+
+    // Instance of RecordWriter that does not use OutputCommitter
+    private val recordWriter = createNoCommitterRecordWriter(path, hadoopAttemptContext)
+
+    private[this] val buffer = new Text()
+
+    override def write(row: Row): Unit = {
+      throw new UnsupportedOperationException("call writeInternal")
+    }
+
+    protected[sql] override def writeInternal(row: InternalRow): Unit = {
+      val utf8string = row.getUTF8String(0)
+      buffer.set(utf8string.getBytes)
+      recordWriter.write(NullWritable.get(), buffer)
+    }
+
+    override def close(): Unit = recordWriter.close(hadoopAttemptContext)
+  }
+
+  /** Create a [[RecordWriter]] that writes the given path without using an [[OutputCommitter]]. */
+  private def createNoCommitterRecordWriter(
+      path: String,
+      hadoopAttemptContext: TaskAttemptContext): RecordWriter[NullWritable, Text] = {
+    // Custom TextOutputFormat that disable use of committer and writes to the given path
+    val outputFormat = new TextOutputFormat[NullWritable, Text]() {
+      override def getOutputCommitter(c: TaskAttemptContext): OutputCommitter = { null }
+      override def getDefaultWorkFile(c: TaskAttemptContext, ext: String): Path = { new Path(path) }
+    }
+    outputFormat.getRecordWriter(hadoopAttemptContext)
+  }
+
+  /** Disable the use of the older API. */
+  def newInstance(
+      path: String,
+      bucketId: Option[Int],
+      dataSchema: StructType,
+      context: TaskAttemptContext): OutputWriter = {
+    throw new UnsupportedOperationException(
+      "this version of newInstance is not supported for " +
+        classOf[TextOutputWriterFactory].getSimpleName)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -40,11 +40,11 @@ object FileStreamSink {
 }
 
 /**
- * A sink that writes out results to parquet files.  Each batch is written out to a unique
- * directory. After all of the files in a batch have been successfully written, the list of
- * file paths is appended to the log atomically. In the case of partial failures, some duplicate
- * data may be present in the target directory, but only one copy of each file will be present
- * in the log.
+ * A sink that writes out results to files on a HDFS-compatible file system. Each batch is written
+ * out to a unique directory. After all of the files in a batch have been successfully written, the
+ * list of file paths is appended to the log atomically. In the case of partial failures, some
+ * duplicate data may be present in the target directory, but only one copy of each file will be
+ * present in the log.
  */
 class FileStreamSink(
     sparkSession: SparkSession,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds support for partitioned `text` format in FileStreamSink.

Specifically, this patch adds a new `TextOutputWriterFactory`, which would return an `OutputWriter` writing data without using an `OutputCommitter`.

 This is the same manner employed by [SPARK-14716](https://github.com/apache/spark/pull/12409) in which we had added support for partitioned `parquet` format.
## How was this patch tested?

The `FileStreamSinkSuite` is expanded to cover tests added for the partitioned `text` format.
