### PR TITLE
[MINOR]fix typo a -> an

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2707,7 +2707,7 @@ setMethod("histogram",
               # use method describe() to compute statistics in one single pass. The new
               # column must have a name that doesn't exist in the dataset.
               # To do so, we generate a random column name with more characters than the
-              # longest colname in the dataset, but no more than 100 (think of a UUID).
+              # longest colname in the dataset, but no more than 100 (think of an UUID).
               # This column name will never be visible to the user, so the name is irrelevant.
               # Limiting the colname length to 100 makes debugging easier and it does
               # introduce a negligible probability of collision: assuming the user has 1 million

--- a/R/pkg/R/RDD.R
+++ b/R/pkg/R/RDD.R
@@ -599,7 +599,7 @@ setMethod("mapPartitionsWithIndex",
 #' The same as `filter()' in Spark.
 #'
 #' @param x The RDD to be filtered.
-#' @param f A unary predicate function.
+#' @param f An unary predicate function.
 #' @examples
 # nolint start
 #'\dontrun{

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -93,7 +93,7 @@ setMethod("approxCountDistinct",
 #' ascii
 #'
 #' Computes the numeric value of the first character of the string column, and returns the
-#' result as a int column.
+#' result as an int column.
 #'
 #' @rdname ascii
 #' @name ascii
@@ -400,7 +400,7 @@ setMethod("crc32",
 
 #' hash
 #'
-#' Calculates the hash code of given columns, and returns the result as a int column.
+#' Calculates the hash code of given columns, and returns the result as an int column.
 #'
 #' @rdname hash
 #' @name hash

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -35,7 +35,7 @@ setClass("GeneralizedLinearRegressionModel", representation(jobj = "jobj"))
 #' @export
 setClass("NaiveBayesModel", representation(jobj = "jobj"))
 
-#' @title S4 class that represents a AFTSurvivalRegressionModel
+#' @title S4 class that represents an AFTSurvivalRegressionModel
 #' @param jobj a Java object reference to the backing Scala AFTSurvivalRegressionWrapper
 #' @export
 setClass("AFTSurvivalRegressionModel", representation(jobj = "jobj"))

--- a/R/pkg/R/pairRDD.R
+++ b/R/pkg/R/pairRDD.R
@@ -409,7 +409,7 @@ setMethod("reduceByKeyLocally",
 #' might group an RDD of type (Int, Int) into an RDD of type (Int, Seq[Int]).
 #' Users provide three functions:
 #' \itemize{
-#'   \item createCombiner, which turns a V into a C (e.g., creates a one-element list)
+#'   \item createCombiner, which turns a V into a C (e.g., creates an one-element list)
 #'   \item mergeValue, to merge a V into a C (e.g., adds it to the end of a list) -
 #'   \item mergeCombiners, to combine two C's into a single one (e.g., concatentates
 #'    two lists).
@@ -473,7 +473,7 @@ setMethod("combineByKey",
 #' Aggregate the values of each key in an RDD, using given combine functions
 #' and a neutral "zero value". This function can return a different result type,
 #' U, than the type of the values in this RDD, V. Thus, we need one operation
-#' for merging a V into a U and one operation for merging two U's, The former
+#' for merging a V into an U and one operation for merging two U's, The former
 #' operation is used for merging values within a partition, and the latter is
 #' used for merging values between partitions. To avoid memory allocation, both
 #' of these functions are allowed to modify and return their first argument

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -483,7 +483,7 @@ processClosure <- function(node, oldEnv, defVars, checkedFuncs, newEnv) {
 
 # Utility function to get user defined function (UDF) dependencies (closure).
 # More specifically, this function captures the values of free variables defined
-# outside a UDF, and stores them in the function's environment.
+# outside an UDF, and stores them in the function's environment.
 # param
 #   func A function whose closure needs to be captured.
 #   checkedFunc An environment of function objects examined during cleanClosure. It can be

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -391,7 +391,7 @@ test_that("read/write json files", {
   expect_is(df, "SparkDataFrame")
   expect_equal(count(df), 3)
 
-  # Test read.df with a user defined schema
+  # Test read.df with an user defined schema
   schema <- structType(structField("name", type = "string"),
                        structField("age", type = "double"))
 

--- a/R/pkg/inst/tests/testthat/test_utils.R
+++ b/R/pkg/inst/tests/testthat/test_utils.R
@@ -85,7 +85,7 @@ test_that("cleanClosure on R functions", {
   g <- function(x) { x + y }
   f <- function(x) {
     defUse <- base::as.integer(x) + 1  # Test for access operators `::`.
-    lapply(x, g) + 1  # Test for capturing function call "g"'s closure as a argument of lapply.
+    lapply(x, g) + 1  # Test for capturing function call "g"'s closure as an argument of lapply.
     l$field[1, 1] <- 3  # Test for access operators `$`.
     res <- defUse + l$field[1, ]  # Test for def-use chain of "defUse", and "" symbol.
     f(res)  # Test for recursive calls.


### PR DESCRIPTION
## What changes were proposed in this pull request?

a->an
similar to #13515 
Use cmds like `find . -name '*.R' | xargs -i sh -c "grep -in ' a [aeiou]' {} && echo {}"` to generate candidates, and review them one by one.
## How was this patch tested?

N/A
