### PR TITLE
[SPARK-15565] [SQL] Add the File Scheme to the Default Value of WAREHOUSE_PATH

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.internal
 
-import java.io.File
 import java.util.{NoSuchElementException, Properties}
 import java.util.concurrent.TimeUnit
 
@@ -56,7 +55,7 @@ object SQLConf {
   val WAREHOUSE_PATH = SQLConfigBuilder("spark.sql.warehouse.dir")
     .doc("The default location for managed databases and tables.")
     .stringConf
-    .createWithDefault("${system:user.dir}/spark-warehouse")
+    .createWithDefault("file:${system:user.dir}/spark-warehouse")
 
   val OPTIMIZER_MAX_ITERATIONS = SQLConfigBuilder("spark.sql.optimizer.maxIterations")
     .internal()
@@ -666,8 +665,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def variableSubstituteDepth: Int = getConf(VARIABLE_SUBSTITUTE_DEPTH)
 
   def warehousePath: String = {
-    getConf(WAREHOUSE_PATH).replace("${system:user.dir}",
-      new File(System.getProperty("user.dir")).toURI.toURL.toString).replace("//", "/")
+    getConf(WAREHOUSE_PATH).replace("${system:user.dir}", System.getProperty("user.dir"))
   }
 
   override def orderByOrdinal: Boolean = getConf(ORDER_BY_ORDINAL)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -56,7 +56,7 @@ object SQLConf {
   val WAREHOUSE_PATH = SQLConfigBuilder("spark.sql.warehouse.dir")
     .doc("The default location for managed databases and tables.")
     .stringConf
-    .createWithDefault("${system:user.dir}" + File.separator + "spark-warehouse")
+    .createWithDefault("${system:user.dir}/spark-warehouse")
 
   val OPTIMIZER_MAX_ITERATIONS = SQLConfigBuilder("spark.sql.optimizer.maxIterations")
     .internal()
@@ -667,8 +667,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
 
   def warehousePath: String = {
     getConf(WAREHOUSE_PATH).replace("${system:user.dir}",
-      new File(System.getProperty("user.dir")).toURI.toURL.toString)
-      .replace(File.separator + File.separator, File.separator)
+      new File(System.getProperty("user.dir")).toURI.toURL.toString).replace("//", "/")
   }
 
   override def orderByOrdinal: Boolean = getConf(ORDER_BY_ORDINAL)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.internal
 
+import java.io.File
 import java.util.{NoSuchElementException, Properties}
 import java.util.concurrent.TimeUnit
 
@@ -55,7 +56,7 @@ object SQLConf {
   val WAREHOUSE_PATH = SQLConfigBuilder("spark.sql.warehouse.dir")
     .doc("The default location for managed databases and tables.")
     .stringConf
-    .createWithDefault("${system:user.dir}/spark-warehouse")
+    .createWithDefault("${system:user.dir}" + File.separator + "spark-warehouse")
 
   val OPTIMIZER_MAX_ITERATIONS = SQLConfigBuilder("spark.sql.optimizer.maxIterations")
     .internal()
@@ -665,7 +666,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def variableSubstituteDepth: Int = getConf(VARIABLE_SUBSTITUTE_DEPTH)
 
   def warehousePath: String = {
-    getConf(WAREHOUSE_PATH).replace("${system:user.dir}", System.getProperty("user.dir"))
+    getConf(WAREHOUSE_PATH).replace("${system:user.dir}",
+      new File(System.getProperty("user.dir")).toURI.toURL.toString)
+      .replace(File.separator + File.separator, File.separator)
   }
 
   override def orderByOrdinal: Boolean = getConf(ORDER_BY_ORDINAL)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -169,6 +169,31 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     }
   }
 
+  test("Create Database using Default Warehouse Path") {
+    withSQLConf(SQLConf.WAREHOUSE_PATH.key -> "") {
+      // Will use the default location if and only if we unset the conf
+      spark.conf.unset(SQLConf.WAREHOUSE_PATH.key)
+      val catalog = spark.sessionState.catalog
+      val dbName = "db1"
+      try {
+        sql(s"CREATE DATABASE $dbName")
+        val db1 = catalog.getDatabaseMetadata(dbName)
+        val expectedLocation =
+          "file:" + appendTrailingSlash(System.getProperty("user.dir")) +
+            s"spark-warehouse/$dbName.db"
+        assert(db1 == CatalogDatabase(
+          dbName,
+          "",
+          expectedLocation,
+          Map.empty))
+        sql(s"DROP DATABASE $dbName CASCADE")
+        assert(!catalog.databaseExists(dbName))
+      } finally {
+        catalog.reset()
+      }
+    }
+  }
+
   test("Create/Drop Database - location") {
     val catalog = sqlContext.sessionState.catalog
     val databaseNames = Seq("db1", "`database`")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.internal
 
-import java.io.File
-
 import org.apache.spark.sql.{QueryTest, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
 
@@ -212,7 +210,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   test("default value of WAREHOUSE_PATH") {
     val original = spark.conf.get(SQLConf.WAREHOUSE_PATH)
     try {
-      // to get the default value, unset it
+      // to get the default value, always unset it
       spark.conf.unset(SQLConf.WAREHOUSE_PATH.key)
       assert(spark.sessionState.conf.warehousePath
         === s"file:${System.getProperty("user.dir")}/spark-warehouse")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -215,7 +215,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
       // to get the default value, unset it
       spark.conf.unset(SQLConf.WAREHOUSE_PATH.key)
       assert(spark.sessionState.conf.warehousePath
-        === s"file:${System.getProperty("user.dir")}" + File.separator + "spark-warehouse")
+        === s"file:${System.getProperty("user.dir")}/spark-warehouse")
     } finally {
       sql(s"set ${SQLConf.WAREHOUSE_PATH}=$original")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.internal
 
+import java.io.File
+
 import org.apache.spark.sql.{QueryTest, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
 
@@ -204,6 +206,18 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     } finally {
       sparkContext.conf.remove("spark.to.be.or.not.to.be")
       sparkContext.conf.remove("spark.sql.with.or.without.you")
+    }
+  }
+
+  test("default value of WAREHOUSE_PATH") {
+    val original = spark.conf.get(SQLConf.WAREHOUSE_PATH)
+    try {
+      // to get the default value, unset it
+      spark.conf.unset(SQLConf.WAREHOUSE_PATH.key)
+      assert(spark.sessionState.conf.warehousePath
+        === s"file:${System.getProperty("user.dir")}" + File.separator + "spark-warehouse")
+    } finally {
+      sql(s"set ${SQLConf.WAREHOUSE_PATH}=$original")
     }
   }
 


### PR DESCRIPTION
#### What changes were proposed in this pull request?

The default value of `spark.sql.warehouse.dir` is `System.getProperty("user.dir")/spark-warehouse`. Since `System.getProperty("user.dir")` is a local dir, we should explicitly set the scheme to local filesystem.

cc @yhuai 
#### How was this patch tested?

Added two test cases
