### PR TITLE
[SPARK-16100] [SQL] avoid crash in TreeNode.withNewChildren

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -201,9 +201,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       case s: StructType => s // Don't convert struct types to some other type of Seq[StructField]
       // Handle Seq[TreeNode] in TreeNode parameters.
       case s: Seq[_] => s.map {
-        case arg: TreeNode[_] if containsChild(arg) =>
+        case arg: TreeNode[_] if containsChild(arg) && remainingOldChildren.size > 0 =>
           val newChild = remainingNewChildren.remove(0)
           val oldChild = remainingOldChildren.remove(0)
+          assert(arg == oldChild)
           if (newChild fastEquals oldChild) {
             oldChild
           } else {
@@ -214,9 +215,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
         case null => null
       }
       case m: Map[_, _] => m.mapValues {
-        case arg: TreeNode[_] if containsChild(arg) =>
+        case arg: TreeNode[_] if containsChild(arg) && remainingOldChildren.size > 0 =>
           val newChild = remainingNewChildren.remove(0)
           val oldChild = remainingOldChildren.remove(0)
+          assert(arg == oldChild)
           if (newChild fastEquals oldChild) {
             oldChild
           } else {
@@ -226,9 +228,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
         case nonChild: AnyRef => nonChild
         case null => null
       }.view.force // `mapValues` is lazy and we need to force it to materialize
-      case arg: TreeNode[_] if containsChild(arg) =>
+      case arg: TreeNode[_] if containsChild(arg) && remainingOldChildren.size > 0 =>
         val newChild = remainingNewChildren.remove(0)
         val oldChild = remainingOldChildren.remove(0)
+        assert(arg == oldChild)
         if (newChild fastEquals oldChild) {
           oldChild
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes a reported bug, which causes IndexOutOfBoundsException during the code generation.
This issue is cased for a `MapObjects` instance which has the same object for `loopVar` and `lambdaFunction`. 

``` scala
case class MapObjects private(
    loopVar: LambdaVariable,
    lambdaFunction: Expression,
    inputData: Expression) extends Expression with NonSQLExpression {

  override def children: Seq[Expression] = lambdaFunction :: inputData :: Nil
```

In such case, `loopVar` is handled as a child in `TreeNode.withNewChildren` since the object is included in children as `lambdaFunction`. 
I add checks for the number of unprocessed children to avoid this issue.
Is there any idea on cleaner way to avoid such a pathological case?

I also add `assert` to confirm that the mapping `Children` and `productElement` is correct.
## How was this patch tested?

Using existing unit tests 
