### PR TITLE
[SPARK-14926] [ML] OneVsRest labelMetadata uses incorrect name

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -196,8 +196,13 @@ final class OneVsRestModel private[ml] (
     }
 
     // output label and label metadata as prediction
+    val predictionMetadata = new MetadataBuilder()
+      .withMetadata(labelMetadata)
+      .putString("name", predictionCol.name)
+      .build()
+
     aggregatedDataset
-      .withColumn($(predictionCol), labelUDF(col(accColName)), labelMetadata)
+      .withColumn($(predictionCol), labelUDF(col(accColName)), predictionMetadata)
       .drop(accColName)
   }
 


### PR DESCRIPTION
_This contribution is my original work and I license the work to the project under the project's open source license._
## What changes were proposed in this pull request?

OneVsRestModel applies labelMetadata to the output column, but the metadata could contain the wrong name. The attribute name was modified to match predictionCol.
## How was this patch tested?

Manual Tests
