### PR TITLE
[SPARK-15750][MLLib][PYSPARK] Constructing FPGrowth fails when no numPartitions specified in pyspark

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -572,10 +572,7 @@ private[python] class PythonMLLibAPI extends Serializable {
       data: JavaRDD[java.lang.Iterable[Any]],
       minSupport: Double,
       numPartitions: Int): FPGrowthModel[Any] = {
-    val fpg = new FPGrowth()
-      .setMinSupport(minSupport)
-      .setNumPartitions(numPartitions)
-
+    val fpg = new FPGrowth(minSupport, numPartitions)
     val model = fpg.run(data.rdd.map(_.asScala.toArray))
     new FPGrowthModelWrapper(model)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/FPGrowth.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/FPGrowth.scala
@@ -162,7 +162,7 @@ object FPGrowthModel extends Loader[FPGrowthModel[_]] {
  *
  */
 @Since("1.3.0")
-class FPGrowth private (
+class FPGrowth private[spark] (
     private var minSupport: Double,
     private var numPartitions: Int) extends Logging with Serializable {
 

--- a/python/pyspark/mllib/fpm.py
+++ b/python/pyspark/mllib/fpm.py
@@ -36,16 +36,13 @@ class FPGrowthModel(JavaModelWrapper, JavaSaveable, JavaLoader):
 
     >>> data = [["a", "b", "c"], ["a", "b", "d", "e"], ["a", "c", "e"], ["a", "c", "f"]]
     >>> rdd = sc.parallelize(data, 2)
-    >>> model1 = FPGrowth.train(rdd, 0.6, 2)
-    >>> model2 = FPGrowth.train(rdd, 0.6)
-    >>> sorted(model1.freqItemsets().collect())
-    [FreqItemset(items=[u'a'], freq=4), FreqItemset(items=[u'c'], freq=3), ...
-    >>> sorted(model2.freqItemsets().collect())
+    >>> model = FPGrowth.train(rdd, 0.6, 2)
+    >>> sorted(model.freqItemsets().collect())
     [FreqItemset(items=[u'a'], freq=4), FreqItemset(items=[u'c'], freq=3), ...
     >>> model_path = temp_path + "/fpm"
-    >>> model1.save(sc, model_path)
+    >>> model.save(sc, model_path)
     >>> sameModel = FPGrowthModel.load(sc, model_path)
-    >>> sorted(model1.freqItemsets().collect()) == sorted(sameModel.freqItemsets().collect())
+    >>> sorted(model.freqItemsets().collect()) == sorted(sameModel.freqItemsets().collect())
     True
 
     .. versionadded:: 1.4.0

--- a/python/pyspark/mllib/fpm.py
+++ b/python/pyspark/mllib/fpm.py
@@ -36,13 +36,16 @@ class FPGrowthModel(JavaModelWrapper, JavaSaveable, JavaLoader):
 
     >>> data = [["a", "b", "c"], ["a", "b", "d", "e"], ["a", "c", "e"], ["a", "c", "f"]]
     >>> rdd = sc.parallelize(data, 2)
-    >>> model = FPGrowth.train(rdd, 0.6, 2)
-    >>> sorted(model.freqItemsets().collect())
+    >>> model1 = FPGrowth.train(rdd, 0.6, 2)
+    >>> model2 = FPGrowth.train(rdd, 0.6)
+    >>> sorted(model1.freqItemsets().collect())
+    [FreqItemset(items=[u'a'], freq=4), FreqItemset(items=[u'c'], freq=3), ...
+    >>> sorted(model2.freqItemsets().collect())
     [FreqItemset(items=[u'a'], freq=4), FreqItemset(items=[u'c'], freq=3), ...
     >>> model_path = temp_path + "/fpm"
-    >>> model.save(sc, model_path)
+    >>> model1.save(sc, model_path)
     >>> sameModel = FPGrowthModel.load(sc, model_path)
-    >>> sorted(model.freqItemsets().collect()) == sorted(sameModel.freqItemsets().collect())
+    >>> sorted(model1.freqItemsets().collect()) == sorted(sameModel.freqItemsets().collect())
     True
 
     .. versionadded:: 1.4.0

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -57,6 +57,7 @@ from pyspark.mllib.linalg import Vector, SparseVector, DenseVector, VectorUDT, _
     DenseMatrix, SparseMatrix, Vectors, Matrices, MatrixUDT
 from pyspark.mllib.linalg.distributed import RowMatrix
 from pyspark.mllib.classification import StreamingLogisticRegressionWithSGD
+from pyspark.mllib.fpm import FPGrowth
 from pyspark.mllib.recommendation import Rating
 from pyspark.mllib.regression import LabeledPoint, StreamingLinearRegressionWithSGD
 from pyspark.mllib.random import RandomRDDs
@@ -1761,6 +1762,17 @@ class DimensionalityReductionTests(MLlibTestCase):
                 # We can just test the updated principal component for equality.
                 self.assertEqualUpToSign(pcs.toArray()[:, k - 1], expected_pcs[:, k - 1])
 
+
+class FPGrowthTest(MLlibTestCase):
+
+    def test_fpgrowth(self):
+        data = [["a", "b", "c"], ["a", "b", "d", "e"], ["a", "c", "e"], ["a", "c", "f"]]
+        rdd = self.sc.parallelize(data, 2)
+        model1 = FPGrowth.train(rdd, 0.6, 2)
+        # use default data partition number when numPartitions is not specified
+        model2 = FPGrowth.train(rdd, 0.6)
+        self.assertEqual(sorted(model1.freqItemsets().collect()),
+                         sorted(model2.freqItemsets().collect()))
 
 if __name__ == "__main__":
     from pyspark.mllib.tests import *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change FPGrowth from private to private[spark]. If no numPartitions is specified, then default value -1 is used. But -1 is only valid in the construction function of FPGrowth, but not in setNumPartitions. So I make this change and use the constructor directly rather than using set method.  
## How was this patch tested?

Unit test is added
