### PR TITLE
[SPARK-16074] [MLLIB] expose VectorUDT/MatrixUDT in a public API

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/linalg/dataTypes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/linalg/dataTypes.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.types.DataType
+
+/**
+ * :: DeveloperApi ::
+ * SQL data types for vectors and matrices.
+ */
+@DeveloperApi
+object sqlDataTypes {
+
+  /** Data type for [[Vector]]. */
+  lazy val VectorType: DataType = new VectorUDT
+
+  /** Data type for [[Matrix]]. */
+  lazy val MatrixType: DataType = new MatrixUDT
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/linalg/dataTypes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/linalg/dataTypes.scala
@@ -28,8 +28,8 @@ import org.apache.spark.sql.types.DataType
 object sqlDataTypes {
 
   /** Data type for [[Vector]]. */
-  lazy val VectorType: DataType = new VectorUDT
+  val VectorType: DataType = new VectorUDT
 
   /** Data type for [[Matrix]]. */
-  lazy val MatrixType: DataType = new MatrixUDT
+  val MatrixType: DataType = new MatrixUDT
 }

--- a/mllib/src/test/java/org/apache/spark/ml/linalg/JavaSQLDataTypesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/linalg/JavaSQLDataTypesSuite.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.spark.ml.linalg.sqlDataTypes.*;
+
+public class JavaSQLDataTypesSuite {
+  @Test
+  public void testSQLDataTypes() {
+    Assert.assertEquals(new VectorUDT(), VectorType());
+    Assert.assertEquals(new MatrixUDT(), MatrixType());
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/linalg/SQLDataTypesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/linalg/SQLDataTypesSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+import org.apache.spark.SparkFunSuite
+
+class SQLDataTypesSuite extends SparkFunSuite {
+  test("sqlDataTypes") {
+    assert(sqlDataTypes.VectorType === new VectorUDT)
+    assert(sqlDataTypes.MatrixType === new MatrixUDT)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Both VectorUDT and MatrixUDT are private APIs, because UserDefinedType itself is private in Spark. However, in order to let developers implement their own transformers and estimators, we should expose both types in a public API to simply the implementation of transformSchema, transform, etc. Otherwise, they need to get the data types using reflection.
## How was this patch tested?

Unit tests in Scala and Java.
