### PR TITLE
[SPARK-15475][SQL] Add tests for writing and reading back empty data for Parquet, Json and Text data sources

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -126,6 +126,22 @@ class TextSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("Write and read back empty data") {
+    withTempPath { path =>
+      val df = spark.read.format("text").load(testFile)
+      val emptyDf = df.limit(0)
+      emptyDf.write
+        .format("text")
+        .save(path.getCanonicalPath)
+
+      val copyEmptyDf = spark.read
+        .format("text")
+        .load(path.getCanonicalPath)
+
+      checkAnswer(emptyDf, copyEmptyDf)
+    }
+  }
+
   private def testFile: String = {
     Thread.currentThread().getContextClassLoader.getResource("text-suite.txt").toString
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/JsonHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/JsonHadoopFsRelationSuite.scala
@@ -108,4 +108,19 @@ class JsonHadoopFsRelationSuite extends HadoopFsRelationTest {
       )
     }
   }
+
+  test("Write and read back empty data") {
+    withTempPath { path =>
+      val emptyDf = spark.range(10).limit(0).toDF()
+      emptyDf.write
+        .format(dataSourceName)
+        .save(path.getCanonicalPath)
+
+      val copyEmptyDf = spark.read
+        .format(dataSourceName)
+        .load(path.getCanonicalPath)
+
+      assert(copyEmptyDf.count() === 0)
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
@@ -228,4 +228,20 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
       }
     }
   }
+
+
+  test("Write and read back empty data") {
+    withTempPath { path =>
+      val emptyDf = spark.range(10).limit(0).toDF()
+      emptyDf.write
+        .format(dataSourceName)
+        .save(path.getCanonicalPath)
+
+      val copyEmptyDf = spark.read
+        .format(dataSourceName)
+        .load(path.getCanonicalPath)
+
+      checkAnswer(emptyDf, copyEmptyDf)
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
@@ -229,7 +229,6 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
     }
   }
 
-
   test("Write and read back empty data") {
     withTempPath { path =>
       val emptyDf = spark.range(10).limit(0).toDF()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
@@ -88,4 +88,20 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
       assert(SimpleTextRelation.lastHadoopConf.get.get("some-random-read-option") == "hahah-READ")
     }
   }
+
+  test("Write and read back empty data") {
+    withTempPath { path =>
+      val emptyDf = spark.range(10).limit(0).toDF()
+      emptyDf.write
+        .format(dataSourceName)
+        .save(path.getCanonicalPath)
+
+      val copyEmptyDf = spark.read
+        .format(dataSourceName)
+        .option("dataSchema", emptyDf.schema.json)
+        .load(path.getCanonicalPath)
+
+      checkAnswer(emptyDf, copyEmptyDf)
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
@@ -88,20 +88,4 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
       assert(SimpleTextRelation.lastHadoopConf.get.get("some-random-read-option") == "hahah-READ")
     }
   }
-
-  test("Write and read back empty data") {
-    withTempPath { path =>
-      val emptyDf = spark.range(10).limit(0).toDF()
-      emptyDf.write
-        .format(dataSourceName)
-        .save(path.getCanonicalPath)
-
-      val copyEmptyDf = spark.read
-        .format(dataSourceName)
-        .option("dataSchema", emptyDf.schema.json)
-        .load(path.getCanonicalPath)
-
-      checkAnswer(emptyDf, copyEmptyDf)
-    }
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the tests for writing and reading back empty data for Parquet, JSON and Text data sources.

The tests were not added in `HadoopFsRelationTest` because each test is a little bit different due to the differences among those data sources.
- JSON dose not write schema when it is empty.
- TEXT needs a `dataSchema` option
- Parquet writes schema when it is empty.
## How was this patch tested?

Unit tests in `ParquetHadoopFsRelationSuite`, `JsonHadoopFsRelationSuite`and `SimpleTextHadoopFsRelationSuite`.
