### PR TITLE
[SPARK-16134][SQL] optimizer rules for typed filter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -293,11 +293,7 @@ package object dsl {
 
       def where(condition: Expression): LogicalPlan = Filter(condition, logicalPlan)
 
-      def filter[T : Encoder](func: T => Boolean): LogicalPlan = {
-        val deserialized = logicalPlan.deserialize[T]
-        val condition = expressions.callFunction(func, BooleanType, deserialized.output.head)
-        Filter(condition, deserialized).serialize[T]
-      }
+      def filter[T : Encoder](func: T => Boolean): LogicalPlan = TypedFilter(func, logicalPlan)
 
       def serialize[T : Encoder]: LogicalPlan = CatalystSerde.serialize[T](logicalPlan)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ReferenceToExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ReferenceToExpressions.scala
@@ -45,6 +45,7 @@ case class ReferenceToExpressions(result: Expression, children: Seq[Expression])
     var maxOrdinal = -1
     result foreach {
       case b: BoundReference if b.ordinal > maxOrdinal => maxOrdinal = b.ordinal
+      case _ =>
     }
     if (maxOrdinal > children.length) {
       return TypeCheckFailure(s"The result expression need $maxOrdinal input expressions, but " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -191,12 +191,12 @@ case class TypedFilter(
 
   override def output: Seq[Attribute] = child.output
 
-  def withObject(obj: LogicalPlan): Filter = {
+  def withObjectProducerChild(obj: LogicalPlan): Filter = {
     assert(obj.output.length == 1)
-    Filter(getCondition(obj.output.head), obj)
+    Filter(typedCondition(obj.output.head), obj)
   }
 
-  def getCondition(input: Expression): Expression = {
+  def typedCondition(input: Expression): Expression = {
     val (funcClass, methodName) = func match {
       case m: FilterFunction[_] => classOf[FilterFunction[_]] -> "call"
       case _ => classOf[Any => Boolean] -> "apply"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -17,11 +17,15 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
+import scala.language.existentials
+
+import org.apache.spark.api.java.function.FilterFunction
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.{Encoder, Row}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedDeserializer
 import org.apache.spark.sql.catalyst.encoders._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.types._
 
 object CatalystSerde {
@@ -45,13 +49,11 @@ object CatalystSerde {
  */
 trait ObjectProducer extends LogicalPlan {
   // The attribute that reference to the single object field this operator outputs.
-  protected def outputObjAttr: Attribute
+  def outputObjAttr: Attribute
 
   override def output: Seq[Attribute] = outputObjAttr :: Nil
 
   override def producedAttributes: AttributeSet = AttributeSet(outputObjAttr)
-
-  def outputObjectType: DataType = outputObjAttr.dataType
 }
 
 /**
@@ -64,7 +66,7 @@ trait ObjectConsumer extends UnaryNode {
   // This operator always need all columns of its child, even it doesn't reference to.
   override def references: AttributeSet = child.outputSet
 
-  def inputObjectType: DataType = child.output.head.dataType
+  def inputObjAttr: Attribute = child.output.head
 }
 
 /**
@@ -166,6 +168,43 @@ case class MapElements(
     func: AnyRef,
     outputObjAttr: Attribute,
     child: LogicalPlan) extends ObjectConsumer with ObjectProducer
+
+object TypedFilter {
+  def apply[T : Encoder](func: AnyRef, child: LogicalPlan): TypedFilter = {
+    TypedFilter(func, UnresolvedDeserializer(encoderFor[T].deserializer), child)
+  }
+}
+
+/**
+ * A relation produced by applying `func` to each element of the `child` and filter them by the
+ * resulting boolean value.
+ *
+ * This is logically equal to a normal [[Filter]] operator whose condition expression is decoding
+ * the input row to object and apply the given function with decoded object. However we need the
+ * encapsulation of [[TypedFilter]] to make the concept more clear and make it easier to write
+ * optimizer rules.
+ */
+case class TypedFilter(
+    func: AnyRef,
+    deserializer: Expression,
+    child: LogicalPlan) extends UnaryNode {
+
+  override def output: Seq[Attribute] = child.output
+
+  def withObject(obj: LogicalPlan): Filter = {
+    assert(obj.output.length == 1)
+    Filter(getCondition(obj.output.head), obj)
+  }
+
+  def getCondition(input: Expression): Expression = {
+    val (funcClass, methodName) = func match {
+      case m: FilterFunction[_] => classOf[FilterFunction[_]] -> "call"
+      case _ => classOf[Any => Boolean] -> "apply"
+    }
+    val funcObj = Literal.create(func, ObjectType(funcClass))
+    Invoke(funcObj, methodName, BooleanType, input :: Nil)
+  }
+}
 
 /** Factory for constructing new `AppendColumn` nodes. */
 object AppendColumns {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TypedFilterOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TypedFilterOptimizationSuite.scala
@@ -23,21 +23,84 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedDeserializer
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.encoders.{encoderFor, ExpressionEncoder}
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, ReferenceToExpressions}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.{BooleanType, ObjectType}
 
 class TypedFilterOptimizationSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches =
       Batch("EliminateSerialization", FixedPoint(50),
         EliminateSerialization) ::
-      Batch("EmbedSerializerInFilter", FixedPoint(50),
-        EmbedSerializerInFilter) :: Nil
+      Batch("CombineTypedFilters", FixedPoint(50),
+        CombineTypedFilters) :: Nil
   }
 
   implicit private def productEncoder[T <: Product : TypeTag] = ExpressionEncoder[T]()
+
+  test("filter after serialize") {
+    val input = LocalRelation('_1.int, '_2.int)
+    val f = (i: (Int, Int)) => i._1 > 0
+
+    val query = input
+      .deserialize[(Int, Int)]
+      .serialize[(Int, Int)]
+      .filter(f).analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = input
+      .deserialize[(Int, Int)]
+      .where(callFunction(f, BooleanType, 'obj))
+      .serialize[(Int, Int)].analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  test("filter after serialize with object change") {
+    val input = LocalRelation('_1.int, '_2.int)
+    val f = (i: OtherTuple) => i._1 > 0
+
+    val query = input
+      .deserialize[(Int, Int)]
+      .serialize[(Int, Int)]
+      .filter(f).analyze
+    val optimized = Optimize.execute(query)
+    comparePlans(optimized, query)
+  }
+
+  test("filter before deserialize") {
+    val input = LocalRelation('_1.int, '_2.int)
+    val f = (i: (Int, Int)) => i._1 > 0
+
+    val query = input
+      .filter(f)
+      .deserialize[(Int, Int)]
+      .serialize[(Int, Int)].analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = input
+      .deserialize[(Int, Int)]
+      .where(callFunction(f, BooleanType, 'obj))
+      .serialize[(Int, Int)].analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  test("filter before deserialize with object change") {
+    val input = LocalRelation('_1.int, '_2.int)
+    val f = (i: OtherTuple) => i._1 > 0
+
+    val query = input
+      .filter(f)
+      .deserialize[(Int, Int)]
+      .serialize[(Int, Int)].analyze
+    val optimized = Optimize.execute(query)
+    comparePlans(optimized, query)
+  }
 
   test("back to back filter") {
     val input = LocalRelation('_1.int, '_2.int)
@@ -48,29 +111,23 @@ class TypedFilterOptimizationSuite extends PlanTest {
 
     val optimized = Optimize.execute(query)
 
-    val expected = input.deserialize[(Int, Int)]
-      .where(callFunction(f1, BooleanType, 'obj))
-      .select('obj.as("obj"))
-      .where(callFunction(f2, BooleanType, 'obj))
-      .serialize[(Int, Int)].analyze
+    val deserializer = UnresolvedDeserializer(encoderFor[(Int, Int)].deserializer)
+    val boundReference = BoundReference(0, ObjectType(classOf[(Int, Int)]), nullable = false)
+    val callFunc1 = callFunction(f1, BooleanType, boundReference)
+    val callFunc2 = callFunction(f2, BooleanType, boundReference)
+    val condition = ReferenceToExpressions(callFunc2 && callFunc1, deserializer :: Nil)
+    val expected = input.where(condition).analyze
 
     comparePlans(optimized, expected)
   }
 
-  // TODO: Remove this after we completely fix SPARK-15632 by adding optimization rules
-  // for typed filters.
-  ignore("embed deserializer in typed filter condition if there is only one filter") {
+  test("back to back filter with object change") {
     val input = LocalRelation('_1.int, '_2.int)
-    val f = (i: (Int, Int)) => i._1 > 0
+    val f1 = (i: (Int, Int)) => i._1 > 0
+    val f2 = (i: OtherTuple) => i._2 > 0
 
-    val query = input.filter(f).analyze
-
+    val query = input.filter(f1).filter(f2).analyze
     val optimized = Optimize.execute(query)
-
-    val deserializer = UnresolvedDeserializer(encoderFor[(Int, Int)].deserializer)
-    val condition = callFunction(f, BooleanType, deserializer)
-    val expected = input.where(condition).select('_1.as("_1"), '_2.as("_2")).analyze
-
-    comparePlans(optimized, expected)
+    comparePlans(optimized, query)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1997,11 +1997,7 @@ class Dataset[T] private[sql](
    */
   @Experimental
   def filter(func: T => Boolean): Dataset[T] = {
-    val deserializer = UnresolvedDeserializer(encoderFor[T].deserializer)
-    val function = Literal.create(func, ObjectType(classOf[T => Boolean]))
-    val condition = Invoke(function, "apply", BooleanType, deserializer :: Nil)
-    val filter = Filter(condition, logicalPlan)
-    withTypedPlan(filter)
+    withTypedPlan(TypedFilter(func, logicalPlan))
   }
 
   /**
@@ -2014,11 +2010,7 @@ class Dataset[T] private[sql](
    */
   @Experimental
   def filter(func: FilterFunction[T]): Dataset[T] = {
-    val deserializer = UnresolvedDeserializer(encoderFor[T].deserializer)
-    val function = Literal.create(func, ObjectType(classOf[FilterFunction[T]]))
-    val condition = Invoke(function, "call", BooleanType, deserializer :: Nil)
-    val filter = Filter(condition, logicalPlan)
-    withTypedPlan(filter)
+    withTypedPlan(TypedFilter(func, logicalPlan))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -385,6 +385,8 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.ProjectExec(projectList, planLater(child)) :: Nil
       case logical.Filter(condition, child) =>
         execution.FilterExec(condition, planLater(child)) :: Nil
+      case f: logical.TypedFilter =>
+        execution.FilterExec(f.getCondition(f.deserializer), planLater(f.child)) :: Nil
       case e @ logical.Expand(_, _, child) =>
         execution.ExpandExec(e.projections, e.output, planLater(child)) :: Nil
       case logical.Window(windowExprs, partitionSpec, orderSpec, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -386,7 +386,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.Filter(condition, child) =>
         execution.FilterExec(condition, planLater(child)) :: Nil
       case f: logical.TypedFilter =>
-        execution.FilterExec(f.getCondition(f.deserializer), planLater(f.child)) :: Nil
+        execution.FilterExec(f.typedCondition(f.deserializer), planLater(f.child)) :: Nil
       case e @ logical.Expand(_, _, child) =>
         execution.ExpandExec(e.projections, e.output, planLater(child)) :: Nil
       case logical.Window(windowExprs, partitionSpec, orderSpec, child) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -238,6 +238,7 @@ abstract class QueryTest extends PlanTest {
       case _: ObjectConsumer => return
       case _: ObjectProducer => return
       case _: AppendColumns => return
+      case _: TypedFilter => return
       case _: LogicalRelation => return
       case p if p.getClass.getSimpleName == "MetastoreRelation" => return
       case _: MemoryPlan => return


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds 3 optimizer rules for typed filter:
1. push typed filter down through `SerializeFromObject` and eliminate the deserialization in filter condition.
2. pull typed filter up through `SerializeFromObject` and eliminate the deserialization in filter condition.
3. combine adjacent typed filters and share the deserialized object among all the condition expressions.

This PR also adds `TypedFilter` logical plan, to separate it from normal filter, so that the concept is more clear and it's easier to write optimizer rules.
## How was this patch tested?

`TypedFilterOptimizationSuite`
