### PR TITLE
[SPARK-15648][SQL]add TeradataDialect.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/TeradataDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/TeradataDialect.scala
@@ -1,0 +1,20 @@
+package org.apache.spark.sql.jdbc
+
+import org.apache.spark.sql.types.{BinaryType, StringType, DataType}
+
+/**
+ * Created by lhl on 5/27/2016.
+ */
+private object TeradataDialect extends JdbcDialect {
+
+  override def canHandle(url: String): Boolean = url.startsWith("jdbc:teradata")
+
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+    case StringType => Option(JdbcType("VARCHAR(255)", java.sql.Types.CLOB))
+    case BinaryType => Option(JdbcType("VARBYTE(4)", java.sql.Types.BLOB))
+    case _ => None
+  }
+  override def getTableExistsQuery(table: String): String = {
+    s"SELECT TOP 1 1 FROM $table"
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found that Spark does not have TeradataDialect.I want to add the TeradataDialect.scala to support Teradata database better.
I override three functions in  TeradataDialect.scala:
1.The url: jdbc:teradata
2.The JDBCType:Teradata database does not support "TEXT",so we replace it with "VARCHAR(255)".Also we replace "BLOB" with "VARBYTE(4)".
3.Teradata database does not support sql like "LIMIT 1",so we replace it with "TOP 1".
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
unit tests.
