### PR TITLE
[SPARK-15652] [launcher] Added a new State (LOST) for the listeners of SparkLauncher

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/LauncherConnection.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/LauncherConnection.java
@@ -25,7 +25,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import org.apache.spark.launcher.SparkAppHandle.State;
 import static org.apache.spark.launcher.LauncherProtocol.*;
 
 /**
@@ -61,15 +61,14 @@ abstract class LauncherConnection implements Closeable, Runnable {
     } catch (EOFException eof) {
       // Remote side has closed the connection, just cleanup.
       try {
-        close();
+        close(eof);
       } catch (Exception unused) {
         // no-op.
       }
     } catch (Exception e) {
       if (!closed) {
-        LOG.log(Level.WARNING, "Error in inbound message handling.", e);
         try {
-          close();
+          close(e);
         } catch (Exception unused) {
           // no-op.
         }
@@ -105,6 +104,19 @@ abstract class LauncherConnection implements Closeable, Runnable {
         }
       }
     }
+  }
+
+  private void close(Exception exp) throws IOException {
+	if (!closed) {
+	  synchronized (this) {
+	    if (!closed) {
+	      handle(new SetState(State.FINISHED_UNKNOWN));
+	      LOG.log(Level.WARNING, "The communication to launch server got disconnected.", exp);
+	      closed = true;
+	      socket.close();
+	    }
+	  }
+	}
   }
 
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/LauncherConnection.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/LauncherConnection.java
@@ -25,7 +25,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.spark.launcher.SparkAppHandle.State;
+
 import static org.apache.spark.launcher.LauncherProtocol.*;
 
 /**
@@ -61,14 +61,15 @@ abstract class LauncherConnection implements Closeable, Runnable {
     } catch (EOFException eof) {
       // Remote side has closed the connection, just cleanup.
       try {
-        close(eof);
+        close();
       } catch (Exception unused) {
         // no-op.
       }
     } catch (Exception e) {
       if (!closed) {
+        LOG.log(Level.WARNING, "Error in inbound message handling.", e);
         try {
-          close(e);
+          close();
         } catch (Exception unused) {
           // no-op.
         }
@@ -104,19 +105,6 @@ abstract class LauncherConnection implements Closeable, Runnable {
         }
       }
     }
-  }
-
-  private void close(Exception exp) throws IOException {
-	if (!closed) {
-	  synchronized (this) {
-	    if (!closed) {
-	      handle(new SetState(State.FINISHED_UNKNOWN));
-	      LOG.log(Level.WARNING, "The communication to launch server got disconnected.", exp);
-	      closed = true;
-	      socket.close();
-	    }
-	  }
-	}
   }
 
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/LauncherServer.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/LauncherServer.java
@@ -338,7 +338,7 @@ class LauncherServer implements Closeable {
       super.close();
       if (handle != null) {
     	if (!handle.getState().isFinal()) {
-    	  LOG.log(Level.WARNING, "Lost connection to launch server.");
+    	  LOG.log(Level.WARNING, "Lost connection to spark application.");
     	  handle.setState(SparkAppHandle.State.LOST);
     	}
         handle.disconnect();

--- a/launcher/src/main/java/org/apache/spark/launcher/LauncherServer.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/LauncherServer.java
@@ -337,6 +337,10 @@ class LauncherServer implements Closeable {
       }
       super.close();
       if (handle != null) {
+    	if (!handle.getState().isFinal()) {
+    	  LOG.log(Level.WARNING, "Lost connection to launch server.");
+    	  handle.setState(SparkAppHandle.State.LOST);
+    	}
         handle.disconnect();
       }
     }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
@@ -47,7 +47,7 @@ public interface SparkAppHandle {
     FAILED(true),
     /** The application was killed. */
     KILLED(true),
