### PR TITLE
[SPARK-15499][PySpark][Tests] Add python testsuite with remote debug and single test parameter to help developer debug code easier

### DIFF
--- a/python/pyspark/debugutil.py
+++ b/python/pyspark/debugutil.py
@@ -1,0 +1,26 @@
+import os
+
+HAS_CHECK_DEBUGGER = False
+def check_debugger():
+    global HAS_CHECK_DEBUGGER
+    
+    if HAS_CHECK_DEBUGGER:
+        return
+    
+    HAS_CHECK_DEBUGGER = True
+    env = dict(os.environ)
+    debug_server = env.get('PYTHON_REMOTE_DEBUG_SERVER')
+    debug_port = env.get('PYTHON_REMOTE_DEBUG_PORT')
+        
+    if debug_server != None and debug_port != None:
+        try:
+            import pydevd
+            print('connecting debug server %s, port %s'
+                    % (debug_server, debug_port))
+            pydevd.settrace(debug_server, 
+                            port=int(debug_port), 
+                            stdoutToServer=False, 
+                            stderrToServer=False)
+        except Exception, e:
+            print(e)
+            raise Exception('init debugger fail.' )

--- a/python/pyspark/debugutil.py
+++ b/python/pyspark/debugutil.py
@@ -38,6 +38,6 @@ def check_debugger():
                             port=int(debug_port), 
                             stdoutToServer=False, 
                             stderrToServer=False)
-        except Exception, e:
+        except Exception as e:
             print(e)
             raise Exception('init debugger fail.' )

--- a/python/pyspark/debugutil.py
+++ b/python/pyspark/debugutil.py
@@ -18,26 +18,28 @@
 import os
 
 HAS_CHECK_DEBUGGER = False
+
+
 def check_debugger():
     global HAS_CHECK_DEBUGGER
-    
+
     if HAS_CHECK_DEBUGGER:
         return
-    
+
     HAS_CHECK_DEBUGGER = True
     env = dict(os.environ)
     debug_server = env.get('PYTHON_REMOTE_DEBUG_SERVER')
     debug_port = env.get('PYTHON_REMOTE_DEBUG_PORT')
-        
-    if debug_server != None and debug_port != None:
+
+    if debug_server is not None and debug_port is not None:
         try:
             import pydevd
             print('connecting debug server %s, port %s'
-                    % (debug_server, debug_port))
-            pydevd.settrace(debug_server, 
-                            port=int(debug_port), 
-                            stdoutToServer=False, 
+                  % (debug_server, debug_port))
+            pydevd.settrace(debug_server,
+                            port=int(debug_port),
+                            stdoutToServer=False,
                             stderrToServer=False)
         except Exception as e:
             print(e)
-            raise Exception('init debugger fail.' )
+            raise Exception('init debugger fail.')

--- a/python/pyspark/debugutil.py
+++ b/python/pyspark/debugutil.py
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 
 HAS_CHECK_DEBUGGER = False

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.debugutil import check_debugger
+check_debugger()
 
 """
 Unit tests for Spark ML Python APIs.

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.debugutil import check_debugger
+check_debugger()
 
 """
 Fuller unit tests for Python MLlib.

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.debugutil import check_debugger
+check_debugger()
 
 """
 Unit tests for pyspark.sql; additional tests are implemented as doctests in

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.debugutil import check_debugger
+check_debugger()
 
 import glob
 import os

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.debugutil import check_debugger
+check_debugger()
 
 """
 Unit tests for PySpark; additional tests are implemented as doctests in

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -32,9 +32,6 @@ if sys.version < '3':
 else:
     import queue as Queue
 
-import pydevd
-print("connecting to debug server, host %s, port %s" % ('n131', 5678))
-pydevd.settrace('n131',port=5678,stdoutToServer=False,stderrToServer=False)
 
 # Append `SPARK_HOME/dev` to the Python path so that we can import the sparktestsupport module
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../dev/"))

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -32,6 +32,9 @@ if sys.version < '3':
 else:
     import queue as Queue
 
