### PR TITLE
[SPARK-9478] [ml] Add class weights to Random Forest

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -122,7 +122,7 @@ class DecisionTreeClassifier @Since("1.4.0") (
       categoricalFeatures: Map[Int, Int],
       numClasses: Int): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, getOldImpurity,
-      subsamplingRate = 1.0)
+      subsamplingRate = 1.0, getClassWeights)
   }
 
   @Since("1.4.1")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -132,7 +132,7 @@ class DecisionTreeClassifier @Since("1.4.0") (
 @Since("1.4.0")
 @Experimental
 object DecisionTreeClassifier extends DefaultParamsReadable[DecisionTreeClassifier] {
-  /** Accessor for supported impurities: entropy, gini */
+  /** Accessor for supported impurities: entropy, gini, weightedgini */
   @Since("1.4.0")
   final val supportedImpurities: Array[String] = TreeClassifierParams.supportedImpurities
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -171,7 +171,7 @@ class DecisionTreeClassificationModel private[ml] (
   }
 
   override protected def predictRaw(features: Vector): Vector = {
-    Vectors.dense(rootNode.predictImpl(features).impurityStats.stats.clone())
+    Vectors.dense(rootNode.predictImpl(features).impurityStats.weightedStats.clone())
   }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -122,7 +122,7 @@ class DecisionTreeClassifier @Since("1.4.0") (
       categoricalFeatures: Map[Int, Int],
       numClasses: Int): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, getOldImpurity,
-      subsamplingRate = 1.0, getClassWeights)
+      subsamplingRate = 1.0)
   }
 
   @Since("1.4.1")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -82,6 +82,9 @@ class DecisionTreeClassifier @Since("1.4.0") (
   @Since("1.6.0")
   override def setSeed(value: Long): this.type = super.setSeed(value)
 
+  @Since("2.0.0")
+  override def setClassWeights(value: Array[Double]): this.type = super.setClassWeights(value)
+
   override protected def train(dataset: Dataset[_]): DecisionTreeClassificationModel = {
     val categoricalFeatures: Map[Int, Int] =
       MetadataUtils.getCategoricalFeatures(dataset.schema($(featuresCol)))

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -127,7 +127,11 @@ abstract class ProbabilisticClassificationModel[
       numColsOutput += 1
     }
     if ($(predictionCol).nonEmpty) {
-      val predUDF = {
+      val predUDF = if ($(rawPredictionCol).nonEmpty) {
+        udf(raw2prediction _).apply(col($(rawPredictionCol)))
+      } else if ($(probabilityCol).nonEmpty) {
+        udf(probability2prediction _).apply(col($(probabilityCol)))
+      } else {
         val predictUDF = udf { (features: Any) =>
           predict(features.asInstanceOf[FeaturesType])
         }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -127,11 +127,7 @@ abstract class ProbabilisticClassificationModel[
       numColsOutput += 1
     }
     if ($(predictionCol).nonEmpty) {
-      val predUDF = if ($(rawPredictionCol).nonEmpty) {
-        udf(raw2prediction _).apply(col($(rawPredictionCol)))
-      } else if ($(probabilityCol).nonEmpty) {
-        udf(probability2prediction _).apply(col($(probabilityCol)))
-      } else {
+      val predUDF = {
         val predictUDF = udf { (features: Any) =>
           predict(features.asInstanceOf[FeaturesType])
         }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -107,9 +107,8 @@ class RandomForestClassifier @Since("1.4.0") (
     val numClasses: Int = getNumClasses(dataset)
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset, numClasses)
     val strategy =
-      super.getOldStrategy(categoricalFeatures = categoricalFeatures, numClasses = numClasses,
-        oldAlgo = OldAlgo.Classification, oldImpurity = getOldImpurity,
-        subsamplingRate = getSubsamplingRate, classWeights = getClassWeights)
+      super.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification,
+        getOldImpurity, getSubsamplingRate, getClassWeights)
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -108,7 +108,7 @@ class RandomForestClassifier @Since("1.4.0") (
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset, numClasses)
     val strategy =
       super.getOldStrategy(categoricalFeatures, numClasses,
-        OldAlgo.Classification, getOldImpurity, getClassWeights)
+        OldAlgo.Classification, getOldImpurity)
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -107,8 +107,9 @@ class RandomForestClassifier @Since("1.4.0") (
     val numClasses: Int = getNumClasses(dataset)
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset, numClasses)
     val strategy =
-      super.getOldStrategy(categoricalFeatures, numClasses,
-        OldAlgo.Classification, getOldImpurity)
+      super.getOldStrategy(categoricalFeatures = categoricalFeatures, numClasses = numClasses,
+        oldAlgo = OldAlgo.Classification, oldImpurity = getOldImpurity,
+        subsamplingRate = getSubsamplingRate, classWeights = getClassWeights)
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -104,7 +104,8 @@ class RandomForestClassifier @Since("1.4.0") (
     val numClasses: Int = getNumClasses(dataset)
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset, numClasses)
     val strategy =
-      super.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, getOldImpurity)
+      super.getOldStrategy(categoricalFeatures, numClasses,
+        OldAlgo.Classification, getOldImpurity, getClassWeights)
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -98,6 +98,9 @@ class RandomForestClassifier @Since("1.4.0") (
   override def setFeatureSubsetStrategy(value: String): this.type =
     super.setFeatureSubsetStrategy(value)
 
+  @Since("2.0.0")
+  override def setClassWeights(value: Array[Double]): this.type = super.setClassWeights(value)
+
   override protected def train(dataset: Dataset[_]): RandomForestClassificationModel = {
     val categoricalFeatures: Map[Int, Int] =
       MetadataUtils.getCategoricalFeatures(dataset.schema($(featuresCol)))

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -199,7 +199,8 @@ class RandomForestClassificationModel private[ml] (
     // Ignore the tree weights since all are 1.0 for now.
     val votes = Array.fill[Double](numClasses)(0.0)
     _trees.view.foreach { tree =>
-      val classCounts: Array[Double] = tree.rootNode.predictImpl(features).impurityStats.stats
+      val classCounts: Array[Double] =
+        tree.rootNode.predictImpl(features).impurityStats.weightedStats
       val total = classCounts.sum
       if (total != 0) {
         var i = 0

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -117,7 +117,7 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   /** (private[ml]) Create a Strategy instance to use with the old API. */
   private[ml] def getOldStrategy(categoricalFeatures: Map[Int, Int]): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, getOldImpurity,
-      subsamplingRate = 1.0)
+      1.0, Array())
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -117,7 +117,7 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   /** (private[ml]) Create a Strategy instance to use with the old API. */
   private[ml] def getOldStrategy(categoricalFeatures: Map[Int, Int]): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, getOldImpurity,
-      subsamplingRate = 1.0, classWeights = Array())
+      subsamplingRate = 1.0)
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -117,7 +117,7 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   /** (private[ml]) Create a Strategy instance to use with the old API. */
   private[ml] def getOldStrategy(categoricalFeatures: Map[Int, Int]): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, getOldImpurity,
-      subsamplingRate = 1.0)
+      subsamplingRate = 1.0, classWeights = Array())
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -117,7 +117,7 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   /** (private[ml]) Create a Strategy instance to use with the old API. */
   private[ml] def getOldStrategy(categoricalFeatures: Map[Int, Int]): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, getOldImpurity,
-      1.0, Array())
+      subsamplingRate = 1.0, classWeights = Array())
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -99,7 +99,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset)
     val strategy =
       super.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, getOldImpurity, Array())
+        OldAlgo.Regression, getOldImpurity)
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -99,7 +99,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset)
     val strategy =
       super.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, getOldImpurity, Array())
+        OldAlgo.Regression, getOldImpurity, classWeights = Array(1, 1))
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -98,9 +98,8 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
       MetadataUtils.getCategoricalFeatures(dataset.schema($(featuresCol)))
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset)
     val strategy =
-      super.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, getOldImpurity, getSubsamplingRate,
-        classWeights = Array())
+      super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression,
+        getOldImpurity, getSubsamplingRate, classWeights = Array())
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -99,7 +99,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset)
     val strategy =
       super.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, getOldImpurity, classWeights = Array(1, 1))
+        OldAlgo.Regression, getOldImpurity, Array())
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -99,7 +99,8 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset)
     val strategy =
       super.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, getOldImpurity)
