### PR TITLE
[SPARK-15733][SQL] Makes the explain output less verbose by hiding some verbose output like None, null, empty List, and etc.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -430,10 +430,18 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
   def argString: String = productIterator.flatMap {
     case tn: TreeNode[_] if allChildren.contains(tn) => Nil
     case Some(tn: TreeNode[_]) if allChildren.contains(tn) => Nil
-    case tn: TreeNode[_] => s"${tn.simpleString}" :: Nil
-    case seq: Seq[BaseType] if seq.toSet.subsetOf(children.toSet) => Nil
+    case tn: TreeNode[_] => tn.simpleString :: Nil
+    case seq: Seq[Any] if seq.toSet.subsetOf(allChildren.asInstanceOf[Set[Any]]) => Nil
+    case iter: Iterable[_] if iter.isEmpty => Nil
     case seq: Seq[_] => seq.mkString("[", ",", "]") :: Nil
-    case set: Set[_] => set.mkString("{", ",", "}") :: Nil
+    case set: Set[_] => set.mkString("{", ", ", "}") :: Nil
+    case array: Array[_] if array.isEmpty => Nil
+    case array: Array[_] => array.mkString("[", ", ", "]") :: Nil
+    case null => Nil
+    case false => Nil
+    case None => Nil
+    case Some(null) => Nil
+    case Some(str: String) => str :: Nil
     case other => other :: Nil
   }.mkString(", ")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -430,6 +430,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
   def argString: String = stringArgs.flatMap {
     case tn: TreeNode[_] if allChildren.contains(tn) => Nil
     case Some(tn: TreeNode[_]) if allChildren.contains(tn) => Nil
+    case Some(tn: TreeNode[_]) => tn.simpleString :: Nil
     case tn: TreeNode[_] => tn.simpleString :: Nil
     case seq: Seq[Any] if seq.toSet.subsetOf(allChildren.asInstanceOf[Set[Any]]) => Nil
     case iter: Iterable[_] if iter.isEmpty => Nil
@@ -440,7 +441,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case null => Nil
     case None => Nil
     case Some(null) => Nil
-    case Some(str: String) => str :: Nil
+    case Some(any) => any :: Nil
     case other => other :: Nil
   }.mkString(", ")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -427,7 +427,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
   private lazy val allChildren: Set[TreeNode[_]] = (children ++ innerChildren).toSet[TreeNode[_]]
 
   /** Returns a string representing the arguments to this node, minus any children */
-  def argString: String = productIterator.flatMap {
+  def argString: String = stringArgs.flatMap {
     case tn: TreeNode[_] if allChildren.contains(tn) => Nil
     case Some(tn: TreeNode[_]) if allChildren.contains(tn) => Nil
     case tn: TreeNode[_] => tn.simpleString :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -433,7 +433,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case tn: TreeNode[_] => tn.simpleString :: Nil
     case seq: Seq[Any] if seq.toSet.subsetOf(allChildren.asInstanceOf[Set[Any]]) => Nil
     case iter: Iterable[_] if iter.isEmpty => Nil
-    case seq: Seq[_] => seq.mkString("[", ",", "]") :: Nil
+    case seq: Seq[_] => seq.mkString("[", ", ", "]") :: Nil
     case set: Set[_] => set.mkString("{", ", ", "}") :: Nil
     case array: Array[_] if array.isEmpty => Nil
     case array: Array[_] => array.mkString("[", ", ", "]") :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -438,7 +438,6 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case array: Array[_] if array.isEmpty => Nil
     case array: Array[_] => array.mkString("[", ", ", "]") :: Nil
     case null => Nil
-    case false => Nil
     case None => Nil
     case Some(null) => Nil
     case Some(str: String) => str :: Nil


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes the explain output less verbose by hiding some verbose output like `None`, `null`, empty List `[]`, empty set `{}`, and etc.

**Before change**:

```
== Physical Plan ==
ExecutedCommand
:  +- ShowTablesCommand None, None
```

**After change**:

```
== Physical Plan ==
ExecutedCommand
:  +- ShowTablesCommand
```
## How was this patch tested?

Manual test.
