### PR TITLE
[SPARK-15676] [SQL] Disallow Column Names as Partition Columns For Hive Tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -50,17 +50,6 @@ object ParserUtils {
     }
   }
 
-  /** Check if duplicate exist in a set of column names. */
-  def checkDuplicateNames[T](colNames: Seq[String], ctx: ParserRuleContext): Unit = {
-    if (colNames.length != colNames.distinct.length) {
-      val duplicateColumns = colNames.groupBy(identity).collect {
-        case (x, ys) if ys.length > 1 => "\"" + x + "\""
-      }
-      throw new ParseException(s"Column repeated in partitioning column(s) or duplicate column " +
-        s"name key in the table definition: ${duplicateColumns.mkString("[", ",", "]")}", ctx)
-    }
-  }
-
   /** Get the code that creates the given node. */
   def source(ctx: ParserRuleContext): String = {
     val stream = ctx.getStart.getInputStream

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -50,6 +50,17 @@ object ParserUtils {
     }
   }
 
+  /** Check if duplicate exist in a set of column names. */
+  def checkDuplicateNames[T](colNames: Seq[String], ctx: ParserRuleContext): Unit = {
+    if (colNames.length != colNames.distinct.length) {
+      val duplicateColumns = colNames.groupBy(identity).collect {
+        case (x, ys) if ys.length > 1 => "\"" + x + "\""
+      }
+      throw new ParseException(s"Column repeated in partitioning column(s) or duplicate column " +
+        s"name key in the table definition: ${duplicateColumns.mkString("[", ",", "]")}", ctx)
+    }
+  }
+
   /** Get the code that creates the given node. */
   def source(ctx: ParserRuleContext): String = {
     val stream = ctx.getStart.getInputStream

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -884,6 +884,10 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     // to include the partition columns here explicitly
     val schema = cols ++ partitionCols
 
+    // Ensuring whether no duplicate name is used in table definition;
+    // Also ensuring the existing columns are not used as partition columns
+    checkDuplicateNames(colNames = schema.map(_.name), ctx)
+
     // Storage format
     val defaultStorage: CatalogStorageFormat = {
       val defaultStorageType = conf.getConfString("hive.default.fileformat", "textfile")
@@ -937,13 +941,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
     selectQuery match {
       case Some(q) => CreateTableAsSelectLogicalPlan(tableDesc, q, ifNotExists)
-      case None =>
-        val partitionColsInTable = partitionCols.map(_.name).toSet.intersect(cols.map(_.name).toSet)
-        if (partitionColsInTable.nonEmpty) {
-          throw new ParseException(s"Column repeated in partitioning columns: " +
-            partitionColsInTable.mkString("[", ",", "]"), ctx)
-        }
-        CreateTableCommand(tableDesc, ifNotExists)
+      case None => CreateTableCommand(tableDesc, ifNotExists)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -322,7 +322,15 @@ class DDLCommandSuite extends PlanTest {
   test("create table - column repeated in partitioning columns") {
     val query = "CREATE TABLE tab1 (key INT, value STRING) PARTITIONED BY (key INT, hr STRING)"
     val e = intercept[ParseException] { parser.parsePlan(query) }
-    assert(e.getMessage.contains("Column repeated in partitioning columns: [key]"))
+    assert(e.getMessage.contains("Column repeated in partitioning column(s) or " +
+      "duplicate column name key in the table definition: [\"key\"]"))
+  }
+
+  test("create table - duplicate column name key in the table definition") {
+    val query = "CREATE TABLE tab1 (key INT, key STRING)"
+    val e = intercept[ParseException] { parser.parsePlan(query) }
+    assert(e.getMessage.contains("Column repeated in partitioning column(s) or " +
+      "duplicate column name key in the table definition: [\"key\"]"))
   }
 
   test("create table using - with partitioned by") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -322,13 +322,15 @@ class DDLCommandSuite extends PlanTest {
   test("create table - column repeated in partitioning columns") {
     val query = "CREATE TABLE tab1 (key INT, value STRING) PARTITIONED BY (key INT, hr STRING)"
     val e = intercept[ParseException] { parser.parsePlan(query) }
-    assert(e.getMessage.contains("Column repeated in partitioning column(s): [\"key\"]"))
+    assert(e.getMessage.contains(
+      "Operation not allowed: Partition columns may not be specified in the schema: [\"key\"]"))
   }
 
-  test("create table - duplicate column name key in the table definition") {
-    val query = "CREATE TABLE tab1 (key INT, key STRING)"
+  test("create table - duplicate column names in the table definition") {
+    val query = "CREATE TABLE default.tab1 (key INT, key STRING)"
     val e = intercept[ParseException] { parser.parsePlan(query) }
-    assert(e.getMessage.contains("Duplicate column name key(s) in the table definition: [\"key\"]"))
+    assert(e.getMessage.contains("Operation not allowed: Duplicated column names found in " +
+      "table definition of `default`.`tab1`: [\"key\"]"))
   }
 
   test("create table using - with partitioned by") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -322,15 +322,13 @@ class DDLCommandSuite extends PlanTest {
   test("create table - column repeated in partitioning columns") {
     val query = "CREATE TABLE tab1 (key INT, value STRING) PARTITIONED BY (key INT, hr STRING)"
     val e = intercept[ParseException] { parser.parsePlan(query) }
-    assert(e.getMessage.contains("Column repeated in partitioning column(s) or " +
-      "duplicate column name key in the table definition: [\"key\"]"))
+    assert(e.getMessage.contains("Column repeated in partitioning column(s): [\"key\"]"))
   }
 
   test("create table - duplicate column name key in the table definition") {
     val query = "CREATE TABLE tab1 (key INT, key STRING)"
     val e = intercept[ParseException] { parser.parsePlan(query) }
-    assert(e.getMessage.contains("Column repeated in partitioning column(s) or " +
-      "duplicate column name key in the table definition: [\"key\"]"))
+    assert(e.getMessage.contains("Duplicate column name key(s) in the table definition: [\"key\"]"))
   }
 
   test("create table using - with partitioned by") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -319,6 +319,12 @@ class DDLCommandSuite extends PlanTest {
     assert(ct.table.storage.locationUri == Some("/something/anything"))
   }
 
+  test("create table - column repeated in partitioning columns") {
+    val query = "CREATE TABLE tab1 (key INT, value STRING) PARTITIONED BY (key INT, hr STRING)"
+    val e = intercept[ParseException] { parser.parsePlan(query) }
+    assert(e.getMessage.contains("Column repeated in partitioning columns: [key]"))
+  }
+
   test("create table using - with partitioned by") {
     val query = "CREATE TABLE my_tab(a INT, b STRING) USING parquet PARTITIONED BY (a)"
     val expected = CreateTableUsing(


### PR DESCRIPTION
#### What changes were proposed in this pull request?

When creating a Hive Table (not data source tables), a common error users might make is to specify an existing column name as a partition column. Below is what Hive returns in this case:

```
hive> CREATE TABLE partitioned (id bigint, data string) PARTITIONED BY (data string, part string);
FAILED: SemanticException [Error 10035]: Column repeated in partitioning columns
```

Currently, the error we issued is very confusing: 

```
org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: MetaException(message:For direct MetaStore DB connections, we don't support retries at the client level.);
```

This PR is to fix the above issue by capturing the usage error in `Parser`. 
#### How was this patch tested?

Added a test case to `DDLCommandSuite`
