### PR TITLE
[MINOR] [MLLIB] deprecate setLabelCol in ChiSqSelectorModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -142,6 +142,7 @@ final class ChiSqSelectorModel private[ml] (
 
   /** @group setParam */
   @Since("1.6.0")
+  @deprecated("labelCol is not used by ChiSqSelectorModel.", "2.0.0")
   def setLabelCol(value: String): this.type = set(labelCol, value)
 
   @Since("2.0.0")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Deprecate `labelCol`, which is not used by ChiSqSelectorModel.
