### PR TITLE
[SPARK-15724] Add benchmarks for performance over wide schemas

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Benchmark.scala
+++ b/core/src/main/scala/org/apache/spark/util/Benchmark.scala
@@ -19,7 +19,6 @@ package org.apache.spark.util
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
 import scala.util.Try
 
 import org.apache.commons.lang3.SystemUtils
@@ -34,28 +33,18 @@ import org.apache.commons.lang3.SystemUtils
  *
  * The benchmark function takes one argument that is the iteration that's being run.
  *
- * @param name name of this benchmark.
- * @param valuesPerIteration number of values used in the test case, used to compute rows/s.
- * @param minNumIters the min number of iterations that will be run per case. Note that this
- *                    should be at least 2 since the first iteration is ignored.
- * @param minTime further iterations will be run for each case until this time is used up.
- * @param outputPerIteration if true, the timing for each run will be printed to stdout.
+ * If outputPerIteration is true, the timing for each run will be printed to stdout.
  */
 private[spark] class Benchmark(
     name: String,
     valuesPerIteration: Long,
-    minNumIters: Int = 3,
-    minTime: FiniteDuration = 2.seconds,
+    defaultNumIters: Int = 5,
     outputPerIteration: Boolean = false) {
-  import Benchmark._
   val benchmarks = mutable.ArrayBuffer.empty[Benchmark.Case]
 
   /**
    * Adds a case to run when run() is called. The given function will be run for several
    * iterations to collect timing statistics.
-   *
-   * @param name of the benchmark case
-   * @param numIters if non-zero, forces exactly this many iterations to be run
    */
   def addCase(name: String, numIters: Int = 0)(f: Int => Unit): Unit = {
     addTimerCase(name, numIters) { timer =>
@@ -69,12 +58,9 @@ private[spark] class Benchmark(
    * Adds a case with manual timing control. When the function is run, timing does not start
    * until timer.startTiming() is called within the given function. The corresponding
    * timer.stopTiming() method must be called before the function returns.
-   *
-   * @param name of the benchmark case
-   * @param numIters if non-zero, forces exactly this many iterations to be run
    */
   def addTimerCase(name: String, numIters: Int = 0)(f: Benchmark.Timer => Unit): Unit = {
-    benchmarks += Benchmark.Case(name, f, numIters)
+    benchmarks += Benchmark.Case(name, f, if (numIters == 0) defaultNumIters else numIters)
   }
 
   /**
@@ -89,7 +75,7 @@ private[spark] class Benchmark(
 
     val results = benchmarks.map { c =>
       println("  Running case: " + c.name)
-      measure(valuesPerIteration, c.numIters)(c.fn)
+      Benchmark.measure(valuesPerIteration, c.numIters, outputPerIteration)(c.fn)
     }
     println
 
@@ -110,39 +96,6 @@ private[spark] class Benchmark(
     }
     println
     // scalastyle:on
-  }
-
-  /**
-   * Runs a single function `f` for iters, returning the average time the function took and
-   * the rate of the function.
-   */
-  def measure(num: Long, overrideNumIters: Int)(f: Timer => Unit): Result = {
-    System.gc()  // ensures garbage from previous cases don't impact this one
-    val minIters = if (overrideNumIters != 0) overrideNumIters else minNumIters
-    val minDuration = if (overrideNumIters != 0) 0.seconds.fromNow else minTime.fromNow
-    val runTimes = ArrayBuffer[Long]()
-    var i = 0
-    while (i < minIters || !minDuration.isOverdue) {
-      val timer = new Benchmark.Timer(i)
-      f(timer)
-      val runTime = timer.totalTime()
-      if (i > 0) {
-        runTimes += runTime
-      }
-
-      if (outputPerIteration) {
-        // scalastyle:off
-        println(s"Iteration $i took ${runTime / 1000} microseconds")
-        // scalastyle:on
-      }
-      i += 1
-    }
-    // scalastyle:off
-    println(s"  Stopped after $i iterations, ${runTimes.sum / 1000000} ms")
-    // scalastyle:on
-    val best = runTimes.min
-    val avg = runTimes.sum / runTimes.size
-    Result(avg / 1000000.0, num / (best / 1000.0), best / 1000000.0)
   }
 }
 
@@ -208,4 +161,30 @@ private[spark] object Benchmark {
     val osVersion = System.getProperty("os.version")
     s"${vmName} ${runtimeVersion} on ${osName} ${osVersion}"
   }
+
+  /**
+   * Runs a single function `f` for iters, returning the average time the function took and
+   * the rate of the function.
+   */
+  def measure(num: Long, iters: Int, outputPerIteration: Boolean)(f: Timer => Unit): Result = {
+    val runTimes = ArrayBuffer[Long]()
+    for (i <- 0 until iters + 1) {
+      val timer = new Benchmark.Timer(i)
+      f(timer)
+      val runTime = timer.totalTime()
+      if (i > 0) {
+        runTimes += runTime
+      }
+
+      if (outputPerIteration) {
+        // scalastyle:off
+        println(s"Iteration $i took ${runTime / 1000} microseconds")
+        // scalastyle:on
+      }
+    }
+    val best = runTimes.min
+    val avg = runTimes.sum / iters
+    Result(avg / 1000000.0, num / (best / 1000.0), best / 1000000.0)
+  }
 }
+

--- a/core/src/main/scala/org/apache/spark/util/Benchmark.scala
+++ b/core/src/main/scala/org/apache/spark/util/Benchmark.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
 import scala.util.Try
 
 import org.apache.commons.lang3.SystemUtils
@@ -33,18 +34,28 @@ import org.apache.commons.lang3.SystemUtils
  *
  * The benchmark function takes one argument that is the iteration that's being run.
  *
- * If outputPerIteration is true, the timing for each run will be printed to stdout.
+ * @param name name of this benchmark.
+ * @param valuesPerIteration number of values used in the test case, used to compute rows/s.
+ * @param minNumIters the min number of iterations that will be run per case. Note that this
+ *                    should be at least 2 since the first iteration is ignored.
+ * @param minTime further iterations will be run for each case until this time is used up.
+ * @param outputPerIteration if true, the timing for each run will be printed to stdout.
  */
 private[spark] class Benchmark(
     name: String,
     valuesPerIteration: Long,
-    defaultNumIters: Int = 5,
+    minNumIters: Int = 3,
+    minTime: FiniteDuration = 2.seconds,
     outputPerIteration: Boolean = false) {
+  import Benchmark._
   val benchmarks = mutable.ArrayBuffer.empty[Benchmark.Case]
 
   /**
    * Adds a case to run when run() is called. The given function will be run for several
    * iterations to collect timing statistics.
+   *
+   * @param name of the benchmark case
+   * @param numIters if non-zero, forces exactly this many iterations to be run
    */
   def addCase(name: String, numIters: Int = 0)(f: Int => Unit): Unit = {
     addTimerCase(name, numIters) { timer =>
@@ -58,9 +69,12 @@ private[spark] class Benchmark(
    * Adds a case with manual timing control. When the function is run, timing does not start
    * until timer.startTiming() is called within the given function. The corresponding
    * timer.stopTiming() method must be called before the function returns.
+   *
+   * @param name of the benchmark case
+   * @param numIters if non-zero, forces exactly this many iterations to be run
    */
   def addTimerCase(name: String, numIters: Int = 0)(f: Benchmark.Timer => Unit): Unit = {
-    benchmarks += Benchmark.Case(name, f, if (numIters == 0) defaultNumIters else numIters)
+    benchmarks += Benchmark.Case(name, f, numIters)
   }
 
   /**
@@ -75,7 +89,7 @@ private[spark] class Benchmark(
 
     val results = benchmarks.map { c =>
       println("  Running case: " + c.name)
-      Benchmark.measure(valuesPerIteration, c.numIters, outputPerIteration)(c.fn)
+      measure(valuesPerIteration, c.numIters)(c.fn)
     }
     println
 
@@ -96,6 +110,39 @@ private[spark] class Benchmark(
     }
     println
     // scalastyle:on
+  }
+
+  /**
+   * Runs a single function `f` for iters, returning the average time the function took and
+   * the rate of the function.
+   */
+  def measure(num: Long, overrideNumIters: Int)(f: Timer => Unit): Result = {
+    System.gc()  // ensures garbage from previous cases don't impact this one
+    val minIters = if (overrideNumIters != 0) overrideNumIters else minNumIters
+    val minDuration = if (overrideNumIters != 0) 0.seconds.fromNow else minTime.fromNow
+    val runTimes = ArrayBuffer[Long]()
+    var i = 0
+    while (i < minIters || !minDuration.isOverdue) {
+      val timer = new Benchmark.Timer(i)
+      f(timer)
+      val runTime = timer.totalTime()
+      if (i > 0) {
+        runTimes += runTime
+      }
+
+      if (outputPerIteration) {
+        // scalastyle:off
+        println(s"Iteration $i took ${runTime / 1000} microseconds")
+        // scalastyle:on
+      }
+      i += 1
+    }
+    // scalastyle:off
+    println(s"  Stopped after $i iterations, ${runTimes.sum / 1000000} ms")
+    // scalastyle:on
+    val best = runTimes.min
+    val avg = runTimes.sum / runTimes.size
+    Result(avg / 1000000.0, num / (best / 1000.0), best / 1000000.0)
   }
 }
 
@@ -161,30 +208,4 @@ private[spark] object Benchmark {
     val osVersion = System.getProperty("os.version")
     s"${vmName} ${runtimeVersion} on ${osName} ${osVersion}"
   }
-
-  /**
-   * Runs a single function `f` for iters, returning the average time the function took and
-   * the rate of the function.
-   */
-  def measure(num: Long, iters: Int, outputPerIteration: Boolean)(f: Timer => Unit): Result = {
-    val runTimes = ArrayBuffer[Long]()
-    for (i <- 0 until iters + 1) {
-      val timer = new Benchmark.Timer(i)
-      f(timer)
-      val runTime = timer.totalTime()
-      if (i > 0) {
-        runTimes += runTime
-      }
-
-      if (outputPerIteration) {
-        // scalastyle:off
-        println(s"Iteration $i took ${runTime / 1000} microseconds")
-        // scalastyle:on
-      }
-    }
-    val best = runTimes.min
-    val avg = runTimes.sum / iters
-    Result(avg / 1000000.0, num / (best / 1000.0), best / 1000000.0)
-  }
 }
-

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -62,7 +62,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  test("many column field read and write") {
+  ignore("many column field read and write") {
     val benchmark = new Benchmark("many column field r/w", scaleFactor)
     for (width <- widthsToTest) {
       // normalize by width to keep constant data size
@@ -97,7 +97,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  test("wide struct field read and write") {
+  ignore("wide struct field read and write") {
     val benchmark = new Benchmark("wide struct field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width
@@ -139,7 +139,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  test("deeply nested struct field read and write") {
+  ignore("deeply nested struct field read and write") {
     val benchmark = new Benchmark("deeply nested struct field r/w", scaleFactor)
     for (depth <- depthsToTest) {
       val numRows = scaleFactor / depth
@@ -176,7 +176,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  test("bushy struct field read and write") {
+  ignore("bushy struct field read and write") {
     val benchmark = new Benchmark("bushy struct field r/w", scaleFactor)
     for (width <- Seq(1, 10, 100, 500)) {
       val numRows = scaleFactor / width

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -92,7 +92,7 @@ class WideSchemaBenchmark extends SparkFunSuite with BeforeAndAfterEach {
     }
   }
 
-  test("parsing large select expressions") {
+  ignore("parsing large select expressions") {
     val benchmark = new Benchmark("parsing large select", 1)
     for (width <- widthsToTest) {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
@@ -115,7 +115,7 @@ parsing large select:                    Best/Avg Time(ms)    Rate(M/s)   Per Ro
 */
   }
 
-  test("many column field read and write") {
+  ignore("many column field read and write") {
     val benchmark = new Benchmark("many column field r/w", scaleFactor)
     for (width <- widthsToTest) {
       // normalize by width to keep constant data size
@@ -155,7 +155,7 @@ many column field r/w:                   Best/Avg Time(ms)    Rate(M/s)   Per Ro
 */
   }
 
-  test("wide struct field read and write") {
+  ignore("wide struct field read and write") {
     val benchmark = new Benchmark("wide struct field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width
@@ -202,7 +202,7 @@ wide struct field r/w:                   Best/Avg Time(ms)    Rate(M/s)   Per Ro
 */
   }
 
-  test("deeply nested struct field read and write") {
+  ignore("deeply nested struct field read and write") {
     val benchmark = new Benchmark("deeply nested struct field r/w", scaleFactor)
     for (depth <- depthsToTest) {
       val numRows = scaleFactor / depth
@@ -242,7 +242,7 @@ deeply nested struct field r/w:          Best/Avg Time(ms)    Rate(M/s)   Per Ro
 */
   }
 
-  test("bushy struct field read and write") {
+  ignore("bushy struct field read and write") {
     val benchmark = new Benchmark("bushy struct field r/w", scaleFactor)
     for (width <- Seq(1, 10, 100, 500)) {
       val numRows = scaleFactor / width
@@ -288,7 +288,7 @@ bushy struct field r/w:                  Best/Avg Time(ms)    Rate(M/s)   Per Ro
 */
   }
 
-  test("wide array field read and write") {
+  ignore("wide array field read and write") {
     val benchmark = new Benchmark("wide array field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width
@@ -335,7 +335,7 @@ wide array field r/w:                    Best/Avg Time(ms)    Rate(M/s)   Per Ro
 */
   }
 
-  test("wide map field read and write") {
+  ignore("wide map field read and write") {
     val benchmark = new Benchmark("wide map field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -17,21 +17,20 @@
 
 package org.apache.spark.sql
 
-<<<<<<< Updated upstream
-=======
 import java.io.File
 
->>>>>>> Stashed changes
+import org.scalatest.BeforeAndAfterEach
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.functions._
-import org.apache.spark.util.Benchmark
+import org.apache.spark.util.{Benchmark, Utils}
 
 /**
  * Benchmark for performance with very wide and nested DataFrames.
  * To run this:
  *  build/sbt "sql/test-only *WideSchemaBenchmark"
  */
-class WideSchemaBenchmark extends SparkFunSuite {
+class WideSchemaBenchmark extends SparkFunSuite with BeforeAndAfterEach {
   private val scaleFactor = 100000
   private val widthsToTest = Seq(1, 10, 100, 1000, 2500)
   private val depthsToTest = Seq(1, 10, 100, 250)
@@ -44,7 +43,52 @@ class WideSchemaBenchmark extends SparkFunSuite {
 
   import sparkSession.implicits._
 
-  ignore("parsing large select expressions") {
+  private var tmpFiles: List[File] = Nil
+
+  override def afterEach() {
+    for (tmpFile <- tmpFiles) {
+      Utils.deleteRecursively(tmpFile)
+    }
+    tmpFiles = Nil
+  }
+
+  /**
+   * Writes the given DataFrame to parquet at a temporary location, and returns a DataFrame
+   * backed by the written parquet files.
+   */
+  private def saveAsParquet(df: DataFrame): DataFrame = {
+    val tmpFile = File.createTempFile("WideSchemaBenchmark", "tmp")
+    tmpFiles ::= tmpFile
+    tmpFile.delete()
+    df.write.parquet(tmpFile.getAbsolutePath)
+    assert(tmpFile.isDirectory())
+    sparkSession.read.parquet(tmpFile.getAbsolutePath)
+  }
+
+  /**
+   * Adds standard set of cases to a benchmark given a dataframe and field to select.
+   */
+  private def addCases(
+      benchmark: Benchmark,
+      df: DataFrame,
+      desc: String,
+      selector: String): Unit = {
+    benchmark.addCase(desc + " (read in-mem)") { iter =>
+      df.selectExpr(s"sum($selector)").collect()
+    }
+    benchmark.addCase(desc + " (write in-mem)") { iter =>
+      df.selectExpr("*", s"hash($selector) as f").selectExpr(s"sum($selector)", "sum(f)").collect()
+    }
+    val parquet = saveAsParquet(df)
+    benchmark.addCase(desc + " (read parquet)") { iter =>
+      parquet.selectExpr(s"sum($selector) as f").collect()
+    }
+    benchmark.addCase(desc + " (write parquet)") { iter =>
+      saveAsParquet(df.selectExpr(s"sum($selector) as f"))
+    }
+  }
+
+  test("parsing large select expressions") {
     val benchmark = new Benchmark("parsing large select", 1)
     for (width <- widthsToTest) {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
@@ -54,20 +98,20 @@ class WideSchemaBenchmark extends SparkFunSuite {
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    parsing large select                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 select expressions                          15 /   19          0.0    15464923.0       1.0X
-    10 select expressions                         26 /   30          0.0    26131438.0       0.6X
-    100 select expressions                        46 /   58          0.0    45719540.0       0.3X
-    1000 select expressions                      285 /  328          0.0   285407972.0       0.1X
-    5000 select expressions                     1482 / 1645          0.0  1482298845.0       0.0X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+parsing large select:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 select expressions                            22 /   25          0.0    22053737.0       1.0X
+10 select expressions                            8 /   13          0.0     8288520.0       2.7X
+100 select expressions                          29 /   32          0.0    29481040.0       0.7X
+1000 select expressions                        268 /  276          0.0   268183159.0       0.1X
+2500 select expressions                        683 /  691          0.0   683422241.0       0.0X
+*/
   }
 
-  ignore("many column field read and write") {
+  test("many column field read and write") {
     val benchmark = new Benchmark("many column field r/w", scaleFactor)
     for (width <- widthsToTest) {
       // normalize by width to keep constant data size
@@ -75,41 +119,39 @@ class WideSchemaBenchmark extends SparkFunSuite {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
       val df = sparkSession.range(numRows).toDF.selectExpr(selectExpr: _*).cache()
       df.count()  // force caching
-      benchmark.addCase(s"$width cols x $numRows rows (read in-mem)") { iter =>
-        df.selectExpr("sum(a_1)").collect()
-      }
-      benchmark.addCase(s"$width cols x $numRows rows (write in-mem)") { iter =>
-        df.selectExpr("*", "hash(a_1) as f").selectExpr("sum(a_1)", "sum(f)").collect()
-      }
-      val parquet = saveAsParquet(df)
-      benchmark.addCase(s"$width cols x $numRows rows (read parquet)") { iter =>
-        parquet.selectExpr("sum(a_1)").collect()
-      }
-      benchmark.addCase(s"$width cols x $numRows rows (write parquet)") { iter =>
-        saveAsParquet(df.selectExpr("sum(a_1)"))
-      }
+      addCases(benchmark, df, s"$width cols x $numRows rows", "a_1")
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    many column field r/w:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 cols x 100000 rows (read)                   41 /   51          2.4         414.5       1.0X
-    1 cols x 100000 rows (write)                  52 /   68          1.9         520.1       0.8X
-    10 cols x 10000 rows (read)                   43 /   49          2.3         426.7       1.0X
-    10 cols x 10000 rows (write)                  48 /   65          2.1         478.3       0.9X
-    100 cols x 1000 rows (read)                   84 /   91          1.2         840.4       0.5X
-    100 cols x 1000 rows (write)                 103 /  122          1.0        1032.1       0.4X
-    1000 cols x 100 rows (read)                  458 /  468          0.2        4575.5       0.1X
-    1000 cols x 100 rows (write)                 849 /  875          0.1        8494.0       0.0X
-    2500 cols x 40 rows (read)                  1077 / 1135          0.1       10770.3       0.0X
-    2500 cols x 40 rows (write)                 2251 / 2351          0.0       22510.8       0.0X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+many column field r/w:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 cols x 100000 rows (read in-mem)              26 /   33          3.8         262.9       1.0X
+1 cols x 100000 rows (write in-mem)             40 /   51          2.5         401.6       0.7X
+1 cols x 100000 rows (read parquet)             37 /   57          2.7         374.3       0.7X
+1 cols x 100000 rows (write parquet)           105 /  157          0.9        1054.9       0.2X
+10 cols x 10000 rows (read in-mem)              26 /   39          3.8         260.5       1.0X
+10 cols x 10000 rows (write in-mem)             37 /   44          2.7         367.4       0.7X
+10 cols x 10000 rows (read parquet)             31 /   39          3.3         305.1       0.9X
+10 cols x 10000 rows (write parquet)            86 /  137          1.2         860.2       0.3X
+100 cols x 1000 rows (read in-mem)              40 /   64          2.5         401.2       0.7X
+100 cols x 1000 rows (write in-mem)            112 /  139          0.9        1118.3       0.2X
+100 cols x 1000 rows (read parquet)             35 /   52          2.9         349.8       0.8X
+100 cols x 1000 rows (write parquet)           150 /  182          0.7        1497.1       0.2X
+1000 cols x 100 rows (read in-mem)             304 /  362          0.3        3043.6       0.1X
+1000 cols x 100 rows (write in-mem)            647 /  729          0.2        6467.8       0.0X
+1000 cols x 100 rows (read parquet)            194 /  235          0.5        1937.7       0.1X
+1000 cols x 100 rows (write parquet)           511 /  521          0.2        5105.0       0.1X
+2500 cols x 40 rows (read in-mem)              915 /  924          0.1        9148.2       0.0X
+2500 cols x 40 rows (write in-mem)            1856 / 1933          0.1       18558.1       0.0X
+2500 cols x 40 rows (read parquet)             802 /  881          0.1        8019.3       0.0X
+2500 cols x 40 rows (write parquet)           1268 / 1291          0.1       12681.6       0.0X
+*/
   }
 
-  ignore("wide struct field read and write") {
+  test("wide struct field read and write") {
     val benchmark = new Benchmark("wide struct field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width
@@ -124,34 +166,39 @@ class WideSchemaBenchmark extends SparkFunSuite {
       datum += "}"
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addCase(s"$width wide x $numRows rows (read)") { iter =>
-        df.selectExpr("sum(value_1)").collect()
-      }
-      benchmark.addCase(s"$width wide x $numRows rows (write)") { iter =>
-        df.selectExpr("*", "hash(value_1) as f").selectExpr(s"sum(value_1)", "sum(f)").collect()
-      }
+      addCases(benchmark, df, s"$width wide x $numRows rows", "value_1")
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    wide struct field r/w:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 wide x 100000 rows (read)                   31 /   38          3.2         309.3       1.0X
-    1 wide x 100000 rows (write)                  55 /   61          1.8         551.6       0.6X
-    10 wide x 10000 rows (read)                   51 /   53          2.0         506.6       0.6X
-    10 wide x 10000 rows (write)                  60 /   71          1.7         596.5       0.5X
-    100 wide x 1000 rows (read)                   74 /   86          1.4         737.4       0.4X
-    100 wide x 1000 rows (write)                 133 /  154          0.8        1332.1       0.2X
-    1000 wide x 100 rows (read)                  377 /  441          0.3        3767.3       0.1X
-    1000 wide x 100 rows (write)                 688 /  828          0.1        6880.8       0.0X
-    2500 wide x 40 rows (read)                   974 / 1044          0.1        9738.1       0.0X
-    2500 wide x 40 rows (write)                 2081 / 2256          0.0       20805.8       0.0X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+wide struct field r/w:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 wide x 100000 rows (read in-mem)              22 /   37          4.6         216.8       1.0X
+1 wide x 100000 rows (write in-mem)             37 /   54          2.7         365.6       0.6X
+1 wide x 100000 rows (read parquet)             27 /   44          3.6         274.7       0.8X
+1 wide x 100000 rows (write parquet)           155 /  183          0.6        1546.3       0.1X
+10 wide x 10000 rows (read in-mem)              27 /   40          3.7         272.1       0.8X
+10 wide x 10000 rows (write in-mem)             32 /   44          3.2         315.7       0.7X
+10 wide x 10000 rows (read parquet)             31 /   44          3.2         309.8       0.7X
+10 wide x 10000 rows (write parquet)           151 /  169          0.7        1509.3       0.1X
+100 wide x 1000 rows (read in-mem)              37 /   62          2.7         374.4       0.6X
+100 wide x 1000 rows (write in-mem)             81 /   96          1.2         805.6       0.3X
+100 wide x 1000 rows (read parquet)             31 /   44          3.3         307.3       0.7X
+100 wide x 1000 rows (write parquet)           174 /  209          0.6        1745.0       0.1X
+1000 wide x 100 rows (read in-mem)             308 /  339          0.3        3082.4       0.1X
+1000 wide x 100 rows (write in-mem)            672 /  696          0.1        6717.7       0.0X
+1000 wide x 100 rows (read parquet)            182 /  228          0.5        1821.2       0.1X
+1000 wide x 100 rows (write parquet)           484 /  497          0.2        4841.2       0.0X
+2500 wide x 40 rows (read in-mem)              727 /  786          0.1        7268.4       0.0X
+2500 wide x 40 rows (write in-mem)            1734 / 1782          0.1       17341.5       0.0X
+2500 wide x 40 rows (read parquet)             882 /  935          0.1        8816.8       0.0X
+2500 wide x 40 rows (write parquet)            935 /  982          0.1        9351.9       0.0X
+*/
   }
 
-  ignore("deeply nested struct field read and write") {
+  test("deeply nested struct field read and write") {
     val benchmark = new Benchmark("deeply nested struct field r/w", scaleFactor)
     for (depth <- depthsToTest) {
       val numRows = scaleFactor / depth
@@ -163,29 +210,32 @@ class WideSchemaBenchmark extends SparkFunSuite {
       }
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addCase(s"$depth deep x $numRows rows (read)") { iter =>
-        df.selectExpr(s"sum($selector)").collect()
-      }
-      benchmark.addCase(s"$depth deep x $numRows rows (write)") { iter =>
-        df.selectExpr("*", s"$selector as f").selectExpr(s"sum($selector)", "sum(f)").collect()
-      }
+      addCases(benchmark, df, s"$depth deep x $numRows rows", selector)
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    deeply nested struct field r/w:        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 deep x 100000 rows (read)                   38 /   49          2.6         382.2       1.0X
-    1 deep x 100000 rows (write)                  38 /   45          2.6         382.1       1.0X
-    10 deep x 10000 rows (read)                   48 /   61          2.1         483.8       0.8X
-    10 deep x 10000 rows (write)                  93 /  104          1.1         931.2       0.4X
-    100 deep x 1000 rows (read)                  151 /  162          0.7        1513.2       0.3X
-    100 deep x 1000 rows (write)                 903 / 1004          0.1        9030.5       0.0X
-    250 deep x 400 rows (read)                   653 /  735          0.2        6526.8       0.1X
-    250 deep x 400 rows (write)                 8749 / 9217          0.0       87490.4       0.0X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+deeply nested struct field r/w:          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 deep x 100000 rows (read in-mem)              24 /   39          4.2         239.0       1.0X
+1 deep x 100000 rows (write in-mem)             34 /   47          3.0         335.1       0.7X
+1 deep x 100000 rows (read parquet)             45 /   51          2.2         446.1       0.5X
+1 deep x 100000 rows (write parquet)            86 /  108          1.2         859.4       0.3X
+10 deep x 10000 rows (read in-mem)              28 /   38          3.6         275.1       0.9X
+10 deep x 10000 rows (write in-mem)             43 /   64          2.3         427.1       0.6X
+10 deep x 10000 rows (read parquet)             44 /   59          2.3         438.1       0.5X
+10 deep x 10000 rows (write parquet)            85 /  110          1.2         853.6       0.3X
+100 deep x 1000 rows (read in-mem)              79 /  100          1.3         785.5       0.3X
+100 deep x 1000 rows (write in-mem)            776 /  800          0.1        7760.3       0.0X
+100 deep x 1000 rows (read parquet)           3302 / 3394          0.0       33021.2       0.0X
+100 deep x 1000 rows (write parquet)           226 /  243          0.4        2259.0       0.1X
+250 deep x 400 rows (read in-mem)              610 /  639          0.2        6104.0       0.0X
+250 deep x 400 rows (write in-mem)            8526 / 8531          0.0       85256.9       0.0X
+250 deep x 400 rows (read parquet)          54968 / 55069          0.0      549681.4       0.0X
+250 deep x 400 rows (write parquet)            714 /  718          0.1        7143.0       0.0X
+*/
   }
 
   test("bushy struct field read and write") {
@@ -206,33 +256,36 @@ class WideSchemaBenchmark extends SparkFunSuite {
       // we should benchmark that too separately.
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addCase(s"$numNodes nodes x $depth deep x $numRows rows (read)") { iter =>
-        df.selectExpr(s"sum($selector)").collect()
-      }
-      benchmark.addCase(s"$numNodes nodes x $depth deep x $numRows rows (write)") { iter =>
-        df.selectExpr("*", s"$selector as f").selectExpr(s"sum($selector)", "sum(f)").collect()
-      }
+      addCases(benchmark, df, s"$numNodes x $depth deep x $numRows rows", selector)
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    bushy struct field r/w:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 nodes x 1 deep x 100000 rows (read)         57 /   69          1.7         571.7       1.0X
-    1 nodes x 1 deep x 100000 rows (write)        61 /   75          1.6         614.4       0.9X
-    16 nodes x 5 deep x 10000 rows (read)         44 /   55          2.3         439.0       1.3X
-    16 nodes x 5 deep x 10000 rows (write)       100 /  126          1.0         999.5       0.6X
-    128 nodes x 8 deep x 1000 rows (read)         53 /   61          1.9         532.9       1.1X
-    128 nodes x 8 deep x 1000 rows (write)       530 /  656          0.2        5295.6       0.1X
-    512 nodes x 10 deep x 200 rows (read)         98 /  134          1.0         979.2       0.6X
-    512 nodes x 10 deep x 200 rows (write)      6698 / 7124          0.0       66977.0       0.0X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+bushy struct field r/w:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 x 1 deep x 100000 rows (read in-mem)         21 /   27          4.7         212.6       1.0X
+1 x 1 deep x 100000 rows (write in-mem)        27 /   38          3.8         265.8       0.8X
+1 x 1 deep x 100000 rows (read parquet)        26 /   32          3.9         259.1       0.8X
+1 x 1 deep x 100000 rows (write parquet)      150 /  169          0.7        1499.5       0.1X
+16 x 5 deep x 10000 rows (read in-mem)         26 /   45          3.9         258.7       0.8X
+16 x 5 deep x 10000 rows (write in-mem)        54 /   58          1.9         535.1       0.4X
+16 x 5 deep x 10000 rows (read parquet)        60 /   84          1.7         595.8       0.4X
+16 x 5 deep x 10000 rows (write parquet)      179 /  184          0.6        1787.5       0.1X
+128 x 8 deep x 1000 rows (read in-mem)         26 /   40          3.8         261.4       0.8X
+128 x 8 deep x 1000 rows (write in-mem)       592 /  592          0.2        5915.3       0.0X
+128 x 8 deep x 1000 rows (read parquet)       203 /  251          0.5        2031.8       0.1X
+128 x 8 deep x 1000 rows (write parquet)      105 /  131          1.0        1045.2       0.2X
+512 x 10 deep x 200 rows (read in-mem)        101 /  125          1.0        1007.4       0.2X
+512 x 10 deep x 200 rows (write in-mem)      6778 / 6943          0.0       67781.1       0.0X
+512 x 10 deep x 200 rows (read parquet)       958 / 1071          0.1        9584.9       0.0X
+512 x 10 deep x 200 rows (write parquet)      173 /  207          0.6        1726.1       0.1X
+*/
   }
 
-  ignore("wide array field read") {
-    val benchmark = new Benchmark("wide array field read", scaleFactor)
+  test("wide array field read and write") {
+    val benchmark = new Benchmark("wide array field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width
       var datum: String = "{\"value\": ["
@@ -246,48 +299,74 @@ class WideSchemaBenchmark extends SparkFunSuite {
       datum += "]}"
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addCase(s"$width wide x $numRows rows") { iter =>
-        df.selectExpr("sum(value[0])").collect()
-      }
+      addCases(benchmark, df, s"$width wide x $numRows rows", "value[0]")
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    wide array field read:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 wide x 100000 rows                          67 /   73          1.5         666.0       1.0X
-    10 wide x 10000 rows                          43 /   46          2.3         425.8       1.6X
-    100 wide x 1000 rows                          35 /   39          2.8         351.6       1.9X
-    1000 wide x 100 rows                          34 /   36          3.0         336.4       2.0X
-    5000 wide x 20 rows                           30 /   32          3.3         301.9       2.2X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+wide array field r/w:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 wide x 100000 rows (read in-mem)              27 /   45          3.7         268.0       1.0X
+1 wide x 100000 rows (write in-mem)             37 /   52          2.7         368.3       0.7X
+1 wide x 100000 rows (read parquet)             52 /   65          1.9         524.9       0.5X
+1 wide x 100000 rows (write parquet)           102 /  139          1.0        1016.7       0.3X
+10 wide x 10000 rows (read in-mem)              20 /   26          5.0         201.7       1.3X
+10 wide x 10000 rows (write in-mem)             26 /   35          3.8         259.8       1.0X
+10 wide x 10000 rows (read parquet)             39 /   59          2.5         393.8       0.7X
+10 wide x 10000 rows (write parquet)           120 /  143          0.8        1201.4       0.2X
+100 wide x 1000 rows (read in-mem)              24 /   31          4.2         240.1       1.1X
+100 wide x 1000 rows (write in-mem)             26 /   35          3.8         264.1       1.0X
+100 wide x 1000 rows (read parquet)             30 /   47          3.4         296.8       0.9X
+100 wide x 1000 rows (write parquet)           109 /  147          0.9        1094.8       0.2X
+1000 wide x 100 rows (read in-mem)              20 /   38          5.0         200.6       1.3X
+1000 wide x 100 rows (write in-mem)             24 /   32          4.1         242.3       1.1X
+1000 wide x 100 rows (read parquet)             47 /   55          2.1         470.1       0.6X
+1000 wide x 100 rows (write parquet)           146 /  164          0.7        1465.0       0.2X
+2500 wide x 40 rows (read in-mem)               20 /   28          5.1         196.1       1.4X
+2500 wide x 40 rows (write in-mem)              25 /   27          4.0         249.3       1.1X
+2500 wide x 40 rows (read parquet)              33 /   48          3.0         332.0       0.8X
+2500 wide x 40 rows (write parquet)            149 /  176          0.7        1489.3       0.2X
+*/
   }
 
-  ignore("wide map field read") {
-    val benchmark = new Benchmark("wide array field read", scaleFactor)
+  test("wide map field read and write") {
+    val benchmark = new Benchmark("wide map field r/w", scaleFactor)
     for (width <- widthsToTest) {
       val numRows = scaleFactor / width
       val datum = Tuple1((1 to width).map(i => ("value_" + i -> 1)).toMap)
-      val df = sparkSession.range(numRows).map(_ => datum).cache()
+      val df = sparkSession.range(numRows).map(_ => datum).toDF.cache()
       df.count()  // force caching
-      benchmark.addCase(s"$width wide x $numRows rows") { iter =>
-        df.selectExpr("sum(_1[\"value_1\"])").collect()
-      }
+      addCases(benchmark, df, s"$width wide x $numRows rows", "_1[\"value_1\"]")
     }
     benchmark.run()
 
-    /*
-    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
-    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    wide array field read:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ----------------------------------------------------------------------------------------------
-    1 wide x 100000 rows                          53 /   65          1.9         533.1       1.0X
-    10 wide x 10000 rows                          40 /   51          2.5         404.5       1.3X
-    100 wide x 1000 rows                          36 /   38          2.8         357.0       1.5X
-    1000 wide x 100 rows                          34 /   36          3.0         338.4       1.6X
-    5000 wide x 20 rows                           34 /   48          2.9         343.4       1.6X
-    */
+/*
+OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+wide map field r/w:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+1 wide x 100000 rows (read in-mem)              27 /   42          3.7         270.9       1.0X
+1 wide x 100000 rows (write in-mem)             40 /   63          2.5         403.4       0.7X
+1 wide x 100000 rows (read parquet)             71 /  114          1.4         705.8       0.4X
+1 wide x 100000 rows (write parquet)           169 /  184          0.6        1689.7       0.2X
+10 wide x 10000 rows (read in-mem)              22 /   35          4.6         216.6       1.3X
+10 wide x 10000 rows (write in-mem)             29 /   34          3.5         285.6       0.9X
+10 wide x 10000 rows (read parquet)             61 /   81          1.6         610.3       0.4X
+10 wide x 10000 rows (write parquet)           150 /  172          0.7        1504.7       0.2X
+100 wide x 1000 rows (read in-mem)              21 /   29          4.8         207.9       1.3X
+100 wide x 1000 rows (write in-mem)             30 /   57          3.3         304.9       0.9X
+100 wide x 1000 rows (read parquet)             36 /   61          2.8         356.7       0.8X
+100 wide x 1000 rows (write parquet)           108 /  136          0.9        1075.7       0.3X
+1000 wide x 100 rows (read in-mem)              22 /   31          4.5         223.0       1.2X
+1000 wide x 100 rows (write in-mem)             33 /   41          3.0         332.0       0.8X
+1000 wide x 100 rows (read parquet)             49 /   66          2.0         493.6       0.5X
+1000 wide x 100 rows (write parquet)           127 /  139          0.8        1265.9       0.2X
+2500 wide x 40 rows (read in-mem)               23 /   34          4.4         226.0       1.2X
+2500 wide x 40 rows (write in-mem)              33 /   42          3.1         326.6       0.8X
+2500 wide x 40 rows (read parquet)              36 /   48          2.8         359.2       0.8X
+2500 wide x 40 rows (write parquet)            155 /  168          0.6        1549.2       0.2X
+*/
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -17,6 +17,11 @@
 
 package org.apache.spark.sql
 
+<<<<<<< Updated upstream
+=======
+import java.io.File
+
+>>>>>>> Stashed changes
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.functions._
 import org.apache.spark.util.Benchmark
@@ -70,11 +75,18 @@ class WideSchemaBenchmark extends SparkFunSuite {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
       val df = sparkSession.range(numRows).toDF.selectExpr(selectExpr: _*).cache()
       df.count()  // force caching
-      benchmark.addCase(s"$width cols x $numRows rows (read)") { iter =>
+      benchmark.addCase(s"$width cols x $numRows rows (read in-mem)") { iter =>
         df.selectExpr("sum(a_1)").collect()
       }
-      benchmark.addCase(s"$width cols x $numRows rows (write)") { iter =>
+      benchmark.addCase(s"$width cols x $numRows rows (write in-mem)") { iter =>
         df.selectExpr("*", "hash(a_1) as f").selectExpr("sum(a_1)", "sum(f)").collect()
+      }
+      val parquet = saveAsParquet(df)
+      benchmark.addCase(s"$width cols x $numRows rows (read parquet)") { iter =>
+        parquet.selectExpr("sum(a_1)").collect()
+      }
+      benchmark.addCase(s"$width cols x $numRows rows (write parquet)") { iter =>
+        saveAsParquet(df.selectExpr("sum(a_1)"))
       }
     }
     benchmark.run()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -176,7 +176,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  ignore("bushy struct field read and write") {
+  test("bushy struct field read and write") {
     val benchmark = new Benchmark("bushy struct field r/w", scaleFactor)
     for (width <- Seq(1, 10, 100, 500)) {
       val numRows = scaleFactor / width
@@ -218,10 +218,6 @@ class WideSchemaBenchmark extends SparkFunSuite {
     512 nodes x 10 deep x 200 rows (write)      6698 / 7124          0.0       66977.0       0.0X
     */
   }
-
-  //
-  // The following benchmarks are for reference: the schema is not actually wide for them.
-  //
 
   ignore("wide array field read") {
     val benchmark = new Benchmark("wide array field read", scaleFactor)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -64,7 +64,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  ignore("wide row field read") {
+  ignore("many column field read") {
     val benchmark = new Benchmark("many column field read", scaleFactor)
     for (width <- widthsToTest) {
       // normalize by width to keep constant data size

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -43,10 +43,8 @@ class WideSchemaBenchmark extends SparkFunSuite {
     val benchmark = new Benchmark("parsing large select", 1)
     for (width <- widthsToTest) {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
-      benchmark.addTimerCase(s"$width select expressions") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width select expressions") { iter =>
         sparkSession.range(1).toDF.selectExpr(selectExpr: _*)
-        timer.stopTiming()
       }
     }
     benchmark.run()
@@ -72,15 +70,11 @@ class WideSchemaBenchmark extends SparkFunSuite {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
       val df = sparkSession.range(numRows).toDF.selectExpr(selectExpr: _*).cache()
       df.count()  // force caching
-      benchmark.addTimerCase(s"$width cols x $numRows rows (read)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width cols x $numRows rows (read)") { iter =>
         df.selectExpr("sum(a_1)").collect()
-        timer.stopTiming()
       }
-      benchmark.addTimerCase(s"$width cols x $numRows rows (write)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width cols x $numRows rows (write)") { iter =>
         df.selectExpr("*", "hash(a_1) as f").selectExpr("sum(a_1)", "sum(f)").collect()
-        timer.stopTiming()
       }
     }
     benchmark.run()
@@ -118,15 +112,11 @@ class WideSchemaBenchmark extends SparkFunSuite {
       datum += "}"
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addTimerCase(s"$width wide x $numRows rows (read)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width wide x $numRows rows (read)") { iter =>
         df.selectExpr("sum(value_1)").collect()
-        timer.stopTiming()
       }
-      benchmark.addTimerCase(s"$width wide x $numRows rows (write)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width wide x $numRows rows (write)") { iter =>
         df.selectExpr("*", "hash(value_1) as f").selectExpr(s"sum(value_1)", "sum(f)").collect()
-        timer.stopTiming()
       }
     }
     benchmark.run()
@@ -161,15 +151,11 @@ class WideSchemaBenchmark extends SparkFunSuite {
       }
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addTimerCase(s"$depth deep x $numRows rows (read)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$depth deep x $numRows rows (read)") { iter =>
         df.selectExpr(s"sum($selector)").collect()
-        timer.stopTiming()
       }
-      benchmark.addTimerCase(s"$depth deep x $numRows rows (write)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$depth deep x $numRows rows (write)") { iter =>
         df.selectExpr("*", s"$selector as f").selectExpr(s"sum($selector)", "sum(f)").collect()
-        timer.stopTiming()
       }
     }
     benchmark.run()
@@ -208,15 +194,11 @@ class WideSchemaBenchmark extends SparkFunSuite {
       // we should benchmark that too separately.
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addTimerCase(s"$numNodes nodes x $depth deep x $numRows rows (read)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$numNodes nodes x $depth deep x $numRows rows (read)") { iter =>
         df.selectExpr(s"sum($selector)").collect()
-        timer.stopTiming()
       }
-      benchmark.addTimerCase(s"$numNodes nodes x $depth deep x $numRows rows (write)") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$numNodes nodes x $depth deep x $numRows rows (write)") { iter =>
         df.selectExpr("*", s"$selector as f").selectExpr(s"sum($selector)", "sum(f)").collect()
-        timer.stopTiming()
       }
     }
     benchmark.run()
@@ -256,10 +238,8 @@ class WideSchemaBenchmark extends SparkFunSuite {
       datum += "]}"
       val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
       df.count()  // force caching
-      benchmark.addTimerCase(s"$width wide x $numRows rows") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width wide x $numRows rows") { iter =>
         df.selectExpr("sum(value[0])").collect()
-        timer.stopTiming()
       }
     }
     benchmark.run()
@@ -284,10 +264,8 @@ class WideSchemaBenchmark extends SparkFunSuite {
       val datum = Tuple1((1 to width).map(i => ("value_" + i -> 1)).toMap)
       val df = sparkSession.range(numRows).map(_ => datum).cache()
       df.count()  // force caching
-      benchmark.addTimerCase(s"$width wide x $numRows rows") { timer =>
-        timer.startTiming()
+      benchmark.addCase(s"$width wide x $numRows rows") { iter =>
         df.selectExpr("sum(_1[\"value_1\"])").collect()
-        timer.stopTiming()
       }
     }
     benchmark.run()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -22,13 +22,13 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.util.Benchmark
 
 /**
- * Benchmark for performance over wide and nested DataFrames.
+ * Benchmark for performance with very wide and nested DataFrames.
  * To run this:
  *  build/sbt "sql/test-only *WideSchemaBenchmark"
  */
 class WideSchemaBenchmark extends SparkFunSuite {
   private val scaleFactor = 100000
-  private val widthsToTest = Seq(1, 10, 100, 1000, 5000)
+  private val widthsToTest = Seq(1, 10, 100, 1000, 5000)  // crashes on higher values
   private val depthsToTest = Seq(1, 10, 100, 250)
   assert(scaleFactor > widthsToTest.max)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -64,7 +64,7 @@ class WideSchemaBenchmark extends SparkFunSuite {
     */
   }
 
-  ignore("many column field read") {
+  ignore("wide row field read") {
     val benchmark = new Benchmark("many column field read", scaleFactor)
     for (width <- widthsToTest) {
       // normalize by width to keep constant data size

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.functions._
+import org.apache.spark.util.Benchmark
+
+/**
+ * Benchmark for performance over wide and nested DataFrames.
+ * To run this:
+ *  build/sbt "sql/test-only *WideSchemaBenchmark"
+ */
+class WideSchemaBenchmark extends SparkFunSuite {
+  private val scaleFactor = 100000
+  private val widthsToTest = Seq(1, 10, 100, 1000, 5000)
+  private val depthsToTest = Seq(1, 10, 100, 250)
+  assert(scaleFactor > widthsToTest.max)
+
+  private lazy val sparkSession = SparkSession.builder
+    .master("local[1]")
+    .appName("microbenchmark")
+    .getOrCreate()
+
+  import sparkSession.implicits._
+
+  ignore("many column query parse") {
+    val benchmark = new Benchmark("many column parse", 1)
+    for (width <- widthsToTest) {
+      val selectExpr = (1 to width).map(i => s"id as a_$i")
+      benchmark.addTimerCase(s"$width column parse") { timer =>
+        timer.startTiming()
+        sparkSession.range(1).toDF.selectExpr(selectExpr: _*)
+        timer.stopTiming()
+      }
+    }
+    benchmark.run()
+
+    /*
+    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+    many column parse:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ----------------------------------------------------------------------------------------------
+    1 column parse                                15 /   19          0.0    15464923.0       1.0X
+    10 column parse                               26 /   30          0.0    26131438.0       0.6X
+    100 column parse                              46 /   58          0.0    45719540.0       0.3X
+    1000 column parse                            285 /  328          0.0   285407972.0       0.1X
+    5000 column parse                           1482 / 1645          0.0  1482298845.0       0.0X
+    */
+  }
+
+  ignore("many column field read") {
+    val benchmark = new Benchmark("many column field read", scaleFactor)
+    for (width <- widthsToTest) {
+      // normalize by width to keep constant data size
+      val numRows = scaleFactor / width
+      val selectExpr = (1 to width).map(i => s"id as a_$i")
+      val df = sparkSession.range(numRows).toDF.selectExpr(selectExpr: _*).cache()
+      df.count()  // force caching
+      benchmark.addTimerCase(s"$width cols x $numRows rows") { timer =>
+        timer.startTiming()
+        df.selectExpr("sum(a_1)").collect()
+        timer.stopTiming()
+      }
+    }
+    benchmark.run()
+
+    /*
+    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+    many column field read:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ----------------------------------------------------------------------------------------------
+    1 cols x 100000 rows                          57 /   67          1.7         572.9       1.0X
+    10 cols x 10000 rows                          35 /   43          2.8         354.1       1.6X
+    100 cols x 1000 rows                          49 /   67          2.0         492.4       1.2X
+    1000 cols x 100 rows                         428 /  459          0.2        4281.8       0.1X
+    5000 cols x 20 rows                         2170 / 2253          0.0       21695.6       0.0X
+    */
+  }
+
+  ignore("wide struct field read") {
+    val benchmark = new Benchmark("wide struct field read", scaleFactor)
+    for (width <- widthsToTest) {
+      val numRows = scaleFactor / width
+      var datum: String = "{"
+      for (i <- 1 to width) {
+        if (i == 1) {
+          datum += s""""value_$i": 1"""
+        } else {
+          datum += s""", "value_$i": 1"""
+        }
+      }
+      datum += "}"
+      val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
+      df.count()  // force caching
+      benchmark.addTimerCase(s"$width wide x $numRows rows") { timer =>
+        timer.startTiming()
+        df.selectExpr("sum(value_1)").collect()
+        timer.stopTiming()
+      }
+    }
+    benchmark.run()
+
+    /*
+    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+    wide struct field read:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ----------------------------------------------------------------------------------------------
+    1 wide x 100000 rows                          33 /   41          3.0         333.9       1.0X
+    10 wide x 10000 rows                          45 /   52          2.2         445.1       0.8X
+    100 wide x 1000 rows                          86 /   95          1.2         856.1       0.4X
+    1000 wide x 100 rows                         265 /  322          0.4        2646.4       0.1X
+    5000 wide x 20 rows                         1882 / 2043          0.1       18817.4       0.0X
+    */
+  }
+
+  ignore("deeply nested struct field read") {
+    val benchmark = new Benchmark("deeply nested struct field read", scaleFactor)
+    for (depth <- depthsToTest) {
+      val numRows = scaleFactor / depth
+      var datum: String = "{\"value\": 1}"
+      var selector: String = "value"
+      for (i <- 1 to depth) {
+        datum = "{\"value\": " + datum + "}"
+        selector = selector + ".value"
+      }
+      val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
+      df.count()  // force caching
+      benchmark.addTimerCase(s"$depth deep x $numRows rows") { timer =>
+        timer.startTiming()
+        df.selectExpr(s"sum($selector)").collect()
+        timer.stopTiming()
+      }
+    }
+    benchmark.run()
+
+    /*
+    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+    deeply nested struct field read:       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ----------------------------------------------------------------------------------------------
+    1 deep x 100000 rows                          45 /   55          2.2         450.4       1.0X
+    10 deep x 10000 rows                          52 /   63          1.9         515.1       0.9X
+    100 deep x 1000 rows                         100 /  119          1.0        1004.0       0.4X
+    250 deep x 400 rows                          534 /  623          0.2        5342.4       0.1X
+    */
+  }
+
+  //
+  // The following benchmarks are for reference: the schema is not actually wide for them.
+  //
+
+  ignore("wide array field read") {
+    val benchmark = new Benchmark("wide array field read", scaleFactor)
+    for (width <- widthsToTest) {
+      val numRows = scaleFactor / width
+      var datum: String = "{\"value\": ["
+      for (i <- 1 to width) {
+        if (i == 1) {
+          datum += "1"
+        } else {
+          datum += ", 1"
+        }
+      }
+      datum += "]}"
+      val df = sparkSession.read.json(sparkSession.range(numRows).map(_ => datum).rdd).cache()
+      df.count()  // force caching
+      benchmark.addTimerCase(s"$width wide x $numRows rows") { timer =>
+        timer.startTiming()
+        df.selectExpr("sum(value[0])").collect()
+        timer.stopTiming()
+      }
+    }
+    benchmark.run()
+
+    /*
+    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+    wide array field read:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ----------------------------------------------------------------------------------------------
+    1 wide x 100000 rows                          67 /   73          1.5         666.0       1.0X
+    10 wide x 10000 rows                          43 /   46          2.3         425.8       1.6X
+    100 wide x 1000 rows                          35 /   39          2.8         351.6       1.9X
+    1000 wide x 100 rows                          34 /   36          3.0         336.4       2.0X
+    5000 wide x 20 rows                           30 /   32          3.3         301.9       2.2X
+    */
+  }
+
+  ignore("wide map field read") {
+    val benchmark = new Benchmark("wide array field read", scaleFactor)
+    for (width <- widthsToTest) {
+      val numRows = scaleFactor / width
+      val datum = Tuple1((1 to width).map(i => ("value_" + i -> 1)).toMap)
+      val df = sparkSession.range(numRows).map(_ => datum).cache()
+      df.count()  // force caching
+      benchmark.addTimerCase(s"$width wide x $numRows rows") { timer =>
+        timer.startTiming()
+        df.selectExpr("sum(_1[\"value_1\"])").collect()
+        timer.stopTiming()
+      }
+    }
+    benchmark.run()
+
+    /*
+    OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
+    Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
+    wide array field read:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ----------------------------------------------------------------------------------------------
+    1 wide x 100000 rows                          53 /   65          1.9         533.1       1.0X
+    10 wide x 10000 rows                          40 /   51          2.5         404.5       1.3X
+    100 wide x 1000 rows                          36 /   38          2.8         357.0       1.5X
+    1000 wide x 100 rows                          34 /   36          3.0         338.4       1.6X
+    5000 wide x 20 rows                           34 /   48          2.9         343.4       1.6X
+    */
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -46,10 +46,14 @@ class WideSchemaBenchmark extends SparkFunSuite with BeforeAndAfterEach {
   private var tmpFiles: List[File] = Nil
 
   override def afterEach() {
-    for (tmpFile <- tmpFiles) {
-      Utils.deleteRecursively(tmpFile)
+    try {
+      for (tmpFile <- tmpFiles) {
+        Utils.deleteRecursively(tmpFile)
+      }
+    } finally {
+      tmpFiles = Nil
+      super.afterEach()
     }
-    tmpFiles = Nil
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WideSchemaBenchmark.scala
@@ -39,11 +39,11 @@ class WideSchemaBenchmark extends SparkFunSuite {
 
   import sparkSession.implicits._
 
-  ignore("many column query parse") {
-    val benchmark = new Benchmark("many column parse", 1)
+  ignore("parsing large select expressions") {
+    val benchmark = new Benchmark("parsing large select", 1)
     for (width <- widthsToTest) {
       val selectExpr = (1 to width).map(i => s"id as a_$i")
-      benchmark.addTimerCase(s"$width column parse") { timer =>
+      benchmark.addTimerCase(s"$width select expressions") { timer =>
         timer.startTiming()
         sparkSession.range(1).toDF.selectExpr(selectExpr: _*)
         timer.stopTiming()
@@ -54,13 +54,13 @@ class WideSchemaBenchmark extends SparkFunSuite {
     /*
     OpenJDK 64-Bit Server VM 1.8.0_66-internal-b17 on Linux 4.2.0-36-generic
     Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz
-    many column parse:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    parsing large select                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ----------------------------------------------------------------------------------------------
-    1 column parse                                15 /   19          0.0    15464923.0       1.0X
-    10 column parse                               26 /   30          0.0    26131438.0       0.6X
-    100 column parse                              46 /   58          0.0    45719540.0       0.3X
-    1000 column parse                            285 /  328          0.0   285407972.0       0.1X
-    5000 column parse                           1482 / 1645          0.0  1482298845.0       0.0X
+    1 select expressions                          15 /   19          0.0    15464923.0       1.0X
+    10 select expressions                         26 /   30          0.0    26131438.0       0.6X
+    100 select expressions                        46 /   58          0.0    45719540.0       0.3X
+    1000 select expressions                      285 /  328          0.0   285407972.0       0.1X
+    5000 select expressions                     1482 / 1645          0.0  1482298845.0       0.0X
     */
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds microbenchmarks for tracking performance of queries over very wide or deeply nested DataFrames. It seems performance degrades when DataFrames get thousands of columns wide or hundreds of fields deep.
## How was this patch tested?

Current results included.

cc @rxin @JoshRosen 
