### PR TITLE
[SPARK-15945] [MLLIB] Conversion between old/new vector columns in a DataFrame (Scala/Java)

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -22,6 +22,7 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
+import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.{VectorUDT => MLVectorUDT}
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.BLAS.dot
@@ -36,7 +37,7 @@ import org.apache.spark.util.random.BernoulliCellSampler
  * Helper methods to load, save and pre-process data used in ML Lib.
  */
 @Since("0.8.0")
-object MLUtils {
+object MLUtils extends Logging {
 
   private[mllib] lazy val EPSILON = {
     var eps = 1.0
@@ -290,6 +291,9 @@ object MLUtils {
       return dataset.toDF()
     }
 
+    logWarning("Vector column conversion has serialization overhead. " +
+      "Please migrate your datasets and workflows to use the spark.ml package.")
+
     // TODO: This implementation has performance issues due to unnecessary serialization.
     // TODO: It is better (but trickier) if we can cast the old vector type to new type directly.
     val convertToML = udf { v: Vector => v.asML }
@@ -338,6 +342,9 @@ object MLUtils {
     if (colSet.isEmpty) {
       return dataset.toDF()
     }
+
+    logWarning("Vector column conversion has serialization overhead. " +
+      "Please migrate your datasets and workflows to use the spark.ml package.")
 
     // TODO: This implementation has performance issues due to unnecessary serialization.
     // TODO: It is better (but trickier) if we can cast the new vector type to old type directly.

--- a/mllib/src/test/java/org/apache/spark/mllib/util/JavaMLUtilsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/util/JavaMLUtilsSuite.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.util;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.spark.SharedSparkSession;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+import org.apache.spark.mllib.regression.LabeledPoint;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+
+public class JavaMLUtilsSuite extends SharedSparkSession {
+
+  @Test
+  public void testConvertOldVectorColumnToNew() {
+    Vector x = Vectors.dense(2.0);
+    Dataset<Row> dataset = spark.createDataFrame(
+      Collections.singletonList(new LabeledPoint(1.0, x)), LabeledPoint.class
+    ).select("label", "features");
+    Row new1 = MLUtils.convertOldVectorColumnsToNew(dataset).first();
+    Assert.assertEquals(RowFactory.create(1.0, x.asML()), new1);
+    Row new2 = MLUtils.convertOldVectorColumnsToNew(dataset, "features").first();
+    Assert.assertEquals(new1, new2);
+    try {
+      MLUtils.convertOldVectorColumnsToNew(dataset, "label");
+      Assert.fail("Should throw an exception on converting non-vector columns.");
+    } catch (IllegalArgumentException ex) {
+      // pass
+    }
+  }
+}

--- a/mllib/src/test/java/org/apache/spark/mllib/util/JavaMLUtilsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/util/JavaMLUtilsSuite.java
@@ -33,20 +33,17 @@ import org.apache.spark.sql.RowFactory;
 public class JavaMLUtilsSuite extends SharedSparkSession {
 
   @Test
-  public void testConvertOldVectorColumnToNew() {
+  public void testConvertVectorColumnsToAndFromML() {
     Vector x = Vectors.dense(2.0);
     Dataset<Row> dataset = spark.createDataFrame(
       Collections.singletonList(new LabeledPoint(1.0, x)), LabeledPoint.class
     ).select("label", "features");
-    Row new1 = MLUtils.convertOldVectorColumnsToNew(dataset).first();
+    Dataset<Row> newDataset1 = MLUtils.convertVectorColumnsToML(dataset);
+    Row new1 = newDataset1.first();
     Assert.assertEquals(RowFactory.create(1.0, x.asML()), new1);
-    Row new2 = MLUtils.convertOldVectorColumnsToNew(dataset, "features").first();
+    Row new2 = MLUtils.convertVectorColumnsToML(dataset, "features").first();
     Assert.assertEquals(new1, new2);
-    try {
-      MLUtils.convertOldVectorColumnsToNew(dataset, "label");
-      Assert.fail("Should throw an exception on converting non-vector columns.");
-    } catch (IllegalArgumentException ex) {
-      // pass
-    }
+    Row old1 = MLUtils.convertVectorColumnsFromML(newDataset1).first();
+    Assert.assertEquals(RowFactory.create(1.0, x), old1);
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -31,6 +31,8 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLUtils._
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.MetadataBuilder
 import org.apache.spark.util.Utils
 
 class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -246,25 +248,57 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(log1pExp(-238423789.865) ~== math.log1p(math.exp(-238423789.865)) absTol 1E-10)
   }
 
-  test("convertOldVectorColumnsToNew") {
+  test("convertVectorColumnsToML") {
     val x = Vectors.sparse(2, Array(1), Array(1.0))
+    val metadata = new MetadataBuilder().putLong("numFeatures", 2L).build()
     val y = Vectors.dense(2.0, 3.0)
     val z = Vectors.dense(4.0)
-    val p = LabeledPoint(5.0, z)
+    val p = (5.0, z)
+    val w = Vectors.dense(6.0).asML
     val df = spark.createDataFrame(Seq(
-      (0, x, y, p)
-    )).toDF("id", "x", "y", "p")
-    val new1 = convertOldVectorColumnsToNew(df).first()
-    assert(new1 === Row(0, x.asML, y.asML, Row(5.0, z)))
-    val new2 = convertOldVectorColumnsToNew(df, "x", "y").first()
+      (0, x, y, p, w)
+    )).toDF("id", "x", "y", "p", "w")
+      .withColumn("x", col("x"), metadata)
+    val newDF1 = convertVectorColumnsToML(df)
+    assert(newDF1.schema("x").metadata === metadata, "Metadata should be preserved.")
+    val new1 = newDF1.first()
+    assert(new1 === Row(0, x.asML, y.asML, Row(5.0, z), w))
+    val new2 = convertVectorColumnsToML(df, "x", "y").first()
     assert(new2 === new1)
-    val new3 = convertOldVectorColumnsToNew(df, "y").first()
-    assert(new3 === Row(0, x, y.asML, Row(5.0, z)))
+    val new3 = convertVectorColumnsToML(df, "y", "w").first()
+    assert(new3 === Row(0, x, y.asML, Row(5.0, z), w))
     intercept[IllegalArgumentException] {
-      convertOldVectorColumnsToNew(df, "p")
+      convertVectorColumnsToML(df, "p")
     }
     intercept[IllegalArgumentException] {
-      convertOldVectorColumnsToNew(df, "p.features")
+      convertVectorColumnsToML(df, "p._2")
+    }
+  }
+
+  test("convertVectorColumnsFromML") {
+    val x = Vectors.sparse(2, Array(1), Array(1.0)).asML
+    val metadata = new MetadataBuilder().putLong("numFeatures", 2L).build()
+    val y = Vectors.dense(2.0, 3.0).asML
+    val z = Vectors.dense(4.0).asML
+    val p = (5.0, z)
+    val w = Vectors.dense(6.0)
+    val df = spark.createDataFrame(Seq(
+      (0, x, y, p, w)
+    )).toDF("id", "x", "y", "p", "w")
+      .withColumn("x", col("x"), metadata)
+    val newDF1 = convertVectorColumnsFromML(df)
+    assert(newDF1.schema("x").metadata === metadata, "Metadata should be preserved.")
+    val new1 = newDF1.first()
+    assert(new1 === Row(0, Vectors.fromML(x), Vectors.fromML(y), Row(5.0, z), w))
+    val new2 = convertVectorColumnsFromML(df, "x", "y").first()
+    assert(new2 === new1)
+    val new3 = convertVectorColumnsFromML(df, "y", "w").first()
+    assert(new3 === Row(0, x, Vectors.fromML(y), Row(5.0, z), w))
+    intercept[IllegalArgumentException] {
+      convertVectorColumnsFromML(df, "p")
+    }
+    intercept[IllegalArgumentException] {
+      convertVectorColumnsFromML(df, "p._2")
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR provides conversion utils between old/new vector columns in a DataFrame. So users can use it to migrate their datasets and pipelines manually. The methods are implemented under `MLUtils` and called `convertVectorColumnsToML` and `convertVectorColumnsFromML`. Both take a DataFrame and a list of vector columns to be converted. It is a no-op on vector columns that are already converted. A warning message is logged if actual conversion happens.

This is the first sub-task under SPARK-15944 to make it easier to migrate existing pipelines to Spark 2.0.
## How was this patch tested?

Unit tests in Scala and Java.

cc: @yanboliang 
