### PR TITLE
[SPARK-15907] [SQL] Issue Exceptions when Not Enough Input Columns for Dynamic Partitioning

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -198,6 +198,16 @@ case class InsertIntoHiveTable(
       if (isDynamic.init.zip(isDynamic.tail).contains((true, false))) {
         throw new SparkException(ErrorMsg.PARTITION_DYN_STA_ORDER.getMsg)
       }
+
+      // For Hive tables, table.outputSet includes both data columns and partition columns
+      assert(table.output.size > partition.size)
+
+      val numDataCols = table.output.size - partition.size
+      if (numDataCols + numDynamicPartitions > child.output.size) {
+        throw new SparkException("Cannot insert into target table because column number are " +
+          s"different: Table requires `${numDataCols + numDynamicPartitions}` columns, but the " +
+          s"input has `${child.output.size}` columns")
+      }
     }
 
     val jobConf = new JobConf(hadoopConf)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -1057,8 +1057,11 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       sql("SET hive.exec.dynamic.partition.mode=nonstrict")
 
       sql("CREATE TABLE IF NOT EXISTS withparts LIKE srcpart")
-      sql("INSERT INTO TABLE withparts PARTITION(ds, hr) SELECT key, value FROM src")
-        .queryExecution.analyzed
+      sql(
+        s"""
+           |INSERT INTO TABLE withparts PARTITION(ds, hr)
+           |SELECT key, value, '2008-04-09', '12' FROM src
+         """.stripMargin).queryExecution.analyzed
     }
 
     assertResult(2, "Duplicated project detected\n" + analyzedPlan) {


### PR DESCRIPTION
#### What changes were proposed in this pull request?

``` SQL
CREATE TABLE table_with_partition(c1 string)
PARTITIONED by (p1 string,p2 string)

INSERT OVERWRITE TABLE table_with_partition
partition (p1='a',p2)
SELECT 'blarr3'
```

In the above example, we do not have enough input columns for dynamic partitioning. The first input column is already taken as data columns. This PR is to issue an exception in this scenario.  

For your reference, below is the behavior of Hive:

```
hive> insert overwrite table t9 partition(p1='1',p2) select col from t1;
FAILED: SemanticException [Error 10044]: Line 1:23 Cannot insert into target table because column number/types are different 'p2': Table insclause-0 has 2 columns, but query has 1 columns.
```
#### How was this patch tested?

Added a test case and fixed an existing test case