+import pydevd
+print("connecting to debug server, host %s, port %s" % ('n131', 5678))
+pydevd.settrace('n131',port=5678,stdoutToServer=False,stderrToServer=False)
 
 # Append `SPARK_HOME/dev` to the Python path so that we can import the sparktestsupport module
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../dev/"))
@@ -63,7 +66,7 @@ else:
     raise Exception("Cannot find assembly build directory, please build Spark first.")
 
 
-def run_individual_python_test(test_name, pyspark_python):
+def run_individual_python_test(test_name, pyspark_python, is_single_test=False, debug_server=None, debug_port=None):
     env = dict(os.environ)
     env.update({
         'SPARK_DIST_CLASSPATH': SPARK_DIST_CLASSPATH,
@@ -72,10 +75,19 @@ def run_individual_python_test(test_name, pyspark_python):
         'PYSPARK_PYTHON': which(pyspark_python),
         'PYSPARK_DRIVER_PYTHON': which(pyspark_python)
     })
+    if is_single_test:
+        if debug_server != None:
+            env.update({'PYTHON_REMOTE_DEBUG_SERVER': debug_server})
+        if debug_port != None:
+            env.update({'PYTHON_REMOTE_DEBUG_PORT': '%d' % debug_port})
+            
     LOGGER.debug("Starting test(%s): %s", pyspark_python, test_name)
     start_time = time.time()
     try:
-        per_test_output = tempfile.TemporaryFile()
+        if is_single_test:
+            per_test_output = None
+        else:
+            per_test_output = tempfile.TemporaryFile()
         retcode = subprocess.Popen(
             [os.path.join(SPARK_HOME, "bin/pyspark"), test_name],
             stderr=per_test_output, stdout=per_test_output, env=env).wait()
@@ -88,16 +100,17 @@ def run_individual_python_test(test_name, pyspark_python):
     # Exit on the first failure.
     if retcode != 0:
         try:
-            with FAILURE_REPORTING_LOCK:
-                with open(LOG_FILE, 'ab') as log_file:
+            if per_test_output != None:
+                with FAILURE_REPORTING_LOCK:
+                    with open(LOG_FILE, 'ab') as log_file:
+                        per_test_output.seek(0)
+                        log_file.writelines(per_test_output)
                     per_test_output.seek(0)
-                    log_file.writelines(per_test_output)
-                per_test_output.seek(0)
-                for line in per_test_output:
-                    decoded_line = line.decode()
-                    if not re.match('[0-9]+', decoded_line):
-                        print(decoded_line, end='')
-                per_test_output.close()
+                    for line in per_test_output:
+                        decoded_line = line.decode()
+                        if not re.match('[0-9]+', decoded_line):
+                            print(decoded_line, end='')
+                    per_test_output.close()
         except:
             LOGGER.exception("Got an exception while trying to print failed test output")
         finally:
@@ -106,7 +119,8 @@ def run_individual_python_test(test_name, pyspark_python):
             # this code is invoked from a thread other than the main thread.
             os._exit(-1)
     else:
-        per_test_output.close()
+        if per_test_output != None:
+           per_test_output.close()
         LOGGER.info("Finished test(%s): %s (%is)", pyspark_python, test_name, duration)
 
 
@@ -140,7 +154,19 @@ def parse_opts():
         "--verbose", action="store_true",
         help="Enable additional debug logging"
     )
-
+    parser.add_option(
+        "--single-test", type="string", default=None,
+        help="specify a python module to run single python test."
+    )
+    parser.add_option(
+        "--debug-server", type="string", default=None,
+        help="debug server host, only used in single test."
+    )
+    parser.add_option(
+        "--debug-port", type="int", default=5678,
+        help="debug server port, only used in single test."
+    )
+    
     (opts, args) = parser.parse_args()
     if args:
         parser.error("Unsupported arguments: %s" % ' '.join(args))
@@ -169,6 +195,15 @@ def main():
                   (module_name, ", ".join(python_modules)))
             sys.exit(-1)
     LOGGER.info("Will test against the following Python executables: %s", python_execs)
+    
+    if(opts.single_test != None):
+        test_goal = opts.single_test
+        LOGGER.info("Will test the single Python module: %s", test_goal)
+        for python_exec in python_execs:
+            run_individual_python_test(test_goal, python_exec,
+                                       True, opts.debug_server, opts.debug_port)
+        return
+    
     LOGGER.info("Will test the following Python modules: %s", [x.name for x in modules_to_test])
 
     task_queue = Queue.PriorityQueue()

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -63,7 +63,8 @@ else:
     raise Exception("Cannot find assembly build directory, please build Spark first.")
 
 
