### PR TITLE
[SPARK-15740] [MLLIB] ignore big model load / save in Word2VecSuite

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala
@@ -91,7 +91,7 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   }
 
-  test("big model load / save") {
+  ignore("big model load / save") {
     // create a model bigger than 32MB since 9000 * 1000 * 4 > 2^25
     val word2VecMap = Map((0 to 9000).map(i => s"$i" -> Array.fill(1000)(0.1f)): _*)
     val model = new Word2VecModel(word2VecMap)


### PR DESCRIPTION
## What changes were proposed in this pull request?

@andrewor14 noticed some OOM errors caused by "test big model load / save" in Word2VecSuite, e.g., https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test/job/spark-master-test-maven-hadoop-2.2/1168/consoleFull. It doesn't show up in the test result because it was OOMed.

This PR disables the test. I will leave the JIRA open for a proper fix
## How was this patch tested?

No new features.
