### PR TITLE
[SPARK-15620][SQL] Fix transformed dataset attributes revolve failure

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -524,6 +524,10 @@ class Analyzer(
           val newVersion = oldVersion.newInstance()
           (oldVersion, newVersion)
 
+        case oldVersion: SerializeFromObject
+            if oldVersion.outputSet.intersect(conflictingAttributes).nonEmpty =>
+          (oldVersion, oldVersion.copy(serializer = oldVersion.serializer.map(_.newInstance())))
+
         // Handle projects that create conflicting aliases.
         case oldVersion @ Project(projectList, _)
             if findAliases(projectList).intersect(conflictingAttributes).nonEmpty =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -771,12 +771,12 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("transformed dataset correctly solve the attributes") {
     val dataset = Seq(1, 2, 3).toDS()
-    val ds1 = dataset.map(_ + 1).as("d1")
-    val ds2 = dataset.map(_ + 2).as("d2")
+    val ds1 = dataset.map(_ + 1)
 
-    checkDataset(ds1.joinWith(ds2, $"d1.value" === $"d2.value"), (3, 3), (4, 4))
-    checkDataset(ds1.intersect(ds2), 3, 4)
-    checkDataset(ds1.except(ds2), 2)
+    checkDataset(ds1.as("d1").joinWith(ds1.as("d2"), $"d1.value" === $"d2.value"),
+      (2, 2), (3, 3), (4, 4))
+    checkDataset(ds1.as("d1").intersect(ds1.as("d2")), 2, 3, 4)
+    checkDataset(ds1.as("d1").except(ds1.as("d2")))
   }
 
   test("SPARK-15441: Dataset outer join") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -767,6 +767,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assertResult(Seq(ClassData("bar", 2))) {
       ds.filter(_.b > 1).collect().toSeq
     }
+  }
 
   test("transformed dataset correctly solve the attributes") {
     val dataset = Seq(1, 2, 3).toDS()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -767,6 +767,15 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assertResult(Seq(ClassData("bar", 2))) {
       ds.filter(_.b > 1).collect().toSeq
     }
+
+  test("transformed dataset correctly solve the attributes") {
+    val dataset = Seq(1, 2, 3).toDS()
+    val ds1 = dataset.map(_ + 1).as("d1")
+    val ds2 = dataset.map(_ + 2).as("d2")
+
+    checkDataset(ds1.joinWith(ds2, $"d1.value" === $"d2.value"), (3, 3), (4, 4))
+    checkDataset(ds1.intersect(ds2), 3, 4)
+    checkDataset(ds1.except(ds2), 2)
   }
 
   test("SPARK-15441: Dataset outer join") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -769,14 +769,14 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("transformed dataset correctly solve the attributes") {
-    val dataset = Seq(1, 2, 3).toDS()
-    val ds1 = dataset.map(_ + 1)
+  test("mapped dataset should resolve duplicated attributes for self join") {
+    val ds = Seq(1, 2, 3).toDS().map(_ + 1)
+    val ds1 = ds.as("d1")
+    val ds2 = ds.as("d2")
 
-    checkDataset(ds1.as("d1").joinWith(ds1.as("d2"), $"d1.value" === $"d2.value"),
-      (2, 2), (3, 3), (4, 4))
-    checkDataset(ds1.as("d1").intersect(ds1.as("d2")), 2, 3, 4)
-    checkDataset(ds1.as("d1").except(ds1.as("d2")))
+    checkDataset(ds1.joinWith(ds2, $"d1.value" === $"d2.value"), (2, 2), (3, 3), (4, 4))
+    checkDataset(ds1.intersect(ds2), 2, 3, 4)
+    checkDataset(ds1.except(ds1))
   }
 
   test("SPARK-15441: Dataset outer join") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Join on transformed dataset has attributes conflicts, which make query execution failure, for example:

```
val dataset = Seq(1, 2, 3).toDs
val mappedDs = dataset.map(_ + 1)

mappedDs.as("t1").joinWith(mappedDs.as("t2"), $"t1.value" === $"t2.value").show()
```

will throw exception:

```
org.apache.spark.sql.AnalysisException: cannot resolve '`t1.value`' given input columns: [value];
  at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
  at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:62)
  at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:59)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:287)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:287)
```
## How was this patch tested?

Unit test.
