### PR TITLE
[SPARK-16115][SQL] Improve error message on non-existent table in Show Partitions command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -643,6 +643,10 @@ case class ShowPartitionsCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
 
+    if (!catalog.tableExists(table)) {
+      throw new AnalysisException(s" Table does not exist")
+    }
+
     if (catalog.isTemporaryTable(table)) {
       throw new AnalysisException(
         s"SHOW PARTITIONS is not allowed on a temporary table: ${table.unquotedString}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -630,6 +630,8 @@ case class ShowColumnsCommand(table: TableIdentifier) extends RunnableCommand {
 case class ShowPartitionsCommand(
     table: TableIdentifier,
     spec: Option[TablePartitionSpec]) extends RunnableCommand {
+
+  // The result of SHOW PARTITIONS has one column called 'partition'
   override val output: Seq[Attribute] = {
     AttributeReference("partition", StringType, nullable = false)() :: Nil
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -646,7 +646,7 @@ case class ShowPartitionsCommand(
     val catalog = sparkSession.sessionState.catalog
 
     if (!catalog.tableExists(table)) {
-      throw new AnalysisException(s" Table does not exist")
+      throw new AnalysisException(s"Table ${table.unquotedString} does not exist")
     }
 
     if (catalog.isTemporaryTable(table)) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -654,6 +654,19 @@ class HiveDDLSuite
     }
   }
 
+  test("test show partitions") {
+    val message = intercept[AnalysisException] {
+      sql("SHOW PARTITIONS default.nonexistentTable")
+    }.getMessage
+    assert(message.contains("Table does not exist"))
+
+    withTable("t1") {
+      sql("CREATE TABLE t1 (key STRING, value STRING) PARTITIONED BY (ds STRING)")
+      sql("ALTER TABLE t1 ADD PARTITION (ds = '1')")
+      assert(sql(" SHOW PARTITIONS t1").schema.getFieldIndex("partition") == Some(0))
+    }
+  }
+
   test("Create Cataloged Table As Select - Drop Table After Runtime Exception") {
     withTable("tab") {
       intercept[RuntimeException] {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -654,12 +654,14 @@ class HiveDDLSuite
     }
   }
 
-  test("test show partitions") {
+  test("show partitions on non-existent table") {
     val message = intercept[AnalysisException] {
       sql("SHOW PARTITIONS default.nonexistentTable")
     }.getMessage
-    assert(message.contains("Table does not exist"))
+    assert(message.contains("Table default.nonexistentTable does not exist"))
+  }
 
+  test("show partitions output schema name") {
     withTable("t1") {
       sql("CREATE TABLE t1 (key STRING, value STRING) PARTITIONED BY (ds STRING)")
       sql("ALTER TABLE t1 ADD PARTITION (ds = '1')")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes include: 
-  Improve the error message when calling show partitions on a non-existent table. 
  Add a check to see if table exists or not and add error message.

Without the fix: 

```
scala> spark.sql("show partitions t1");
org.apache.spark.sql.AnalysisException: SHOW PARTITIONS is not allowed on a table that is not partitioned: default.t1;

```

With the fix: 

```
scala> spark.sql("SHOW PARTITIONS t1").show;
org.apache.spark.sql.AnalysisException:  Table t1 does not exist;
```
## How was this patch tested?
- Added unit tests to cover these scenarios
- Following unit tests were run successfully:  hive/test, sql/test, catalyst/test
