### PR TITLE
[WIP][SPARK-15822][SQL] avoid UTF8String references into freed pages

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -461,7 +461,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return UTF8String.fromBytes(newBytes);
   }
 
-  private UTF8String copy() {
+  public UTF8String copy() {
     byte[] newBytes = new byte[this.numBytes];
     copyMemory(base, offset, newBytes, BYTE_ARRAY_OFFSET, this.numBytes);
     return UTF8String.fromBytes(newBytes);

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -461,6 +461,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return UTF8String.fromBytes(newBytes);
   }
 
+  private UTF8String copy() {
+    byte[] newBytes = new byte[this.numBytes];
+    copyMemory(base, offset, newBytes, BYTE_ARRAY_OFFSET, this.numBytes);
+    return UTF8String.fromBytes(newBytes);
+  }
+  
   public UTF8String trim() {
     int s = 0;
     int e = this.numBytes - 1;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -344,7 +344,7 @@ case class SortMergeJoinExec(
            |  $value = ${ev.value}.copy();
            |} else {
            |  $value = ${ev.value};
-           |} 
+           |}
          """.stripMargin
       ExprCode(code, "false", value)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -340,7 +340,11 @@ case class SortMergeJoinExec(
       ctx.addMutableState(ctx.javaType(leftKeys(i).dataType), value, "")
       val code =
         s"""
-           |$value = ${ev.value};
+           |if (${ev.value} instanceof UTF8String) {
+           |  $value = ${ev.value}.copy();
+           |} else {
+           |  $value = ${ev.value};
+           |} 
          """.stripMargin
       ExprCode(code, "false", value)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SMJ codegen we need to save copies of UTF8String values as the final iterator.next() will free the underlying memory page.
## How was this patch tested?

Test application as described in 15822 now passes.
