### PR TITLE
[SPARK-16107] [R] group glm methods in documentation

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -115,7 +115,7 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
           })
 
 #' @title Generalized Linear Models (R-compliant)
-#  Fits a generalized linear model, similarly to R's glm().
+#'  Fits a generalized linear model, similarly to R's glm().
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
 #'                operators are supported, including '~', '.', ':', '+', and '-'.
 #' @param data SparkDataFrame for training.
@@ -143,7 +143,6 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "SparkDat
             spark.glm(data, formula, family, tol = epsilon, maxIter = maxit)
           })
 
-#' @title Summary of GLM model
 #  Returns the summary of a model produced by glm() or spark.glm(), similarly to R's summary().
 #' @param object A fitted generalized linear model
 #' @return \code{summary} returns a summary object of the fitted model, a list of components
@@ -183,7 +182,6 @@ setMethod("summary", signature(object = "GeneralizedLinearRegressionModel"),
             return(ans)
           })
 
-#' @title Print summary of GLM model
 #  Print the summary of GeneralizedLinearRegressionModel
 #' @rdname spark.glm
 #' @param x Summary object of fitted generalized linear model returned by \code{summary} function
@@ -215,7 +213,6 @@ print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
   invisible(x)
   }
 
-#' @title Make predictions using the produced generalized linear model
 #  Makes predictions from a generalized linear model produced by glm() or spark.glm(),
 #  similarly to R's predict().
 #' @param newData SparkDataFrame for testing
@@ -472,7 +469,6 @@ setMethod("write.ml", signature(object = "AFTSurvivalRegressionModel", path = "c
             invisible(callJMethod(writer, "save", path))
           })
 
-#' @title Save fitted GLM model
 #  Save the generalized linear model to the input path.
 #' @param path The directory where the model is saved
 #' @param overwrite Overwrites or not if the output path already exists. Default is FALSE

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -53,7 +53,7 @@ setClass("AFTSurvivalRegressionModel", representation(jobj = "jobj"))
 #' @note KMeansModel since 2.0.0
 setClass("KMeansModel", representation(jobj = "jobj"))
 
-#' Fits a generalized linear model
+#' Generalized Linear Models
 #'
 #' Fits a generalized linear model against a Spark DataFrame.
 #'
@@ -68,6 +68,7 @@ setClass("KMeansModel", representation(jobj = "jobj"))
 #' @param maxIter Integer giving the maximal number of IRLS iterations.
 #' @return a fitted generalized linear model
 #' @rdname spark.glm
+#' @name spark.glm
 #' @export
 #' @examples
 #' \dontrun{
@@ -98,9 +99,8 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
                                 tol, as.integer(maxIter))
             return(new("GeneralizedLinearRegressionModel", jobj = jobj))
           })
-
 #' Fits a generalized linear model (R-compliant).
-#'
+#' 
 #' Fits a generalized linear model, similarly to R's glm().
 #'
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
@@ -129,13 +129,12 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "SparkDat
             spark.glm(data, formula, family, tol = epsilon, maxIter = maxit)
           })
 
-#' Get the summary of a generalized linear model
-#'
+
 #' Returns the summary of a model produced by glm() or spark.glm(), similarly to R's summary().
 #'
 #' @param object A fitted generalized linear model
 #' @return coefficients the model's coefficients, intercept
-#' @rdname summary
+#' @rdname spark.glm
 #' @export
 #' @examples
 #' \dontrun{
@@ -175,8 +174,7 @@ setMethod("summary", signature(object = "GeneralizedLinearRegressionModel"),
 
 #' Print the summary of GeneralizedLinearRegressionModel
 #'
-#' @rdname print
-#' @name print.summary.GeneralizedLinearRegressionModel
+#' @rdname spark.glm
 #' @export
 #' @note print.summary.GeneralizedLinearRegressionModel since 2.0.0
 print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
@@ -205,15 +203,14 @@ print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
   invisible(x)
   }
 
-#' Predicted values based on model
-#'
+
 #' Makes predictions from a generalized linear model produced by glm() or spark.glm(),
 #' similarly to R's predict().
 #'
 #' @param object A fitted generalized linear model
 #' @param newData SparkDataFrame for testing
 #' @return SparkDataFrame containing predicted labels in a column named "prediction"
