### PR TITLE
[SPARK-16104][SQL] Do not creaate CSV writer object for every flush when writing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -55,52 +55,6 @@ private[sql] abstract class CsvReader(params: CSVOptions, headers: Seq[String]) 
 }
 
 /**
- * Converts a sequence of string to CSV string
- *
- * @param params Parameters object for configuration
- * @param headers headers for columns
- */
-private[sql] class LineCsvWriter(params: CSVOptions, headers: Seq[String]) extends Logging {
-  private val writerSettings = new CsvWriterSettings
-  private val format = writerSettings.getFormat
-
-  format.setDelimiter(params.delimiter)
-  format.setLineSeparator(params.rowSeparator)
-  format.setQuote(params.quote)
-  format.setQuoteEscape(params.escape)
-  format.setComment(params.comment)
-
-  writerSettings.setNullValue(params.nullValue)
-  writerSettings.setEmptyValue(params.nullValue)
-  writerSettings.setSkipEmptyLines(true)
-  writerSettings.setQuoteAllFields(false)
-  writerSettings.setHeaders(headers: _*)
-  writerSettings.setQuoteEscapingEnabled(params.escapeQuotes)
-
-  private var buffer = new ByteArrayOutputStream()
-  private var writer = new CsvWriter(
-    new OutputStreamWriter(buffer, StandardCharsets.UTF_8),
-    writerSettings)
-
-  def writeRow(row: Seq[String], includeHeader: Boolean): Unit = {
-    if (includeHeader) {
-      writer.writeHeaders()
-    }
-    writer.writeRow(row.toArray: _*)
-  }
-
-  def flush(): String = {
-    writer.close()
-    val lines = buffer.toString.stripLineEnd
-    buffer = new ByteArrayOutputStream()
-    writer = new CsvWriter(
-      new OutputStreamWriter(buffer, StandardCharsets.UTF_8),
-      writerSettings)
-    lines
-  }
-}
-
-/**
  * Parser for parsing a line at a time. Not efficient for bulk data.
  *
  * @param params Parameters object

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -254,4 +254,3 @@ private class StringIteratorReader(val iter: Iterator[String]) extends java.io.R
 
   override def close(): Unit = { }
 }
-

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -62,7 +62,6 @@ private[sql] abstract class CsvReader(params: CSVOptions, headers: Seq[String]) 
 private[sql] class LineCsvWriter(params: CSVOptions, headers: Seq[String]) extends Logging {
   private val writerSettings = new CsvWriterSettings
   private val format = writerSettings.getFormat
-  private val buffer = new CharArrayWriter()
 
   format.setDelimiter(params.delimiter)
   format.setLineSeparator(params.rowSeparator)
@@ -77,6 +76,7 @@ private[sql] class LineCsvWriter(params: CSVOptions, headers: Seq[String]) exten
   writerSettings.setHeaders(headers: _*)
   writerSettings.setQuoteEscapingEnabled(params.escapeQuotes)
 
+  private val buffer = new CharArrayWriter()
   private val writer = new CsvWriter(buffer, writerSettings)
 
   def writeRow(row: Seq[String], includeHeader: Boolean): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -59,14 +59,10 @@ private[sql] abstract class CsvReader(params: CSVOptions, headers: Seq[String]) 
  * @param params Parameters object for configuration
  * @param headers headers for columns
  */
