### PR TITLE
[SPARK-15730][SQL] Respect the --hiveconf in the spark-sql command line

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -156,6 +156,9 @@ private[hive] object SparkSQLCLIDriver extends Logging {
     // Execute -i init files (always in silent mode)
     cli.processInitFiles(sessionState)
 
+    // Respect the configurations from the command line and .hiverc for backward-compatible
+    SparkSQLEnv.applyOverridedConf(sessionState)
+
     if (sessionState.execString != null) {
       System.exit(cli.processLine(sessionState.execString))
     }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive.thriftserver
 
 import java.io.PrintStream
 
-import scala.collection.JavaConverters._
+import org.apache.hadoop.hive.ql.session.SessionState
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
@@ -63,6 +63,14 @@ private[hive] object SparkSQLEnv extends Logging {
       sessionState.metadataHive.setInfo(new PrintStream(System.err, true, "UTF-8"))
       sessionState.metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
       sparkSession.conf.set("spark.sql.hive.version", HiveUtils.hiveExecutionVersion)
+    }
+  }
+
+  def applyOverridedConf(ss: SessionState): Unit = {
+    val it = ss.getOverriddenConfigurations.entrySet().iterator()
+    while (it.hasNext) {
+      val kv = it.next()
+      SparkSQLEnv.sqlContext.setConf(kv.getKey, kv.getValue)
     }
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -277,10 +277,10 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("apply hiveconf from cli command") {
     runCliWithin(2.minute)(
-      s"SET conf1;" -> "conftest",
-      s"SET conf2;" -> "1",
-      // bypassed by SparkSQLCLIDriver
-      s"SET ${ConfVars.METASTORECONNECTURLKEY};" -> "undefined"
+      "SET conf1;" -> "conftest",
+      "SET conf2;" -> "1",
+      "SET conf3=${hiveconf:conf1};" -> "conftest",
+      "SET conf3;" -> "conftest"
     )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -91,6 +91,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
          |  --hiveconf ${ConfVars.METASTORECONNECTURLKEY}=$jdbcUrl
          |  --hiveconf ${ConfVars.METASTOREWAREHOUSE}=$warehousePath
          |  --hiveconf ${ConfVars.SCRATCHDIR}=$scratchDirPath
+         |  --hiveconf conf1=conftest
+         |  --hiveconf conf2=1
        """.stripMargin.split("\\s+").toSeq ++ extraArgs
     }
 
@@ -270,6 +272,15 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(2.minute)(
       s"ADD FILE $dataFilePath;" -> "",
       s"LIST FILE $dataFilePath;" -> "small_kv.txt"
+    )
+  }
+
+  test("apply hiveconf from cli command") {
+    runCliWithin(2.minute)(
+      s"SET conf1;" -> "conftest",
+      s"SET conf2;" -> "1",
+      // bypassed by SparkSQLCLIDriver
+      s"SET ${ConfVars.METASTORECONNECTURLKEY};" -> "undefined"
     )
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should respect the --hiveconf in the spark-sql command line, otherwise, the existing applications based on the spark 1.6 and earlier will broke, as the configurations specified via --hiveconf are missing
## How was this patch tested?

I've added the unit test, but still need to be verified with real application.
