### PR TITLE
[SPARK-16002][SQL]Sleep when no new data arrives to avoid 100% CPU usage

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ListingFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ListingFileCatalog.scala
@@ -82,7 +82,7 @@ class ListingFileCatalog(
       val pathFilter = FileInputFormat.getInputPathFilter(jobConf)
       val statuses: Seq[FileStatus] = paths.flatMap { path =>
         val fs = path.getFileSystem(hadoopConf)
-        logInfo(s"Listing $path on driver")
+        logTrace(s"Listing $path on driver")
         Try {
           HadoopFsRelation.listLeafFiles(fs, fs.getFileStatus(path), pathFilter)
         }.getOrElse(Array.empty[FileStatus])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -398,7 +398,7 @@ private[sql] object HadoopFsRelation extends Logging {
   // tasks/jobs may leave partial/corrupted data files there.  Files and directories whose name
   // start with "." are also ignored.
   def listLeafFiles(fs: FileSystem, status: FileStatus, filter: PathFilter): Array[FileStatus] = {
-    logInfo(s"Listing ${status.getPath}")
+    logTrace(s"Listing ${status.getPath}")
     val name = status.getPath.getName.toLowerCase
     if (shouldFilterOut(name)) {
       Array.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -120,7 +120,13 @@ class FileStreamSource(
     val catalog = new ListingFileCatalog(sparkSession, globbedPaths, options, Some(new StructType))
     val files = catalog.allFiles().map(_.getPath.toUri.toString)
     val endTime = System.nanoTime
-    logInfo(s"Listed ${files.size} in ${(endTime.toDouble - startTime) / 1000000}ms")
+    val listingTimeMs = (endTime.toDouble - startTime) / 1000000
+    if (listingTimeMs > 2000) {
+      // Output a warning when listing files uses more than 2 seconds.
+      logWarning(s"Listed ${files.size} file(s) in $listingTimeMs ms")
+    } else {
+      logTrace(s"Listed ${files.size} file(s) in $listingTimeMs ms")
+    }
     logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
     files
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -534,7 +534,7 @@ object SQLConf {
   val FILE_SINK_LOG_CLEANUP_DELAY =
     SQLConfigBuilder("spark.sql.streaming.fileSink.log.cleanupDelay")
       .internal()
-      .doc("How long in milliseconds a file is guaranteed to be visible for all readers.")
+      .doc("How long that a file is guaranteed to be visible for all readers.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(60 * 1000L) // 10 minutes
 
@@ -548,8 +548,8 @@ object SQLConf {
   val STREAMING_POLLING_DELAY =
     SQLConfigBuilder("spark.sql.streaming.pollingDelay")
       .internal()
-      .doc("How long in milliseconds to delay polling new data when no data is available")
-      .longConf
+      .doc("How long to delay polling new data when no data is available")
+      .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(10L)
 
   object Deprecated {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -545,6 +545,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val STREAMING_POLLING_DELAY =
+    SQLConfigBuilder("spark.sql.streaming.pollingDelay")
+      .internal()
+      .doc("How long in milliseconds to delay polling new data when no data is available")
+      .longConf
+      .createWithDefault(10L)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -137,7 +137,7 @@ class StreamSuite extends StreamTest {
     }
   }
 
-  ignore("minimize delay between batch construction and execution") {
+  test("minimize delay between batch construction and execution") {
 
     // For each batch, we would retrieve new data's offsets and log them before we run the execution
     // This checks whether the key of the offset log is the expected batch id
@@ -164,6 +164,7 @@ class StreamSuite extends StreamTest {
       /* -- batch 0 ----------------------- */
       // Add some data in batch 0
       AddData(inputData, 1, 2, 3),
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000), // 10 seconds
 
       /* -- batch 1 ----------------------- */
@@ -174,6 +175,7 @@ class StreamSuite extends StreamTest {
       CheckSinkLatestBatchId(0),
       // Add some data in batch 1
       AddData(inputData, 4, 5, 6),
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch _ ----------------------- */
@@ -183,8 +185,11 @@ class StreamSuite extends StreamTest {
       CheckOffsetLogLatestBatchId(1),
       CheckSinkLatestBatchId(1),
 
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch __ ---------------------- */
@@ -201,6 +206,7 @@ class StreamSuite extends StreamTest {
 
       /* -- batch 1 rerun ----------------- */
       // this batch 1 would re-run because the latest batch id logged in offset log is 1
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch 2 ----------------------- */
@@ -211,6 +217,7 @@ class StreamSuite extends StreamTest {
       CheckSinkLatestBatchId(1),
       // Add some data in batch 2
       AddData(inputData, 7, 8, 9),
+      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch 3 ----------------------- */

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -137,7 +137,7 @@ class StreamSuite extends StreamTest {
     }
   }
 
-  test("minimize delay between batch construction and execution") {
+  ignore("minimize delay between batch construction and execution") {
 
     // For each batch, we would retrieve new data's offsets and log them before we run the execution
     // This checks whether the key of the offset log is the expected batch id

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -164,7 +164,6 @@ class StreamSuite extends StreamTest {
       /* -- batch 0 ----------------------- */
       // Add some data in batch 0
       AddData(inputData, 1, 2, 3),
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000), // 10 seconds
 
       /* -- batch 1 ----------------------- */
@@ -175,7 +174,6 @@ class StreamSuite extends StreamTest {
       CheckSinkLatestBatchId(0),
       // Add some data in batch 1
       AddData(inputData, 4, 5, 6),
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch _ ----------------------- */
@@ -185,11 +183,8 @@ class StreamSuite extends StreamTest {
       CheckOffsetLogLatestBatchId(1),
       CheckSinkLatestBatchId(1),
 
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch __ ---------------------- */
@@ -206,7 +201,6 @@ class StreamSuite extends StreamTest {
 
       /* -- batch 1 rerun ----------------- */
       // this batch 1 would re-run because the latest batch id logged in offset log is 1
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch 2 ----------------------- */
@@ -217,7 +211,6 @@ class StreamSuite extends StreamTest {
       CheckSinkLatestBatchId(1),
       // Add some data in batch 2
       AddData(inputData, 7, 8, 9),
-      EnsureManualClockInWaitingState,
       AdvanceManualClock(10 * 1000),
 
       /* -- batch 3 ----------------------- */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a configuration to allow people to set a minimum polling delay when no new data arrives (default is 10ms). This PR also cleans up some INFO logs.
## How was this patch tested?

Existing unit tests.
