### PR TITLE
[SPARK-15328][MLLIB][ML] Word2Vec import for original binary format

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -244,7 +244,7 @@ class Word2VecModel private[ml] (
       .mapValues(vv => Vectors.dense(vv.map(_.toDouble)))
       .map(identity) // mapValues doesn't return a serializable map (SI-7005)
     val bVectors = dataset.sparkSession.sparkContext.broadcast(vectors)
-    val d = $(vectorSize)
+    val d = vectors.head._2.size
     val word2Vec = udf { sentence: Seq[String] =>
       if (sentence.isEmpty) {
         Vectors.sparse(d, Array.empty[Int], Array.empty[Double])
@@ -308,6 +308,19 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
       DefaultParamsReader.getAndSetParams(model, metadata)
       model
     }
+
+    /**
+     * Load Google word2vec model
+     *
+     * @see [[https://code.google.com/p/word2vec/]]
+     * @param file Google word2vec model file
+     * @return a Word2VecModel
+     */
+    def loadGoogleModel(file: String): Word2VecModel = {
+      val oldModel = feature.Word2VecModel.loadGoogleModel(sc, file)
+      val model = new Word2VecModel(Identifiable.randomUID("GoogleWord2vec"), oldModel)
+      model
+    }
   }
 
   @Since("1.6.0")
@@ -315,4 +328,7 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
 
   @Since("1.6.0")
   override def load(path: String): Word2VecModel = super.load(path)
+
+  def loadGoogleModel(file: String): Word2VecModel =
+    new Word2VecModelReader().loadGoogleModel(file)
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.mllib.feature
 
+import java.io.DataInputStream
 import java.lang.{Iterable => JavaIterable}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import org.json4s.DefaultFormats
@@ -666,5 +668,63 @@ object Word2VecModel extends Loader[Word2VecModel] {
         s"($loadedClassName, $loadedVersion).  Supported:\n" +
         s"  ($classNameV1_0, 1.0)")
     }
