### PR TITLE
[SPARK-11959] [SPARK-15484] [Doc] [ML] Document WLS and IRLS

### DIFF
--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -32,7 +32,7 @@ algorithm in the family of quasi-Newton methods to solve the optimization proble
 `$\min_{\wv \in\R^d} \; f(\wv)$`. The L-BFGS method approximates the objective function locally as a 
 quadratic without evaluating the second partial derivatives of the objective function to construct the 
 Hessian matrix. The Hessian matrix is approximated by previous gradient evaluations, so there is no 
-vertical scalability issue (the number of training features) when computing the Hessian matrix 
+vertical scalability issue (the number of training features) unlike computing the Hessian matrix 
 explicitly in Newton's method. As a result, L-BFGS often achieves faster convergence compared with 
 other first-order optimizations.
 
@@ -45,11 +45,11 @@ L-BFGS is used as a solver for [LinearRegression](api/scala/index.html#org.apach
 [AFTSurvivalRegression](api/scala/index.html#org.apache.spark.ml.regression.AFTSurvivalRegression)
 and [MultilayerPerceptronClassifier](api/scala/index.html#org.apache.spark.ml.classification.MultilayerPerceptronClassifier).
 
-The `spark.ml` L-BFGS solver calls the corresponding implementation in [breeze](https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/optimize/LBFGS.scala).
+MLlib L-BFGS solver calls the corresponding implementation in [breeze](https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/optimize/LBFGS.scala).
 
 ## Normal equation solver for weighted least squares (normal)
 
-`spark.ml` implements normal equation solver for weighted least squares by [WeightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala).
+MLlib implements normal equation solver for [weighted least squares](https://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares) by [WeightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala).
 
 Given $n$ weighted observations $(w_i, a_i, b_i)$:
 
@@ -69,11 +69,11 @@ Unlike the original dataset which can only be stored in distributed system,
 these statistics can be easily loaded into memory on a single machine, and then we can solve the objective function through Cholesky factorization on the driver.
 
 WeightedLeastSquares only supports L2 regularization and provides options to enable or disable regularization, standardizing features and labels.
-In order to take the normal equation approach efficiently, WeightedLeastSquares only supports the number of features is no more than 4096.
+In order to take the normal equation approach efficiently, WeightedLeastSquares requires that the number of features be no more than 4096. For larger problems, use L-BFGS instead.
 
 ## Iteratively re-weighted least squares (IRLS)
 
-`spark.ml` implements iteratively reweighted least squares (IRLS) by [IterativelyReweightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala).
+MLlib implements [iteratively reweighted least squares (IRLS)](https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares) by [IterativelyReweightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala).
 It can be used to find the maximum likelihood estimates of a generalized linear model (GLM), find M-estimator in robust regression and other optimization problems.
 Refer to [Iteratively Reweighted Least Squares for Maximum Likelihood Estimation, and some Robust and Resistant Alternatives](http://www.jstor.org/stable/2345503) for more information.
 
@@ -83,6 +83,6 @@ It solves certain optimization problems iteratively:
 * solve a weighted least squares (WLS) problem by WeightedLeastSquares.
 * repeat above steps until convergence.
 
-Due to it involves solving a weighted least squares (WLS) problem by WeightedLeastSquares in each step of the iteration,
-it also only supports the number of features is no more than 4096.
-Currently IRLS was used as the default solver of [GeneralizedLinearRegression](api/scala/index.html#org.apache.spark.ml.regression.GeneralizedLinearRegression).
+Since it involves solving a weighted least squares (WLS) problem by WeightedLeastSquares in each iteration,
+it also requires the number of features to be no more than 4096.
+Currently IRLS is used as the default solver of [GeneralizedLinearRegression](api/scala/index.html#org.apache.spark.ml.regression.GeneralizedLinearRegression).

--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -47,7 +47,7 @@ and [MultilayerPerceptronClassifier](api/scala/index.html#org.apache.spark.ml.cl
 
 MLlib L-BFGS solver calls the corresponding implementation in [breeze](https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/optimize/LBFGS.scala).
 
-## Normal equation solver for weighted least squares (normal)
+## Normal equation solver for weighted least squares
 
 MLlib implements normal equation solver for [weighted least squares](https://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares) by [WeightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala).
 
@@ -61,12 +61,12 @@ The number of features for each observation is $m$. We use the following weighte
 `\[   
 minimize_{x}\frac{1}{2} \sum_{i=1}^n \frac{w_i(a_i^T x -b_i)^2}{\sum_{k=1}^n w_k} + \frac{1}{2}\frac{\lambda}{\delta}\sum_{j=1}^m(\sigma_{j} x_{j})^2
 \]`
-where $\lambda$ is the regularization parameter, $\delta$ is the population standard deviation of label
+where $\lambda$ is the regularization parameter, $\delta$ is the population standard deviation of the label
 and $\sigma_j$ is the population standard deviation of the j-th feature column.
 
 This objective function has an analytic solution and it requires only one pass over the data to collect necessary statistics to solve.
 Unlike the original dataset which can only be stored in a distributed system,
-these statistics can be easily loaded into memory on a single machine, and then we can solve the objective function through Cholesky factorization on the driver.
+these statistics can be loaded into memory on a single machine if the number of features is relatively small, and then we can solve the objective function through Cholesky factorization on the driver.
 
 WeightedLeastSquares only supports L2 regularization and provides options to enable or disable regularization and standardization.
 In order to make the normal equation approach efficient, WeightedLeastSquares requires that the number of features be no more than 4096. For larger problems, use L-BFGS instead.

--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -4,10 +4,85 @@ title: Advanced topics - spark.ml
 displayTitle: Advanced topics - spark.ml
 ---
 
-# Optimization of linear methods
+* Table of contents
+{:toc}
 
-The optimization algorithm underlying the implementation is called
+`\[
+\newcommand{\R}{\mathbb{R}}
+\newcommand{\E}{\mathbb{E}} 
+\newcommand{\x}{\mathbf{x}}
+\newcommand{\y}{\mathbf{y}}
+\newcommand{\wv}{\mathbf{w}}
+\newcommand{\av}{\mathbf{\alpha}}
+\newcommand{\bv}{\mathbf{b}}
+\newcommand{\N}{\mathbb{N}}
+\newcommand{\id}{\mathbf{I}} 
+\newcommand{\ind}{\mathbf{1}} 
+\newcommand{\0}{\mathbf{0}} 
+\newcommand{\unit}{\mathbf{e}} 
+\newcommand{\one}{\mathbf{1}} 
+\newcommand{\zero}{\mathbf{0}}
+\]`
+
+# Optimization of linear methods (developer)
+
+## Limited-memory BFGS (L-BFGS)
+[L-BFGS](http://en.wikipedia.org/wiki/Limited-memory_BFGS) is an optimization 
+algorithm in the family of quasi-Newton methods to solve the optimization problems of the form 
+`$\min_{\wv \in\R^d} \; f(\wv)$`. The L-BFGS method approximates the objective function locally as a 
+quadratic without evaluating the second partial derivatives of the objective function to construct the 
+Hessian matrix. The Hessian matrix is approximated by previous gradient evaluations, so there is no 
+vertical scalability issue (the number of training features) when computing the Hessian matrix 
+explicitly in Newton's method. As a result, L-BFGS often achieves rapider convergence compared with 
+other first-order optimization.
+
 [Orthant-Wise Limited-memory
 QuasiNewton](http://research-srv.microsoft.com/en-us/um/people/jfgao/paper/icml07scalable.pdf)
-(OWL-QN). It is an extension of L-BFGS that can effectively handle L1
-regularization and elastic net.
+(OWL-QN) is an extension of L-BFGS that can effectively handle L1 regularization and elastic net.
+
+L-BFGS was used as solver for [LinearRegression](api/scala/index.html#org.apache.spark.ml.regression.LinearRegression),
+[LogisticRegression](api/scala/index.html#org.apache.spark.ml.classification.LogisticRegression),
+[AFTSurvivalRegression](api/scala/index.html#org.apache.spark.ml.regression.AFTSurvivalRegression)
+and [MultilayerPerceptronClassifier](api/scala/index.html#org.apache.spark.ml.classification.MultilayerPerceptronClassifier).
+
+`spark.ml` L-BFGS solver calls the corresponding implementation in [breeze](https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/optimize/LBFGS.scala).
+
+## Normal equation solver for weighted least squares (normal)
+
+`spark.ml` implements normal equation solver for weighted least squares by [WeightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala).
+
+Given $n$ weighted observations $(w_i, a_i, b_i)$:
+
+* $w_i$ the weight of i-th observation
+* $a_i$ the features vector of i-th observation
+* $b_i$ the label of i-th observation
+
+The number of features for each observation is $m$. We use the following weighted least squares formulation:
+`\[   
+minimize_{x}\frac{1}{2} \sum_{i=1}^n \frac{w_i(a_i^T x -b_i)^2}{\sum_{i=1}^n w_i} + \frac{1}{2}\frac{\lambda}{\delta}\sum_{j=1}^m(\sigma_{j} x_{j})^2
+\]`
+where $\lambda$ is the regularization parameter, $\delta$ is the population standard deviation of label
+and $\sigma_j$ is the population standard deviation of the j-th feature column.
+
+This objective function has an analytic solution and it requires only one pass to collect necessary statistics to solve this function.
+Unlike the original dataset which can only be stored in distributed system,
+these statistics can be easily loaded into memory of a single machine, and then we can solve the objective function through Cholesky factorization on driver.
+
+WeightedLeastSquares only supports L2 regularization and provides options to enable or disable regularization, standardizing features and labels.
+In order to take the normal equation approach efficiently, WeightedLeastSquares only supports the number of features is no more than 4096.
+
+## Iteratively re-weighted least squares (IRLS)
+
+`spark.ml` implements the method of iteratively reweighted least squares (IRLS) by [IterativelyReweightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala).
+It can be used to find maximum likelihood estimates of a generalized linear model (GLM), find M-estimator in robust regression and other optimization problems.
+Refer to [Iteratively Reweighted Least Squares for Maximum Likelihood Estimation, and some Robust and Resistant Alternatives](http://www.jstor.org/stable/2345503) for more information.
+
+It solves certain optimization problems by an iterative way:
+
+* linearize the objective at current solution and update corresponding weight.
+* solve a weighted least squares (WLS) problem by WeightedLeastSquares.
+* repeat above steps until convergence.
+
+Due to it involves solving a weighted least squares (WLS) problem by WeightedLeastSquares in each step of the iteration,
+it also only supports the number of features is no more than 4096.
+Currently IRLS was used as the default solver of [GeneralizedLinearRegression](api/scala/index.html#org.apache.spark.ml.regression.GeneralizedLinearRegression).

--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -37,8 +37,8 @@ explicitly in Newton's method. As a result, L-BFGS often achieves faster converg
 other first-order optimizations.
 
 [Orthant-Wise Limited-memory
-QuasiNewton](http://research-srv.microsoft.com/en-us/um/people/jfgao/paper/icml07scalable.pdf)
-(OWL-QN) is an extension of L-BFGS that can effectively handle L1 regularization and elastic net.
+Quasi-Newton](http://research-srv.microsoft.com/en-us/um/people/jfgao/paper/icml07scalable.pdf)
+(OWL-QN) is an extension of L-BFGS that can effectively handle L1 and elastic net regularization.
 
 L-BFGS is used as a solver for [LinearRegression](api/scala/index.html#org.apache.spark.ml.regression.LinearRegression),
 [LogisticRegression](api/scala/index.html#org.apache.spark.ml.classification.LogisticRegression),
@@ -65,19 +65,19 @@ where $\lambda$ is the regularization parameter, $\delta$ is the population stan
 and $\sigma_j$ is the population standard deviation of the j-th feature column.
 
 This objective function has an analytic solution and it requires only one pass over the data to collect necessary statistics to solve.
-Unlike the original dataset which can only be stored in distributed system,
+Unlike the original dataset which can only be stored in a distributed system,
 these statistics can be easily loaded into memory on a single machine, and then we can solve the objective function through Cholesky factorization on the driver.
 
-WeightedLeastSquares only supports L2 regularization and provides options to enable or disable regularization, standardizing features and labels.
-In order to take the normal equation approach efficiently, WeightedLeastSquares requires that the number of features be no more than 4096. For larger problems, use L-BFGS instead.
+WeightedLeastSquares only supports L2 regularization and provides options to enable or disable regularization and standardization.
+In order to make the normal equation approach efficient, WeightedLeastSquares requires that the number of features be no more than 4096. For larger problems, use L-BFGS instead.
 
-## Iteratively re-weighted least squares (IRLS)
+## Iteratively reweighted least squares (IRLS)
 
 MLlib implements [iteratively reweighted least squares (IRLS)](https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares) by [IterativelyReweightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala).
 It can be used to find the maximum likelihood estimates of a generalized linear model (GLM), find M-estimator in robust regression and other optimization problems.
 Refer to [Iteratively Reweighted Least Squares for Maximum Likelihood Estimation, and some Robust and Resistant Alternatives](http://www.jstor.org/stable/2345503) for more information.
 
-It solves certain optimization problems iteratively:
+It solves certain optimization problems iteratively through the following procedure:
 
 * linearize the objective at current solution and update corresponding weight.
 * solve a weighted least squares (WLS) problem by WeightedLeastSquares.

--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -33,19 +33,19 @@ algorithm in the family of quasi-Newton methods to solve the optimization proble
 quadratic without evaluating the second partial derivatives of the objective function to construct the 
 Hessian matrix. The Hessian matrix is approximated by previous gradient evaluations, so there is no 
 vertical scalability issue (the number of training features) when computing the Hessian matrix 
-explicitly in Newton's method. As a result, L-BFGS often achieves rapider convergence compared with 
-other first-order optimization.
+explicitly in Newton's method. As a result, L-BFGS often achieves faster convergence compared with 
+other first-order optimizations.
 
 [Orthant-Wise Limited-memory
 QuasiNewton](http://research-srv.microsoft.com/en-us/um/people/jfgao/paper/icml07scalable.pdf)
 (OWL-QN) is an extension of L-BFGS that can effectively handle L1 regularization and elastic net.
 
-L-BFGS was used as solver for [LinearRegression](api/scala/index.html#org.apache.spark.ml.regression.LinearRegression),
+L-BFGS is used as a solver for [LinearRegression](api/scala/index.html#org.apache.spark.ml.regression.LinearRegression),
 [LogisticRegression](api/scala/index.html#org.apache.spark.ml.classification.LogisticRegression),
 [AFTSurvivalRegression](api/scala/index.html#org.apache.spark.ml.regression.AFTSurvivalRegression)
 and [MultilayerPerceptronClassifier](api/scala/index.html#org.apache.spark.ml.classification.MultilayerPerceptronClassifier).
 
-`spark.ml` L-BFGS solver calls the corresponding implementation in [breeze](https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/optimize/LBFGS.scala).
+The `spark.ml` L-BFGS solver calls the corresponding implementation in [breeze](https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/optimize/LBFGS.scala).
 
 ## Normal equation solver for weighted least squares (normal)
 
@@ -64,20 +64,20 @@ minimize_{x}\frac{1}{2} \sum_{i=1}^n \frac{w_i(a_i^T x -b_i)^2}{\sum_{i=1}^n w_i
 where $\lambda$ is the regularization parameter, $\delta$ is the population standard deviation of label
 and $\sigma_j$ is the population standard deviation of the j-th feature column.
 
-This objective function has an analytic solution and it requires only one pass to collect necessary statistics to solve this function.
+This objective function has an analytic solution and it requires only one pass over the data to collect necessary statistics to solve.
 Unlike the original dataset which can only be stored in distributed system,
-these statistics can be easily loaded into memory of a single machine, and then we can solve the objective function through Cholesky factorization on driver.
+these statistics can be easily loaded into memory on a single machine, and then we can solve the objective function through Cholesky factorization on the driver.
 
 WeightedLeastSquares only supports L2 regularization and provides options to enable or disable regularization, standardizing features and labels.
 In order to take the normal equation approach efficiently, WeightedLeastSquares only supports the number of features is no more than 4096.
 
 ## Iteratively re-weighted least squares (IRLS)
 
-`spark.ml` implements the method of iteratively reweighted least squares (IRLS) by [IterativelyReweightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala).
-It can be used to find maximum likelihood estimates of a generalized linear model (GLM), find M-estimator in robust regression and other optimization problems.
+`spark.ml` implements iteratively reweighted least squares (IRLS) by [IterativelyReweightedLeastSquares](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala).
+It can be used to find the maximum likelihood estimates of a generalized linear model (GLM), find M-estimator in robust regression and other optimization problems.
 Refer to [Iteratively Reweighted Least Squares for Maximum Likelihood Estimation, and some Robust and Resistant Alternatives](http://www.jstor.org/stable/2345503) for more information.
 
-It solves certain optimization problems by an iterative way:
+It solves certain optimization problems iteratively:
 
 * linearize the objective at current solution and update corresponding weight.
 * solve a weighted least squares (WLS) problem by WeightedLeastSquares.

--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -59,7 +59,7 @@ Given $n$ weighted observations $(w_i, a_i, b_i)$:
 
 The number of features for each observation is $m$. We use the following weighted least squares formulation:
 `\[   
-minimize_{x}\frac{1}{2} \sum_{i=1}^n \frac{w_i(a_i^T x -b_i)^2}{\sum_{i=1}^n w_i} + \frac{1}{2}\frac{\lambda}{\delta}\sum_{j=1}^m(\sigma_{j} x_{j})^2
+minimize_{x}\frac{1}{2} \sum_{i=1}^n \frac{w_i(a_i^T x -b_i)^2}{\sum_{k=1}^n w_k} + \frac{1}{2}\frac{\lambda}{\delta}\sum_{j=1}^m(\sigma_{j} x_{j})^2
 \]`
 where $\lambda$ is the regularization parameter, $\delta$ is the population standard deviation of label
 and $\sigma_j$ is the population standard deviation of the j-th feature column.

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
@@ -38,7 +38,7 @@ private[ml] class IterativelyReweightedLeastSquaresModel(
 /**
  * Implements the method of iteratively reweighted least squares (IRLS) which is used to solve
  * certain optimization problems by an iterative method. In each step of the iterations, it
- * involves solving a weighted lease squares (WLS) problem by [[WeightedLeastSquares]].
+ * involves solving a weighted least squares (WLS) problem by [[WeightedLeastSquares]].
  * It can be used to find maximum likelihood estimates of a generalized linear model (GLM),
  * find M-estimator in robust regression and other optimization problems.
  *


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Document `WeightedLeastSquares`(normal equation) and `IterativelyReweightedLeastSquares`.
- Copy `L-BFGS` documents from `spark.mllib` to `spark.ml`.

Due to the session `Optimization of linear methods` is used for developers, I think we should provide the brief introduction of the optimization method, necessary references and how it implements in Spark. It's not necessary to paste all mathematical formula and derivation here. If developers/users want to learn more, they can track reference. 
## How was this patch tested?

Document update, no tests.
