### PR TITLE
[SPARK-15776][SQL] Divide Expression inside Aggregation function is casted to wrong type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -530,9 +530,11 @@ object TypeCoercion {
       // Decimal and Double remain the same
       case d: Divide if d.dataType == DoubleType => d
       case d: Divide if d.dataType.isInstanceOf[DecimalType] => d
-
-      case Divide(left, right) => Divide(Cast(left, DoubleType), Cast(right, DoubleType))
+      case Divide(left, right) if isNumeric(left) && isNumeric(right) =>
+        Divide(Cast(left, DoubleType), Cast(right, DoubleType))
     }
+
+    private def isNumeric(ex: Expression): Boolean = ex.dataType.isInstanceOf[NumericType]
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -525,7 +525,7 @@ object TypeCoercion {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
       // Skip nodes who has not been resolved yet,
       // as this is an extra rule which should be applied at last.
-      case e if !e.resolved => e
+      case e if !e.childrenResolved => e
 
       // Decimal and Double remain the same
       case d: Divide if d.dataType == DoubleType => d

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -213,7 +213,7 @@ case class Multiply(left: Expression, right: Expression)
 case class Divide(left: Expression, right: Expression)
     extends BinaryArithmetic with NullIntolerant {
 
-  override def inputType: AbstractDataType = NumericType
+  override def inputType: AbstractDataType = TypeCollection(DoubleType, DecimalType)
 
   override def symbol: String = "/"
   override def decimalMethod: String = "$div"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -221,7 +221,6 @@ case class Divide(left: Expression, right: Expression)
 
   private lazy val div: (Any, Any) => Any = dataType match {
     case ft: FractionalType => ft.fractional.asInstanceOf[Fractional[Any]].div
-    case it: IntegralType => it.integral.asInstanceOf[Integral[Any]].quot
   }
 
   override def eval(input: InternalRow): Any = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -85,7 +85,7 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertError(Subtract('booleanField, 'booleanField),
       "requires (numeric or calendarinterval) type")
     assertError(Multiply('booleanField, 'booleanField), "requires numeric type")
-    assertError(Divide('booleanField, 'booleanField), "requires numeric type")
+    assertError(Divide('booleanField, 'booleanField), "requires (double or decimal) type")
     assertError(Remainder('booleanField, 'booleanField), "requires numeric type")
 
     assertError(BitwiseAnd('booleanField, 'booleanField), "requires integral type")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -642,19 +642,27 @@ class TypeCoercionSuite extends PlanTest {
     )
   }
 
-  test("SPARK-15776 Divide expression's dataType should be casted to Double or Decimal") {
+  test("SPARK-15776 Divide expression's dataType should be casted to Double or Decimal " +
+    "in aggregation function") {
     val rules = Seq(FunctionArgumentConversion, Division)
-    // Casts integer to double
+    // Casts Integer to Double
     ruleTest(rules, sum(Divide(4, 3)), sum(Divide(Cast(4, DoubleType), Cast(3, DoubleType))))
-    // Left expression is already Double, skip
+    // Left expression is Double, right expression is Int
     ruleTest(rules, sum(Divide(4.0, 3)), sum(Divide(4.0, 3)))
+    // Left expression is Int, right expression is Double
+    ruleTest(rules, sum(Divide(4, 3.0)), sum(Divide(Cast(4, DoubleType), Cast(3.0, DoubleType))))
     // Casts Float to Double
     ruleTest(
       rules,
       sum(Divide(4.0f, 3)),
       sum(Divide(Cast(4.0f, DoubleType), Cast(3, DoubleType))))
-    // Lefts expression is already Decimal, skip
+    // Left expression is Decimal, right expression is Int
     ruleTest(rules, sum(Divide(Decimal(4.0), 3)), sum(Divide(Decimal(4.0), 3)))
+    // Left expression is Int, right expression is Decimal
+    ruleTest(
+      rules,
+      sum(Divide(4, Decimal(3.0))),
+      sum(Divide(Cast(4, DoubleType), Cast(Decimal(3.0), DoubleType))))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -138,19 +138,6 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     }
   }
 
-  test("SPARK-15776: Divide report unresolved when children's data type is " +
-    "neither DecimalType nor DoubleType") {
-    assert(!(Divide(Literal(1.toByte), Literal(2.toByte)).resolved))
-    assert(!(Divide(Literal(1.toShort), Literal(2.toShort)).resolved))
-    assert(!(Divide(Literal(1), Literal(2)).resolved))
-    assert(!(Divide(Literal(1L), Literal(2L)).resolved))
-    assert(!(Divide(Literal(1.0f), Literal(2.0f)).resolved))
-
-    // Resolved if children's dataType is DoubleType or DecimalType
-    assert(Divide(Literal(1.0), Literal(2.0)).resolved)
-    assert(Divide(Literal(Decimal(1.0)), Literal(Decimal(2.0))).resolved)
-  }
-
   // By fixing SPARK-15776, Divide's inputType is required to be DoubleType of DecimalType.
   // TODO: in future release, we should add a IntegerDivide to support integral types.
   ignore("/ (Divide) for integral type") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -133,7 +133,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
       checkEvaluation(Divide(left, Literal(convert(0))), null)  // divide by zero
     }
 
