### PR TITLE
[SPARK-15749][SQL]make the error message more meaningful

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -78,8 +78,8 @@ private[sql] object PreInsertCastAndRename extends Rule[LogicalPlan] {
         // schema of the relation.
         if (l.output.size != child.output.size) {
           sys.error(
-            s"$l requires that the query in the SELECT clause of the INSERT INTO/OVERWRITE " +
-              s"statement generates the same number of columns as its schema.")
+            s"$l requires that the data to be inserted have " +
+              s"the same number of columns as the target table.")
         }
         castAndRenameChildOutput(i, l.output, child)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -78,8 +78,9 @@ private[sql] object PreInsertCastAndRename extends Rule[LogicalPlan] {
         // schema of the relation.
         if (l.output.size != child.output.size) {
           sys.error(
-            s"$l requires that the data to be inserted have " +
-              s"the same number of columns as the target table.")
+            s"$l requires that the data to be inserted have the same number of columns as the " +
+              s"target table: target table has ${l.output.size} column(s) but " +
+              s"the inserted data has ${child.output.size} column(s).")
         }
         castAndRenameChildOutput(i, l.output, child)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -94,7 +94,7 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
       """.stripMargin)
     }.getMessage
     assert(
-      message.contains("generates the same number of columns as its schema"),
+      message.contains("requires that the data to be inserted have the same number of columns"),
       "SELECT clause generating a different number of columns should not be not allowed."
     )
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

For table test1 (C1 varchar (10), C2 varchar (10)), when I insert a row using

```
sqlContext.sql("insert into test1 values ('abc', 'def', 1)")
```

I got error message

```
Exception in thread "main" java.lang.RuntimeException: RelationC1#0,C2#1 JDBCRelation(test1)
requires that the query in the SELECT clause of the INSERT INTO/OVERWRITE statement 
generates the same number of columns as its schema.
```

The error message is a little confusing. In my simple insert statement, it doesn't have a SELECT clause.

I will change the error message to a more general one

```
Exception in thread "main" java.lang.RuntimeException: RelationC1#0,C2#1 JDBCRelation(test1)
requires that the data to be inserted have the same number of columns as the target table.
```
## How was this patch tested?

I tested the patch using my simple unit test, but it's a very trivial change and I don't think I need to check in any test. 
