### PR TITLE
[SPARK-14321][SQL] Reduce date format cost and string-to-date cost in date functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -399,6 +399,8 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
   override def nullable: Boolean = true
 
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
+  private lazy val formatter: SimpleDateFormat =
+    Try(new SimpleDateFormat(constFormat.toString)).getOrElse(null)
 
   override def eval(input: InternalRow): Any = {
     val t = left.eval(input)
@@ -411,11 +413,11 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
         case TimestampType =>
           t.asInstanceOf[Long] / 1000000L
         case StringType if right.foldable =>
-          if (constFormat != null) {
-            Try(new SimpleDateFormat(constFormat.toString).parse(
-              t.asInstanceOf[UTF8String].toString).getTime / 1000L).getOrElse(null)
-          } else {
+          if (constFormat == null || formatter == null) {
             null
+          } else {
+            Try(formatter.parse(
+              t.asInstanceOf[UTF8String].toString).getTime / 1000L).getOrElse(null)
           }
         case StringType =>
           val f = right.eval(input)
@@ -435,12 +437,13 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
       case StringType if right.foldable =>
         val sdf = classOf[SimpleDateFormat].getName
         val fString = if (constFormat == null) null else constFormat.toString
-        val formatter = ctx.freshName("formatter")
         if (fString == null) {
           ev.copy(code = s"""
             boolean ${ev.isNull} = true;
             ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
         } else {
+          val formatter = ctx.freshName("formatter")
+          ctx.addMutableState(sdf, formatter, s"""$formatter = null;""")
           val eval1 = left.genCode(ctx)
           ev.copy(code = s"""
             ${eval1.code}
@@ -448,7 +451,9 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
             ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
             if (!${ev.isNull}) {
               try {
-                $sdf $formatter = new $sdf("$fString");
+                if ($formatter == null) {
+                  $formatter = new $sdf("$fString");
+                }
                 ${ev.value} =
                   $formatter.parse(${eval1.value}.toString()).getTime() / 1000L;
               } catch (java.lang.Throwable e) {
@@ -520,6 +525,8 @@ case class FromUnixTime(sec: Expression, format: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(LongType, StringType)
 
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
+  private lazy val formatter: SimpleDateFormat =
+    Try(new SimpleDateFormat(constFormat.toString)).getOrElse(null)
 
   override def eval(input: InternalRow): Any = {
     val time = left.eval(input)
@@ -527,10 +534,10 @@ case class FromUnixTime(sec: Expression, format: Expression)
       null
     } else {
       if (format.foldable) {
-        if (constFormat == null) {
+        if (constFormat == null || formatter == null) {
           null
         } else {
-          Try(UTF8String.fromString(new SimpleDateFormat(constFormat.toString).format(
+          Try(UTF8String.fromString(formatter.format(
             new java.util.Date(time.asInstanceOf[Long] * 1000L)))).getOrElse(null)
         }
       } else {
@@ -554,6 +561,8 @@ case class FromUnixTime(sec: Expression, format: Expression)
           boolean ${ev.isNull} = true;
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
       } else {
+        val sdfTerm = ctx.freshName("formatter")
+        ctx.addMutableState(sdf, sdfTerm, s"""$sdfTerm = null;""")
         val t = left.genCode(ctx)
         ev.copy(code = s"""
           ${t.code}
@@ -561,7 +570,10 @@ case class FromUnixTime(sec: Expression, format: Expression)
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
           if (!${ev.isNull}) {
             try {
-              ${ev.value} = UTF8String.fromString(new $sdf("${constFormat.toString}").format(
+              if ($sdfTerm == null) {
+                $sdfTerm = new $sdf("${constFormat.toString}");
+              }
+              ${ev.value} = UTF8String.fromString($sdfTerm.format(
                 new java.util.Date(${t.value} * 1000L)));
             } catch (java.lang.Throwable e) {
               ${ev.isNull} = true;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -561,8 +561,8 @@ case class FromUnixTime(sec: Expression, format: Expression)
           boolean ${ev.isNull} = true;
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
       } else {
-        val sdfTerm = ctx.freshName("formatter")
-        ctx.addMutableState(sdf, sdfTerm, s"""$sdfTerm = null;""")
+        val formatter = ctx.freshName("formatter")
+        ctx.addMutableState(sdf, formatter, s"""$formatter = null;""")
         val t = left.genCode(ctx)
         ev.copy(code = s"""
           ${t.code}
@@ -570,10 +570,10 @@ case class FromUnixTime(sec: Expression, format: Expression)
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
           if (!${ev.isNull}) {
             try {
-              if ($sdfTerm == null) {
-                $sdfTerm = new $sdf("${constFormat.toString}");
+              if ($formatter == null) {
+                $formatter = new $sdf("${constFormat.toString}");
               }
-              ${ev.value} = UTF8String.fromString($sdfTerm.format(
+              ${ev.value} = UTF8String.fromString($formatter.format(
                 new java.util.Date(${t.value} * 1000L)));
             } catch (java.lang.Throwable e) {
               ${ev.isNull} = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Here is the generated code snippet when executing date functions. SimpleDateFormat is fairly expensive and can show up bottleneck when processing millions of records. It would be better to instantiate it once.

```
/* 066 */     UTF8String primitive5 = null;
/* 067 */     if (!isNull4) {
/* 068 */       try {
/* 069 */         primitive5 = UTF8String.fromString(new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(
/* 070 */             new java.util.Date(primitive7 * 1000L)));
/* 071 */       } catch (java.lang.Throwable e) {
/* 072 */         isNull4 = true;
/* 073 */       }
/* 074 */     }
```

With modified code, here is the generated code

```
/* 010 */   private java.text.SimpleDateFormat sdf2;
/* 011 */   private UnsafeRow result13;
/* 012 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder bufferHolder14;
/* 013 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter rowWriter15;
/* 014 */
...
...
/* 065 */     boolean isNull0 = isNull3;
/* 066 */     UTF8String primitive1 = null;
/* 067 */     if (!isNull0) {
/* 068 */       try {
/* 069 */         if (sdf2 == null) {
/* 070 */           sdf2 = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
/* 071 */         }
/* 072 */         primitive1 = UTF8String.fromString(sdf2.format(
/* 073 */             new java.util.Date(primitive4 * 1000L)));
/* 074 */       } catch (java.lang.Throwable e) {
/* 075 */         isNull0 = true;
/* 076 */       }
/* 077 */     }
```

Similarly Calendar.getInstance was used in DateTimeUtils which can be lazily inited.
## How was this patch tested?

org.apache.spark.sql.catalyst.expressions.DateExpressionsSuite,org.apache.spark.sql.catalyst.util.DateTimeUtilsSuite
