### PR TITLE
[SPARK-15853][SQL]HDFSMetadataLog.get should close the input stream

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -175,8 +175,12 @@ class HDFSMetadataLog[T: ClassTag](sparkSession: SparkSession, path: String)
     val batchMetadataFile = batchIdToPath(batchId)
     if (fileManager.exists(batchMetadataFile)) {
       val input = fileManager.open(batchMetadataFile)
-      val bytes = IOUtils.toByteArray(input)
-      Some(deserialize(bytes))
+      try {
+        val bytes = IOUtils.toByteArray(input)
+        Some(deserialize(bytes))
+      } finally {
+        input.close()
+      }
     } else {
       logDebug(s"Unable to find batch $batchMetadataFile")
       None


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR closes the input stream created in `HDFSMetadataLog.get`
## How was this patch tested?

Jenkins unit tests.
