### PR TITLE
[SPARK-16006][SQL] Attemping to write empty DataFrame with no fields throws non-intuitive exception

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -339,9 +339,6 @@ private[sql] object PartitioningUtils {
   private val upCastingOrder: Seq[DataType] =
     Seq(NullType, IntegerType, LongType, FloatType, DoubleType, StringType)
 
-  /**
-   * Validate partition columns for writing executions.
-   */
   def validatePartitionColumn(
       schema: StructType,
       partitionColumns: Seq[String],
@@ -354,10 +351,8 @@ private[sql] object PartitioningUtils {
       }
     }
 
-    if (schema.fields.isEmpty) {
-      throw new AnalysisException("Cannot write dataset with no fields")
-    } else if (partitionColumns.size == schema.fields.length) {
-      throw new AnalysisException("Cannot use all columns for partition columns")
+    if (partitionColumns.nonEmpty && partitionColumns.size == schema.fields.length) {
+      throw new AnalysisException(s"Cannot use all columns for partition columns")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -339,6 +339,9 @@ private[sql] object PartitioningUtils {
   private val upCastingOrder: Seq[DataType] =
     Seq(NullType, IntegerType, LongType, FloatType, DoubleType, StringType)
 
+  /**
+   * Validate partition columns for writing executions.
+   */
   def validatePartitionColumn(
       schema: StructType,
       partitionColumns: Seq[String],
@@ -351,8 +354,10 @@ private[sql] object PartitioningUtils {
       }
     }
 
-    if (partitionColumns.size == schema.fields.size) {
-      throw new AnalysisException(s"Cannot use all columns for partition columns")
+    if (schema.fields.isEmpty) {
+      throw new AnalysisException("Cannot write dataset with no fields")
+    } else if (partitionColumns.size == schema.fields.length) {
+      throw new AnalysisException("Cannot use all columns for partition columns")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -214,18 +214,13 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
   test("prevent all column partitioning") {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
-      var e = intercept[AnalysisException] {
-        spark.emptyDataFrame.write.format("text").mode("overwrite").save(path)
-      }
-      assert(e.getMessage.contains("Cannot write dataset with no fields"))
-      e = intercept[AnalysisException] {
+      intercept[AnalysisException] {
         spark.range(10).write.format("parquet").mode("overwrite").partitionBy("id").save(path)
       }
-      assert(e.getMessage.contains("Cannot use all columns for partition columns"))
-      e = intercept[AnalysisException] {
+      intercept[AnalysisException] {
         spark.range(10).write.format("csv").mode("overwrite").partitionBy("id").save(path)
       }
-      assert(e.getMessage.contains("Cannot use all columns for partition columns"))
+      spark.emptyDataFrame.write.format("parquet").mode("overwrite").save(path)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR allows `emptyDataFrame.write` since the user didn't specify any partition columns.

**Before**

``` scala
scala> spark.emptyDataFrame.write.parquet("/tmp/t1")
org.apache.spark.sql.AnalysisException: Cannot use all columns for partition columns;
scala> spark.emptyDataFrame.write.csv("/tmp/t1")
org.apache.spark.sql.AnalysisException: Cannot use all columns for partition columns;
```

After this PR, there occurs no exceptions and the created directory has only one file, `_SUCCESS`, as expected.
## How was this patch tested?

Pass the Jenkins tests including updated test cases.
