### PR TITLE
[SPARK-15957] [ML] RFormula supports forcing to index label

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -111,18 +111,18 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
    * we can force to index label even it is numeric type by setting this param with true.
    * Default: false.
    */
-  @Since("2.0.0")
-  val indexLabel: BooleanParam = new BooleanParam(this, "indexLabel",
+  @Since("2.1.0")
+  val forceIndexLabel: BooleanParam = new BooleanParam(this, "forceIndexLabel",
     "Force to index label whether it is numeric or string")
-  setDefault(indexLabel -> false)
+  setDefault(forceIndexLabel -> false)
 
   /** @group getParam */
-  @Since("2.0.0")
-  def getIndexLabel: Boolean = $(indexLabel)
+  @Since("2.1.0")
+  def getForceIndexLabel: Boolean = $(forceIndexLabel)
 
   /** @group setParam */
-  @Since("2.0.0")
-  def setIndexLabel(value: Boolean): this.type = set(indexLabel, value)
+  @Since("2.1.0")
+  def setForceIndexLabel(value: Boolean): this.type = set(forceIndexLabel, value)
 
   /** Whether the formula specifies fitting an intercept. */
   private[ml] def hasIntercept: Boolean = {
@@ -188,7 +188,7 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
     encoderStages += new ColumnPruner(tempColumns.toSet)
 
     if ((dataset.schema.fieldNames.contains(resolvedFormula.label) &&
-      dataset.schema(resolvedFormula.label).dataType == StringType) || $(indexLabel)) {
+      dataset.schema(resolvedFormula.label).dataType == StringType) || $(forceIndexLabel)) {
       encoderStages += new StringIndexer()
         .setInputCol(resolvedFormula.label)
         .setOutputCol($(labelCol))
@@ -201,7 +201,7 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   @Since("1.5.0")
   // optimistic schema; does not contain any ML attributes
   override def transformSchema(schema: StructType): StructType = {
-    require(!hasLabelCol(schema) || !$(indexLabel),
+    require(!hasLabelCol(schema) || !$(forceIndexLabel),
       "If label column already exists, indexLabel can not be set with true.")
     if (hasLabelCol(schema)) {
       StructType(schema.fields :+ StructField($(featuresCol), new VectorUDT, true))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -202,7 +202,7 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   // optimistic schema; does not contain any ML attributes
   override def transformSchema(schema: StructType): StructType = {
     require(!hasLabelCol(schema) || !$(forceIndexLabel),
-      "If label column already exists, indexLabel can not be set with true.")
+      "If label column already exists, forceIndexLabel can not be set with true.")
     if (hasLabelCol(schema)) {
       StructType(schema.fields :+ StructField($(featuresCol), new VectorUDT, true))
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -105,18 +105,23 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   def setLabelCol(value: String): this.type = set(labelCol, value)
 
   /**
-   * Force to index label whether it is numeric or string.
-   * For classification algorithms, we force to index label by setting it with true.
+   * Force to index label whether it is numeric or string type.
+   * Usually we index label only when it is string type.
+   * If the formula was used by classification algorithms,
+   * we can force to index label even it is numeric type by setting this param with true.
    * Default: false.
    */
+  @Since("2.0.0")
   val indexLabel: BooleanParam = new BooleanParam(this, "indexLabel",
     "Force to index label whether it is numeric or string")
   setDefault(indexLabel -> false)
 
   /** @group getParam */
+  @Since("2.0.0")
   def getIndexLabel: Boolean = $(indexLabel)
 
   /** @group setParam */
+  @Since("2.0.0")
   def setIndexLabel(value: Boolean): this.type = set(indexLabel, value)
 
   /** Whether the formula specifies fitting an intercept. */
@@ -197,7 +202,7 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   // optimistic schema; does not contain any ML attributes
   override def transformSchema(schema: StructType): StructType = {
     require(!hasLabelCol(schema) || !$(indexLabel),
-      "If label column already exists, indexLabel can not be set as true.")
+      "If label column already exists, indexLabel can not be set with true.")
     if (hasLabelCol(schema)) {
       StructType(schema.fields :+ StructField($(featuresCol), new VectorUDT, true))
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -110,6 +110,7 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
    * If the formula was used by classification algorithms,
    * we can force to index label even it is numeric type by setting this param with true.
    * Default: false.
+   * @group param
    */
   @Since("2.1.0")
   val forceIndexLabel: BooleanParam = new BooleanParam(this, "forceIndexLabel",

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -57,7 +57,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     }
   }
 
-  test("label column already exists and indexLabel was set with false") {
+  test("label column already exists and forceIndexLabel was set with false") {
     val formula = new RFormula().setFormula("y ~ x").setLabelCol("y")
     val original = Seq((0, 1.0), (2, 2.0)).toDF("x", "y")
     val model = formula.fit(original)
@@ -66,8 +66,8 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     assert(resultSchema.toString == model.transform(original).schema.toString)
   }
 
-  test("label column already exists but indexLabel was set with true") {
-    val formula = new RFormula().setFormula("y ~ x").setLabelCol("y").setIndexLabel(true)
+  test("label column already exists but forceIndexLabel was set with true") {
+    val formula = new RFormula().setFormula("y ~ x").setLabelCol("y").setForceIndexLabel(true)
     val original = spark.createDataFrame(Seq((0, 1.0), (2, 2.0))).toDF("x", "y")
     intercept[IllegalArgumentException] {
       formula.fit(original)
@@ -146,7 +146,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
   }
 
   test("force to index label even it is numeric type") {
-    val formula = new RFormula().setFormula("id ~ a + b").setIndexLabel(true)
+    val formula = new RFormula().setFormula("id ~ a + b").setForceIndexLabel(true)
     val original = spark.createDataFrame(
       Seq((1.0, "foo", 4), (1.0, "bar", 4), (0.0, "bar", 5), (1.0, "baz", 5))
     ).toDF("id", "a", "b")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -57,7 +57,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     }
   }
 
-  test("label column already exists and indexLabel was set as false") {
+  test("label column already exists and indexLabel was set with false") {
     val formula = new RFormula().setFormula("y ~ x").setLabelCol("y")
     val original = Seq((0, 1.0), (2, 2.0)).toDF("x", "y")
     val model = formula.fit(original)
@@ -66,7 +66,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     assert(resultSchema.toString == model.transform(original).schema.toString)
   }
 
-  test("label column already exists but indexLabel was set as true") {
+  test("label column already exists but indexLabel was set with true") {
     val formula = new RFormula().setFormula("y ~ x").setLabelCol("y").setIndexLabel(true)
     val original = spark.createDataFrame(Seq((0, 1.0), (2, 2.0))).toDF("x", "y")
     intercept[IllegalArgumentException] {
@@ -145,7 +145,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     assert(result.collect() === expected.collect())
   }
 
-  test("Force to index label") {
+  test("force to index label even it is numeric type") {
     val formula = new RFormula().setFormula("id ~ a + b").setIndexLabel(true)
     val original = spark.createDataFrame(
       Seq((1.0, "foo", 4), (1.0, "bar", 4), (0.0, "bar", 5), (1.0, "baz", 5))


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RFormula` will index label only when it is string type currently. If the label is numeric type and we use `RFormula` to present a classification model, there is no label attributes in label column metadata. The label attributes are useful when making prediction for classification, so we can force to index label by `StringIndexer` whether it is numeric or string type for classification. Then SparkR wrappers can extract label attributes from label column metadata successfully. This feature can help us to fix bug similar with [SPARK-15153](https://issues.apache.org/jira/browse/SPARK-15153).
For regression, we will still to keep label as numeric type.
In this PR, we add a param `indexLabel` to control whether to force to index label for `RFormula`.
## How was this patch tested?

Unit tests.
