### PR TITLE
[SPARK-16018][Shuffle] Shade netty to load shuffle jar in Nodemanger

### DIFF
--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -96,6 +96,13 @@
                 <include>com.fasterxml.jackson.**</include>
               </includes>
             </relocation>
+            <relocation>
+              <pattern>io.netty</pattern>
+              <shadedPattern>${spark.shade.packageName}.io.netty</shadedPattern>
+              <includes>
+                <include>io.netty.**</include>
+              </includes>
+            </relocation>
           </relocations>
         </configuration>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shade the netty.io namespace so that we can use it in shuffle independent of the dependencies being pulled by hadoop jars.
## How was this patch tested?

Ran a decent job involving shuffle write/read and tested the new spark-x-yarn-shuffle jar. After shading netty.io namespace, the nodemanager loads and shuffle job completes successfully.
