### PR TITLE
[MINOR][PYSPARK][EXAMPLES] Changed examples to use SparkSession.sparkContext instead of _sc

### DIFF
--- a/examples/src/main/python/als.py
+++ b/examples/src/main/python/als.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         .appName("PythonALS")\
         .getOrCreate()
 
-    sc = spark._sc
+    sc = spark.sparkContext
 
     M = int(sys.argv[1]) if len(sys.argv) > 1 else 100
     U = int(sys.argv[2]) if len(sys.argv) > 2 else 500

--- a/examples/src/main/python/avro_inputformat.py
+++ b/examples/src/main/python/avro_inputformat.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
         .appName("AvroKeyInputFormat")\
         .getOrCreate()
 
-    sc = spark._sc
+    sc = spark.sparkContext
 
     conf = None
     if len(sys.argv) == 3:

--- a/examples/src/main/python/parquet_inputformat.py
+++ b/examples/src/main/python/parquet_inputformat.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         .appName("ParquetInputFormat")\
         .getOrCreate()
 
-    sc = spark._sc
+    sc = spark.sparkContext
 
     parquet_rdd = sc.newAPIHadoopFile(
         path,

--- a/examples/src/main/python/pi.py
+++ b/examples/src/main/python/pi.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         .appName("PythonPi")\
         .getOrCreate()
 
-    sc = spark._sc
+    sc = spark.sparkContext
 
     partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
     n = 100000 * partitions

--- a/examples/src/main/python/transitive_closure.py
+++ b/examples/src/main/python/transitive_closure.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         .appName("PythonTransitiveClosure")\
         .getOrCreate()
 
-    sc = spark._sc
+    sc = spark.sparkContext
 
     partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
     tc = sc.parallelize(generateGraph(), partitions).cache()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some PySpark examples need a SparkContext and get it by accessing _sc directly from the session.  These examples should use the provided property `sparkContext` in `SparkSession` instead.
## How was this patch tested?

Ran modified examples
