### PR TITLE
[SPARK-15844] [core] HistoryServer doesn't come up if spark.authenticate = true

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -291,26 +291,17 @@ object HistoryServer extends Logging {
 
   /**
    * Create a security manager.
-   * This includes any fixup of the configurations needed to produce a security manager
-   * capable of starting the History Server.
+   * This turns off security in the SecurityManager, so that the the History Server can start
+   * in a Spark cluster where security is enabled.
    * @param config configuration for the SecurityManager constructor
-   * @return
+   * @return the security manager for use in constructing the History Server.
    */
   private[history] def createSecurityManager(config: SparkConf): SecurityManager = {
-    patchSecuritySettings(config)
-    new SecurityManager(config)
-  }
-
-  /**
-   * Fix up the configuration of a spark configuration so that the security manager will
-   * always start.
-   * @param config configuration to be used in a SecurityManager constructor
-   */
-  private def patchSecuritySettings(config: SparkConf): Unit = {
     if (config.getBoolean(SecurityManager.SPARK_AUTH_CONF, false)) {
       logDebug(s"Clearing ${SecurityManager.SPARK_AUTH_CONF}")
       config.set(SecurityManager.SPARK_AUTH_CONF, "false")
     }
+    new SecurityManager(config)
   }
 
   def initSecurity() {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -303,17 +303,13 @@ object HistoryServer extends Logging {
 
   /**
    * Fix up the configuration of a spark configuration so that the security manager will
-   * start. Specifically, if spark authentication is set via an environment variable
-   * or a a spark config option, the configuration must be patched with a dummy authentication
-   * secret.
+   * always start.
    * @param config configuration to be used in a SecurityManager constructor
    */
   private def patchSecuritySettings(config: SparkConf): Unit = {
-    if (config.getBoolean(SecurityManager.SPARK_AUTH_CONF, false)
-        && config.getenv(SecurityManager.ENV_AUTH_SECRET) == null
-        && config.getOption(SecurityManager.SPARK_AUTH_SECRET_CONF).isEmpty) {
-      logDebug(s"Setting ${SecurityManager.SPARK_AUTH_SECRET_CONF} to a dummy value")
-      config.set(SecurityManager.SPARK_AUTH_SECRET_CONF, "dummy")
+    if (config.getBoolean(SecurityManager.SPARK_AUTH_CONF, false)) {
+      logDebug(s"Clearing ${SecurityManager.SPARK_AUTH_CONF}")
+      config.set(SecurityManager.SPARK_AUTH_CONF, "false")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -296,7 +296,7 @@ object HistoryServer extends Logging {
    * @param config configuration for the SecurityManager constructor
    * @return
    */
-  def createSecurityManager(config: SparkConf): SecurityManager = {
+  private[history] def createSecurityManager(config: SparkConf): SecurityManager = {
     patchSecuritySettings(config)
     new SecurityManager(config)
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -288,7 +288,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
 
     provider = new FsHistoryProvider(conf)
     provider.checkForLogs()
-    val securityManager = new SecurityManager(conf)
+    val securityManager = HistoryServer.createSecurityManager(conf)
 
     server = new HistoryServer(conf, provider, securityManager, 18080)
     server.initialize()
@@ -353,7 +353,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
    * Verify that the security manager needed for the history server can be instantiated
    * when `spark.authenticate` is `true`, rather than raise an `IllegalArgumentException`.
    */
-  test("SecurityManagerStartsWithSecureShuffle") {
+  test("security manager starts with spark.authenticate set") {
     val conf = new SparkConf()
       .set("spark.testing", "true")
       .set(SecurityManager.SPARK_AUTH_CONF, "true")

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -352,7 +352,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
   /**
    * Verify that the security manager needed for the history server can be instantiated
    * when `spark.authenticate` is `true`, rather than raise an `IllegalArgumentException`.
-   **/
+   */
   test("SecurityManagerStartsWithSecureShuffle") {
     val conf = new SparkConf()
       .set("spark.testing", "true")

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -75,7 +75,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .set("spark.testing", "true")
     provider = new FsHistoryProvider(conf)
     provider.checkForLogs()
-    val securityManager = new SecurityManager(conf)
+    val securityManager = HistoryServer.createSecurityManager(conf)
 
     server = new HistoryServer(conf, provider, securityManager, 18080)
     server.initialize()
@@ -347,6 +347,15 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       quit()
     }
 
+  /**
+   * Verify that the security manager needed for the history server can be instantiated
+   * even if spark.authenticate is set
+   */
+  test("SecurityManagerStartsWithSecureShuffle") {
+    val conf = new SparkConf()
+        .set("spark.testing", "true")
+        .set(SecurityManager.SPARK_AUTH_CONF, "true")
+    HistoryServer.createSecurityManager(conf)
   }
 
   test("incomplete apps get refreshed") {

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -347,6 +347,8 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       quit()
     }
 
+  }
+
   /**
    * Verify that the security manager needed for the history server can be instantiated
    * even if spark.authenticate is set

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -351,12 +351,12 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
 
   /**
    * Verify that the security manager needed for the history server can be instantiated
-   * even if spark.authenticate is set
-   */
+   * when `spark.authenticate` is `true`, rather than raise an `IllegalArgumentException`.
+   **/
   test("SecurityManagerStartsWithSecureShuffle") {
     val conf = new SparkConf()
-        .set("spark.testing", "true")
-        .set(SecurityManager.SPARK_AUTH_CONF, "true")
+      .set("spark.testing", "true")
+      .set(SecurityManager.SPARK_AUTH_CONF, "true")
     HistoryServer.createSecurityManager(conf)
   }
 
@@ -379,7 +379,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .set("spark.history.cache.window", "250ms")
       .remove("spark.testing")
     val provider = new FsHistoryProvider(myConf)
-    val securityManager = new SecurityManager(myConf)
+    val securityManager = HistoryServer.createSecurityManager(myConf)
 
     sc = new SparkContext("local", "test", myConf)
     val logDirUri = logDir.toURI


### PR DESCRIPTION
## What changes were proposed in this pull request?

During history server startup, the spark configuration is examined. If security.authentication is
set, log at debug and set the value to false, so that {{SecurityManager}} can be created.

## How was this patch tested?

A new test in `HistoryServerSuite` sets the `spark.authenticate` property to true, tries to create a security manager via a new package-private method `HistoryServer.createSecurityManager(SparkConf)`. This is the method used in `HistoryServer.main`. All other instantiations of a security manager in `HistoryServerSuite` have been switched to the new method, for consistency with the production code.
