### PR TITLE
[SPARK-15916][SQL]  Correctly pushdown top level AND operators with parenthesis in JDBC data source

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -305,7 +305,7 @@ private[sql] class JDBCRDD(
    * `filters`, but as a WHERE clause suitable for injection into a SQL query.
    */
   private val filterWhereClause: String =
-    filters.flatMap(JDBCRDD.compileFilter).mkString(" AND ")
+    filters.flatMap(JDBCRDD.compileFilter).map(p => s"($p)").mkString(" AND ")
 
   /**
    * A WHERE clause representing both `filters`, if any, and the current partition.

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -233,6 +233,10 @@ class JDBCSuite extends SparkFunSuite
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE 'fr%'")).collect().size == 1)
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE '%ed'")).collect().size == 1)
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE '%re%'")).collect().size == 1)
+    val orPrecedenceSql =
+      "SELECT * FROM foobar WHERE (NAME = 'fred' OR THEID = 100) AND THEID < 1"
+    assert(checkPushdown(sql(orPrecedenceSql)).collect().size == 0)
+
     assert(checkPushdown(sql("SELECT * FROM nulltypes WHERE A IS NULL")).collect().size == 1)
     assert(checkPushdown(sql("SELECT * FROM nulltypes WHERE A IS NOT NULL")).collect().size == 0)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR  inserts the correct parenthesis between top level `AND` operators.

For example, the where clause below:

```
WHERE (NAME = 'fred' OR THEID = 100) AND THEID < 1
```

is being parsed as below:

```
WHERE (NAME = 'fred') OR (THEID = 100) AND (THEID < 1)
```

This is fine for other sub filters for each element in `Array[Filter]` but it is not considering the parenthesis and precedence with `AND` between elements in `Array[Filter]`.

This PR produces the correct condition as below:

```
WHERE ((NAME = 'fred') OR (THEID = 100)) AND (THEID < 1)
```
## How was this patch tested?

Unit test in `JDBCSuite`.
