### PR TITLE
[SPARK-9623] [ML] Provide conditional variance for RandomForestRegressor

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
@@ -44,7 +44,8 @@ private[shared] object SharedParamsCodeGen {
         " probabilities. Note: Not all models output well-calibrated probability estimates!" +
         " These probabilities should be treated as confidences, not precise probabilities",
         Some("\"probability\"")),
-      ParamDesc[String]("varianceCol", "Column name for the biased sample variance of prediction"),
+      ParamDesc[String]("varianceCol", "Column name for the biased sample variance of prediction",
+        Some("\"variance\"")),
       ParamDesc[Double]("threshold",
         "threshold in binary classification prediction, in range [0, 1]", Some("0.5"),
         isValid = "ParamValidators.inRange(0, 1)", finalMethods = false),

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -149,6 +149,8 @@ private[ml] trait HasVarianceCol extends Params {
    */
   final val varianceCol: Param[String] = new Param[String](this, "varianceCol", "Column name for the biased sample variance of prediction")
 
+  setDefault(varianceCol, "variance")
+
   /** @group getParam */
   final def getVarianceCol: String = $(varianceCol)
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -95,7 +95,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
     super.setFeatureSubsetStrategy(value)
 
   @Since("2.1.0")
-  /** @group getParam */
+  /** @group setParam */
   def setVarianceCol(value: String): this.type = set(varianceCol, value)
 
   override protected def train(dataset: Dataset[_]): RandomForestRegressionModel = {
@@ -174,7 +174,7 @@ class RandomForestRegressionModel private[ml] (
   private lazy val _treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
 
   @Since("2.1.0")
-  /** @group getParam */
+  /** @group setParam */
   def setVarianceCol(value: String): this.type = set(varianceCol, value)
 
   @Since("1.4.0")
@@ -202,8 +202,7 @@ class RandomForestRegressionModel private[ml] (
     val predictVarianceUDF = udf { (features: Any) =>
       bcastModel.value.predictVariance(features.asInstanceOf[Vector])
     }
-    output = output.withColumn($(varianceCol), predictVarianceUDF(col($(featuresCol))))
-    output.toDF
+    output.withColumn($(varianceCol), predictVarianceUDF(col($(featuresCol)))).toDF
   }
 
   override protected def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -409,10 +409,24 @@ private[ml] trait RandomForestClassificationModelParams extends TreeEnsemblePara
   with HasFeatureSubsetStrategy with TreeClassifierParams
 
 private[ml] trait RandomForestRegressorParams
-  extends RandomForestParams with TreeRegressorParams
+  extends RandomForestParams with TreeRegressorParams with HasVarianceCol
 
 private[ml] trait RandomForestRegressionModelParams extends TreeEnsembleParams
-  with HasFeatureSubsetStrategy with TreeRegressorParams
+  with HasFeatureSubsetStrategy with TreeRegressorParams with HasVarianceCol {
+
+  override protected def validateAndTransformSchema(
+      schema: StructType,
+      fitting: Boolean,
+      featuresDataType: DataType): StructType = {
+    val newSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
+      SchemaUtils.appendColumn(newSchema, $(varianceCol), DoubleType)
+    } else {
+      newSchema
+    }
+  }
+
+}
 
 /**
  * Parameters for Gradient-Boosted Tree algorithms.


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is useful to get the variance of predictions from the `RandomForestRegressor` to plot confidence intervals on the predictions. I verified the formula from page 17 of this paper (http://arxiv.org/pdf/1211.0906v2.pdf)
The returned dataframe now has a column `variance` that can be set by `setVarianceCol` that calculates the variance.

The variance is calculated by summing up the mean of the variance of each decision tree + mean of the prediction^2 of each tree - square(mean of the prediction of each tree)

This pull request is highly inspired from https://github.com/apache/spark/pull/8866/files
## How was this patch tested?

I added a couple of tests to the RandomForestRegression test suite.
