### PR TITLE
[SPARK-15538][SQL] Adding error check  for truncate table on a datasource table or view.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -292,10 +292,18 @@ case class TruncateTableCommand(
     } else if (catalog.isTemporaryTable(tableName)) {
       logError(s"table '$tableName' in TRUNCATE TABLE is a temporary table.")
     } else {
+      val table = catalog.getTableMetadata(tableName)
+      if (table.tableType == VIEW ) {
+        throw new AnalysisException(
+          s"TRUNCATE TABLE is not allowed on a view: ${table.qualifiedName}")
+      } else if (DDLUtils.isDatasourceTable(table)) {
+        throw new AnalysisException(
+          s"TRUNCATE TABLE is not allowed on a datasource table: ${table.qualifiedName}")
+      }
+
       val locations = if (partitionSpec.isDefined) {
         catalog.listPartitions(tableName, partitionSpec).map(_.storage.locationUri)
       } else {
-        val table = catalog.getTableMetadata(tableName)
         if (table.partitionColumnNames.nonEmpty) {
           catalog.listPartitions(tableName).map(_.storage.locationUri)
         } else {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -345,6 +345,19 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       checkAnswer(
         sql("SELECT employeeID, employeeName FROM part_table"),
         Seq.empty[Row])
+
+      withView("v1") {
+        sql(s"CREATE VIEW v1 AS SELECT * FROM non_part_table")
+        val msg = intercept[AnalysisException] {
+          sql("truncate table v1")
+        }.getMessage
+        assert(msg.contains("is not allowed on a view"))
+      }
+
+      val msg = intercept[AnalysisException] {
+        sql("TRUNCATE TABLE parquet_tab1")
+      }.getMessage
+      assert(msg.contains("is not allowed on a datasource table"))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds  check to throw error when user attempts truncate table on data source table or view. Currently 
TRUNCATE TABLE returns success when user attempts truncate table on data source table or view. But the table is not truncated.  
## How was this patch tested?

Added unit test cases. 

@hvanhovell 
