### PR TITLE
[SPARK-16116][SQL]ConsoleSink should not require checkpointLocation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -272,6 +272,12 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
         useTempCheckpointLocation = true,
         trigger = trigger)
     } else {
+      val (useTempCheckpointLocation, recoverFromCheckpointLocation) =
+        if (source == "console") {
+          (true, false)
+        } else {
+          (false, true)
+        }
       val dataSource =
         DataSource(
           df.sparkSession,
@@ -284,6 +290,8 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
         df,
         dataSource.createSink(outputMode),
         outputMode,
+        useTempCheckpointLocation = useTempCheckpointLocation,
+        recoverFromCheckpointLocation = recoverFromCheckpointLocation,
         trigger = trigger)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -457,4 +457,14 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
       }
     }
   }
+
+  test("ConsoleSink should not require checkpointLocation") {
+    LastOptions.clear()
+    val df = spark.readStream
+      .format("org.apache.spark.sql.streaming.test")
+      .load()
+
+    val sq = df.writeStream.format("console").start()
+    sq.stop()
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the user uses `ConsoleSink`, we should use a temp location if `checkpointLocation` is not specified.
## How was this patch tested?

The added unit test.
