### PR TITLE
[SPARK-15868] [Web UI] Executors table in Executors tab should sort Executor IDs in numerical order

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ui.exec
 import java.net.URLEncoder
 import javax.servlet.http.HttpServletRequest
 
+import scala.util.Try
 import scala.xml.Node
 
 import org.apache.spark.status.api.v1.ExecutorSummary
@@ -53,6 +54,9 @@ private[ui] class ExecutorsPage(
   // When GCTimePercent is edited change ToolTips.TASK_TIME to match
   private val GCTimePercent = 0.1
 
+  // a safe String to Int for sorting ids (converts non-numeric Strings to -1)
+  private def strToInt(str: String) : Int = Try(str.toInt).getOrElse(-1)
+
   def render(request: HttpServletRequest): Seq[Node] = {
     val (activeExecutorInfo, deadExecutorInfo) = listener.synchronized {
       // The follow codes should be protected by `listener` to make sure no executors will be
@@ -69,13 +73,13 @@ private[ui] class ExecutorsPage(
     }
 
     val execInfo = activeExecutorInfo ++ deadExecutorInfo
-    val execInfoSorted = execInfo.sortBy(_.id)
+    val execInfoSorted = execInfo.sortWith((a, b) => strToInt(a.id) > strToInt(b.id))
     val logsExist = execInfo.filter(_.executorLogs.nonEmpty).nonEmpty
 
     val execTable = {
       <table class={UIUtils.TABLE_CLASS_STRIPED_SORTABLE}>
         <thead>
-          <th>Executor ID</th>
+          <th class="sorttable_numeric">Executor ID</th>
           <th>Address</th>
           <th>Status</th>
           <th>RDD Blocks</th>
@@ -136,7 +140,7 @@ private[ui] class ExecutorsPage(
       }
 
     <tr>
-      <td>{info.id}</td>
+      <td sorttable_customkey={strToInt(info.id).toString}>{info.id}</td>
       <td>{info.hostPort}</td>
       <td sorttable_customkey={executorStatus.toString}>
         {executorStatus}

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -55,7 +55,7 @@ private[ui] class ExecutorsPage(
   private val GCTimePercent = 0.1
 
   // a safe String to Int for sorting ids (converts non-numeric Strings to -1)
-  private def strToInt(str: String) : Int = Try(str.toInt).getOrElse(-1)
+  private def idStrToInt(str: String) : Int = Try(str.toInt).getOrElse(-1)
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val (activeExecutorInfo, deadExecutorInfo) = listener.synchronized {
@@ -73,7 +73,8 @@ private[ui] class ExecutorsPage(
     }
 
     val execInfo = activeExecutorInfo ++ deadExecutorInfo
-    val execInfoSorted = execInfo.sortWith((a, b) => strToInt(a.id) > strToInt(b.id))
+    implicit val idOrder = Ordering[Int].on((s: String) => idStrToInt(s)).reverse
+    val execInfoSorted = execInfo.sortBy(_.id)
     val logsExist = execInfo.filter(_.executorLogs.nonEmpty).nonEmpty
 
     val execTable = {
@@ -140,7 +141,7 @@ private[ui] class ExecutorsPage(
       }
 
     <tr>
-      <td sorttable_customkey={strToInt(info.id).toString}>{info.id}</td>
+      <td sorttable_customkey={idStrToInt(info.id).toString}>{info.id}</td>
       <td>{info.hostPort}</td>
       <td sorttable_customkey={executorStatus.toString}>
         {executorStatus}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the Executors table sorts by id using a string sort (since that's what it is stored as). Since  the id is a number (other than the driver) we should be sorting numerically. I have changed both the initial sort on page load as well as the table sort to sort on id numerically, treating non-numeric strings (like the driver) as "-1"
## How was this patch tested?

Manually tested and dev/run-tests

![pageload](https://cloud.githubusercontent.com/assets/13952758/16027882/d32edd0a-318e-11e6-9faf-fc972b7c36ab.png)
![sorted](https://cloud.githubusercontent.com/assets/13952758/16027883/d34541c6-318e-11e6-9ed7-6bfc0cd4152e.png)