-private[sql] class LineCsvWriter(
-    params: CSVOptions,
-    headers: Seq[String],
-    charArrayWriter: CharArrayWriter)
-  extends Logging {
-
+private[sql] class LineCsvWriter(params: CSVOptions, headers: Seq[String]) extends Logging {
   private val writerSettings = new CsvWriterSettings
   private val format = writerSettings.getFormat
+  private val buffer = new CharArrayWriter()
 
   format.setDelimiter(params.delimiter)
   format.setLineSeparator(params.rowSeparator)
@@ -81,7 +77,7 @@ private[sql] class LineCsvWriter(
   writerSettings.setHeaders(headers: _*)
   writerSettings.setQuoteEscapingEnabled(params.escapeQuotes)
 
-  private val writer = new CsvWriter(charArrayWriter, writerSettings)
+  private val writer = new CsvWriter(buffer, writerSettings)
 
   def writeRow(row: Seq[String], includeHeader: Boolean): Unit = {
     if (includeHeader) {
@@ -92,8 +88,8 @@ private[sql] class LineCsvWriter(
 
   def flush(): String = {
     writer.flush()
-    val lines = charArrayWriter.toString.stripLineEnd
-    charArrayWriter.reset()
+    val lines = buffer.toString.stripLineEnd
+    buffer.reset()
     lines
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import java.io.{ByteArrayOutputStream, CharArrayWriter, OutputStreamWriter, StringReader}
-import java.nio.charset.StandardCharsets
+import java.io.{CharArrayWriter, StringReader}
 
 import com.univocity.parsers.csv._
 
@@ -63,7 +62,9 @@ private[sql] abstract class CsvReader(params: CSVOptions, headers: Seq[String]) 
 private[sql] class LineCsvWriter(
     params: CSVOptions,
     headers: Seq[String],
-    charArrayWriter: CharArrayWriter) extends Logging {
+    charArrayWriter: CharArrayWriter)
+  extends Logging {
+
   private val writerSettings = new CsvWriterSettings
   private val format = writerSettings.getFormat
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -216,4 +216,3 @@ private[sql] class CsvOutputWriter(
     recordWriter.close(context)
   }
 }
-

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -17,8 +17,11 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
+import java.io.CharArrayWriter
+
 import scala.util.control.NonFatal
 
+import com.univocity.parsers.csv.{CsvWriter, CsvWriterSettings}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{NullWritable, Text}
 import org.apache.hadoop.mapreduce.RecordWriter
@@ -145,14 +148,14 @@ object CSVRelation extends Logging {
   }
 }
 
-private[sql] class CSVOutputWriterFactory(params: CSVOptions) extends OutputWriterFactory {
+private[sql] class CSVOutputWriterFactory(options: CSVOptions) extends OutputWriterFactory {
   override def newInstance(
       path: String,
       bucketId: Option[Int],
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
     if (bucketId.isDefined) sys.error("csv doesn't support bucketing")
-    new CsvOutputWriter(path, dataSchema, context, params)
+    new CsvOutputWriter(path, dataSchema, context, options)
   }
 }
 
@@ -160,10 +163,10 @@ private[sql] class CsvOutputWriter(
     path: String,
     dataSchema: StructType,
     context: TaskAttemptContext,
-    params: CSVOptions) extends OutputWriter with Logging {
+    options: CSVOptions) extends OutputWriter with Logging {
 
   // create the Generator without separator inserted between 2 records
-  private[this] val text = new Text()
+  private[this] val result = new Text()
 
   private val recordWriter: RecordWriter[NullWritable, Text] = {
     new TextOutputFormat[NullWritable, Text]() {
@@ -177,38 +180,61 @@ private[sql] class CsvOutputWriter(
     }.getRecordWriter(context)
   }
 
+  private val headers = dataSchema.fieldNames
+
+  private[this] val writer = new CharArrayWriter()
+  private[this] val csvWriter = {
+    val writerSettings = new CsvWriterSettings
+    val format = writerSettings.getFormat
+
+    format.setDelimiter(options.delimiter)
+    format.setLineSeparator(options.rowSeparator)
+    format.setQuote(options.quote)
+    format.setQuoteEscape(options.escape)
+    format.setComment(options.comment)
+
+    writerSettings.setNullValue(options.nullValue)
+    writerSettings.setEmptyValue(options.nullValue)
+    writerSettings.setSkipEmptyLines(true)
+    writerSettings.setQuoteAllFields(false)
+    writerSettings.setHeaders(headers: _*)
+    writerSettings.setQuoteEscapingEnabled(options.escapeQuotes)
+
+    new CsvWriter(writer, writerSettings)
+  }
+  private[this] var writeHeader = options.headerFlag
+
   private val FLUSH_BATCH_SIZE = 1024L
   private var records: Long = 0L
-  private val csvWriter = new LineCsvWriter(params, dataSchema.fieldNames.toSeq)
-
-  private def rowToString(row: Seq[Any]): Seq[String] = row.map { field =>
-    if (field != null) {
-      field.toString
-    } else {
-      params.nullValue
-    }
-  }
 
   override def write(row: Row): Unit = throw new UnsupportedOperationException("call writeInternal")
 
   override protected[sql] def writeInternal(row: InternalRow): Unit = {
-    csvWriter.writeRow(rowToString(row.toSeq(dataSchema)), records == 0L && params.headerFlag)
+    val tokens = row.toSeq(dataSchema).map { field =>
+        if (field != null) field.toString else options.nullValue
+      }
+    if (writeHeader) {
+      csvWriter.writeHeaders()
+    }
+    csvWriter.writeRow(tokens: _*)
+
     records += 1
     if (records % FLUSH_BATCH_SIZE == 0) {
       flush()
     }
+    writeHeader = false
   }
 
   private def flush(): Unit = {
-    val lines = csvWriter.flush()
-    if (lines.nonEmpty) {
-      text.set(lines)
-      recordWriter.write(NullWritable.get(), text)
-    }
+    csvWriter.flush()
+    result.set(writer.toString.stripLineEnd)
+    writer.reset()
+    recordWriter.write(NullWritable.get(), result)
   }
 
   override def close(): Unit = {
     flush()
+    csvWriter.close()
     recordWriter.close(context)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import java.io.CharArrayWriter
-
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
@@ -182,7 +180,7 @@ private[sql] class CsvOutputWriter(
   private val FLUSH_BATCH_SIZE = 1024L
   private var records: Long = 0L
   private val csvWriter =
-    new LineCsvWriter(params, dataSchema.fieldNames.toSeq, new CharArrayWriter())
+    new LineCsvWriter(params, dataSchema.fieldNames.toSeq)
 
   private def rowToString(row: Seq[Any]): Seq[String] = row.map { field =>
     if (field != null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -179,8 +179,7 @@ private[sql] class CsvOutputWriter(
 
   private val FLUSH_BATCH_SIZE = 1024L
   private var records: Long = 0L
-  private val csvWriter =
-    new LineCsvWriter(params, dataSchema.fieldNames.toSeq)
+  private val csvWriter = new LineCsvWriter(params, dataSchema.fieldNames.toSeq)
 
   private def rowToString(row: Seq[Any]): Seq[String] = row.map { field =>
     if (field != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR let `CsvWriter` object is not created for each time but able to be reused. This way was taken after from JSON data source.

Original `CsvWriter` was being created for each row but it was enhanced in https://github.com/apache/spark/pull/13229. However, it still creates `CsvWriter` object for each `flush()` in `LineCsvWriter`. It seems it does not have to close the object and re-create this for every flush. 

It follows the original logic as it is but `CsvWriter` is reused by reseting `CharArrayWriter`. 
## How was this patch tested?

Existing tests should cover this.
