### PR TITLE
[SPARK-15977][SQL] Fix TRUNCATE TABLE for Spark specific datasource tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -269,6 +269,7 @@ case class CreateDataSourceTableAsSelectCommand(
 object CreateDataSourceTableUtils extends Logging {
 
   val DATASOURCE_PREFIX = "spark.sql.sources."
+  val DATASOURCE_PATH = "path"
   val DATASOURCE_PROVIDER = DATASOURCE_PREFIX + "provider"
   val DATASOURCE_WRITEJOBUUID = DATASOURCE_PREFIX + "writeJobUUID"
   val DATASOURCE_OUTPUTPATH = DATASOURCE_PREFIX + "output.path"
@@ -382,7 +383,7 @@ object CreateDataSourceTableUtils extends Logging {
         tableType = tableType,
         schema = Nil,
         storage = CatalogStorageFormat(
-          locationUri = None,
+          locationUri = options.get(DATASOURCE_PATH),
           inputFormat = None,
           outputFormat = None,
           serde = None,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -269,7 +269,6 @@ case class CreateDataSourceTableAsSelectCommand(
 object CreateDataSourceTableUtils extends Logging {
 
   val DATASOURCE_PREFIX = "spark.sql.sources."
-  val DATASOURCE_PATH = "path"
   val DATASOURCE_PROVIDER = DATASOURCE_PREFIX + "provider"
   val DATASOURCE_WRITEJOBUUID = DATASOURCE_PREFIX + "writeJobUUID"
   val DATASOURCE_OUTPUTPATH = DATASOURCE_PREFIX + "output.path"
@@ -383,7 +382,7 @@ object CreateDataSourceTableUtils extends Logging {
         tableType = tableType,
         schema = Nil,
         storage = CatalogStorageFormat(
-          locationUri = options.get(DATASOURCE_PATH),
+          locationUri = None,
           inputFormat = None,
           outputFormat = None,
           serde = None,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -348,7 +348,9 @@ case class TruncateTableCommand(
         s"for tables that are not partitioned: '$tableName'")
     }
     val locations =
-      if (isDatasourceTable || table.partitionColumnNames.isEmpty) {
+      if (isDatasourceTable) {
+        Seq(table.storage.serdeProperties.get("path"))
+      } else if (table.partitionColumnNames.isEmpty) {
         Seq(table.storage.locationUri)
       } else {
         catalog.listPartitions(tableName, partitionSpec).map(_.storage.locationUri)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TRUNCATE TABLE` is currently broken for Spark specific datasource tables (json, csv, ...). This PR correctly sets the location for these datasources which allows them to be truncated.
## How was this patch tested?

Extended the datasources `TRUNCATE TABLE` tests in `DDLSuite`.
