### PR TITLE
[SPARK-15770][CORE][SQL][ML] Annotation audit for Experimental and DeveloperApi 2

### DIFF
--- a/core/src/main/scala/org/apache/spark/FutureAction.scala
+++ b/core/src/main/scala/org/apache/spark/FutureAction.scala
@@ -107,6 +107,7 @@ trait FutureAction[T] extends Future[T] {
 
 
 /**
+ * :: DeveloperApi ::
  * A [[FutureAction]] holding the result of an action that triggers a single job. Examples include
  * count, collect, reduce.
  */
@@ -149,6 +150,7 @@ class SimpleFutureAction[T] private[spark](jobWaiter: JobWaiter[_], resultFunc: 
 
 
 /**
+ * :: DeveloperApi ::
  * Handle via which a "run" function passed to a [[ComplexFutureAction]]
  * can submit jobs for execution.
  */
@@ -169,6 +171,7 @@ trait JobSubmitter {
 
 
 /**
+ * :: DeveloperApi ::
  * A [[FutureAction]] for actions that could trigger multiple Spark jobs. Examples include take,
  * takeSample. Cancellation works by setting the cancelled flag to true and cancelling any pending
  * jobs.

--- a/core/src/main/scala/org/apache/spark/SerializableWritable.scala
+++ b/core/src/main/scala/org/apache/spark/SerializableWritable.scala
@@ -26,6 +26,9 @@ import org.apache.hadoop.io.Writable
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.util.Utils
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 class SerializableWritable[T <: Writable](@transient var t: T) extends Serializable {
 

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -168,11 +168,14 @@ abstract class TaskContext extends Serializable {
    */
   def getLocalProperty(key: String): String
 
+  /**
+   * :: DeveloperApi ::
+   */
   @DeveloperApi
   def taskMetrics(): TaskMetrics
 
   /**
-   * ::DeveloperApi::
+   * :: DeveloperApi ::
    * Returns all metrics sources with the given name which are associated with the instance
    * which runs the task. For more information see [[org.apache.spark.metrics.MetricsSystem!]].
    */

--- a/core/src/main/scala/org/apache/spark/api/java/JavaHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaHadoopRDD.scala
@@ -27,12 +27,18 @@ import org.apache.spark.api.java.JavaSparkContext._
 import org.apache.spark.api.java.function.{Function2 => JFunction2}
 import org.apache.spark.rdd.HadoopRDD
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 class JavaHadoopRDD[K, V](rdd: HadoopRDD[K, V])
     (implicit override val kClassTag: ClassTag[K], implicit override val vClassTag: ClassTag[V])
   extends JavaPairRDD[K, V](rdd) {
 
-  /** Maps over a partition, providing the InputSplit that was used as the base of the partition. */
+  /**
+   * :: DeveloperApi ::
+   * Maps over a partition, providing the InputSplit that was used as the base of the partition.
+   */
   @DeveloperApi
   def mapPartitionsWithInputSplit[R](
       f: JFunction2[InputSplit, java.util.Iterator[(K, V)], java.util.Iterator[R]],

--- a/core/src/main/scala/org/apache/spark/api/java/JavaNewHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaNewHadoopRDD.scala
@@ -27,12 +27,18 @@ import org.apache.spark.api.java.JavaSparkContext._
 import org.apache.spark.api.java.function.{Function2 => JFunction2}
 import org.apache.spark.rdd.NewHadoopRDD
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 class JavaNewHadoopRDD[K, V](rdd: NewHadoopRDD[K, V])
     (implicit override val kClassTag: ClassTag[K], implicit override val vClassTag: ClassTag[V])
   extends JavaPairRDD[K, V](rdd) {
 
-  /** Maps over a partition, providing the InputSplit that was used as the base of the partition. */
+  /**
+   * :: DeveloperApi ::
+   * Maps over a partition, providing the InputSplit that was used as the base of the partition.
+   */
   @DeveloperApi
   def mapPartitionsWithInputSplit[R](
       f: JFunction2[InputSplit, java.util.Iterator[(K, V)], java.util.Iterator[R]],

--- a/core/src/main/scala/org/apache/spark/deploy/master/LeaderElectionAgent.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/LeaderElectionAgent.scala
@@ -30,6 +30,9 @@ trait LeaderElectionAgent {
   def stop() {} // to avoid noops in implementations.
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 trait LeaderElectable {
   def electedLeader(): Unit

--- a/core/src/main/scala/org/apache/spark/deploy/master/PersistenceEngine.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/PersistenceEngine.scala
@@ -23,6 +23,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rpc.RpcEnv
 
 /**
+ * :: DeveloperApi ::
  * Allows Master to persist any state that is necessary in order to recover from a failure.
  * The following semantics are required:
  *   - addApplication and addWorker are called before completing registration of a new app/worker.

--- a/core/src/main/scala/org/apache/spark/deploy/master/RecoveryModeFactory.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/RecoveryModeFactory.scala
@@ -23,7 +23,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.Serializer
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  *
  * Implementation of this class can be plugged in as recovery mode alternative for Spark's
  * Standalone mode.

--- a/core/src/main/scala/org/apache/spark/partial/package.scala
+++ b/core/src/main/scala/org/apache/spark/partial/package.scala
@@ -18,8 +18,6 @@
 package org.apache.spark
 
 /**
- * :: Experimental ::
- *
  * Support for approximate results. This provides convenient api and also implementation for
  * approximate calculation.
  *

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -302,7 +302,10 @@ class HadoopRDD[K, V](
     new InterruptibleIterator[(K, V)](context, iter)
   }
 
-  /** Maps over a partition, providing the InputSplit that was used as the base of the partition. */
+  /**
+   * :: DeveloperApi ::
+   * Maps over a partition, providing the InputSplit that was used as the base of the partition.
+   */
   @DeveloperApi
   def mapPartitionsWithInputSplit[U: ClassTag](
       f: (InputSplit, Iterator[(K, V)]) => Iterator[U],

--- a/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
@@ -234,7 +234,10 @@ class NewHadoopRDD[K, V](
     new InterruptibleIterator(context, iter)
   }
 
-  /** Maps over a partition, providing the InputSplit that was used as the base of the partition. */
+  /**
+   * :: DeveloperApi ::
+   * Maps over a partition, providing the InputSplit that was used as the base of the partition.
+   */
   @DeveloperApi
   def mapPartitionsWithInputSplit[U: ClassTag](
       f: (InputSplit, Iterator[(K, V)]) => Iterator[U],

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionPruningRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionPruningRDD.scala
@@ -68,7 +68,9 @@ class PartitionPruningRDD[T: ClassTag](
     dependencies.head.asInstanceOf[PruneDependency[T]].partitions
 }
 
-
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 object PartitionPruningRDD {
 

--- a/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
@@ -58,6 +58,9 @@ private[spark] class UnionPartition[T: ClassTag](
   }
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 class UnionRDD[T: ClassTag](
     sc: SparkContext,

--- a/core/src/main/scala/org/apache/spark/rdd/coalesce-public.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/coalesce-public.scala
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.Partition
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A PartitionCoalescer defines how to coalesce the partitions of a given RDD.
  */
 @DeveloperApi
@@ -41,7 +41,7 @@ trait PartitionCoalescer {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A group of [[Partition]]s
  * @param prefLoc preferred location for the partition group
  */

--- a/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
@@ -26,6 +26,9 @@ import org.apache.spark.annotation.DeveloperApi
 @DeveloperApi
 sealed trait JobResult
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case object JobSucceeded extends JobResult
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -31,6 +31,9 @@ import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.storage.{BlockManagerId, BlockUpdatedInfo}
 import org.apache.spark.ui.SparkUI
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "Event")
 trait SparkListenerEvent {
@@ -38,20 +41,35 @@ trait SparkListenerEvent {
   protected[spark] def logEvent: Boolean = true
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerStageSubmitted(stageInfo: StageInfo, properties: Properties = null)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerStageCompleted(stageInfo: StageInfo) extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerTaskStart(stageId: Int, stageAttemptId: Int, taskInfo: TaskInfo)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerTaskGettingResult(taskInfo: TaskInfo) extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerTaskEnd(
     stageId: Int,
@@ -63,6 +81,9 @@ case class SparkListenerTaskEnd(
     @Nullable taskMetrics: TaskMetrics)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerJobStart(
     jobId: Int,
@@ -75,6 +96,9 @@ case class SparkListenerJobStart(
   val stageIds: Seq[Int] = stageInfos.map(_.stageId)
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerJobEnd(
     jobId: Int,
@@ -82,33 +106,55 @@ case class SparkListenerJobEnd(
     jobResult: JobResult)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerEnvironmentUpdate(environmentDetails: Map[String, Seq[(String, String)]])
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerBlockManagerAdded(time: Long, blockManagerId: BlockManagerId, maxMem: Long)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerBlockManagerRemoved(time: Long, blockManagerId: BlockManagerId)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerUnpersistRDD(rddId: Int) extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerExecutorAdded(time: Long, executorId: String, executorInfo: ExecutorInfo)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerExecutorRemoved(time: Long, executorId: String, reason: String)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerBlockUpdated(blockUpdatedInfo: BlockUpdatedInfo) extends SparkListenerEvent
 
 /**
+ * :: DeveloperApi ::
  * Periodic updates from executors.
  * @param execId executor id
  * @param accumUpdates sequence of (taskId, stageId, stageAttemptId, accumUpdates)
@@ -119,6 +165,9 @@ case class SparkListenerExecutorMetricsUpdate(
     accumUpdates: Seq[(Long, Int, Int, Seq[AccumulableInfo])])
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerApplicationStart(
     appName: String,
@@ -128,6 +177,9 @@ case class SparkListenerApplicationStart(
     appAttemptId: Option[String],
     driverLogs: Option[Map[String, String]] = None) extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerApplicationEnd(time: Long) extends SparkListenerEvent
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SplitInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SplitInfo.scala
@@ -21,8 +21,11 @@ import collection.mutable.ArrayBuffer
 
 import org.apache.spark.annotation.DeveloperApi
 
-// information about a specific split instance : handles both split instances.
-// So that we do not need to worry about the differences.
+/**
+ * :: DeveloperApi ::
+ * information about a specific split instance : handles both split instances.
+ * So that we do not need to worry about the differences.
+ */
 @DeveloperApi
 class SplitInfo(
     val inputFormatClazz: Class[_],

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskLocality.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskLocality.scala
@@ -19,6 +19,9 @@ package org.apache.spark.scheduler
 
 import org.apache.spark.annotation.DeveloperApi
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 object TaskLocality extends Enumeration {
   // Process local is expected to be used ONLY within TaskSetManager for now.

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle
 import org.apache.spark.annotation.DeveloperApi
 
 /**
+ * :: DeveloperApi ::
  * An opaque handle to a shuffle, used by a ShuffleManager to pass information about it to tasks.
  *
  * @param shuffleId ID of the shuffle

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -48,38 +48,59 @@ sealed abstract class BlockId {
   }
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class RDDBlockId(rddId: Int, splitIndex: Int) extends BlockId {
   override def name: String = "rdd_" + rddId + "_" + splitIndex
 }
 
-// Format of the shuffle block ids (including data and index) should be kept in sync with
-// org.apache.spark.network.shuffle.ExternalShuffleBlockResolver#getBlockData().
+/**
+ * :: DeveloperApi ::
+ * Format of the shuffle block ids (including data and index) should be kept in sync with
+ * org.apache.spark.network.shuffle.ExternalShuffleBlockResolver#getBlockData().
+ */
 @DeveloperApi
 case class ShuffleBlockId(shuffleId: Int, mapId: Int, reduceId: Int) extends BlockId {
   override def name: String = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class ShuffleDataBlockId(shuffleId: Int, mapId: Int, reduceId: Int) extends BlockId {
   override def name: String = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId + ".data"
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class ShuffleIndexBlockId(shuffleId: Int, mapId: Int, reduceId: Int) extends BlockId {
   override def name: String = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId + ".index"
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class BroadcastBlockId(broadcastId: Long, field: String = "") extends BlockId {
   override def name: String = "broadcast_" + broadcastId + (if (field == "") "" else "_" + field)
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class TaskResultBlockId(taskId: Long) extends BlockId {
   override def name: String = "taskresult_" + taskId
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamBlockId(streamId: Int, uniqueId: Long) extends BlockId {
   override def name: String = "input-" + streamId + "-" + uniqueId
@@ -100,6 +121,9 @@ private[spark] case class TestBlockId(id: String) extends BlockId {
   override def name: String = "test_" + id
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 object BlockId {
   val RDD = "rdd_([0-9]+)_([0-9]+)".r

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -401,11 +401,17 @@ class BlockManagerMasterEndpoint(
   }
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class BlockStatus(storageLevel: StorageLevel, memSize: Long, diskSize: Long) {
   def isCached: Boolean = memSize + diskSize > 0
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 object BlockStatus {
   def empty: BlockStatus = BlockStatus(StorageLevel.NONE, memSize = 0L, diskSize = 0L)

--- a/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
+++ b/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
@@ -21,6 +21,9 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.{RDD, RDDOperationScope}
 import org.apache.spark.util.Utils
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 class RDDInfo(
     val id: Int,

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaCluster.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaCluster.scala
@@ -363,6 +363,9 @@ class KafkaCluster(val kafkaParams: Map[String, String]) extends Serializable {
   }
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 object KafkaCluster {
   type Err = ArrayBuffer[Throwable]

--- a/mllib-local/src/main/scala/org/apache/spark/ml/stat/distribution/MultivariateGaussian.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/stat/distribution/MultivariateGaussian.scala
@@ -25,6 +25,7 @@ import org.apache.spark.ml.linalg.{Matrices, Matrix, Vector, Vectors}
 
 
 /**
+ * :: DeveloperApi ::
  * This class provides basic functionality for a Multivariate Gaussian (Normal) Distribution. In
  * the event that the covariance matrix is singular, the density will be computed in a
  * reduced dimensional subspace under which the distribution is supported.

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -126,6 +126,9 @@ class DecisionTreeClassifier @Since("1.4.0") (
   override def copy(extra: ParamMap): DecisionTreeClassifier = defaultCopy(extra)
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.4.0")
 @Experimental
 object DecisionTreeClassifier extends DefaultParamsReadable[DecisionTreeClassifier] {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -148,6 +148,9 @@ class GBTClassifier @Since("1.4.0") (
   override def copy(extra: ParamMap): GBTClassifier = defaultCopy(extra)
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.4.0")
 @Experimental
 object GBTClassifier extends DefaultParamsReadable[GBTClassifier] {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -123,6 +123,9 @@ class RandomForestClassifier @Since("1.4.0") (
   override def copy(extra: ParamMap): RandomForestClassifier = defaultCopy(extra)
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.4.0")
 @Experimental
 object RandomForestClassifier extends DefaultParamsReadable[RandomForestClassifier] {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LabeledPoint.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LabeledPoint.scala
@@ -23,6 +23,7 @@ import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.linalg.Vector
 
 /**
+ * :: Experimental ::
  * Class that represents the features and labels of a data point.
  *
  * @param label Label for this data point.

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -951,6 +951,9 @@ final class ParamMap private[ml] (private val map: mutable.Map[Param[Any], Any])
   def size: Int = map.size
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.2.0")
 @Experimental
 object ParamMap {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -124,6 +124,9 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   override def copy(extra: ParamMap): DecisionTreeRegressor = defaultCopy(extra)
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.4.0")
 @Experimental
 object DecisionTreeRegressor extends DefaultParamsReadable[DecisionTreeRegressor] {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -134,6 +134,9 @@ class GBTRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   override def copy(extra: ParamMap): GBTRegressor = defaultCopy(extra)
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.4.0")
 @Experimental
 object GBTRegressor extends DefaultParamsReadable[GBTRegressor] {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -117,6 +117,9 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   override def copy(extra: ParamMap): RandomForestRegressor = defaultCopy(extra)
 }
 
+/**
+ * :: Experimental ::
+ */
 @Since("1.4.0")
 @Experimental
 object RandomForestRegressor extends DefaultParamsReadable[RandomForestRegressor]{

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -68,6 +68,7 @@ private[util] sealed trait BaseReadWrite {
 }
 
 /**
+ * :: Experimental ::
  * Abstract class for utility classes that can save ML instances.
  */
 @Experimental
@@ -145,6 +146,7 @@ private[ml] trait DefaultParamsWritable extends MLWritable { self: Params =>
 }
 
 /**
+ * :: Experimental ::
  * Abstract class for utility classes that can load ML instances.
  *
  * @tparam T ML instance type
@@ -164,6 +166,7 @@ abstract class MLReader[T] extends BaseReadWrite {
 }
 
 /**
+ * :: Experimental ::
  * Trait for objects that provide [[MLReader]].
  *
  * @tparam T ML instance type

--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
@@ -230,6 +230,9 @@ class PrefixSpan private (
 
 }
 
+/**
+ * :: Experimental ::
+ */
 @Experimental
 @Since("1.5.0")
 object PrefixSpan extends Logging {

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkCommandLine.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkCommandLine.scala
@@ -22,6 +22,7 @@ import scala.Predef._
 import org.apache.spark.annotation.DeveloperApi
 
 /**
+ * :: DeveloperApi ::
  * Command class enabling Spark-specific command line options (provided by
  * <i>org.apache.spark.repl.SparkRunnerSettings</i>).
  *

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkHelper.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkHelper.scala
@@ -23,11 +23,13 @@ import org.apache.spark.annotation.DeveloperApi
 //       settings "explicitParentLoader" method
 
 /**
+ * :: DeveloperApi ::
  * Provides exposure for the explicitParentLoader method on settings instances.
  */
 @DeveloperApi
 object SparkHelper {
   /**
+   * :: DeveloperApi ::
    * Retrieves the explicit parent loader for the provided settings.
    *
    * @param settings The settings whose explicit parent loader to retrieve

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -46,7 +46,9 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.Utils
 
-/** The Scala interactive shell.  It provides a read-eval-print loop
+/**
+ * :: DeveloperApi ::
+ *  The Scala interactive shell.  It provides a read-eval-print loop
  *  around the Interpreter class.
  *  After instantiation, clients should call the main() method.
  *
@@ -126,7 +128,10 @@ class SparkILoop(
     }
   }
 
-  // NOTE: Must be public for visibility
+  /**
+   * :: DeveloperApi ::
+   *  NOTE: Must be public for visibility
+   */
   @DeveloperApi
   var sparkContext: SparkContext = _
 
@@ -312,6 +317,7 @@ class SparkILoop(
   private var currentPrompt = Properties.shellPromptString
 
   /**
+   * :: DeveloperApi ::
    * Sets the prompt string used by the REPL.
    *
    * @param prompt The new prompt string
@@ -320,6 +326,7 @@ class SparkILoop(
   def setPrompt(prompt: String) = currentPrompt = prompt
 
   /**
+   * :: DeveloperApi ::
    * Represents the current prompt string used by the REPL.
    *
    * @return The current prompt string
@@ -603,6 +610,7 @@ class SparkILoop(
   // }
 
   /**
+   * :: DeveloperApi ::
    * Provides a list of available commands.
    *
    * @return The list of commands
@@ -1001,7 +1009,10 @@ class SparkILoop(
     true
   }
 
-  // NOTE: Must be public for visibility
+  /**
+   * :: DeveloperApi ::
+   * NOTE: Must be public for visibility
+   */
   @DeveloperApi
   def createSparkSession(): SparkSession = {
     val execUri = System.getenv("SPARK_EXECUTOR_URI")

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -54,7 +54,9 @@ import org.apache.spark.annotation.DeveloperApi
 //   def show() = pp(this, 0)
 // }
 
-  /** An interpreter for Scala code.
+  /**
+   * :: DeveloperApi ::
+   *  An interpreter for Scala code.
    *
    *  The main public entry points are compile(), interpret(), and bind().
    *  The compile() method loads a complete Scala file.  The interpret() method
@@ -106,6 +108,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Returns the path to the output directory containing all generated
      * class files that will be served by the REPL class server.
      */
@@ -178,6 +181,7 @@ import org.apache.spark.annotation.DeveloperApi
     private[repl] lazy val reporter: ConsoleReporter = new SparkIMain.ReplReporter(this)
 
     /**
+     * :: DeveloperApi ::
      * Determines if errors were reported (typically during compilation).
      *
      * @note This is not for runtime errors
@@ -218,6 +222,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Initializes the underlying compiler/interpreter in a blocking fashion.
      *
      * @note Must be executed before using SparkIMain!
@@ -234,6 +239,7 @@ import org.apache.spark.annotation.DeveloperApi
     /** the public, go through the future compiler */
 
     /**
+     * :: DeveloperApi ::
      * The underlying compiler used to generate ASTs and execute code.
      */
     @DeveloperApi
@@ -292,6 +298,7 @@ import org.apache.spark.annotation.DeveloperApi
     import memberHandlers._
 
     /**
+     * :: DeveloperApi ::
      * Suppresses overwriting print results during the operation.
      *
      * @param body The block to execute
@@ -308,6 +315,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Completely masks all output during the operation (minus JVM standard
      * out and error).
      *
@@ -346,6 +354,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Contains the code (in string form) representing a wrapper around all
      * code executed by this instance.
      *
@@ -355,6 +364,7 @@ import org.apache.spark.annotation.DeveloperApi
     def executionWrapper = _executionWrapper
 
     /**
+     * :: DeveloperApi ::
      * Sets the code to use as a wrapper around all code executed by this
      * instance.
      *
@@ -364,6 +374,7 @@ import org.apache.spark.annotation.DeveloperApi
     def setExecutionWrapper(code: String) = _executionWrapper = code
 
     /**
+     * :: DeveloperApi ::
      * Clears the code used as a wrapper around all code executed by
      * this instance.
      */
@@ -374,6 +385,7 @@ import org.apache.spark.annotation.DeveloperApi
     private lazy val isettings = new SparkISettings(this)
 
     /**
+     * :: DeveloperApi ::
      * Instantiates a new compiler used by SparkIMain. Overridable to provide
      * own instance of a compiler.
      *
@@ -392,6 +404,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Adds any specified jars to the compile and runtime classpaths.
      *
      * @note Currently only supports jars, not directories
@@ -444,6 +457,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Represents the parent classloader used by this instance. Can be
      * overridden to provide alternative classloader.
      *
@@ -511,6 +525,7 @@ import org.apache.spark.annotation.DeveloperApi
     private[repl] def setContextClassLoader() = classLoader.setAsContext()
 
     /**
+     * :: DeveloperApi ::
      * Returns the real name of a class based on its repl-defined name.
      *
      * ==Example==
@@ -536,6 +551,7 @@ import org.apache.spark.annotation.DeveloperApi
     private[repl] def optFlatName(id: String) = requestForIdent(id) map (_ fullFlatName id)
 
     /**
+     * :: DeveloperApi ::
      * Retrieves all simple names contained in the current instance.
      *
      * @return A list of sorted names
@@ -548,6 +564,7 @@ import org.apache.spark.annotation.DeveloperApi
     private[repl] def pathToTerm(id: String): String = pathToName(newTermName(id))
 
     /**
+     * :: DeveloperApi ::
      * Retrieves the full code path to access the specified simple name
      * content.
      *
@@ -647,6 +664,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
     /**
+     * :: DeveloperApi ::
      * Compiles specified source files.
      *
      * @param sources The sequence of source files to compile
@@ -658,6 +676,7 @@ import org.apache.spark.annotation.DeveloperApi
       compileSourcesKeepingRun(sources: _*)._1
 
     /**
+     * :: DeveloperApi ::
      * Compiles a string of code.
      *
      * @param code The string of code to compile
@@ -786,6 +805,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Interpret one line of input. All feedback, including parse errors
    * and evaluation results, are printed via the supplied compiler's
    * reporter. Values defined are available for future interpreted strings.
@@ -801,6 +821,7 @@ import org.apache.spark.annotation.DeveloperApi
   def interpret(line: String): IR.Result = interpret(line, false)
 
   /**
+   * :: DeveloperApi ::
    * Interpret one line of input. All feedback, including parse errors
    * and evaluation results, are printed via the supplied compiler's
    * reporter. Values defined are available for future interpreted strings.
@@ -855,6 +876,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Bind a specified name to a specified value.  The name may
    * later be used by expressions passed to interpret.
    *
@@ -891,6 +913,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Bind a specified name to a specified value directly.
    *
    * @note This updates internal bound names directly
@@ -914,6 +937,7 @@ import org.apache.spark.annotation.DeveloperApi
   private def directBind[T: ru.TypeTag : ClassTag](name: String, value: T): IR.Result = directBind((name, value))
 
   /**
+   * :: DeveloperApi ::
    * Overwrites previously-bound val with a new instance.
    *
    * @param p The named parameters used to provide the name, value, and type
@@ -933,6 +957,7 @@ import org.apache.spark.annotation.DeveloperApi
   private def quietImport(ids: String*): IR.Result = beQuietDuring(addImports(ids: _*))
 
   /**
+   * :: DeveloperApi ::
    * Executes an import statement per "id" provided
    *
    * @example addImports("org.apache.spark.SparkContext")
@@ -955,6 +980,7 @@ import org.apache.spark.annotation.DeveloperApi
   private def bindValue(name: String, x: Any): IR.Result                        = bind(name, TypeStrings.fromValue(x), x)
 
   /**
+   * :: DeveloperApi ::
    * Reset this interpreter, forgetting all user-specified requests.
    */
   @DeveloperApi
@@ -970,6 +996,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Stops the underlying REPL class server and flushes the reporter used
    * for compiler output.
    */
@@ -979,6 +1006,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Captures the session names (which are set by system properties) once, instead of for each line.
    */
   @DeveloperApi
@@ -1332,6 +1360,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Returns the name of the most recent interpreter result. Useful for
    * for extracting information regarding the previous result.
    *
@@ -1350,6 +1379,7 @@ import org.apache.spark.annotation.DeveloperApi
   private var mostRecentWarnings: List[(global.Position, String)] = Nil
 
   /**
+   * :: DeveloperApi ::
    * Returns a list of recent warnings from compiler execution.
    *
    * @return The list of tuples (compiler position, warning)
@@ -1382,6 +1412,7 @@ import org.apache.spark.annotation.DeveloperApi
     }
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the object representing the id (variable name, method name,
    * class name, etc) provided.
    *
@@ -1395,6 +1426,7 @@ import org.apache.spark.annotation.DeveloperApi
     requestForName(newTermName(id)) flatMap (_.getEval)
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the class representing the id (variable name, method name,
    * class name, etc) provided.
    *
@@ -1408,6 +1440,7 @@ import org.apache.spark.annotation.DeveloperApi
     valueOfTerm(id) map (_.getClass)
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the type representing the id (variable name, method name,
    * class name, etc) provided.
    *
@@ -1423,6 +1456,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the symbol representing the id (variable name, method name,
    * class name, etc) provided.
    *
@@ -1440,6 +1474,7 @@ import org.apache.spark.annotation.DeveloperApi
     requestForName(newTypeName(id)).fold(NoSymbol: Symbol)(_ definedTypeSymbol id)
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the runtime class and type representing the id (variable name,
    * method name, class name, etc) provided.
    *
@@ -1459,6 +1494,7 @@ import org.apache.spark.annotation.DeveloperApi
   }
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the runtime type representing the id (variable name,
    * method name, class name, etc) provided.
    *
@@ -1494,6 +1530,7 @@ import org.apache.spark.annotation.DeveloperApi
   } with SparkExprTyper { }
 
   /**
+   * :: DeveloperApi ::
    * Constructs a list of abstract syntax trees representing the provided code.
    *
    * @param line The line of code to parse and construct into ASTs
@@ -1504,6 +1541,7 @@ import org.apache.spark.annotation.DeveloperApi
   def parse(line: String): Option[List[Tree]] = exprTyper.parse(line)
 
   /**
+   * :: DeveloperApi ::
    * Constructs a Symbol representing the final result of the expression
    * provided or representing the definition provided.
    *
@@ -1516,6 +1554,7 @@ import org.apache.spark.annotation.DeveloperApi
     exprTyper.symbolOfLine(code)
 
   /**
+   * :: DeveloperApi ::
    * Constructs type information based on the provided expression's final
    * result or the definition provided.
    *
@@ -1533,6 +1572,7 @@ import org.apache.spark.annotation.DeveloperApi
   protected def onlyTypes(xs: List[Name]) = xs collect { case x: TypeName => x }
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the defined, public names in the compiler.
    *
    * @return The list of matching "term" names
@@ -1541,6 +1581,7 @@ import org.apache.spark.annotation.DeveloperApi
   def definedTerms      = onlyTerms(allDefinedNames) filterNot isInternalTermName
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the defined type names in the compiler.
    *
    * @return The list of matching type names
@@ -1549,6 +1590,7 @@ import org.apache.spark.annotation.DeveloperApi
   def definedTypes      = onlyTypes(allDefinedNames)
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the defined symbols in the compiler.
    *
    * @return The set of matching Symbol instances
@@ -1557,6 +1599,7 @@ import org.apache.spark.annotation.DeveloperApi
   def definedSymbols    = prevRequestList.flatMap(_.definedSymbols.values).toSet[Symbol]
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the list of public symbols in the compiler.
    *
    * @return The list of public Symbol instances
@@ -1567,6 +1610,7 @@ import org.apache.spark.annotation.DeveloperApi
   // Terms with user-given names (i.e. not res0 and not synthetic)
 
   /**
+   * :: DeveloperApi ::
    * Retrieves defined, public names that are not res0 or the result of a direct bind.
    *
    * @return The list of matching "term" names
@@ -1595,6 +1639,7 @@ import org.apache.spark.annotation.DeveloperApi
   private def apply[T: ClassTag] : Symbol = apply(classTag[T].runtimeClass.getName)
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the Symbols representing classes in the compiler.
    *
    * @return The list of matching ClassSymbol instances
@@ -1603,6 +1648,7 @@ import org.apache.spark.annotation.DeveloperApi
   def classSymbols  = allDefSymbols collect { case x: ClassSymbol => x }
 
   /**
+   * :: DeveloperApi ::
    * Retrieves the Symbols representing methods in the compiler.
    *
    * @return The list of matching MethodSymbol instances

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkJLineCompletion.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkJLineCompletion.scala
@@ -19,6 +19,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
 
 /**
+ * :: DeveloperApi ::
  * Represents an auto-completion tool for the supplied interpreter that
  * utilizes supplied queries for valid completions based on the current
  * contents of the internal buffer.
@@ -39,12 +40,14 @@ class SparkJLineCompletion(val intp: SparkIMain) extends Completion with Complet
   import intp.{ debugging }
 
   /**
+   * :: DeveloperApi ::
    * Represents the level of verbosity. Increments with consecutive tabs.
    */
   @DeveloperApi
   var verbosity: Int = 0
 
   /**
+   * :: DeveloperApi ::
    * Resets the level of verbosity to zero.
    */
   @DeveloperApi
@@ -310,6 +313,7 @@ class SparkJLineCompletion(val intp: SparkIMain) extends Completion with Complet
     topLevelFor(Parsed.dotted(buf + ".", buf.length + 1))
 
   /**
+   * :: DeveloperApi ::
    * Constructs a new ScalaCompleter for auto completion.
    *
    * @return The new JLineTabCompletion instance

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionDescription.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionDescription.java
@@ -23,8 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * ::DeveloperApi::
-
+ * :: DeveloperApi ::
  * A function description type which can be recognized by FunctionRegistry, and will be used to
  * show the usage of the function in human language.
  *

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/types/SQLUserDefinedType.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/types/SQLUserDefinedType.java
@@ -22,7 +22,7 @@ import java.lang.annotation.*;
 import org.apache.spark.annotation.DeveloperApi;
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A user-defined type which can be automatically recognized by a SQLContext and registered.
  * WARNING: UDTs are currently only supported from Scala.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -185,6 +185,9 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   override def toString: String = toBigDecimal.toString()
 
+  /**
+   * :: DeveloperApi ::
+   */
   @DeveloperApi
   def toDebugString: String = {
     if (decimalVal.ne(null)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -84,6 +84,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   }
 
   /**
+   * :: Experimental ::
    * Specifies how data of a streaming DataFrame/Dataset is written to a streaming sink.
    *   - `OutputMode.Append()`: only the new rows in the streaming DataFrame/Dataset will be
    *                            written to the sink
@@ -100,6 +101,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   }
 
   /**
+   * :: Experimental ::
    * Specifies how data of a streaming DataFrame/Dataset is written to a streaming sink.
    *   - `append`:   only the new rows in the streaming DataFrame/Dataset will be written to
    *                 the sink

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -453,6 +453,7 @@ class Dataset[T] private[sql](
   def isLocal: Boolean = logicalPlan.isInstanceOf[LocalRelation]
 
   /**
+   * :: Experimental ::
    * Returns true if this [[Dataset]] contains one or more sources that continuously
    * return data as it arrives. A [[Dataset]] that reads data from a streaming source
    * must be executed as a [[ContinuousQuery]] using the `startStream()` method in

--- a/sql/core/src/main/scala/org/apache/spark/sql/ExperimentalMethods.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ExperimentalMethods.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 class ExperimentalMethods private[sql]() {
 
   /**
+   * :: Experimental ::
    * Allows extra strategies to be injected into the query planner at runtime.  Note this API
    * should be considered experimental and is not intended to be stable across releases.
    *
@@ -44,6 +45,9 @@ class ExperimentalMethods private[sql]() {
   @Experimental
   @volatile var extraStrategies: Seq[Strategy] = Nil
 
+  /**
+   * :: Experimental ::
+   */
   @Experimental
   @volatile var extraOptimizations: Seq[Rule[LogicalPlan]] = Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -91,6 +91,7 @@ class SQLContext private[sql](val sparkSession: SparkSession)
   def newSession(): SQLContext = sparkSession.newSession().sqlContext
 
   /**
+   * :: Experimental ::
    * An interface to register custom [[org.apache.spark.sql.util.QueryExecutionListener]]s
    * that listen for execution metrics.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * ::Experimental::
+ * :: Experimental ::
  * A factory that produces [[OutputWriter]]s.  A new [[OutputWriterFactory]] is created on driver
  * side for each write job issued when writing to a [[HadoopFsRelation]], and then gets serialized
  * to executor side to create actual [[OutputWriter]]s on the fly.
@@ -82,7 +82,7 @@ abstract class OutputWriterFactory extends Serializable {
 }
 
 /**
- * ::Experimental::
+ * :: Experimental ::
  * [[OutputWriter]] is used together with [[HadoopFsRelation]] for persisting rows to the
  * underlying file system.  Subclasses of [[OutputWriter]] must provide a zero-argument constructor.
  * An [[OutputWriter]] instance is created and initialized when a new output file is opened on

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -28,6 +28,9 @@ import org.apache.spark.sql.execution.metric._
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.AccumulatorContext
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerSQLExecutionStart(
     executionId: Long,
@@ -38,6 +41,9 @@ case class SparkListenerSQLExecutionStart(
     time: Long)
   extends SparkListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class SparkListenerSQLExecutionEnd(executionId: Long, time: Long)
   extends SparkListenerEvent

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.functions
 import org.apache.spark.sql.types.DataType
 
 /**
+ * :: Experimental ::
  * A user-defined function. To create one, use the `udf` functions in [[functions]].
  * Note that the user-defined functions must be deterministic. Due to optimization,
  * duplicate invocations may be eliminated or the function may even be invoked more times than

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2567,6 +2567,7 @@ object functions {
   }
 
   /**
+   * :: Experimental ::
    * Bucketize rows into one or more time windows given a timestamp specifying column. Window
    * starts are inclusive but the window ends are exclusive, e.g. 12:05 will be in the window
    * [12:05,12:10) but not in [12:00,12:05). Windows can support microsecond precision. Windows in
@@ -2621,6 +2622,7 @@ object functions {
 
 
   /**
+   * :: Experimental ::
    * Bucketize rows into one or more time windows given a timestamp specifying column. Window
    * starts are inclusive but the window ends are exclusive, e.g. 12:05 will be in the window
    * [12:05,12:10) but not in [12:00,12:05). Windows can support microsecond precision. Windows in
@@ -2663,6 +2665,7 @@ object functions {
   }
 
   /**
+   * :: Experimental ::
    * Generates tumbling time windows given a timestamp specifying column. Window
    * starts are inclusive but the window ends are exclusive, e.g. 12:05 will be in the window
    * [12:05,12:10) but not in [12:00,12:05). Windows can support microsecond precision. Windows in

--- a/sql/core/src/main/scala/org/apache/spark/sql/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/package.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.execution.SparkPlan
 package object sql {
 
   /**
+   * :: DeveloperApi ::
    * Converts a logical plan into zero or more SparkPlans.  This API is exposed for experimenting
    * with the query planner and is not designed to be stable across spark releases.  Developers
    * writing libraries should instead consider using the stable APIs provided in

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * Data sources should implement this trait so that they can register an alias to their data source.
  * This allows users to give the data source alias as the format type over the fully qualified
  * class name.
@@ -53,7 +53,7 @@ trait DataSourceRegister {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * Implemented by objects that produce relations for a specific kind of data source.  When
  * Spark SQL is given a DDL operation with a USING clause specified (to specify the implemented
  * RelationProvider), this interface is used to pass in the parameters specified by a user.
@@ -78,7 +78,7 @@ trait RelationProvider {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * Implemented by objects that produce relations for a specific kind of data source
  * with a given schema.  When Spark SQL is given a DDL operation with a USING clause specified (
  * to specify the implemented SchemaRelationProvider) and a user defined schema, this interface
@@ -143,6 +143,7 @@ trait StreamSinkProvider {
 }
 
 /**
+ * :: DeveloperApi ::
  * @since 1.3.0
  */
 @DeveloperApi
@@ -169,7 +170,7 @@ trait CreatableRelationProvider {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * Represents a collection of tuples with a known schema. Classes that extend BaseRelation must
  * be able to produce the schema of their data in the form of a [[StructType]]. Concrete
  * implementation should inherit from one of the descendant `Scan` classes, which define various
@@ -227,7 +228,7 @@ abstract class BaseRelation {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A BaseRelation that can produce all of its tuples as an RDD of Row objects.
  *
  * @since 1.3.0
@@ -238,7 +239,7 @@ trait TableScan {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A BaseRelation that can eliminate unneeded columns before producing an RDD
  * containing all of its tuples as Row objects.
  *
@@ -250,7 +251,7 @@ trait PrunedScan {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A BaseRelation that can eliminate unneeded columns and filter using selected
  * predicates before producing an RDD containing all matching tuples as Row objects.
  *
@@ -269,7 +270,7 @@ trait PrunedFilteredScan {
 }
 
 /**
- * ::DeveloperApi::
+ * :: DeveloperApi ::
  * A BaseRelation that can be used to insert data into it through the insert method.
  * If overwrite in insert method is true, the old data in the relation should be overwritten with
  * the new data. If overwrite in insert method is false, the new data should be appended.
@@ -292,7 +293,7 @@ trait InsertableRelation {
 }
 
 /**
- * ::Experimental::
+ * :: Experimental ::
  * An interface for experimenting with a more direct connection to the query planner.  Compared to
  * [[PrunedFilteredScan]], this operator receives the raw expressions from the
  * [[org.apache.spark.sql.catalyst.plans.logical.LogicalPlan]].  Unlike the other APIs this

--- a/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.execution.QueryExecution
 trait QueryExecutionListener {
 
   /**
+   * :: DeveloperApi ::
    * A callback function that will be called when a query executed successfully.
    * Note that this can be invoked by multiple different threads.
    *
@@ -49,6 +50,7 @@ trait QueryExecutionListener {
   def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit
 
   /**
+   * :: DeveloperApi ::
    * A callback function that will be called when a query execution failed.
    * Note that this can be invoked by multiple different threads.
    *
@@ -71,6 +73,7 @@ trait QueryExecutionListener {
 class ExecutionListenerManager private[sql] () extends Logging {
 
   /**
+   * :: DeveloperApi ::
    * Registers the specified [[QueryExecutionListener]].
    */
   @DeveloperApi
@@ -79,6 +82,7 @@ class ExecutionListenerManager private[sql] () extends Logging {
   }
 
   /**
+   * :: DeveloperApi ::
    * Unregisters the specified [[QueryExecutionListener]].
    */
   @DeveloperApi
@@ -87,6 +91,7 @@ class ExecutionListenerManager private[sql] () extends Logging {
   }
 
   /**
+   * :: DeveloperApi ::
    * Removes all the registered [[QueryExecutionListener]].
    */
   @DeveloperApi

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -526,8 +526,6 @@ class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
   }
 
   /**
-   * :: DeveloperApi ::
-   *
    * Return the current state of the context. The context can be in three possible states -
    * <ul>
    *   <li>

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/InputInfoTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/InputInfoTracker.scala
@@ -41,6 +41,9 @@ case class StreamInputInfo(
     metadata.get(StreamInputInfo.METADATA_KEY_DESCRIPTION).map(_.toString)
 }
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 object StreamInputInfo {
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
@@ -29,31 +29,55 @@ import org.apache.spark.util.Distribution
 @DeveloperApi
 sealed trait StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerBatchSubmitted(batchInfo: BatchInfo) extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerBatchCompleted(batchInfo: BatchInfo) extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerBatchStarted(batchInfo: BatchInfo) extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerOutputOperationStarted(outputOperationInfo: OutputOperationInfo)
   extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerOutputOperationCompleted(outputOperationInfo: OutputOperationInfo)
   extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerReceiverStarted(receiverInfo: ReceiverInfo)
   extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerReceiverError(receiverInfo: ReceiverInfo)
   extends StreamingListenerEvent
 
+/**
+ * :: DeveloperApi ::
+ */
 @DeveloperApi
 case class StreamingListenerReceiverStopped(receiverInfo: ReceiverInfo)
   extends StreamingListenerEvent


### PR DESCRIPTION
## What changes were proposed in this pull request?

1, remove comments `:: Experimental ::` for non-experimental API
2, remove comments `:: DeveloperApi ::` for non-developer API
2, add comments `:: Experimental ::` for experimental API
3, add comments `:: DeveloperApi ::` for developerApi API
4, reformat comments : `::DeveloperApi::` -> `:: DeveloperApi ::`, `::Experimental::` -> `:: Experimental ::`

Use cmds like 
`find . -name '*.scala' | xargs -i sh -c 'a=$(grep -c ":: Experimental ::" {}); b=$(grep -c "@Experimental" {}); echo {},$a,$b' | awk 'BEGIN{FS=","} $2!=$3{print $0}'` to verify coverage
## How was this patch tested?

manual tests
