### PR TITLE
[SPARK-10408] [ML] Implement stacked autoencoder

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/ann/LossFunction.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/ann/LossFunction.scala
@@ -122,3 +122,63 @@ private[ann] class SoftmaxLayerModelWithCrossEntropyLoss extends LayerModel with
     -Bsum( target :* brzlog(output)) / output.cols
   }
 }
+
+private[ml] class EmptyLayerWithSquaredError extends Layer {
+  override val weightSize = 0
+  override def getOutputSize(inputSize: Int): Int = inputSize
+  override val inPlace = true
+  override def createModel(weights: BDV[Double]): LayerModel =
+    new EmptyLayerModelWithSquaredError()
+  override def initModel(weights: BDV[Double], random: Random): LayerModel =
+    new EmptyLayerModelWithSquaredError()
+}
+
+private[ann] class EmptyLayerModelWithSquaredError extends LayerModel with LossFunction {
+
+  val weights = new BDV[Double](0)
+
+  override def loss(output: BDM[Double], target: BDM[Double], delta: BDM[Double]): Double = {
+    ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)
+    Bsum(delta :* delta) / 2 / output.cols
+  }
+
+  override def eval(data: BDM[Double], output: BDM[Double]): Unit = {}
+  override def computePrevDelta(
+                                 nextDelta: BDM[Double],
+                                 input: BDM[Double],
+                                 delta: BDM[Double]): Unit = {}
+  override def grad(delta: BDM[Double], input: BDM[Double], cumGrad: BDV[Double]): Unit = {}
+}
+
+private[ml] class SigmoidLayerWithCrossEntropyLoss extends Layer {
+  override val weightSize = 0
+  override def getOutputSize(inputSize: Int): Int = inputSize
+  override val inPlace = true
+  override def createModel(weights: BDV[Double]): LayerModel =
+    new SigmoidLayerModelWithCrossEntropyLoss()
+  override def initModel(weights: BDV[Double], random: Random): LayerModel =
+    new SigmoidLayerModelWithCrossEntropyLoss()
+}
+
+private[ann] class SigmoidLayerModelWithCrossEntropyLoss
+  extends FunctionalLayerModel(new FunctionalLayer(new SigmoidFunction)) with LossFunction {
+  // TODO: make a common place where ones matrices reside
+  private var oneMatrix: BDM[Double] = null
+  private val epsilon = 1e-15
+  private var epsilonMatrix: BDM[Double] = null
+
+  override def loss(output: BDM[Double], target: BDM[Double], delta: BDM[Double]): Double = {
+    if (oneMatrix == null || oneMatrix.cols != target.cols) {
+      oneMatrix = BDM.ones[Double](target.rows, target.cols)
+    }
+    if (epsilonMatrix == null || epsilonMatrix.cols != target.cols) {
+      epsilonMatrix = BDM.fill[Double](target.rows, target.cols)(epsilon)
+    }
+    ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)
+    // NB: operation :* don't have execution priority over summation
+    // TODO: is adding epsilon a good way to fight log(o) ?
+    -Bsum((target :* brzlog(output + epsilonMatrix)) +
+      ((oneMatrix - target) :* brzlog(oneMatrix - output + epsilonMatrix))) / output.cols
+  }
+}
+

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
@@ -32,7 +32,7 @@ import org.apache.spark.ml.util._
 import org.apache.spark.sql.Dataset
 
 /** Params for Multilayer Perceptron. */
