### PR TITLE
[SPARK-16030] [SQL] Allow specifying static partitions when inserting to data source tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -22,15 +22,16 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
+import org.apache.spark.sql.catalyst.{CatalystConf, CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.CatalystTypeConverters.convertToScala
+import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SimpleCatalogRelation}
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.DataSourceScanExec.PUSHED_FILTERS
@@ -43,11 +44,94 @@ import org.apache.spark.unsafe.types.UTF8String
  * Replaces generic operations with specific variants that are designed to work with Spark
  * SQL Data Sources.
  */
-private[sql] object DataSourceAnalysis extends Rule[LogicalPlan] {
+private[sql] case class DataSourceAnalysis(conf: CatalystConf) extends Rule[LogicalPlan] {
+
+  def resolver: Resolver = {
+    if (conf.caseSensitiveAnalysis) {
+      caseSensitiveResolution
+    } else {
+      caseInsensitiveResolution
+    }
+  }
+
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case i @ logical.InsertIntoTable(
-           l @ LogicalRelation(t: HadoopFsRelation, _, _), part, query, overwrite, false)
-        if query.resolved && t.schema.asNullable == query.schema.asNullable =>
+    l @ LogicalRelation(t: HadoopFsRelation, _, _), parts, query, overwrite, false)
+      if query.resolved && parts.exists(_._2.isDefined) =>
+
+      val staticPartitions = parts.flatMap {
+        case (partKey, Some(partValue)) => (partKey, partValue) :: Nil
+        case (_, None) => Nil
+      }
+
+      // The total number of static partition columns and columns provided in the SELECT
+      // clause need to match the number of columns of the target table.
+      if (staticPartitions.size + query.output.size != l.output.size) {
+        throw new AnalysisException(
+          s"$l requires that the data to be inserted have the same number of " +
+            s"columns as the target table: target table has ${l.output.size} " +
+            s"column(s) but the inserted data has ${query.output.size + staticPartitions.size} " +
+            s"column(s), which contain ${staticPartitions.size} partition column(s) having " +
+            s"constant values.")
+      }
+
+      if (parts.size != t.partitionSchema.fields.size) {
+        throw new AnalysisException(
+          s"$l requires that the data to be inserted have the same number of " +
+            s"partition columns as the target table: target table " +
+            s"has ${t.partitionSchema.fields.size} partition column(s) but the inserted " +
+            s"data has ${parts.size} partition columns specified.")
+      }
+
+      staticPartitions.foreach {
+        case (partKey, partValue) =>
+          if (!t.partitionSchema.fields.exists(field => resolver(field.name, partKey))) {
+            throw new AnalysisException(
+              s"$partKey is not a partition column. Partition columns are " +
+                s"${t.partitionSchema.fields.map(_.name).mkString("[", ",", "]")}")
+          }
+      }
+
+      val partitionList = t.partitionSchema.fields.map { field =>
+        val potentialSpecs = staticPartitions.filter {
+          case (partKey, partValue) => resolver(field.name, partKey)
+        }
+        if (potentialSpecs.size == 0) {
+          None
+        } else if (potentialSpecs.size == 1) {
+          val partValue = potentialSpecs.head._2
+          Some(Alias(Cast(Literal(partValue), field.dataType), "_staticPart")())
+        } else {
+          throw new AnalysisException(
+            s"Partition column ${field.name} have multiple values specified, " +
+              s"${potentialSpecs.mkString("[", ", ", "]")}. Please only specify a single value.")
+        }
+      }
+
+      partitionList.sliding(2).foreach { v =>
+        // If there are dynamic partitions before any static partitions,
+        // we will throw an exception
+        if (v(0).isEmpty && v(1).isDefined) {
+          throw new AnalysisException(
+            s"The ordering of partition columns is " +
+              s"${t.partitionSchema.fields.map(_.name).mkString("[", ",", "]")}. " +
+              "All partition columns having constant values need to appear before other " +
+              "partition columns that do not have an assigned constant value.")
+        }
+      }
+
+      val projectList =
+        query.output.take(l.output.size - t.partitionSchema.fields.size) ++
+        partitionList.take(staticPartitions.size).map(_.get) ++
+        query.output.takeRight(t.partitionSchema.fields.size - staticPartitions.size)
+
+      i.copy(partition = parts.map(p => (p._1, None)), child = Project(projectList, query))
+
+    case i @ logical.InsertIntoTable(
+           l @ LogicalRelation(t: HadoopFsRelation, _, _), parts, query, overwrite, false)
+        if query.resolved &&
+          t.schema.asNullable == query.schema.asNullable &&
+          parts.forall(_._2.isEmpty) =>
 
       // Sanity checks
       if (t.location.paths.size != 1) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -131,7 +131,7 @@ private[sql] case class DataSourceAnalysis(conf: CatalystConf) extends Rule[Logi
            l @ LogicalRelation(t: HadoopFsRelation, _, _), parts, query, overwrite, false)
         if query.resolved &&
           t.schema.asNullable == query.schema.asNullable &&
-          parts.forall(_._2.isEmpty) =>
+          (parts.isEmpty || parts.forall(_._2.isEmpty)) =>
 
       // Sanity checks
       if (t.location.paths.size != 1) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -180,13 +180,6 @@ private[sql] case class PreWriteCheck(conf: SQLConf, catalog: SessionCatalog)
         // The relation in l is not an InsertableRelation.
         failAnalysis(s"$l does not allow insertion.")
 
-      case logical.InsertIntoTable(t, _, _, _, _) =>
-        if (!t.isInstanceOf[LeafNode] || t == OneRowRelation || t.isInstanceOf[LocalRelation]) {
-          failAnalysis(s"Inserting into an RDD-based table is not allowed.")
-        } else {
-          // OK
-        }
-
       case c: CreateTableUsingAsSelect =>
         // When the SaveMode is Overwrite, we need to check if the table is an input table of
         // the query. If so, we will throw an AnalysisException to let users know it is not allowed.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -113,7 +113,7 @@ private[sql] class SessionState(sparkSession: SparkSession) {
       override val extendedResolutionRules =
         PreInsertCastAndRename ::
         new FindDataSourceTable(sparkSession) ::
-        DataSourceAnalysis ::
+        DataSourceAnalysis(conf) ::
         (if (conf.runSQLonFile) new ResolveDataSource(sparkSession) :: Nil else Nil)
 
       override val extendedCheckRules = Seq(datasources.PreWriteCheck(conf, catalog))

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -89,7 +89,7 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
   }
 
   test("SELECT clause generating a different number of columns is not allowed.") {
-    val message = intercept[RuntimeException] {
+    val message = intercept[AnalysisException] {
       sql(
         s"""
         |INSERT OVERWRITE TABLE jsonTable SELECT a FROM jt
@@ -299,28 +299,44 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
 
       sql("INSERT INTO TABLE srcSparkPart PARTITION (c=11, b=10) SELECT 9, 12")
 
+      // c is defined twice. Parser will complain.
       intercept[ParseException] {
         sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c=15, c=16) SELECT 13")
       }
 
+      // d is not a partitioning column.
       intercept[AnalysisException] {
         sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c=15, d=16) SELECT 13, 14")
       }
 
+      // d is not a partitioning column. The total number of columns is correct.
       intercept[AnalysisException] {
         sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c=15, d=16) SELECT 13")
       }
 
+      // The data is missing a column.
       intercept[AnalysisException] {
         sql("INSERT INTO TABLE srcSparkPart PARTITION (c=15, b=16) SELECT 13")
       }
 
+      // d is not a partitioning column.
       intercept[AnalysisException] {
         sql("INSERT INTO TABLE srcSparkPart PARTITION (b=15, d=15) SELECT 13, 14")
       }
 
+      // The statement is missing a column.
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b=15) SELECT 13, 14")
+      }
+
+      // The statement is missing a column.
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b=15) SELECT 13, 14, 16")
+      }
+
       sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c) SELECT 13, 16, 15")
 
+      // Dynamic partitioning columns need to be after static partitioning columns.
       intercept[AnalysisException] {
         sql("INSERT INTO TABLE srcSparkPart PARTITION (b, c=19) SELECT 17, 20, 18")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
@@ -281,6 +282,64 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
       checkAnswer(
         sql("SELECT a, b FROM target2"),
         sql("SELECT a, b FROM jt")
+      )
+    }
+  }
+
+  test("SPARK-16030: allow specifying static partitions when inserting to data source tables") {
+    withTable("srcSparkPart") {
+      spark
+        .createDataFrame(Seq((1, 2, 3, 4)))
+        .toDF("a", "b", "c", "d")
+        .write
+        .partitionBy("b", "c")
+        .saveAsTable("srcSparkPart")
+
+      sql("INSERT INTO TABLE srcSparkPart PARTITION (b=6, c=7) SELECT 5, 8")
+
+      sql("INSERT INTO TABLE srcSparkPart PARTITION (c=11, b=10) SELECT 9, 12")
+
+      intercept[ParseException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c=15, c=16) SELECT 13")
+      }
+
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c=15, d=16) SELECT 13, 14")
+      }
+
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c=15, d=16) SELECT 13")
+      }
+
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (c=15, b=16) SELECT 13")
+      }
+
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b=15, d=15) SELECT 13, 14")
+      }
+
+      sql("INSERT INTO TABLE srcSparkPart PARTITION (b=14, c) SELECT 13, 16, 15")
+
+      intercept[AnalysisException] {
+        sql("INSERT INTO TABLE srcSparkPart PARTITION (b, c=19) SELECT 17, 20, 18")
+      }
+
+      sql("INSERT INTO TABLE srcSparkPart PARTITION (b, c) SELECT 17, 20, 18, 19")
+
+      sql("INSERT INTO TABLE srcSparkPart PARTITION (c, b) SELECT 21, 24, 22, 23")
+
+      sql("INSERT INTO TABLE srcSparkPart SELECT 25, 28, 26, 27")
+
+      checkAnswer(
+        sql("SELECT a, b, c, d FROM srcSparkPart"),
+        Row(1, 2, 3, 4) ::
+        Row(5, 6, 7, 8) ::
+        Row(9, 10, 11, 12) ::
+        Row(13, 14, 15, 16) ::
+        Row(17, 18, 19, 20) ::
+        Row(21, 22, 23, 24) ::
+        Row(25, 26, 27, 28) :: Nil
       )
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
@@ -67,7 +67,7 @@ private[hive] class HiveSessionState(sparkSession: SparkSession)
         catalog.CreateTables ::
         catalog.PreInsertionCasts ::
         PreInsertCastAndRename ::
-        DataSourceAnalysis ::
+        DataSourceAnalysis(conf) ::
         (if (conf.runSQLonFile) new ResolveDataSource(sparkSession) :: Nil else Nil)
 
       override val extendedCheckRules = Seq(PreWriteCheck(conf, catalog))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the static partition support to INSERT statement when the target table is a data source table.
## How was this patch tested?

New tests in `InsertSuite`
