### PR TITLE
[SPARK-16161][SQL] Ambiguous error message for unsupported correlated predicate subqueries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -920,11 +920,8 @@ class Analyzer(
           q transformExpressions {
             case u @ UnresolvedAttribute(nameParts) =>
               withPosition(u) {
-                val outer = outers.iterator
-                var expr = Option.empty[NamedExpression]
-                while (expr.isEmpty && outer.hasNext) {
-                  expr = outer.next().resolve(nameParts, resolver)
-                }
+                val expr = outers.iterator.map(_.resolve(nameParts, resolver))
+                  .collectFirst{case Some(attr) => attr}
                 expr match {
                   case Some(outerAttr) => OuterReference(outerAttr)
                   case None =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -923,7 +923,7 @@ class Analyzer(
               withPosition(u) {
                 try {
                   val outer = outers.iterator
-                  var expr: Option[NamedExpression] = None
+                  var expr = Option.empty[NamedExpression]
                   while (expr.isEmpty && outer.hasNext) {
                     expr = outer.next().resolve(nameParts, resolver)
                   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -789,5 +789,4 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
       assert(e.message.contains("Correlated column in subquery cannot be resolved"))
     }
   }
->>>>>>> [SPARK-16161] Ambiguous error message for unsupported correlated predicate subqueries
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -600,6 +600,7 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
         Row(1) :: Nil)
      }
    }
+
   test("SPARK-16161: Correlated subqueries with various levels of correlation.") {
     withTempView("t1", "t2", "t3", "t4") {
       Seq((1, 1), (2, 2), (3, 3)).toDF("c1", "c2").createOrReplaceTempView("t1")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Subqueries with deep correlation fail with ambiguous error message.

**Problem repro:**

``` SQL
Seq((1, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t1")
Seq((1, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t2")
Seq((1, 1), (2, 2)).toDF("c1", "c2").createOrReplaceTempView("t3")

sql("select c1 from t1 where c1 IN (select t2.c1 from t2 where t2.c2 IN (select t3.c2 from t3 where t3.c1 = t1.c1))").show()

org.apache.spark.sql.AnalysisException: filter expression 'listquery()' of type array<null> is not a boolean.;
  at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$class.failAnalysis(CheckAnalysis.scala:40)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.failAnalysis(Analyzer.scala:58)
```

Based on testing, Spark supports one level of correlation in predicate and scalar subqueries. An example of supported correlation is shown below.

``` SQL
select c1 from t1
where c1 IN (select t2.c1 from t2 where t2.c2 IN (select t3.c2 from t3 where t3.c1 = t2.c1))
```

If the query has deep correlation, such as in the first example, where the inner subquery is correlated
to the outer most query block, the above error message is issued. 

This PR changes the error message to the following one:

``` SQL
Correlated column in subquery cannot be resolved: t1.c1; line 5 pos 28
org.apache.spark.sql.AnalysisException: Correlated column in subquery cannot be resolved: t1.c1; line 5 pos 28
  at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$class.failAnalysis(CheckAnalysis.scala:40)
```

**Problem description:**
Rule ResolveSubqueries resolves subqueries by first invoking the Analyzer on the subquery tree and then attempting to resolve the correlated column references using the outer plans. If the subquery was succesfully resolved, the rule completes rewritting the subquery. Otherwise, the unresolved plan is returned. Later, CheckAnalysis will not report the original problem, but the result of cascading resolution failures. 

**Solution:**
When resolving an UnresolvedAlias in resolveOuterReferences(), use the entire sequence of available outer plans, instead of one outer plan at a time. With this design, resolveOuterReferences() resolves any leaf expressions, or issues an error if the column cannot be resolved. Then, if the correlation is resolved, the subsequent call to execute() will resolve any references to previously unresolved correlated columns.
## How was this patch tested?

Add new test unit to the SubquerySuite.