+        OldAlgo.Regression, getOldImpurity, getSubsamplingRate,
+        classWeights = Array())
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -98,7 +98,8 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
       MetadataUtils.getCategoricalFeatures(dataset.schema($(featuresCol)))
     val oldDataset: RDD[LabeledPoint] = extractLabeledPoints(dataset)
     val strategy =
-      super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, getOldImpurity)
+      super.getOldStrategy(categoricalFeatures, numClasses = 0,
+        OldAlgo.Regression, getOldImpurity, Array())
 
     val instr = Instrumentation.create(this, oldDataset)
     instr.logParams(params: _*)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.tree.impl
 import org.apache.spark.mllib.tree.impurity._
 
 
-
 /**
  * DecisionTree statistics aggregator for a node.
  * This holds a flat array of statistics for a set of (features, bins)
@@ -38,6 +37,7 @@ private[spark] class DTStatsAggregator(
     case Gini => new GiniAggregator(metadata.numClasses)
     case Entropy => new EntropyAggregator(metadata.numClasses)
     case Variance => new VarianceAggregator()
+    case WeightedGini => new WeightedGiniAggregator(metadata.numClasses, metadata.classWeights)
     case _ => throw new IllegalArgumentException(s"Bad impurity parameter: ${metadata.impurity}")
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
@@ -53,7 +53,8 @@ private[spark] class DecisionTreeMetadata(
     val minInstancesPerNode: Int,
     val minInfoGain: Double,
     val numTrees: Int,
-    val numFeaturesPerNode: Int) extends Serializable {
+    val numFeaturesPerNode: Int,
+    val classWeights: Array[Double]) extends Serializable {
 
   def isUnordered(featureIndex: Int): Boolean = unorderedFeatures.contains(featureIndex)
 
@@ -207,7 +208,8 @@ private[spark] object DecisionTreeMetadata extends Logging {
     new DecisionTreeMetadata(numFeatures, numExamples, numClasses, numBins.max,
       strategy.categoricalFeaturesInfo, unorderedFeatures.toSet, numBins,
       strategy.impurity, strategy.quantileCalculationStrategy, strategy.maxDepth,
-      strategy.minInstancesPerNode, strategy.minInfoGain, numTrees, numFeaturesPerNode)
+      strategy.minInstancesPerNode, strategy.minInfoGain, numTrees, numFeaturesPerNode,
+      strategy.classWeights)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -657,8 +657,15 @@ private[spark] object RandomForest extends Logging {
     val leftImpurity = leftImpurityCalculator.calculate() // Note: This equals 0 if count = 0
     val rightImpurity = rightImpurityCalculator.calculate()
 
-    val leftWeight = leftCount / totalCount.toDouble
-    val rightWeight = rightCount / totalCount.toDouble
+    // Weighted count is equivalent to normal count using Gini or Entropy impurity
+    // where the class weights are assumed to be uniform
+    val leftWeightedCount = leftImpurityCalculator.weightedCount
+    val rightWeightedCount = rightImpurityCalculator.weightedCount
+
+    val totalWeightedCount = leftWeightedCount + rightWeightedCount
+
+    val leftWeight = leftWeightedCount / totalWeightedCount.toDouble
+    val rightWeight = rightWeightedCount / totalWeightedCount.toDouble
 
     val gain = impurity - leftWeight * leftImpurity - rightWeight * rightImpurity
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -342,6 +342,8 @@ private[ml] object DecisionTreeModelReadWrite {
       Param.jsonDecode[String](compact(render(impurityJson)))
     }
 
+    // Get class weights to construct ImpurityCalculator. This value
+    // is ignored unless the impurity is WeightedGini
     val classWeights: Array[Double] = {
       val classWeightsJson: JValue = metadata.getParamValue("classWeights")
       compact(render(classWeightsJson)).split("\\[|,|\\]")
@@ -445,6 +447,8 @@ private[ml] object EnsembleModelReadWrite {
       Param.jsonDecode[String](compact(render(impurityJson)))
     }
 
+    // Get class weights to construct ImpurityCalculator. This value
+    // is ignored unless the impurity is WeightedGini
     val classWeights: Array[Double] = {
       val classWeightsJson: JValue = metadata.getParamValue("classWeights")
       val classWeightsArray = compact(render(classWeightsJson)).split("\\[|,|\\]")

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -155,7 +155,7 @@ private[ml] trait DecisionTreeParams extends PredictorParams
    */
   def setCheckpointInterval(value: Int): this.type = set(checkpointInterval, value)
 
-  /** (private[ml]) Create a Strategy instance to use with the old API. */
+  /** (private[ml]) Create a Strategy instance. */
   private[ml] def getOldStrategy(
       categoricalFeatures: Map[Int, Int],
       numClasses: Int,
@@ -181,25 +181,25 @@ private[ml] trait DecisionTreeParams extends PredictorParams
 
   /** (private[ml]) Create a Strategy whose interface is compatible with the old API. */
   private[ml] def getOldStrategy(
-    categoricalFeatures: Map[Int, Int],
-    numClasses: Int,
-    oldAlgo: OldAlgo.Algo,
-    oldImpurity: OldImpurity,
-    subsamplingRate: Double): OldStrategy = {
-  val strategy = OldStrategy.defaultStrategy(oldAlgo)
-  strategy.impurity = oldImpurity
-  strategy.checkpointInterval = getCheckpointInterval
-  strategy.maxBins = getMaxBins
-  strategy.maxDepth = getMaxDepth
-  strategy.maxMemoryInMB = getMaxMemoryInMB
-  strategy.minInfoGain = getMinInfoGain
-  strategy.minInstancesPerNode = getMinInstancesPerNode
-  strategy.useNodeIdCache = getCacheNodeIds
-  strategy.numClasses = numClasses
-  strategy.categoricalFeaturesInfo = categoricalFeatures
-  strategy.subsamplingRate = subsamplingRate
-  strategy.classWeights = Array(1.0, 1.0)
-  strategy
+      categoricalFeatures: Map[Int, Int],
+      numClasses: Int,
+      oldAlgo: OldAlgo.Algo,
+      oldImpurity: OldImpurity,
+      subsamplingRate: Double): OldStrategy = {
+    val strategy = OldStrategy.defaultStrategy(oldAlgo)
+    strategy.impurity = oldImpurity
+    strategy.checkpointInterval = getCheckpointInterval
+    strategy.maxBins = getMaxBins
+    strategy.maxDepth = getMaxDepth
+    strategy.maxMemoryInMB = getMaxMemoryInMB
+    strategy.minInfoGain = getMinInfoGain
+    strategy.minInstancesPerNode = getMinInstancesPerNode
+    strategy.useNodeIdCache = getCacheNodeIds
+    strategy.numClasses = numClasses
+    strategy.categoricalFeaturesInfo = categoricalFeatures
+    strategy.subsamplingRate = subsamplingRate
+    strategy.classWeights = Array(1.0, 1.0)
+    strategy
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -18,12 +18,13 @@
 package org.apache.spark.ml.tree
 
 import scala.util.Try
+
 import org.apache.spark.ml.PredictorParams
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util.SchemaUtils
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo, BoostingStrategy => OldBoostingStrategy, Strategy => OldStrategy}
-import org.apache.spark.mllib.tree.impurity.{WeightedGini, Entropy => OldEntropy, Gini => OldGini, Impurity => OldImpurity, Variance => OldVariance}
+import org.apache.spark.mllib.tree.impurity.{Entropy => OldEntropy, Gini => OldGini, Impurity => OldImpurity, Variance => OldVariance, WeightedGini}
 import org.apache.spark.mllib.tree.loss.{AbsoluteError => OldAbsoluteError, LogLoss => OldLogLoss, Loss => OldLoss, SquaredError => OldSquaredError}
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 
@@ -185,16 +186,16 @@ private[ml] trait DecisionTreeParams extends PredictorParams
 private[ml] trait TreeClassifierParams extends Params {
 
   /**
-    * An array that stores the weights of class labels. All elements must be non-negative.
-    * (default = Array(1, 1))
-    * @group expertParam
-    */
+   * An array that stores the weights of class labels. All elements must be non-negative.
+   * (default = Array(1, 1))
+   * @group expertParam
+   */
   final val classWeights: DoubleArrayParam = new DoubleArrayParam(this, "classWeights", "An array" +
     " that stores the weights of class labels. All elements must be non-negative.")
 
   /**
    * Criterion used for information gain calculation (case-insensitive).
-   * Supported: "entropy" and "gini".
+   * Supported: "entropy", "gini" and "weightedgini".
    * (default = gini)
    * @group param
    */
@@ -233,7 +234,8 @@ private[ml] trait TreeClassifierParams extends Params {
 
 private[ml] object TreeClassifierParams {
   // These options should be lowercase.
-  final val supportedImpurities: Array[String] = Array("entropy", "gini", "weightedgini").map(_.toLowerCase)
+  final val supportedImpurities: Array[String] = Array("entropy", "gini", "weightedgini")
+    .map(_.toLowerCase)
 }
 
 private[ml] trait DecisionTreeClassifierParams

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -176,8 +176,7 @@ private[ml] trait DecisionTreeParams extends PredictorParams
       numClasses: Int,
       oldAlgo: OldAlgo.Algo,
       oldImpurity: OldImpurity,
-      subsamplingRate: Double,
-      classWeights: Array[Double]): OldStrategy = {
+      subsamplingRate: Double): OldStrategy = {
     val strategy = OldStrategy.defaultStrategy(oldAlgo)
     strategy.impurity = oldImpurity
     strategy.checkpointInterval = getCheckpointInterval
@@ -190,7 +189,7 @@ private[ml] trait DecisionTreeParams extends PredictorParams
     strategy.numClasses = numClasses
     strategy.categoricalFeaturesInfo = categoricalFeatures
     strategy.subsamplingRate = subsamplingRate
-    strategy.classWeights = classWeights
+    strategy.classWeights = getClassWeights
     strategy
   }
 }
@@ -331,10 +330,9 @@ private[ml] trait TreeEnsembleParams extends DecisionTreeParams {
       categoricalFeatures: Map[Int, Int],
       numClasses: Int,
       oldAlgo: OldAlgo.Algo,
-      oldImpurity: OldImpurity,
-      classWeights: Array[Double] = Array()): OldStrategy = {
+      oldImpurity: OldImpurity): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses, oldAlgo,
-      oldImpurity, getSubsamplingRate, classWeights)
+      oldImpurity, getSubsamplingRate)
   }
 }
 
