### PR TITLE
[SPARK-15159][SPARKR] SparkR SparkSession API

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -6,7 +6,7 @@ importFrom(methods, setGeneric, setMethod, setOldClass)
 #useDynLib(SparkR, stringHashCode)
 
 # S3 methods exported
-export("sparkR.session.getOrCreate")
+export("sparkR.session")
 export("sparkR.init")
 export("sparkR.stop")
 export("sparkR.session.stop")

--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -6,9 +6,14 @@ importFrom(methods, setGeneric, setMethod, setOldClass)
 #useDynLib(SparkR, stringHashCode)
 
 # S3 methods exported
+export("sparkR.session.getOrCreate")
 export("sparkR.init")
 export("sparkR.stop")
+export("sparkR.session.stop")
 export("print.jobj")
+
+export("sparkRSQL.init",
+       "sparkRHive.init")
 
 # MLlib integration
 exportMethods("glm",
@@ -286,9 +291,6 @@ exportMethods("%in%",
 
 exportClasses("GroupedData")
 exportMethods("agg")
-
-export("sparkRSQL.init",
-       "sparkRHive.init")
 
 export("as.DataFrame",
        "cacheTable",

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2333,9 +2333,7 @@ setMethod("write.df",
           signature(df = "SparkDataFrame", path = "character"),
           function(df, path, source = NULL, mode = "error", ...){
             if (is.null(source)) {
-              sqlContext <- getSqlContext()
-              source <- callJMethod(sqlContext, "getConf", "spark.sql.sources.default",
-                                    "org.apache.spark.sql.parquet")
+              source <- getDefaultSqlSource()
             }
             jmode <- convertToJSaveMode(mode)
             options <- varargsToEnv(...)
@@ -2393,9 +2391,7 @@ setMethod("saveAsTable",
           signature(df = "SparkDataFrame", tableName = "character"),
           function(df, tableName, source = NULL, mode="error", ...){
             if (is.null(source)) {
-              sqlContext <- getSqlContext()
-              source <- callJMethod(sqlContext, "getConf", "spark.sql.sources.default",
-                                    "org.apache.spark.sql.parquet")
+              source <- getDefaultSqlSource()
             }
             jmode <- convertToJSaveMode(mode)
             options <- varargsToEnv(...)

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -673,7 +673,8 @@ read.df.default <- function(path = NULL, source = NULL, schema = NULL, ...) {
     sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "loadDF", sparkSession, source,
                        schema$jobj, options)
   } else {
-    sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "loadDF", sparkSession, source, options)
+    sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+                       "loadDF", sparkSession, source, options)
   }
   dataFrame(sdf)
 }

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -53,7 +53,8 @@ dispatchFunc <- function(newFuncSig, x, ...) {
   # Strip sqlContext from list of parameters and then pass the rest along.
   contextNames <- c("org.apache.spark.sql.SQLContext",
                     "org.apache.spark.sql.hive.HiveContext",
-                    "org.apache.spark.sql.hive.test.TestHiveContext")
+                    "org.apache.spark.sql.hive.test.TestHiveContext",
+                    "org.apache.spark.sql.SparkSession")
   if (missing(x) && length(list(...)) == 0) {
     f()
   } else if (class(x) == "jobj" &&
@@ -65,14 +66,12 @@ dispatchFunc <- function(newFuncSig, x, ...) {
   }
 }
 
-#' return the SQL Context
-getSqlContext <- function() {
-  if (exists(".sparkRHivesc", envir = .sparkREnv)) {
-    get(".sparkRHivesc", envir = .sparkREnv)
-  } else if (exists(".sparkRSQLsc", envir = .sparkREnv)) {
-    get(".sparkRSQLsc", envir = .sparkREnv)
+#' return the SparkSession
+getSparkSession <- function() {
+  if (exists(".sparkRsession", envir = .sparkREnv)) {
+    get(".sparkRsession", envir = .sparkREnv)
   } else {
-    stop("SQL context not initialized")
+    stop("SparkSession not initialized")
   }
 }
 
@@ -109,6 +108,13 @@ infer_type <- function(x) {
   }
 }
 
+getDefaultSqlSource <- function() {
+  sparkSession <- getSparkSession()
+  conf <- callJMethod(sparkSession, "conf")
+  source <- callJMethod(conf, "get", "spark.sql.sources.default", "org.apache.spark.sql.parquet")
+  source
+}
+
 #' Create a SparkDataFrame
 #'
 #' Converts R data.frame or list into SparkDataFrame.
@@ -131,7 +137,7 @@ infer_type <- function(x) {
 
 # TODO(davies): support sampling and infer type from NA
 createDataFrame.default <- function(data, schema = NULL, samplingRatio = 1.0) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   if (is.data.frame(data)) {
       # get the names of columns, they will be put into RDD
       if (is.null(schema)) {
@@ -158,7 +164,7 @@ createDataFrame.default <- function(data, schema = NULL, samplingRatio = 1.0) {
       data <- do.call(mapply, append(args, data))
   }
   if (is.list(data)) {
-    sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sqlContext)
+    sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
     rdd <- parallelize(sc, data)
   } else if (inherits(data, "RDD")) {
     rdd <- data
@@ -201,7 +207,7 @@ createDataFrame.default <- function(data, schema = NULL, samplingRatio = 1.0) {
   jrdd <- getJRDD(lapply(rdd, function(x) x), "row")
   srdd <- callJMethod(jrdd, "rdd")
   sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "createDF",
-                     srdd, schema$jobj, sqlContext)
+                     srdd, schema$jobj, sparkSession)
   dataFrame(sdf)
 }
 
@@ -265,10 +271,10 @@ setMethod("toDF", signature(x = "RDD"),
 #' @method read.json default
 
 read.json.default <- function(path) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   # Allow the user to have a more flexible definiton of the text file path
   paths <- as.list(suppressWarnings(normalizePath(path)))
-  read <- callJMethod(sqlContext, "read")
+  read <- callJMethod(sparkSession, "read")
   sdf <- callJMethod(read, "json", paths)
   dataFrame(sdf)
 }
@@ -336,10 +342,10 @@ jsonRDD <- function(sqlContext, rdd, schema = NULL, samplingRatio = 1.0) {
 #' @method read.parquet default
 
 read.parquet.default <- function(path) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   # Allow the user to have a more flexible definiton of the text file path
   paths <- as.list(suppressWarnings(normalizePath(path)))
-  read <- callJMethod(sqlContext, "read")
+  read <- callJMethod(sparkSession, "read")
   sdf <- callJMethod(read, "parquet", paths)
   dataFrame(sdf)
 }
@@ -385,10 +391,10 @@ parquetFile <- function(x, ...) {
 #' @method read.text default
 
 read.text.default <- function(path) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   # Allow the user to have a more flexible definiton of the text file path
   paths <- as.list(suppressWarnings(normalizePath(path)))
-  read <- callJMethod(sqlContext, "read")
+  read <- callJMethod(sparkSession, "read")
   sdf <- callJMethod(read, "text", paths)
   dataFrame(sdf)
 }
@@ -418,8 +424,8 @@ read.text <- function(x, ...) {
 #' @method sql default
 
 sql.default <- function(sqlQuery) {
-  sqlContext <- getSqlContext()
-  sdf <- callJMethod(sqlContext, "sql", sqlQuery)
+  sparkSession <- getSparkSession()
+  sdf <- callJMethod(sparkSession, "sql", sqlQuery)
   dataFrame(sdf)
 }
 
@@ -449,8 +455,8 @@ sql <- function(x, ...) {
 #' @note since 2.0.0
 
 tableToDF <- function(tableName) {
-  sqlContext <- getSqlContext()
-  sdf <- callJMethod(sqlContext, "table", tableName)
+  sparkSession <- getSparkSession()
+  sdf <- callJMethod(sparkSession, "table", tableName)
   dataFrame(sdf)
 }
 
@@ -472,12 +478,8 @@ tableToDF <- function(tableName) {
 #' @method tables default
 
 tables.default <- function(databaseName = NULL) {
-  sqlContext <- getSqlContext()
-  jdf <- if (is.null(databaseName)) {
-    callJMethod(sqlContext, "tables")
-  } else {
-    callJMethod(sqlContext, "tables", databaseName)
-  }
+  sparkSession <- getSparkSession()
+  jdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getTables", sparkSession, databaseName)
   dataFrame(jdf)
 }
 
@@ -503,12 +505,11 @@ tables <- function(x, ...) {
 #' @method tableNames default
 
 tableNames.default <- function(databaseName = NULL) {
-  sqlContext <- getSqlContext()
-  if (is.null(databaseName)) {
-    callJMethod(sqlContext, "tableNames")
-  } else {
-    callJMethod(sqlContext, "tableNames", databaseName)
-  }
+  sparkSession <- getSparkSession()
+  jdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+                     "getTableNames",
+                     sparkSession,
+                     databaseName)
 }
 
 tableNames <- function(x, ...) {
@@ -536,8 +537,9 @@ tableNames <- function(x, ...) {
 #' @method cacheTable default
 
 cacheTable.default <- function(tableName) {
-  sqlContext <- getSqlContext()
-  callJMethod(sqlContext, "cacheTable", tableName)
+  sparkSession <- getSparkSession()
+  catalog <- callJMethod(sparkSession, "catalog")
+  callJMethod(catalog, "cacheTable", tableName)
 }
 
 cacheTable <- function(x, ...) {
@@ -565,8 +567,9 @@ cacheTable <- function(x, ...) {
 #' @method uncacheTable default
 
 uncacheTable.default <- function(tableName) {
-  sqlContext <- getSqlContext()
-  callJMethod(sqlContext, "uncacheTable", tableName)
+  sparkSession <- getSparkSession()
+  catalog <- callJMethod(sparkSession, "catalog")
+  callJMethod(catalog, "uncacheTable", tableName)
 }
 
 uncacheTable <- function(x, ...) {
@@ -587,8 +590,9 @@ uncacheTable <- function(x, ...) {
 #' @method clearCache default
 
 clearCache.default <- function() {
-  sqlContext <- getSqlContext()
-  callJMethod(sqlContext, "clearCache")
+  sparkSession <- getSparkSession()
+  catalog <- callJMethod(sparkSession, "catalog")
+  callJMethod(catalog, "clearCache")
 }
 
 clearCache <- function() {
@@ -615,11 +619,12 @@ clearCache <- function() {
 #' @method dropTempTable default
 
 dropTempTable.default <- function(tableName) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   if (class(tableName) != "character") {
     stop("tableName must be a string.")
   }
-  callJMethod(sqlContext, "dropTempTable", tableName)
+  catalog <- callJMethod(sparkSession, "catalog")
+  callJMethod(catalog, "dropTempView", tableName)
 }
 
 dropTempTable <- function(x, ...) {
@@ -655,21 +660,20 @@ dropTempTable <- function(x, ...) {
 #' @method read.df default
 
 read.df.default <- function(path = NULL, source = NULL, schema = NULL, ...) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   options <- varargsToEnv(...)
   if (!is.null(path)) {
     options[["path"]] <- path
   }
   if (is.null(source)) {
-    source <- callJMethod(sqlContext, "getConf", "spark.sql.sources.default",
-                          "org.apache.spark.sql.parquet")
+    source <- getDefaultSqlSource()
   }
   if (!is.null(schema)) {
     stopifnot(class(schema) == "structType")
-    sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "loadDF", sqlContext, source,
+    sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "loadDF", sparkSession, source,
                        schema$jobj, options)
   } else {
-    sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "loadDF", sqlContext, source, options)
+    sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "loadDF", sparkSession, source, options)
   }
   dataFrame(sdf)
 }
@@ -715,12 +719,13 @@ loadDF <- function(x, ...) {
 #' @method createExternalTable default
 
 createExternalTable.default <- function(tableName, path = NULL, source = NULL, ...) {
-  sqlContext <- getSqlContext()
+  sparkSession <- getSparkSession()
   options <- varargsToEnv(...)
   if (!is.null(path)) {
     options[["path"]] <- path
   }
-  sdf <- callJMethod(sqlContext, "createExternalTable", tableName, source, options)
+  catalog <- callJMethod(sparkSession, "catalog")
+  sdf <- callJMethod(catalog, "createExternalTable", tableName, source, options)
   dataFrame(sdf)
 }
 
@@ -768,11 +773,11 @@ read.jdbc <- function(url, tableName,
                       numPartitions = 0L, predicates = list(), ...) {
   jprops <- varargsToJProperties(...)
 
-  read <- callJMethod(sqlContext, "read")
+  read <- callJMethod(sparkSession, "read")
   if (!is.null(partitionColumn)) {
     if (is.null(numPartitions) || numPartitions == 0) {
-      sqlContext <- getSqlContext()
-      sc <- callJMethod(sqlContext, "sparkContext")
+      sparkSession <- getSparkSession()
+      sc <- callJMethod(sparkSession, "sparkContext")
       numPartitions <- callJMethod(sc, "defaultParallelism")
     } else {
       numPartitions <- numToInt(numPartitions)

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -772,11 +772,10 @@ read.jdbc <- function(url, tableName,
                       partitionColumn = NULL, lowerBound = NULL, upperBound = NULL,
                       numPartitions = 0L, predicates = list(), ...) {
   jprops <- varargsToJProperties(...)
-
+  sparkSession <- getSparkSession()
   read <- callJMethod(sparkSession, "read")
   if (!is.null(partitionColumn)) {
     if (is.null(numPartitions) || numPartitions == 0) {
-      sparkSession <- getSparkSession()
       sc <- callJMethod(sparkSession, "sparkContext")
       numPartitions <- callJMethod(sc, "defaultParallelism")
     } else {

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -506,10 +506,10 @@ tables <- function(x, ...) {
 
 tableNames.default <- function(databaseName = NULL) {
   sparkSession <- getSparkSession()
-  jdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils",
-                     "getTableNames",
-                     sparkSession,
-                     databaseName)
+  callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+              "getTableNames",
+              sparkSession,
+              databaseName)
 }
 
 tableNames <- function(x, ...) {

--- a/R/pkg/R/backend.R
+++ b/R/pkg/R/backend.R
@@ -68,7 +68,7 @@ isRemoveMethod <- function(isStatic, objId, methodName) {
 # methodName - name of method to be invoked
 invokeJava <- function(isStatic, objId, methodName, ...) {
   if (!exists(".sparkRCon", .sparkREnv)) {
-    stop("No connection to backend found. Please re-run sparkR.session.getOrCreate()")
+    stop("No connection to backend found. Please re-run sparkR.session()")
   }
 
   # If this isn't a removeJObject call

--- a/R/pkg/R/backend.R
+++ b/R/pkg/R/backend.R
@@ -68,7 +68,7 @@ isRemoveMethod <- function(isStatic, objId, methodName) {
 # methodName - name of method to be invoked
 invokeJava <- function(isStatic, objId, methodName, ...) {
   if (!exists(".sparkRCon", .sparkREnv)) {
-    stop("No connection to backend found. Please re-run sparkR.init")
+    stop("No connection to backend found. Please re-run sparkR.session.getOrCreate()")
   }
 
   # If this isn't a removeJObject call

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -28,9 +28,8 @@ connExists <- function(env) {
   })
 }
 
-#' Stop the Spark context.
-#'
-#' Also terminates the backend this R session is connected to
+#' @rdname sparkR.session.stop
+#' @name sparkR.stop
 #' @export
 sparkR.stop <- function() {
   sparkR.session.stop()
@@ -39,6 +38,8 @@ sparkR.stop <- function() {
 #' Stop the Spark Session and Spark Context.
 #'
 #' Also terminates the backend this R session is connected to.
+#' @rdname sparkR.session.stop
+#' @name sparkR.session.stop
 #' @export
 #' @note since 2.0.0
 sparkR.session.stop <- function() {
@@ -120,7 +121,7 @@ sparkR.init <- function(
   sparkExecutorEnv = list(),
   sparkJars = "",
   sparkPackages = "") {
-  .Deprecated("sparkR.session.getOrCreate")
+  .Deprecated("sparkR.session")
   sparkR.sparkContext(master,
      appName,
      sparkHome,
@@ -264,14 +265,14 @@ sparkR.sparkContext <- function(
 #'}
 
 sparkRSQL.init <- function(jsc = NULL) {
-  .Deprecated("sparkR.session.getOrCreate")
+  .Deprecated("sparkR.session")
 
   if (exists(".sparkRsession", envir = .sparkREnv)) {
     return(get(".sparkRsession", envir = .sparkREnv))
   }
 
   # Default to without Hive support for backward compatibility.
-  sparkR.session.getOrCreate(enableHiveSupport = FALSE)
+  sparkR.session(enableHiveSupport = FALSE)
 }
 
 #' Initialize a new HiveContext.
@@ -290,14 +291,14 @@ sparkRSQL.init <- function(jsc = NULL) {
 #'}
 
 sparkRHive.init <- function(jsc = NULL) {
-  .Deprecated("sparkR.session.getOrCreate")
+  .Deprecated("sparkR.session")
 
   if (exists(".sparkRsession", envir = .sparkREnv)) {
     return(get(".sparkRsession", envir = .sparkREnv))
   }
 
   # Default to without Hive support for backward compatibility.
-  sparkR.session.getOrCreate(enableHiveSupport = TRUE)
+  sparkR.session(enableHiveSupport = TRUE)
 }
 
 #' Get the existing SparkSession or initialize a new SparkSession.
@@ -309,33 +310,32 @@ sparkRHive.init <- function(jsc = NULL) {
 #' @param appName Application name to register with cluster manager
 #' @param sparkHome Spark Home directory
 #' @param sparkConfig Named list of Spark configuration to set on worker nodes
-#' @param sparkExecutorConfig Named list of Spark configuration to be used when launching executors
+#' @param sparkExecutorEnv Named list of environment variables to be used when launching executors
 #' @param sparkJars Character vector of jar files to pass to the worker nodes
 #' @param sparkPackages Character vector of packages from spark-packages.org
 #' @param enableHiveSupport Enable support for Hive
 #' @export
 #' @examples
 #'\dontrun{
-#' sparkR.session.getOrCreate()
+#' sparkR.session()
 #' df <- read.json(path)
 #'
-#' sparkR.session.getOrCreate("local[2]", "SparkR", "/home/spark")
-#' sparkR.session.getOrCreate("yarn-client", "SparkR", "/home/spark",
+#' sparkR.session("local[2]", "SparkR", "/home/spark")
+#' sparkR.session("yarn-client", "SparkR", "/home/spark",
 #'                            list(spark.executor.memory="4g"),
 #'                            list(LD_LIBRARY_PATH="/directory of JVM libraries (libjvm.so) on workers/"),
 #'                            c("one.jar", "two.jar", "three.jar"),
 #'                            c("com.databricks:spark-avro_2.10:2.0.1"))
-#' sparkR.session.getOrCreate(spark.master = "yarn-client",
+#' sparkR.session(spark.master = "yarn-client",
 #'                            spark.executor.memory = "4g")
 #'}
 #' @note since 2.0.0
 
-sparkR.session.getOrCreate <- function(
+sparkR.session <- function(
   master = "",
   appName = "SparkR",
   sparkHome = Sys.getenv("SPARK_HOME"),
   sparkConfig = list(),
-  sparkExecutorConfig = list(),
   sparkJars = "",
   sparkPackages = "",
   enableHiveSupport = TRUE,
@@ -355,9 +355,9 @@ sparkR.session.getOrCreate <- function(
     overrideEnvs(sparkConfigMap, paramMap)
   }
 
-  sparkExecutorConfigMap <- convertNamedListToEnv(sparkExecutorConfig)
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
-    sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorConfigMap,
+    sparkExecutorEnvMap <- new.env()
+    sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorEnvMap,
        sparkJars, sparkPackages)
     stopifnot(exists(".sparkRjsc", envir = .sparkREnv))
   }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -33,7 +33,6 @@ connExists <- function(env) {
 #' Also terminates the backend this R session is connected to
 #' @export
 sparkR.stop <- function() {
-  .Deprecated("sparkR.session.stop")
   sparkR.session.stop()
 }
 

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -279,6 +279,9 @@ sparkRSQL.init <- function(jsc = NULL) {
 #'
 #' This function creates a HiveContext from an existing JavaSparkContext
 #'
+#' Starting SparkR 2.0, a SparkSession is initialized and returned instead.
+#' This API is deprecated and kept for backward compatibility only.
+#'
 #' @param jsc The existing JavaSparkContext created with SparkR.init()
 #' @export
 #' @examples

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -317,6 +317,15 @@ convertEnvsToList <- function(keys, vals) {
          })
 }
 
+# Utility function to merge 2 environments with the second overriding values in the first
+# env1 is changed in place
+overrideEnvs <- function(env1, env2) {
+  lapply(ls(env2),
+         function(name) {
+           env1[[name]] <- env2[[name]]
+         })
+}
+
 # Utility function to capture the varargs into environment object
 varargsToEnv <- function(...) {
   # Based on http://stackoverflow.com/a/3057419/4577954

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -18,16 +18,16 @@
 .First <- function() {
   home <- Sys.getenv("SPARK_HOME")
   .libPaths(c(file.path(home, "R", "lib"), .libPaths()))
-  Sys.setenv(NOAWT=1)
+  Sys.setenv(NOAWT = 1)
 
   # Make sure SparkR package is the last loaded one
   old <- getOption("defaultPackages")
   options(defaultPackages = c(old, "SparkR"))
 
-  spark <- SparkR::sparkR.session.getOrCreate()
-  assign("spark", spark, envir=.GlobalEnv)
+  spark <- SparkR::sparkR.session()
+  assign("spark", spark, envir = .GlobalEnv)
   sc <- SparkR:::callJMethod(spark, "sparkContext")
-  assign("sc", sc, envir=.GlobalEnv)
+  assign("sc", sc, envir = .GlobalEnv)
   sparkVer <- SparkR:::callJMethod(sc, "version")
   cat("\n Welcome to")
   cat("\n")

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -26,7 +26,7 @@
 
   spark <- SparkR::sparkR.session()
   assign("spark", spark, envir = .GlobalEnv)
-  sc <- SparkR:::callJMethod(spark, "sparkContext")
+  sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", spark)
   assign("sc", sc, envir = .GlobalEnv)
   sparkVer <- SparkR:::callJMethod(sc, "version")
   cat("\n Welcome to")

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -24,11 +24,11 @@
   old <- getOption("defaultPackages")
   options(defaultPackages = c(old, "SparkR"))
 
-  sc <- SparkR::sparkR.init()
+  spark <- SparkR::sparkR.session.getOrCreate()
+  assign("spark", spark, envir=.GlobalEnv)
+  sc <- SparkR:::callJMethod(spark, "sparkContext")
   assign("sc", sc, envir=.GlobalEnv)
-  sqlContext <- SparkR::sparkRSQL.init(sc)
   sparkVer <- SparkR:::callJMethod(sc, "version")
-  assign("sqlContext", sqlContext, envir=.GlobalEnv)
   cat("\n Welcome to")
   cat("\n")
   cat("    ____              __", "\n")
@@ -43,5 +43,5 @@
   cat("    /_/", "\n")
   cat("\n")
 
-  cat("\n Spark context is available as sc, SQL context is available as sqlContext\n")
+  cat("\n SparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/tests/testthat/jarTest.R
+++ b/R/pkg/inst/tests/testthat/jarTest.R
@@ -16,7 +16,8 @@
 #
 library(SparkR)
 
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 helloTest <- SparkR:::callJStatic("sparkR.test.hello",
                                   "helloWorld",
@@ -27,6 +28,6 @@ basicFunction <- SparkR:::callJStatic("sparkR.test.basicFunction",
                                       2L,
                                       2L)
 
-sparkR.stop()
+sparkR.session.stop()
 output <- c(helloTest, basicFunction)
 writeLines(output)

--- a/R/pkg/inst/tests/testthat/jarTest.R
+++ b/R/pkg/inst/tests/testthat/jarTest.R
@@ -16,8 +16,7 @@
 #
 library(SparkR)
 
-sparkSession <- sparkR.session.getOrCreate()
-sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sparkSession <- sparkR.session()
 
 helloTest <- SparkR:::callJStatic("sparkR.test.hello",
                                   "helloWorld",

--- a/R/pkg/inst/tests/testthat/packageInAJarTest.R
+++ b/R/pkg/inst/tests/testthat/packageInAJarTest.R
@@ -17,7 +17,7 @@
 library(SparkR)
 library(sparkPackageTest)
 
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 
 run1 <- myfunc(5L)
 

--- a/R/pkg/inst/tests/testthat/packageInAJarTest.R
+++ b/R/pkg/inst/tests/testthat/packageInAJarTest.R
@@ -17,13 +17,13 @@
 library(SparkR)
 library(sparkPackageTest)
 
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
 
 run1 <- myfunc(5L)
 
 run2 <- myfunc(-4L)
 
-sparkR.stop()
+sparkR.session.stop()
 
 if (run1 != 6) quit(save = "no", status = 1)
 

--- a/R/pkg/inst/tests/testthat/test_Serde.R
+++ b/R/pkg/inst/tests/testthat/test_Serde.R
@@ -17,7 +17,7 @@
 
 context("SerDe functionality")
 
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 
 test_that("SerDe of primitive types", {
   x <- callJStatic("SparkRHandler", "echo", 1L)

--- a/R/pkg/inst/tests/testthat/test_Serde.R
+++ b/R/pkg/inst/tests/testthat/test_Serde.R
@@ -75,5 +75,3 @@ test_that("SerDe of list of lists", {
   y <- callJStatic("SparkRHandler", "echo", x)
   expect_equal(x, y)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_Serde.R
+++ b/R/pkg/inst/tests/testthat/test_Serde.R
@@ -17,7 +17,7 @@
 
 context("SerDe functionality")
 
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
 
 test_that("SerDe of primitive types", {
   x <- callJStatic("SparkRHandler", "echo", 1L)
@@ -75,3 +75,5 @@ test_that("SerDe of list of lists", {
   y <- callJStatic("SparkRHandler", "echo", x)
   expect_equal(x, y)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_Serde.R
+++ b/R/pkg/inst/tests/testthat/test_Serde.R
@@ -76,4 +76,4 @@ test_that("SerDe of list of lists", {
   expect_equal(x, y)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_binaryFile.R
+++ b/R/pkg/inst/tests/testthat/test_binaryFile.R
@@ -18,7 +18,7 @@
 context("functions on binary files")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 mockFile <- c("Spark is pretty.", "Spark is awesome.")

--- a/R/pkg/inst/tests/testthat/test_binaryFile.R
+++ b/R/pkg/inst/tests/testthat/test_binaryFile.R
@@ -18,7 +18,8 @@
 context("functions on binary files")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 mockFile <- c("Spark is pretty.", "Spark is awesome.")
 
@@ -87,3 +88,5 @@ test_that("saveAsObjectFile()/objectFile() works with multiple paths", {
   unlink(fileName1, recursive = TRUE)
   unlink(fileName2, recursive = TRUE)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_binaryFile.R
+++ b/R/pkg/inst/tests/testthat/test_binaryFile.R
@@ -89,4 +89,4 @@ test_that("saveAsObjectFile()/objectFile() works with multiple paths", {
   unlink(fileName2, recursive = TRUE)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_binaryFile.R
+++ b/R/pkg/inst/tests/testthat/test_binaryFile.R
@@ -88,5 +88,3 @@ test_that("saveAsObjectFile()/objectFile() works with multiple paths", {
   unlink(fileName1, recursive = TRUE)
   unlink(fileName2, recursive = TRUE)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_binary_function.R
+++ b/R/pkg/inst/tests/testthat/test_binary_function.R
@@ -101,4 +101,4 @@ test_that("zipPartitions() on RDDs", {
   unlink(fileName)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_binary_function.R
+++ b/R/pkg/inst/tests/testthat/test_binary_function.R
@@ -18,7 +18,8 @@
 context("binary functions")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data
 nums <- 1:10
@@ -99,3 +100,5 @@ test_that("zipPartitions() on RDDs", {
 
   unlink(fileName)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_binary_function.R
+++ b/R/pkg/inst/tests/testthat/test_binary_function.R
@@ -18,7 +18,7 @@
 context("binary functions")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data

--- a/R/pkg/inst/tests/testthat/test_binary_function.R
+++ b/R/pkg/inst/tests/testthat/test_binary_function.R
@@ -100,5 +100,3 @@ test_that("zipPartitions() on RDDs", {
 
   unlink(fileName)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_broadcast.R
+++ b/R/pkg/inst/tests/testthat/test_broadcast.R
@@ -47,5 +47,3 @@ test_that("without using broadcast variable", {
   expected <- list(sum(randomMat) * 1, sum(randomMat) * 2)
   expect_equal(actual, expected)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_broadcast.R
+++ b/R/pkg/inst/tests/testthat/test_broadcast.R
@@ -18,7 +18,8 @@
 context("broadcast variables")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Partitioned data
 nums <- 1:2
@@ -46,3 +47,5 @@ test_that("without using broadcast variable", {
   expected <- list(sum(randomMat) * 1, sum(randomMat) * 2)
   expect_equal(actual, expected)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_broadcast.R
+++ b/R/pkg/inst/tests/testthat/test_broadcast.R
@@ -18,7 +18,7 @@
 context("broadcast variables")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Partitioned data

--- a/R/pkg/inst/tests/testthat/test_broadcast.R
+++ b/R/pkg/inst/tests/testthat/test_broadcast.R
@@ -48,4 +48,4 @@ test_that("without using broadcast variable", {
   expect_equal(actual, expected)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -54,6 +54,17 @@ test_that("Check masked functions", {
                sort(namesOfMaskedCompletely, na.last = TRUE))
 })
 
+test_that("repeatedly starting and stopping SparkR", {
+  for (i in 1:4) {
+    sc <- suppressWarnings(sparkR.init())
+    rdd <- parallelize(sc, 1:20, 2L)
+    expect_equal(count(rdd), 20)
+    suppressWarnings(sparkR.stop())
+  }
+})
+
+# Does not work consistently even with Hive off
+# nolint start
 # test_that("repeatedly starting and stopping SparkR", {
 #   for (i in 1:4) {
 #     sparkR.session(enableHiveSupport = FALSE)
@@ -63,6 +74,7 @@ test_that("Check masked functions", {
 #     Sys.sleep(5) # Need more time to shutdown Hive metastore
 #   }
 # })
+# nolint end
 
 test_that("rdd GC across sparkR.stop", {
   sc <- sparkR.sparkContext() # sc should get id 0

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -56,7 +56,7 @@ test_that("Check masked functions", {
 
 # test_that("repeatedly starting and stopping SparkR", {
 #   for (i in 1:4) {
-#     sparkR.session.getOrCreate()
+#     sparkR.session(enableHiveSupport = FALSE)
 #     df <- createDataFrame(data.frame(dummy=1:i))
 #     expect_equal(count(df), i)
 #     sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_includePackage.R
+++ b/R/pkg/inst/tests/testthat/test_includePackage.R
@@ -18,7 +18,8 @@
 context("include R packages")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Partitioned data
 nums <- 1:2
@@ -55,3 +56,5 @@ test_that("use include package", {
     actual <- collect(data)
   }
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_includePackage.R
+++ b/R/pkg/inst/tests/testthat/test_includePackage.R
@@ -56,5 +56,3 @@ test_that("use include package", {
     actual <- collect(data)
   }
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_includePackage.R
+++ b/R/pkg/inst/tests/testthat/test_includePackage.R
@@ -18,7 +18,7 @@
 context("include R packages")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Partitioned data

--- a/R/pkg/inst/tests/testthat/test_includePackage.R
+++ b/R/pkg/inst/tests/testthat/test_includePackage.R
@@ -57,4 +57,4 @@ test_that("use include package", {
   }
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -20,7 +20,7 @@ library(testthat)
 context("MLlib functions")
 
 # Tests for MLlib functions in SparkR
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 
 test_that("formula of spark.glm", {
   training <- suppressWarnings(createDataFrame(iris))

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -20,10 +20,7 @@ library(testthat)
 context("MLlib functions")
 
 # Tests for MLlib functions in SparkR
-
-sc <- sparkR.init()
-
-sqlContext <- sparkRSQL.init(sc)
+sparkSession <- sparkR.session.getOrCreate()
 
 test_that("formula of spark.glm", {
   training <- suppressWarnings(createDataFrame(iris))
@@ -456,3 +453,5 @@ test_that("spark.survreg", {
     expect_equal(predict(model, rData)[[1]], 3.724591, tolerance = 1e-4)
   }
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -454,4 +454,4 @@ test_that("spark.survreg", {
   }
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -453,5 +453,3 @@ test_that("spark.survreg", {
     expect_equal(predict(model, rData)[[1]], 3.724591, tolerance = 1e-4)
   }
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_parallelize_collect.R
+++ b/R/pkg/inst/tests/testthat/test_parallelize_collect.R
@@ -109,4 +109,4 @@ test_that("parallelize() and collect() work for lists of pairs (pairwise data)",
   expect_equal(collect(strPairsRDDD2), strPairs)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_parallelize_collect.R
+++ b/R/pkg/inst/tests/testthat/test_parallelize_collect.R
@@ -108,5 +108,3 @@ test_that("parallelize() and collect() work for lists of pairs (pairwise data)",
   expect_equal(collect(strPairsRDDD1), strPairs)
   expect_equal(collect(strPairsRDDD2), strPairs)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_parallelize_collect.R
+++ b/R/pkg/inst/tests/testthat/test_parallelize_collect.R
@@ -33,7 +33,7 @@ numPairs <- list(list(1, 1), list(1, 2), list(2, 2), list(2, 3))
 strPairs <- list(list(strList, strList), list(strList, strList))
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 jsc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Tests

--- a/R/pkg/inst/tests/testthat/test_parallelize_collect.R
+++ b/R/pkg/inst/tests/testthat/test_parallelize_collect.R
@@ -33,7 +33,8 @@ numPairs <- list(list(1, 1), list(1, 2), list(2, 2), list(2, 3))
 strPairs <- list(list(strList, strList), list(strList, strList))
 
 # JavaSparkContext handle
-jsc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+jsc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Tests
 
@@ -107,3 +108,5 @@ test_that("parallelize() and collect() work for lists of pairs (pairwise data)",
   expect_equal(collect(strPairsRDDD1), strPairs)
   expect_equal(collect(strPairsRDDD2), strPairs)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_rdd.R
+++ b/R/pkg/inst/tests/testthat/test_rdd.R
@@ -18,7 +18,7 @@
 context("basic RDD functions")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data

--- a/R/pkg/inst/tests/testthat/test_rdd.R
+++ b/R/pkg/inst/tests/testthat/test_rdd.R
@@ -801,4 +801,4 @@ test_that("Test correct concurrency of RRDD.compute()", {
   expect_equal(count, 1000)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_rdd.R
+++ b/R/pkg/inst/tests/testthat/test_rdd.R
@@ -800,5 +800,3 @@ test_that("Test correct concurrency of RRDD.compute()", {
   count <- callJMethod(zrdd, "count")
   expect_equal(count, 1000)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_rdd.R
+++ b/R/pkg/inst/tests/testthat/test_rdd.R
@@ -18,7 +18,8 @@
 context("basic RDD functions")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data
 nums <- 1:10
@@ -799,3 +800,5 @@ test_that("Test correct concurrency of RRDD.compute()", {
   count <- callJMethod(zrdd, "count")
   expect_equal(count, 1000)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_shuffle.R
+++ b/R/pkg/inst/tests/testthat/test_shuffle.R
@@ -221,4 +221,4 @@ test_that("test partitionBy with string keys", {
   expect_equal(sortKeyValueList(actual_second), sortKeyValueList(expected_second))
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_shuffle.R
+++ b/R/pkg/inst/tests/testthat/test_shuffle.R
@@ -18,7 +18,8 @@
 context("partitionBy, groupByKey, reduceByKey etc.")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data
 intPairs <- list(list(1L, -1), list(2L, 100), list(2L, 1), list(1L, 200))
@@ -219,3 +220,5 @@ test_that("test partitionBy with string keys", {
   expect_equal(sortKeyValueList(actual_first), sortKeyValueList(expected_first))
   expect_equal(sortKeyValueList(actual_second), sortKeyValueList(expected_second))
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_shuffle.R
+++ b/R/pkg/inst/tests/testthat/test_shuffle.R
@@ -220,5 +220,3 @@ test_that("test partitionBy with string keys", {
   expect_equal(sortKeyValueList(actual_first), sortKeyValueList(expected_first))
   expect_equal(sortKeyValueList(actual_second), sortKeyValueList(expected_second))
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_shuffle.R
+++ b/R/pkg/inst/tests/testthat/test_shuffle.R
@@ -18,7 +18,7 @@
 context("partitionBy, groupByKey, reduceByKey etc.")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -60,7 +60,7 @@ unsetHiveContext <- function() {
 
 # Tests for SparkSQL functions in SparkR
 
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 mockLines <- c("{\"name\":\"Michael\"}",
@@ -96,8 +96,8 @@ test_that("calling sparkRSQL.init returns existing SparkSession", {
   expect_equal(suppressWarnings(sparkRSQL.init(sc)), sparkSession)
 })
 
-test_that("calling sparkR.session.getOrCreate returns existing SparkSession", {
-  expect_equal(sparkR.session.getOrCreate(), sparkSession)
+test_that("calling sparkR.session returns existing SparkSession", {
+  expect_equal(sparkR.session(), sparkSession)
 })
 
 test_that("infer types and check types", {
@@ -2324,7 +2324,7 @@ test_that("Change config on SparkSession", {
   value <- as.character(runif(1))
   l <- list(value)
   names(l) <- property
-  sparkR.session.getOrCreate(l)
+  sparkR.session(l)
 
   conf <- callJMethod(sparkSession, "conf")
   newValue <- callJMethod(conf, "get", property, "")

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2301,7 +2301,6 @@ test_that("createDataFrame sqlContext parameter backward compatibility", {
 test_that("randomSplit", {
   num <- 4000
   df <- createDataFrame(data.frame(id = 1:num))
-
   weights <- c(2, 3, 5)
   df_list <- randomSplit(df, weights)
   expect_equal(length(weights), length(df_list))
@@ -2316,6 +2315,31 @@ test_that("randomSplit", {
   expect_true(all(sapply(abs(counts / num - weights / sum(weights)), function(e) { e < 0.05 })))
 })
 
+test_that("Change config on SparkSession", {
+  conf <- callJMethod(sparkSession, "conf")
+  property <- paste0("spark.testing.", as.character(runif(1)))
+  value <- as.character(runif(1))
+  callJMethod(conf, "set", property, value)
+
+  value <- as.character(runif(1))
+  l <- list(value)
+  names(l) <- property
+  sparkR.session.getOrCreate(l)
+
+  conf <- callJMethod(sparkSession, "conf")
+  newValue <- callJMethod(conf, "get", property, "")
+
+  expect_equal(value, newValue)
+})
+
+test_that("enableHiveSupport on SparkSession", {
+  setHiveContext(sc)
+  unsetHiveContext()
+  # if we are still here, it must be built with hive
+  conf <- callJMethod(sparkSession, "conf")
+  value <- callJMethod(conf, "get", "spark.sql.catalogImplementation", "")
+  expect_equal(value, "hive")
+})
 
 unlink(parquetPath)
 unlink(jsonPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2316,20 +2316,29 @@ test_that("randomSplit", {
 })
 
 test_that("Change config on SparkSession", {
+  # first, set it to a random but known value
   conf <- callJMethod(sparkSession, "conf")
   property <- paste0("spark.testing.", as.character(runif(1)))
-  value <- as.character(runif(1))
-  callJMethod(conf, "set", property, value)
+  value1 <- as.character(runif(1))
+  callJMethod(conf, "set", property, value1)
 
-  value <- as.character(runif(1))
-  l <- list(value)
+  # next, change the same property to the new value
+  value2 <- as.character(runif(1))
+  l <- list(value2)
   names(l) <- property
-  sparkR.session(l)
+  sparkR.session(sparkConfig = l)
 
   conf <- callJMethod(sparkSession, "conf")
   newValue <- callJMethod(conf, "get", property, "")
+  expect_equal(value2, newValue)
 
-  expect_equal(value, newValue)
+  value <- as.character(runif(1))
+  sparkR.session(spark.app.name = "sparkSession test", spark.testing.r.session.r = value)
+  conf <- callJMethod(sparkSession, "conf")
+  appNameValue <- callJMethod(conf, "get", "spark.app.name", "")
+  testValue <- callJMethod(conf, "get", "spark.testing.r.session.r", "")
+  expect_equal(appNameValue, "sparkSession test")
+  expect_equal(testValue, value)
 })
 
 test_that("enableHiveSupport on SparkSession", {

--- a/R/pkg/inst/tests/testthat/test_take.R
+++ b/R/pkg/inst/tests/testthat/test_take.R
@@ -66,4 +66,4 @@ test_that("take() gives back the original elements in correct count and order", 
   expect_equal(length(take(numVectorRDD, 0)), 0)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_take.R
+++ b/R/pkg/inst/tests/testthat/test_take.R
@@ -30,7 +30,7 @@ strList <- list("Dexter Morgan: Blood. Sometimes it sets my teeth on edge, ",
                 "raising me. But they're both dead now. I didn't kill them. Honest.")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 test_that("take() gives back the original elements in correct count and order", {

--- a/R/pkg/inst/tests/testthat/test_take.R
+++ b/R/pkg/inst/tests/testthat/test_take.R
@@ -65,5 +65,3 @@ test_that("take() gives back the original elements in correct count and order", 
   expect_equal(length(take(numListRDD, 0)), 0)
   expect_equal(length(take(numVectorRDD, 0)), 0)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_take.R
+++ b/R/pkg/inst/tests/testthat/test_take.R
@@ -30,10 +30,11 @@ strList <- list("Dexter Morgan: Blood. Sometimes it sets my teeth on edge, ",
                 "raising me. But they're both dead now. I didn't kill them. Honest.")
 
 # JavaSparkContext handle
-jsc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 test_that("take() gives back the original elements in correct count and order", {
-  numVectorRDD <- parallelize(jsc, numVector, 10)
+  numVectorRDD <- parallelize(sc, numVector, 10)
   # case: number of elements to take is less than the size of the first partition
   expect_equal(take(numVectorRDD, 1), as.list(head(numVector, n = 1)))
   # case: number of elements to take is the same as the size of the first partition
@@ -42,20 +43,20 @@ test_that("take() gives back the original elements in correct count and order", 
   expect_equal(take(numVectorRDD, length(numVector)), as.list(numVector))
   expect_equal(take(numVectorRDD, length(numVector) + 1), as.list(numVector))
 
-  numListRDD <- parallelize(jsc, numList, 1)
-  numListRDD2 <- parallelize(jsc, numList, 4)
+  numListRDD <- parallelize(sc, numList, 1)
+  numListRDD2 <- parallelize(sc, numList, 4)
   expect_equal(take(numListRDD, 3), take(numListRDD2, 3))
   expect_equal(take(numListRDD, 5), take(numListRDD2, 5))
   expect_equal(take(numListRDD, 1), as.list(head(numList, n = 1)))
   expect_equal(take(numListRDD2, 999), numList)
 
-  strVectorRDD <- parallelize(jsc, strVector, 2)
-  strVectorRDD2 <- parallelize(jsc, strVector, 3)
+  strVectorRDD <- parallelize(sc, strVector, 2)
+  strVectorRDD2 <- parallelize(sc, strVector, 3)
   expect_equal(take(strVectorRDD, 4), as.list(strVector))
   expect_equal(take(strVectorRDD2, 2), as.list(head(strVector, n = 2)))
 
-  strListRDD <- parallelize(jsc, strList, 4)
-  strListRDD2 <- parallelize(jsc, strList, 1)
+  strListRDD <- parallelize(sc, strList, 4)
+  strListRDD2 <- parallelize(sc, strList, 1)
   expect_equal(take(strListRDD, 3), as.list(head(strList, n = 3)))
   expect_equal(take(strListRDD2, 1), as.list(head(strList, n = 1)))
 
@@ -64,3 +65,5 @@ test_that("take() gives back the original elements in correct count and order", 
   expect_equal(length(take(numListRDD, 0)), 0)
   expect_equal(length(take(numVectorRDD, 0)), 0)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_textFile.R
+++ b/R/pkg/inst/tests/testthat/test_textFile.R
@@ -161,4 +161,4 @@ test_that("Pipelined operations on RDDs created using textFile", {
   unlink(fileName)
 })
 
-#sparkR.session.stop()
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_textFile.R
+++ b/R/pkg/inst/tests/testthat/test_textFile.R
@@ -160,5 +160,3 @@ test_that("Pipelined operations on RDDs created using textFile", {
 
   unlink(fileName)
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_textFile.R
+++ b/R/pkg/inst/tests/testthat/test_textFile.R
@@ -18,7 +18,7 @@
 context("the textFile() function")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 mockFile <- c("Spark is pretty.", "Spark is awesome.")

--- a/R/pkg/inst/tests/testthat/test_textFile.R
+++ b/R/pkg/inst/tests/testthat/test_textFile.R
@@ -18,7 +18,8 @@
 context("the textFile() function")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 mockFile <- c("Spark is pretty.", "Spark is awesome.")
 
@@ -159,3 +160,5 @@ test_that("Pipelined operations on RDDs created using textFile", {
 
   unlink(fileName)
 })
+
+#sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_utils.R
+++ b/R/pkg/inst/tests/testthat/test_utils.R
@@ -170,4 +170,17 @@ test_that("hashCode", {
   expect_error(hashCode("bc53d3605e8a5b7de1e8e271c2317645"), NA)
 })
 
-#sparkR.session.stop()
+test_that("overrideEnvs", {
+  config <- new.env()
+  config[["spark.master"]] <- "foo"
+  config[["config_only"]] <- "ok"
+  param <- new.env()
+  param[["spark.master"]] <- "local"
+  param[["param_only"]] <- "blah"
+  overrideEnvs(config, param)
+  expect_equal(config[["spark.master"]], "local")
+  expect_equal(config[["param_only"]], "blah")
+  expect_equal(config[["config_only"]], "ok")
+})
+
+sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_utils.R
+++ b/R/pkg/inst/tests/testthat/test_utils.R
@@ -18,7 +18,7 @@
 context("functions in utils.R")
 
 # JavaSparkContext handle
-sparkSession <- sparkR.session.getOrCreate()
+sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 test_that("convertJListToRList() gives back (deserializes) the original JLists

--- a/R/pkg/inst/tests/testthat/test_utils.R
+++ b/R/pkg/inst/tests/testthat/test_utils.R
@@ -182,5 +182,3 @@ test_that("overrideEnvs", {
   expect_equal(config[["param_only"]], "blah")
   expect_equal(config[["config_only"]], "ok")
 })
-
-sparkR.session.stop()

--- a/R/pkg/inst/tests/testthat/test_utils.R
+++ b/R/pkg/inst/tests/testthat/test_utils.R
@@ -18,7 +18,8 @@
 context("functions in utils.R")
 
 # JavaSparkContext handle
-sc <- sparkR.init()
+sparkSession <- sparkR.session.getOrCreate()
+sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
 test_that("convertJListToRList() gives back (deserializes) the original JLists
           of strings and integers", {
@@ -168,3 +169,5 @@ test_that("convertToJSaveMode", {
 test_that("hashCode", {
   expect_error(hashCode("bc53d3605e8a5b7de1e8e271c2317645"), NA)
 })
+
+#sparkR.session.stop()

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -26,12 +26,21 @@ import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.api.r.SerDe
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, RelationalGroupedDataset, Row, SaveMode, SQLContext}
+import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.types._
 
 private[sql] object SQLUtils {
   SerDe.registerSqlSerDe((readSqlObject, writeSqlObject))
+
+  def getOrCreateSparkSession(jsc: JavaSparkContext): SparkSession = {
+    if (SparkSession.hiveClassesArePresent) {
+      SparkSession.builder().sparkContext(HiveUtils.withHiveExternalCatalog(jsc.sc)).getOrCreate()
+    } else {
+      SparkSession.builder().sparkContext(jsc.sc).getOrCreate()
+    }
+  }
 
   def createSQLContext(jsc: JavaSparkContext): SQLContext = {
     SQLContext.getOrCreate(jsc.sc)

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -22,32 +22,35 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, Da
 import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 
+import org.apache.spark.SparkContext
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.api.r.SerDe
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.config.CATALOG_IMPLEMENTATION
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.apache.spark.sql.hive.HiveUtils
+import org.apache.spark.sql.execution.command.ShowTablesCommand
 import org.apache.spark.sql.types._
 
 private[sql] object SQLUtils {
   SerDe.registerSqlSerDe((readSqlObject, writeSqlObject))
 
-  def getOrCreateSparkSession(jsc: JavaSparkContext): SparkSession = {
-    if (SparkSession.hiveClassesArePresent) {
-      SparkSession.builder().sparkContext(HiveUtils.withHiveExternalCatalog(jsc.sc)).getOrCreate()
+  def withHiveExternalCatalog(sc: SparkContext): SparkContext = {
+    sc.conf.set(CATALOG_IMPLEMENTATION.key, "hive")
+    sc
+  }
+
+  def getOrCreateSparkSession(jsc: JavaSparkContext, enableHiveSupport: Boolean): SparkSession = {
+    if (SparkSession.hiveClassesArePresent && enableHiveSupport) {
+      SparkSession.builder().sparkContext(withHiveExternalCatalog(jsc.sc)).getOrCreate()
     } else {
       SparkSession.builder().sparkContext(jsc.sc).getOrCreate()
     }
   }
 
-  def createSQLContext(jsc: JavaSparkContext): SQLContext = {
-    SQLContext.getOrCreate(jsc.sc)
-  }
-
-  def getJavaSparkContext(sqlCtx: SQLContext): JavaSparkContext = {
-    new JavaSparkContext(sqlCtx.sparkContext)
+  def getJavaSparkContext(spark: SparkSession): JavaSparkContext = {
+    new JavaSparkContext(spark.sparkContext)
   }
 
   def createStructType(fields : Seq[StructField]): StructType = {
@@ -104,10 +107,10 @@ private[sql] object SQLUtils {
     StructField(name, dtObj, nullable)
   }
 
-  def createDF(rdd: RDD[Array[Byte]], schema: StructType, sqlContext: SQLContext): DataFrame = {
+  def createDF(rdd: RDD[Array[Byte]], schema: StructType, sparkSession: SparkSession): DataFrame = {
     val num = schema.fields.length
     val rowRDD = rdd.map(bytesToRow(_, schema))
-    sqlContext.createDataFrame(rowRDD, schema)
+    sparkSession.createDataFrame(rowRDD, schema)
   }
 
   def dfToRowRDD(df: DataFrame): JavaRDD[Array[Byte]] = {
@@ -200,18 +203,18 @@ private[sql] object SQLUtils {
   }
 
   def loadDF(
-      sqlContext: SQLContext,
+      sparkSession: SparkSession,
       source: String,
       options: java.util.Map[String, String]): DataFrame = {
-    sqlContext.read.format(source).options(options).load()
+    sparkSession.read.format(source).options(options).load()
   }
 
   def loadDF(
-      sqlContext: SQLContext,
+      sparkSession: SparkSession,
       source: String,
       schema: StructType,
       options: java.util.Map[String, String]): DataFrame = {
-    sqlContext.read.format(source).schema(schema).options(options).load()
+    sparkSession.read.format(source).schema(schema).options(options).load()
   }
 
   def readSqlObject(dis: DataInputStream, dataType: Char): Object = {
@@ -234,6 +237,24 @@ private[sql] object SQLUtils {
         true
       case _ =>
         false
+    }
+  }
+
+  def getTables(sparkSession: SparkSession, databaseName: String): DataFrame = {
+    databaseName match {
+      case n: String if n != null && n.trim.nonEmpty =>
+        Dataset.ofRows(sparkSession, ShowTablesCommand(Some(n), None))
+      case _ =>
+        Dataset.ofRows(sparkSession, ShowTablesCommand(None, None))
+    }
+  }
+
+  def getTableNames(sparkSession: SparkSession, databaseName: String): Array[String] = {
+    databaseName match {
+      case n: String if n != null && n.trim.nonEmpty =>
+        sparkSession.catalog.listTables(n).collect().map(_.name)
+      case _ =>
+        sparkSession.catalog.listTables().collect().map(_.name)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -55,7 +55,9 @@ private[sql] object SQLUtils {
     spark
   }
 
-  def setSparkContextSessionConf(spark: SparkSession, sparkConfigMap: JMap[Object, Object]) = {
+  def setSparkContextSessionConf(
+      spark: SparkSession,
+      sparkConfigMap: JMap[Object, Object]): Unit = {
     for ((name, value) <- sparkConfigMap.asScala) {
       spark.conf.set(name.toString, value.toString)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR introduces the new SparkSession API for SparkR.
`sparkR.session.getOrCreate()` and `sparkR.session.stop()`

"getOrCreate" is a bit unusual in R but it's important to name this clearly.

SparkR implementation should
- SparkSession is the main entrypoint (vs SparkContext; due to limited functionality supported with SparkContext in SparkR)
- SparkSession replaces SQLContext and HiveContext (both a wrapper around SparkSession, and because of API changes, supporting all 3 would be a lot more work)
- Changes to SparkSession is mostly transparent to users due to SPARK-10903
- Full backward compatibility is expected - users should be able to initialize everything just in Spark 1.6.1 (`sparkR.init()`), but with deprecation warning
- Mostly cosmetic changes to parameter list - users should be able to move to `sparkR.session.getOrCreate()` easily
- An advanced syntax with named parameters (aka varargs aka "...") is supported; that should be closer to the Builder syntax that is in Scala/Python (which unfortunately does not work in R because it will look like this: `enableHiveSupport(config(config(master(appName(builder(), "foo"), "local"), "first", "value"), "next, "value"))`
- Updating config on an existing SparkSession is supported, the behavior is the same as Python, in which config is applied to both SparkContext and SparkSession
- Some SparkSession changes are not matched in SparkR, mostly because it would be breaking API change: `catalog` object, `createOrReplaceTempView`
- Other SQLContext workarounds are replicated in SparkR, eg. `tables`, `tableNames`
- `sparkR` shell is updated to use the SparkSession entrypoint (`sqlContext` is removed, just like with Scale/Python) 
- All tests are updated to use the SparkSession entrypoint
- A bug in `read.jdbc` is fixed

TODO
- [x] Add more tests
- [ ] Separate PR - update all roxygen2 doc coding example
- [ ] Separate PR - update SparkR programming guide
## How was this patch tested?

unit tests, manual tests

@shivaram @sun-rui @rxin 