-#' @rdname predict
+#' @rdname spark.glm
 #' @export
 #' @examples
 #' \dontrun{
@@ -471,8 +468,6 @@ setMethod("write.ml", signature(object = "AFTSurvivalRegressionModel", path = "c
             invisible(callJMethod(writer, "save", path))
           })
 
-#' Save fitted MLlib model to the input path
-#'
 #' Save the generalized linear model to the input path.
 #'
 #' @param object A fitted generalized linear model
@@ -480,8 +475,7 @@ setMethod("write.ml", signature(object = "AFTSurvivalRegressionModel", path = "c
 #' @param overwrite Overwrites or not if the output path already exists. Default is FALSE
 #'                  which means throw exception if the output path exists.
 #'
-#' @rdname write.ml
-#' @name write.ml
+#' @rdname spark.glm
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -55,7 +55,7 @@ setClass("KMeansModel", representation(jobj = "jobj"))
 
 #' Generalized Linear Models
 #'
-#' Fit generalized linear model against a Spark DataFrame. Can print, make predictions on the
+#' Fits generalized linear model against a Spark DataFrame. Users can print, make predictions on the
 #' produced model and save the model to the input path.
 #'
 #' @param data SparkDataFrame for training.
@@ -91,9 +91,8 @@ setClass("KMeansModel", representation(jobj = "jobj"))
 #' savedModel <- read.ml(path)
 #' summary(savedModel)
 #' }
-
-
 #' @note spark.glm since 2.0.0
+#' @seealso \link{glm}, \link{read.ml}
 setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
           function(data, formula, family = gaussian, tol = 1e-6, maxIter = 25) {
             if (is.character(family)) {
@@ -115,7 +114,8 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
             return(new("GeneralizedLinearRegressionModel", jobj = jobj))
           })
 
-#' @title Fit a generalized linear model
+#' @title Generalized Linear Models (R-compliant)
+#  Fits a generalized linear model, similarly to R's glm().
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
 #'                operators are supported, including '~', '.', ':', '+', and '-'.
 #' @param data SparkDataFrame for training.
@@ -125,16 +125,26 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 #'               \url{https://stat.ethz.ch/R-manual/R-devel/library/stats/html/family.html}.
 #' @param epsilon Positive convergence tolerance of iterations.
 #' @param maxit Integer giving the maximal number of IRLS iterations.
-#' @return \code{spark.glm} returns a fitted generalized linear model.
+#' @return \code{glm} returns a fitted generalized linear model.
 #' @rdname glm
 #' @export
+#' @examples
+#' \dontrun{
+#' sparkR.session()
+#' data(iris)
+#' df <- createDataFrame(iris)
+#' model <- glm(Sepal_Length ~ Sepal_Width, df, family = "gaussian")
+#' summary(model)
+#' }
 #' @note glm since 1.5.0
+#' @seealso \link{spark.glm}
 setMethod("glm", signature(formula = "formula", family = "ANY", data = "SparkDataFrame"),
           function(formula, family = gaussian, data, epsilon = 1e-6, maxit = 25) {
             spark.glm(data, formula, family, tol = epsilon, maxIter = maxit)
           })
 
-#' @title Return a summary of the produced generalized linear model
+#' @title Summary of GLM model
+#  Returns the summary of a model produced by glm() or spark.glm(), similarly to R's summary().
 #' @param object A fitted generalized linear model
 #' @return \code{summary} returns a summary object of the fitted model, a list of components
 #'         including at least the coefficients, null/residual deviance, null/residual degrees
@@ -173,7 +183,8 @@ setMethod("summary", signature(object = "GeneralizedLinearRegressionModel"),
             return(ans)
           })
 
-#' @title Print the summary of the produced generalized linear model
+#' @title Print summary of GLM model
+#  Print the summary of GeneralizedLinearRegressionModel
 #' @rdname spark.glm
 #' @param x Summary object of fitted generalized linear model returned by \code{summary} function
 #' @export
@@ -205,6 +216,8 @@ print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
   }
 
 #' @title Make predictions using the produced generalized linear model
