### PR TITLE
[YARN][Doc][Minor] Remove several obsolete env variables and update the doc

### DIFF
--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -40,10 +40,6 @@
 # - SPARK_EXECUTOR_CORES, Number of cores for the executors (Default: 1).
 # - SPARK_EXECUTOR_MEMORY, Memory per Executor (e.g. 1000M, 2G) (Default: 1G)
 # - SPARK_DRIVER_MEMORY, Memory for Driver (e.g. 1000M, 2G) (Default: 1G)
-# - SPARK_YARN_APP_NAME, The name of your application (Default: Spark)
-# - SPARK_YARN_QUEUE, The hadoop queue to use for allocation requests (Default: 'default')
-# - SPARK_YARN_DIST_FILES, Comma separated list of files to be distributed with the job.
-# - SPARK_YARN_DIST_ARCHIVES, Comma separated list of archives to be distributed with the job.
 
 # Options for the daemons used in the standalone deploy mode
 # - SPARK_MASTER_IP, to bind the master to a different IP address or hostname

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -60,6 +60,14 @@ Running Spark on YARN requires a binary distribution of Spark which is built wit
 Binary distributions can be downloaded from the [downloads page](http://spark.apache.org/downloads.html) of the project website.
 To build Spark yourself, refer to [Building Spark](building-spark.html).
 
+To make Spark runtime jars accessible from YARN side, basically you will have 3 options:
+
+- Zip all the jars under `$SPARK_HOME/jars` and specify the path of zip file through `spark.yarn.archive`, Spark will add this zip file into distributed cache.
+- Specify the list of jars under `$SPARK_HOME/jars` with `spark.yarn.jars`, Spark will resolve globs and add into distributed cache. Should be noted the path support "*", so you could specify like `spark.yarn.jars=$SPARK_HOME/jars/*`.
+- If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will zip all the jars under `$SPARK_HOME/jars` and add this zip file into distributed cache automatically.
+
+Please be aware that `spark.yarn.archive` and `spark.yarn.jars` also support HDFS path. If you already put Spark runtime jars on the HDFS, YARN will directly pick them from HDFS, no need to upload from local environment each time when application starts, this will siginificantly save the start time of Spark application.
+
 # Configuration
 
 Most of the configs are the same for Spark on YARN as for other deployment modes. See the [configuration page](configuration.html) for more information on those.  These are configs that are specific to Spark on YARN.
@@ -98,6 +106,8 @@ log4j configuration, which may cause issues when they run on the same node (e.g.
 to the same log file).
 
 If you need a reference to the proper location to put log files in the YARN so that YARN can properly display and aggregate them, use `spark.yarn.app.container.log.dir` in your `log4j.properties`. For example, `log4j.appender.file_appender.File=${spark.yarn.app.container.log.dir}/spark.log`. For streaming applications, configuring `RollingFileAppender` and setting file location to YARN's log directory will avoid disk overflow caused by large log files, and logs can be accessed using YARN's log utility.
+
+To use a custom metrics.properties for the application master and executors, just update the `SPARK_CONF_DIR/metrics.properties` file, it will automatically uploaded with other configurations, so you don't need to specify it manually with --files.
 
 #### Spark Properties
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -60,7 +60,7 @@ Running Spark on YARN requires a binary distribution of Spark which is built wit
 Binary distributions can be downloaded from the [downloads page](http://spark.apache.org/downloads.html) of the project website.
 To build Spark yourself, refer to [Building Spark](building-spark.html).
 
-To make Spark runtime jars accessible from YARN side, you can specify through `spark.yarn.archive` or `spark.yarn.jars`, for details please refer to [Spark Properties](running-on-yarn.html#spark-properties). If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will fall back to zip all the jars under `$SPARK_HOME/jars` and upload to the distributed cache.
+To make Spark runtime jars accessible from YARN side, you can specify `spark.yarn.archive` or `spark.yarn.jars`. For details please refer to [Spark Properties](running-on-yarn.html#spark-properties). If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will create a zip file with all jars under `$SPARK_HOME/jars` and upload it to the distributed cache.
 
 # Configuration
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -60,7 +60,7 @@ Running Spark on YARN requires a binary distribution of Spark which is built wit
 Binary distributions can be downloaded from the [downloads page](http://spark.apache.org/downloads.html) of the project website.
 To build Spark yourself, refer to [Building Spark](building-spark.html).
 
-To make Spark runtime jars accessible from YARN side, basically you could specify through `spark.yarn.archive` or `spark.yarn.jars`, for the details please refer to [Spark Properties](running-on-yarn.html#spark-properties). If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will fall back to zip all the jars under `$SPARK_HOME/jars` and upload to distributed cache.
+To make Spark runtime jars accessible from YARN side, you can specify through `spark.yarn.archive` or `spark.yarn.jars`, for details please refer to [Spark Properties](running-on-yarn.html#spark-properties). If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will fall back to zip all the jars under `$SPARK_HOME/jars` and upload to the distributed cache.
 
 # Configuration
 
@@ -101,7 +101,7 @@ to the same log file).
 
 If you need a reference to the proper location to put log files in the YARN so that YARN can properly display and aggregate them, use `spark.yarn.app.container.log.dir` in your `log4j.properties`. For example, `log4j.appender.file_appender.File=${spark.yarn.app.container.log.dir}/spark.log`. For streaming applications, configuring `RollingFileAppender` and setting file location to YARN's log directory will avoid disk overflow caused by large log files, and logs can be accessed using YARN's log utility.
 
-To use a custom metrics.properties for the application master and executors, just update the `$SPARK_CONF_DIR/metrics.properties` file, it will automatically uploaded with other configurations, so you don't need to specify it manually with --files.
+To use a custom metrics.properties for the application master and executors, update the `$SPARK_CONF_DIR/metrics.properties` file. It will automatically be uploaded with other configurations, so you don't need to specify it manually with `--files`.
 
 #### Spark Properties
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -60,13 +60,7 @@ Running Spark on YARN requires a binary distribution of Spark which is built wit
 Binary distributions can be downloaded from the [downloads page](http://spark.apache.org/downloads.html) of the project website.
 To build Spark yourself, refer to [Building Spark](building-spark.html).
 
-To make Spark runtime jars accessible from YARN side, basically you will have 3 options:
-
-- Zip all the jars under `$SPARK_HOME/jars` and specify the path of zip file through `spark.yarn.archive`, Spark will add this zip file into distributed cache.
-- Specify the list of jars under `$SPARK_HOME/jars` with `spark.yarn.jars`, Spark will resolve globs and add into distributed cache. Should be noted the path support "*", so you could specify like `spark.yarn.jars=$SPARK_HOME/jars/*`.
-- If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will zip all the jars under `$SPARK_HOME/jars` and add this zip file into distributed cache automatically.
-
-Please be aware that `spark.yarn.archive` and `spark.yarn.jars` also support HDFS path. If you already put Spark runtime jars on the HDFS, YARN will directly pick them from HDFS, no need to upload from local environment each time when application starts, this will siginificantly save the start time of Spark application.
+To make Spark runtime jars accessible from YARN side, basically you could specify through `spark.yarn.archive` or `spark.yarn.jars`, for the details please refer to [Spark Properties](running-on-yarn.html#spark-properties). If neither `spark.yarn.archive` nor `spark.yarn.jars` is specified, Spark will fall back to zip all the jars under `$SPARK_HOME/jars` and upload to distributed cache.
 
 # Configuration
 
@@ -107,7 +101,7 @@ to the same log file).
 
 If you need a reference to the proper location to put log files in the YARN so that YARN can properly display and aggregate them, use `spark.yarn.app.container.log.dir` in your `log4j.properties`. For example, `log4j.appender.file_appender.File=${spark.yarn.app.container.log.dir}/spark.log`. For streaming applications, configuring `RollingFileAppender` and setting file location to YARN's log directory will avoid disk overflow caused by large log files, and logs can be accessed using YARN's log utility.
 
-To use a custom metrics.properties for the application master and executors, just update the `SPARK_CONF_DIR/metrics.properties` file, it will automatically uploaded with other configurations, so you don't need to specify it manually with --files.
+To use a custom metrics.properties for the application master and executors, just update the `$SPARK_CONF_DIR/metrics.properties` file, it will automatically uploaded with other configurations, so you don't need to specify it manually with --files.
 
 #### Spark Properties
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove several obsolete env variables not supported for Spark on YARN now, also updates the docs to include several changes with 2.0.
## How was this patch tested?

N/A

CC @vanzin @tgravescs
