### PR TITLE
[SPARK-15824][SQL] Execute WITH .... INSERT ... statements immediately

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -179,7 +179,7 @@ class Dataset[T] private[sql](
       case _ => false
     }
 
-    queryExecution.logical match {
+    queryExecution.analyzed match {
       // For various commands (like DDL) and queries with side effects, we force query execution
       // to happen right away to let these side effects take place eagerly.
       case p if hasSideEffects(p) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -179,15 +179,15 @@ class Dataset[T] private[sql](
       case _ => false
     }
 
-    def materialize: LogicalPlan = {
-      LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
-    }
     queryExecution.analyzed match {
       // For various commands (like DDL) and queries with side effects, we force query execution
       // to happen right away to let these side effects take place eagerly.
-      case p if hasSideEffects(p) => materialize
-      case Union(children) if children.forall(hasSideEffects) => materialize
-      case _ => queryExecution.analyzed
+      case p if hasSideEffects(p) =>
+        LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
+      case Union(children) if children.forall(hasSideEffects) =>
+        LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
+      case _ =>
+        queryExecution.analyzed
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -179,15 +179,16 @@ class Dataset[T] private[sql](
       case _ => false
     }
 
-    queryExecution.analyzed match {
+    def materialize: LogicalPlan = {
+      LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
+    }
+    queryExecution.logical match {
       // For various commands (like DDL) and queries with side effects, we force query execution
       // to happen right away to let these side effects take place eagerly.
-      case p if hasSideEffects(p) =>
-        LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
-      case Union(children) if children.forall(hasSideEffects) =>
-        LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
-      case _ =>
-        queryExecution.analyzed
+      case p if hasSideEffects(p) => materialize
+      case Union(children) if children.forall(hasSideEffects) => materialize
+      case With(p, _) if hasSideEffects(p) => materialize
+      case _ => queryExecution.analyzed
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -182,12 +182,11 @@ class Dataset[T] private[sql](
     def materialize: LogicalPlan = {
       LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
     }
-    queryExecution.logical match {
+    queryExecution.analyzed match {
       // For various commands (like DDL) and queries with side effects, we force query execution
       // to happen right away to let these side effects take place eagerly.
       case p if hasSideEffects(p) => materialize
       case Union(children) if children.forall(hasSideEffects) => materialize
-      case With(p, _) if hasSideEffects(p) => materialize
       case _ => queryExecution.analyzed
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -279,7 +279,7 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
           |INSERT INTO target2 SELECT a, b WHERE a > 5
         """.stripMargin)
       checkAnswer(
-        sql("SELECT a, b FROM target"),
+        sql("SELECT a, b FROM target2"),
         sql("SELECT a, b FROM jt")
       )
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.sources
 import java.io.File
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
@@ -261,9 +262,22 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
   }
 
   test("SPARK-15824 - Execute an INSERT wrapped in a WITH statement immediately") {
-    withTable("target") {
-      sql("CREATE TABLE target(a INT, b STRING) USING JSON")
+    withTable("target", "target2") {
+      sql(s"CREATE TABLE target(a INT, b STRING) USING JSON")
       sql("WITH tbl AS (SELECT * FROM jt) INSERT OVERWRITE TABLE target SELECT a, b FROM tbl")
+      checkAnswer(
+        sql("SELECT a, b FROM target"),
+        sql("SELECT a, b FROM jt")
+      )
+
+      sql(s"CREATE TABLE target2(a INT, b STRING) USING JSON")
+      val e = sql(
+        """
+          |WITH tbl AS (SELECT * FROM jt)
+          |FROM tbl
+          |INSERT INTO target2 SELECT a, b WHERE a <= 5
+          |INSERT INTO target2 SELECT a, b WHERE a > 5
+        """.stripMargin)
       checkAnswer(
         sql("SELECT a, b FROM target"),
         sql("SELECT a, b FROM jt")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -259,4 +259,15 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
 
     spark.catalog.dropTempView("oneToTen")
   }
+
+  test("SPARK-15824 - Execute an INSERT wrapped in a WITH statement immediately") {
+    withTable("target") {
+      sql("CREATE TABLE target(a INT, b STRING) USING JSON")
+      sql("WITH tbl AS (SELECT 1, 'a') INSERT OVERWRITE TABLE target SELECT a, b FROM jt")
+      checkAnswer(
+        sql("SELECT a, b FROM target"),
+        (1 to 10).map(i => Row(i, s"str$i"))
+      )
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -263,10 +263,10 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
   test("SPARK-15824 - Execute an INSERT wrapped in a WITH statement immediately") {
     withTable("target") {
       sql("CREATE TABLE target(a INT, b STRING) USING JSON")
-      sql("WITH tbl AS (SELECT 1, 'a') INSERT OVERWRITE TABLE target SELECT a, b FROM jt")
+      sql("WITH tbl AS (SELECT * FROM jt) INSERT OVERWRITE TABLE target SELECT a, b FROM tbl")
       checkAnswer(
         sql("SELECT a, b FROM target"),
-        (1 to 10).map(i => Row(i, s"str$i"))
+        sql("SELECT a, b FROM jt")
       )
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -544,7 +544,7 @@ private[hive] case class InsertIntoHiveTable(
     child: LogicalPlan,
     overwrite: Boolean,
     ifNotExists: Boolean)
-  extends LogicalPlan {
+  extends LogicalPlan with Command {
 
   override def children: Seq[LogicalPlan] = child :: Nil
   override def output: Seq[Attribute] = Seq.empty


### PR DESCRIPTION
## What changes were proposed in this pull request?

We currently immediately execute `INSERT` commands when they are issued. This is not the case as soon as we use a `WITH` to define common table expressions, for example:

``` sql
WITH
tbl AS (SELECT * FROM x WHERE id = 10)
INSERT INTO y
SELECT *
FROM   tbl
```

This PR fixes this problem. This PR closes https://github.com/apache/spark/pull/13561 (which fixes the a instance of this problem in the ThriftSever).
## How was this patch tested?

Added a test to `InsertSuite`
