### PR TITLE
[SPARK-15737] [CORE] fix jetty warning

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -89,6 +89,7 @@ private[spark] abstract class RestSubmissionServer(
     server.addConnector(connector)
 
     val mainHandler = new ServletContextHandler
+    mainHandler.setServer(server)
     mainHandler.setContextPath("/")
     contextToServlet.foreach { case (prefix, servlet) =>
       mainHandler.addServlet(new ServletHolder(servlet), prefix)

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -291,6 +291,7 @@ private[spark] object JettyUtils extends Logging {
 
       val errorHandler = new ErrorHandler()
       errorHandler.setShowStacks(true)
+      errorHandler.setServer(server)
       server.addBean(errorHandler)
       server.setHandler(collection)
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

After upgrading Jetty to 9.2, we always see "WARN org.eclipse.jetty.server.handler.AbstractHandler: No Server set for org.eclipse.jetty.server.handler.ErrorHandler" while running any test cases. 

This PR will fix it. 
## How was this patch tested?

The existing test cases will cover it.
