### PR TITLE
[HOTFIX][SPARK-15613][SQL]Set test runtime timezone for DateTimeUtilSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -21,15 +21,25 @@ import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
 import java.util.{Calendar, TimeZone}
 
+import org.scalatest.BeforeAndAfterAll
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.unsafe.types.UTF8String
 
-class DateTimeUtilsSuite extends SparkFunSuite {
+class DateTimeUtilsSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   private[this] def getInUTCDays(timestamp: Long): Int = {
     val tz = TimeZone.getDefault
     ((timestamp + tz.getOffset(timestamp)) / MILLIS_PER_DAY).toInt
+  }
+
+  private val originalTimeZone = TimeZone.getDefault
+  override def beforeAll(): Unit = {
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+  }
+  override def afterAll(): Unit = {
+    TimeZone.setDefault(originalTimeZone)
   }
 
   test("timestamp and us") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

With not default timezone setting in DateTimeUtilsSuite and use `Timestamp.valueOf` method could cause problems in a different time zone from PST. This PR fix this reported in #13652 by @robbinspg and @lw-lin
## How was this patch tested?

Existed tests do that.

cc @davies 
