### PR TITLE
[SPARK-15822][SQL] Prevent byte array backed classes from referencing freed memory

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -460,12 +460,6 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     copyMemory(base, offset + start, newBytes, BYTE_ARRAY_OFFSET, len);
     return UTF8String.fromBytes(newBytes);
   }
-
-  public UTF8String copy() {
-    byte[] newBytes = new byte[this.numBytes];
-    copyMemory(base, offset, newBytes, BYTE_ARRAY_OFFSET, this.numBytes);
-    return UTF8String.fromBytes(newBytes);
-  }
   
   public UTF8String trim() {
     int s = 0;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -460,7 +460,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     copyMemory(base, offset + start, newBytes, BYTE_ARRAY_OFFSET, len);
     return UTF8String.fromBytes(newBytes);
   }
-  
+
   public UTF8String trim() {
     int s = 0;
     int e = this.numBytes - 1;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -461,7 +461,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return UTF8String.fromBytes(newBytes);
   }
 
-  private UTF8String copy() {
+  public UTF8String copy() {
     byte[] newBytes = new byte[this.numBytes];
     copyMemory(base, offset, newBytes, BYTE_ARRAY_OFFSET, this.numBytes);
     return UTF8String.fromBytes(newBytes);

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -461,6 +461,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return UTF8String.fromBytes(newBytes);
   }
 
+  private UTF8String copy() {
+    byte[] newBytes = new byte[this.numBytes];
+    copyMemory(base, offset, newBytes, BYTE_ARRAY_OFFSET, this.numBytes);
+    return UTF8String.fromBytes(newBytes);
+  }
+  
   public UTF8String trim() {
     int s = 0;
     int e = this.numBytes - 1;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -344,7 +344,7 @@ case class SortMergeJoinExec(
            |  $value = ${ev.value}.copy();
            |} else {
            |  $value = ${ev.value};
-           |} 
+           |}
          """.stripMargin
       ExprCode(code, "false", value)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.{BinaryExecNode, CodegenSupport, RowIterator, SparkPlan}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
-import org.apache.spark.sql.types.{ArrayType, MapType, StringType, StructType}
 import org.apache.spark.util.collection.BitSet
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -337,15 +337,7 @@ case class SortMergeJoinExec(
 
   private def copyKeys(ctx: CodegenContext, vars: Seq[ExprCode]): Seq[ExprCode] = {
     vars.zipWithIndex.map { case (ev, i) =>
-      val value = ctx.freshName("value")
-      ctx.addMutableState(ctx.javaType(leftKeys(i).dataType), value, "")
-      val code = leftKeys(i).dataType match {
-        case StringType | _: StructType | _: ArrayType | _: MapType =>
-          s"$value = ${ev.value}.copy();"
-        case _ =>
-          s"$value = ${ev.value};"
-      }
-      ExprCode(code, "false", value)
+      ctx.addBufferedState(leftKeys(i).dataType, "value", ev.value)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -340,7 +340,11 @@ case class SortMergeJoinExec(
       ctx.addMutableState(ctx.javaType(leftKeys(i).dataType), value, "")
       val code =
         s"""
-           |$value = ${ev.value};
+           |if (${ev.value} instanceof UTF8String) {
+           |  $value = ${ev.value}.copy();
+           |} else {
+           |  $value = ${ev.value};
+           |} 
          """.stripMargin
       ExprCode(code, "false", value)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`UTF8String` and all `Unsafe*` classes are backed by either on-heap or off-heap byte arrays. The code generated version `SortMergeJoin` buffers the left hand side join keys during iteration. This was actually problematic in off-heap mode when one of the keys is a `UTF8String` (or any other 'Unsafe*` object) and the left hand side iterator was exhausted (and released its memory); the buffered keys would reference freed memory. This causes Seg-faults and all kinds of other undefined behavior when we would use one these buffered keys.

This PR fixes this problem by creating copies of the buffered variables. I have added a general method to the `CodeGenerator` for this. I have checked all places in which this could happen, and only `SortMergeJoin` had this problem.

This PR is largely based on the work of @robbinspg and he should be credited for this.

closes https://github.com/apache/spark/pull/13707
## How was this patch tested?

Manually tested on problematic workloads.
