### PR TITLE
[SPARK-15654][SQL] Check if all the input files are splittable in FileSourceStrategy

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -146,8 +146,8 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
           val maxSplitBytes = {
             // Since `LineRecordReader` in hadoop cannot split files compressed by some codecs
             // (e.g., gzip), check if all the input files are splittable here.
-            if (HadoopFsRelation.canSplitFiles(
-                selectedPartitions.flatMap(_.files),
+            if (files.fileFormat.canSplitFiles(
+                selectedPartitions.flatMap(_.files).map(_.getPath),
                 files.sparkSession.sessionState.newHadoopConfWithOptions(files.options))) {
               Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
             } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -336,7 +336,7 @@ trait FileCatalog {
 
 
 /**
- * Helper methods for gathering metadata from HDFS.
+ * Helper methods for gathering metadata in hadoop-related files.
  */
 private[sql] object HadoopFsRelation extends Logging {
 
@@ -463,7 +463,8 @@ private[sql] object HadoopFsRelation extends Logging {
     mutable.LinkedHashSet(hadoopFakeStatuses: _*)
   }
 
-  def isFilesSplittable(files: Seq[FileStatus], conf: Configuration): Boolean = {
+  // Return true iff all the input files can be split by `LineRecordReader`
+  def canSplitFiles(files: Seq[FileStatus], conf: Configuration): Boolean = {
     files.forall { file =>
       val codec = (new CompressionCodecFactory(conf)).getCodec(file.getPath)
       codec == null || codec.isInstanceOf[SplittableCompressionCodec]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -216,6 +216,13 @@ trait FileFormat {
   }
 
   /**
+   * Return true iff input formats can be split into multiple input splits.
+   */
+  def canSplitFiles(files: Seq[Path], conf: Configuration): Boolean = {
+    true
+  }
+
+  /**
    * Returns a function that can be used to read a single file in as an Iterator of InternalRow.
    *
    * @param dataSchema The global data schema. It can be either specified by the user, or
@@ -336,7 +343,7 @@ trait FileCatalog {
 
 
 /**
- * Helper methods for gathering metadata in hadoop-related files.
+ * Helper methods for gathering metadata from HDFS.
  */
 private[sql] object HadoopFsRelation extends Logging {
 
@@ -461,13 +468,5 @@ private[sql] object HadoopFsRelation extends Logging {
         blockLocations)
     }
     mutable.LinkedHashSet(hadoopFakeStatuses: _*)
-  }
-
-  // Return true iff all the input files can be split by `LineRecordReader`
-  def canSplitFiles(files: Seq[FileStatus], conf: Configuration): Boolean = {
-    files.forall { file =>
-      val codec = (new CompressionCodecFactory(conf)).getCodec(file.getPath)
-      codec == null || codec.isInstanceOf[SplittableCompressionCodec]
-    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet, PredicateHelper}
 import org.apache.spark.sql.catalyst.util
 import org.apache.spark.sql.execution.DataSourceScanExec
+import org.apache.spark.sql.execution.datasources.text.TextFileFormat
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources._
@@ -466,7 +467,7 @@ object LastArguments {
 }
 
 /** A test [[FileFormat]] that records the arguments passed to buildReader, and returns nothing. */
-class TestFileFormat extends FileFormat {
+class TestFileFormat extends TextFileFormat {
 
   override def toString: String = "TestFileFormat"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is to check if all the input files are splittable in FileSourceStrategy
because `LineRecordReader` in hadoop cannot split files compressed by some codecs (e.g., gzip). 
## How was this patch tested?

Added tests in FileSourceStrategySuite