-    /** The Spark Submit JVM got killed with a unknown status. */
+    /** The Spark Submit JVM exited with a unknown status. */
     LOST(true);
 
     private final boolean isFinal;

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
@@ -43,12 +43,12 @@ public interface SparkAppHandle {
     RUNNING(false),
     /** The application finished with a successful status. */
     FINISHED(true),
-    /** The Spark Submit JVM got killed with a unknown status. */
-    FINISHED_UNKNOWN(true),
     /** The application finished with a failed status. */
     FAILED(true),
     /** The application was killed. */
-    KILLED(true);
+    KILLED(true),
+    /** The Spark Submit JVM got killed with a unknown status. */
+    LOST(true);
 
     private final boolean isFinal;
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
@@ -43,6 +43,8 @@ public interface SparkAppHandle {
     RUNNING(false),
     /** The application finished with a successful status. */
     FINISHED(true),
+    /** The Spark Submit JVM got killed with a unknown status. */
+    FINISHED_UNKNOWN(true),
     /** The application finished with a failed status. */
     FAILED(true),
     /** The application was killed. */

--- a/launcher/src/test/java/org/apache/spark/launcher/LauncherServerSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/LauncherServerSuite.java
@@ -17,19 +17,42 @@
 
 package org.apache.spark.launcher;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.spark.launcher.LauncherProtocol.Hello;
+import org.apache.spark.launcher.LauncherProtocol.Message;
+import org.apache.spark.launcher.LauncherProtocol.SetAppId;
+import org.apache.spark.launcher.LauncherProtocol.SetState;
+import org.apache.spark.launcher.LauncherProtocol.Stop;
+import org.apache.spark.launcher.SparkAppHandle.State;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.mockito.Mockito;
 
-import static org.apache.spark.launcher.LauncherProtocol.*;
+import com.google.common.collect.Lists;
+
 
 public class LauncherServerSuite extends BaseSuite {
 
@@ -152,6 +175,102 @@ public class LauncherServerSuite extends BaseSuite {
     }
   }
 
+  @Test
+  public void testSparkSubmitVmShutsDown() throws Exception {
+	LauncherServer launchServer = (LauncherServer)Mockito.mock(LauncherServer.class);
+	Socket socket = (Socket)Mockito.mock(Socket.class);
+	Mockito.when(socket.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+	Mockito.when(socket.getInputStream()).thenReturn(getMessageInputStream(new LauncherProtocol.Message[] {
+	  new LauncherProtocol.Hello("someSecret", "someVersion"),
+	  new LauncherProtocol.SetState(SparkAppHandle.State.SUBMITTED), new LauncherProtocol.SetState(
+	    SparkAppHandle.State.RUNNING) })).thenThrow(new Throwable[] {
+	      new EOFException("Probably Remote JVM Shutdown") });
+
+	ChildProcAppHandle appHandle = new ChildProcAppHandle("someSecret", launchServer);
+	final BlockingQueue stateQueue = new ArrayBlockingQueue(10);
+	List<State> expectedStateList = Lists.newArrayList(State.CONNECTED,State.SUBMITTED,State.RUNNING, State.FINISHED_UNKNOWN);
+	final List<State> realStateList = Lists.newArrayList();
+	appHandle.addListener(new SparkAppHandle.Listener() {
+	  public void stateChanged(SparkAppHandle handle) {
+	    stateQueue.offer(handle.getState());
+	  }
+
+	  public void infoChanged(SparkAppHandle handle) {
+	  }
+	});
+	DummyLauncherConnection launcherConnection = new DummyLauncherConnection(
+	  socket, appHandle);
+	final AtomicBoolean jobFinished = new AtomicBoolean(false);
+	Thread clientPollerThread = new Thread() {
+	  public void run() {
+	    while (!jobFinished.get()) {
+	      SparkAppHandle.State state = SparkAppHandle.State.UNKNOWN;
+	      try {
+	        state = (SparkAppHandle.State)stateQueue.take();
+	      } catch (InterruptedException e) {
+	        Thread.currentThread().interrupt();
+	        throw new RuntimeException(e);
+	      }
+
+	      switch (state) {
+	        case CONNECTED:
+	          realStateList.add(state);
+	          break;
+	        case FAILED:
+              realStateList.add(state);
+	          jobFinished.set(true);
+	          break;
+	        case FINISHED:
+	          jobFinished.set(true);
+	          realStateList.add(state);
+	          break;
+	        case KILLED:
+	          jobFinished.set(true);
+	          realStateList.add(state);
+	          break;
+	        case RUNNING:
+	          realStateList.add(state);
+	          break;
+	        case SUBMITTED:
+	          realStateList.add(state);
+	          break;
+	        case UNKNOWN:
+	          realStateList.add(state);
+	          break;
+	        case FINISHED_UNKNOWN:
+	          jobFinished.set(true);
+	          realStateList.add(state);
+	          break;
+	        default:
+	          throw new RuntimeException("some exception");
+	      }
+	    }
+	  }
+	};
+	clientPollerThread.start();
+	Thread launcherThread = new Thread(launcherConnection);
+	launcherThread.start();
+	launcherThread.join();
+
+	clientPollerThread.join(10000L);
+	assertEquals(expectedStateList, realStateList);
+	assertTrue(jobFinished.get());
+  }
+
+  private static InputStream getMessageInputStream(Message ... messages) {
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	try {
+	  ObjectOutputStream os = new ObjectOutputStream(out);
+	  for (Message message : messages) {
+		os.writeObject(message);
+	  }
+	} catch (IOException e) {
+	  throw new RuntimeException(e);
+	}
+	return new ByteArrayInputStream(out.toByteArray());
+  }
+
+
   private void kill(SparkAppHandle handle) {
     if (handle != null) {
       handle.kill();
@@ -187,6 +306,43 @@ public class LauncherServerSuite extends BaseSuite {
       inbound.offer(msg);
     }
 
+  }
+
+  public class DummyLauncherConnection extends LauncherConnection {
+ 	private ChildProcAppHandle _appAppHandle;
+ 	DummyLauncherConnection(Socket socket, ChildProcAppHandle appHandle)
+ 		throws IOException {
+ 		super(socket);
+ 		_appAppHandle = appHandle;
+ 	}
+
+ 	@Override
+ 	protected void handle(Message msg) throws IOException {
+ 	  try {
+ 		if (msg instanceof Hello) {
+ 		  if (_appAppHandle != null) {
+ 		    _appAppHandle.setState(SparkAppHandle.State.CONNECTED);
+ 			_appAppHandle.setConnection(this);
+ 		  } else {
+ 			throw new IllegalArgumentException("Received Hello for unknown client.");
+ 		  }
+ 		} else {
+ 		  if (_appAppHandle == null) {
+ 			throw new IllegalArgumentException("Expected hello, got: " + msg != null ? msg.getClass().getName() : null);
+ 	      }
+ 		  if (msg instanceof SetAppId) {
+ 		    SetAppId set = (SetAppId) msg;
+ 		    _appAppHandle.setAppId(set.appId);
+ 		  } else if (msg instanceof SetState) {
+ 		    _appAppHandle.setState(((SetState) msg).state);
+ 		  } else {
+ 			throw new IllegalArgumentException("Invalid message: " + msg != null ? msg.getClass().getName() : null);
+ 		  }
+ 	    }
+ 	  } catch (Exception e) {
+ 	  close();
+ 	  }
+    }
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This situation can happen when the LauncherConnection gets an exception while reading through the socket and terminating silently without notifying making the client/listener think that the job is still in previous state.
The fix force sends a notification to client that the job finished with unknown status and let client handle it accordingly.
## How was this patch tested?

Added a unit test.
