### PR TITLE
[SPARK-15824][SQL] Run 'with ... insert ... select' failed when use spark thriftserver

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -34,7 +34,7 @@ import org.apache.hive.service.cli.session.HiveSession
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Row => SparkRow, SQLContext}
-import org.apache.spark.sql.execution.command.SetCommand
+import org.apache.spark.sql.execution.command.{ExecutedCommandExec, SetCommand}
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -225,7 +225,10 @@ private[hive] class SparkExecuteStatementOperation(
         if (useIncrementalCollect) {
           result.toLocalIterator.asScala
         } else {
-          result.collect().iterator
+          sqlContext.sessionState.executePlan(result.logicalPlan).executedPlan match {
+            case command: ExecutedCommandExec => command.executeCollectPublic().iterator
+            case _ => result.collect().iterator
+          }
         }
       }
       dataTypes = result.queryExecution.analyzed.output.map(_.dataType).toArray

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -227,7 +227,8 @@ class HiveThriftHttpServerSuite extends HiveThriftJdbcTest {
       val queries = Seq(
         "DROP TABLE IF EXISTS ori",
         "CREATE TABLE ori(key INT, value STRING)",
-        "")
+        "DROP TABLE IF EXISTS result_parquet",
+        "CREATE TABLE result_parquet(key INT, value STRING) STORED AS parquet")
 
       queries.foreach(statement.execute)
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -222,6 +222,20 @@ class HiveThriftHttpServerSuite extends HiveThriftJdbcTest {
     }
   }
 
+  test("SPARK-15824 'with ... insert ...select'") {
+    withJdbcStatement { statement =>
+      val queries = Seq(
+        "DROP TABLE IF EXISTS ori",
+        "CREATE TABLE ori(key INT, value STRING)",
+        "")
+
+      queries.foreach(statement.execute)
+
+      statement.executeQuery(
+        "WITH v as (select 1, 'a') INSERT INTO TABLE result_parquet SELECT * FROM ori")
+    }
+  }
+
   test("test multiple session") {
     import org.apache.spark.sql.internal.SQLConf
     var defaultV1: String = null


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dataset.collect will call withNewExecutionId and InsertIntoHadoopFsRelationCommand also will call withNewExecutionId, then for below SQL will cause IllegalArgumentException(spark.sql.execution.id is already set")

``` sql
create table src(k int, v int);
create table src_parquet(k int, v int) stored as parquet;
with v as (select 1, 2) insert into table src_parquet from src;
```

Usq spark-sql don't have this problem, so do as spark-sql on thriftserver.
## How was this patch tested?

Add new UT
