### PR TITLE
[MINOR] [MLLIB] move setCheckpointInterval to non-expert setters

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -151,7 +151,7 @@ private[ml] trait DecisionTreeParams extends PredictorParams
    * [[org.apache.spark.SparkContext]].
    * Must be >= 1.
    * (default = 10)
-   * @group expertSetParam
+   * @group setParam
    */
   def setCheckpointInterval(value: Int): this.type = set(checkpointInterval, value)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `checkpointInterval` is a non-expert param. This PR moves its setter to non-expert group.
