### PR TITLE
[SPARK-15294][R] Add `pivot` to SparkR

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -293,6 +293,7 @@ exportMethods("%in%",
 
 exportClasses("GroupedData")
 exportMethods("agg")
+exportMethods("pivot")
 
 export("as.DataFrame",
        "cacheTable",

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -160,6 +160,10 @@ setGeneric("persist", function(x, newLevel) { standardGeneric("persist") })
 # @export
 setGeneric("pipeRDD", function(x, command, env = list()) { standardGeneric("pipeRDD")})
 
+# @rdname pivot
+# @export
+setGeneric("pivot", function(x, colname, values = list()) { standardGeneric("pivot") })
+
 # @rdname reduce
 # @export
 setGeneric("reduce", function(x, func) { standardGeneric("reduce") })

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -148,12 +148,13 @@ methods <- c("avg", "max", "mean", "min", "sum")
 #' df <- createDataFrame(data.frame(
 #'     earnings = c(10000, 10000, 11000, 15000, 12000, 20000, 21000, 22000),
 #'     course = c("R", "Python", "R", "Python", "R", "Python", "R", "Python"),
-#'     year = c(2013, 2013, 2014, 2014, 2015, 2015, 2016, 2016)
+#'     period = c("1H", "1H", "2H", "2H", "1H", "1H", "2H", "2H"),
+#'     year = c(2015, 2015, 2015, 2015, 2016, 2016, 2016, 2016)
 #' ))
-#' collect(sum(pivot(groupBy(df, "year"), "course"), "earnings"))
-#' collect(sum(pivot(groupBy(df, "year"), "course", "R"), "earnings"))
-#' collect(sum(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings"))
-#' collect(sum(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings"))
+#' sum(pivot(groupBy(df, "year"), "course"), "earnings")
+#' min(pivot(groupBy(df, "year"), "course", "R"), "earnings")
+#' max(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings")
+#' mean(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings")
 #' }
 #' @note pivot since 2.0.0
 setMethod("pivot",

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -138,7 +138,7 @@ methods <- c("avg", "max", "mean", "min", "sum")
 #'
 #' @param x a GroupedData object
 #' @param colname A column name
-#' @param values A list or vector of distinct values for the output columns.
+#' @param values A value or a list/vector of distinct values for the output columns.
 #' @return GroupedData object
 #' @rdname pivot
 #' @family agg
@@ -152,6 +152,7 @@ methods <- c("avg", "max", "mean", "min", "sum")
 #'     year = c(2013, 2013, 2014, 2014, 2015, 2015, 2016, 2016)
 #' ))
 #' collect(sum(pivot(groupBy(df, "year"), "course"), "earnings"))
+#' collect(sum(pivot(groupBy(df, "year"), "course", "R"), "earnings"))
 #' collect(sum(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings"))
 #' collect(sum(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings"))
 #' }
@@ -163,7 +164,7 @@ setMethod("pivot",
               result <- callJMethod(x@sgd, "pivot", colname)
             } else {
               if (length(values) > length(unique(values))) {
-                stop("Values in list are not unique")
+                stop("Values are not unique")
               }
               result <- callJMethod(x@sgd, "pivot", colname, as.list(values))
             }

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -141,7 +141,6 @@ methods <- c("avg", "max", "mean", "min", "sum")
 #' @param values A value or a list/vector of distinct values for the output columns.
 #' @return GroupedData object
 #' @rdname pivot
-#' @family agg
 #' @name pivot
 #' @export
 #' @examples
@@ -158,8 +157,9 @@ methods <- c("avg", "max", "mean", "min", "sum")
 #' }
 #' @note pivot since 2.0.0
 setMethod("pivot",
-          signature(x = "GroupedData"),
+          signature(x = "GroupedData", colname = "character"),
           function(x, colname, values = list()){
+            stopifnot(length(colname) == 1)
             if (length(values) == 0) {
               result <- callJMethod(x@sgd, "pivot", colname)
             } else {

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -151,10 +151,10 @@ methods <- c("avg", "max", "mean", "min", "sum")
 #'     period = c("1H", "1H", "2H", "2H", "1H", "1H", "2H", "2H"),
 #'     year = c(2015, 2015, 2015, 2015, 2016, 2016, 2016, 2016)
 #' ))
-#' sum(pivot(groupBy(df, "year"), "course"), "earnings")
-#' min(pivot(groupBy(df, "year"), "course", "R"), "earnings")
-#' max(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings")
-#' mean(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings")
+#' group_sum <- sum(pivot(groupBy(df, "year"), "course"), "earnings")
+#' group_min <- min(pivot(groupBy(df, "year"), "course", "R"), "earnings")
+#' group_max <- max(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings")
+#' group_mean <- mean(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings")
 #' }
 #' @note pivot since 2.0.0
 setMethod("pivot",

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1406,6 +1406,7 @@ test_that("pivot GroupedData column", {
   sum1 <- collect(sum(pivot(groupBy(df, "year"), "course"), "earnings"))
   sum2 <- collect(sum(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings"))
   sum3 <- collect(sum(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings"))
+  sum4 <- collect(sum(pivot(groupBy(df, "year"), "course", "R"), "earnings"))
 
   correct_answer <- data.frame(
     year = c(2013, 2014, 2015, 2016),
@@ -1415,6 +1416,10 @@ test_that("pivot GroupedData column", {
   expect_equal(sum1, correct_answer)
   expect_equal(sum2, correct_answer)
   expect_equal(sum3, correct_answer)
+  expect_equal(sum4, correct_answer[, c("year", "R")])
+
+  expect_error(collect(sum(pivot(groupBy(df, "year"), "course", c("R", "R")), "earnings")))
+  expect_error(collect(sum(pivot(groupBy(df, "year"), "course", list("R", "R")), "earnings")))
 })
 
 test_that("arrange() and orderBy() on a DataFrame", {

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1408,9 +1408,9 @@ test_that("pivot GroupedData column", {
   sum3 <- collect(sum(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings"))
 
   correct_answer <- data.frame(
-    year=c(2013,2014,2015,2016),
-    Python=c(10000,15000,20000,22000),
-    R=c(10000, 11000, 12000, 21000)
+    year = c(2013, 2014, 2015, 2016),
+    Python = c(10000, 15000, 20000, 22000),
+    R = c(10000, 11000, 12000, 21000)
   )
   expect_equal(sum1, correct_answer)
   expect_equal(sum2, correct_answer)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1397,6 +1397,26 @@ test_that("group by, agg functions", {
   unlink(jsonPath3)
 })
 
+test_that("pivot GroupedData column", {
+  df <- createDataFrame(data.frame(
+    earnings = c(10000, 10000, 11000, 15000, 12000, 20000, 21000, 22000),
+    course = c("R", "Python", "R", "Python", "R", "Python", "R", "Python"),
+    year = c(2013, 2013, 2014, 2014, 2015, 2015, 2016, 2016)
+  ))
+  sum1 <- collect(sum(pivot(groupBy(df, "year"), "course"), "earnings"))
+  sum2 <- collect(sum(pivot(groupBy(df, "year"), "course", c("Python", "R")), "earnings"))
+  sum3 <- collect(sum(pivot(groupBy(df, "year"), "course", list("Python", "R")), "earnings"))
+
+  correct_answer <- data.frame(
+    year=c(2013,2014,2015,2016),
+    Python=c(10000,15000,20000,22000),
+    R=c(10000, 11000, 12000, 21000)
+  )
+  expect_equal(sum1, correct_answer)
+  expect_equal(sum2, correct_answer)
+  expect_equal(sum3, correct_answer)
+})
+
 test_that("arrange() and orderBy() on a DataFrame", {
   df <- read.json(jsonPath)
   sorted <- arrange(df, df$age)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds `pivot` function to SparkR for API parity. Since this PR is based on https://github.com/apache/spark/pull/13295 , @mhnatiuk should be credited for the work he did.
## How was this patch tested?

Pass the Jenkins tests (including new testcase.)
