### PR TITLE
[SPARK-15480][UI][Streaming]show missed InputInfo in streaming UI

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.streaming.scheduler
 
+import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 import org.apache.spark.SparkEnv
@@ -76,6 +77,10 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
 
   // last batch whose completion,checkpointing and metadata cleanup has been completed
   private var lastProcessedBatch: Time = null
+
+  // On some batch time, a JobSet with no jobs will be submit. We record such batch time here in
+  // order to correct the input info of later jobSet with jobs.
+  private var batchTimesWithNoJob: mutable.HashSet[Time] = mutable.HashSet[Time]()
 
   /** Start generation of jobs */
   def start(): Unit = synchronized {
@@ -249,7 +254,15 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
       graph.generateJobs(time) // generate jobs using allocated block
     } match {
       case Success(jobs) =>
-        val streamIdToInputInfos = jobScheduler.inputInfoTracker.getInfo(time)
+        val streamIdToInputInfos = if (jobs.isEmpty) {
+          batchTimesWithNoJob.add(time)
+          Map.empty[Int, StreamInputInfo]
+        } else {
+          batchTimesWithNoJob.add(time)
+          val inputInfo = jobScheduler.inputInfoTracker.getInfo(batchTimesWithNoJob)
+          batchTimesWithNoJob.clear()
+          inputInfo
+        }
         jobScheduler.submitJobSet(JobSet(time, jobs, streamIdToInputInfos))
       case Failure(e) =>
         jobScheduler.reportError("Error generating jobs for time " + time, e)

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -21,6 +21,7 @@ import java.util.Properties
 import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.HashSet
 import scala.util.Failure
 
 import org.apache.commons.lang.SerializationUtils
@@ -63,6 +64,8 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
   private var executorAllocationManager: Option[ExecutorAllocationManager] = None
 
   private var eventLoop: EventLoop[JobSchedulerEvent] = null
+
+  private val inputInfoMissedTimes = HashSet[Time]()
 
   def start(): Unit = synchronized {
     if (eventLoop != null) return // scheduler has already been started
@@ -139,6 +142,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
   def submitJobSet(jobSet: JobSet) {
     if (jobSet.jobs.isEmpty) {
       logInfo("No jobs added for time " + jobSet.time)
+      inputInfoMissedTimes.add(jobSet.time)
     } else {
       listenerBus.post(StreamingListenerBatchSubmitted(jobSet.toBatchInfo))
       jobSets.put(jobSet.time, jobSet)
@@ -193,6 +197,14 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
     listenerBus.post(StreamingListenerOutputOperationCompleted(job.toOutputOperationInfo))
     logInfo("Finished job " + job.id + " from job set of time " + jobSet.time)
     if (jobSet.hasCompleted) {
+      // submit fake BatchCompleted event to show missing inputInfo on Streaming UI
+      inputInfoMissedTimes.foreach (time => {
+        val streamIdToInputInfos = inputInfoTracker.getInfo(time)
+        val fakeJobSet = JobSet(time, Seq(), streamIdToInputInfos)
+        listenerBus.post(StreamingListenerBatchCompleted(fakeJobSet.toBatchInfo))
+      })
+      inputInfoMissedTimes.clear()
+
       jobSets.remove(jobSet.time)
       jobGenerator.onBatchCompletion(jobSet.time)
       logInfo("Total delay: %.3f s for time %s (execution: %.3f s)".format(

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobSet.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobSet.scala
@@ -50,7 +50,7 @@ case class JobSet(
 
   def hasStarted: Boolean = processingStartTime > 0
 
-  def hasCompleted: Boolean = incompleteJobs.isEmpty
+  def hasCompleted: Boolean = incompleteJobs.isEmpty && processingStartTime >= 0
 
   // Time taken to process all the jobs from the time they started processing
   // (i.e. not including the time they wait in the streaming scheduler queue)


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's a bug in Streaming UI. If BatchDuration is changed by window operation, InputInfo on time with no output ops will not be shown in streaming UI.

Here is a simple example to reproduce:

``` scala
val inputDStream = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](ssc, kafkaParam, topic)
val matchedDStream = inputDStream.window(batchInteval*2, batchInteval*2)
matchedDStream.foreachRDD(rdd => {
    val count = rdd.count()
    println(s"2 count number: ${count}")
})
```
## How was this patch tested?

manually tested

I manually input 6 records from Kafka. According to output, there are indeed 6 records processed
![output](https://cloud.githubusercontent.com/assets/13216322/15495140/e1f63e10-21c0-11e6-8156-f0e9694459c2.png)

but according to web UI,  input records show 0.
![original](https://cloud.githubusercontent.com/assets/13216322/15495079/82de34a0-21c0-11e6-9422-f922dff98da6.png)

**And here is the Screenshot after my change:**
![newresult](https://cloud.githubusercontent.com/assets/13216322/15702063/6bcd7aa4-2810-11e6-881e-cffed9b84acc.png)
