### PR TITLE
[SPARK-15859][SQL] Optimize the partition pruning within the disjunction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -94,19 +94,19 @@ object PhysicalOperation extends PredicateHelper {
   }
 
   /**
-   * Drop the non-partition key expression in the disjunctions, to optimize the partition pruning.
-   * For instances: (We assume part1 & part2 are the partition keys)
+   * Drop the non-partition key expression from the given expression, to optimize the
+   * partition pruning. For instances: (We assume part1 & part2 are the partition keys):
    * (part1 == 1 and a > 3) or (part2 == 2 and a < 5)  ==> (part1 == 1 or part1 == 2)
    * (part1 == 1 and a > 3) or (a < 100) => None
    * (a > 100 && b < 100) or (part1 = 10) => None
    * (a > 100 && b < 100 and part1 = 10) or (part1 == 2) => (part1 = 10 or part1 == 2)
-   * @param predicate disjunctions
+   * @param predicate The given expression
    * @param partitionKeyIds partition keys in attribute set
    * @return
    */
-  def partitionPrunningFromDisjunction(
+  def extractPartitionKeyExpression(
     predicate: Expression, partitionKeyIds: AttributeSet): Option[Expression] = {
-    // ignore the pure non-partition key expression in conjunction of the expression tree
+    // drop the non-partition key expression in conjunction of the expression tree
     val additionalPartPredicate = predicate transformUp {
       case a @ And(left, right) if a.deterministic &&
         left.references.intersect(partitionKeyIds).isEmpty => right

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -92,6 +92,36 @@ object PhysicalOperation extends PredicateHelper {
           .map(Alias(_, a.name)(a.exprId, a.qualifier, isGenerated = a.isGenerated)).getOrElse(a)
     }
   }
+
+  /**
+   * Drop the non-partition key expression in the disjunctions, to optimize the partition pruning.
+   * For instances: (We assume part1 & part2 are the partition keys)
+   * (part1 == 1 and a > 3) or (part2 == 2 and a < 5)  ==> (part1 == 1 or part1 == 2)
+   * (part1 == 1 and a > 3) or (a < 100) => None
+   * (a > 100 && b < 100) or (part1 = 10) => None
+   * (a > 100 && b < 100 and part1 = 10) or (part1 == 2) => (part1 = 10 or part1 == 2)
+   * @param predicate disjunctions
+   * @param partitionKeyIds partition keys in attribute set
+   * @return
+   */
+  def partitionPrunningFromDisjunction(
+    predicate: Expression, partitionKeyIds: AttributeSet): Option[Expression] = {
+    // ignore the pure non-partition key expression in conjunction of the expression tree
+    val additionalPartPredicate = predicate transformUp {
+      case a @ And(left, right) if a.deterministic &&
+        left.references.intersect(partitionKeyIds).isEmpty => right
+      case a @ And(left, right) if a.deterministic &&
+        right.references.intersect(partitionKeyIds).isEmpty => left
+    }
+
+    if (additionalPartPredicate.references.nonEmpty &&
+      additionalPartPredicate.references.subsetOf(partitionKeyIds)) {
+      // the expression attribute keys are all from the partition keys
+      Some(additionalPartPredicate)
+    } else {
+      None
+    }
+  }
 }
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -65,15 +65,20 @@ private[hive] trait HiveStrategies {
         // hive table scan operator to be used for partition pruning.
         val partitionKeyIds = AttributeSet(relation.partitionKeys)
         val (pruningPredicates, otherPredicates) = predicates.partition { predicate =>
-          !predicate.references.isEmpty &&
+          predicate.references.nonEmpty &&
           predicate.references.subsetOf(partitionKeyIds)
         }
+        val additionalPartPredicates =
+          PhysicalOperation.partitionPrunningFromDisjunction(
+            otherPredicates.foldLeft[Expression](Literal(true))(And(_, _)), partitionKeyIds)
 
         pruneFilterProject(
           projectList,
           otherPredicates,
           identity[Seq[Expression]],
-          HiveTableScanExec(_, relation, pruningPredicates)(sparkSession)) :: Nil
+        HiveTableScanExec(_,
+            relation,
+            pruningPredicates ++ additionalPartPredicates)(sparkSession)) :: Nil
       case _ =>
         Nil
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -69,7 +69,7 @@ private[hive] trait HiveStrategies {
           predicate.references.subsetOf(partitionKeyIds)
         }
         val additionalPartPredicates =
-          PhysicalOperation.partitionPrunningFromDisjunction(
+          PhysicalOperation.extractPartitionKeyExpression(
             otherPredicates.foldLeft[Expression](Literal(true))(And(_, _)), partitionKeyIds)
 
         pruneFilterProject(


### PR DESCRIPTION
## What changes were proposed in this pull request?

The typical query may looks like: (part1 is the partition key)

``` sql
SELECT * FROM table WHERE (part1 = 1 AND id > 12) OR (part1 = 5 AND id < 100)
```

Currently, Spark will ignore the partition key in the disjunction, and causes full table scan, however, only 2 partitions required. This PR aims to drop the non-partition keys from the filter and try to extract the partition key expressions for partition pruning.

For instance:

``` scala
(part1 = 1 AND id > 12) OR (part1 = 5 AND id < 100) ==> (part1 = 1) OR (part1 = 5)
(part1 = 1 AND a > 3) OR (part2 = 2 AND a < 5)  ==> (part1 = 1 or part1 = 2)
(part1 = 1 AND a > 3) OR (a < 100) => None
(a > 100 AND b < 100) OR (part1 = 10) => None
(a > 100 AND b < 100 AND part1 = 10) OR (part1 = 2) => (part1 = 10 or part1 = 2)
```

This PR will only works for the HiveTableScan, will submit another PR to optimize the data source API back-end scan.
## How was this patch tested?

The unit test is also included in this PR.
