### PR TITLE
[SPARK-15598][SQL] Change Aggregator.zero to Aggregator.init

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -88,7 +88,7 @@ case class TypedAggregateExpression(
     bufferSerializer.map(_.toAttribute.asInstanceOf[AttributeReference])
 
   override lazy val initialValues: Seq[Expression] = {
-    val zero = Literal.fromObject(aggregator.zero, bufferExternalType)
+    val zero = Literal.fromObject(aggregator.init(1), bufferExternalType)
     bufferSerializer.map(ReferenceToExpressions(_, zero :: Nil))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/typedaggregators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/typedaggregators.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.expressions.Aggregator
 
 
 class TypedSumDouble[IN](f: IN => Double) extends Aggregator[IN, Double, Double] {
-  override def zero: Double = 0.0
+  override def init(a: IN): Double = 0.0
   override def reduce(b: Double, a: IN): Double = b + f(a)
   override def merge(b1: Double, b2: Double): Double = b1 + b2
   override def finish(reduction: Double): Double = reduction
@@ -46,7 +46,7 @@ class TypedSumDouble[IN](f: IN => Double) extends Aggregator[IN, Double, Double]
 
 
 class TypedSumLong[IN](f: IN => Long) extends Aggregator[IN, Long, Long] {
-  override def zero: Long = 0L
+  override def init(a: IN): Long = 0L
   override def reduce(b: Long, a: IN): Long = b + f(a)
   override def merge(b1: Long, b2: Long): Long = b1 + b2
   override def finish(reduction: Long): Long = reduction
@@ -64,7 +64,7 @@ class TypedSumLong[IN](f: IN => Long) extends Aggregator[IN, Long, Long] {
 
 
 class TypedCount[IN](f: IN => Any) extends Aggregator[IN, Long, Long] {
-  override def zero: Long = 0
+  override def init(a: IN): Long = 0
   override def reduce(b: Long, a: IN): Long = {
     if (f(a) == null) b else b + 1
   }
@@ -83,7 +83,7 @@ class TypedCount[IN](f: IN => Any) extends Aggregator[IN, Long, Long] {
 
 
 class TypedAverage[IN](f: IN => Double) extends Aggregator[IN, (Double, Long), Double] {
-  override def zero: (Double, Long) = (0.0, 0L)
+  override def init(a: IN): (Double, Long) = (0.0, 0L)
   override def reduce(b: (Double, Long), a: IN): (Double, Long) = (f(a) + b._1, 1 + b._2)
   override def finish(reduction: (Double, Long)): Double = reduction._1 / reduction._2
   override def merge(b1: (Double, Long), b2: (Double, Long)): (Double, Long) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
@@ -54,10 +54,10 @@ import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
 abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
 
   /**
-   * A zero value for this aggregation. Should satisfy the property that any b + zero = b.
+   * A initial value for this aggregation.
    * @since 1.6.0
    */
-  def zero: BUF
+  def init(a: IN): BUF
 
   /**
    * Combine two values to produce a new value.  For performance, the function may modify `b` and

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/JavaDatasetAggregatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/JavaDatasetAggregatorSuite.java
@@ -54,7 +54,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
 
   static class IntSumOf extends Aggregator<Tuple2<String, Integer>, Integer, Integer> {
     @Override
-    public Integer zero() {
+    public Integer init(Tuple2<String, Integer> t) {
       return 0;
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.test.SharedSQLContext
 
 
 object ComplexResultAgg extends Aggregator[(String, Int), (Long, Long), (Long, Long)] {
-  override def zero: (Long, Long) = (0, 0)
+  override def init(a: (String, Int)): (Long, Long) = (0, 0)
   override def reduce(countAndSum: (Long, Long), input: (String, Int)): (Long, Long) = {
     (countAndSum._1 + 1, countAndSum._2 + input._2)
   }
@@ -43,7 +43,7 @@ object ComplexResultAgg extends Aggregator[(String, Int), (Long, Long), (Long, L
 case class AggData(a: Int, b: String)
 
 object ClassInputAgg extends Aggregator[AggData, Int, Int] {
-  override def zero: Int = 0
+  override def init(aggData: AggData): Int = 0
   override def reduce(b: Int, a: AggData): Int = b + a.a
   override def finish(reduction: Int): Int = reduction
   override def merge(b1: Int, b2: Int): Int = b1 + b2
@@ -53,7 +53,7 @@ object ClassInputAgg extends Aggregator[AggData, Int, Int] {
 
 
 object ComplexBufferAgg extends Aggregator[AggData, (Int, AggData), Int] {
-  override def zero: (Int, AggData) = 0 -> AggData(0, "0")
+  override def init(aggData: AggData): (Int, AggData) = 0 -> AggData(0, "0")
   override def reduce(b: (Int, AggData), a: AggData): (Int, AggData) = (b._1 + 1, a)
   override def finish(reduction: (Int, AggData)): Int = reduction._1
   override def merge(b1: (Int, AggData), b2: (Int, AggData)): (Int, AggData) =
@@ -64,7 +64,7 @@ object ComplexBufferAgg extends Aggregator[AggData, (Int, AggData), Int] {
 
 
 object NameAgg extends Aggregator[AggData, String, String] {
-  def zero: String = ""
+  def init(aggData: AggData): String = ""
   def reduce(b: String, a: AggData): String = a.b + b
   def merge(b1: String, b2: String): String = b1 + b2
   def finish(r: String): String = r
@@ -74,7 +74,7 @@ object NameAgg extends Aggregator[AggData, String, String] {
 
 
 object SeqAgg extends Aggregator[AggData, Seq[Int], Seq[Int]] {
-  def zero: Seq[Int] = Nil
+  def init(aggData: AggData): Seq[Int] = Nil
   def reduce(b: Seq[Int], a: AggData): Seq[Int] = a.a +: b
   def merge(b1: Seq[Int], b2: Seq[Int]): Seq[Int] = b1 ++ b2
   def finish(r: Seq[Int]): Seq[Int] = r
@@ -87,7 +87,7 @@ class ParameterizedTypeSum[IN, OUT : Numeric : Encoder](f: IN => OUT)
   extends Aggregator[IN, OUT, OUT] {
 
   private val numeric = implicitly[Numeric[OUT]]
-  override def zero: OUT = numeric.zero
+  override def init(in: IN): OUT = numeric.zero
   override def reduce(b: OUT, a: IN): OUT = numeric.plus(b, f(a))
   override def merge(b1: OUT, b2: OUT): OUT = numeric.plus(b1, b2)
   override def finish(reduction: OUT): OUT = reduction
@@ -96,7 +96,7 @@ class ParameterizedTypeSum[IN, OUT : Numeric : Encoder](f: IN => OUT)
 }
 
 object RowAgg extends Aggregator[Row, Int, Int] {
-  def zero: Int = 0
+  def init(row: Row): Int = 0
   def reduce(b: Int, a: Row): Int = a.getInt(0) + b
   def merge(b1: Int, b2: Int): Int = b1 + b2
   def finish(r: Int): Int = r

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetBenchmark.scala
@@ -117,7 +117,7 @@ object DatasetBenchmark {
   }
 
   object ComplexAggregator extends Aggregator[Data, Data, Long] {
-    override def zero: Data = Data(0, "")
+    override def init(data: Data): Data = Data(0, "")
 
     override def reduce(b: Data, a: Data): Data = Data(b.l + a.l, "")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

org.apache.spark.sql.expressions.Aggregator currently requires defining the zero value for an aggregator. This is actually a limitation making it difficult to implement APIs such as reduce. In reduce (or reduceByKey), a single associative and commutative reduce function is specified by the user, and there is no definition of zero value.
A small tweak to the API is to change zero to init, taking an input, similar to the following:

``` scala
abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
  def init(a: IN): BUF
  def reduce(b: BUF, a: IN): BUF
  def merge(b1: BUF, b2: BUF): BUF
  def finish(reduction: BUF): OUT
}
```

Then reduce can be implemented using:
`f: (T, T) => T`

``` scala
new Aggregator[T, T, T] {
  override def init(a: T): T = identify
  override def reduce(b: T, a: T): T = f(b, a)
  override def merge(b1: T, b2: T): T = f(b1, b2)
  override def finish(reduction: T): T = identify
}
```
## How was this patch tested?

Existing tests
