### PR TITLE
[SPARK-15769][SQL] Add Encoder for input type to Aggregator

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/expressions/javalang/typed.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/expressions/javalang/typed.java
@@ -19,6 +19,7 @@ package org.apache.spark.sql.expressions.javalang;
 
 import org.apache.spark.annotation.Experimental;
 import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.TypedColumn;
 import org.apache.spark.sql.execution.aggregate.TypedAverage;
 import org.apache.spark.sql.execution.aggregate.TypedCount;
@@ -42,8 +43,8 @@ public class typed {
    *
    * @since 2.0.0
    */
-  public static <T> TypedColumn<T, Double> avg(MapFunction<T, Double> f) {
-    return new TypedAverage<T>(f).toColumnJava();
+  public static <T> TypedColumn<T, Double> avg(MapFunction<T, Double> f, Encoder<T> encoder) {
+    return new TypedAverage<T>(f, encoder).toColumnJava();
   }
 
   /**
@@ -51,8 +52,8 @@ public class typed {
    *
    * @since 2.0.0
    */
-  public static <T> TypedColumn<T, Long> count(MapFunction<T, Object> f) {
-    return new TypedCount<T>(f).toColumnJava();
+  public static <T> TypedColumn<T, Long> count(MapFunction<T, Object> f, Encoder<T> encoder) {
+    return new TypedCount<T>(f, encoder).toColumnJava();
   }
 
   /**
@@ -60,8 +61,8 @@ public class typed {
    *
    * @since 2.0.0
    */
-  public static <T> TypedColumn<T, Double> sum(MapFunction<T, Double> f) {
-    return new TypedSumDouble<T>(f).toColumnJava();
+  public static <T> TypedColumn<T, Double> sum(MapFunction<T, Double> f, Encoder<T> encoder) {
+    return new TypedSumDouble<T>(f, encoder).toColumnJava();
   }
 
   /**
@@ -69,7 +70,7 @@ public class typed {
    *
    * @since 2.0.0
    */
-  public static <T> TypedColumn<T, Long> sumLong(MapFunction<T, Long> f) {
-    return new TypedSumLong<T>(f).toColumnJava();
+  public static <T> TypedColumn<T, Long> sumLong(MapFunction<T, Long> f, Encoder<T> encoder) {
+    return new TypedSumLong<T>(f, encoder).toColumnJava();
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -64,21 +64,6 @@ class TypedColumn[-T, U](
   extends Column(expr) {
 
   /**
-   * Inserts the specific input type and schema into any expressions that are expected to operate
-   * on a decoded object.
-   */
-  private[sql] def withInputType(
-      inputDeserializer: Expression,
-      inputAttributes: Seq[Attribute]): TypedColumn[T, U] = {
-    val unresolvedDeserializer = UnresolvedDeserializer(inputDeserializer, inputAttributes)
-    val newExpr = expr transform {
-      case ta: TypedAggregateExpression if ta.inputDeserializer.isEmpty =>
-        ta.copy(inputDeserializer = Some(unresolvedDeserializer))
-    }
-    new TypedColumn[T, U](newExpr, encoder)
-  }
-
-  /**
    * Gives the TypedColumn a name (alias).
    * If the current TypedColumn has metadata associated with it, this metadata will be propagated
    * to the new column.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -991,9 +991,7 @@ class Dataset[T] private[sql](
     new Dataset[U1](
       sparkSession,
       Project(
-        c1.withInputType(
-          unresolvedTEncoder.deserializer,
-          logicalPlan.output).named :: Nil,
+        c1.named :: Nil,
         logicalPlan),
       implicitly[Encoder[U1]])
   }
@@ -1006,7 +1004,7 @@ class Dataset[T] private[sql](
   protected def selectUntyped(columns: TypedColumn[_, _]*): Dataset[_] = {
     val encoders = columns.map(_.encoder)
     val namedColumns =
-      columns.map(_.withInputType(unresolvedTEncoder.deserializer, logicalPlan.output).named)
+      columns.map(_.named)
     val execution = new QueryExecution(sparkSession, Project(namedColumns, logicalPlan))
     new Dataset(sparkSession, execution, ExpressionEncoder.tuple(encoders))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -208,8 +208,7 @@ class KeyValueGroupedDataset[K, V] private[sql](
    */
   protected def aggUntyped(columns: TypedColumn[_, _]*): Dataset[_] = {
     val encoders = columns.map(_.encoder)
-    val namedColumns =
-      columns.map(_.withInputType(unresolvedVEncoder.deserializer, dataAttributes).named)
+    val namedColumns = columns.map(_.named)
     val keyColumn = if (resolvedKEncoder.flat) {
       assert(groupingAttributes.length == 1)
       groupingAttributes.head

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -213,11 +213,7 @@ class RelationalGroupedDataset protected[sql](
    */
   @scala.annotation.varargs
   def agg(expr: Column, exprs: Column*): DataFrame = {
-    toDF((expr +: exprs).map {
-      case typed: TypedColumn[_, _] =>
-        typed.withInputType(df.unresolvedTEncoder.deserializer, df.logicalPlan.output).expr
-      case c => c.expr
-    })
+    toDF((expr +: exprs).map(_.expr))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/typedaggregators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/typedaggregators.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.expressions.Aggregator
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-class TypedSumDouble[IN](f: IN => Double) extends Aggregator[IN, Double, Double] {
+class TypedSumDouble[IN](f: IN => Double)(implicit val inputEncoder: Encoder[IN])
+    extends Aggregator[IN, Double, Double] {
   override def zero: Double = 0.0
   override def reduce(b: Double, a: IN): Double = b + f(a)
   override def merge(b1: Double, b2: Double): Double = b1 + b2
@@ -37,7 +38,8 @@ class TypedSumDouble[IN](f: IN => Double) extends Aggregator[IN, Double, Double]
   override def outputEncoder: Encoder[Double] = ExpressionEncoder[Double]()
 
   // Java api support
-  def this(f: MapFunction[IN, java.lang.Double]) = this(x => f.call(x).asInstanceOf[Double])
+  def this(f: MapFunction[IN, java.lang.Double], encoder: Encoder[IN]) =
+    this(x => f.call(x).asInstanceOf[Double])(encoder)
 
   def toColumnJava: TypedColumn[IN, java.lang.Double] = {
     toColumn.asInstanceOf[TypedColumn[IN, java.lang.Double]]
@@ -45,7 +47,8 @@ class TypedSumDouble[IN](f: IN => Double) extends Aggregator[IN, Double, Double]
 }
 
 
-class TypedSumLong[IN](f: IN => Long) extends Aggregator[IN, Long, Long] {
+class TypedSumLong[IN](f: IN => Long)(implicit val inputEncoder: Encoder[IN])
+    extends Aggregator[IN, Long, Long] {
   override def zero: Long = 0L
   override def reduce(b: Long, a: IN): Long = b + f(a)
   override def merge(b1: Long, b2: Long): Long = b1 + b2
@@ -55,7 +58,8 @@ class TypedSumLong[IN](f: IN => Long) extends Aggregator[IN, Long, Long] {
   override def outputEncoder: Encoder[Long] = ExpressionEncoder[Long]()
 
   // Java api support
-  def this(f: MapFunction[IN, java.lang.Long]) = this(x => f.call(x).asInstanceOf[Long])
+  def this(f: MapFunction[IN, java.lang.Long], encoder: Encoder[IN]) =
+    this(x => f.call(x).asInstanceOf[Long])(encoder)
 
   def toColumnJava: TypedColumn[IN, java.lang.Long] = {
     toColumn.asInstanceOf[TypedColumn[IN, java.lang.Long]]
@@ -63,7 +67,8 @@ class TypedSumLong[IN](f: IN => Long) extends Aggregator[IN, Long, Long] {
 }
 
 
-class TypedCount[IN](f: IN => Any) extends Aggregator[IN, Long, Long] {
+class TypedCount[IN](f: IN => Any)(implicit val inputEncoder: Encoder[IN])
+    extends Aggregator[IN, Long, Long] {
   override def zero: Long = 0
   override def reduce(b: Long, a: IN): Long = {
     if (f(a) == null) b else b + 1
@@ -75,14 +80,16 @@ class TypedCount[IN](f: IN => Any) extends Aggregator[IN, Long, Long] {
   override def outputEncoder: Encoder[Long] = ExpressionEncoder[Long]()
 
   // Java api support
-  def this(f: MapFunction[IN, Object]) = this(x => f.call(x))
+  def this(f: MapFunction[IN, Object], encoder: Encoder[IN]) =
+    this(x => f.call(x))(encoder)
   def toColumnJava: TypedColumn[IN, java.lang.Long] = {
     toColumn.asInstanceOf[TypedColumn[IN, java.lang.Long]]
   }
 }
 
 
-class TypedAverage[IN](f: IN => Double) extends Aggregator[IN, (Double, Long), Double] {
+class TypedAverage[IN](f: IN => Double)(implicit val inputEncoder: Encoder[IN])
+    extends Aggregator[IN, (Double, Long), Double] {
   override def zero: (Double, Long) = (0.0, 0L)
   override def reduce(b: (Double, Long), a: IN): (Double, Long) = (f(a) + b._1, 1 + b._2)
   override def finish(reduction: (Double, Long)): Double = reduction._1 / reduction._2
@@ -94,7 +101,8 @@ class TypedAverage[IN](f: IN => Double) extends Aggregator[IN, (Double, Long), D
   override def outputEncoder: Encoder[Double] = ExpressionEncoder[Double]()
 
   // Java api support
-  def this(f: MapFunction[IN, java.lang.Double]) = this(x => f.call(x).asInstanceOf[Double])
+  def this(f: MapFunction[IN, java.lang.Double], encoder: Encoder[IN]) =
+    this(x => f.call(x).asInstanceOf[Double])(encoder)
   def toColumnJava: TypedColumn[IN, java.lang.Double] = {
     toColumn.asInstanceOf[TypedColumn[IN, java.lang.Double]]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
@@ -114,4 +114,18 @@ abstract class Aggregator[IN, BUF, OUT] extends Serializable {
 
     new TypedColumn[IN, OUT](expr, encoderFor[OUT])
   }
+
+  def apply(columnNames: String*): TypedColumn[IN, OUT] = {
+    implicit val aEncoder = inputEncoder
+    implicit val bEncoder = bufferEncoder
+    implicit val cEncoder = outputEncoder
+
+    val expr =
+      AggregateExpression(
+        TypedAggregateExpression(this, Some(columnNames)),
+        Complete,
+        isDistinct = false)
+
+    new TypedColumn[IN, OUT](expr, encoderFor[OUT])
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
@@ -51,7 +51,7 @@ import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
  * @since 1.6.0
  */
 @Experimental
-abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
+abstract class Aggregator[IN, BUF, OUT] extends Serializable {
 
   /**
    * A zero value for this aggregation. Should satisfy the property that any b + zero = b.
@@ -79,6 +79,12 @@ abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
   def finish(reduction: BUF): OUT
 
   /**
+   * Specifies the [[Encoder]] for the input value type.
+   * @since 2.0.0
+   */
+  def inputEncoder: Encoder[IN]
+
+  /**
    * Specifies the [[Encoder]] for the intermediate value type.
    * @since 2.0.0
    */
@@ -96,6 +102,7 @@ abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
    * @since 1.6.0
    */
   def toColumn: TypedColumn[IN, OUT] = {
+    implicit val aEncoder = inputEncoder
     implicit val bEncoder = bufferEncoder
     implicit val cEncoder = outputEncoder
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/scalalang/typed.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/scalalang/typed.scala
@@ -53,28 +53,29 @@ object typed {
    *
    * @since 2.0.0
    */
-  def avg[IN](f: IN => Double): TypedColumn[IN, Double] = new TypedAverage(f).toColumn
+  def avg[IN: Encoder](f: IN => Double): TypedColumn[IN, Double] = new TypedAverage(f).toColumn
 
   /**
    * Count aggregate function.
    *
    * @since 2.0.0
    */
-  def count[IN](f: IN => Any): TypedColumn[IN, Long] = new TypedCount(f).toColumn
+  def count[IN: Encoder](f: IN => Any): TypedColumn[IN, Long] = new TypedCount(f).toColumn
 
   /**
    * Sum aggregate function for floating point (double) type.
    *
    * @since 2.0.0
    */
-  def sum[IN](f: IN => Double): TypedColumn[IN, Double] = new TypedSumDouble[IN](f).toColumn
+  def sum[IN: Encoder](f: IN => Double): TypedColumn[IN, Double] =
+    new TypedSumDouble[IN](f).toColumn
 
   /**
    * Sum aggregate function for integral (long, i.e. 64 bit integer) type.
    *
    * @since 2.0.0
    */
-  def sumLong[IN](f: IN => Long): TypedColumn[IN, Long] = new TypedSumLong[IN](f).toColumn
+  def sumLong[IN: Encoder](f: IN => Long): TypedColumn[IN, Long] = new TypedSumLong[IN](f).toColumn
 
   // TODO:
   // stddevOf: Double

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetAggregatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetAggregatorSuite.java
@@ -74,6 +74,11 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
     }
 
     @Override
+    public Encoder<Tuple2<String, Integer>> inputEncoder() {
+      return Encoders.tuple(Encoders.STRING(), Encoders.INT());
+    }
+
+      @Override
     public Encoder<Integer> bufferEncoder() {
       return Encoders.INT();
     }
@@ -92,7 +97,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
         public Double call(Tuple2<String, Integer> value) throws Exception {
           return (double)(value._2() * 2);
         }
-      }));
+      }, Encoders.tuple(Encoders.STRING(), Encoders.INT())));
     Assert.assertEquals(Arrays.asList(tuple2("a", 3.0), tuple2("b", 6.0)), agged.collectAsList());
   }
 
@@ -104,7 +109,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
         public Object call(Tuple2<String, Integer> value) throws Exception {
           return value;
         }
-      }));
+      }, Encoders.tuple(Encoders.STRING(), Encoders.INT())));
     Assert.assertEquals(Arrays.asList(tuple2("a", 2), tuple2("b", 1)), agged.collectAsList());
   }
 
@@ -116,7 +121,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
         public Double call(Tuple2<String, Integer> value) throws Exception {
           return (double)value._2();
         }
-      }));
+      }, Encoders.tuple(Encoders.STRING(), Encoders.INT())));
     Assert.assertEquals(Arrays.asList(tuple2("a", 3.0), tuple2("b", 3.0)), agged.collectAsList());
   }
 
@@ -128,7 +133,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
         public Long call(Tuple2<String, Integer> value) throws Exception {
           return (long)value._2();
         }
-      }));
+      }, Encoders.tuple(Encoders.STRING(), Encoders.INT())));
     Assert.assertEquals(Arrays.asList(tuple2("a", 3), tuple2("b", 3)), agged.collectAsList());
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetBenchmark.scala
@@ -125,6 +125,8 @@ object DatasetBenchmark {
 
     override def merge(b1: Data, b2: Data): Data = Data(b1.l + b2.l, "")
 
+    override def inputEncoder: Encoder[Data] = Encoders.product[Data]
+
     override def bufferEncoder: Encoder[Data] = Encoders.product[Data]
 
     override def outputEncoder: Encoder[Long] = Encoders.scalaLong


### PR DESCRIPTION
## What changes were proposed in this pull request?

Aggregator also has an Encoder for the input type
## How was this patch tested?

Add tests to DatasetAggregatorSuite to upcast aggregator input types and apply Aggregator only to selected columns
