### PR TITLE
[SPARK-15597][SQL] Add SparkSession.emptyDataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -223,6 +223,13 @@ class SparkSession private(
   }
 
   /**
+   * Creates a new [[Dataset]] containing zero elements.
+   * @return 2.0.0
+   */
+  @Experimental
+  def emptyDataset[T: Encoder]: Dataset[T] = emptyDataFrame.as[T]
+
+  /**
    * :: Experimental ::
    * Creates a [[DataFrame]] from an RDD of Product (e.g. case classes, tuples).
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -223,11 +223,16 @@ class SparkSession private(
   }
 
   /**
-   * Creates a new [[Dataset]] containing zero elements.
+   * :: Experimental ::
+   * Creates a new [[Dataset]] of type T containing zero elements.
+   *
    * @return 2.0.0
    */
   @Experimental
-  def emptyDataset[T: Encoder]: Dataset[T] = emptyDataFrame.as[T]
+  def emptyDataset[T: Encoder]: Dataset[T] = {
+    val encoder = implicitly[Encoder[T]]
+    new Dataset(self, LocalRelation(encoder.schema.toAttributes), encoder)
+  }
 
   /**
    * :: Experimental ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -46,6 +46,12 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       1, 1, 1)
   }
 
+  test("emptyDataset") {
+    val ds = spark.emptyDataset[Int]
+    assert(ds.count() == 0L)
+    assert(ds.collect() == Array.empty[Int])
+  }
+
   test("range") {
     assert(spark.range(10).map(_ + 1).reduce(_ + _) == 55)
     assert(spark.range(10).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -49,7 +49,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   test("emptyDataset") {
     val ds = spark.emptyDataset[Int]
     assert(ds.count() == 0L)
-    assert(ds.collect() == Array.empty[Int])
+    assert(ds.collect() sameElements Array.empty[Int])
   }
 
   test("range") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds a new function emptyDataset to SparkSession, for creating an empty dataset.
## How was this patch tested?

Added a test case.
