### PR TITLE
[SPARK-16160] [STREAMING] Clear last remembered metadata window per dstream upon context graceful stop

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -146,6 +146,9 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
         Thread.sleep(pollTime)
       }
       logInfo("Waited for jobs to be processed and checkpoints to be written")
+
+      // do final cleanup in the same thread
+      clearMetadata(Time(clock.getTimeMillis) + graph.getMaxInputStreamRememberDuration)
     } else {
       logInfo("Stopping JobGenerator immediately")
       // Stop timer and graph immediately, ignore unprocessed data and pending jobs


### PR DESCRIPTION
## What changes were proposed in this pull request?

When stopping a streaming context gracefully, the last remembered window for each dstream is not cleared. If the streaming context is stopped without stopping the spark context, the persisted garbage rdds would still be there especially when there is a relatively large remember duration in case of windowing or checkpointing.

In this PR, `JobGenerator` makes a final call to `clearMetadata` such that all remembered metadata are cleared on graceful stop of a streaming context.
## How was this patch tested?

A new unit test is introduced that captures this case.
