### PR TITLE
[SPARK-15722][SQL] Disallow specifying schema in CTAS statement

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -940,9 +940,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
     selectQuery match {
       case Some(q) =>
-        // If there exists an unresolved relation in the children, then it means we're
-        // selecting from a table. In that case we shouldn't provide our own schema.
-        if (q.children.exists(_.isInstanceOf[UnresolvedRelation]) && schema.nonEmpty) {
+        // Just use whatever is projected in the select statement as our schema
+        if (schema.nonEmpty) {
           throw operationNotAllowed(
             "Schema may not be specified in a Create Table As Select (CTAS) statement",
             ctx)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -939,6 +939,12 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
     selectQuery match {
       case Some(q) =>
+        // Just use whatever is projected in the select statement as our schema
+        if (schema.nonEmpty) {
+          throw operationNotAllowed(
+            "Schema may not be specified in a Create Table As Select (CTAS) statement",
+            ctx)
+        }
         // Hive does not allow to use a CTAS statement to create a partitioned table.
         if (tableDesc.partitionColumnNames.nonEmpty) {
           val errorMessage = "A Create Table As Select (CTAS) statement is not allowed to " +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/LogicalPlanToSQLSuite.scala
@@ -744,24 +744,14 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
 
   test("SPARK-14933 - select parquet table") {
     withTable("parquet_t") {
-      sql(
-        """
-          |create table parquet_t (c1 int, c2 string)
-          |stored as parquet select 1, 'abc'
-        """.stripMargin)
-
+      sql("create table parquet_t stored as parquet as select 1 as c1, 'abc' as c2")
       checkHiveQl("select * from parquet_t")
     }
   }
 
   test("SPARK-14933 - select orc table") {
     withTable("orc_t") {
-      sql(
-        """
-          |create table orc_t (c1 int, c2 string)
-          |stored as orc select 1, 'abc'
-        """.stripMargin)
-
+      sql("create table orc_t stored as orc as select 1 as c1, 'abc' as c2")
       checkHiveQl("select * from orc_t")
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -51,12 +51,6 @@ class HiveDDLCommandSuite extends PlanTest {
   test("Test CTAS #1") {
     val s1 =
       """CREATE EXTERNAL TABLE IF NOT EXISTS mydb.page_view
-        |(viewTime INT,
-        |userid BIGINT,
-        |page_url STRING,
-        |referrer_url STRING,
-        |ip STRING COMMENT 'IP Address of the User',
-        |country STRING COMMENT 'country of origination')
         |COMMENT 'This is the staging page view table'
         |STORED AS RCFILE
         |LOCATION '/user/external/page_view'
@@ -91,12 +85,6 @@ class HiveDDLCommandSuite extends PlanTest {
   test("Test CTAS #2") {
     val s2 =
       """CREATE EXTERNAL TABLE IF NOT EXISTS mydb.page_view
-        |(viewTime INT,
-        |userid BIGINT,
-        |page_url STRING,
-        |referrer_url STRING,
-        |ip STRING COMMENT 'IP Address of the User',
-        |country STRING COMMENT 'country of origination')
         |COMMENT 'This is the staging page view table'
         |ROW FORMAT SERDE 'parquet.hive.serde.ParquetHiveSerDe'
         | STORED AS

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -190,6 +190,11 @@ class HiveDDLCommandSuite extends PlanTest {
       " AS SELECT key, value FROM (SELECT 1 as key, 2 as value) tmp")
   }
 
+  test("CTAS statement with schema is not allowed") {
+    assertUnsupported(s"CREATE TABLE ctas1 (age INT, name STRING) " +
+      "AS SELECT key, value FROM (SELECT 1 as key, 2 as value) tmp")
+  }
+
   test("unsupported operations") {
     intercept[ParseException] {
       parser.parsePlan(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -168,14 +168,7 @@ class HiveDDLCommandSuite extends PlanTest {
 
   test("CTAS statement with schema") {
     assertUnsupported(s"CREATE TABLE ctas1 (age INT, name STRING) AS SELECT * FROM src")
-    parser.parsePlan(s"CREATE TABLE ctas1 (age INT, name STRING) AS SELECT 1, 'hello'") match {
-      case cmd: CreateHiveTableAsSelectLogicalPlan =>
-        assert(cmd.tableDesc.schema.toSet ==
-          Set(CatalogColumn("age", "int"), CatalogColumn("name", "string")))
-      case other =>
-        fail(s"Expected ${CreateHiveTableAsSelectLogicalPlan.getClass.getSimpleName}, " +
-          s"but parsed ${other.getClass.getSimpleName}")
-    }
+    assertUnsupported(s"CREATE TABLE ctas1 (age INT, name STRING) AS SELECT 1, 'hello'")
   }
 
   test("unsupported operations") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -435,10 +435,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
     }
 
     // Non-External parquet pointing to /tmp/...
-
-    sql("CREATE TABLE parquet_tmp(c1 int, c2 int) " +
-      " STORED AS parquet " +
-      " AS SELECT 1, 2")
+    sql("CREATE TABLE parquet_tmp STORED AS parquet AS SELECT 1, 2")
 
     val answer4 =
       sql("SELECT input_file_name() as file FROM parquet_tmp").head().getString(0)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
@@ -308,10 +308,7 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("SPARK-14933 - create view from hive parquet tabale") {
     withTable("t_part") {
       withView("v_part") {
-        spark.sql(
-          """create table t_part (c1 int, c2 int)
-            |stored as parquet as select 1 as a, 2 as b
-          """.stripMargin)
+        spark.sql("create table t_part stored as parquet as select 1 as a, 2 as b")
         spark.sql("create view v_part as select * from t_part")
         checkAnswer(
           sql("select * from t_part"),
@@ -323,10 +320,7 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("SPARK-14933 - create view from hive orc tabale") {
     withTable("t_orc") {
       withView("v_orc") {
-        spark.sql(
-          """create table t_orc (c1 int, c2 int)
-            |stored as orc as select 1 as a, 2 as b
-          """.stripMargin)
+        spark.sql("create table t_orc stored as orc as select 1 as a, 2 as b")
         spark.sql("create view v_orc as select * from t_orc")
         checkAnswer(
           sql("select * from t_orc"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of this patch, the following throws an exception because the schemas may not match:

```
CREATE TABLE students (age INT, name STRING) AS SELECT * FROM boxes
```

but this is OK:

```
CREATE TABLE students AS SELECT * FROM boxes
```
## How was this patch tested?

SQLQuerySuite, HiveDDLCommandSuite
