### PR TITLE
[SPARK-15707][SQL] Make Code Neat - Use map instead of if check.

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -236,9 +236,8 @@ object RandomDataGenerator {
         // convert it to catalyst value to call udt's deserialize.
         val toCatalystType = CatalystTypeConverters.createToCatalystConverter(udt.sqlType)
 
-        if (maybeSqlTypeGenerator.isDefined) {
-          val sqlTypeGenerator = maybeSqlTypeGenerator.get
-          val generator = () => {
+        maybeSqlTypeGenerator.map { sqlTypeGenerator =>
+          () => {
             val generatedScalaValue = sqlTypeGenerator.apply()
             if (generatedScalaValue == null) {
               null
@@ -246,9 +245,6 @@ object RandomDataGenerator {
               udt.deserialize(toCatalystType(generatedScalaValue))
             }
           }
-          Some(generator)
-        } else {
-          None
         }
       case unsupportedType => None
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In forType function of object RandomDataGenerator, the code following:
if (maybeSqlTypeGenerator.isDefined){
  ....
  Some(generator)
} else{
 None
}
will be changed. Instead, maybeSqlTypeGenerator.map will be used.
## How was this patch tested?

All of the current unit tests passed.