@@ -477,7 +475,8 @@ private[ml] trait GBTParams extends TreeEnsembleParams with HasMaxIter with HasS
       categoricalFeatures: Map[Int, Int],
       oldAlgo: OldAlgo.Algo): OldBoostingStrategy = {
     val strategy = super.getOldStrategy(categoricalFeatures, numClasses = 2,
-      oldAlgo, OldVariance, classWeights = Array(1.0, 1.0))
+      oldAlgo, OldVariance)
+
     // NOTE: The old API does not support "seed" so we ignore it.
     new OldBoostingStrategy(strategy, getOldLossType, getMaxIter, getStepSize)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -102,8 +102,17 @@ private[ml] trait DecisionTreeParams extends PredictorParams
     " algorithm will cache node IDs for each instance. Caching can speed up training of deeper" +
     " trees.")
 
+  /**
+   * An array that stores the weights of class labels. All elements must be non-negative.
+   * (default = Array(1, 1))
+   * @group Param
+   */
+  final val classWeights: DoubleArrayParam = new DoubleArrayParam(this, "classWeights", "An array" +
+    " that stores the weights of class labels. All elements must be non-negative.")
+
   setDefault(maxDepth -> 5, maxBins -> 32, minInstancesPerNode -> 1, minInfoGain -> 0.0,
-    maxMemoryInMB -> 256, cacheNodeIds -> false, checkpointInterval -> 10)
+    maxMemoryInMB -> 256, cacheNodeIds -> false, checkpointInterval -> 10,
+    classWeights -> Array(1.0, 1.0))
 
   /** @group setParam */
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
@@ -143,6 +152,12 @@ private[ml] trait DecisionTreeParams extends PredictorParams
 
   /** @group expertGetParam */
   final def getCacheNodeIds: Boolean = $(cacheNodeIds)
+
+  /** @group SetParam */
+  def setClassWeights(value: Array[Double]): this.type = set(classWeights, value)
+
+  /** @group GetParam */
+  final def getClassWeights: Array[Double] = $(classWeights)
 
   /**
    * Specifies how often to checkpoint the cached node IDs.
@@ -186,14 +201,6 @@ private[ml] trait DecisionTreeParams extends PredictorParams
 private[ml] trait TreeClassifierParams extends Params {
 
   /**
-   * An array that stores the weights of class labels. All elements must be non-negative.
-   * (default = Array(1, 1))
-   * @group expertParam
-   */
-  final val classWeights: DoubleArrayParam = new DoubleArrayParam(this, "classWeights", "An array" +
-    " that stores the weights of class labels. All elements must be non-negative.")
-
-  /**
    * Criterion used for information gain calculation (case-insensitive).
    * Supported: "entropy", "gini" and "weightedgini".
    * (default = gini)
@@ -204,13 +211,7 @@ private[ml] trait TreeClassifierParams extends Params {
     s" ${TreeClassifierParams.supportedImpurities.mkString(", ")}",
     (value: String) => TreeClassifierParams.supportedImpurities.contains(value.toLowerCase))
 
-  setDefault(impurity -> "gini", classWeights -> Array(1.0, 1.0))
-
-  /** @group expertSetParam */
-  def setClassWeights(value: Array[Double]): this.type = set(classWeights, value)
-
-  /** @group expertGetParam */
-  final def getClassWeights: Array[Double] = $(classWeights)
+  setDefault(impurity -> "gini")
 
   /** @group setParam */
   def setImpurity(value: String): this.type = set(impurity, value)
