### PR TITLE
[SPARK-15803][PYSPARK] Support with statement syntax for SparkSession

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -555,6 +555,22 @@ class SparkSession(object):
         """
         self._sc.stop()
 
+    @since(2.0)
+    def __enter__(self):
+        """
+        Enable 'with SparkSession.builder.(...).getOrCreate() as session: app' syntax.
+        """
+        return self
+
+    @since(2.0)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Enable 'with SparkSession.builder.(...).getOrCreate() as session: app' syntax.
+
+        Specifically stop the SparkSession on exit of the with block.
+        """
+        self.stop()
+
 
 def _test():
     import os


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support with statement syntax for SparkSession in pyspark
## How was this patch tested?

Manually verify it. Although I can add unit test for it, it would affect other unit test because the SparkContext is stopped after the with statement. 
