### PR TITLE
[SPARK-16077] [PYSPARK] catch the exception from pickle.whichmodule()

### DIFF
--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -334,7 +334,6 @@ class CloudPickler(Pickler):
             try:
                 # whichmodule() could fail, see
                 # https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling
-
                 modname = pickle.whichmodule(obj, name)
             except Exception:
                 modname = '__main__'

--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -170,6 +170,8 @@ class CloudPickler(Pickler):
         if name is None:
             name = obj.__name__
         try:
+            # whichmodule() could fail, see
+            # https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling
             modname = pickle.whichmodule(obj, name)
         except Exception:
             modname = None
@@ -330,6 +332,9 @@ class CloudPickler(Pickler):
         modname = getattr(obj, "__module__", None)
         if modname is None:
             try:
+                # whichmodule() could fail, see
+                # https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling
+
                 modname = pickle.whichmodule(obj, name)
             except Exception:
                 modname = '__main__'

--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -169,7 +169,10 @@ class CloudPickler(Pickler):
 
         if name is None:
             name = obj.__name__
-        modname = pickle.whichmodule(obj, name)
+        try:
+            modname = pickle.whichmodule(obj, name)
+        except Exception:
+            modname = None
         # print('which gives %s %s %s' % (modname, obj, name))
         try:
             themodule = sys.modules[modname]
@@ -326,7 +329,10 @@ class CloudPickler(Pickler):
 
         modname = getattr(obj, "__module__", None)
         if modname is None:
-            modname = pickle.whichmodule(obj, name)
+            try:
+                modname = pickle.whichmodule(obj, name)
+            except Exception:
+                modname = '__main__'
 
         if modname == '__main__':
             themodule = None


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the case that we don't know which module a object came from, will call pickle.whichmodule() to go throught all the loaded modules to find the object, which could fail because some modules, for example, six, see https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling

We should ignore the exception here, use `__main__` as the module name (it means we can't find the module).
## How was this patch tested?

Manual tested. Can't have a unit test for this.
