### PR TITLE
[SPARK-15939][ML][PySpark] Clarify ml.linalg usage

### DIFF
--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -16,11 +16,11 @@
 #
 
 """
-MLlib utilities for linear algebra. For dense vectors, MLlib
-uses the NumPy C{array} type, so you can simply pass NumPy arrays
-around. For sparse vectors, users can construct a L{SparseVector}
-object from MLlib or pass SciPy C{scipy.sparse} column vectors if
-SciPy is available in their environment.
+ML utilities for linear algebra. For dense vectors, ML uses the NumPy
+C{array} type, so you can simply pass NumPy arrays around. For sparse
+vectors, users can construct a L{SparseVector} object from ML or pass
+SciPy C{scipy.sparse} column vectors if SciPy is available in their
+environment.
 """
 
 import sys
@@ -54,7 +54,7 @@ if sys.version_info[:2] == (2, 7):
     copy_reg.pickle(array.array, fast_pickle_array)
 
 
-# Check whether we have SciPy. MLlib works without it too, but if we have it, some methods,
+# Check whether we have SciPy. ML works without it too, but if we have it, some methods,
 # such as _dot and _serialize_double_vector, start to support scipy.sparse matrices.
 
 try:
@@ -457,7 +457,7 @@ class DenseVector(Vector):
 
 class SparseVector(Vector):
     """
-    A simple sparse vector class for passing data to MLlib. Users may
+    A simple sparse vector class for passing data to ML. Users may
     alternatively pass SciPy's {scipy.sparse} data types.
     """
     def __init__(self, size, *args):
@@ -733,8 +733,8 @@ class Vectors(object):
     """
     Factory methods for working with vectors. Note that dense vectors
     are simply represented as NumPy array objects, so there is no need
-    to covert them for use in MLlib. For sparse vectors, the factory
-    methods in this class create an MLlib-compatible type, or users
+    to covert them for use in ML. For sparse vectors, the factory
+    methods in this class create an ML-compatible type, or users
     can pass in SciPy's C{scipy.sparse} column vectors.
     """
 

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -161,7 +161,7 @@ class TypeConverters(object):
     @staticmethod
     def toVector(value):
         """
-        Convert a value to a MLlib Vector, if possible.
+        Convert a value to a ML Vector, if possible.
         """
         if isinstance(value, Vector):
             return value

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -72,9 +72,9 @@ from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
 ser = PickleSerializer()
 
 
-class MLlibTestCase(unittest.TestCase):
+class MLTestCase(unittest.TestCase):
     def setUp(self):
-        self.sc = SparkContext('local[4]', "MLlib tests")
+        self.sc = SparkContext('local[4]', "ML tests")
         self.spark = SparkSession(self.sc)
 
     def tearDown(self):
@@ -1191,7 +1191,7 @@ def _squared_distance(a, b):
         return b.squared_distance(a)
 
 
-class VectorTests(MLlibTestCase):
+class VectorTests(MLTestCase):
 
     def _test_serialize(self, v):
         self.assertEqual(v, ser.loads(ser.dumps(v)))
@@ -1454,7 +1454,7 @@ class VectorTests(MLlibTestCase):
         self.assertEqual(tmp.numNonzeros(), 1)
 
 
-class VectorUDTTests(MLlibTestCase):
+class VectorUDTTests(MLTestCase):
 
     dv0 = DenseVector([])
     dv1 = DenseVector([1.0, 2.0])
@@ -1487,7 +1487,7 @@ class VectorUDTTests(MLlibTestCase):
                 raise TypeError("expecting a vector but got %r of type %r" % (v, type(v)))
 
 
-class MatrixUDTTests(MLlibTestCase):
+class MatrixUDTTests(MLTestCase):
 
     dm1 = DenseMatrix(3, 2, [0, 1, 4, 5, 9, 10])
     dm2 = DenseMatrix(3, 2, [0, 1, 4, 5, 9, 10], isTransposed=True)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1, update comments in `pyspark.ml` that it use `ml.linalg` not `mllib.linalg`
2, rename `MLlibTestCase` to `MLTestCase` in `ml.tests.py`
## How was this patch tested?

N/A
