### PR TITLE
[SPARK-16339] [CORE] ScriptTransform does not print stderr when outstream is lost

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -317,9 +317,9 @@ private class ScriptTransformationWriterThread(
       case t: Throwable =>
         // An error occurred while writing input, so kill the child process. According to the
         // Javadoc this call will not throw an exception:
-        _exception = e
+        _exception = t
         proc.destroy()
-        throw e
+        throw t
     } finally {
       try {
         Utils.tryLogNonFatalError(outputStream.close())

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -312,7 +312,6 @@ private class ScriptTransformationWriterThread(
           }
         }
       }
-      Utils.tryLogNonFatalError(outputStream.close())
       threwException = false
     } catch {
       case e @ Throwable =>
@@ -323,6 +322,7 @@ private class ScriptTransformationWriterThread(
         throw e
     } finally {
       try {
+        Utils.tryLogNonFatalError(outputStream.close())
         if (proc.waitFor() != 0) {
           logError(stderrBuffer.toString) // log the stderr circular buffer
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -314,7 +314,7 @@ private class ScriptTransformationWriterThread(
       }
       threwException = false
     } catch {
-      case e @ Throwable =>
+      case NonFatal(e) =>
         // An error occurred while writing input, so kill the child process. According to the
         // Javadoc this call will not throw an exception:
         _exception = e

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -314,7 +314,7 @@ private class ScriptTransformationWriterThread(
       }
       threwException = false
     } catch {
-      case NonFatal(e) =>
+      case t: Throwable =>
         // An error occurred while writing input, so kill the child process. According to the
         // Javadoc this call will not throw an exception:
         _exception = e

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -322,10 +322,10 @@ private class ScriptTransformationWriterThread(
         throw e
     } finally {
       try {
-        outputStream.close()
         if (proc.waitFor() != 0) {
           logError(stderrBuffer.toString) // log the stderr circular buffer
         }
+        outputStream.close()
       } catch {
         case NonFatal(exceptionFromFinallyBlock) =>
           if (!threwException) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -312,10 +312,10 @@ private class ScriptTransformationWriterThread(
           }
         }
       }
+      Utils.tryLogNonFatalError(outputStream.close())
       threwException = false
-      outputStream.close()
     } catch {
-      case NonFatal(e) =>
+      case e @ Throwable =>
         // An error occurred while writing input, so kill the child process. According to the
         // Javadoc this call will not throw an exception:
         _exception = e

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -313,6 +313,7 @@ private class ScriptTransformationWriterThread(
         }
       }
       threwException = false
+      outputStream.close()
     } catch {
       case NonFatal(e) =>
         // An error occurred while writing input, so kill the child process. According to the
@@ -325,7 +326,6 @@ private class ScriptTransformationWriterThread(
         if (proc.waitFor() != 0) {
           logError(stderrBuffer.toString) // log the stderr circular buffer
         }
-        outputStream.close()
       } catch {
         case NonFatal(exceptionFromFinallyBlock) =>
           if (!threwException) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if due to some failure, the outstream gets destroyed or closed and later `outstream.close()` leads to IOException in such case. Due to this, the `stderrBuffer` does not get logged and there is no way for users to see why the job failed. 

The change is to first display the stderr buffer and then try closing the outstream.
## How was this patch tested?

The correct way to test this fix would be to grep the log to see if the `stderrBuffer` gets logged but I dont think having test cases which do that is a good idea.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

…
