### PR TITLE
[SPARK-15677][SQL] Query with scalar sub-query in the SELECT list throws UnsupportedOperationException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -84,13 +84,6 @@ object ScalarSubquery {
       case _ => false
     }.isDefined
   }
-
-  def hasScalarSubquery(e: Expression): Boolean = {
-    e.find {
-      case e: ScalarSubquery => true
-      case _ => false
-    }.isDefined
-  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -84,6 +84,13 @@ object ScalarSubquery {
       case _ => false
     }.isDefined
   }
+
+  def hasScalarSubquery(e: Expression): Boolean = {
+    e.find {
+      case e: ScalarSubquery => true
+      case _ => false
+    }.isDefined
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1468,8 +1468,8 @@ object DecimalAggregates extends Rule[LogicalPlan] {
  */
 object ConvertToLocalRelation extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case p @ Project(projectList, LocalRelation(output, data))
-        if !p.expressions.exists(hasUnevaluableExpr) =>
+    case Project(projectList, LocalRelation(output, data))
+        if !projectList.exists(hasUnevaluableExpr) =>
       val projection = new InterpretedProjection(projectList, output)
       LocalRelation(projectList.map(_.toAttribute), data.map(projection))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1469,9 +1469,13 @@ object DecimalAggregates extends Rule[LogicalPlan] {
 object ConvertToLocalRelation extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case p @ Project(projectList, LocalRelation(output, data))
-        if !p.expressions.exists(ScalarSubquery.hasScalarSubquery) =>
+        if !p.expressions.exists(hasUnevaluableExpr) =>
       val projection = new InterpretedProjection(projectList, output)
       LocalRelation(projectList.map(_.toAttribute), data.map(projection))
+  }
+
+  private def hasUnevaluableExpr(expr: Expression): Boolean = {
+    expr.find(e => e.isInstanceOf[Unevaluable] && !e.isInstanceOf[AttributeReference]).isDefined
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1468,7 +1468,8 @@ object DecimalAggregates extends Rule[LogicalPlan] {
  */
 object ConvertToLocalRelation extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case Project(projectList, LocalRelation(output, data)) =>
+    case p @ Project(projectList, LocalRelation(output, data))
+        if !p.expressions.exists(ScalarSubquery.hasScalarSubquery) =>
       val projection = new InterpretedProjection(projectList, output)
       LocalRelation(projectList.map(_.toAttribute), data.map(projection))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -100,6 +100,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
   test("uncorrelated scalar subquery on a DataFrame generated query") {
     val df = Seq((1, "one"), (2, "two"), (3, "three")).toDF("key", "value")
     df.createOrReplaceTempView("subqueryData")
+    val t1 = Seq((1, 1), (2, 2)).toDF("c1", "c2")
+    t1.createOrReplaceTempView("t1")
 
     checkAnswer(
       sql("select (select key from subqueryData where key > 2 order by key limit 1) + 1"),
@@ -120,6 +122,16 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
       sql("select (select min(value) from subqueryData" +
         " where key = (select max(key) from subqueryData) - 1)"),
       Array(Row("two"))
+    )
+
+    checkAnswer(
+      sql("select (select 1 as col) from t1"),
+      Array(Row(1), Row(1))
+    )
+
+    checkAnswer(
+      sql("select c1 + (select min(key) from subqueryData) from t1"),
+      Array(Row(2), Row(3))
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Queries with scalar sub-query in the SELECT list run against a local, in-memory relation throw 
UnsupportedOperationException exception.

Problem repro:

``` SQL
scala> Seq((1, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t1")
scala> Seq((1, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t2")
scala> sql("select (select min(c1) from t2) from t1").show()

java.lang.UnsupportedOperationException: Cannot evaluate expression: scalar-subquery#62 []
  at org.apache.spark.sql.catalyst.expressions.Unevaluable$class.eval(Expression.scala:215)
  at org.apache.spark.sql.catalyst.expressions.ScalarSubquery.eval(subquery.scala:62)
  at org.apache.spark.sql.catalyst.expressions.Alias.eval(namedExpressions.scala:142)
  at org.apache.spark.sql.catalyst.expressions.InterpretedProjection.apply(Projection.scala:45)
  at org.apache.spark.sql.catalyst.expressions.InterpretedProjection.apply(Projection.scala:29)
  at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
  at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
  at scala.collection.immutable.List.foreach(List.scala:381)
  at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
  at scala.collection.immutable.List.map(List.scala:285)
  at org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation$$anonfun$apply$37.applyOrElse(Optimizer.scala:1473)
```

The problem is specific to local, in memory relations. It is caused by rule ConvertToLocalRelation, which attempts to push down 
a scalar-subquery expression to the local tables. 

The solution prevents the rule to apply if Project references scalar subqueries.
## How was this patch tested?

Added regression tests to SubquerySuite.scala