+#  Makes predictions from a generalized linear model produced by glm() or spark.glm(),
+#  similarly to R's predict().
 #' @param newData SparkDataFrame for testing
 #' @return \code{predict} returns a SparkDataFrame containing predicted labels in a column named "prediction"
 #' @rdname spark.glm
@@ -459,8 +472,8 @@ setMethod("write.ml", signature(object = "AFTSurvivalRegressionModel", path = "c
             invisible(callJMethod(writer, "save", path))
           })
 
-#' @title Save fitted generalized linear model to the input path
-#'
+#' @title Save fitted GLM model
+#  Save the generalized linear model to the input path.
 #' @param path The directory where the model is saved
 #' @param overwrite Overwrites or not if the output path already exists. Default is FALSE
 #'                  which means throw exception if the output path exists.
@@ -468,7 +481,6 @@ setMethod("write.ml", signature(object = "AFTSurvivalRegressionModel", path = "c
 #' @rdname spark.glm
 #' @export
 #' @note write.ml(GeneralizedLinearRegressionModel, character) since 2.0.0
-#' @seealso \link{read.ml}
 setMethod("write.ml", signature(object = "GeneralizedLinearRegressionModel", path = "character"),
           function(object, path, overwrite = FALSE) {
             writer <- callJMethod(object@jobj, "write")

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -114,8 +114,9 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
             return(new("GeneralizedLinearRegressionModel", jobj = jobj))
           })
 
-#' @title Generalized Linear Models (R-compliant)
-#'  Fits a generalized linear model, similarly to R's glm().
+#' Generalized Linear Models (R-compliant)
+#'
+#' Fits a generalized linear model, similarly to R's glm().
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
 #'                operators are supported, including '~', '.', ':', '+', and '-'.
 #' @param data SparkDataFrame for training.
@@ -144,6 +145,7 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "SparkDat
           })
 
 #  Returns the summary of a model produced by glm() or spark.glm(), similarly to R's summary().
+#'
 #' @param object A fitted generalized linear model
 #' @return \code{summary} returns a summary object of the fitted model, a list of components
 #'         including at least the coefficients, null/residual deviance, null/residual degrees
@@ -182,7 +184,8 @@ setMethod("summary", signature(object = "GeneralizedLinearRegressionModel"),
             return(ans)
           })
 
-#  Print the summary of GeneralizedLinearRegressionModel
+#  Prints the summary of GeneralizedLinearRegressionModel
+#'
 #' @rdname spark.glm
 #' @param x Summary object of fitted generalized linear model returned by \code{summary} function
 #' @export
@@ -215,6 +218,7 @@ print.summary.GeneralizedLinearRegressionModel <- function(x, ...) {
 
 #  Makes predictions from a generalized linear model produced by glm() or spark.glm(),
 #  similarly to R's predict().
+#'
 #' @param newData SparkDataFrame for testing
 #' @return \code{predict} returns a SparkDataFrame containing predicted labels in a column named "prediction"
 #' @rdname spark.glm
@@ -469,7 +473,8 @@ setMethod("write.ml", signature(object = "AFTSurvivalRegressionModel", path = "c
             invisible(callJMethod(writer, "save", path))
           })
 
-#  Save the generalized linear model to the input path.
+#  Saves the generalized linear model to the input path.
+#'
 #' @param path The directory where the model is saved
 #' @param overwrite Overwrites or not if the output path already exists. Default is FALSE
 #'                  which means throw exception if the output path exists.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This groups GLM methods (spark.glm, summary, print, predict and write.ml) in the documentation. The example code was updated.
## How was this patch tested?

N/A

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

![screen shot 2016-06-21 at 2 31 37 pm](https://cloud.githubusercontent.com/assets/15318264/16247077/f6eafc04-37bc-11e6-89a8-7898ff3e4078.png)
![screen shot 2016-06-21 at 2 31 45 pm](https://cloud.githubusercontent.com/assets/15318264/16247078/f6eb1c16-37bc-11e6-940a-2b595b10617c.png)
