### PR TITLE
[SPARK-16131] initialize internal logger lazily in Scala preferred way

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -32,7 +32,10 @@ private[spark] trait Logging {
 
   // Make the log field transient so that objects with Logging can
   // be serialized and used on another machine
-  @transient private var log_ : Logger = null
+  @transient private lazy val log_ : Logger = {
+    initializeLogIfNecessary(false)
+    LoggerFactory.getLogger(logName)
+  }
 
   // Method to get the logger name for this object
   protected def logName = {
@@ -41,13 +44,7 @@ private[spark] trait Logging {
   }
 
   // Method to get or create the logger for this object
-  protected def log: Logger = {
-    if (log_ == null) {
-      initializeLogIfNecessary(false)
-      log_ = LoggerFactory.getLogger(logName)
-    }
-    log_
-  }
+  protected def log: Logger = log_
 
   // Log methods that take only a String
   protected def logInfo(msg: => String) {

--- a/core/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -32,7 +32,7 @@ private[spark] trait Logging {
 
   // Make the log field transient so that objects with Logging can
   // be serialized and used on another machine
-  @transient private lazy val log_ : Logger = {
+  @transient lazy val log : Logger = {
     initializeLogIfNecessary(false)
     LoggerFactory.getLogger(logName)
   }
@@ -42,9 +42,6 @@ private[spark] trait Logging {
     // Ignore trailing $'s in the class names for Scala objects
     this.getClass.getName.stripSuffix("$")
   }
-
-  // Method to get or create the logger for this object
-  protected def log: Logger = log_
 
   // Log methods that take only a String
   protected def logInfo(msg: => String) {

--- a/core/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -32,7 +32,7 @@ private[spark] trait Logging {
 
   // Make the log field transient so that objects with Logging can
   // be serialized and used on another machine
-  @transient lazy val log : Logger = {
+  @transient lazy val log: Logger = {
     initializeLogIfNecessary(false)
     LoggerFactory.getLogger(logName)
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -100,8 +100,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     // instance across threads
     private val ser = SparkEnv.get.closureSerializer.newInstance()
 
-    override protected def log = CoarseGrainedSchedulerBackend.this.log
-
     protected val addressToExecutorId = new HashMap[RpcAddress, String]
 
     private val reviveThread =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Initialize logger instance lazily in Scala preferred way
## How was this patch tested?

By running `./build/mvn clean test` locally
