### PR TITLE
[SPARK-15476][SQL] Support for reading text data source without specifying schema

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
@@ -515,8 +515,6 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
         .save(subdir.getCanonicalPath)
 
       // Inferring schema should throw error as it should not find any file to infer
-      // Currently, text data source has the default schema with
-      // the string type column with the name `_c0`.
       val e = intercept[Exception] {
         spark.read.format(dataSourceName).load(dir.getCanonicalPath)
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
@@ -68,18 +68,18 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
 
   test("Support for the default schema if the schema is not given") {
     withTempPath { path =>
-      val emptyDf = spark.range(10)toDF()
-      emptyDf.write
+      val df = spark.range(10)toDF()
+      df.write
         .format(dataSourceName)
         .save(path.getCanonicalPath)
 
-      val copyEmptyDf = spark.read
+      val copyDf = spark.read
         .format(dataSourceName)
         .load(path.getCanonicalPath)
 
       val expected = StructType(
         StructField("_c0", StringType, nullable = true) :: Nil)
-      assert(copyEmptyDf.schema === expected)
+      assert(copyDf.schema === expected)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
@@ -66,6 +66,23 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
     }
   }
 
+  test("Support for the default schema if the schema is not given") {
+    withTempPath { path =>
+      val emptyDf = spark.range(10)toDF()
+      emptyDf.write
+        .format(dataSourceName)
+        .save(path.getCanonicalPath)
+
+      val copyEmptyDf = spark.read
+        .format(dataSourceName)
+        .load(path.getCanonicalPath)
+
+      val expected = StructType(
+        StructField("_c0", StringType, nullable = true) :: Nil)
+      assert(copyEmptyDf.schema === expected)
+    }
+  }
+
   test("test hadoop conf option propagation") {
     withTempPath { file =>
       // Test write side

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
@@ -21,13 +21,16 @@ import java.text.NumberFormat
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.hadoop.io.{NullWritable, Text}
+import org.apache.hadoop.io.{LongWritable, NullWritable, Text}
+import org.apache.hadoop.mapred.{JobConf, TextInputFormat}
 import org.apache.hadoop.mapreduce.{Job, RecordWriter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.hadoop.mapreduce.lib.output.{FileOutputFormat, TextOutputFormat}
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{sources, Row, SparkSession}
 import org.apache.spark.sql.catalyst.{expressions, InternalRow}
-import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, InterpretedPredicate, InterpretedProjection, JoinedRow, Literal}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.types.{DataType, StringType, StructField, StructType}
@@ -40,10 +43,39 @@ class SimpleTextSource extends FileFormat with DataSourceRegister {
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    val schema = options.get("dataSchema")
-      .map(DataType.fromJson(_).asInstanceOf[StructType])
-      .getOrElse(StructType(StructField("_c0", StringType, nullable = true) :: Nil))
+    val schema = if (options.contains("dataSchema")) {
+      DataType.fromJson(options("dataSchema")).asInstanceOf[StructType]
+    } else {
+      val firstRow = baseRDD(sparkSession, files).take(1).headOption.orNull
+      val fields = firstRow.split(",", -1).zipWithIndex.map { case (_, index) =>
+        StructField(s"_c$index", StringType, nullable = true)
+      }
+      StructType(fields)
+    }
     Some(schema)
+  }
+
+  private def baseRDD(
+      sparkSession: SparkSession,
+      files: Seq[FileStatus]): RDD[String] = {
+    val textFiles = files.filterNot { status =>
+      val name = status.getPath.getName
+      name.startsWith("_") || name.startsWith(".")
+    }.toArray
+
+    val job = Job.getInstance(sparkSession.sessionState.newHadoopConf())
+    val conf = job.getConfiguration
+    val paths = textFiles.map(_.getPath)
+
+    if (paths.nonEmpty) {
+      FileInputFormat.setInputPaths(job, paths: _*)
+    }
+
+    sparkSession.sparkContext.hadoopRDD(
+      conf.asInstanceOf[JobConf],
+      classOf[TextInputFormat],
+      classOf[LongWritable],
+      classOf[Text]).map(_._2.toString)
   }
 
   override def prepareWrite(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
@@ -59,7 +59,6 @@ class SimpleTextSource extends FileFormat with DataSourceRegister {
         }
         StructType(fields)
       }
-
       Some(schema)
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.{expressions, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, InterpretedPredicate, InterpretedProjection, JoinedRow, Literal}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.types.{DataType, StringType, StructField, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
 class SimpleTextSource extends FileFormat with DataSourceRegister {
@@ -40,7 +40,10 @@ class SimpleTextSource extends FileFormat with DataSourceRegister {
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    Some(DataType.fromJson(options("dataSchema")).asInstanceOf[StructType])
+    val schema = options.get("dataSchema")
+      .map(DataType.fromJson(_).asInstanceOf[StructType])
+      .getOrElse(StructType(StructField("_c0", StringType, nullable = true) :: Nil))
+    Some(schema)
   }
 
   override def prepareWrite(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextRelation.scala
@@ -47,11 +47,16 @@ class SimpleTextSource extends FileFormat with DataSourceRegister {
       DataType.fromJson(options("dataSchema")).asInstanceOf[StructType]
     } else {
       val firstRow = baseRDD(sparkSession, files).take(1).headOption.orNull
-      val fields = firstRow.split(",", -1).zipWithIndex.map { case (_, index) =>
-        StructField(s"_c$index", StringType, nullable = true)
+      val fields: Seq[StructField] = if (firstRow != null) {
+        firstRow.split(",", -1).zipWithIndex.map { case (_, index) =>
+          StructField(s"_c$index", StringType, nullable = true)
+        }
+      } else {
+        Seq.empty[StructField]
       }
       StructType(fields)
     }
+
     Some(schema)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Text data source requires a schema.

So the codes below:

``` scala
emptyDf.write
  .format("test")
  .save(path.getCanonicalPath)

val copyEmptyDf = spark.read
  .format("test")
  .load(path.getCanonicalPath)

copyEmptyDf.show()
```

throws an exception below:

``` scala
key not found: dataSchema
java.util.NoSuchElementException: key not found: dataSchema
    at scala.collection.MapLike$class.default(MapLike.scala:228)
    at org.apache.spark.sql.execution.datasources.CaseInsensitiveMap.default(ddl.scala:139)
    at scala.collection.MapLike$class.apply(MapLike.scala:141)
    at org.apache.spark.sql.execution.datasources.CaseInsensitiveMap.apply(ddl.scala:139)
    at org.apache.spark.sql.sources.SimpleTextSource.inferSchema(SimpleTextRelation.scala:43)
    at org.apache.spark.sql.execution.datasources.DataSource$$anonfun$15.apply(DataSource.scala:347)
    at org.apache.spark.sql.execution.datasources.DataSource$$anonfun$15.apply(DataSource.scala:347)
    at scala.Option.orElse(Option.scala:289)
```

This PR adds the support for a default schema with unnamed columns just like CSV data sources.
## How was this patch tested?

Unit test in `SimpleTextHadoopFsRelationSuite`.
