### PR TITLE
[SPARK-14321][SQL] Reduce date format cost and string-to-date cost in date functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -399,6 +399,8 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
   override def nullable: Boolean = true
 
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
+  private lazy val formatter: SimpleDateFormat =
+    Try(new SimpleDateFormat(constFormat.toString)).getOrElse(null)
 
   override def eval(input: InternalRow): Any = {
     val t = left.eval(input)
@@ -411,11 +413,11 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
         case TimestampType =>
           t.asInstanceOf[Long] / 1000000L
         case StringType if right.foldable =>
-          if (constFormat != null) {
-            Try(new SimpleDateFormat(constFormat.toString).parse(
-              t.asInstanceOf[UTF8String].toString).getTime / 1000L).getOrElse(null)
-          } else {
+          if (constFormat == null || formatter == null) {
             null
+          } else {
+            Try(formatter.parse(
+              t.asInstanceOf[UTF8String].toString).getTime / 1000L).getOrElse(null)
           }
         case StringType =>
           val f = right.eval(input)
@@ -435,12 +437,13 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
       case StringType if right.foldable =>
         val sdf = classOf[SimpleDateFormat].getName
         val fString = if (constFormat == null) null else constFormat.toString
-        val formatter = ctx.freshName("formatter")
         if (fString == null) {
           ev.copy(code = s"""
             boolean ${ev.isNull} = true;
             ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
         } else {
+          val formatter = ctx.freshName("formatter")
+          ctx.addMutableState(sdf, formatter, s"""$formatter = null;""")
           val eval1 = left.genCode(ctx)
           ev.copy(code = s"""
             ${eval1.code}
@@ -448,7 +451,9 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
             ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
             if (!${ev.isNull}) {
               try {
-                $sdf $formatter = new $sdf("$fString");
+                if ($formatter == null) {
+                  $formatter = new $sdf("$fString");
+                }
                 ${ev.value} =
                   $formatter.parse(${eval1.value}.toString()).getTime() / 1000L;
               } catch (java.lang.Throwable e) {
@@ -520,6 +525,8 @@ case class FromUnixTime(sec: Expression, format: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(LongType, StringType)
 
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
+  private lazy val formatter: SimpleDateFormat =
+    Try(new SimpleDateFormat(constFormat.toString)).getOrElse(null)
 
   override def eval(input: InternalRow): Any = {
     val time = left.eval(input)
@@ -527,10 +534,10 @@ case class FromUnixTime(sec: Expression, format: Expression)
       null
     } else {
       if (format.foldable) {
-        if (constFormat == null) {
+        if (constFormat == null || formatter == null) {
           null
         } else {
-          Try(UTF8String.fromString(new SimpleDateFormat(constFormat.toString).format(
+          Try(UTF8String.fromString(formatter.format(
             new java.util.Date(time.asInstanceOf[Long] * 1000L)))).getOrElse(null)
         }
       } else {
@@ -554,6 +561,8 @@ case class FromUnixTime(sec: Expression, format: Expression)
           boolean ${ev.isNull} = true;
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
       } else {
+        val sdfTerm = ctx.freshName("formatter")
+        ctx.addMutableState(sdf, sdfTerm, s"""$sdfTerm = null;""")
         val t = left.genCode(ctx)
         ev.copy(code = s"""
           ${t.code}
@@ -561,7 +570,10 @@ case class FromUnixTime(sec: Expression, format: Expression)
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
           if (!${ev.isNull}) {
             try {
-              ${ev.value} = UTF8String.fromString(new $sdf("${constFormat.toString}").format(
+              if ($sdfTerm == null) {
+                $sdfTerm = new $sdf("${constFormat.toString}");
+              }
+              ${ev.value} = UTF8String.fromString($sdfTerm.format(
                 new java.util.Date(${t.value} * 1000L)));
             } catch (java.lang.Throwable e) {
               ${ev.isNull} = true;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -437,9 +437,7 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
       case StringType if right.foldable =>
         val sdf = classOf[SimpleDateFormat].getName
         if (formatter == null) {
-          ev.copy(code = s"""
-            boolean ${ev.isNull} = true;
-            ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
+          ExprCode("", "true", ctx.defaultValue(dataType))
         } else {
           val formatterName = ctx.addReferenceObj("formatter", formatter, sdf)
           val eval1 = left.genCode(ctx)
@@ -553,9 +551,7 @@ case class FromUnixTime(sec: Expression, format: Expression)
     val sdf = classOf[SimpleDateFormat].getName
     if (format.foldable) {
       if (formatter == null) {
-        ev.copy(code = s"""
-          boolean ${ev.isNull} = true;
-          ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
+        ExprCode("", "true", "(UTF8String) null")
       } else {
         val formatterName = ctx.addReferenceObj("formatter", formatter, sdf)
         val t = left.genCode(ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -561,8 +561,8 @@ case class FromUnixTime(sec: Expression, format: Expression)
           boolean ${ev.isNull} = true;
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
       } else {
-        val sdfTerm = ctx.freshName("formatter")
-        ctx.addMutableState(sdf, sdfTerm, s"""$sdfTerm = null;""")
+        val formatter = ctx.freshName("formatter")
+        ctx.addMutableState(sdf, formatter, s"""$formatter = null;""")
         val t = left.genCode(ctx)
         ev.copy(code = s"""
           ${t.code}
@@ -570,10 +570,10 @@ case class FromUnixTime(sec: Expression, format: Expression)
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
           if (!${ev.isNull}) {
             try {
-              if ($sdfTerm == null) {
-                $sdfTerm = new $sdf("${constFormat.toString}");
+              if ($formatter == null) {
+                $formatter = new $sdf("${constFormat.toString}");
               }
-              ${ev.value} = UTF8String.fromString($sdfTerm.format(
+              ${ev.value} = UTF8String.fromString($formatter.format(
                 new java.util.Date(${t.value} * 1000L)));
             } catch (java.lang.Throwable e) {
               ${ev.isNull} = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current implementations of `UnixTime` and `FromUnixTime` do not cache their parser/formatter as much as they could. This PR resolved this issue.

This PR is a take over from https://github.com/apache/spark/pull/13522 and further optimizes the re-use of the parser/formatter. It also fixes the improves handling (catching the actual exception instead of `Throwable`). All credits for this work should go to @rajeshbalamohan.

This PR closes https://github.com/apache/spark/pull/13522
## How was this patch tested?

Current tests.
