### PR TITLE
[SPARK-15871][SQL] Add `assertNotPartitioned` check in `DataFrameWriter`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -62,19 +62,19 @@ class BucketedWriteSuite extends QueryTest with SQLTestUtils with TestHiveSingle
   test("write bucketed data using save()") {
     val df = Seq(1 -> "a", 2 -> "b").toDF("i", "j")
 
-    val e = intercept[IllegalArgumentException] {
+    val e = intercept[AnalysisException] {
       df.write.bucketBy(2, "i").parquet("/tmp/path")
     }
-    assert(e.getMessage == "'save' does not support bucketing right now.")
+    assert(e.getMessage == "'save' does not support bucketing right now;")
   }
 
   test("write bucketed data using insertInto()") {
     val df = Seq(1 -> "a", 2 -> "b").toDF("i", "j")
 
-    val e = intercept[IllegalArgumentException] {
+    val e = intercept[AnalysisException] {
       df.write.bucketBy(2, "i").insertInto("tt")
     }
-    assert(e.getMessage == "'insertInto' does not support bucketing right now.")
+    assert(e.getMessage == "'insertInto' does not support bucketing right now;")
   }
 
   private val df = (0 until 50).map(i => (i % 5, i % 13, i.toString)).toDF("i", "j", "k")


### PR DESCRIPTION
## What changes were proposed in this pull request?

It doesn't make sense to specify partitioning parameters, when we write data out from Datasets/DataFrames into `jdbc` tables or streaming `ForeachWriter`s.

This patch adds `assertNotPartitioned` check in `DataFrameWriter`.

<table>
<tr>
    <td align="center"><strong>operation</strong></td>
    <td align="center"><strong>should check not partitioned?</strong></td>
</tr>
<tr>
    <td align="center">mode</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">outputMode</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">trigger</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">format</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">option/options</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">partitionBy</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">bucketBy</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">sortBy</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">save</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">queryName</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">startStream</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">foreach</td>
    <td align="center">yes</td>
</tr>
<tr>
    <td align="center">insertInto</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">saveAsTable</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">jdbc</td>
    <td align="center">yes</td>
</tr>
<tr>
    <td align="center">json</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">parquet</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">orc</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">text</td>
    <td align="center"></td>
</tr>
<tr>
    <td align="center">csv</td>
    <td align="center"></td>
</tr>
</table>

## How was this patch tested?

New dedicated tests.
