### PR TITLE
Revert "Incorrectly merged AFTAggregator with zero total count" for branch-1.6

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -496,7 +496,7 @@ private class AFTAggregator(parameters: BDV[Double], fitIntercept: Boolean)
    * @return This AFTAggregator object.
    */
   def merge(other: AFTAggregator): this.type = {
-    if (other.count != 0) {
+    if (totalCnt != 0) {
       totalCnt += other.totalCnt
       lossSum += other.lossSum
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -346,18 +346,6 @@ class AFTSurvivalRegressionSuite
     testEstimatorAndModelReadWrite(aft, datasetMultivariate,
       AFTSurvivalRegressionSuite.allParamSettings, checkModelData)
   }
-
-  test("SPARK-15892: Incorrectly merged AFTAggregator with zero total count") {
-    // This `dataset` will contain an empty partition because it has two rows but
-    // the parallelism is bigger than that. Because the issue was about `AFTAggregator`s
-    // being merged incorrectly when it has an empty partition, running the codes below
-    // should not throw an exception.
-    val dataset = sqlContext.createDataFrame(
-      sc.parallelize(generateAFTInput(
-        1, Array(5.5), Array(0.8), 2, 42, 1.0, 2.0, 2.0), numSlices = 3))
-    val trainer = new AFTSurvivalRegression()
-    trainer.fit(dataset)
-  }
 }
 
 object AFTSurvivalRegressionSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -352,7 +352,7 @@ class AFTSurvivalRegressionSuite
     // the parallelism is bigger than that. Because the issue was about `AFTAggregator`s
     // being merged incorrectly when it has an empty partition, running the codes below
     // should not throw an exception.
-    val dataset = spark.createDataFrame(
+    val dataset = sqlContext.createDataFrame(
       sc.parallelize(generateAFTInput(
         1, Array(5.5), Array(0.8), 2, 42, 1.0, 2.0, 2.0), numSlices = 3))
     val trainer = new AFTSurvivalRegression()


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/spark/pull/13619 was merged into master, branch-2.0 but branch-1.6 as well.

This is currently being failed due to the use of `spark` instead of `sqlContext` but it even fails after changing this to `sqlContext`. 

It seems the reason is the behaviour was changed in https://github.com/apache/spark/commit/101663f1ae222a919fc40510aa4f2bad22d1be6f.
## How was this patch tested?

Jenkins tests.
