### PR TITLE
[SPARK-15601][CORE] CircularBuffer's toString() to print only the contents written if buffer isn't full

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2353,7 +2353,7 @@ private[spark] class CircularBuffer(sizeInBytes: Int = 10240) extends java.io.Ou
     pos = (pos + 1) % buffer.length
     isBufferFull = isBufferFull || (pos == 0)
   }
-  
+
   override def toString: String = {
     val end = new String(buffer, 0, pos, StandardCharsets.UTF_8)
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -686,9 +686,9 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val stream = new java.io.PrintStream(buffer, true, "UTF-8")
 
     // scalastyle:off println
-    stream.println("test circular test circular test circular test circular test circular")
+    stream.print("test circular\n test circular\r test circular\n test circular\r test circular\n")
     // scalastyle:on println
-    assert(buffer.toString === "t circular test circular\n")
+    assert(buffer.toString === " circular\r test circular\n")
   }
 
   test("circular buffer: if the buffer isn't full, print only the contents written") {
@@ -699,9 +699,9 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(buffer.toString === "")
 
     // scalastyle:off println
-    stream.println("test")
+    stream.print("test")
     // scalastyle:on println
-    assert(buffer.toString === "test\n")
+    assert(buffer.toString === "test")
   }
 
   test("nanSafeCompareDoubles") {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -691,6 +691,19 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(buffer.toString === "t circular test circular\n")
   }
 
+  test("circular buffer: if the buffer isn't full, print only the contents written") {
+    val buffer = new CircularBuffer(25)
+    val stream = new java.io.PrintStream(buffer, true, "UTF-8")
+
+    // corner case: if nothing was written to the buffer, display nothing
+    assert(buffer.toString === "")
+
+    // scalastyle:off println
+    stream.println("test")
+    // scalastyle:on println
+    assert(buffer.toString === "test\n")
+  }
+
   test("nanSafeCompareDoubles") {
     def shouldMatchDefaultOrder(a: Double, b: Double): Unit = {
       assert(Utils.nanSafeCompareDoubles(a, b) === JDouble.compare(a, b))

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, FileOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, FileOutputStream, PrintStream}
 import java.lang.{Double => JDouble, Float => JFloat}
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
@@ -681,27 +681,37 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(!Utils.isInDirectory(nullFile, childFile3))
   }
 
-  test("circular buffer") {
-    val buffer = new CircularBuffer(25)
-    val stream = new java.io.PrintStream(buffer, true, "UTF-8")
-
-    // scalastyle:off println
-    stream.print("test circular\n test circular\r test circular\n test circular\r test circular\n")
-    // scalastyle:on println
-    assert(buffer.toString === " circular\r test circular\n")
+  test("circular buffer: if nothing was written to the buffer, display nothing") {
+    val buffer = new CircularBuffer(4)
+    assert(buffer.toString === "")
   }
 
   test("circular buffer: if the buffer isn't full, print only the contents written") {
-    val buffer = new CircularBuffer(25)
-    val stream = new java.io.PrintStream(buffer, true, "UTF-8")
-
-    // corner case: if nothing was written to the buffer, display nothing
-    assert(buffer.toString === "")
-
-    // scalastyle:off println
+    val buffer = new CircularBuffer(10)
+    val stream = new PrintStream(buffer, true, "UTF-8")
     stream.print("test")
-    // scalastyle:on println
     assert(buffer.toString === "test")
+  }
+
+  test("circular buffer: data written == size of the buffer") {
+    val buffer = new CircularBuffer(4)
+    val stream = new PrintStream(buffer, true, "UTF-8")
+
+    // fill the buffer to its exact size so that it just hits overflow
+    stream.print("test")
+    assert(buffer.toString === "test")
+
+    // add more data to the buffer
+    stream.print("12")
+    assert(buffer.toString === "st12")
+  }
+
+  test("circular buffer: multiple overflow") {
+    val buffer = new CircularBuffer(25)
+    val stream = new PrintStream(buffer, true, "UTF-8")
+
+    stream.print("test circular test circular test circular test circular test circular")
+    assert(buffer.toString === "st circular test circular")
   }
 
   test("nanSafeCompareDoubles") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. The class allocated 4x space than needed as it was using `Int` to store the `Byte` values
2. If CircularBuffer isn't full, currently toString() will print some garbage chars along with the content written as is tries to print the entire array allocated for the buffer. The fix is to keep track of buffer getting full and don't print the tail of the buffer if it isn't full (suggestion by @sameeragarwal over https://github.com/apache/spark/pull/12194#discussion_r64495331)
3. Simplified `toString()`
## How was this patch tested?

Added new test case