-private[classification] trait MultilayerPerceptronParams extends PredictorParams
+private[ml] trait MultilayerPerceptronParams extends PredictorParams
   with HasSeed with HasMaxIter with HasTol with HasStepSize {
   /**
    * Layer sizes including input size and output size.

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StackedAutoencoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StackedAutoencoder.scala
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import breeze.linalg.{DenseVector => BDV}
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.ann._
+import org.apache.spark.ml.classification.MultilayerPerceptronParams
+import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
+import org.apache.spark.ml.param.{BooleanParam, ParamMap, Params}
+import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.storage.StorageLevel
+
+/**
+ * Params for [[StackedAutoencoder]].
+ */
+private[feature] trait StackedAutoencoderParams extends Params with HasInputCol with HasOutputCol {
+  /**
+   * True if data is in [0, 1] interval.
+   * Default: false
+   * @group expertParam
+   */
+  final val dataIn01Interval: BooleanParam = new BooleanParam(this, "dataIn01Interval",
+    "True if data is in [0, 1] interval." +
+      " Sets the layer on the top of the autoencoder: linear + sigmoid (true) " +
+      " or linear (false)")
+
+  /** @group getParam */
+  final def getDataIn01Interval: Boolean = $(dataIn01Interval)
+
+  /**
+   * True if one wants to have decoder.
+   * Default: false
+   * @group expertParam
+   */
+  final val buildDecoder: BooleanParam = new BooleanParam(this, "buildDecoder",
+    "True to produce a decoder.")
+
+  /** @group getParam */
+  final def getBuildDecoder: Boolean = $(buildDecoder)
+
+  /**
+   * True to cache the intermediate data in memory. Otherwise disk caching is used.
+   * Default: true
+   * @group expertParam
+   */
+  final val memoryOnlyCaching: BooleanParam = new BooleanParam(this, "memoryOnlyCaching",
+    "True to cache the intermediate data in memory only.")
+
+  /** @group getParam */
+  final def getMemoryOnlyCaching: Boolean = $(memoryOnlyCaching)
+
+  setDefault(dataIn01Interval -> true, buildDecoder -> false, memoryOnlyCaching -> true)
+}
+
+
+@Experimental
+class StackedAutoencoder (override val uid: String)
+  extends Estimator[StackedAutoencoderModel]
+  with MultilayerPerceptronParams with StackedAutoencoderParams {
+
+  def this() = this(Identifiable.randomUID("stackedAutoencoder"))
+
+  /** @group setParam */
+  def setDataIn01Interval(value: Boolean): this.type = set(dataIn01Interval, value)
+
+  /** @group setParam */
+  def setBuildDecoder(value: Boolean): this.type = set(buildDecoder, value)
+
+  // TODO: make sure that user understands how to set it. Make correctness check
+  /** @group setParam */
+  def setLayers(value: Array[Int]): this.type = set(layers, value)
+
+  /** @group setParam */
+  def setBlockSize(value: Int): this.type = set(blockSize, value)
+
+  /** @group setParam */
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /**
+   * Set the maximum number of iterations.
+   * Default is 100.
+   * @group setParam
+   */
+  def setMaxIter(value: Int): this.type = set(maxIter, value)
+
+  /**
+   * Set the convergence tolerance of iterations.
+   * Smaller value will lead to higher accuracy with the cost of more iterations.
+   * Default is 1E-4.
+   * @group setParam
+   */
+  def setTol(value: Double): this.type = set(tol, value)
+
+  /**
+   * Set the seed for weights initialization.
+   * @group setParam
+   */
+  def setSeed(value: Long): this.type = set(seed, value)
+
+  /**
+   * Set the model weights.
+   * @group setParam
+   */
+  def setInitialWeights(value: Vector): this.type = set(initialWeights, value)
+
+  /**
+   * Fits a model to the input data.
+   */
+  override def fit(dataset: Dataset[_]): StackedAutoencoderModel = {
+    val storageLevel =
+      if ($(memoryOnlyCaching)) StorageLevel.MEMORY_ONLY else StorageLevel.DISK_ONLY
+    var stackedEncoderOffset = 0
+    val stackedEncoderWeights = if (!this.isSet(this.initialWeights)) {
+      val size =
+        FeedForwardTopology.multiLayerPerceptron($(layers)).layers.foldLeft(0)( (b, layer) =>
+          b + layer.weightSize)
+      new Array[Double](size)
+    } else {
+      $(initialWeights).toArray
+    }
+    // decoder if needed
+    var stackedDecoderOffset = 0
+    val decoderLayers = $(layers).reverse
+    val stackedDecoderWeights: Array[Double] = if ($(buildDecoder)) {
+      val size =
+        FeedForwardTopology.multiLayerPerceptron(decoderLayers).layers.foldLeft(0)( (b, layer) =>
+          b + layer.weightSize)
+      stackedDecoderOffset = size
+      new Array[Double](size)
+    } else {
+      new Array[Double](0)
+    }
+    // TODO: use single instance of vectors
+    var data = dataset.select($(inputCol)).rdd.map { case Row(x: Vector) => (x, x) }
+    var previousData = data
+    val linearInput = !$(dataIn01Interval)
+    // Train autoencoder for each layer except the last
+    for (i <- 0 until $(layers).length - 1) {
+      val currentLayers = Array($(layers)(i), $(layers)(i + 1), $(layers)(i))
+      val currentTopology = FeedForwardTopology.multiLayerPerceptron(currentLayers, false)
+      val isLastLayer = i == $(layers).length - 2
+      val isFirstLayer = i == 0
+      if (isFirstLayer && linearInput) {
+        currentTopology.layers(currentTopology.layers.length - 1) = new EmptyLayerWithSquaredError()
+      }
+      val FeedForwardTrainer =
+        new FeedForwardTrainer(currentTopology, currentLayers(0), currentLayers.last)
+          .setStackSize($(blockSize))
+          .setSeed($(seed))
+      FeedForwardTrainer.LBFGSOptimizer
+        .setConvergenceTol($(tol))
+        .setNumIterations($(maxIter))
+      val currentModel = FeedForwardTrainer.train(data)
+      val currentWeights = currentModel.weights.toArray
+      val encoderWeightSize = currentTopology.layers(0).weightSize
+      System.arraycopy(
+        currentWeights, 0, stackedEncoderWeights, stackedEncoderOffset, encoderWeightSize)
+      stackedEncoderOffset += encoderWeightSize
+      // input data for the next autoencoder in the stack
+      if (!isLastLayer) { // intermediate layers
+        val encoderTopology = FeedForwardTopology.multiLayerPerceptron(currentLayers.init, false)
+        // Due to Vector inefficiency it will copy weights
+        val encoderModel = encoderTopology.model(
+          Vectors.fromBreeze(new BDV[Double](currentWeights, 0, 1, encoderWeightSize)))
+        // TODO: perform block operations
+        previousData = data
+        data = data.map { x =>
+          val y = encoderModel.predict(x._1)
+          (y, y)
+        }
+        // persist and materialize the intermediate data
+        data.persist(storageLevel)
+        data.count()
+        // unpersist the data that is persisted inside the loop
+        if (!isFirstLayer) previousData.unpersist()
+      } else { // last layer
+        // unpersist the data that remains from the last intermediate layer
+        if (!isFirstLayer) data.unpersist()
+      }
+      // if needs decoder
+      if ($(buildDecoder)) {
+        val decoderWeightSize = currentWeights.length - encoderWeightSize
+        stackedDecoderOffset -= decoderWeightSize
+        System.arraycopy(currentWeights, encoderWeightSize, stackedDecoderWeights,
+          stackedDecoderOffset, decoderWeightSize)
+      }
+    }
+    new StackedAutoencoderModel(uid + "model", $(layers), Vectors.dense(stackedEncoderWeights),
+      Vectors.dense(stackedDecoderWeights), linearInput)
+  }
+
+  override def copy(extra: ParamMap): Estimator[StackedAutoencoderModel] = defaultCopy(extra)
+
+  /**
+   * :: DeveloperApi ::
+   *
+   * Derives the output schema from the input schema.
+   */
+  override def transformSchema(schema: StructType): StructType = {
+    val inputType = schema($(inputCol)).dataType
+    require(inputType.isInstanceOf[VectorUDT],
+      s"Input column ${$(inputCol)} must be a vector column")
+    require(!schema.fieldNames.contains($(outputCol)),
+      s"Output column ${$(outputCol)} already exists.")
+    val outputFields = schema.fields :+ StructField($(outputCol), new VectorUDT, false)
+    StructType(outputFields)
+  }
+}
+
+@Experimental
+class StackedAutoencoderModel private[ml] (
+    override val uid: String,
+    val layers: Array[Int],
+    val encoderWeights: Vector,
+    val decoderWeights: Vector,
+    linearOutput: Boolean) extends Model[StackedAutoencoderModel] with StackedAutoencoderParams {
+
+  /** @group setParam */
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  private val encoderModel = {
+    val topology = FeedForwardTopology.multiLayerPerceptron(layers, false)
+    topology.model(encoderWeights)
+  }
+
+  private val decoderModel = {
+    if (decoderWeights != null && decoderWeights.size > 0) {
+      val topology = FeedForwardTopology.multiLayerPerceptron(layers.reverse, false)
+      if (linearOutput) {
+        topology.layers(topology.layers.length - 1) = new EmptyLayerWithSquaredError()
+      }
+      topology.model(decoderWeights)
+    } else {
+      null
+    }
+  }
+
+  override def copy(extra: ParamMap): StackedAutoencoderModel = {
+    copyValues(
+      new StackedAutoencoderModel(uid, layers, encoderWeights, decoderWeights, linearOutput), extra)
+  }
+
+  /**
+   * Transforms the input dataset.
+   */
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
+    val pcaOp = udf { encoderModel.predict _ }
+    dataset.withColumn($(outputCol), pcaOp(col($(inputCol))))
+  }
+
+  def encode(dataset: DataFrame): DataFrame = transform(dataset)
+
+  def decode(dataset: DataFrame): DataFrame = {
+    // TODO: show something if no decoder
+    transformSchema(dataset.schema, logging = true)
+    val pcaOp = udf { decoderModel.predict _ }
+    dataset.withColumn($(outputCol), pcaOp(col($(inputCol))))
+  }
+
+  /**
+   * :: DeveloperApi ::
+   *
+   * Derives the output schema from the input schema.
+   */
+  override def transformSchema(schema: StructType): StructType = {
+    val inputType = schema($(inputCol)).dataType
+    require(inputType.isInstanceOf[VectorUDT],
+      s"Input column ${$(inputCol)} must be a vector column")
+    require(!schema.fieldNames.contains($(outputCol)),
+      s"Output column ${$(outputCol)} already exists.")
+    val outputFields = schema.fields :+ StructField($(outputCol), new VectorUDT, false)
+    StructType(outputFields)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/ann/GradientSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/ann/GradientSuite.scala
@@ -32,7 +32,9 @@ class GradientSuite extends SparkFunSuite with MLlibTestSparkContext {
     val topology = FeedForwardTopology.multiLayerPerceptron(Array(3, 4, 2), softmaxOnTop = false)
     val layersWithErrors = Seq(
       new SigmoidLayerWithSquaredError(),
-      new SoftmaxLayerWithCrossEntropyLoss()
+      new SoftmaxLayerWithCrossEntropyLoss(),
+      new SigmoidLayerWithCrossEntropyLoss(),
+      new EmptyLayerWithSquaredError()
     )
     // check all layers that provide loss computation
     // 1) compute loss and gradient given the model and initial weights

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StackedAutoencoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StackedAutoencoderSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.ml.feature
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.classification.MultilayerPerceptronClassifier
 import org.apache.spark.ml.linalg.{Vector, Vectors}
-import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.Row
 
 class StackedAutoencoderSuite extends SparkFunSuite with MLlibTestSparkContext {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StackedAutoencoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StackedAutoencoderSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.classification.MultilayerPerceptronClassifier
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.sql.Row
+
+class StackedAutoencoderSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  // using data similar to https://inst.eecs.berkeley.edu/~cs182/sp08/assignments/a3-tlearn.html
+  val binaryData = Seq(
+    Vectors.dense(Array(1.0, 0.0, 0.0, 0.0)),
+    Vectors.dense(Array(0.0, 1.0, 0.0, 0.0)),
+    Vectors.dense(Array(0.0, 0.0, 1.0, 0.0)),
+    Vectors.dense(Array(0.0, 0.0, 0.0, 1.0)))
+
+  val real01Data = Seq(
+    Vectors.dense(Array(0.5, 0.1, 0.1, 0.1)),
+    Vectors.dense(Array(0.1, 0.6, 0.5, 0.5)),
+    Vectors.dense(Array(0.5, 0.5, 0.5, 0.5)),
+    Vectors.dense(Array(0.9, 0.9, 0.9, 0.9)))
+
+  val realData = Seq(
+    Vectors.dense(Array(10.0, 0.0, 0.0, 0.0)),
+    Vectors.dense(Array(0.0, 1.0, 0.0, 0.0)),
+    Vectors.dense(Array(0.0, 0.0, 10.0, 0.0)),
+    Vectors.dense(Array(0.0, 0.0, 0.0, 10.0)))
+
+  test("Autoencoder reconstructs the original data by encoding and decoding") {
+    val dataSets = Seq(binaryData, real01Data, realData)
+    val dataTypes = Seq(true, true, false)
+    val dataSetAndTypes = dataSets.zip(dataTypes)
+    for ((data, is01) <- dataSetAndTypes) {
+      val rdd = sc.parallelize(data, 1).map(x => Tuple1(x))
+      val df = spark.createDataFrame(rdd).toDF("input")
+      val stackedAutoencoder = new StackedAutoencoder()
+        .setLayers(Array(4, 3, 3))
+        .setBlockSize(1)
+        .setMaxIter(100)
+        .setSeed(11L)
+        .setTol(1e-6)
+        .setInputCol("input")
+        .setOutputCol("output")
+        .setDataIn01Interval(is01)
+        .setBuildDecoder(true)
+      // TODO: find a way to inherit the input and output parameter value from estimator
+      val saModel = stackedAutoencoder.fit(df)
+      saModel.setInputCol("input").setOutputCol("encoded")
+      // encoding
+      val encodedData = saModel.transform(df)
+      // decoding
+      saModel.setInputCol("encoded").setOutputCol("decoded")
+      val decodedData = saModel.decode(encodedData)
+      // epsilon == 1/100 of the maximum value
+      val eps = if (is01) 1.0 / 100 else 10.0 / 100
+      decodedData.collect.foreach { case Row(input: Vector, _: Vector, decoded: Vector) =>
+        assert(input ~== decoded absTol eps)
+      }
+    }
+  }
+
+  test("Autoencoder use for pre-training") {
+    val dataFrame = spark.createDataFrame(Seq(
+      (Vectors.dense(0.0, 0.0), 0.0),
+      (Vectors.dense(0.0, 1.0), 1.0),
+      (Vectors.dense(1.0, 0.0), 1.0),
+      (Vectors.dense(1.0, 1.0), 0.0))
+    ).toDF("features", "label")
+    val layers = Array[Int](2, 7, 6, 5, 4, 3, 2)
+    val trainer = new MultilayerPerceptronClassifier()
+      .setLayers(layers)
+      .setBlockSize(1)
+      .setSeed(12L)
+      .setMaxIter(1)
+      .setTol(1e-6)
+    val initialWeights = trainer.fit(dataFrame).weights
+    trainer
+      .setInitialWeights(initialWeights.copy)
+      .setMaxIter(10)
+    val badModel = trainer.fit(dataFrame)
+    val badResult = badModel.transform(dataFrame)
+    val badPredictionAndLabels = badResult.select("prediction", "label").collect()
+    // solution converged to a bad optimum
+    assert(!badPredictionAndLabels.forall { case Row(p: Double, l: Double) =>
+      p == l
+    }, "Model should not predict as expected")
+
+    // pre-train all layers except last as stacked autoencoder
+    val encoderLayers = layers.init
+    val autoEncoder = new StackedAutoencoder("stackedAutoencoder")
+      .setBlockSize(1)
+      .setBuildDecoder(false)
+      .setDataIn01Interval(true)
+      .setInputCol("features")
+      .setLayers(encoderLayers)
+      .setMaxIter(10)
+      .setSeed(12L)
+      .setTol(1e-6)
+    val autoEncoderModel = autoEncoder.fit(dataFrame)
+    val autoEncoderWeights = autoEncoderModel.encoderWeights
+    // initialize weights for the classifier and copy pre-trained weights
+    System.arraycopy(
+      autoEncoderWeights.toArray, 0, initialWeights.toArray, 0, autoEncoderWeights.toArray.length)
+    val preTrainer = new MultilayerPerceptronClassifier()
+      .setLayers(layers)
+      .setBlockSize(1)
+      .setInitialWeights(initialWeights)
+      .setMaxIter(10)
+      .setTol(1e-6)
+    val preModel = preTrainer.fit(dataFrame)
+    val preResult = preModel.transform(dataFrame)
+    val predictionAndLabels = preResult.select("prediction", "label").collect()
+    predictionAndLabels.foreach { case Row(p: Double, l: Double) =>
+      assert(p == l)
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement stacked autoencoder
- Base on ml.ann Layer and LossFunction
- Implement two loss functions `EmptyLayerWithSquaredError` and `SigmoidLayerWithSquaredError` to handle inputs (-inf, +inf) and [0, 1]
- Implement greedy training
- Provide encoder and decoder
## How was this patch tested?

Provide unit tests
- Gradient correctness of the new LossFunctions
- Correct reconstruction of the original data by encoding and decoding (based on Berkeley's CS182)
- Successful pre-training of deep network with 6 hidden layers
