### PR TITLE
[SQL] Minor HashAggregateExec string output fixes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -774,13 +774,13 @@ case class HashAggregateExec(
 
     testFallbackStartsAt match {
       case None =>
-        val keyString = Utils.truncatedString(groupingExpressions, "[", ",", "]")
-        val functionString = Utils.truncatedString(allAggregateExpressions, "[", ",", "]")
-        val outputString = Utils.truncatedString(output, "[", ",", "]")
+        val keyString = Utils.truncatedString(groupingExpressions, "[", ", ", "]")
+        val functionString = Utils.truncatedString(allAggregateExpressions, "[", ", ", "]")
+        val outputString = Utils.truncatedString(output, "[", ", ", "]")
         if (verbose) {
-          s"HashAggregate(key=$keyString, functions=$functionString, output=$outputString)"
+          s"HashAggregate(keys=$keyString, functions=$functionString, output=$outputString)"
         } else {
-          s"HashAggregate(key=$keyString, functions=$functionString)"
+          s"HashAggregate(keys=$keyString, functions=$functionString)"
         }
       case Some(fallbackStartsAt) =>
         s"HashAggregateWithControlledFallback $groupingExpressions " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes some minor `.toString` format issues for `HashAggregateExec`.

Before:

```
*HashAggregate(key=[a#234L,b#235L], functions=[count(1),max(c#236L)], output=[a#234L,b#235L,count(c)#247L,max(c)#248L])
```

After:

```
*HashAggregate(keys=[a#234L, b#235L], functions=[count(1), max(c#236L)], output=[a#234L, b#235L, count(c)#247L, max(c)#248L])
```
## How was this patch tested?

Manually tested.
