### PR TITLE
[SPARK-15688][SQL] RelationalGroupedDataset.toDF should not add group by xpressions that are already added in the aggregate expressions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -48,6 +48,8 @@ class RelationalGroupedDataset protected[sql](
     val aggregates = if (df.sparkSession.sessionState.conf.dataFrameRetainGroupColumns) {
       val agg = Aggregate(groupingExprs, aggExprs.map(alias), df.logicalPlan)
       val plan = df.sparkSession.sessionState.executePlan(agg).analyzed
+      // Find the root aggregate node in the analyzed plan. When aggregate expressions
+      // contain window expressions, the root node of the analyzed plan is not an Aggregate.
       val aggAnalyzed = plan.find(_.isInstanceOf[Aggregate]).getOrElse(agg).asInstanceOf[Aggregate]
       def findDup(e: Expression) = aggAnalyzed.aggregateExpressions.exists {
         case a: Alias => a.child.semanticEquals(e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -46,7 +46,18 @@ class RelationalGroupedDataset protected[sql](
 
   private[this] def toDF(aggExprs: Seq[Expression]): DataFrame = {
     val aggregates = if (df.sparkSession.sessionState.conf.dataFrameRetainGroupColumns) {
-      groupingExprs ++ aggExprs
+      val agg = Aggregate(groupingExprs, aggExprs.map(alias), df.logicalPlan)
+      val plan = df.sparkSession.sessionState.executePlan(agg).analyzed
+      val aggAnalyzed = plan.find(_.isInstanceOf[Aggregate]).getOrElse(agg).asInstanceOf[Aggregate]
+      def findDup(e: Expression) = aggAnalyzed.aggregateExpressions.exists {
+        case a: Alias => a.child.semanticEquals(e)
+        case o => o.semanticEquals(e)
+      }
+      // Remove the duplicates that appear in both grouping and aggregate expressions.
+      val newGroupingExprs = groupingExprs.zip(aggAnalyzed.groupingExpressions).filterNot {
+        case (_, e) => findDup(e)
+      }.map(_._1)
+      newGroupingExprs ++ aggExprs
     } else {
       aggExprs
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -207,12 +207,12 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
       Seq(Row(1, 3), Row(2, 3), Row(3, 3))
     )
 
-    spark.conf.set(SQLConf.DATAFRAME_RETAIN_GROUP_COLUMNS.key, false)
-    checkAnswer(
-      testData2.groupBy("a").agg(sum($"b")),
-      Seq(Row(3), Row(3), Row(3))
-    )
-    spark.conf.set(SQLConf.DATAFRAME_RETAIN_GROUP_COLUMNS.key, true)
+    withSQLConf(SQLConf.DATAFRAME_RETAIN_GROUP_COLUMNS.key -> "false") {
+      checkAnswer(
+        testData2.groupBy("a").agg(sum($"b")),
+        Seq(Row(3), Row(3), Row(3))
+      )
+    }
   }
 
   test("agg without groups") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.expressions.Aggregator
 import org.apache.spark.sql.expressions.scalalang.typed
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
-
 
 object ComplexResultAgg extends Aggregator[(String, Int), (Long, Long), (Long, Long)] {
   override def zero: (Long, Long) = (0, 0)
@@ -226,22 +226,24 @@ class DatasetAggregatorSuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-15688: Remove redundant expressions from aggregate") {
     val df = Seq(1 -> "a", 2 -> "b", 3 -> "b").toDF("col1", "col2")
-    // Aggregate expression contains the group by column and should appear once in the output.
-    val df1 = df.groupBy("col1").agg($"col1", count("*"))
-    assert(df1.schema.map(_.name) === Seq("col1", "count(1)"))
-    // Only the column that is missing in aggregate expression should be added to aggregate expr.
-    val df2 = df.groupBy("col1", "col2").agg($"col1", count("*"))
-    assert(df2.schema.map(_.name) === Seq("col2", "col1", "count(1)"))
-    // Complex expression in group by and aggregate clause.
-    val df3 = df.groupBy(expr("col1 + 2")).agg(expr("col1 + 2"), count("*"))
-    assert(df3.schema.map(_.name) === Seq("(col1 + 2)", "count(1)"))
-    // Group by column should be added as its not part of aggregate expression.
-    val df4 = df.groupBy("col1").agg(min("col1"), max("col1"))
-    assert(df4.schema.map(_.name) === Seq("col1", "min(col1)", "max(col1)"))
-    // Multiple aggregates in the plan.
-    val df5 = df.groupBy("col1", "col2").agg($"col1", $"col2")
-      .groupBy("col1").agg($"col1", count("*"))
-    assert(df5.schema.map(_.name) === Seq("col1", "count(1)"))
+    withSQLConf(SQLConf.DATAFRAME_RETAIN_GROUP_COLUMNS.key -> "true") {
+      // Aggregate expression contains the group by column and should appear once in the output.
+      val df1 = df.groupBy("col1").agg($"col1", count("*"))
+      assert(df1.schema.map(_.name) === Seq("col1", "count(1)"))
+      // Only the column that is missing in aggregate expression should be added to aggregate expr.
+      val df2 = df.groupBy("col1", "col2").agg($"col1", count("*"))
+      assert(df2.schema.map(_.name) === Seq("col2", "col1", "count(1)"))
+      // Complex expression in group by and aggregate clause.
+      val df3 = df.groupBy(expr("col1 + 2")).agg(expr("col1 + 2"), count("*"))
+      assert(df3.schema.map(_.name) === Seq("(col1 + 2)", "count(1)"))
+      // Group by expressions should be added as they are not part of aggregate expression.
+      val df4 = df.groupBy("col1").agg(min("col1"), max("col1"))
+      assert(df4.schema.map(_.name) === Seq("col1", "min(col1)", "max(col1)"))
+      // Multiple aggregates in the plan.
+      val df5 = df.groupBy("col1", "col2").agg($"col1", $"col2")
+        .groupBy("col1").agg($"col1", count("*"))
+      assert(df5.schema.map(_.name) === Seq("col1", "count(1)"))
+    }
   }
 
   test("SPARK-14675: ClassFormatError when use Seq as Aggregator buffer type") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The dataset aggregate methods (agg) computes aggregates and produces
the resulting dataset. Currently the resulting data set includes the 
grouping columns even though the aggregation expression already
contains the columns resulting in duplicate columns.

``` SQL
val df = Seq(1 -> "a", 2 -> "b", 3 -> "b").toDF("col1", "col2")
val df1 = df.groupBy("col1").agg($"col1", count("*")).show()
+----+----+--------+
|col1|col1|count(1)|
+----+----+--------+
|   3|   3|       1|
|   1|   1|       1|
|   2|   2|       1|
+----+----+--------+
```

This PR addresses the problem by only including grouping columns
in the dataset if they were not already contained by the aggregate
expressions.

``` SQL
val df1 = df.groupBy("col1").agg($"col1", count("*")).show()
+----+--------+
|col1|count(1)|
+----+--------+
|   3|       1|
|   1|       1|
|   2|       1|
+----+--------+
```

**Normal Aggregate plan.**

``` SQL
Aggregate [col1#5], [col1#5,count(1) AS count(1)#15L]
+- Project [_1#2 AS col1#5,_2#3 AS col2#6]
   +- LocalRelation [_1#2,_2#3], [[0,1,1800000001,61],[0,2,1800000001,62],[0,3,1800000001,62]]
```

**Plan with window expressions in aggregate.**

``` SQL
Project [sum(earnings)#21,grouping_id(course, year)#22,RANK() OVER (PARTITION BY grouping_id(course, year) ORDER BY sum(earnings) ASC UnspecifiedFrame)#23]
+- Project [sum(earnings)#21,grouping_id(course, year)#22,_w0#24,_w1#25,RANK() OVER (PARTITION BY grouping_id(course, year) ORDER BY sum(earnings) ASC UnspecifiedFrame)#23,RANK() OVER (PARTITION BY grouping_id(course, year) ORDER BY sum(earnings) ASC UnspecifiedFrame)#23]
   +- Window [rank(_w1#25) windowspecdefinition(_w0#24, _w1#25 ASC, ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS RANK() OVER (PARTITION BY grouping_id(course, year) ORDER BY sum(earnings) ASC UnspecifiedFrame)#23], [_w0#24], [_w1#25 ASC]
      +- !Aggregate [course#4,year#5], [sum(earnings#6) AS sum(earnings)#21,grouping_id(course#4, year#5) AS grouping_id(course, year)#22,grouping_id(course#4, year#5) AS _w0#24,sum(earnings#6) AS _w1#25]
         +- LogicalRDD [course#4,year#5,earnings#6], MapPartitionsRDD[1] at apply at Transformer.scala:22

```
## How was this patch tested?

Added tests in DatasetAggregatorSuite
