### PR TITLE
[SPARK-13484] [SQL] Prevent illegal NULL propagation when filtering outer-join results

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -636,6 +636,10 @@ class Analyzer(
             ExtractValue(child, fieldExpr, resolver)
         }
 
+        // Replaces attribute references in a filter if it has a join as a child and it references
+        // some columns on the base relations of the join. This is because outer joins change
+        // nullability on columns and this could cause wrong NULL propagation in Optimizer.
+        // See SPARK-13484 for the concrete query of this case.
         resolvedPlan.transform {
           case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
             val joinOutput = new ArrayBuffer[(Attribute, Attribute)]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -109,6 +109,8 @@ class Analyzer(
       TimeWindowing ::
       TypeCoercion.typeCoercionRules ++
       extendedResolutionRules : _*),
+    Batch("Solve", Once,
+      SolveIllegalReferences),
     Batch("Nondeterministic", Once,
       PullOutNondeterministic),
     Batch("UDF", Once,
@@ -1461,6 +1463,30 @@ class Analyzer(
           s"output by the UDTF expected ${elementAttrs.size} aliases but got " +
           s"${names.mkString(",")} ")
       }
+    }
+  }
+
+  /**
+   * Replaces attribute references in a filter if it has a join as a child and it references some
+   * columns on the base relations of the join. This is because outer joins change nullability on
+   * columns and this could cause wrong NULL propagation in Optimizer.
+   * See SPARK-13484 for the concrete query of this case.
+   */
+  object SolveIllegalReferences extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+       case q: LogicalPlan =>
+        q.transform {
+          case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
+            val joinOutput = new ArrayBuffer[(Attribute, Attribute)]
+            j.output.map {
+              case a: AttributeReference => joinOutput += ((a, a))
+            }
+            val joinOutputMap = AttributeMap(joinOutput)
+            val newFilterCond = filterCondition.transform {
+              case a: AttributeReference => joinOutputMap.get(a).getOrElse(a)
+            }
+            Filter(newFilterCond, j)
+        }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -627,7 +627,7 @@ class Analyzer(
 
       case q: LogicalPlan =>
         logTrace(s"Attempting to resolve ${q.simpleString}")
-        val resolvedPlan = q transformExpressionsUp  {
+        q transformExpressionsUp  {
           case u @ UnresolvedAttribute(nameParts) =>
             // Leave unchanged if resolution fails.  Hopefully will be resolved next round.
             val result =
@@ -636,23 +636,6 @@ class Analyzer(
             result
           case UnresolvedExtractValue(child, fieldExpr) if child.resolved =>
             ExtractValue(child, fieldExpr, resolver)
-        }
-
-        // Replaces attribute references in a filter if it has a join as a child and it references
-        // some columns on the base relations of the join. This is because outer joins change
-        // nullability on columns and this could cause wrong NULL propagation in Optimizer.
-        // See SPARK-13484 for the concrete query of this case.
-        resolvedPlan.transform {
-          case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
-            val joinOutput = new ArrayBuffer[(Attribute, Attribute)]
-            j.output.map {
-              case a: AttributeReference => joinOutput += ((a, a))
-            }
-            val joinOutputMap = AttributeMap(joinOutput)
-            val newFilterCond = filterCondition.transform {
-              case a: AttributeReference => joinOutputMap.get(a).getOrElse(a)
-            }
-            Filter(newFilterCond, j)
         }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1478,7 +1478,7 @@ class Analyzer(
         q.transform {
           case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
             val joinOutput = new ArrayBuffer[(Attribute, Attribute)]
-            j.output.map {
+            j.output.foreach {
               case a: AttributeReference => joinOutput += ((a, a))
             }
             val joinOutputMap = AttributeMap(joinOutput)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -625,7 +625,7 @@ class Analyzer(
 
       case q: LogicalPlan =>
         logTrace(s"Attempting to resolve ${q.simpleString}")
-        q transformExpressionsUp  {
+        val resolvedPlan = q transformExpressionsUp  {
           case u @ UnresolvedAttribute(nameParts) =>
             // Leave unchanged if resolution fails.  Hopefully will be resolved next round.
             val result =
@@ -634,6 +634,19 @@ class Analyzer(
             result
           case UnresolvedExtractValue(child, fieldExpr) if child.resolved =>
             ExtractValue(child, fieldExpr, resolver)
+        }
+
+        resolvedPlan.transform {
+          case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
+            val joinOutput = new ArrayBuffer[(Attribute, Attribute)]
+            j.output.map {
+              case a: AttributeReference => joinOutput += ((a, a))
+            }
+            val joinOutputMap = AttributeMap(joinOutput)
+            val newFilterCond = filterCondition.transform {
+              case a: AttributeReference => joinOutputMap.get(a).getOrElse(a)
+            }
+            Filter(newFilterCond, j)
         }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1466,10 +1466,12 @@ class Analyzer(
         val childrenOutput = p.children.flatMap(c => c.output).groupBy(_.exprId).flatMap {
           case (exprId, attributes) =>
             // If there are multiple Attributes having the same ExprId, we need to resolve
-            // the conflict of nullable field.
-            val nullable = attributes.map(_.nullable).reduce(_ || _)
+            // the conflict of nullable field. We do not really expect this happen.
+            val nullable = attributes.exists(_.nullable)
             attributes.map(attr => attr.withNullability(nullable))
         }.toSeq
+        // At here, we create an AttributeMap that only compare the exprId for the lookup
+        // operation. So, we can find the corresponding input attribute's nullability.
         val attributeMap = AttributeMap[Attribute](childrenOutput.map(attr => attr -> attr))
         // For an Attribute used by the current LogicalPlan, if it is from its children,
         // we fix the nullable field by using the nullability setting of the corresponding

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.objects.NewInstance
 import org.apache.spark.sql.catalyst.optimizer.BooleanSimplification
-import org.apache.spark.sql.catalyst.planning.IntegerIndex
+import org.apache.spark.sql.catalyst.planning.{ExtractJoinOutputAttributes, IntegerIndex}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, _}
 import org.apache.spark.sql.catalyst.rules._
@@ -1467,25 +1467,27 @@ class Analyzer(
   }
 
   /**
-   * Replaces attribute references in a filter if it has a join as a child and it references some
-   * columns on the base relations of the join. This is because outer joins change nullability on
-   * columns and this could cause wrong NULL propagation in Optimizer.
-   * See SPARK-13484 for the concrete query of this case.
+   * Corrects attribute references in an expression tree of some operators (e.g., filters and
+   * projects) if these operators have a join as a child and the references point to columns on the
+   * input relation of the join. This is because some joins change the nullability of input columns
+   * and this could cause illegal optimization (e.g., NULL propagation) and wrong answers.
+   * See SPARK-13484 and SPARK-13801 for the concrete queries of this case.
    */
   object SolveIllegalReferences extends Rule[LogicalPlan] {
+
+    private def replaceReferences(e: Expression, attrMap: AttributeMap[Attribute]) = e.transform {
+      case a: AttributeReference => attrMap.get(a).getOrElse(a)
+    }
+
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-       case q: LogicalPlan =>
+      case q: LogicalPlan =>
         q.transform {
-          case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
-            val joinOutput = new ArrayBuffer[(Attribute, Attribute)]
-            j.output.foreach {
-              case a: AttributeReference => joinOutput += ((a, a))
-            }
-            val joinOutputMap = AttributeMap(joinOutput)
-            val newFilterCond = filterCondition.transform {
-              case a: AttributeReference => joinOutputMap.get(a).getOrElse(a)
-            }
-            Filter(newFilterCond, j)
+          case f @ Filter(filterCondition, ExtractJoinOutputAttributes(join, joinOutputMap)) =>
+            f.copy(condition = replaceReferences(filterCondition, joinOutputMap))
+          case p @ Project(projectList, ExtractJoinOutputAttributes(join, joinOutputMap)) =>
+            p.copy(projectList = projectList.map { e =>
+              replaceReferences(e, joinOutputMap).asInstanceOf[NamedExpression]
+            })
         }
     }
   }
@@ -2170,4 +2172,3 @@ object TimeWindowing extends Rule[LogicalPlan] {
       }
   }
 }
-

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -181,6 +181,23 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
   }
 }
 
+/**
+ * An extractor for join output attributes directly under a given operator.
+ */
+object ExtractJoinOutputAttributes {
+
+  def unapply(plan: LogicalPlan): Option[(Join, AttributeMap[Attribute])] = {
+    plan.collectFirst {
+      case j: Join => j
+    }.map { join =>
+      val joinOutput = new mutable.ArrayBuffer[(Attribute, Attribute)]
+      join.output.foreach {
+        case a: AttributeReference => joinOutput += ((a, a))
+      }
+      (join, AttributeMap(joinOutput))
+    }
+  }
+}
 
 /**
  * A pattern that collects all adjacent unions and returns their children as a Seq.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -181,6 +181,7 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
   }
 }
 
+
 /**
  * A pattern that collects all adjacent unions and returns their children as a Seq.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -182,24 +182,6 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
 }
 
 /**
- * An extractor for join output attributes directly under a given operator.
- */
-object ExtractJoinOutputAttributes {
-
-  def unapply(plan: LogicalPlan): Option[(Join, AttributeMap[Attribute])] = {
-    plan.collectFirst {
-      case j: Join => j
-    }.map { join =>
-      val joinOutput = new mutable.ArrayBuffer[(Attribute, Attribute)]
-      join.output.foreach {
-        case a: AttributeReference => joinOutput += ((a, a))
-      }
-      (join, AttributeMap(joinOutput))
-    }
-  }
-}
-
-/**
  * A pattern that collects all adjacent unions and returns their children as a Seq.
  */
 object Unions {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
@@ -100,7 +100,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
     val naturalPlan = r3.join(r4, NaturalJoin(FullOuter), None)
     val usingPlan = r3.join(r4, UsingJoin(FullOuter, Seq(UnresolvedAttribute("b"))), None)
     val expected = r3.join(r4, FullOuter, Some(EqualTo(bNotNull, bNotNull))).select(
-      Alias(Coalesce(Seq(bNotNull, bNotNull)), "b")(), a, c)
+      Alias(Coalesce(Seq(b, b)), "b")(), a, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -205,7 +205,8 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       Row(1, 2, "1", 1, 3, "1") :: Nil)
   }
 
-  test("filter outer join results using a non-nullable column from a right table") {
+  test("process outer join results using the non-nullable columns in the join input") {
+    // Filter data using a non-nullable column from a right table
     val df1 = Seq((0, 0), (1, 0), (2, 0), (3, 0), (4, 0)).toDF("id", "count")
     val df2 = Seq(Tuple1(0), Tuple1(1)).toDF("id").groupBy("id").count
     checkAnswer(
@@ -213,6 +214,15 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       Row(2, 0, null, null) ::
       Row(3, 0, null, null) ::
       Row(4, 0, null, null) :: Nil
+    )
+
+    // Coalesce data using non-nullable columns in input tables
+    val df3 = Seq((1, 1)).toDF("a", "b")
+    val df4 = Seq((2, 2)).toDF("a", "b")
+    checkAnswer(
+      df3.join(df4, df3("a") === df4("a"), "outer")
+        .select(coalesce(df3("a"), df3("b")), coalesce(df4("a"), df4("b"))),
+      Row(1, null) :: Row(null, 2) :: Nil
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -204,4 +204,15 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       leftJoin2Inner,
       Row(1, 2, "1", 1, 3, "1") :: Nil)
   }
+
+  test("filter outer join results using a non-nullable column from a right table") {
+    val df1 = Seq((0, 0), (1, 0), (2, 0), (3, 0), (4, 0)).toDF("id", "count")
+    val df2 = Seq(Tuple1(0), Tuple1(1)).toDF("id").groupBy("id").count
+    checkAnswer(
+      df1.join(df2, df1("id") === df2("id"), "left_outer").filter(df2("count").isNull),
+      Row(2, 0, null, null) ::
+      Row(3, 0, null, null) ::
+      Row(4, 0, null, null) :: Nil
+    )
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR add a rule at the end of analyzer to correct nullable fields of attributes in a logical plan by using nullable fields of the corresponding attributes in its children logical plans (these plans generate the input rows).

This is another approach for addressing SPARK-13484 (the first approach is https://github.com/apache/spark/pull/11371). 

Close #113711
