### PR TITLE
[SPARK-16063][SQL] Add storageLevel to Dataset

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -376,23 +376,46 @@ class DataFrame(object):
 
     @since(1.3)
     def cache(self):
-        """ Persists with the default storage level (C{MEMORY_ONLY}).
+        """Persists the :class:`DataFrame` with the default storage level (C{MEMORY_AND_DISK}).
+
+        .. note:: the default storage level has changed to C{MEMORY_AND_DISK} to match Scala in 2.0.
         """
         self.is_cached = True
         self._jdf.cache()
         return self
 
     @since(1.3)
-    def persist(self, storageLevel=StorageLevel.MEMORY_ONLY):
-        """Sets the storage level to persist its values across operations
-        after the first time it is computed. This can only be used to assign
-        a new storage level if the RDD does not have a storage level set yet.
-        If no storage level is specified defaults to (C{MEMORY_ONLY}).
+    def persist(self, storageLevel=StorageLevel.MEMORY_AND_DISK):
+        """Sets the storage level to persist the contents of the :class:`DataFrame` across
+        operations after the first time it is computed. This can only be used to assign
+        a new storage level if the :class:`DataFrame` does not have a storage level set yet.
+        If no storage level is specified defaults to (C{MEMORY_AND_DISK}).
+
+        .. note:: the default storage level has changed to C{MEMORY_AND_DISK} to match Scala in 2.0.
         """
         self.is_cached = True
         javaStorageLevel = self._sc._getJavaStorageLevel(storageLevel)
         self._jdf.persist(javaStorageLevel)
         return self
+
+    @since(2.0)
+    def storageLevel(self):
+        """Get the :class:`DataFrame`'s current storage level.
+
+        >>> df.storageLevel()
+        StorageLevel(False, False, False, False, 1)
+        >>> df.cache().storageLevel()
+        StorageLevel(True, True, False, True, 1)
+        >>> df2.persist(StorageLevel.DISK_ONLY_2).storageLevel()
+        StorageLevel(True, False, False, False, 2)
+        """
+        java_storage_level = self._jdf.storageLevel()
+        storage_level = StorageLevel(java_storage_level.useDisk(),
+                                     java_storage_level.useMemory(),
+                                     java_storage_level.useOffHeap(),
+                                     java_storage_level.deserialized(),
+                                     java_storage_level.replication())
+        return storage_level
 
     @since(1.3)
     def unpersist(self, blocking=False):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -398,15 +398,16 @@ class DataFrame(object):
         self._jdf.persist(javaStorageLevel)
         return self
 
