### PR TITLE
[Minor][ML] Enable java save/load tests for ML

### DIFF
--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,11 +30,12 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 public class JavaDecisionTreeClassifierSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -62,18 +65,15 @@ public class JavaDecisionTreeClassifierSuite extends SharedSparkSession {
     model.depth();
     model.toDebugString();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model3.save(sc.sc(), path);
+      model.save(path);
       DecisionTreeClassificationModel sameModel =
-        DecisionTreeClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+        DecisionTreeClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
@@ -68,7 +68,7 @@ public class JavaDecisionTreeClassifierSuite extends SharedSparkSession {
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model.save(path);
+      model.write().overwrite().save(path);
       DecisionTreeClassificationModel sameModel =
         DecisionTreeClassificationModel.load(path);
       TreeTests.checkEqual(model, sameModel);

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
@@ -73,7 +73,7 @@ public class JavaGBTClassifierSuite extends SharedSparkSession {
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model.save(path);
+      model.write().overwrite().save(path);
       GBTClassificationModel sameModel = GBTClassificationModel.load(path);
       TreeTests.checkEqual(model, sameModel);
     } finally {

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,11 +30,12 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 public class JavaGBTClassifierSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -67,17 +70,14 @@ public class JavaGBTClassifierSuite extends SharedSparkSession {
     model.trees();
     model.treeWeights();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model3.save(sc.sc(), path);
-      GBTClassificationModel sameModel = GBTClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+      model.save(path);
+      GBTClassificationModel sameModel = GBTClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -96,7 +96,7 @@ public class JavaRandomForestClassifierSuite extends SharedSparkSession {
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model.save(path);
+      model.write().overwrite().save(path);
       RandomForestClassificationModel sameModel =
           RandomForestClassificationModel.load(path);
       TreeTests.checkEqual(model, sameModel);

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,11 +32,12 @@ import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 public class JavaRandomForestClassifierSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -90,18 +93,15 @@ public class JavaRandomForestClassifierSuite extends SharedSparkSession {
     model.treeWeights();
     Vector importances = model.featureImportances();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model3.save(sc.sc(), path);
+      model.save(path);
       RandomForestClassificationModel sameModel =
-          RandomForestClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+          RandomForestClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,12 +31,12 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-
+import org.apache.spark.util.Utils;
 
 public class JavaDecisionTreeRegressorSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -64,17 +66,14 @@ public class JavaDecisionTreeRegressorSuite extends SharedSparkSession {
     model.depth();
     model.toDebugString();
 
-    /*
-    // TODO: Add test once save/load are implemented.   SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model2.save(sc.sc(), path);
-      DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
@@ -69,7 +69,7 @@ public class JavaDecisionTreeRegressorSuite extends SharedSparkSession {
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model.save(path);
+      model.write().overwrite().save(path);
       DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(path);
       TreeTests.checkEqual(model, sameModel);
     } finally {

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,12 +31,12 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-
+import org.apache.spark.util.Utils;
 
 public class JavaGBTRegressorSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -68,17 +70,14 @@ public class JavaGBTRegressorSuite extends SharedSparkSession {
     model.trees();
     model.treeWeights();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model2.save(sc.sc(), path);
-      GBTRegressionModel sameModel = GBTRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      GBTRegressionModel sameModel = GBTRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
@@ -73,7 +73,7 @@ public class JavaGBTRegressorSuite extends SharedSparkSession {
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model.save(path);
+      model.write().overwrite().save(path);
       GBTRegressionModel sameModel = GBTRegressionModel.load(path);
       TreeTests.checkEqual(model, sameModel);
     } finally {

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -97,7 +97,7 @@ public class JavaRandomForestRegressorSuite extends SharedSparkSession {
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model.save(path);
+      model.write().overwrite().save(path);
       RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(path);
       TreeTests.checkEqual(model, sameModel);
     } finally {

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,12 +33,12 @@ import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-
+import org.apache.spark.util.Utils;
 
 public class JavaRandomForestRegressorSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -92,17 +94,14 @@ public class JavaRandomForestRegressorSuite extends SharedSparkSession {
     model.treeWeights();
     Vector importances = model.featureImportances();
 
-    /*
-    // TODO: Add test once save/load are implemented.   SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String path = tempDir.toURI().toString();
     try {
-      model2.save(sc.sc(), path);
-      RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -58,8 +58,6 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.apache.spark.sql.types.StructType;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because `SPARK-6725` is already Resolved, the `TODO` save/load tests depending on it can be enabled.
BTW,  remove unused imports in `SpecificParquetRecordReaderBase.java` to pass `lint-java`
## How was this patch tested?

Unit tests
local `lint-java`
