### PR TITLE
[SPARK-15858][ML]: Fix calculating error by tree stack over flow prob…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -211,15 +211,13 @@ private[spark] object GradientBoostedTrees extends Logging {
 
     val dataCount = remappedData.count()
     val evaluation = remappedData.map { point =>
-      treesIndices.map { idx => {
+      treesIndices.map { idx =>
         val prediction = broadcastTrees.value(idx)
           .rootNode
           .predictImpl(point.features)
           .prediction
         prediction * localTreeWeights(idx)
-      }
-      }
-        .scanLeft(0.0)(_ + _).drop(1)
+      }.scanLeft(0.0)(_ + _).drop(1)
         .map(prediction => loss.computeError(prediction, point.label))
     }
       .aggregate(treesIndices.map(_ => 0.0))(

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -205,31 +205,31 @@ private[spark] object GradientBoostedTrees extends Logging {
       case _ => data
     }
 
-    val numIterations = trees.length
-    val evaluationArray = Array.fill(numIterations)(0.0)
-    val localTreeWeights = treeWeights
-
-    var predictionAndError = computeInitialPredictionAndError(
-      remappedData, localTreeWeights(0), trees(0), loss)
-
-    evaluationArray(0) = predictionAndError.values.mean()
-
     val broadcastTrees = sc.broadcast(trees)
-    (1 until numIterations).foreach { nTree =>
-      predictionAndError = remappedData.zip(predictionAndError).mapPartitions { iter =>
-        val currentTree = broadcastTrees.value(nTree)
-        val currentTreeWeight = localTreeWeights(nTree)
-        iter.map { case (point, (pred, error)) =>
-          val newPred = updatePrediction(point.features, pred, currentTree, currentTreeWeight)
-          val newError = loss.computeError(newPred, point.label)
-          (newPred, newError)
-        }
-      }
-      evaluationArray(nTree) = predictionAndError.values.mean()
-    }
+    val localTreeWeights = treeWeights
+    val treesIndices = trees.indices
 
-    broadcastTrees.unpersist()
-    evaluationArray
+    val dataCount = remappedData.count()
+    val evaluation = remappedData
+      .map { (point: LabeledPoint) =>
+        treesIndices
+          .map(idx => {
+              val prediction = broadcastTrees.value(idx)
+                .rootNode
+                .predictImpl(point.features)
+                .prediction
+              prediction * localTreeWeights(idx)
+            }
+          )
+          .scanLeft(0.0)(_ + _).drop(1)
+          .map(prediction => loss.computeError(prediction, point.label))
+      }
+      .aggregate(treesIndices.map(_ => 0.0))(
+        (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
+        (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
+      .map(d => d / dataCount)
+    broadcastTrees.destroy()
+    evaluation.toArray
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -217,8 +217,9 @@ private[spark] object GradientBoostedTrees extends Logging {
           .predictImpl(point.features)
           .prediction
         prediction * localTreeWeights(idx)
-      }.scanLeft(0.0)(_ + _).drop(1)
-        .map(prediction => loss.computeError(prediction, point.label))
+      }
+      .scanLeft(0.0)(_ + _).drop(1)
+      .map(prediction => loss.computeError(prediction, point.label))
     }
       .aggregate(treesIndices.map(_ => 0.0))(
         (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -221,10 +221,11 @@ private[spark] object GradientBoostedTrees extends Logging {
       .scanLeft(0.0)(_ + _).drop(1)
       .map(prediction => loss.computeError(prediction, point.label))
     }
-      .aggregate(treesIndices.map(_ => 0.0))(
-        (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
-        (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
-      .map(_ / dataCount)
+    .aggregate(treesIndices.map(_ => 0.0))(
+      (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
+      (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
+    .map(_ / dataCount)
+
     broadcastTrees.destroy()
     evaluation.toArray
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
@@ -151,31 +151,24 @@ class GradientBoostedTreesModel @Since("1.2.0") (
       case _ => data
     }
 
-    val numIterations = trees.length
-    val evaluationArray = Array.fill(numIterations)(0.0)
-    val localTreeWeights = treeWeights
-
-    var predictionAndError = GradientBoostedTreesModel.computeInitialPredictionAndError(
-      remappedData, localTreeWeights(0), trees(0), loss)
-
-    evaluationArray(0) = predictionAndError.values.mean()
-
     val broadcastTrees = sc.broadcast(trees)
-    (1 until numIterations).foreach { nTree =>
-      predictionAndError = remappedData.zip(predictionAndError).mapPartitions { iter =>
-        val currentTree = broadcastTrees.value(nTree)
-        val currentTreeWeight = localTreeWeights(nTree)
-        iter.map { case (point, (pred, error)) =>
-          val newPred = pred + currentTree.predict(point.features) * currentTreeWeight
-          val newError = loss.computeError(newPred, point.label)
-          (newPred, newError)
-        }
-      }
-      evaluationArray(nTree) = predictionAndError.values.mean()
-    }
+    val localTreeWeights = treeWeights
+    val treesIndices = trees.indices
 
-    broadcastTrees.unpersist()
-    evaluationArray
+    val dataCount = remappedData.count()
+    val evaluation = remappedData
+      .map { (point: LabeledPoint) =>
+        treesIndices
+          .map(idx => broadcastTrees.value(idx).predict(point.features) * localTreeWeights(idx))
+          .scanLeft(0.0)(_ + _).drop(1)
+          .map(prediction => loss.computeError(prediction, point.label))
+      }
+      .aggregate(treesIndices.map(_ => 0.0))(
+        (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
+        (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
+      .map(d => d / dataCount)
+    broadcastTrees.destroy()
+    evaluation.toArray
   }
 
   override protected def formatVersion: String = GradientBoostedTreesModel.formatVersion

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
@@ -165,7 +165,7 @@ class GradientBoostedTreesModel @Since("1.2.0") (
       .aggregate(treesIndices.map(_ => 0.0))(
         (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
         (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
-      .map(d => d / dataCount)
+      .map(_ / dataCount)
     broadcastTrees.destroy()
     evaluation.toArray
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
@@ -162,10 +162,11 @@ class GradientBoostedTreesModel @Since("1.2.0") (
         .scanLeft(0.0)(_ + _).drop(1)
         .map(prediction => loss.computeError(prediction, point.label))
     }
-      .aggregate(treesIndices.map(_ => 0.0))(
-        (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
-        (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
-      .map(_ / dataCount)
+    .aggregate(treesIndices.map(_ => 0.0))(
+      (aggregated, row) => treesIndices.map(idx => aggregated(idx) + row(idx)),
+      (a, b) => treesIndices.map(idx => a(idx) + b(idx)))
+    .map(_ / dataCount)
+
     broadcastTrees.destroy()
     evaluation.toArray
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

What changes were proposed in this pull request?

Improving evaluateEachIteration function in mllib as it fails when trying to calculate error by tree for a model that has more than 500 trees
## How was this patch tested?

the batch tested on productions data set (2K rows x 2K features) training a gradient boosted model without validation with 1000 maxIteration settings, then trying to produce the error by tree, the new patch was able to perform the calculation within 30 seconds, while previously it was take hours then fail.

**PS**: It would be better if this PR can be cherry picked into release branches 1.6.1 and 2.0 