-def run_individual_python_test(test_name, pyspark_python, is_single_test=False, debug_server=None, debug_port=None):
+def run_individual_python_test(test_name, pyspark_python,
+                               is_single_test=False, debug_server=None, debug_port=None):
     env = dict(os.environ)
     env.update({
         'SPARK_DIST_CLASSPATH': SPARK_DIST_CLASSPATH,
@@ -73,11 +74,11 @@ def run_individual_python_test(test_name, pyspark_python, is_single_test=False, 
         'PYSPARK_DRIVER_PYTHON': which(pyspark_python)
     })
     if is_single_test:
-        if debug_server != None:
+        if debug_server is not None:
             env.update({'PYTHON_REMOTE_DEBUG_SERVER': debug_server})
-        if debug_port != None:
+        if debug_port is not None:
             env.update({'PYTHON_REMOTE_DEBUG_PORT': '%d' % debug_port})
-            
+
     LOGGER.debug("Starting test(%s): %s", pyspark_python, test_name)
     start_time = time.time()
     try:
@@ -97,7 +98,7 @@ def run_individual_python_test(test_name, pyspark_python, is_single_test=False, 
     # Exit on the first failure.
     if retcode != 0:
         try:
-            if per_test_output != None:
+            if per_test_output is not None:
                 with FAILURE_REPORTING_LOCK:
                     with open(LOG_FILE, 'ab') as log_file:
                         per_test_output.seek(0)
@@ -116,8 +117,8 @@ def run_individual_python_test(test_name, pyspark_python, is_single_test=False, 
             # this code is invoked from a thread other than the main thread.
             os._exit(-1)
     else:
-        if per_test_output != None:
-           per_test_output.close()
+        if per_test_output is not None:
+            per_test_output.close()
         LOGGER.info("Finished test(%s): %s (%is)", pyspark_python, test_name, duration)
 
 
@@ -163,7 +164,7 @@ def parse_opts():
         "--debug-port", type="int", default=5678,
         help="debug server port, only used in single test."
     )
-    
+
     (opts, args) = parser.parse_args()
     if args:
         parser.error("Unsupported arguments: %s" % ' '.join(args))
@@ -192,15 +193,15 @@ def main():
                   (module_name, ", ".join(python_modules)))
             sys.exit(-1)
     LOGGER.info("Will test against the following Python executables: %s", python_execs)
-    
-    if(opts.single_test != None):
+
+    if(opts.single_test is not None):
         test_goal = opts.single_test
         LOGGER.info("Will test the single Python module: %s", test_goal)
         for python_exec in python_execs:
             run_individual_python_test(test_goal, python_exec,
                                        True, opts.debug_server, opts.debug_port)
         return
-    
+
     LOGGER.info("Will test the following Python modules: %s", [x.name for x in modules_to_test])
 
     task_queue = Queue.PriorityQueue()


### PR DESCRIPTION
## What changes were proposed in this pull request?

To python/run-tests.py script, I add the following parameters:

`--single-test=SINGLE_TEST`
`specify a python module to run single python test.`
`--debug-server=DEBUG_SERVER`
`debug server host, only used in single test.`
`--debug-port=DEBUG_PORT`
`debug server port, only used in single test.`

Now, for example, I want to debug only pyspark.tests, I can use the following command:
(first startup debug server in your python IDE such as pycharm or pydev, your IED on machine which has host MY_DEV_MACHINE and using debug port 5678, and make sure the machine running test can connect to MY_DEV_MACHINE, and python must install pydevd module first.)

`python/run-tests --python-executables=python2.7 --single-test=pyspark.tests --debug-server=MY_DEV_MACHINE --debug-port=5678`

the parameter --single-test specify the single python testsuite you want to test, currently you can use the following value:

`pyspark.tests`
`pyspark.ml.tests`
`pyspark.mllib.tests`
`pyspark.sql.tests`
`pyspark.streaming.tests`

Adding parameters then develop and debug python script will be quite easier, I think.
## How was this patch tested?

Existing test.
