### PR TITLE
[SPARK-15821] [DOCS] Include parallel build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To build Spark and its example programs, run:
     build/mvn -DskipTests clean package
 
 (You do not need to do this if you downloaded a pre-built package.)
+
+You can build Spark using more than one thread by using the -T option with Maven, see ["Parallel builds in Maven 3"](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3).
 More detailed documentation is available from the project site, at
 ["Building Spark"](http://spark.apache.org/docs/latest/building-spark.html).
 For developing Spark using an IDE, see [Eclipse](https://cwiki.apache.org/confluence/display/SPARK/Useful+Developer+Tools#UsefulDeveloperTools-Eclipse)

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -42,8 +42,6 @@ function exit_with_usage {
   echo "usage:"
   cl_options="[--name] [--tgz] [--mvn <mvn-command>]"
   echo "make-distribution.sh $cl_options <maven build options>"
-  echo "Decrease build times by adding the -T option: -T 1C will result in Maven using one thread per core."
-  echo "For example, dev/make-distribution.sh -T 1C --name hadoop-2.7 -Phadoop-2.7"
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
   echo ""
   exit 1
@@ -55,7 +53,7 @@ while (( "$#" )); do
     --hadoop)
       echo "Error: '--hadoop' is no longer supported:"
       echo "Error: use Maven profiles and options -Dhadoop.version and -Dyarn.version instead."
-      echo "Error: Related profiles include hadoop-2.2, hadoop-2.3, hadoop-2.4 and hadoop-2.7."
+      echo "Error: Related profiles include hadoop-2.2, hadoop-2.3, hadoop-2.4, hadoop-2.6 and hadoop-2.7."
       exit_with_usage
       ;;
     --with-yarn)
@@ -80,10 +78,6 @@ while (( "$#" )); do
     --help)
       exit_with_usage
       ;;
-    -T)
-    NUM_THREADS="$2"
-    shift
-    ;;
     *)
       break
       ;;
@@ -156,13 +150,7 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCac
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
-
-# If NUM_THREADS is set we actually want to add the -T in (removed with shift earlier)
-if [ -n "$NUM_THREADS" ]; then
-  MVN_T_OPTION="-T"
-fi
-
-BUILD_COMMAND=("$MVN" $MVN_T_OPTION $NUM_THREADS clean package -DskipTests $@)
+BUILD_COMMAND=("$MVN" -T 1C clean package -DskipTests $@)
 
 # Actually build the jar
 echo -e "\nBuilding with..."

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -43,7 +43,7 @@ function exit_with_usage {
   cl_options="[--name] [--tgz] [--mvn <mvn-command>]"
   echo "make-distribution.sh $cl_options <maven build options>"
   echo "Decrease build times by adding the -T option: -T 1C will result in Maven using one thread per core."
-  echo "For example, dev/make-distribution.sh -T 1C --name hadoop-2.7.2 -Psparkr -Pyarn -Phadoop-2.7 -Phive -Phive-thriftserver -Dscala-2.11"
+  echo "For example, dev/make-distribution.sh -T 1C --name hadoop-2.7 -Phadoop-2.7"
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
   echo ""
   exit 1

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -42,6 +42,7 @@ function exit_with_usage {
   echo "usage:"
   cl_options="[--name] [--tgz] [--mvn <mvn-command>]"
   echo "make-distribution.sh $cl_options <maven build options>"
+  echo "Decrease build times with the -T option: -T 1C will result in Maven using one thread per core."
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
   echo ""
   exit 1
@@ -53,7 +54,7 @@ while (( "$#" )); do
     --hadoop)
       echo "Error: '--hadoop' is no longer supported:"
       echo "Error: use Maven profiles and options -Dhadoop.version and -Dyarn.version instead."
-      echo "Error: Related profiles include hadoop-2.2, hadoop-2.3 and hadoop-2.4."
+      echo "Error: Related profiles include hadoop-2.2, hadoop-2.3, hadoop-2.4 and hadoop-2.7."
       exit_with_usage
       ;;
     --with-yarn)


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should mention that users can build Spark using multiple threads to decrease build times; either here or in "Building Spark"
## How was this patch tested?

Built on machines with between one core to 192 cores using mvn -T 1C and observed faster build times with no loss in stability

In response to the question here https://issues.apache.org/jira/browse/SPARK-15821 I think we should suggest this option as we know it works for Spark and can result in faster builds
