### PR TITLE
[SPARK-15491][SQL]fix assertion failure for JDBC DataFrame to JSON

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -546,7 +546,9 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
 
   protected def jsonFields: List[JField] = {
     val fieldNames = getConstructorParameterNames(getClass)
-    val fieldValues = productIterator.toSeq ++ otherCopyArgs
+    val fieldValues = fieldNames.map { name =>
+        this.getClass.getMethod(name).invoke(this)
+    }
     assert(fieldNames.length == fieldValues.length, s"${getClass.getSimpleName} fields: " +
       fieldNames.mkString(", ") + s", values: " + fieldValues.map(_.toString).mkString(", "))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -594,7 +594,9 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     // returns null if the product type doesn't have a primary constructor, e.g. HiveFunctionWrapper
     case p: Product => try {
       val fieldNames = getConstructorParameterNames(p.getClass)
-      val fieldValues = p.productIterator.toSeq
+      val fieldValues = fieldNames.map { name =>
+        p.getClass.getMethod(name).invoke(p)
+      }
       assert(fieldNames.length == fieldValues.length)
       ("product-class" -> JString(p.getClass.getName)) :: fieldNames.zip(fieldValues).map {
         case (name, value) => name -> parseToJson(value)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -661,4 +661,15 @@ class JDBCSuite extends SparkFunSuite
     assert(oracleDialect.getJDBCType(StringType).
       map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
   }
+
+  test("SPARK 15491: Test JSON serialization for JDBC DataFrame") {
+    val JDBCDFtoJson = sqlContext.read.format("jdbc").options(
+      Map("url" -> urlWithUserAndPass,
+        "dbtable" -> "test.people")).load().queryExecution.logical.toJSON
+    assert(JDBCDFtoJson.contains("\"url\":\"jdbc:h2:mem:testdb0;user=testUser;password=testPass\"")
+      && JDBCDFtoJson.contains("\"table\":\"test.people\"")
+      && JDBCDFtoJson.contains("\"parts\":null")
+      && JDBCDFtoJson.contains("\"properties\":null")
+      && JDBCDFtoJson.contains("\"sparkSession\":null"))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -661,15 +661,4 @@ class JDBCSuite extends SparkFunSuite
     assert(oracleDialect.getJDBCType(StringType).
       map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
   }
-
-  test("SPARK 15491: Test JSON serialization for JDBC DataFrame") {
-    val JDBCDFtoJson = sqlContext.read.format("jdbc").options(
-      Map("url" -> urlWithUserAndPass,
-        "dbtable" -> "test.people")).load().queryExecution.logical.toJSON
-    assert(JDBCDFtoJson.contains("\"url\":\"jdbc:h2:mem:testdb0;user=testUser;password=testPass\"")
-      && JDBCDFtoJson.contains("\"table\":\"test.people\"")
-      && JDBCDFtoJson.contains("\"parts\":null")
-      && JDBCDFtoJson.contains("\"properties\":null")
-      && JDBCDFtoJson.contains("\"sparkSession\":null"))
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

 in TreeNode.scala parseToJson, it has

```

case p: Product => try {
      val fieldNames = getConstructorParameterNames(p.getClass)
      val fieldValues = p.productIterator.toSeq
      assert(fieldNames.length == fieldValues.length)
      ("product-class" -> JString(p.getClass.getName)) :: fieldNames.zip(fieldValues).map {
        case (name, value) => name -> parseToJson(value)
      }.toList

```

For a class that has two level of constructor parameters, for example, 

```

private[sql] case class JDBCRelation(
    url: String,
    table: String,
    parts: Array[Partition],
    properties: Properties = new Properties())(@transient val sparkSession: SparkSession)

```

**val fieldValues = p.productIterator.toSeq** will only get the values for the first level of constructor parameters, in this case, 4 parameters,  but 
**val fieldNames = getConstructorParameterNames(p.getClass)**
will get all the 5 parameters, so **assert(fieldNames.length == fieldValues.length)** will fail. 

I will change code to make fieldValues have all the parameters. 
## How was this patch tested?

Added a unit test.
