### PR TITLE
[SPARK-15681][core] allow lowercase or mixed case log level string when calling sc.setLogLevel

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -76,6 +76,8 @@ import org.apache.spark.util._
  *   this config overrides the default configs as well as system properties.
  */
 class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationClient {
+  // original log level
+  private val originalLogLevel = org.apache.log4j.Logger.getRootLogger().getLevel
 
   // The call site where this SparkContext was constructed.
   private val creationSite: CallSite = Utils.getCallSite()
@@ -362,6 +364,14 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
         s"Supplied level $logLevel did not match one of: ${validLevels.mkString(",")}")
     }
     Utils.setLogLevel(org.apache.log4j.Level.toLevel(logLevel))
+  }
+
+  /**
+   * Reset log level to original one when this SparkContext was created.
+   * @since 2.0.0
+   */
+  def resetLogLevel(): Unit = {
+    Utils.setLogLevel(originalLogLevel)
   }
 
   try {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -358,8 +358,9 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   def setLogLevel(logLevel: String) {
     // let's allow lowcase or mixed case too
     val upperCased = logLevel.toUpperCase(Locale.ENGLISH)
-    require(SparkContext.validLevels.contains(upperCased),
-      s"Supplied level $logLevel did not match one of: ${SparkContext.validLevels.mkString(",")}")
+    require(SparkContext.VALID_LOG_LEVELS.contains(upperCased),
+      s"Supplied level $logLevel did not match one of:" +
+        s" ${SparkContext.VALID_LOG_LEVELS.mkString(",")}")
     Utils.setLogLevel(org.apache.log4j.Level.toLevel(upperCased))
   }
 
@@ -2178,7 +2179,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
  * various Spark features.
  */
 object SparkContext extends Logging {
-  private val validLevels = Set("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
+  private val VALID_LOG_LEVELS =
+    Set("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
 
   /**
    * Lock that guards access to global variables that track SparkContext construction.

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -359,7 +359,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    */
   def setLogLevel(logLevel: String) {
     val validLevels = Seq("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
-    if (!validLevels.contains(logLevel)) {
+    // let's allow lowcase or mixed case too
+    if (!validLevels.contains(logLevel.toUpperCase)) {
       throw new IllegalArgumentException(
         s"Supplied level $logLevel did not match one of: ${validLevels.mkString(",")}")
     }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -356,13 +356,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Valid log levels include: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
    */
   def setLogLevel(logLevel: String) {
-    val validLevels = Seq("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
     // let's allow lowcase or mixed case too
-    if (!validLevels.contains(logLevel.toUpperCase(Locale.ENGLISH))) {
-      throw new IllegalArgumentException(
-        s"Supplied level $logLevel did not match one of: ${validLevels.mkString(",")}")
-    }
-    Utils.setLogLevel(org.apache.log4j.Level.toLevel(logLevel))
+    val upperCased = logLevel.toUpperCase(Locale.ENGLISH)
+    require(SparkContext.validLevels.contains(upperCased),
+      s"Supplied level $logLevel did not match one of: ${SparkContext.validLevels.mkString(",")}")
+    Utils.setLogLevel(org.apache.log4j.Level.toLevel(upperCased))
   }
 
   try {
@@ -2180,6 +2178,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
  * various Spark features.
  */
 object SparkContext extends Logging {
+  private val validLevels = Set("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
 
   /**
    * Lock that guards access to global variables that track SparkContext construction.

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -20,7 +20,7 @@ package org.apache.spark
 import java.io._
 import java.lang.reflect.Constructor
 import java.net.URI
-import java.util.{Arrays, Properties, ServiceLoader, UUID}
+import java.util.{Arrays, Locale, Properties, ServiceLoader, UUID}
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 
@@ -76,8 +76,6 @@ import org.apache.spark.util._
  *   this config overrides the default configs as well as system properties.
  */
 class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationClient {
-  // original log level
-  private val originalLogLevel = org.apache.log4j.Logger.getRootLogger().getLevel
 
   // The call site where this SparkContext was constructed.
   private val creationSite: CallSite = Utils.getCallSite()
@@ -360,19 +358,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   def setLogLevel(logLevel: String) {
     val validLevels = Seq("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
     // let's allow lowcase or mixed case too
-    if (!validLevels.contains(logLevel.toUpperCase)) {
+    if (!validLevels.contains(logLevel.toUpperCase(Locale.ENGLISH))) {
       throw new IllegalArgumentException(
         s"Supplied level $logLevel did not match one of: ${validLevels.mkString(",")}")
     }
     Utils.setLogLevel(org.apache.log4j.Level.toLevel(logLevel))
-  }
-
-  /**
-   * Reset log level to original one when this SparkContext was created.
-   * @since 2.0.0
-   */
-  def resetLogLevel(): Unit = {
-    Utils.setLogLevel(originalLogLevel)
   }
 
   try {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -363,4 +363,15 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
     sc.stop()
     assert(result == null)
   }
+
+  test("log level case-insensitive and reset log level") {
+    sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+    val originalLevel = org.apache.log4j.Logger.getRootLogger().getLevel
+    sc.setLogLevel("debug")
+    assert(org.apache.log4j.Logger.getRootLogger().getLevel === org.apache.log4j.Level.DEBUG)
+    sc.setLogLevel("INfo")
+    assert( org.apache.log4j.Logger.getRootLogger().getLevel=== org.apache.log4j.Level.INFO)
+    sc.resetLogLevel()
+    assert(org.apache.log4j.Logger.getRootLogger().getLevel === originalLevel)
+  }
 }

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -367,11 +367,14 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
   test("log level case-insensitive and reset log level") {
     sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
     val originalLevel = org.apache.log4j.Logger.getRootLogger().getLevel
-    sc.setLogLevel("debug")
-    assert(org.apache.log4j.Logger.getRootLogger().getLevel === org.apache.log4j.Level.DEBUG)
-    sc.setLogLevel("INfo")
-    assert( org.apache.log4j.Logger.getRootLogger().getLevel=== org.apache.log4j.Level.INFO)
-    sc.resetLogLevel()
-    assert(org.apache.log4j.Logger.getRootLogger().getLevel === originalLevel)
+    try {
+      sc.setLogLevel("debug")
+      assert(org.apache.log4j.Logger.getRootLogger().getLevel === org.apache.log4j.Level.DEBUG)
+      sc.setLogLevel("INfo")
+      assert(org.apache.log4j.Logger.getRootLogger().getLevel === org.apache.log4j.Level.INFO)
+    } finally {
+      sc.setLogLevel(originalLevel.toString)
+      assert(org.apache.log4j.Logger.getRootLogger().getLevel === originalLevel)
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -375,6 +375,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
     } finally {
       sc.setLogLevel(originalLevel.toString)
       assert(org.apache.log4j.Logger.getRootLogger().getLevel === originalLevel)
+      sc.stop()
     }
   }
 }

--- a/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -21,7 +21,6 @@ import java.io._
 import java.net.URLClassLoader
 
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.commons.lang3.StringEscapeUtils
 import org.apache.log4j.{Level, LogManager}
 import org.apache.spark.{SparkContext, SparkFunSuite}

--- a/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -21,6 +21,7 @@ import java.io._
 import java.net.URLClassLoader
 
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.commons.lang3.StringEscapeUtils
 import org.apache.log4j.{Level, LogManager}
 import org.apache.spark.{SparkContext, SparkFunSuite}
@@ -51,7 +52,7 @@ class ReplSuite extends SparkFunSuite {
     System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
 
     Main.conf.set("spark.master", master)
-    Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out, true)))
+    Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out)))
 
     if (oldExecutorClasspath != null) {
       System.setProperty(CONF_EXECUTOR_CLASSPATH, oldExecutorClasspath)
@@ -448,27 +449,5 @@ class ReplSuite extends SparkFunSuite {
       """.stripMargin)
     assertDoesNotContain("AssertionError", output)
     assertDoesNotContain("Exception", output)
-  }
-
-  test("reset log level") {
-    val logger = org.apache.log4j.Logger.getRootLogger()
-    val output1 = runInterpreter("local",
-      """
-        |sc.setLogLevel("debug")
-        |sc.range(1, 10)
-      """.stripMargin
-    )
-    println(output1)
-    assertContains("DEBUG ClosureCleaner", output1)
- /*
-    val output2 = runInterpreter("local",
-      """
-        |sc.setLogLevel("debug")
-        |sc.resetLogLevel
-        |sc.range(1, 10)
-      """.stripMargin
-    )
-    assertDoesNotContain("DEBUG ClosureCleaner", output2)
-    */
   }
 }

--- a/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -51,7 +51,7 @@ class ReplSuite extends SparkFunSuite {
     System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
 
     Main.conf.set("spark.master", master)
-    Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out)))
+    Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out, true)))
 
     if (oldExecutorClasspath != null) {
       System.setProperty(CONF_EXECUTOR_CLASSPATH, oldExecutorClasspath)
@@ -448,5 +448,27 @@ class ReplSuite extends SparkFunSuite {
       """.stripMargin)
     assertDoesNotContain("AssertionError", output)
     assertDoesNotContain("Exception", output)
+  }
+
+  test("reset log level") {
+    val logger = org.apache.log4j.Logger.getRootLogger()
+    val output1 = runInterpreter("local",
+      """
+        |sc.setLogLevel("debug")
+        |sc.range(1, 10)
+      """.stripMargin
+    )
+    println(output1)
+    assertContains("DEBUG ClosureCleaner", output1)
+ /*
+    val output2 = runInterpreter("local",
+      """
+        |sc.setLogLevel("debug")
+        |sc.resetLogLevel
+        |sc.range(1, 10)
+      """.stripMargin
+    )
+    assertDoesNotContain("DEBUG ClosureCleaner", output2)
+    */
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `SparkContext API setLogLevel(level: String)`can not handle lower case or mixed case input string. But `org.apache.log4j.Level.toLevel` can take lowercase or mixed case. 

This PR is to allow case-insensitive user input for the log level.
## How was this patch tested?

A unit testcase is added.
