### PR TITLE
[SPARK-15559][PYTHON][STREAMING] Add hash method for TopicAndPartition

### DIFF
--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -284,6 +284,9 @@ class TopicAndPartition(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash((self._topic, self._partition))
+
     def __ne__(self, other):
         return not self.__eq__(other)
 

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1173,6 +1173,7 @@ class KafkaStreamTests(PySparkStreamingTestCase):
         topic_and_partition_d = TopicAndPartition("foo", 1)
 
         self.assertEqual(topic_and_partition_a, topic_and_partition_b)
+        self.assertEqual(hash(topic_and_partition_a), hash(topic_and_partition_b))
         self.assertNotEqual(topic_and_partition_a, topic_and_partition_c)
         self.assertNotEqual(topic_and_partition_a, topic_and_partition_d)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds implementation of `__hash__` method for `TopicAndPartition`
## How was this patch tested?

PySpark unit tests (`--python-executables python3.5 --modules pyspark-streaming`)