+    @property
     @since(2.0)
     def storageLevel(self):
         """Get the :class:`DataFrame`'s current storage level.
 
-        >>> df.storageLevel()
+        >>> df.storageLevel
         StorageLevel(False, False, False, False, 1)
-        >>> df.cache().storageLevel()
+        >>> df.cache().storageLevel
         StorageLevel(True, True, False, True, 1)
-        >>> df2.persist(StorageLevel.DISK_ONLY_2).storageLevel()
+        >>> df2.persist(StorageLevel.DISK_ONLY_2).storageLevel
         StorageLevel(True, False, False, False, 2)
         """
         java_storage_level = self._jdf.storageLevel()

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.catalyst.optimizer.CombineUnions
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.usePrettyExpression
-import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.{FileRelation, LogicalRDD, QueryExecution, SQLExecution}
 import org.apache.spark.sql.execution.command.{CreateViewCommand, ExplainCommand}
 import org.apache.spark.sql.execution.datasources.{CreateTableUsingAsSelect, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.json.JacksonGenerator
@@ -2203,7 +2203,6 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the number of rows in the Dataset.
-   *
    * @group action
    * @since 1.6.0
    */
@@ -2357,7 +2356,6 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the content of the Dataset as a [[JavaRDD]] of [[Row]]s.
-   *
    * @group basic
    * @since 1.6.0
    */
@@ -2365,7 +2363,6 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the content of the Dataset as a [[JavaRDD]] of [[Row]]s.
-   *
    * @group basic
    * @since 1.6.0
    */
@@ -2455,7 +2452,6 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the content of the Dataset as a Dataset of JSON strings.
-   *
    * @since 2.0.0
    */
   def toJSON: Dataset[String] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.catalyst.optimizer.CombineUnions
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.usePrettyExpression
-import org.apache.spark.sql.execution.{FileRelation, LogicalRDD, QueryExecution, SQLExecution}
+import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.{CreateViewCommand, ExplainCommand}
 import org.apache.spark.sql.execution.datasources.{CreateTableUsingAsSelect, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.json.JacksonGenerator
@@ -2292,6 +2292,19 @@ class Dataset[T] private[sql](
    * @since 1.6.0
    */
   def cache(): this.type = persist()
+
+  /**
+   * Get the Dataset's current storage level, or StorageLevel.NONE if not persisted.
+   *
+   * @group basic
+   * @since 2.0.0
+   */
+  def getStorageLevel(): StorageLevel = {
+    sparkSession.sharedState.cacheManager.lookupCachedData(this).map {
+      case CachedData(_, relation) =>
+        relation.storageLevel
+    }.getOrElse(StorageLevel.NONE)
+  }
 
   /**
    * Persist this Dataset with the given storage level.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2203,6 +2203,7 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the number of rows in the Dataset.
+   *
    * @group action
    * @since 1.6.0
    */
@@ -2294,19 +2295,6 @@ class Dataset[T] private[sql](
   def cache(): this.type = persist()
 
   /**
-   * Get the Dataset's current storage level, or StorageLevel.NONE if not persisted.
-   *
-   * @group basic
-   * @since 2.0.0
-   */
-  def getStorageLevel(): StorageLevel = {
-    sparkSession.sharedState.cacheManager.lookupCachedData(this).map {
-      case CachedData(_, relation) =>
-        relation.storageLevel
-    }.getOrElse(StorageLevel.NONE)
-  }
-
-  /**
    * Persist this Dataset with the given storage level.
    * @param newLevel One of: `MEMORY_ONLY`, `MEMORY_AND_DISK`, `MEMORY_ONLY_SER`,
    *                 `MEMORY_AND_DISK_SER`, `DISK_ONLY`, `MEMORY_ONLY_2`,
@@ -2318,6 +2306,18 @@ class Dataset[T] private[sql](
   def persist(newLevel: StorageLevel): this.type = {
     sparkSession.sharedState.cacheManager.cacheQuery(this, None, newLevel)
     this
+  }
+
+  /**
+   * Get the Dataset's current storage level, or StorageLevel.NONE if not persisted.
+   *
+   * @group basic
+   * @since 2.0.0
+   */
+  def getStorageLevel(): StorageLevel = {
+    sparkSession.sharedState.cacheManager.lookupCachedData(this).map { cachedData =>
+      cachedData.cachedRepresentation.storageLevel
+    }.getOrElse(StorageLevel.NONE)
   }
 
   /**
@@ -2357,6 +2357,7 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the content of the Dataset as a [[JavaRDD]] of [[Row]]s.
+   *
    * @group basic
    * @since 1.6.0
    */
@@ -2364,6 +2365,7 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the content of the Dataset as a [[JavaRDD]] of [[Row]]s.
+   *
    * @group basic
    * @since 1.6.0
    */
@@ -2453,6 +2455,7 @@ class Dataset[T] private[sql](
 
   /**
    * Returns the content of the Dataset as a Dataset of JSON strings.
+   *
    * @since 2.0.0
    */
   def toJSON: Dataset[String] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2313,7 +2313,7 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 2.0.0
    */
-  def getStorageLevel(): StorageLevel = {
+  def storageLevel(): StorageLevel = {
     sparkSession.sharedState.cacheManager.lookupCachedData(this).map { cachedData =>
       cachedData.cachedRepresentation.storageLevel
     }.getOrElse(StorageLevel.NONE)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2313,7 +2313,7 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 2.0.0
    */
-  def storageLevel(): StorageLevel = {
+  def storageLevel: StorageLevel = {
     sparkSession.sharedState.cacheManager.lookupCachedData(this).map { cachedData =>
       cachedData.cachedRepresentation.storageLevel
     }.getOrElse(StorageLevel.NONE)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -34,17 +34,17 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     // default storage level
     ds1.persist()
     ds2.cache()
-    assert(ds1.getStorageLevel() == StorageLevel.MEMORY_AND_DISK)
-    assert(ds2.getStorageLevel() == StorageLevel.MEMORY_AND_DISK)
+    assert(ds1.storageLevel() == StorageLevel.MEMORY_AND_DISK)
+    assert(ds2.storageLevel() == StorageLevel.MEMORY_AND_DISK)
     // unpersist
     ds1.unpersist()
-    assert(ds1.getStorageLevel() == StorageLevel.NONE)
+    assert(ds1.storageLevel() == StorageLevel.NONE)
     // non-default storage level
     ds1.persist(StorageLevel.MEMORY_ONLY_2)
-    assert(ds1.getStorageLevel() == StorageLevel.MEMORY_ONLY_2)
+    assert(ds1.storageLevel() == StorageLevel.MEMORY_ONLY_2)
     // joined Dataset should not be persisted
     val joined = ds1.joinWith(ds2, $"a.value" === $"b.value")
-    assert(joined.getStorageLevel() == StorageLevel.NONE)
+    assert(joined.storageLevel() == StorageLevel.NONE)
   }
 
   test("persist and unpersist") {
@@ -60,7 +60,7 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
       2, 3, 4)
     // Drop the cache.
     cached.unpersist()
-    assert(cached.getStorageLevel() == StorageLevel.NONE, "The Dataset should not be cached.")
+    assert(cached.storageLevel() == StorageLevel.NONE, "The Dataset should not be cached.")
   }
 
   test("persist and then rebind right encoder when join 2 datasets") {
@@ -77,9 +77,9 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     assertCached(joined, 2)
 
     ds1.unpersist()
-    assert(ds1.getStorageLevel() == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
+    assert(ds1.storageLevel() == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
     ds2.unpersist()
-    assert(ds2.getStorageLevel() == StorageLevel.NONE, "The Dataset ds2 should not be cached.")
+    assert(ds2.storageLevel() == StorageLevel.NONE, "The Dataset ds2 should not be cached.")
   }
 
   test("persist and then groupBy columns asKey, map") {
@@ -94,8 +94,8 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     assertCached(agged.filter(_._1 == "b"))
 
     ds.unpersist()
-    assert(ds.getStorageLevel() == StorageLevel.NONE, "The Dataset ds should not be cached.")
+    assert(ds.storageLevel() == StorageLevel.NONE, "The Dataset ds should not be cached.")
     agged.unpersist()
-    assert(agged.getStorageLevel() == StorageLevel.NONE, "The Dataset agged should not be cached.")
+    assert(agged.storageLevel() == StorageLevel.NONE, "The Dataset agged should not be cached.")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -21,10 +21,31 @@ import scala.language.postfixOps
 
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.storage.StorageLevel
 
 
 class DatasetCacheSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
+
+  test("get storage level") {
+    val ds1 = Seq("1", "2").toDS().as("a")
+    val ds2 = Seq(2, 3).toDS().as("b")
+
+    // default storage level
+    ds1.persist()
+    ds2.cache()
+    assert(ds1.getStorageLevel() == StorageLevel.MEMORY_AND_DISK)
+    assert(ds2.getStorageLevel() == StorageLevel.MEMORY_AND_DISK)
+    // unpersist
+    ds1.unpersist()
+    assert(ds1.getStorageLevel() == StorageLevel.NONE)
+    // non-default storage level
+    ds1.persist(StorageLevel.MEMORY_ONLY_2)
+    assert(ds1.getStorageLevel() == StorageLevel.MEMORY_ONLY_2)
+    // joined Dataset should not be persisted
+    val joined = ds1.joinWith(ds2, $"a.value" === $"b.value")
+    assert(joined.getStorageLevel() == StorageLevel.NONE)
+  }
 
   test("persist and unpersist") {
     val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS().select(expr("_2 + 1").as[Int])
@@ -39,8 +60,7 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
       2, 3, 4)
     // Drop the cache.
     cached.unpersist()
-    assert(spark.sharedState.cacheManager.lookupCachedData(cached).isEmpty,
-      "The Dataset should not be cached.")
+    assert(cached.getStorageLevel() == StorageLevel.NONE, "The Dataset should not be cached.")
   }
 
   test("persist and then rebind right encoder when join 2 datasets") {
@@ -57,11 +77,9 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     assertCached(joined, 2)
 
     ds1.unpersist()
-    assert(spark.sharedState.cacheManager.lookupCachedData(ds1).isEmpty,
-      "The Dataset ds1 should not be cached.")
+    assert(ds1.getStorageLevel() == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
     ds2.unpersist()
-    assert(spark.sharedState.cacheManager.lookupCachedData(ds2).isEmpty,
-      "The Dataset ds2 should not be cached.")
+    assert(ds2.getStorageLevel() == StorageLevel.NONE, "The Dataset ds2 should not be cached.")
   }
 
   test("persist and then groupBy columns asKey, map") {
@@ -76,10 +94,8 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     assertCached(agged.filter(_._1 == "b"))
 
     ds.unpersist()
-    assert(spark.sharedState.cacheManager.lookupCachedData(ds).isEmpty,
-      "The Dataset ds should not be cached.")
+    assert(ds.getStorageLevel() == StorageLevel.NONE, "The Dataset ds should not be cached.")
     agged.unpersist()
-    assert(spark.sharedState.cacheManager.lookupCachedData(agged).isEmpty,
-      "The Dataset agged should not be cached.")
+    assert(agged.getStorageLevel() == StorageLevel.NONE, "The Dataset agged should not be cached.")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -34,17 +34,17 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     // default storage level
     ds1.persist()
     ds2.cache()
-    assert(ds1.storageLevel() == StorageLevel.MEMORY_AND_DISK)
-    assert(ds2.storageLevel() == StorageLevel.MEMORY_AND_DISK)
+    assert(ds1.storageLevel == StorageLevel.MEMORY_AND_DISK)
+    assert(ds2.storageLevel == StorageLevel.MEMORY_AND_DISK)
     // unpersist
     ds1.unpersist()
-    assert(ds1.storageLevel() == StorageLevel.NONE)
+    assert(ds1.storageLevel == StorageLevel.NONE)
     // non-default storage level
     ds1.persist(StorageLevel.MEMORY_ONLY_2)
-    assert(ds1.storageLevel() == StorageLevel.MEMORY_ONLY_2)
+    assert(ds1.storageLevel == StorageLevel.MEMORY_ONLY_2)
     // joined Dataset should not be persisted
     val joined = ds1.joinWith(ds2, $"a.value" === $"b.value")
-    assert(joined.storageLevel() == StorageLevel.NONE)
+    assert(joined.storageLevel == StorageLevel.NONE)
   }
 
   test("persist and unpersist") {
@@ -60,7 +60,7 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
       2, 3, 4)
     // Drop the cache.
     cached.unpersist()
-    assert(cached.storageLevel() == StorageLevel.NONE, "The Dataset should not be cached.")
+    assert(cached.storageLevel == StorageLevel.NONE, "The Dataset should not be cached.")
   }
 
   test("persist and then rebind right encoder when join 2 datasets") {
@@ -77,9 +77,9 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     assertCached(joined, 2)
 
     ds1.unpersist()
-    assert(ds1.storageLevel() == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
+    assert(ds1.storageLevel == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
     ds2.unpersist()
-    assert(ds2.storageLevel() == StorageLevel.NONE, "The Dataset ds2 should not be cached.")
+    assert(ds2.storageLevel == StorageLevel.NONE, "The Dataset ds2 should not be cached.")
   }
 
   test("persist and then groupBy columns asKey, map") {
@@ -94,8 +94,8 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     assertCached(agged.filter(_._1 == "b"))
 
     ds.unpersist()
-    assert(ds.storageLevel() == StorageLevel.NONE, "The Dataset ds should not be cached.")
+    assert(ds.storageLevel == StorageLevel.NONE, "The Dataset ds should not be cached.")
     agged.unpersist()
-    assert(agged.storageLevel() == StorageLevel.NONE, "The Dataset agged should not be cached.")
+    assert(agged.storageLevel == StorageLevel.NONE, "The Dataset agged should not be cached.")
   }
 }


### PR DESCRIPTION
[SPARK-11905](https://issues.apache.org/jira/browse/SPARK-11905) added support for `persist`/`cache` for `Dataset`. However, there is no user-facing API to check if a `Dataset` is cached and if so what the storage level is. This PR adds `getStorageLevel` to `Dataset`, analogous to `RDD.getStorageLevel`.
## How was this patch tested?

Updated `DatasetCacheSuite`.
