### PR TITLE
[SPARK-15739][GraphX] Expose aggregateMessagesWithActiveSet to users.

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -405,7 +405,7 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    *   will be run on edges with *both* vertices in the active set. The active set must have the
    *   same index as the graph's vertices.
    */
-  private[graphx] def aggregateMessagesWithActiveSet[A: ClassTag](
+  def aggregateMessagesWithActiveSet[A: ClassTag](
       sendMsg: EdgeContext[VD, ED, A] => Unit,
       mergeMsg: (A, A) => A,
       tripletFields: TripletFields,


### PR DESCRIPTION
## What changes were proposed in this pull request?

It would be fairly trivial to create custom versions of Pregel that would work for many other use cases if `aggregateMessagesWithActiveSet` were not a private method. See SPARK-15739 for a discussion.
## How was this patch tested?

No tests were added.
