### PR TITLE
[SPARK-16094][SQL] Support HashAggregateExec for non-partial aggregates

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -35,7 +35,7 @@ object AggUtils {
 
     val completeAggregateExpressions = aggregateExpressions.map(_.copy(mode = Complete))
     val completeAggregateAttributes = completeAggregateExpressions.map(_.resultAttribute)
-    SortAggregateExec(
+    createAggregate(
       requiredChildDistributionExpressions = Some(groupingExpressions),
       groupingExpressions = groupingExpressions,
       aggregateExpressions = completeAggregateExpressions,

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -457,6 +457,36 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
     )
   }
 
+  test("collect functions array") {
+    val df = Seq((1, 3, 3, 3), (2, 3, 3, 3), (3, 4, 1, 2))
+      .toDF("a", "x", "y", "z")
+      .select($"a", array($"x", $"y", $"z").as("b"))
+    checkAnswer(
+      df.select(collect_list($"a"), sort_array(collect_list($"b"))),
+      Seq(Row(Seq(1, 2, 3), Seq(Seq(3, 3, 3), Seq(3, 3, 3), Seq(4, 1, 2))))
+    )
+    checkAnswer(
+      df.select(collect_set($"a"), sort_array(collect_set($"b"))),
+      Seq(Row(Seq(1, 2, 3), Seq(Seq(3, 3, 3), Seq(4, 1, 2))))
+    )
+  }
+
+  test("collect functions map") {
+    val df = Seq((1, 3, 0), (2, 3, 0), (3, 4, 1))
+      .toDF("a", "x", "y")
+      .select($"a", map($"x", $"y").as("b"))
+    checkAnswer(
+      df.select(collect_list($"a"), collect_list($"b")),
+      Seq(Row(Seq(1, 2, 3), Seq(Map(3 -> 0), Map(3 -> 0), Map(4 -> 1))))
+    )
+    // TODO: We need to implement `UnsafeMapData#hashCode` and `UnsafeMapData#equals` for getting
+    // a set of input data.
+    checkAnswer(
+      df.select(collect_set($"a"), collect_set($"b")),
+      Seq(Row(Seq(1, 2, 3), Seq(Map(3 -> 0), Map(3 -> 0), Map(4 -> 1))))
+    )
+  }
+
   test("SPARK-14664: Decimal sum/avg over window should work.") {
     checkAnswer(
       spark.sql("select sum(a) over () from values 1.0, 2.0, 3.0 T(a)"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1339,6 +1339,17 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("non-partial collect_set/collect_list aggregate test") {
+    checkAnswer(
+      testData4.groupBy("key").agg(collect_set($"value")),
+      Row(1, Array("1")) :: Row(2, Array("2")) :: Row(3, Array("3")) :: Nil
+    )
+    checkAnswer(
+      testData4.groupBy("key").agg(collect_list($"value")),
+      Row(1, Array("1", "1")) :: Row(2, Array("2", "2")) :: Row(3, Array("3", "3")) :: Nil
+    )
+  }
+
   test("fix case sensitivity of partition by") {
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       withTempPath { path =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -72,6 +72,18 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
+  protected lazy val testData4: DataFrame = {
+    val df = spark.sparkContext.parallelize(
+      TestData(1, "1") ::
+      TestData(1, "1") ::
+      TestData(2, "2") ::
+      TestData(2, "2") ::
+      TestData(3, "3") ::
+      TestData(3, "3") :: Nil, 2).toDF()
+    df.createOrReplaceTempView("testData4")
+    df
+  }
+
   protected lazy val negativeData: DataFrame = {
     val df = spark.sparkContext.parallelize(
       (1 to 100).map(i => TestData(-i, (-i).toString))).toDF()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current spark cannot use `HashAggregateExec` for non-partial aggregates because `Collect` (`CollectSet`/`CollectList`) uses a single shared buffer inside. Since SortAggregateExec is expensive in some cases, we'd better off fixing this.

This pr is to change plans from

```
SortAggregate(key=[key#3077], functions=[collect_set(value#3078, 0, 0)], output=[key#3077,collect_set(value)#3088])
+- *Sort [key#3077 ASC], false, 0
   +- Exchange hashpartitioning(key#3077, 5)
      +- Scan ExistingRDD[key#3077,value#3078]
```

into

```
HashAggregate(keys=[key#3077], functions=[collect_set(value#3078, 0, 0)], output=[key#3077, collect_set(value)#3088])
+- Exchange hashpartitioning(key#3077, 5)
   +- Scan ExistingRDD[key#3077,value#3078]
```
## How was this patch tested?

Checked non-partial aggregates (`collect_set` and `collect_list`) worked well for `HashAggregateExec` in `DataFrameSuite`.
