### PR TITLE
Added dot vector operation for the class DenseVector

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -537,6 +537,22 @@ class DenseVector @Since("2.0.0") ( @Since("2.0.0") val values: Array[Double]) e
       maxIdx
     }
   }
+  
+  /**
+ * Function that returns the result of multiply this DenseVector by another DenseVector.
+ *
+ * @param other The second DenseVector
+ * @return The resulting Double value
+ */
+  def dot(other: DenseVector): Double = {
+    require(this.size == other.size, "DenseVectors dimmensions must be the same." +
+    s" You provided ${this.size} items and " +
+    s" ${other.size} items.")
+
+    return BLAS.dot(this,other)  
+    
+  }
+  
 }
 
 @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -712,6 +712,23 @@ class DenseVector @Since("1.0.0") (
   override def asML: newlinalg.DenseVector = {
     new newlinalg.DenseVector(values)
   }
+  
+  /**
+ * Function that returns the result of multiply this DenseVector by another DenseVector.
+ *
+ * @param other The second DenseVector
+ * @return The resulting Double value
+ */
+  @Since("2.0.0")
+  def dot(other: DenseVector): Double = {
+    require(this.size == other.size, "DenseVectors dimmensions must be the same." +
+    s" You provided ${this.size} items and " +
+    s" ${other.size} items.")
+
+    return BLAS.dot(this,other)  
+    
+  }
+  
 }
 
 @Since("1.3.0")


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this pull request I have added the dot product operation in the class DenseVector. This function uses the BLAS class to perform this operation.

I am planning to contribute in the linalg package by adding and testing local and distributed operations, so I decided to start with this simple operation.
## How was this patch tested?

This pull request has been tested by building the Spark master branch and testing the function in the spark-shell by multiplying one vector with another.