-    DataTypeTestUtils.numericTypeWithoutDecimal.foreach { tpe =>
+    Seq(DoubleType, DecimalType.SYSTEM_DEFAULT).foreach { tpe =>
       checkConsistencyBetweenInterpretedAndCodegen(Divide, tpe, tpe)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -117,8 +117,13 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     }
   }
 
+  private def testDecimalAndDoubleType(testFunc: (Int => Any) => Unit): Unit = {
+    testFunc(_.toDouble)
+    testFunc(Decimal(_))
+  }
+
   test("/ (Divide) basic") {
-    testNumericDataTypes { convert =>
+    testDecimalAndDoubleType { convert =>
       val left = Literal(convert(2))
       val right = Literal(convert(1))
       val dataType = left.dataType
@@ -133,7 +138,22 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     }
   }
 
-  test("/ (Divide) for integral type") {
+  test("SPARK-15776: Divide report unresolved when children's data type is " +
+    "neither DecimalType nor DoubleType") {
+    assert(!(Divide(Literal(1.toByte), Literal(2.toByte)).resolved))
+    assert(!(Divide(Literal(1.toShort), Literal(2.toShort)).resolved))
+    assert(!(Divide(Literal(1), Literal(2)).resolved))
+    assert(!(Divide(Literal(1L), Literal(2L)).resolved))
+    assert(!(Divide(Literal(1.0f), Literal(2.0f)).resolved))
+
+    // Resolved if children's dataType is DoubleType or DecimalType
+    assert(Divide(Literal(1.0), Literal(2.0)).resolved)
+    assert(Divide(Literal(Decimal(1.0)), Literal(Decimal(2.0))).resolved)
+  }
+
+  // By fixing SPARK-15776, Divide's inputType is required to be DoubleType of DecimalType.
+  // TODO: in future release, we should add a IntegerDivide to support integral types.
+  ignore("/ (Divide) for integral type") {
     checkEvaluation(Divide(Literal(1.toByte), Literal(2.toByte)), 0.toByte)
     checkEvaluation(Divide(Literal(1.toShort), Literal(2.toShort)), 0.toShort)
     checkEvaluation(Divide(Literal(1), Literal(2)), 0)
@@ -141,12 +161,6 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Divide(positiveShortLit, negativeShortLit), 0.toShort)
     checkEvaluation(Divide(positiveIntLit, negativeIntLit), 0)
     checkEvaluation(Divide(positiveLongLit, negativeLongLit), 0L)
-  }
-
-  test("/ (Divide) for floating point") {
-    checkEvaluation(Divide(Literal(1.0f), Literal(2.0f)), 0.5f)
-    checkEvaluation(Divide(Literal(1.0), Literal(2.0)), 0.5)
-    checkEvaluation(Divide(Literal(Decimal(1.0)), Literal(Decimal(2.0))), Decimal(0.5))
   }
 
   test("% (Remainder)") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -298,7 +298,7 @@ class ConstraintPropagationSuite extends SparkFunSuite {
         Cast(resolveColumn(tr, "a"), LongType) * resolveColumn(tr, "b") + Cast(100, LongType) ===
           Cast(resolveColumn(tr, "c"), LongType),
         Cast(resolveColumn(tr, "d"), DoubleType) /
-          Cast(Cast(10, LongType), DoubleType) ===
+          Cast(10, DoubleType) ===
             Cast(resolveColumn(tr, "e"), DoubleType),
         IsNotNull(resolveColumn(tr, "a")),
         IsNotNull(resolveColumn(tr, "b")),
@@ -312,7 +312,7 @@ class ConstraintPropagationSuite extends SparkFunSuite {
         Cast(resolveColumn(tr, "a"), LongType) * resolveColumn(tr, "b") - Cast(10, LongType) >=
           Cast(resolveColumn(tr, "c"), LongType),
         Cast(resolveColumn(tr, "d"), DoubleType) /
-          Cast(Cast(10, LongType), DoubleType) <
+          Cast(10, DoubleType) <
             Cast(resolveColumn(tr, "e"), DoubleType),
         IsNotNull(resolveColumn(tr, "a")),
         IsNotNull(resolveColumn(tr, "b")),

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2847,4 +2847,15 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   test("SPARK-15887: hive-site.xml should be loaded") {
     assert(spark.sessionState.newHadoopConf().get("hive.in.test") == "true")
   }
+
+  test("SPARK-15776 Divide expression inside an Aggregation function should not " +
+    "be casted to wrong type") {
+    val doubleSchema = StructType(StructField("a", DoubleType, true) :: Nil)
+    assert(sql("select sum(4/3) as a").schema == doubleSchema)
+    assert(sql("select sum(cast(4.0 as double) / 3) as a").schema == doubleSchema)
+    assert(sql("select sum(cast(4.0 as float) / 3) as a").schema == doubleSchema)
+
+    val decimalSchema = StructType(StructField("a", DecimalType(31, 11), true) :: Nil)
+    assert(sql("select sum(cast(4.0 as decimal) / 3) as a").schema == decimalSchema)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2847,15 +2847,4 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   test("SPARK-15887: hive-site.xml should be loaded") {
     assert(spark.sessionState.newHadoopConf().get("hive.in.test") == "true")
   }
-
-  test("SPARK-15776 Divide expression inside an Aggregation function should not " +
-    "be casted to wrong type") {
-    val doubleSchema = StructType(StructField("a", DoubleType, true) :: Nil)
-    assert(sql("select sum(4/3) as a").schema == doubleSchema)
-    assert(sql("select sum(cast(4.0 as double) / 3) as a").schema == doubleSchema)
-    assert(sql("select sum(cast(4.0 as float) / 3) as a").schema == doubleSchema)
-
-    val decimalSchema = StructType(StructField("a", DecimalType(31, 11), true) :: Nil)
-    assert(sql("select sum(cast(4.0 as decimal) / 3) as a").schema == decimalSchema)
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the problem that Divide Expression inside Aggregation function is casted to wrong type, which cause `select 1/2` and `select sum(1/2)`returning different result.

**Before the change:**

```
scala> sql("select 1/2 as a").show()
+---+
|  a|
+---+
|0.5|
+---+

scala> sql("select sum(1/2) as a").show()
+---+
|  a|
+---+
|0  |
+---+

scala> sql("select sum(1 / 2) as a").schema
res4: org.apache.spark.sql.types.StructType = StructType(StructField(a,LongType,true))
```

**After the change:**

```
scala> sql("select 1/2 as a").show()
+---+
|  a|
+---+
|0.5|
+---+

scala> sql("select sum(1/2) as a").show()
+---+
|  a|
+---+
|0.5|
+---+

scala> sql("select sum(1/2) as a").schema
res4: org.apache.spark.sql.types.StructType = StructType(StructField(a,DoubleType,true))
```
## How was this patch tested?

Unit test.

This PR is based on https://github.com/apache/spark/pull/13524 by @Sephiroth-Lin
