### PR TITLE
[SPARK-15980][SQL] Add PushPredicateThroughObjectConsumer rule to Optimizer.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -227,6 +227,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       "b")
   }
 
+  test("map and filter") {
+    val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
+    checkDataset(
+      ds.map(v => (v._1, v._2 + 1)).filter(_._1 == "b"),
+      ("b", 3))
+  }
+
   test("SPARK-15632: typed filter should preserve the underlying logical schema") {
     val ds = spark.range(10)
     val ds2 = ds.filter(_ > 3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds `PushPredicateThroughObjectConsumer` rule to push-down predicates through `ObjectConsumer`.
And as an example, I implemented push-down typed filter through `SerializeFromObject`.

The optimized plan for the following `DataFrame`:

```
Seq(("a", 1), ("b", 2), ("c", 3)).toDS().map(v => (v._1, v._2 + 1)).filter(_._1 == "b")
```

was before patch:

```
Filter <function1>.apply
+- SerializeFromObject [staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, assertnotnull(input[0, scala.Tuple2, true], top level non-flat input object)._1, true) AS _1#449, assertnotnull(input[0, scala.Tuple2, true], top level non-flat input object)._2 AS _2#450]
   +- MapElements <function1>, obj#448: scala.Tuple2
      +- DeserializeToObject newInstance(class scala.Tuple2), obj#447: scala.Tuple2
         +- LocalRelation [_1#442, _2#443]
```

becomes after patch:

```
SerializeFromObject [staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, assertnotnull(input[0, scala.Tuple2, true], top level non-flat input object)._1, true) AS _1#449, assertnotnull(input[0, scala.Tuple2, true], top level non-flat input object)._2 AS _2#450]
+- Filter <function1>.apply
   +- MapElements <function1>, obj#448: scala.Tuple2
      +- DeserializeToObject newInstance(class scala.Tuple2), obj#447: scala.Tuple2
         +- LocalRelation [_1#442, _2#443]
```
## How was this patch tested?

Added tests to check if push-down typed filter through `SerializeFromObject` correctly works.
