### PR TITLE
[SPARK-16010] [SQL] Code Refactoring, Test Case Improvement and Description Updates for SQLConf spark.sql.parquet.filterPushdown

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -215,7 +215,8 @@ object SQLConf {
     .createWithDefault("snappy")
 
   val PARQUET_FILTER_PUSHDOWN_ENABLED = SQLConfigBuilder("spark.sql.parquet.filterPushdown")
-    .doc("Enables Parquet filter push-down optimization when set to true.")
+    .doc("Enables Parquet filter push-down optimization when set to true and vectorized parquet " +
+      "decoding is not being used.")
     .booleanConf
     .createWithDefault(true)
 
@@ -236,7 +237,8 @@ object SQLConf {
 
   val PARQUET_VECTORIZED_READER_ENABLED =
     SQLConfigBuilder("spark.sql.parquet.enableVectorizedReader")
-      .doc("Enables vectorized parquet decoding.")
+      .doc("Enables vectorized parquet decoding when set to true and all the data types of " +
+        "the table schemas are atomic types.")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -452,8 +452,8 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
           val df = spark.read.parquet(path).filter("a = 2")
 
           // The result should be single row.
-          // When a filter is pushed to Parquet, Parquet can apply it to every row group.
-          // So, we can check the number of rows returned from the Parquet
+          // When a filter is pushed to Parquet, Parquet can apply it to every row group and
+          // then every row. So, we can check the number of rows returned from the Parquet
           // to make sure our filter pushdown work.
           assert(stripSparkFilter(df).count == 1)
         }
@@ -524,8 +524,8 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
           val path = s"${dir.getCanonicalPath}/table1"
           (1 to 5).map(i => (i.toFloat, i%3)).toDF("a", "b").write.parquet(path)
 
-          // When a filter is pushed to Parquet, Parquet can apply it to every row group.
-          // So, we can check the number of rows returned from the Parquet
+          // When a filter is pushed to Parquet, Parquet can apply it to every row group and
+          // then every row. So, we can check the number of rows returned from the Parquet
           // to make sure our filter pushdown work.
           val df = spark.read.parquet(path).where("b in (0,2)")
           assert(stripSparkFilter(df).count == 3)
@@ -559,8 +559,8 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
         withTempPath { dir =>
           val path = s"${dir.getCanonicalPath}/table1"
           (1 to 3).map(i => (i, i.toString)).toDF("a", "b").write.parquet(path)
-          // When a filter is pushed to Parquet, Parquet can apply it to every row group.
-          // So, we can check the number of rows returned from the Parquet
+          // When a filter is pushed to Parquet, Parquet can apply it to every row group and
+          // then every row. So, we can check the number of rows returned from the Parquet
           // to make sure our filter pushdown work.
           val df = spark.read.parquet(path).where("a > 2")
           val numExpectedRows = if (pushDown == "true") 1 else 3

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -553,6 +553,7 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
       // When SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key is set to true and all the data types
       // of the table schema are AtomicType, the parquet reader uses vectorizedReader.
       // In this mode, filters will not be pushed down, no matter whether
+      // SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key is true or not.
       withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> pushDown,
           SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
         withTempPath { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -452,7 +452,7 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
           val df = spark.read.parquet(path).filter("a = 2")
 
           // The result should be single row.
-          // When a filter is pushed to Parquet, Parquet can apply it to every row.
+          // When a filter is pushed to Parquet, Parquet can apply it to every row group.
           // So, we can check the number of rows returned from the Parquet
           // to make sure our filter pushdown work.
           assert(stripSparkFilter(df).count == 1)
@@ -524,7 +524,7 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
           val path = s"${dir.getCanonicalPath}/table1"
           (1 to 5).map(i => (i.toFloat, i%3)).toDF("a", "b").write.parquet(path)
 
-          // When a filter is pushed to Parquet, Parquet can apply it to every row.
+          // When a filter is pushed to Parquet, Parquet can apply it to every row group.
           // So, we can check the number of rows returned from the Parquet
           // to make sure our filter pushdown work.
           val df = spark.read.parquet(path).where("b in (0,2)")
@@ -559,7 +559,7 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
         withTempPath { dir =>
           val path = s"${dir.getCanonicalPath}/table1"
           (1 to 3).map(i => (i, i.toString)).toDF("a", "b").write.parquet(path)
-          // When a filter is pushed to Parquet, Parquet can apply it to every row.
+          // When a filter is pushed to Parquet, Parquet can apply it to every row group.
           // So, we can check the number of rows returned from the Parquet
           // to make sure our filter pushdown work.
           val df = spark.read.parquet(path).where("a > 2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -550,6 +550,9 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
     import testImplicits._
 
     Seq("true", "false").foreach { pushDown =>
+      // When SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key is set to true and all the data types
+      // of the table schema are AtomicType, the parquet reader uses vectorizedReader.
+      // In this mode, filters will not be pushed down, no matter whether
       withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> pushDown,
           SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
         withTempPath { dir =>


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Starting Spark 2.0, vectorized decoding is introduced for improving parquet reading performance. This feature changes the filter pushdown behavior of parquet reading. Thus, this PR updates the out-of-dated description of two external `SQLConf`: `spark.sql.parquet.filterPushdown` and `spark.sql.parquet.enableVectorizedReader`. 

The PR also slightly simplifies the code for building `parquetReader`. cc @davies @liancheng @marmbrus 

Because the current test cases do not verify the behavior when `spark.sql.parquet.filterPushdown` is set to `false`, added a test case for improving the test case coverage. Also, improved the test case when the parquet file path points to either non-existent files or non-existent hosts. 
#### How was this patch tested?

Added the related test cases.
