### PR TITLE
[SPARK-15551][MINOR][DOCS][SQL] Replace groupBy with groupByKey in KeyValueGroupedDataset Scaladoc

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1255,6 +1255,7 @@ class Dataset[T] private[sql](
    * :: Experimental ::
    * (Scala-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
+   * Replaces `groupBy` combined with `keyAs` from Spark 1.6.
    *
    * @group typedrel
    * @since 2.0.0
@@ -1277,6 +1278,7 @@ class Dataset[T] private[sql](
    * :: Experimental ::
    * (Java-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
+   * Replaces `groupBy` combined with `keyAs` from Spark 1.6.
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -29,8 +29,8 @@ import org.apache.spark.sql.execution.QueryExecution
 /**
  * :: Experimental ::
  * A [[Dataset]] has been logically grouped by a user specified grouping key.  Users should not
- * construct a [[KeyValueGroupedDataset]] directly, but should instead call `groupBy` on an existing
- * [[Dataset]].
+ * construct a [[KeyValueGroupedDataset]] directly, but should instead call `groupByKey` on an
+ * existing [[Dataset]].
  *
  * @since 2.0.0
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace groupBy with groupByKey in KeyValueGroupedDataset Scaladoc and update Scaladoc on dataset groupByKey to mention that it is a replacement for the old groupBy + keyAs.
## How was this patch tested?

Verified groupByKey behaved as groupBy + keyAs used to function against spark 2.0 preview and built unidoc locally.
