### PR TITLE
SPARK-15858: Fix calculating error by tree stack over flow problem an…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -205,31 +205,24 @@ private[spark] object GradientBoostedTrees extends Logging {
       case _ => data
     }
 
-    val numIterations = trees.length
-    val evaluationArray = Array.fill(numIterations)(0.0)
-    val localTreeWeights = treeWeights
-
-    var predictionAndError = computeInitialPredictionAndError(
-      remappedData, localTreeWeights(0), trees(0), loss)
-
-    evaluationArray(0) = predictionAndError.values.mean()
-
     val broadcastTrees = sc.broadcast(trees)
-    (1 until numIterations).foreach { nTree =>
-      predictionAndError = remappedData.zip(predictionAndError).mapPartitions { iter =>
-        val currentTree = broadcastTrees.value(nTree)
-        val currentTreeWeight = localTreeWeights(nTree)
-        iter.map { case (point, (pred, error)) =>
-          val newPred = updatePrediction(point.features, pred, currentTree, currentTreeWeight)
-          val newError = loss.computeError(newPred, point.label)
-          (newPred, newError)
-        }
-      }
-      evaluationArray(nTree) = predictionAndError.values.mean()
-    }
+    val localTreeWeights = treeWeights
+    val treesIndices = trees.indices
 
-    broadcastTrees.unpersist()
-    evaluationArray
+    val dataCount = remappedData.count()
+    val evaluation = remappedData
+      .map { (point: LabeledPoint) =>
+        treesIndices
+          .map(idx => broadcastTrees.value(idx).rootNode.predictImpl(point.features).prediction * localTreeWeights(idx))
+          .scanLeft(0.0)(_ + _).drop(1)
+          .map(prediction => loss.computeError(prediction, point.label))
+      }
+      .aggregate(treesIndices.map(_ => 0.0))(
+        (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
+        (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
+      .map(d => d / dataCount)
+    broadcastTrees.destroy()
+    evaluation.toArray
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -213,7 +213,14 @@ private[spark] object GradientBoostedTrees extends Logging {
     val evaluation = remappedData
       .map { (point: LabeledPoint) =>
         treesIndices
-          .map(idx => broadcastTrees.value(idx).rootNode.predictImpl(point.features).prediction * localTreeWeights(idx))
+          .map (idx => {
+            val prediction = broadcastTrees
+              .value(idx)
+              .rootNode
+              .predictImpl(point.features)
+              .prediction
+            prediction * localTreeWeights(idx)
+          })
           .scanLeft(0.0)(_ + _).drop(1)
           .map(prediction => loss.computeError(prediction, point.label))
       }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
@@ -151,31 +151,24 @@ class GradientBoostedTreesModel @Since("1.2.0") (
       case _ => data
     }
 
-    val numIterations = trees.length
-    val evaluationArray = Array.fill(numIterations)(0.0)
-    val localTreeWeights = treeWeights
-
-    var predictionAndError = GradientBoostedTreesModel.computeInitialPredictionAndError(
-      remappedData, localTreeWeights(0), trees(0), loss)
-
-    evaluationArray(0) = predictionAndError.values.mean()
-
     val broadcastTrees = sc.broadcast(trees)
-    (1 until numIterations).foreach { nTree =>
-      predictionAndError = remappedData.zip(predictionAndError).mapPartitions { iter =>
-        val currentTree = broadcastTrees.value(nTree)
-        val currentTreeWeight = localTreeWeights(nTree)
-        iter.map { case (point, (pred, error)) =>
-          val newPred = pred + currentTree.predict(point.features) * currentTreeWeight
-          val newError = loss.computeError(newPred, point.label)
-          (newPred, newError)
-        }
-      }
-      evaluationArray(nTree) = predictionAndError.values.mean()
-    }
+    val localTreeWeights = treeWeights
+    val treesIndices = trees.indices
 
-    broadcastTrees.unpersist()
-    evaluationArray
+    val dataCount = remappedData.count()
+    val evaluation = remappedData
+      .map { (point: LabeledPoint) =>
+        treesIndices
+          .map(idx => broadcastTrees.value(idx).predict(point.features) * localTreeWeights(idx))
+          .scanLeft(0.0)(_ + _).drop(1)
+          .map(prediction => loss.computeError(prediction, point.label))
+      }
+      .aggregate(treesIndices.map(_ => 0.0))(
+        (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
+        (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
+      .map(d => d / dataCount)
+    broadcastTrees.destroy()
+    evaluation.toArray
   }
 
   override protected def formatVersion: String = GradientBoostedTreesModel.formatVersion


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improving evaluateEachIteration function in mllib as it fails when trying to calculate error by tree for a model that has more than 500 trees
## How was this patch tested?

the batch tested on productions data set (2K rows x 2K features) training a gradient boosted model without validation with 1000 maxIteration settings, then trying to produce the error by tree, the new patch was able to perform the calculation within 30 seconds, while previously it was take hours then fail.
