### PR TITLE
[SPARK-15542][SparkR] Make error message clear for script './R/install-dev.sh' when R is missing on Mac

### DIFF
--- a/R/install-dev.sh
+++ b/R/install-dev.sh
@@ -41,7 +41,7 @@ if [ ! -z "$R_HOME" ]
   else
     # if command 'which R' finds no R home, then exit
     if ! [ `command -v R` ]; then
-      echo "Cannot find R home by running 'which R', please make sure R is properly installed."
+      echo "Cannot find R home, please make sure R is properly installed."
       exit 1
     fi
     R_SCRIPT_PATH="$(dirname $(which R))"

--- a/R/install-dev.sh
+++ b/R/install-dev.sh
@@ -38,7 +38,12 @@ pushd $FWDIR > /dev/null
 if [ ! -z "$R_HOME" ]
   then
     R_SCRIPT_PATH="$R_HOME/bin"
-   else
+  else
+    # if command 'which R' finds no R home, then exit
+    if ! which R >/dev/null; then
+      echo "Cannot find R home by running 'which R', please make sure R is properly installed."
+      exit 1
+    fi
     R_SCRIPT_PATH="$(dirname $(which R))"
 fi
 echo "USING R_HOME = $R_HOME"

--- a/R/install-dev.sh
+++ b/R/install-dev.sh
@@ -40,7 +40,7 @@ if [ ! -z "$R_HOME" ]
     R_SCRIPT_PATH="$R_HOME/bin"
   else
     # if system wide R_HOME is not found, then exit
-    if ! [ `command -v R` ]; then
+    if [ ! `command -v R` ]; then
       echo "Cannot find 'R_HOME'. Please specify 'R_HOME' or make sure R is properly installed."
       exit 1
     fi

--- a/R/install-dev.sh
+++ b/R/install-dev.sh
@@ -39,9 +39,9 @@ if [ ! -z "$R_HOME" ]
   then
     R_SCRIPT_PATH="$R_HOME/bin"
   else
-    # if command 'which R' finds no R home, then exit
+    # if system wide R_HOME is not found, then exit
     if ! [ `command -v R` ]; then
-      echo "Cannot find R home, please make sure R is properly installed."
+      echo "Cannot find 'R_HOME'. Please specify 'R_HOME' or make sure R is properly installed."
       exit 1
     fi
     R_SCRIPT_PATH="$(dirname $(which R))"

--- a/R/install-dev.sh
+++ b/R/install-dev.sh
@@ -40,7 +40,7 @@ if [ ! -z "$R_HOME" ]
     R_SCRIPT_PATH="$R_HOME/bin"
   else
     # if command 'which R' finds no R home, then exit
-    if ! which R >/dev/null; then
+    if ! [ `command -v R` ]; then
       echo "Cannot find R home by running 'which R', please make sure R is properly installed."
       exit 1
     fi


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-15542
## What changes were proposed in this pull request?

When running`./R/install-dev.sh` in **Mac OS EI Captain** environment, I got

```
mbp185-xr:spark xin$ ./R/install-dev.sh
usage: dirname path
```

This message is very confusing to me, and then I found R is not properly configured on my Mac when this script is using `$(which R)` to get R home.

I tried similar situation on CentOS with R missing, and it's giving me very clear error message while MacOS is not.
on CentOS:

```
[root@ip-xxx-31-9-xx spark]# which R
/usr/bin/which: no R in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/lib/jvm/java-1.7.0-openjdk.x86_64/bin:/root/bin)
```

but on Mac, if not found then nothing returned and this is causing the confusing message for R build failure and running R/install-dev.sh:

```
mbp185-xr:spark xin$ which R
mbp185-xr:spark xin$
```

Here I just added a clear message for this miss configuration for R when running `R/install-dev.sh`.

```
mbp185-xr:spark xin$ ./R/install-dev.sh
Cannot find R home by running 'which R', please make sure R is properly installed.
```
## How was this patch tested?

Manually tested on local machine.
