### PR TITLE
[SPARK-15820][PySpark][SQL]Add Catalog.refreshTable into python API

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -232,6 +232,11 @@ class Catalog(object):
         """Removes all cached tables from the in-memory cache."""
         self._jcatalog.clearCache()
 
+    @since(2.0)
+    def refreshTable(self, tableName):
+        """Invalidate and refresh all the cached the metadata of the given table."""
+        self._jcatalog.refreshTable(tableName)
+
     def _reset(self):
         """(Internal use only) Drop all existing databases (except "default"), tables,
         partitions and functions, and set the current database to "default".

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -234,7 +234,7 @@ class Catalog(object):
 
     @since(2.0)
     def refreshTable(self, tableName):
-        """Invalidate and refresh all the cached the metadata of the given table."""
+        """Invalidate and refresh all the cached metadata of the given table."""
         self._jcatalog.refreshTable(tableName)
 
     def _reset(self):

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -214,7 +214,7 @@ abstract class Catalog {
   def clearCache(): Unit
 
   /**
-   * Invalidate and refresh all the cached the metadata of the given table. For performance reasons,
+   * Invalidate and refresh all the cached metadata of the given table. For performance reasons,
    * Spark SQL or the external data source library it uses might cache certain metadata about a
    * table, such as the location of blocks. When those change outside of Spark SQL, users should
    * call this function to invalidate the cache.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Catalog.refreshTable API into python interface for Spark-SQL.
## How was this patch tested?

Existing test.