+  }
+
+  /**
+   * Load Google word2vec model
+   *
+   * @see [[https://code.google.com/p/word2vec/]]
+   * @param sc SparkContext object
+   * @param file Google word2vec model file
+   * @return a Word2VecModel
+   */
+  def loadGoogleModel(sc: SparkContext, file: String): Word2VecModel = {
+
+    // ASCII values for common delimiter characters.
+    val SPACE = 32
+    val LF = 10
+
+    // Read a string from the data input stream.
+    def readToken(dis: DataInputStream, delimiters: Set[Int] = Set(SPACE, LF)): String = {
+      val bytes = new ArrayBuffer[Byte]()
+      val sb = new StringBuilder()
+      var byte = dis.readByte()
+      while (!delimiters.contains(byte)) {
+        bytes.append(byte)
+        byte = dis.readByte()
+      }
+      sb.append(new String(bytes.toArray[Byte])).toString()
+    }
+
+    // Read a float from the data input stream.
+    def readFloat(dis: DataInputStream): Float = {
+      java.lang.Float.intBitsToFloat(Integer.reverseBytes(dis.readInt()))
+    }
+
+    // Read a model file.
+    val pds = sc.binaryFiles(file).first()._2
+    val dis = new DataInputStream(pds.open())
+
+    val vocab = new mutable.HashMap[String, Array[Float]]()
+
+    // Read header info.
+    val numWords = readToken(dis).toInt
+    val vecSize = readToken(dis).toInt
+
+    val vector = new Array[Float](vecSize)
+    for (_ <- 0 until numWords) {
+      // Read the word.
+      val word = readToken(dis)
+      // Read the vector.
+      for (i <- 0 until vecSize) vector(i) = readFloat(dis)
+      // Store the normalized vector representation.
+      val normFactor = math.sqrt(vector.foldLeft(0.0) { (sum, x) => sum + (x * x) }).toFloat
+      vocab.put(word, vector.map(_ / normFactor))
+
+      dis.read()
+    }
+
+    dis.close()
+    new Word2VecModel(vocab.toMap)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.ml.feature
 
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param.ParamsSuite
@@ -25,6 +29,7 @@ import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.feature.{Word2VecModel => OldWord2VecModel}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.Row
+import org.apache.spark.util.Utils
 
 class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 
@@ -206,6 +211,89 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     val instance = new Word2VecModel("myWord2VecModel", oldModel)
     val newInstance = testDefaultReadWrite(instance)
     assert(newInstance.getVectors.collect() === instance.getVectors.collect())
+  }
+
+  test("load Google word2vec model") {
+    val tempDir = Utils.createTempDir()
+    val modelFile = new File(tempDir, "google-word2vec-ml-00000.bin")
+
+    // This byte array is pre-trained model by Google word2vec.
+    // training text:
+    //   "a a a a a b b b b b b c c c c c c c"
+    // Parameters for training:
+    //   -cbow 1 -size 5 -window 5 -negative 0 -hs 0 -sample 1e-4 -threads 4 -binary 1 -iter 3
+    val testModelBytes = Array[Byte](52, 32, 53, 10, 60, 47, 115, 62, 32, 51, -13, -93, 61, -51,
+      4, -75, 61, 51, -29, -100, -67, -51, 68, -122, -67, 102, -26, -33, 60, 10, 99, 32, -51, 124,
+      119, 61, 102, 38, -102, 60, 0, -128, -118, 59, -102, -103, -109, -67, -51, -68, 53, 61, 10,
+      98, 32, 0, 112, -78, -67, -102, -71, -52, 60, 51, 51, 118, -68, 51, -45, -100, -68, 0, -48,
+      -121, -67, 10, 97, 32, 0, 48, 26, -67, -51, 76, 83, 61, 102, -42, 119, 61, -102, 57, 115,
+      61, -51, -36, 2, 61, 10)
+
+    val bbuf = ByteBuffer.wrap(testModelBytes)
+    // write model to file
+    val file = new FileOutputStream(modelFile)
+    val channel = file.getChannel
+    channel.write(bbuf)
+    channel.close()
+    file.close()
+
+    try {
+      val model = Word2VecModel.loadGoogleModel(modelFile.getAbsolutePath)
+
+      val expectedSimilarity = Array(0.031741, -0.333541)
+      val (synonyms, similarity) = model.findSynonyms("a", 2).rdd.map {
+        case Row(w: String, sim: Double) => (w, sim)
+      }.collect().unzip
+
+      assert(synonyms.toArray === Array("b", "c"))
+      expectedSimilarity.zip(similarity).foreach {
+        case (expected, actual) => assert(actual ~== expected absTol 1E-5)
+      }
+    } finally {
+      Utils.deleteRecursively(tempDir)
+    }
+  }
+
+  test("load Google word2vec model and transform data") {
+    val tempDir = Utils.createTempDir()
+    val modelFile = new File(tempDir, "google-word2vec-ml-00000.bin")
+
+    // This byte array is pre-trained model by Google word2vec.
+    // training text:
+    //   "a a a a a b b b b b b c c c c c c c"
+    // Parameters for training:
+    //   -cbow 1 -size 5 -window 5 -negative 0 -hs 0 -sample 1e-4 -threads 4 -binary 1 -iter 3
+    val testModelBytes = Array[Byte](52, 32, 53, 10, 60, 47, 115, 62, 32, 51, -13, -93, 61, -51,
+      4, -75, 61, 51, -29, -100, -67, -51, 68, -122, -67, 102, -26, -33, 60, 10, 99, 32, -51, 124,
+      119, 61, 102, 38, -102, 60, 0, -128, -118, 59, -102, -103, -109, -67, -51, -68, 53, 61, 10,
+      98, 32, 0, 112, -78, -67, -102, -71, -52, 60, 51, 51, 118, -68, 51, -45, -100, -68, 0, -48,
+      -121, -67, 10, 97, 32, 0, 48, 26, -67, -51, 76, 83, 61, 102, -42, 119, 61, -102, 57, 115,
+      61, -51, -36, 2, 61, 10)
+
+    val bbuf = ByteBuffer.wrap(testModelBytes)
+    // write model to file
+    val file = new FileOutputStream(modelFile)
+    val channel = file.getChannel
+    channel.write(bbuf)
+    channel.close()
+    file.close()
+
+    val docDF = spark.createDataFrame(Seq(
+      ("a b c".split(" "), Vectors.dense(-0.175498, 0.286932, 0.151694, -0.104103, 0.043563)),
+      ("a a b b".split(" "), Vectors.dense(-0.548897, 0.341438, 0.207558, 0.184567, -0.144418)),
+      ("a a a c".split(" "), Vectors.dense(-0.111882, 0.393534, 0.419402, 0.231431, 0.321057))
+    )).toDF("text", "expected")
+
+    try {
+      val model = Word2VecModel.loadGoogleModel(modelFile.getAbsolutePath)
+      model.setInputCol("text").setOutputCol("result")
+        .transform(docDF).select("result", "expected").collect().foreach {
+        case Row(vector1: Vector, vector2: Vector) =>
+          assert(vector1 ~== vector2 absTol 1E-5, "Transformed vector is different with expected.")
+      }
+    } finally {
+      Utils.deleteRecursively(tempDir)
+    }
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala
@@ -17,8 +17,13 @@
 
 package org.apache.spark.mllib.feature
 
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.util.Utils
 
 class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -103,6 +108,43 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext {
       model.save(sc, path)
       val sameModel = Word2VecModel.load(sc, path)
       assert(sameModel.getVectors.mapValues(_.toSeq) === model.getVectors.mapValues(_.toSeq))
+    } finally {
+      Utils.deleteRecursively(tempDir)
+    }
+  }
+
+  test("load Google word2vec model") {
+    val tempDir = Utils.createTempDir()
+    val modelFile = new File(tempDir, "google-word2vec-mllib-00000.bin")
+
+    // This byte array is pre-trained model by Google word2vec.
+    // training text:
+    //   "a a a a a b b b b b b c c c c c c c"
+    // Parameters for training:
+    //   -cbow 1 -size 5 -window 5 -negative 0 -hs 0 -sample 1e-4 -threads 4 -binary 1 -iter 3
+    val testModelBytes = Array[Byte](52, 32, 53, 10, 60, 47, 115, 62, 32, 51, -13, -93, 61, -51,
+      4, -75, 61, 51, -29, -100, -67, -51, 68, -122, -67, 102, -26, -33, 60, 10, 99, 32, -51, 124,
+      119, 61, 102, 38, -102, 60, 0, -128, -118, 59, -102, -103, -109, -67, -51, -68, 53, 61, 10,
+      98, 32, 0, 112, -78, -67, -102, -71, -52, 60, 51, 51, 118, -68, 51, -45, -100, -68, 0, -48,
+      -121, -67, 10, 97, 32, 0, 48, 26, -67, -51, 76, 83, 61, 102, -42, 119, 61, -102, 57, 115,
+      61, -51, -36, 2, 61, 10)
+
+    val bbuf = ByteBuffer.wrap(testModelBytes)
+    // write model to file
+    val file = new FileOutputStream(modelFile)
+    val channel = file.getChannel
+    channel.write(bbuf)
+    channel.close()
+    file.close()
+
+    try {
+      val model = Word2VecModel.loadGoogleModel(sc, modelFile.getAbsolutePath)
+
+      val num = 2
+      val syms = model.findSynonyms("a", num)
+      assert(syms.length == num)
+      assert(syms(0)._1 == "b" && (syms(0)._2 ~== 0.031741 absTol 1e-5))
+      assert(syms(1)._1 == "c" && (syms(1)._2 ~== -0.333541 absTol 1e-5))
     } finally {
       Utils.deleteRecursively(tempDir)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `loadGoogleModel()` function to import original wor2vec binary format.
## How was this patch tested?

`mllib.feature.Word2VecSuite` and `ml.feature.Word2VecSuite`

I also tested with real model:
![spark_load_google_word2vec](https://cloud.githubusercontent.com/assets/5399861/15271931/2a8d4f4a-1a93-11e6-880b-27122f608909.png)
