### PR TITLE
[CORE][DOC][MINOR] Remove incorrect scaladoc

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -254,8 +254,6 @@ private[spark] trait SparkListenerInterface {
  * :: DeveloperApi ::
  * A default implementation for [[SparkListenerInterface]] that has no-op implementations for
  * all callbacks.
- *
- * Note that this is an internal interface which might change in different Spark releases.
  */
 @DeveloperApi
 abstract class SparkListener extends SparkListenerInterface {


### PR DESCRIPTION
## What changes were proposed in this pull request?

It removes a sentence about `SparkListener` being internal and may change in the future yet the class is `@DeveloperApi` that may or may not say the same. If it does not, it's clearly incorrect. If it says what `@DeveloperApi` is for, it's a duplication (and/or would require other `@DeveloperApi` to have it, too).
## How was this patch tested?

manual build
