### PR TITLE
[SPARK-15613] set correct TimeZone in test cases "to UTC timestamp" and "from UTC t…

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -485,8 +485,10 @@ class DateTimeUtilsSuite extends SparkFunSuite {
 
   test("from UTC timestamp") {
     def test(utc: String, tz: String, expected: String): Unit = {
-      assert(toJavaTimestamp(fromUTCTime(fromJavaTimestamp(Timestamp.valueOf(utc)), tz)).toString
-        === expected)
+      DateTimeTestUtils.withDefaultTimeZone(TimeZone.getTimeZone("UTC")) {
+        assert(toJavaTimestamp(fromUTCTime(fromJavaTimestamp(Timestamp.valueOf(utc)), tz)).toString
+          === expected)
+      }
     }
     test("2011-12-25 09:00:00.123456", "UTC", "2011-12-25 09:00:00.123456")
     test("2011-12-25 09:00:00.123456", "JST", "2011-12-25 18:00:00.123456")
@@ -502,9 +504,11 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   }
 
   test("to UTC timestamp") {
-    def test(utc: String, tz: String, expected: String): Unit = {
-      assert(toJavaTimestamp(toUTCTime(fromJavaTimestamp(Timestamp.valueOf(utc)), tz)).toString
-        === expected)
+    def test(ts: String, tz: String, expected: String): Unit = {
+      DateTimeTestUtils.withDefaultTimeZone(TimeZone.getTimeZone(tz)) {
+        assert(toJavaTimestamp(toUTCTime(fromJavaTimestamp(Timestamp.valueOf(ts)), tz)).toString
+          === expected)
+      }
     }
     test("2011-12-25 09:00:00.123456", "UTC", "2011-12-25 09:00:00.123456")
     test("2011-12-25 18:00:00.123456", "JST", "2011-12-25 09:00:00.123456")


### PR DESCRIPTION
## What changes were proposed in this pull request?

setting the correct time zone in test cases "to UTC timestamp" and "from UTC timestamp"
## How was this patch tested?

running regression DateTimeUtilSuite while setting using various JVM time zones
