### PR TITLE
[SPARK-16054] [SQL] Verification of Multiple DataFrameReader API Usage

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -437,11 +437,6 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
         "Operation not allowed: specifying the input schema when reading tables from " +
         s"catalog. table: `$tableName`, schema: `${userSpecifiedSchema.get}`.")
     }
-    if (extraOptions.nonEmpty) {
-      throw new IllegalArgumentException(
-        "Operation not allowed: specifying the input option when reading tables from " +
-          s"catalog. table: `$tableName`, option: `${extraOptions.mkString(", ")}`.")
-    }
 
     Dataset.ofRows(sparkSession,
       sparkSession.sessionState.catalog.lookupRelation(

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -245,6 +245,16 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       table: String,
       parts: Array[Partition],
       connectionProperties: Properties): DataFrame = {
+    if (userSpecifiedSource.nonEmpty) {
+      throw new IllegalArgumentException(
+        "Operation not allowed: specifying the input data source format when reading tables from " +
+          s"JDBC connections. table: `$table`, format: `${userSpecifiedSource.get}`.")
+    }
+    if (userSpecifiedSchema.nonEmpty) {
+      throw new IllegalArgumentException(
+        "Operation not allowed: specifying the input schema when reading tables from " +
+          s"JDBC connections. table: `$table`, schema: `${userSpecifiedSchema.get}`.")
+    }
     val props = new Properties()
     extraOptions.foreach { case (key, value) =>
       props.put(key, value)
@@ -424,17 +434,17 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
   def table(tableName: String): DataFrame = {
     if (userSpecifiedSource.nonEmpty) {
       throw new IllegalArgumentException(
-        "Operation not allowed: specifying the input data source format when reading table from " +
+        "Operation not allowed: specifying the input data source format when reading tables from " +
         s"catalog. table: `$tableName`, format: `${userSpecifiedSource.get}`.")
     }
     if (userSpecifiedSchema.nonEmpty) {
       throw new IllegalArgumentException(
-        "Operation not allowed: specifying the input schema when reading table from " +
+        "Operation not allowed: specifying the input schema when reading tables from " +
         s"catalog. table: `$tableName`, schema: `${userSpecifiedSchema.get}`.")
     }
     if (extraOptions.nonEmpty) {
       throw new IllegalArgumentException(
-        "Operation not allowed: specifying the input option when reading table from " +
+        "Operation not allowed: specifying the input option when reading tables from " +
           s"catalog. table: `$tableName`, option: `${extraOptions.mkString(", ")}`.")
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -245,11 +245,6 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       table: String,
       parts: Array[Partition],
       connectionProperties: Properties): DataFrame = {
-    if (userSpecifiedSource.nonEmpty) {
-      throw new IllegalArgumentException(
-        "Operation not allowed: specifying the input data source format when reading tables from " +
-          s"JDBC connections. table: `$table`, format: `${userSpecifiedSource.get}`.")
-    }
     if (userSpecifiedSchema.nonEmpty) {
       throw new IllegalArgumentException(
         "Operation not allowed: specifying the input schema when reading tables from " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -45,11 +45,6 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * @since 1.4.0
    */
   def format(source: String): DataFrameReader = {
-    if (this.userSpecifiedSource.nonEmpty) {
-      throw new IllegalArgumentException(
-        "Operation not allowed: the input data source format has already been set. " +
-        s"Existing: `${this.userSpecifiedSource.get}`, new: `$source`.")
-    }
     this.userSpecifiedSource = Option(source)
     this
   }
@@ -62,11 +57,6 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * @since 1.4.0
    */
   def schema(schema: StructType): DataFrameReader = {
-    if (this.userSpecifiedSchema.nonEmpty) {
-      throw new IllegalArgumentException(
-        "Operation not allowed: the input schema has already been set. " +
-          s"Existing: `${this.userSpecifiedSchema.get}`, new: `$schema`.")
-    }
     this.userSpecifiedSchema = Option(schema)
     this
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.execution.DataSourceScanExec
 import org.apache.spark.sql.execution.command.ExplainCommand
 import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.execution.datasources.jdbc.{JDBCRelation, JDBCRDD}
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCRDD, JDBCRelation}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -338,21 +338,20 @@ class JDBCSuite extends SparkFunSuite
 
   test("Basic API") {
     assert(spark.read.jdbc(
-      urlWithUserAndPass, "TEST.PEOPLE", new Properties)
-      .collect().length === 3)
+      urlWithUserAndPass, "TEST.PEOPLE", new Properties).count == 3)
   }
 
   test("Basic API with FetchSize") {
     val properties = new Properties
     properties.setProperty("fetchSize", "2")
     assert(spark.read.jdbc(
-      urlWithUserAndPass, "TEST.PEOPLE", properties).collect().length === 3)
+      urlWithUserAndPass, "TEST.PEOPLE", properties).count == 3)
   }
 
   test("Option API with FetchSize") {
     val dfUsingOption = spark.read.option("fetchSize", "2").jdbc(
       urlWithUserAndPass, "TEST.PEOPLE", new Properties)
-    assert(dfUsingOption.count() == 3)
+    assert(dfUsingOption.count == 3)
     val logicalRelation =
       dfUsingOption.queryExecution.analyzed.find(_.isInstanceOf[LogicalRelation])
     assert(logicalRelation.isDefined)
@@ -370,7 +369,7 @@ class JDBCSuite extends SparkFunSuite
         .option("password", "testPass")
         .format("jdbc")
         .load()
-    assert(dfUsingOption.count() == 3)
+    assert(dfUsingOption.count == 3)
   }
 
   test("Using schema") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -228,34 +228,6 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("format or schema are specified twice") {
-    val schema1 = StructType(StructField("c1", IntegerType) :: Nil)
-    val schema2 = StructType(StructField("c2", IntegerType) :: Nil)
-    val format = "parquet"
-    val df = spark.createDataFrame(sparkContext.parallelize(Row(3) :: Nil), schema1)
-
-    withTempPath { path =>
-      df.write.format("json").mode("overwrite").save(path.getCanonicalPath)
-      // correct way:
-      spark.read.json(path.getCanonicalPath)
-
-      // not allowed to specify the format more than once
-      var e = intercept[IllegalArgumentException] {
-        spark.read.format(format).json(path.getCanonicalPath)
-      }.getMessage
-      assert(e.contains("Operation not allowed: the input data source format has already been " +
-        "set. Existing: `parquet`, new: `json`"))
-
-      // not allowed to specify the schema more than once.
-      e = intercept[IllegalArgumentException] {
-        spark.read.schema(schema1).schema(schema2).json(path.getCanonicalPath)
-      }.getMessage
-      assert(e.contains("Operation not allowed: the input schema has already been set. " +
-        "Existing: `StructType(StructField(c1,IntegerType,true))`, " +
-        "new: `StructType(StructField(c2,IntegerType,true))`"))
-    }
-  }
-
   test("check jdbc() does not support partitioning or bucketing") {
     val df = spark.read.text(Utils.createTempDir(namePrefix = "text").getCanonicalPath)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -201,7 +201,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext {
     assert(LastOptions.parameters("doubleOpt") == "6.7")
   }
 
-  test("reading catalog table") {
+  test("reading cataloged table") {
     val schema = StructType(StructField("c1", IntegerType) :: Nil)
     val format = "parquet"
     val df = spark.createDataFrame(sparkContext.parallelize(Row(3) :: Nil), schema)
@@ -225,13 +225,6 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext {
       }.getMessage
       assert(e.contains("Operation not allowed: specifying the input schema when reading tables " +
         "from catalog. table: `tab`, schema: `StructType(StructField(c1,IntegerType,true))`"))
-
-      // not allowed to specify options.
-      e = intercept[IllegalArgumentException] {
-        spark.read.options(Map("header" -> "true", "mode" -> "dropmalformed")).table(tableName)
-      }.getMessage
-      assert(e.contains("Operation not allowed: specifying the input option when reading " +
-        "tables from catalog. table: `tab`, option: `header -> true, mode -> dropmalformed`"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -217,21 +217,21 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext {
         spark.read.format(format).table(tableName)
       }.getMessage
       assert(e.contains("Operation not allowed: specifying the input data source format " +
-        "when reading table from catalog. table: `tab`, format: `parquet`"))
+        "when reading tables from catalog. table: `tab`, format: `parquet`"))
 
       // not allowed to specify schema.
       e = intercept[IllegalArgumentException] {
         spark.read.schema(schema).table(tableName)
       }.getMessage
-      assert(e.contains("Operation not allowed: specifying the input schema when reading table " +
+      assert(e.contains("Operation not allowed: specifying the input schema when reading tables " +
         "from catalog. table: `tab`, schema: `StructType(StructField(c1,IntegerType,true))`"))
 
       // not allowed to specify options.
       e = intercept[IllegalArgumentException] {
         spark.read.options(Map("header" -> "true", "mode" -> "dropmalformed")).table(tableName)
       }.getMessage
-      assert(e.contains("Operation not allowed: specifying the input option when reading table " +
-        "from catalog. table: `tab`, option: `header -> true, mode -> dropmalformed`"))
+      assert(e.contains("Operation not allowed: specifying the input option when reading " +
+        "tables from catalog. table: `tab`, option: `header -> true, mode -> dropmalformed`"))
     }
   }
 


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Below are **potential user errors** when using DataFrameReader APIs
- Specify the format when reading tables from catalog.

``` scala
spark.read.format("parquet").table(tableName)
```
- Specify the schema when reading tables from catalog

``` scala
val schema = StructType(StructField("c1", IntegerType) :: Nil)
spark.read.schema(schema).table(tableName)
```
- ~~Specify the options when reading tables from catalog~~

~~`spark.read.options(Map("header" -> "true", "mode" -> "dropmalformed")).table(tableName)`~~
- ~~Specify the format more than once~~
  ~~`val format = "parquet"`~~
  ~~`spark.read.format(format).json(path.getCanonicalPath)`~~
- ~~Specify schema more than once.~~
  ~~`spark.read.schema(schema1).schema(schema2).json(path.getCanonicalPath)`~~
- Specify the schema when reading tables from JDBC

``` scala
val schema = StructType(StructField("c1", IntegerType) :: Nil)
spark.read.schema(schema).jdbc(urlWithUserAndPass, "TEST.PEOPLE", new Properties)
```

This PR detects these user errors and issues the exception.
#### How was this patch tested?

Test cases are added to `DataFrameReaderWriterSuite`
