### PR TITLE
[SPARK-15851][Build] Fix the call of the bash script to enable proper run in Windows

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -357,7 +357,8 @@
             <configuration>
               <!-- Execute the shell script to generate the spark build information. -->
               <tasks>
-                <exec executable="${project.basedir}/../build/spark-build-info">
+                <exec executable="bash">
+		  <arg value="${project.basedir}/../build/spark-build-info"/>
                   <arg value="${project.build.directory}/extra-resources"/>
                   <arg value="${pom.version}"/>
                 </exec>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+i<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-i<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -458,7 +458,7 @@ object Core {
     resourceGenerators in Compile += Def.task {
       val buildScript = baseDirectory.value + "/../build/spark-build-info"
       val targetDir = baseDirectory.value + "/target/extra-resources/"
-      val command =  buildScript + " " + targetDir + " " + version.value
+      val command =  "bash " + buildScript + " " + targetDir + " " + version.value
       Process(command).!!
       val propsFile = baseDirectory.value / "target" / "extra-resources" / "spark-version-info.properties"
       Seq(propsFile)

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -458,7 +458,7 @@ object Core {
     resourceGenerators in Compile += Def.task {
       val buildScript = baseDirectory.value + "/../build/spark-build-info"
       val targetDir = baseDirectory.value + "/target/extra-resources/"
-      val command =  "bash " + buildScript + " " + targetDir + " " + version.value
+      val command = Seq("bash", buildScript, targetDir, version.value)
       Process(command).!!
       val propsFile = baseDirectory.value / "target" / "extra-resources" / "spark-version-info.properties"
       Seq(propsFile)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The way bash script `build/spark-build-info` is called from core/pom.xml prevents Spark building on Windows. Instead of calling the script directly we call bash and pass the script as an argument. This enables running it on Windows with bash installed which typically comes with Git.

This brings https://github.com/apache/spark/pull/13612 up-to-date and also addresses comments from the code review.

Closes #13612
## How was this patch tested?

I built manually (on a Mac) to verify it didn't break Mac compilation.
