### PR TITLE
[SPARK-16124][SQL] fix `getHiveFile` return file url in jar that cannot be load in SQL

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.hive.test
 
-import java.io.File
+import java.io.{File, FileOutputStream}
 import java.util.{Set => JavaSet}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.language.implicitConversions
 
+import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry
@@ -180,7 +181,12 @@ private[hive] class TestHiveSparkSession(
   ShutdownHookManager.registerShutdownDeleteDir(hiveFilesTemp)
 
   def getHiveFile(path: String): File = {
-    new File(Thread.currentThread().getContextClassLoader.getResource(path).getFile)
+    val tempFile = File.createTempFile(path, "tmp")
+    tempFile.deleteOnExit()
+    val in = Thread.currentThread().getContextClassLoader.getResourceAsStream(path)
+    val out = new FileOutputStream(tempFile)
+    IOUtils.copy(in, out)
+    tempFile
   }
 
   val describedTable = "DESCRIBE (\\w+)".r


### PR DESCRIPTION
## What changes were proposed in this pull request?

I create a temp file from output stream of the file in jar and return that file
## How was this patch tested?

manual tests
