### PR TITLE
[Minor][Core] Fix display wrong free memory size in the log

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -377,7 +377,8 @@ private[spark] class MemoryStore(
         entries.put(blockId, entry)
       }
       logInfo("Block %s stored as bytes in memory (estimated size %s, free %s)".format(
-        blockId, Utils.bytesToString(entry.size), Utils.bytesToString(blocksMemoryUsed)))
+        blockId, Utils.bytesToString(entry.size),
+        Utils.bytesToString(maxMemory - blocksMemoryUsed)))
       Right(entry.size)
     } else {
       // We ran out of space while unrolling the values for this block


### PR DESCRIPTION
## What changes were proposed in this pull request?

Free memory size displayed in the log is wrong (used memory), fix to make it correct.
## How was this patch tested?

N/A
