### PR TITLE
[SPARK-15717][GraphX] Cannot perform RDD operations on a checkpointed VertexRDD.

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/EdgeRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/EdgeRDD.scala
@@ -55,6 +55,11 @@ abstract class EdgeRDD[ED](
     }
   }
 
+  override def computeOrReadCheckpoint(part: Partition, context: TaskContext)
+      : Iterator[Edge[ED]] = {
+    compute(part, context)
+  }
+
   /**
    * Map the values in an edge partitioning preserving the structure but changing the values.
    *

--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -69,6 +69,11 @@ abstract class VertexRDD[VD](
     firstParent[ShippableVertexPartition[VD]].iterator(part, context).next().iterator
   }
 
+  override def computeOrReadCheckpoint(part: Partition, context: TaskContext)
+      : Iterator[(VertexId, VD)] = {
+    compute(part, context)
+  }
+
   /**
    * Construct a new VertexRDD that is indexed by only the visible vertices. The resulting
    * VertexRDD will be based on a different index and can no longer be quickly joined with this

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.graphx
 import org.apache.spark.{HashPartitioner, SparkContext, SparkFunSuite}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.Utils
 
 class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
 
@@ -194,6 +195,23 @@ class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
       assert(rdd.getStorageLevel == StorageLevel.NONE)
       rdd.cache()
       assert(rdd.getStorageLevel == StorageLevel.MEMORY_ONLY)
+    }
+  }
+
+  test("checkpointed transformations") {
+    withSpark { sc =>
+      val tempDir = Utils.createTempDir()
+      val path = tempDir.toURI.toString
+
+      sc.setCheckpointDir(path)
+
+      val verts = vertices(sc, 5)
+      verts.checkpoint()
+      verts.count()
+
+      assert(verts.collect.toSet == Set(0L -> 0, 1L -> 1, 2L -> 2, 3L -> 3, 4L -> 4, 5L -> 5))
+
+      Utils.deleteRecursively(tempDir)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Operations defined in RDD that are not overwritten in VertexRDD fail when the VertexRDD is checkpointed and materialized.
## How was this patch tested?

New unit tests were added.
