### PR TITLE
[SPARK-15851] [Build] Fix the call of the bash script to enable proper run in Windows

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -357,7 +357,8 @@
             <configuration>
               <!-- Execute the shell script to generate the spark build information. -->
               <tasks>
-                <exec executable="${project.basedir}/../build/spark-build-info">
+                <exec executable="bash">
+		  <arg value="${project.basedir}/../build/spark-build-info"/>
                   <arg value="${project.build.directory}/extra-resources"/>
                   <arg value="${pom.version}"/>
                 </exec>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -458,7 +458,7 @@ object Core {
     resourceGenerators in Compile += Def.task {
       val buildScript = baseDirectory.value + "/../build/spark-build-info"
       val targetDir = baseDirectory.value + "/target/extra-resources/"
-      val command =  buildScript + " " + targetDir + " " + version.value
+      val command =  "bash " + buildScript + " " + targetDir + " " + version.value
       Process(command).!!
       val propsFile = baseDirectory.value / "target" / "extra-resources" / "spark-version-info.properties"
       Seq(propsFile)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The way bash script `build/spark-build-info` is called from `core/pom.xml` prevents Spark building on Windows. Instead of calling the script directly we call `bash` and pass the script as an argument. This enables running it on Windows with bash installed which typically comes with Git.
## How was this patch tested?

Build tested on Windows 7 and Red Hat Enterprise Linux Server release 6.8 
