### PR TITLE
[SPARK-15706] [SQL] Fix Wrong Answer when using IF NOT EXISTS in INSERT OVERWRITE for DYNAMIC PARTITION

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -199,7 +199,7 @@ query
     ;
 
 insertInto
-    : INSERT OVERWRITE TABLE tableIdentifier partitionSpec? (IF NOT EXISTS)?
+    : INSERT OVERWRITE TABLE tableIdentifier (partitionSpec (IF NOT EXISTS)?)?
     | INSERT INTO TABLE? tableIdentifier partitionSpec?
     ;
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -171,12 +171,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
     val tableIdent = visitTableIdentifier(ctx.tableIdentifier)
     val partitionKeys = Option(ctx.partitionSpec).map(visitPartitionSpec).getOrElse(Map.empty)
 
-    if (ctx.EXISTS != null && ctx.partitionSpec == null) {
-      throw new ParseException(
-        s"IF NOT EXISTS is not expected when Partition Spec is not specified.", ctx)
-    }
-
-    val dynamicPartitionKeys = partitionKeys.filter { case (k, v) => v.isEmpty }
+    val dynamicPartitionKeys = partitionKeys.filter(_._2.isEmpty)
     if (ctx.EXISTS != null && dynamicPartitionKeys.nonEmpty) {
       throw new ParseException(s"Dynamic partitions do not support IF NOT EXISTS. Specified " +
         "partitions with value: " + dynamicPartitionKeys.keys.mkString("[", ",", "]"), ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -377,6 +377,7 @@ case class InsertIntoTable(
   }
 
   assert(overwrite || !ifNotExists)
+  assert(partition.values.forall(_.nonEmpty) || !ifNotExists)
   override lazy val resolved: Boolean =
     childrenResolved && table.resolved && expectedColumns.forall { expected =>
     child.output.size == expected.size && child.output.zip(expected).forall {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -202,8 +202,7 @@ class PlanParserSuite extends PlanTest {
     val sql = "select * from t"
     intercept(s"insert overwrite table s partition (e = 1, x) if not exists $sql",
       "Dynamic partitions do not support IF NOT EXISTS. Specified partitions with value: [x]")
-    intercept(s"insert overwrite table s if not exists $sql",
-      "IF NOT EXISTS is not expected when Partition Spec is not specified")
+    intercept[ParseException](parsePlan(s"insert overwrite table s if not exists $sql"))
   }
 
   test("aggregation") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -182,14 +182,12 @@ class PlanParserSuite extends PlanTest {
     // Single inserts
     assertEqual(s"insert overwrite table s $sql",
       insert(Map.empty, overwrite = true))
-    assertEqual(s"insert overwrite table s if not exists $sql",
-      insert(Map.empty, overwrite = true, ifNotExists = true))
+    assertEqual(s"insert overwrite table s partition (e = 1) if not exists $sql",
+      insert(Map("e" -> Option("1")), overwrite = true, ifNotExists = true))
     assertEqual(s"insert into s $sql",
       insert(Map.empty))
     assertEqual(s"insert into table s partition (c = 'd', e = 1) $sql",
       insert(Map("c" -> Option("d"), "e" -> Option("1"))))
-    assertEqual(s"insert overwrite table s partition (c = 'd', x) if not exists $sql",
-      insert(Map("c" -> Option("d"), "x" -> None), overwrite = true, ifNotExists = true))
 
     // Multi insert
     val plan2 = table("t").where('x > 5).select(star())
@@ -198,6 +196,14 @@ class PlanParserSuite extends PlanTest {
         table("s"), Map.empty, plan.limit(1), overwrite = false, ifNotExists = false).union(
         InsertIntoTable(
           table("u"), Map.empty, plan2, overwrite = false, ifNotExists = false)))
+  }
+
+  test ("insert with if not exists") {
+    val sql = "select * from t"
+    intercept(s"insert overwrite table s partition (e = 1, x) if not exists $sql",
+      "Dynamic partitions do not support IF NOT EXISTS. Specified partitions with value: [x]")
+    intercept(s"insert overwrite table s if not exists $sql",
+      "IF NOT EXISTS is not expected when Partition Spec is not specified")
   }
 
   test("aggregation") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -200,10 +200,10 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
     val e = intercept[AnalysisException] {
       sql(
         """
-        |INSERT OVERWRITE TABLE table_with_partition
-        |partition (p1='a',p2) IF NOT EXISTS
-        |SELECT 'blarr3'
-      """.stripMargin)
+          |INSERT OVERWRITE TABLE table_with_partition
+          |partition (p1='a',p2) IF NOT EXISTS
+          |SELECT 'blarr3'
+        """.stripMargin)
     }
     assert(e.getMessage.contains(
       "Dynamic partitions do not support IF NOT EXISTS. Specified partitions with value: [p2]"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -167,59 +167,71 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
   }
 
   test("INSERT OVERWRITE - partition IF NOT EXISTS") {
-    val tmpDir = Utils.createTempDir()
-    val selQuery = "select c1, p1, p2 from table_with_partition"
-    sql(
-      s"""
-         |CREATE TABLE table_with_partition(c1 string)
-         |PARTITIONED by (p1 string,p2 string)
-         |location '${tmpDir.toURI.toString}'
-        """.stripMargin)
-    sql(
-      """
-        |INSERT OVERWRITE TABLE table_with_partition
-        |partition (p1='a',p2='b')
-        |SELECT 'blarr'
-      """.stripMargin)
+    withTempDir { tmpDir =>
+      val table = "table_with_partition"
+      withTable(table) {
+        val selQuery = s"select c1, p1, p2 from $table"
+        sql(
+          s"""
+             |CREATE TABLE $table(c1 string)
+             |PARTITIONED by (p1 string,p2 string)
+             |location '${tmpDir.toURI.toString}'
+           """.stripMargin)
+        sql(
+          s"""
+             |INSERT OVERWRITE TABLE $table
+             |partition (p1='a',p2='b')
+             |SELECT 'blarr'
+           """.stripMargin)
+        checkAnswer(
+          sql(selQuery),
+          Row("blarr", "a", "b"))
 
-    checkAnswer(
-      sql(selQuery),
-      Row("blarr", "a", "b"))
+        sql(
+          s"""
+             |INSERT OVERWRITE TABLE $table
+             |partition (p1='a',p2='b')
+             |SELECT 'blarr2'
+           """.stripMargin)
+        checkAnswer(
+          sql(selQuery),
+          Row("blarr2", "a", "b"))
 
-    sql(
-      """
-        |INSERT OVERWRITE TABLE table_with_partition
-        |partition (p1='a',p2='b')
-        |SELECT 'blarr2'
-      """.stripMargin)
+        var e = intercept[AnalysisException] {
+          sql(
+            s"""
+               |INSERT OVERWRITE TABLE $table
+               |partition (p1='a',p2) IF NOT EXISTS
+               |SELECT 'blarr3', 'newPartition'
+             """.stripMargin)
+        }
+        assert(e.getMessage.contains(
+          "Dynamic partitions do not support IF NOT EXISTS. Specified partitions with value: [p2]"))
 
-    checkAnswer(
-      sql(selQuery),
-      Row("blarr2", "a", "b"))
+        e = intercept[AnalysisException] {
+          sql(
+            s"""
+               |INSERT OVERWRITE TABLE $table
+               |partition (p1='a',p2) IF NOT EXISTS
+               |SELECT 'blarr3', 'b'
+             """.stripMargin)
+        }
+        assert(e.getMessage.contains(
+          "Dynamic partitions do not support IF NOT EXISTS. Specified partitions with value: [p2]"))
 
-    val e = intercept[AnalysisException] {
-      sql(
-        """
-          |INSERT OVERWRITE TABLE table_with_partition
-          |partition (p1='a',p2) IF NOT EXISTS
-          |SELECT 'blarr3'
-        """.stripMargin)
+        // If the partition already exists, the insert will overwrite the data
+        // unless users specify IF NOT EXISTS
+        sql(
+          s"""
+             |INSERT OVERWRITE TABLE $table
+             |partition (p1='a',p2='b') IF NOT EXISTS
+             |SELECT 'blarr3'
+           """.stripMargin)
+        checkAnswer(
+          sql(selQuery),
+          Row("blarr2", "a", "b"))
+      }
     }
-    assert(e.getMessage.contains(
-      "Dynamic partitions do not support IF NOT EXISTS. Specified partitions with value: [p2]"))
-
-    // If the partition already exists, the insert will overwrite the data
-    // unless users specify IF NOT EXISTS
-    sql(
-      """
-        |INSERT OVERWRITE TABLE table_with_partition
-        |partition (p1='a',p2='b') IF NOT EXISTS
-        |SELECT 'blarr3'
-      """.stripMargin)
-
-    checkAnswer(
-      sql(selQuery),
-      Row("blarr2", "a", "b"))
   }
 
   test("Insert ArrayType.containsNull == false") {


### PR DESCRIPTION
#### What changes were proposed in this pull request?

`IF NOT EXISTS` in `INSERT OVERWRITE` should not support dynamic partitions. If we specify `IF NOT EXISTS`, the inserted statement is not shown in the table. 

This PR is to issue an exception in this case, just like what Hive does. Also issue an exception if users specify `IF NOT EXISTS` if users do not specify any `PARTITION` specification. 
#### How was this patch tested?

Added test cases into `PlanParserSuite` and `InsertIntoHiveTableSuite`