@@ -331,7 +332,7 @@ private[ml] trait TreeEnsembleParams extends DecisionTreeParams {
       numClasses: Int,
       oldAlgo: OldAlgo.Algo,
       oldImpurity: OldImpurity,
-      classWeights: Array[Double]): OldStrategy = {
+      classWeights: Array[Double] = Array()): OldStrategy = {
     super.getOldStrategy(categoricalFeatures, numClasses, oldAlgo,
       oldImpurity, getSubsamplingRate, classWeights)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -66,6 +66,8 @@ import org.apache.spark.mllib.tree.impurity.{Entropy, Gini, Impurity, Variance, 
  *                           E.g. 10 means that the cache will get checkpointed every 10 updates. If
  *                           the checkpoint directory is not set in
  *                           [[org.apache.spark.SparkContext]], this setting is ignored.
+ * @param classWeights Weights of classes used in classification problems. It will be ignored in
+ *                     regression problems.
  */
 @Since("1.0.0")
 class Strategy @Since("1.3.0") (

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -84,7 +84,7 @@ class Strategy @Since("1.3.0") (
     @Since("1.2.0") @BeanProperty var subsamplingRate: Double = 1,
     @Since("1.2.0") @BeanProperty var useNodeIdCache: Boolean = false,
     @Since("1.2.0") @BeanProperty var checkpointInterval: Int = 10,
-    @Since("2.0.0") @BeanProperty var classWeights: Array[Double] = Array(1, 1))
+    @Since("2.0.0") var classWeights: Array[Int] = Array(1, 1))
   extends Serializable {
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -102,7 +102,7 @@ class Strategy @Since("1.3.0") (
   }
 
   /**
-   *  Make the class compatible with previous versions
+   *  Make the Strategy class compatible with old API
    */
   @Since("2.0.0")
   def this(

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -84,7 +84,7 @@ class Strategy @Since("1.3.0") (
     @Since("1.2.0") @BeanProperty var subsamplingRate: Double = 1,
     @Since("1.2.0") @BeanProperty var useNodeIdCache: Boolean = false,
     @Since("1.2.0") @BeanProperty var checkpointInterval: Int = 10,
-    @Since("2.0.0") var classWeights: Array[Int] = Array(1, 1))
+    @Since("2.0.0") var classWeights: Array[Double] = Array(1, 1))
   extends Serializable {
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -82,7 +82,8 @@ class Strategy @Since("1.3.0") (
     @Since("1.2.0") @BeanProperty var subsamplingRate: Double = 1,
     @Since("1.2.0") @BeanProperty var useNodeIdCache: Boolean = false,
     @Since("1.2.0") @BeanProperty var checkpointInterval: Int = 10,
-    @Since("2.0.0") @BeanProperty var classWeights: Array[Double] = Array()) extends Serializable {
+    @Since("2.0.0") @BeanProperty var classWeights: Array[Double] = Array(1, 1))
+  extends Serializable {
 
   /**
    */

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -84,7 +84,7 @@ class Strategy @Since("1.3.0") (
     @Since("1.2.0") @BeanProperty var subsamplingRate: Double = 1,
     @Since("1.2.0") @BeanProperty var useNodeIdCache: Boolean = false,
     @Since("1.2.0") @BeanProperty var checkpointInterval: Int = 10,
-    @Since("2.0.0") var classWeights: Array[Double] = Array(1, 1))
+    @Since("2.0.0") @BeanProperty var classWeights: Array[Double] = Array(1.0, 1.0))
   extends Serializable {
 
   /**
@@ -99,6 +99,29 @@ class Strategy @Since("1.3.0") (
   @Since("1.2.0")
   def isMulticlassWithCategoricalFeatures: Boolean = {
     isMulticlassClassification && (categoricalFeaturesInfo.size > 0)
+  }
+
+  /**
+   *  Make the class compatible with previous versions
+   */
+  @Since("2.0.0")
+  def this(
+    algo: Algo,
+    impurity: Impurity,
+    maxDepth: Int,
+    numClasses: Int,
+    maxBins: Int,
+    quantileCalculationStrategy: QuantileStrategy,
+    categoricalFeaturesInfo: Map[Int, Int],
+    minInstancesPerNode: Int,
+    minInfoGain: Double,
+    maxMemoryInMB: Int,
+    subsamplingRate: Double,
+    useNodeIdCache: Boolean,
+    checkpointInterval: Int) {
+    this(algo, impurity, maxDepth, numClasses, maxBins, quantileCalculationStrategy,
+      categoricalFeaturesInfo, minInstancesPerNode, minInfoGain, maxMemoryInMB,
+      subsamplingRate, useNodeIdCache, checkpointInterval, Array())
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
@@ -139,8 +139,8 @@ private[spark] class EntropyCalculator(stats: Array[Double]) extends ImpurityCal
   def count: Long = stats.sum.toLong
 
   /**
-    * Weighted summary statistics of data points, which in this case assume uniform class weights
-    */
+   * Weighted summary statistics of data points, which in this case assume uniform class weights
+   */
   def weightedCount: Double = stats.sum
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala
@@ -135,6 +135,11 @@ private[spark] class GiniCalculator(stats: Array[Double]) extends ImpurityCalcul
   def count: Long = stats.sum.toLong
 
   /**
+   * Weighted summary statistics of data points, which in this case assume uniform class weights
+   */
+  def weightedCount: Double = stats.sum
+
+  /**
    * Prediction which should be made based on the sufficient statistics.
    */
   def predict: Double = if (count == 0) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -191,11 +191,13 @@ private[spark] object ImpurityCalculator {
    * Create an [[ImpurityCalculator]] instance of the given impurity type and with
    * the given stats.
    */
-  def getCalculator(impurity: String, stats: Array[Double]): ImpurityCalculator = {
+  def getCalculator(impurity: String, stats: Array[Double],
+                    classWeights: Array[Double]): ImpurityCalculator = {
     impurity match {
       case "gini" => new GiniCalculator(stats)
       case "entropy" => new EntropyCalculator(stats)
       case "variance" => new VarianceCalculator(stats)
+      case "weightedgini" => new WeightedGiniCalculator(stats, classWeights)
       case _ =>
         throw new IllegalArgumentException(
           s"ImpurityCalculator builder did not recognize impurity type: $impurity")

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -99,6 +99,7 @@ private[spark] abstract class ImpurityAggregator(val statsSize: Int) extends Ser
  */
 private[spark] abstract class ImpurityCalculator(val stats: Array[Double]) extends Serializable {
 
+  val weightedStats: Array[Double] = stats
   /**
    * Make a deep copy of this [[ImpurityCalculator]].
    */

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -148,6 +148,11 @@ private[spark] abstract class ImpurityCalculator(val stats: Array[Double]) exten
   def count: Long
 
   /**
+   * Weighted summary statistics of data points
+   */
+  def weightedCount: Double
+
+  /**
    * Prediction which should be made based on the sufficient statistics.
    */
   def predict: Double

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
@@ -123,8 +123,8 @@ private[spark] class VarianceCalculator(stats: Array[Double]) extends ImpurityCa
   def count: Long = stats(0).toLong
 
   /**
-    * Weighted summary statistics of data points, which in this case assume uniform class weights
-    */
+   * Weighted summary statistics of data points, which in this case assume uniform class weights
+   */
   def weightedCount: Double = stats(0)
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
@@ -123,6 +123,11 @@ private[spark] class VarianceCalculator(stats: Array[Double]) extends ImpurityCa
   def count: Long = stats(0).toLong
 
   /**
+    * Weighted summary statistics of data points, which in this case assume uniform class weights
+    */
+  def weightedCount: Double = stats(0)
+
+  /**
    * Prediction which should be made based on the sufficient statistics.
    */
   def predict: Double = if (count == 0) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
@@ -64,7 +64,7 @@ object WeightedGini extends Impurity {
   @Since("1.0.0")
   @DeveloperApi
   override def calculate(count: Double, sum: Double, sumSquares: Double): Double =
-    throw new UnsupportedOperationException("Gini.calculate")
+    throw new UnsupportedOperationException("WeightedGini.calculate")
 
   /**
    * Get this impurity instance.
@@ -82,7 +82,7 @@ object WeightedGini extends Impurity {
  * @param numClasses  Number of classes for label.
  * @param weights Weights of classes
  */
-private[tree] class WeightedGiniAggregator(numClasses: Int, weights: Array[Double])
+private[spark] class WeightedGiniAggregator(numClasses: Int, weights: Array[Double])
   extends ImpurityAggregator(numClasses) with Serializable {
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
@@ -21,11 +21,10 @@ import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
 
 /**
  * :: Experimental ::
- * Class for calculating the
- * [[http://en.wikipedia.org/wiki/Decision_tree_learning#Gini_impurity Gini impurity]]
- * during binary classification.
+ * Class for calculating the Gini impurity with class weights using
+ * altered prior method during classification.
  */
-@Since("1.0.0")
+@Since("2.0.0")
 @Experimental
 object WeightedGini extends Impurity {
 
@@ -36,7 +35,7 @@ object WeightedGini extends Impurity {
    * @param weightedTotalCount sum of counts for all labels
    * @return information value, or 0 if totalCount = 0
    */
-  @Since("1.1.0")
+  @Since("2.0.0")
   @DeveloperApi
   override def calculate(weightedCounts: Array[Double], weightedTotalCount: Double): Double = {
     if (weightedTotalCount == 0) {
@@ -61,7 +60,7 @@ object WeightedGini extends Impurity {
    * @param sumSquares summation of squares of the labels
    * @return information value, or 0 if count = 0
    */
-  @Since("1.0.0")
+  @Since("2.0.0")
   @DeveloperApi
   override def calculate(count: Double, sum: Double, sumSquares: Double): Double =
     throw new UnsupportedOperationException("WeightedGini.calculate")
@@ -70,7 +69,7 @@ object WeightedGini extends Impurity {
    * Get this impurity instance.
    * This is useful for passing impurity parameters to a Strategy in Java.
    */
-  @Since("1.1.0")
+  @Since("2.0.0")
   def instance: this.type = this
 
 }
@@ -179,10 +178,10 @@ private[spark] class WeightedGiniCalculator(stats: Array[Double], classWeights: 
       s"Two ImpurityCalculator instances cannot be added with different counts sizes." +
         s"  Sizes are ${stats.length} and ${other.stats.length}.")
     val otherCalculator = other.asInstanceOf[WeightedGiniCalculator]
+    val len = otherCalculator.stats.length
     var i = 0
-    val len = other.stats.length
     while (i < len) {
-      stats(i) += other.stats(i)
+      stats(i) += otherCalculator.stats(i)
       weightedStats(i) += otherCalculator.weightedStats(i)
       i += 1
     }
@@ -198,10 +197,10 @@ private[spark] class WeightedGiniCalculator(stats: Array[Double], classWeights: 
       s"Two ImpurityCalculator instances cannot be subtracted with different counts sizes." +
         s"  Sizes are ${stats.length} and ${other.stats.length}.")
     val otherCalculator = other.asInstanceOf[WeightedGiniCalculator]
+    val len = otherCalculator.stats.length
     var i = 0
-    val len = other.stats.length
     while (i < len) {
-      stats(i) -= other.stats(i)
+      stats(i) -= otherCalculator.stats(i)
       weightedStats(i) -= otherCalculator.weightedStats(i)
       i += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
@@ -122,7 +122,7 @@ private[spark] class WeightedGiniAggregator(numClasses: Int, classWeights: Array
 private[spark] class WeightedGiniCalculator(stats: Array[Double], classWeights: Array[Double])
   extends ImpurityCalculator(stats) {
 
-  var weightedStats = stats.zip(classWeights).map(x => x._1 * x._2)
+  override val weightedStats = stats.zip(classWeights).map(x => x._1 * x._2)
   /**
    * Make a deep copy of this [[ImpurityCalculator]].
    */

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
@@ -80,9 +80,9 @@ object WeightedGini extends Impurity {
  * in order to compute impurity from a sample.
  * Note: Instances of this class do not hold the data; they operate on views of the data.
  * @param numClasses  Number of classes for label.
- * @param weights Weights of classes
+ * @param classWeights Weights of classes
  */
-private[spark] class WeightedGiniAggregator(numClasses: Int, weights: Array[Double])
+private[spark] class WeightedGiniAggregator(numClasses: Int, classWeights: Array[Double])
   extends ImpurityAggregator(numClasses) with Serializable {
 
   /**
@@ -108,7 +108,7 @@ private[spark] class WeightedGiniAggregator(numClasses: Int, weights: Array[Doub
    * @param offset    Start index of stats for this (node, feature, bin).
    */
   def getCalculator(allStats: Array[Double], offset: Int): WeightedGiniCalculator = {
-    new WeightedGiniCalculator(allStats.view(offset, offset + statsSize).toArray, weights)
+    new WeightedGiniCalculator(allStats.view(offset, offset + statsSize).toArray, classWeights)
   }
 }
 
@@ -117,16 +117,16 @@ private[spark] class WeightedGiniAggregator(numClasses: Int, weights: Array[Doub
  * Unlike [[WeightedGiniAggregator]], this class stores its own data and is for a specific
  * (node, feature, bin).
  * @param stats  Array of sufficient statistics for a (node, feature, bin).
- * @param weights Weights of classes
+ * @param classWeights Weights of classes
  */
-private[spark] class WeightedGiniCalculator(stats: Array[Double], weights: Array[Double])
+private[spark] class WeightedGiniCalculator(stats: Array[Double], classWeights: Array[Double])
   extends ImpurityCalculator(stats) {
 
-  var weightedStats = stats.zip(weights).map(x => x._1 * x._2)
+  var weightedStats = stats.zip(classWeights).map(x => x._1 * x._2)
   /**
    * Make a deep copy of this [[ImpurityCalculator]].
    */
-  def copy: WeightedGiniCalculator = new WeightedGiniCalculator(stats.clone(), weights.clone())
+  def copy: WeightedGiniCalculator = new WeightedGiniCalculator(stats.clone(), classWeights.clone())
 
   /**
    * Calculate the impurity from the stored sufficient statistics.

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/WeightedGini.scala
@@ -21,37 +21,33 @@ import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
 
 /**
  * :: Experimental ::
- * Class for calculating [[http://en.wikipedia.org/wiki/Binary_entropy_function entropy]] during
- * binary classification.
+ * Class for calculating the
+ * [[http://en.wikipedia.org/wiki/Decision_tree_learning#Gini_impurity Gini impurity]]
+ * during binary classification.
  */
 @Since("1.0.0")
 @Experimental
-object Entropy extends Impurity {
-
-  private[tree] def log2(x: Double) = scala.math.log(x) / scala.math.log(2)
+object WeightedGini extends Impurity {
 
   /**
    * :: DeveloperApi ::
    * information calculation for multiclass classification
-   * @param counts Array[Double] with counts for each label
-   * @param totalCount sum of counts for all labels
+   * @param weightedCounts Array[Double] with counts for each label
+   * @param weightedTotalCount sum of counts for all labels
    * @return information value, or 0 if totalCount = 0
    */
   @Since("1.1.0")
   @DeveloperApi
-  override def calculate(counts: Array[Double], totalCount: Double): Double = {
-    if (totalCount == 0) {
+  override def calculate(weightedCounts: Array[Double], weightedTotalCount: Double): Double = {
+    if (weightedTotalCount == 0) {
       return 0
     }
-    val numClasses = counts.length
-    var impurity = 0.0
+    val numClasses = weightedCounts.length
+    var impurity = 1.0
     var classIndex = 0
     while (classIndex < numClasses) {
-      val classCount = counts(classIndex)
-      if (classCount != 0) {
-        val freq = classCount / totalCount
-        impurity -= freq * log2(freq)
-      }
+      val freq = weightedCounts(classIndex) / weightedTotalCount
+      impurity -= freq * freq
       classIndex += 1
     }
     impurity
@@ -68,7 +64,7 @@ object Entropy extends Impurity {
   @Since("1.0.0")
   @DeveloperApi
   override def calculate(count: Double, sum: Double, sumSquares: Double): Double =
-    throw new UnsupportedOperationException("Entropy.calculate")
+    throw new UnsupportedOperationException("Gini.calculate")
 
   /**
    * Get this impurity instance.
@@ -84,8 +80,9 @@ object Entropy extends Impurity {
  * in order to compute impurity from a sample.
  * Note: Instances of this class do not hold the data; they operate on views of the data.
  * @param numClasses  Number of classes for label.
+ * @param weights Weights of classes
  */
-private[spark] class EntropyAggregator(numClasses: Int)
+private[tree] class WeightedGiniAggregator(numClasses: Int, weights: Array[Double])
   extends ImpurityAggregator(numClasses) with Serializable {
 
   /**
@@ -95,11 +92,11 @@ private[spark] class EntropyAggregator(numClasses: Int)
    */
   def update(allStats: Array[Double], offset: Int, label: Double, instanceWeight: Double): Unit = {
     if (label >= statsSize) {
-      throw new IllegalArgumentException(s"EntropyAggregator given label $label" +
+      throw new IllegalArgumentException(s"WeightedGiniAggregator given label $label" +
         s" but requires label < numClasses (= $statsSize).")
     }
     if (label < 0) {
-      throw new IllegalArgumentException(s"EntropyAggregator given label $label" +
+      throw new IllegalArgumentException(s"WeightedGiniAggregator given label $label" +
         s"but requires label is non-negative.")
     }
     allStats(offset + label.toInt) += instanceWeight
@@ -110,28 +107,31 @@ private[spark] class EntropyAggregator(numClasses: Int)
    * @param allStats  Flat stats array, with stats for this (node, feature, bin) contiguous.
    * @param offset    Start index of stats for this (node, feature, bin).
    */
-  def getCalculator(allStats: Array[Double], offset: Int): EntropyCalculator = {
-    new EntropyCalculator(allStats.view(offset, offset + statsSize).toArray)
+  def getCalculator(allStats: Array[Double], offset: Int): WeightedGiniCalculator = {
+    new WeightedGiniCalculator(allStats.view(offset, offset + statsSize).toArray, weights)
   }
 }
 
 /**
  * Stores statistics for one (node, feature, bin) for calculating impurity.
- * Unlike [[EntropyAggregator]], this class stores its own data and is for a specific
+ * Unlike [[WeightedGiniAggregator]], this class stores its own data and is for a specific
  * (node, feature, bin).
  * @param stats  Array of sufficient statistics for a (node, feature, bin).
+ * @param weights Weights of classes
  */
-private[spark] class EntropyCalculator(stats: Array[Double]) extends ImpurityCalculator(stats) {
+private[spark] class WeightedGiniCalculator(stats: Array[Double], weights: Array[Double])
+  extends ImpurityCalculator(stats) {
 
+  var weightedStats = stats.zip(weights).map(x => x._1 * x._2)
   /**
    * Make a deep copy of this [[ImpurityCalculator]].
    */
-  def copy: EntropyCalculator = new EntropyCalculator(stats.clone())
+  def copy: WeightedGiniCalculator = new WeightedGiniCalculator(stats.clone(), weights.clone())
 
   /**
    * Calculate the impurity from the stored sufficient statistics.
    */
-  def calculate(): Double = Entropy.calculate(stats, stats.sum)
+  def calculate(): Double = WeightedGini.calculate(weightedStats, weightedStats.sum)
 
   /**
    * Number of data points accounted for in the sufficient statistics.
@@ -139,9 +139,9 @@ private[spark] class EntropyCalculator(stats: Array[Double]) extends ImpurityCal
   def count: Long = stats.sum.toLong
 
   /**
-    * Weighted summary statistics of data points, which in this case assume uniform class weights
-    */
-  def weightedCount: Double = stats.sum
+   * Weighted summary statistics of data points
+   */
+  def weightedCount: Double = weightedStats.sum
 
   /**
    * Prediction which should be made based on the sufficient statistics.
@@ -149,7 +149,7 @@ private[spark] class EntropyCalculator(stats: Array[Double]) extends ImpurityCal
   def predict: Double = if (count == 0) {
     0
   } else {
-    indexOfLargestArrayElement(stats)
+    indexOfLargestArrayElement(weightedStats)
   }
 
   /**
@@ -158,16 +158,53 @@ private[spark] class EntropyCalculator(stats: Array[Double]) extends ImpurityCal
   override def prob(label: Double): Double = {
     val lbl = label.toInt
     require(lbl < stats.length,
-      s"EntropyCalculator.prob given invalid label: $lbl (should be < ${stats.length}")
-    require(lbl >= 0, "Entropy does not support negative labels")
-    val cnt = count
+      s"WeightedGiniCalculator.prob given invalid label: $lbl (should be < ${stats.length}")
+    require(lbl >= 0, "WeightedGiniImpurity does not support negative labels")
+    val cnt = weightedCount
     if (cnt == 0) {
       0
     } else {
-      stats(lbl) / cnt
+      weightedStats(lbl) / cnt
     }
   }
 
-  override def toString: String = s"EntropyCalculator(stats = [${stats.mkString(", ")}])"
+  override def toString: String = s"WeightedGiniCalculator(stats = [${stats.mkString(", ")}])"
 
+  /**
+   * Add the stats from another calculator into this one, modifying and returning this calculator.
+   * Update the weightedStats at the same time
+   */
+  override def add(other: ImpurityCalculator): ImpurityCalculator = {
+    require(stats.length == other.stats.length,
+      s"Two ImpurityCalculator instances cannot be added with different counts sizes." +
+        s"  Sizes are ${stats.length} and ${other.stats.length}.")
+    val otherCalculator = other.asInstanceOf[WeightedGiniCalculator]
+    var i = 0
+    val len = other.stats.length
+    while (i < len) {
+      stats(i) += other.stats(i)
+      weightedStats(i) += otherCalculator.weightedStats(i)
+      i += 1
+    }
+    this
+  }
+
+  /**
+   * Subtract the stats from another calculator from this one, modifying and returning this
+   * calculator. Update the weightedStats at the same time
+   */
+  override def subtract(other: ImpurityCalculator): ImpurityCalculator = {
+    require(stats.length == other.stats.length,
+      s"Two ImpurityCalculator instances cannot be subtracted with different counts sizes." +
+        s"  Sizes are ${stats.length} and ${other.stats.length}.")
+    val otherCalculator = other.asInstanceOf[WeightedGiniCalculator]
+    var i = 0
+    val len = other.stats.length
+    while (i < len) {
+      stats(i) -= other.stats(i)
+      weightedStats(i) -= otherCalculator.weightedStats(i)
+      i += 1
+    }
+    this
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -72,7 +72,7 @@ class DecisionTreeClassifierSuite
   // Tests calling train()
   /////////////////////////////////////////////////////////////////////////////
 
-  test("Binary classification with setting explicit uniform class weights") {
+  test("Binary classification with explicitly setting uniform class weights") {
     val dt = new DecisionTreeClassifier()
       .setImpurity("WeightedGini")
       .setMaxDepth(2)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import scala.io.Source
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
@@ -74,40 +72,16 @@ class DecisionTreeClassifierSuite
   // Tests calling train()
   /////////////////////////////////////////////////////////////////////////////
 
-  test("classification with class weights") {
-    val buf = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_train.csv")
-      .getLines
-    val header = buf.take(1).next()
-    var data = new Array[LabeledPoint](1000)
-    var idx : Int = 0
-    for (row <- buf) {
-      val cols = row.split(",").map(_.trim)
-      // scala style: off println
-      // println(s"${cols(0)}|${cols(1)}|${cols(2)}|${cols(3)}|${cols(4)}")
-      // println( cols(0).getClass)
-      // scala style: on println
-      data(idx) = new LabeledPoint(cols(0).toDouble,
-        Vectors.dense(cols(1).toDouble, cols(2).toDouble))
-      idx += 1
-    }
-    // scalastyle:off println
-    // println(data)
-    // scalastyle:on println
-    val IrIsRDD = sc.parallelize(data)
+  test("Binary classification with setting explicit uniform class weights") {
     val dt = new DecisionTreeClassifier()
-      .setImpurity("weightedgini")
-      .setMaxDepth(3)
-      .setMaxBins(400)
-      .setMinInstancesPerNode(1)
-      .setClassWeights(Array(1, 1000))
-    val categoricalFeatures: Map[Int, Int] = Map()
-    val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
-    val newTree = dt.fit(newData)
-    val predoutput = newTree.transform(newData)
-    // scalastyle:off println
-    predoutput.show(1000)
-    // println(newTree.toDebugString)
-    // scalastyle:on println
+      .setImpurity("WeightedGini")
+      .setMaxDepth(2)
+      .setMaxBins(100)
+      .setSeed(1)
+      .setClassWeights(Array(1, 1))
+    val categoricalFeatures = Map(0 -> 3, 1 -> 3)
+    val numClasses = 2
+    compareAPIs(categoricalDataPointsRDD, dt, categoricalFeatures, numClasses)
   }
 
   test("Binary classification stump with ordered categorical features") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -30,6 +30,9 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 
+import scala.io.Source
+import org.apache.spark.mllib.evaluation.MulticlassMetrics
+
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 
@@ -68,6 +71,72 @@ class DecisionTreeClassifierSuite
   /////////////////////////////////////////////////////////////////////////////
   // Tests calling train()
   /////////////////////////////////////////////////////////////////////////////
+
+  test("classification with class weights") {
+    val buf = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_train.csv").getLines
+    val header = buf.take(1).next()
+    var data = new Array[LabeledPoint](1000)
+    var idx : Int = 0
+    for (row <- buf) {
+      val cols = row.split(",").map(_.trim)
+      // scalastyle:off println
+      //println(s"${cols(0)}|${cols(1)}|${cols(2)}|${cols(3)}|${cols(4)}")
+      //println( cols(0).getClass)
+      // scalastyle:on println
+      data(idx) = new LabeledPoint(cols(0).toDouble,
+        Vectors.dense(cols(1).toDouble, cols(2).toDouble))
+      idx += 1
+    }
+    // scalastyle:off println
+    //println(data)
+    // scalastyle:on println
+    val IrIsRDD = sc.parallelize(data)
+    val dt = new DecisionTreeClassifier()
+      .setImpurity("weightedgini")
+      .setMaxDepth(3)
+      .setMaxBins(400)
+      .setMinInstancesPerNode(1)
+      .setClassWeights(Array(1, 10000))
+    val categoricalFeatures: Map[Int, Int] = Map()
+    val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
+    val newTree = dt.fit(newData)
+    val predoutput = newTree.transform(newData)
+    // scalastyle:off println
+    predoutput.show(1000)
+    println(newTree.toDebugString)
+    // scalastyle:on println
+    /*
+    val predictionsAndLabels = predoutput.select("prediction", "label")
+      .map(row => (row.getDouble(0), row.getDouble(1)))
+    val metrics = new MulticlassMetrics(predictionsAndLabels)
+    val confusionMatrix = metrics.confusionMatrix
+    // scalastyle:off println
+    println(confusionMatrix.toString())
+    // scalastyle:on println
+    val buf2 = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_test.csv").getLines
+    val header2 = buf2.take(1).next()
+    var data2 = new Array[LabeledPoint](250)
+    idx = 0
+    for (row <- buf2) {
+      val cols = row.split(",").map(_.trim)
+      data2(idx) = new LabeledPoint(cols(0).toDouble,
+        Vectors.dense(cols(1).toDouble, cols(2).toDouble))
+      idx += 1
+    }
+    // scalastyle:off println
+    //println(data)
+    // scalastyle:on println
+    val IrIsRDD2 = sc.parallelize(data2)
+    val newData2: DataFrame = TreeTests.setMetadata(IrIsRDD2, categoricalFeatures, 2)
+    val predoutput2 = newTree.transform(newData2)
+    val predictions = predoutput2.select("prediction", "label")
+      .map(row => (row.getDouble(0), row.getDouble(1)))
+    val metrics2 = new MulticlassMetrics(predictions)
+    val confusionMatrix2 = metrics2.confusionMatrix
+    // scalastyle:off println
+    println(confusionMatrix2.toString())
+    // scalastyle:on println */
+  }
 
   test("Binary classification stump with ordered categorical features") {
     val dt = new DecisionTreeClassifier()

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -99,13 +99,13 @@ class DecisionTreeClassifierSuite
       .setMaxDepth(3)
       .setMaxBins(400)
       .setMinInstancesPerNode(1)
-      .setClassWeights(Array(1, 1))
+      .setClassWeights(Array(1, 1000))
     val categoricalFeatures: Map[Int, Int] = Map()
     val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
     val newTree = dt.fit(newData)
     val predoutput = newTree.transform(newData)
     // scalastyle:off println
-    // predoutput.show(1000)
+    predoutput.show(1000)
     // println(newTree.toDebugString)
     // scalastyle:on println
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -79,7 +79,7 @@ class DecisionTreeClassifierSuite
     val numClasses = 2
     compareAPIs(categoricalDataPointsRDD, dt, categoricalFeatures, numClasses)
   }
-
+/*
   test("Binary classification stump with fixed labels 0,1 for Entropy,Gini") {
     val dt = new DecisionTreeClassifier()
       .setMaxDepth(3)
@@ -91,7 +91,7 @@ class DecisionTreeClassifierSuite
         compareAPIs(rdd, dt, categoricalFeatures = Map.empty[Int, Int], numClasses)
       }
     }
-  }
+  }*/
 
   test("Multiclass classification stump with 3-ary (unordered) categorical features") {
     val rdd = categoricalDataPointsForMulticlassRDD

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{DataFrame, Row}
 import scala.io.Source
 import org.apache.spark.mllib.evaluation.MulticlassMetrics
 
+
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 
@@ -96,14 +97,14 @@ class DecisionTreeClassifierSuite
       .setMaxDepth(3)
       .setMaxBins(400)
       .setMinInstancesPerNode(1)
-      .setClassWeights(Array(1, 1000))
+      .setClassWeights(Array(1, 1))
     val categoricalFeatures: Map[Int, Int] = Map()
     val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
     val newTree = dt.fit(newData)
     val predoutput = newTree.transform(newData)
     // scalastyle:off println
-    predoutput.show(1000)
-    println(newTree.toDebugString)
+    //predoutput.show(1000)
+    //println(newTree.toDebugString)
     // scalastyle:on println
     /*
     val predictionsAndLabels = predoutput.select("prediction", "label")
@@ -148,7 +149,7 @@ class DecisionTreeClassifierSuite
     val numClasses = 2
     compareAPIs(categoricalDataPointsRDD, dt, categoricalFeatures, numClasses)
   }
-/*
+
   test("Binary classification stump with fixed labels 0,1 for Entropy,Gini") {
     val dt = new DecisionTreeClassifier()
       .setMaxDepth(3)
@@ -160,7 +161,7 @@ class DecisionTreeClassifierSuite
         compareAPIs(rdd, dt, categoricalFeatures = Map.empty[Int, Int], numClasses)
       }
     }
-  }*/
+  }
 
   test("Multiclass classification stump with 3-ary (unordered) categorical features") {
     val rdd = categoricalDataPointsForMulticlassRDD

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification
 
+import scala.io.Source
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
@@ -30,8 +32,7 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 
-import scala.io.Source
-import org.apache.spark.mllib.evaluation.MulticlassMetrics
+
 
 
 class DecisionTreeClassifierSuite
@@ -74,22 +75,23 @@ class DecisionTreeClassifierSuite
   /////////////////////////////////////////////////////////////////////////////
 
   test("classification with class weights") {
-    val buf = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_train.csv").getLines
+    val buf = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_train.csv")
+      .getLines
     val header = buf.take(1).next()
     var data = new Array[LabeledPoint](1000)
     var idx : Int = 0
     for (row <- buf) {
       val cols = row.split(",").map(_.trim)
-      // scalastyle:off println
-      //println(s"${cols(0)}|${cols(1)}|${cols(2)}|${cols(3)}|${cols(4)}")
-      //println( cols(0).getClass)
-      // scalastyle:on println
+      // scala style: off println
+      // println(s"${cols(0)}|${cols(1)}|${cols(2)}|${cols(3)}|${cols(4)}")
+      // println( cols(0).getClass)
+      // scala style: on println
       data(idx) = new LabeledPoint(cols(0).toDouble,
         Vectors.dense(cols(1).toDouble, cols(2).toDouble))
       idx += 1
     }
     // scalastyle:off println
-    //println(data)
+    // println(data)
     // scalastyle:on println
     val IrIsRDD = sc.parallelize(data)
     val dt = new DecisionTreeClassifier()
@@ -103,40 +105,9 @@ class DecisionTreeClassifierSuite
     val newTree = dt.fit(newData)
     val predoutput = newTree.transform(newData)
     // scalastyle:off println
-    //predoutput.show(1000)
-    //println(newTree.toDebugString)
+    // predoutput.show(1000)
+    // println(newTree.toDebugString)
     // scalastyle:on println
-    /*
-    val predictionsAndLabels = predoutput.select("prediction", "label")
-      .map(row => (row.getDouble(0), row.getDouble(1)))
-    val metrics = new MulticlassMetrics(predictionsAndLabels)
-    val confusionMatrix = metrics.confusionMatrix
-    // scalastyle:off println
-    println(confusionMatrix.toString())
-    // scalastyle:on println
-    val buf2 = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_test.csv").getLines
-    val header2 = buf2.take(1).next()
-    var data2 = new Array[LabeledPoint](250)
-    idx = 0
-    for (row <- buf2) {
-      val cols = row.split(",").map(_.trim)
-      data2(idx) = new LabeledPoint(cols(0).toDouble,
-        Vectors.dense(cols(1).toDouble, cols(2).toDouble))
-      idx += 1
-    }
-    // scalastyle:off println
-    //println(data)
-    // scalastyle:on println
-    val IrIsRDD2 = sc.parallelize(data2)
-    val newData2: DataFrame = TreeTests.setMetadata(IrIsRDD2, categoricalFeatures, 2)
-    val predoutput2 = newTree.transform(newData2)
-    val predictions = predoutput2.select("prediction", "label")
-      .map(row => (row.getDouble(0), row.getDouble(1)))
-    val metrics2 = new MulticlassMetrics(predictions)
-    val confusionMatrix2 = metrics2.confusionMatrix
-    // scalastyle:off println
-    println(confusionMatrix2.toString())
-    // scalastyle:on println */
   }
 
   test("Binary classification stump with ordered categorical features") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -30,9 +30,6 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 
-
-
-
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -96,7 +96,7 @@ class DecisionTreeClassifierSuite
       .setMaxDepth(3)
       .setMaxBins(400)
       .setMinInstancesPerNode(1)
-      .setClassWeights(Array(1, 10000))
+      .setClassWeights(Array(1, 1))
     val categoricalFeatures: Map[Int, Int] = Map()
     val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
     val newTree = dt.fit(newData)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -96,7 +96,7 @@ class DecisionTreeClassifierSuite
       .setMaxDepth(3)
       .setMaxBins(400)
       .setMinInstancesPerNode(1)
-      .setClassWeights(Array(1, 1))
+      .setClassWeights(Array(1, 1000))
     val categoricalFeatures: Map[Int, Int] = Map()
     val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
     val newTree = dt.fit(newData)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -79,43 +79,6 @@ class RandomForestClassifierSuite
     ParamsSuite.checkParams(model)
   }
 
-  test("classification with class weights") {
-    val buf = Source.fromFile("/Users/yueweina/Documents/spark/data/mllib/unbalenced_train.csv")
-      .getLines
-    val header = buf.take(1).next()
-    var data = new Array[LabeledPoint](1000)
-    var idx : Int = 0
-    for (row <- buf) {
-      val cols = row.split(",").map(_.trim)
-      // scala style: off println
-      // println(s"${cols(0)}|${cols(1)}|${cols(2)}|${cols(3)}|${cols(4)}")
-      // println( cols(0).getClass)
-      // scala style: on println
-      data(idx) = new LabeledPoint(cols(0).toDouble,
-        Vectors.dense(cols(1).toDouble, cols(2).toDouble))
-      idx += 1
-    }
-    // scalastyle:off println
-    // println(data)
-    // scalastyle:on println
-    val IrIsRDD = sc.parallelize(data)
-    val rf = new RandomForestClassifier()
-      .setImpurity("weightedgini")
-      .setMaxDepth(3)
-      .setMaxBins(400)
-      .setMinInstancesPerNode(1)
-      .setClassWeights(Array(1, 1000))
-      .setSubsamplingRate(1)
-    val categoricalFeatures: Map[Int, Int] = Map()
-    val newData: DataFrame = TreeTests.setMetadata(IrIsRDD, categoricalFeatures, 2)
-    val newTree = rf.fit(newData)
-    val predoutput = newTree.transform(newData)
-    // scalastyle:off println
-    predoutput.show(1000)
-    //println(newTree.toDebugString)
-    // scalastyle:on println
-  }
-
   test("Binary classification with continuous features:" +
     " comparing DecisionTree vs. RandomForest(numTrees = 1)") {
     val rf = new RandomForestClassifier()

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -210,7 +210,7 @@ class RandomForestClassifierSuite
       assert(model.numClasses === model2.numClasses)
     }
 
-    val rf = new RandomForestClassifier().setNumTrees(2)
+    val rf = new RandomForestClassifier().setNumTrees(2).setClassWeights(Array())
     val rdd = TreeTests.getTreeReadWriteData(sc)
 
     val allParamSettings = TreeTests.allParamSettings ++ Map("impurity" -> "entropy")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -234,7 +234,7 @@ private object RandomForestClassifierSuite extends SparkFunSuite {
       numClasses: Int): Unit = {
     val numFeatures = data.first().features.size
     val oldStrategy =
-      rf.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, rf.getOldImpurity)
+      rf.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, rf.getOldImpurity, rf.getClassWeights)
     val oldModel = OldRandomForest.trainClassifier(
       data.map(OldLabeledPoint.fromML), oldStrategy, rf.getNumTrees, rf.getFeatureSubsetStrategy,
       rf.getSeed.toInt)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -238,7 +238,7 @@ private object RandomForestClassifierSuite extends SparkFunSuite {
     val numFeatures = data.first().features.size
     val oldStrategy =
       rf.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification,
-        rf.getOldImpurity)
+        rf.getOldImpurity, rf.getSubsamplingRate, rf.getClassWeights)
     val oldModel = OldRandomForest.trainClassifier(
       data.map(OldLabeledPoint.fromML), oldStrategy, rf.getNumTrees, rf.getFeatureSubsetStrategy,
       rf.getSeed.toInt)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -234,7 +234,8 @@ private object RandomForestClassifierSuite extends SparkFunSuite {
       numClasses: Int): Unit = {
     val numFeatures = data.first().features.size
     val oldStrategy =
-      rf.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, rf.getOldImpurity, rf.getClassWeights)
+      rf.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification,
+        rf.getOldImpurity, rf.getClassWeights)
     val oldModel = OldRandomForest.trainClassifier(
       data.map(OldLabeledPoint.fromML), oldStrategy, rf.getNumTrees, rf.getFeatureSubsetStrategy,
       rf.getSeed.toInt)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -238,7 +238,7 @@ private object RandomForestClassifierSuite extends SparkFunSuite {
     val numFeatures = data.first().features.size
     val oldStrategy =
       rf.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification,
-        rf.getOldImpurity, rf.getClassWeights)
+        rf.getOldImpurity)
     val oldModel = OldRandomForest.trainClassifier(
       data.map(OldLabeledPoint.fromML), oldStrategy, rf.getNumTrees, rf.getFeatureSubsetStrategy,
       rf.getSeed.toInt)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import scala.io.Source
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
@@ -33,7 +31,6 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
-
 
 /**
  * Test suite for [[RandomForestClassifier]].
@@ -213,7 +210,7 @@ class RandomForestClassifierSuite
       assert(model.numClasses === model2.numClasses)
     }
 
-    val rf = new RandomForestClassifier().setNumTrees(2).setClassWeights(Array())
+    val rf = new RandomForestClassifier().setNumTrees(2)
     val rdd = TreeTests.getTreeReadWriteData(sc)
 
     val allParamSettings = TreeTests.allParamSettings ++ Map("impurity" -> "entropy")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -141,7 +141,8 @@ private object RandomForestRegressorSuite extends SparkFunSuite {
     val numFeatures = data.first().features.size
     val oldStrategy =
       rf.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, rf.getOldImpurity)
+        OldAlgo.Regression, rf.getOldImpurity, rf.getSubsamplingRate,
+        classWeights = Array())
     val oldModel = OldRandomForest.trainRegressor(data.map(OldLabeledPoint.fromML), oldStrategy,
       rf.getNumTrees, rf.getFeatureSubsetStrategy, rf.getSeed.toInt)
     val newData: DataFrame = TreeTests.setMetadata(data, categoricalFeatures, numClasses = 0)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -140,7 +140,8 @@ private object RandomForestRegressorSuite extends SparkFunSuite {
       categoricalFeatures: Map[Int, Int]): Unit = {
     val numFeatures = data.first().features.size
     val oldStrategy =
-      rf.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, rf.getOldImpurity)
+      rf.getOldStrategy(categoricalFeatures, numClasses = 0,
+        OldAlgo.Regression, rf.getOldImpurity, classWeights = Array())
     val oldModel = OldRandomForest.trainRegressor(data.map(OldLabeledPoint.fromML), oldStrategy,
       rf.getNumTrees, rf.getFeatureSubsetStrategy, rf.getSeed.toInt)
     val newData: DataFrame = TreeTests.setMetadata(data, categoricalFeatures, numClasses = 0)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -141,7 +141,7 @@ private object RandomForestRegressorSuite extends SparkFunSuite {
     val numFeatures = data.first().features.size
     val oldStrategy =
       rf.getOldStrategy(categoricalFeatures, numClasses = 0,
-        OldAlgo.Regression, rf.getOldImpurity, classWeights = Array())
+        OldAlgo.Regression, rf.getOldImpurity)
     val oldModel = OldRandomForest.trainRegressor(data.map(OldLabeledPoint.fromML), oldStrategy,
       rf.getNumTrees, rf.getFeatureSubsetStrategy, rf.getSeed.toInt)
     val newData: DataFrame = TreeTests.setMetadata(data, categoricalFeatures, numClasses = 0)

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -93,7 +93,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(6), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0
+        0, 0, 0.0, 0, 0, Array()
       )
       val featureSamples = Array.fill(200000)(math.random)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
@@ -110,7 +110,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(5), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0
+        0, 0, 0.0, 0, 0, Array()
       )
       val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
@@ -124,7 +124,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(3), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0
+        0, 0, 0.0, 0, 0, Array()
       )
       val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
@@ -138,7 +138,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(3), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0
+        0, 0, 0.0, 0, 0, Array()
       )
       val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -93,7 +93,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(6), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0, Array()
+        0, 0, 0.0, 0, 0, Array[Double]()
       )
       val featureSamples = Array.fill(200000)(math.random)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
@@ -110,7 +110,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(5), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0, Array()
+        0, 0, 0.0, 0, 0, Array[Double]()
       )
       val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
@@ -124,7 +124,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(3), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0, Array()
+        0, 0, 0.0, 0, 0, Array[Double]()
       )
       val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
@@ -138,7 +138,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
         Array(3), Gini, QuantileStrategy.Sort,
-        0, 0, 0.0, 0, 0, Array()
+        0, 0, 0.0, 0, 0, Array[Double]()
       )
       val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -94,7 +94,7 @@ This file is divided into 3 sections:
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-    <parameters><parameter name="maxParameters"><![CDATA[10]]></parameter></parameters>
+    <parameters><parameter name="maxParameters"><![CDATA[15]]></parameter></parameters>
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to implement class weights support to Random Forest (and also Decision Tree). This is useful in handling unbalanced data in classification problems.
## How was this patch tested?

Add a unit test in the `DecisionTreeClassifierSuite`. Manual tests are also done locally on an unbalanced dataset.
