### PR TITLE
[SPARK-15607][ML] Remove redundant toArray in ml.linalg

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -716,7 +716,7 @@ class SparseVector @Since("2.0.0") (
       currentIdx += 1
       i_v
     }.unzip
-    new SparseVector(selectedIndices.length, sliceInds.toArray, sliceVals.toArray)
+    new SparseVector(selectedIndices.length, sliceInds, sliceVals)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`sliceInds, sliceVals` are already of type `Array`, so remove `toArray`
## How was this patch tested?

local build
