### PR TITLE
[SPARK-15472][SQL] Add support for writing in `csv`, `json`, `text` formats in Structured Streaming

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/StreamingOutputWriterFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/StreamingOutputWriterFactory.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.{NullWritable, Text}
+import org.apache.hadoop.mapreduce.{OutputCommitter, RecordWriter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat
+
+import org.apache.spark.sql.types.StructType
+
+private[datasources] abstract class StreamingOutputWriterFactory extends OutputWriterFactory {
+
+  /** Create a [[RecordWriter]] that writes the given path without using OutputCommitter */
+  private[datasources] def createNoCommitterTextRecordWriter(
+      path: String,
+      hadoopAttemptContext: TaskAttemptContext,
+      defaultWorkingFileFuc: (TaskAttemptContext, String) => Path
+    ): RecordWriter[NullWritable, Text] = {
+    // Custom OutputFormat that disable use of committer and writes to the given path
+    val outputFormat = new TextOutputFormat[NullWritable, Text]() {
+      override def getOutputCommitter(c: TaskAttemptContext): OutputCommitter = { null }
+      override def getDefaultWorkFile(c: TaskAttemptContext, ext: String): Path = {
+        defaultWorkingFileFuc(c, ext)
+      }
+    }
+    outputFormat.getRecordWriter(hadoopAttemptContext)
+  }
+
+  /** Disable the use of the older API. */
+  override def newInstance(
+      path: String,
+      bucketId: Option[Int],
+      dataSchema: StructType,
+      context: TaskAttemptContext): OutputWriter = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} does not support this version of newInstance")
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -488,7 +488,12 @@ private[sql] class ParquetOutputWriterFactory(
     // Custom ParquetOutputFormat that disable use of committer and writes to the given path
     val outputFormat = new ParquetOutputFormat[InternalRow]() {
       override def getOutputCommitter(c: TaskAttemptContext): OutputCommitter = { null }
-      override def getDefaultWorkFile(c: TaskAttemptContext, ext: String): Path = { new Path(path) }
+      override def getDefaultWorkFile(c: TaskAttemptContext, ext: String): Path = {
+        // It has the `.parquet` extension at the end because (de)compression tools
+        // such as gunzip would not be able to decompress this as the compression
+        // is not applied on this whole file but on each "page" in Parquet format.
+        new Path(s"$path$ext")
+      }
     }
     outputFormat.getRecordWriter(hadoopAttemptContext)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds support for writing in `csv`, `json`, `text` formats in Structured Streaming:

**1. at a high level, this patch forms the following hierarchy**(`text` as an example):

```
                <OutputWriter>
                      ↑
             TextOutputWriterBase
                 ↗          ↖
BatchTextOutputWriter   StreamingTextOutputWriter
```

```
                    <OutputWriterFactory>
                        ↗          ↖
BatchTextOutputWriterFactory   StreamingOutputWriterFactory
                                              ↑
                              StreamingTextOutputWriterFactory
```

The `StreamingTextOutputWriter` and other 'streaming' output writers would write data **without** using an `OutputCommitter`. This was the same approach taken by [SPARK-14716](https://github.com/apache/spark/pull/12409).

**2. to support compression, this patch attaches an extension to the path assigned by `FileStreamSink`**, which is slightly different from [SPARK-14716](https://github.com/apache/spark/pull/12409). For example, if we are writing out using the `gzip` compression and `FileStreamSink` assigns path `${uuid}` to a text writer, then in the end the file written out will be `${uuid}.txt.gz` -- so that when we read the file back, we'll correctly interpret it as `gzip` compressed.
## How was this patch tested?

`FileStreamSinkSuite` is expanded much more to cover the added `csv`, `json`, `text` formats:

``` scala
test(" csv - unpartitioned data - codecs: none/gzip")
test("json - unpartitioned data - codecs: none/gzip")
test("text - unpartitioned data - codecs: none/gzip")

test(" csv - partitioned data - codecs: none/gzip")
test("json - partitioned data - codecs: none/gzip")
test("text - partitioned data - codecs: none/gzip")

test(" csv - unpartitioned writing and batch reading - codecs: none/gzip")
test("json - unpartitioned writing and batch reading - codecs: none/gzip")
test("text - unpartitioned writing and batch reading - codecs: none/gzip")

test(" csv - partitioned writing and batch reading - codecs: none/gzip")
test("json - partitioned writing and batch reading - codecs: none/gzip")
test("text - partitioned writing and batch reading - codecs: none/gzip")
```
