### PR TITLE
[SPARK-15474][SQL]ORC data source fails to write and read back empty dataframe

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
@@ -211,7 +211,7 @@ private[orc] class OrcOutputWriter(
   // flag to decide whether `OrcRecordWriter.close()` needs to be called.
   private var recordWriterInstantiated = false
 
-  private lazy val recordWriter: RecordWriter[NullWritable, Writable] = {
+  private val recordWriter: RecordWriter[NullWritable, Writable] = {
     recordWriterInstantiated = true
     val uniqueWriteJobId = conf.get("spark.sql.sources.writeJobUUID")
     val taskAttemptId = context.getTaskAttemptID

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.test.TestHive._
 import org.apache.spark.sql.hive.test.TestHive.implicits._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
 
 case class AllDataTypesWithNonPrimitiveType(
     stringField: String,
@@ -93,6 +94,12 @@ class OrcQuerySuite extends QueryTest with BeforeAndAfterAll with OrcTest {
       checkAnswer(
         read.orc(file),
         data.toDF().collect())
+    }
+  }
+
+  test("Read/write empty dataset") {
+    withOrcFile(Seq.empty[Tuple1[Int]]) { file =>
+      assert(new StructType() === spark.read.orc(file).schema)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently ORC data source fails to write and read empty data.
This PR provides a fix for this issue.
## How was this patch tested?

unit tests
