### PR TITLE
[SPARK-15612][SQL] Raise exception if decimal `scale` >= `precision`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
  * A Decimal that must have fixed precision (the maximum number of digits) and scale (the number
  * of digits on right side of dot).
  *
- * The precision can be up to 38, scale can also be up to 38 (less or equal to precision).
+ * The precision can be up to 38, scale must be less than precision.
  *
  * The default precision and scale is (10, 0).
  *
@@ -40,9 +40,9 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 @DeveloperApi
 case class DecimalType(precision: Int, scale: Int) extends FractionalType {
 
-  if (scale > precision) {
+  if (scale >= precision) {
     throw new AnalysisException(
-      s"Decimal scale ($scale) cannot be greater than precision ($precision).")
+      s"Decimal scale ($scale) must be less than precision ($precision).")
   }
 
   if (precision > DecimalType.MAX_PRECISION) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.types
 
 import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.sql.AnalysisException
 
 class DataTypeSuite extends SparkFunSuite {
 
@@ -198,6 +199,16 @@ class DataTypeSuite extends SparkFunSuite {
     assert(arrayType.existsRecursively(_.isInstanceOf[MapType]))
     assert(arrayType.existsRecursively(_.isInstanceOf[ArrayType]))
     assert(!arrayType.existsRecursively(_.isInstanceOf[IntegerType]))
+  }
+
+  test("decimal: scale < precision <= 38") {
+    intercept[AnalysisException] {
+      new DecimalType(10, 10)
+    }
+    new DecimalType(38, 37)
+    intercept[AnalysisException] {
+      new DecimalType(39, 37)
+    }
   }
 
   def checkDataTypeJsonRepr(dataType: DataType): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark raises exceptions only when decimal `scale` > `precision`. However, the value becames `null` if `scale` = `precision`. We should raise exceptions for that case, too.

**Before**

``` scala
scala> sql("select cast('1' as Decimal(2,1))")
res0: org.apache.spark.sql.DataFrame = [CAST(1 AS DECIMAL(2,1)): decimal(2,1)]

scala> sql("select cast('1' as Decimal(2,2))")
res1: org.apache.spark.sql.DataFrame = [CAST(1 AS DECIMAL(2,2)): decimal(2,2)]

scala> sql("select cast('1' as Decimal(2,3))")
org.apache.spark.sql.catalyst.parser.ParseException:
Decimal scale (3) cannot be greater than precision (2).

scala> sql("select cast('1' as Decimal(2,1))").head
res2: org.apache.spark.sql.Row = [1.0]

scala> sql("select cast('1' as Decimal(2,2))").head
res3: org.apache.spark.sql.Row = [null]
```

**After**

``` scala
scala> sql("select cast('1' as Decimal(2,1))")
res0: org.apache.spark.sql.DataFrame = [CAST(1 AS DECIMAL(2,1)): decimal(2,1)]

scala> sql("select cast('1' as Decimal(2,2))")
org.apache.spark.sql.catalyst.parser.ParseException:
Decimal scale (2) must be less than precision (2).
```
## How was this patch tested?

Pass the Jenkins tests (with a new testcase)
