### PR TITLE
[SPARK-15937] [yarn] Improving the logic to wait for an initialised Spark Context

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -523,7 +523,7 @@ private[spark] class ApplicationMaster(
           logError(("SparkContext did not initialize after waiting for %d ms. Please check earlier"
             + " log output for errors. Failing the application.").format(totalWaitTime))
         } else {
-          Some(sparkContext)
+          return Some(sparkContext)
         }
       }
       None


### PR DESCRIPTION
## What changes were proposed in this pull request?

As per this fix we take into account if the job has already finished while waiting instead of just basing the logic if the Spark Context reference is available or not. Similar approach is being is used in org.apache.spark.deploy.yarn.ApplicationMaster.runDriver(securityMgr: SecurityManager) to check if the job is finished or not before declaring it failed.
