### PR TITLE
[SPARK-15966][DOC] Add closing tag to fix rendering issue for Spark monitoring

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -157,7 +157,7 @@ The history server can be configured as follows:
       If enabled, access control checks are made regardless of what the individual application had
       set for <code>spark.ui.acls.enable</code> when the application was run. The application owner
       will always have authorization to view their own application and any users specified via
-      <code>spark.ui.view.acls</code> and groups specified via <code>spark.ui.view.acls.groups<code>
+      <code>spark.ui.view.acls</code> and groups specified via <code>spark.ui.view.acls.groups</code>
       when the application was run will also have authorization to view that application.
       If disabled, no access control checks are made.
     </td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds the missing closing tag for spark.ui.view.acls.groups
## How was this patch tested?

I built the docs locally and verified the changed in browser.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
**Before:**
![image](https://cloud.githubusercontent.com/assets/7732317/16135005/49fc0724-33e6-11e6-9390-98711593fa5b.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/7732317/16135021/62b5c4a8-33e6-11e6-8118-b22fda5c66eb.png)
