### PR TITLE
[SPARK-16154] [MLLIB] Update spark.ml and spark.mllib package docs

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/package.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/package.scala
@@ -18,8 +18,8 @@
 package org.apache.spark
 
 /**
- * Spark ML is a component that adds a new set of machine learning APIs to let users quickly
- * assemble and configure practical machine learning pipelines.
+ * DataFrame-based machine learning APIs to let users quickly assemble and configure practical
+ * machine learning pipelines.
  *
  * @groupname param Parameters
  * @groupdesc param A list of (hyper-)parameter keys this algorithm can take. Users can set and get

--- a/mllib/src/main/scala/org/apache/spark/mllib/JavaPackage.java
+++ b/mllib/src/main/scala/org/apache/spark/mllib/JavaPackage.java
@@ -15,8 +15,15 @@
  * limitations under the License.
  */
 
+package org.apache.spark.mllib;
+
+import org.apache.spark.annotation.AlphaComponent;
+
 /**
- * DataFrame-based machine learning APIs to let users quickly assemble and configure practical
- * machine learning pipelines.
+ * A dummy class as a workaround to show the package doc of <code>spark.mllib</code> in generated
+ * Java API docs.
+ * @see <a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4492654" target="_blank">
+ *      JDK-4492654</a>
  */
-package org.apache.spark.ml;
+@AlphaComponent
+public class JavaPackage {}

--- a/mllib/src/main/scala/org/apache/spark/mllib/JavaPackage.java
+++ b/mllib/src/main/scala/org/apache/spark/mllib/JavaPackage.java
@@ -26,4 +26,6 @@ import org.apache.spark.annotation.AlphaComponent;
  *      JDK-4492654</a>
  */
 @AlphaComponent
-public class JavaPackage {}
+public class JavaPackage {
+  private JavaPackage() {}
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/package-info.java
+++ b/mllib/src/main/scala/org/apache/spark/mllib/package-info.java
@@ -16,6 +16,26 @@
  */
 
 /**
- * Spark's machine learning library.
+ * RDD-based machine learning APIs (in maintenance mode).
+ *
+ * The <code>spark.mllib</code> package is in maintenance mode as of the Spark 2.0.0 release to
+ * encourage migration to the DataFrame-based APIs under the <code>spark.mllib</code> package.
+ * While in maintenance mode,
+ * <ul>
+ *   <li>
+ *     no new features in the RDD-based <code>spark.mllib</code> package will be accepted, unless
+ *     they block implementing new features in the DataFrame-based <code>spark.ml</code> package;
+ *   </li>
+ *   <li>
+ *     bug fixes in the RDD-based APIs will still be accepted.
+ *   </li>
+ * </ul>
+ *
+ * The developers will continue adding more features to the DataFrame-based APIs in the 2.x series
+ * to reach feature parity with the RDD-based APIs.
+ * And once we reach feature parity, this package will be deprecated.
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/SPARK-4591" target="_blank">SPARK-4591</a> to
+ *      track the progress of feature parity
  */
 package org.apache.spark.mllib;

--- a/mllib/src/main/scala/org/apache/spark/mllib/package-info.java
+++ b/mllib/src/main/scala/org/apache/spark/mllib/package-info.java
@@ -19,7 +19,7 @@
  * RDD-based machine learning APIs (in maintenance mode).
  *
  * The <code>spark.mllib</code> package is in maintenance mode as of the Spark 2.0.0 release to
- * encourage migration to the DataFrame-based APIs under the <code>spark.mllib</code> package.
+ * encourage migration to the DataFrame-based APIs under the <code>spark.ml</code> package.
  * While in maintenance mode,
  * <ul>
  *   <li>

--- a/mllib/src/main/scala/org/apache/spark/mllib/package.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/package.scala
@@ -18,6 +18,21 @@
 package org.apache.spark
 
 /**
- * Spark's machine learning library.
+ * RDD-based machine learning APIs (in maintenance mode).
+ *
+ * The `spark.mllib` package is in maintenance mode as of the Spark 2.0.0 release to encourage
+ * migration to the DataFrame-based APIs under the [[org.apache.spark.ml]] package.
+ * While in maintenance mode,
+ *
+ *  - no new features in the RDD-based `spark.mllib` package will be accepted, unless they block
+ *    implementing new features in the DataFrame-based `spark.ml` package;
+ *  - bug fixes in the RDD-based APIs will still be accepted.
+ *
+ * The developers will continue adding more features to the DataFrame-based APIs in the 2.x series
+ * to reach feature parity with the RDD-based APIs.
+ * And once we reach feature parity, this package will be deprecated.
+ *
+ * @see [[https://issues.apache.org/jira/browse/SPARK-4591 SPARK-4591]] to track the progress of
+ *     feature parity
  */
 package object mllib


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since we decided to switch spark.mllib package into maintenance mode in 2.0, it would be nice to update the package docs to reflect this change.
## How was this patch tested?

Manually checked generated APIs.
