### PR TITLE
[SPARK-15913][CORE] Dispatcher.stopped should be enclosed by synchronized block.

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/Dispatcher.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/Dispatcher.scala
@@ -144,7 +144,7 @@ private[netty] class Dispatcher(nettyEnv: NettyRpcEnv) extends Logging {
       endpointName: String,
       message: InboxMessage,
       callbackIfStopped: (Exception) => Unit): Unit = {
-    val error: Option[Exception] = synchronized {
+    val error = synchronized {
       val data = endpoints.get(endpointName)
       if (stopped) {
         Some(new RpcEnvStoppedException())
@@ -156,10 +156,8 @@ private[netty] class Dispatcher(nettyEnv: NettyRpcEnv) extends Logging {
         None
       }
     }
-    if (error.isDefined) {
-      // We don't need to call `onStop` in the `synchronized` block
-      callbackIfStopped(error.get)
-    }
+    // We don't need to call `onStop` in the `synchronized` block
+    error.foreach(callbackIfStopped)
   }
 
   def stop(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Dispatcher.stopped` is guarded by `this`, but it is used without synchronization in `postMessage` function. This PR fixes this and also the exception message became more accurate.
## How was this patch tested?

Pass the existing Jenkins tests.
