### PR TITLE
[SPARK-16174][SQL] Improve `OptimizeIn` optimizer to remove literal repetitions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -132,7 +132,8 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate
   }
 
   override def children: Seq[Expression] = value +: list
-  lazy val inSetConvertible = children.forall(_.deterministic)
+  lazy val inSetConvertible =
+    children.forall(_.deterministic) && list.forall(_.isInstanceOf[Literal])
 
   override def nullable: Boolean = children.exists(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -132,8 +132,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate
   }
 
   override def children: Seq[Expression] = value +: list
-  lazy val inSetConvertible =
-    children.forall(_.deterministic) && list.forall(_.isInstanceOf[Literal])
+  lazy val inSetConvertible = list.forall(_.isInstanceOf[Literal])
 
   override def nullable: Boolean = children.exists(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -132,7 +132,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate
   }
 
   override def children: Seq[Expression] = value +: list
-  lazy val optimizable = children.forall(_.deterministic)
+  lazy val inSetConvertible = children.forall(_.deterministic)
 
   override def nullable: Boolean = children.exists(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -132,6 +132,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate
   }
 
   override def children: Seq[Expression] = value +: list
+  lazy val optimizable = children.forall(_.deterministic)
 
   override def nullable: Boolean = children.exists(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -828,16 +828,16 @@ object ConstantFolding extends Rule[LogicalPlan] {
 case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case q: LogicalPlan => q transformExpressionsDown {
-      case i @ In(v, l) =>
-        val (deterministics, others) = l.partition(_.deterministic)
+      case i @ In(v, list) =>
+        val (deterministics, others) = list.partition(_.deterministic)
         val newList = ExpressionSet(deterministics).toSeq ++ others
         if (newList.forall(_.isInstanceOf[Literal]) &&
             newList.size > conf.optimizerInSetConversionThreshold) {
           val hSet = newList.map(e => e.eval(EmptyRow))
           InSet(v, HashSet() ++ hSet)
-        } else if (newList.length < l.length) {
+        } else if (newList.length < list.length) {
           i.copy(v, newList)
-        } else { // newList.length == l.length
+        } else { // newList.length == list.length
           i
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -828,7 +828,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
 case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case q: LogicalPlan => q transformExpressionsDown {
-      case i @ In(v, list) if list.forall(_.deterministic) =>
+      case i @ In(v, list) if i.optimizable =>
         val newList = ExpressionSet(list).toSeq
         if (newList.forall(_.isInstanceOf[Literal]) &&
             newList.size > conf.optimizerInSetConversionThreshold) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -820,8 +820,10 @@ object ConstantFolding extends Rule[LogicalPlan] {
 }
 
 /**
- * Removes literal repetitions from IN predicate and replaces [[In (value, seq[Literal])]]
- * with optimized version[[InSet (value, HashSet[Literal])]] which is much faster.
+ * Optimize IN predicates:
+ * 1. Removes deterministic repetitions.
+ * 2. Replaces [[In (value, seq[Literal])]] with optimized version
+ *    [[InSet (value, HashSet[Literal])]] which is much faster.
  */
 case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -828,7 +828,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
 case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case q: LogicalPlan => q transformExpressionsDown {
-      case i @ In(v, list) if i.optimizable =>
+      case i @ In(v, list) if i.inSetConvertible =>
         val newList = ExpressionSet(list).toSeq
         if (newList.forall(_.isInstanceOf[Literal]) &&
             newList.size > conf.optimizerInSetConversionThreshold) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -828,9 +828,8 @@ object ConstantFolding extends Rule[LogicalPlan] {
 case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case q: LogicalPlan => q transformExpressionsDown {
-      case i @ In(v, list) =>
-        val (deterministics, others) = list.partition(_.deterministic)
-        val newList = ExpressionSet(deterministics).toSeq ++ others
+      case i @ In(v, list) if list.forall(_.deterministic) =>
+        val newList = ExpressionSet(list).toSeq
         if (newList.forall(_.isInstanceOf[Literal]) &&
             newList.size > conf.optimizerInSetConversionThreshold) {
           val hSet = newList.map(e => e.eval(EmptyRow))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -834,7 +834,7 @@ case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
           val hSet = newList.map(e => e.eval(EmptyRow))
           InSet(v, HashSet() ++ hSet)
         } else if (newList.size < list.size) {
-          In(v, newList)
+          expr.copy(list = newList)
         } else { // newList.length == list.length
           expr
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -834,7 +834,7 @@ case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
           val hSet = newList.map(e => e.eval(EmptyRow))
           InSet(v, HashSet() ++ hSet)
         } else if (newList.size < list.size) {
-          expr.copy(value = v, list = newList)
+          In(v, newList)
         } else { // newList.length == list.length
           expr
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -835,7 +835,7 @@ case class OptimizeIn(conf: CatalystConf) extends Rule[LogicalPlan] {
           InSet(v, HashSet() ++ hSet)
         } else if (newList.length < l.length) {
           i.copy(v, newList)
-        } else { // netList.length == l.length
+        } else { // newList.length == l.length
           i
         }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -58,7 +58,9 @@ class OptimizeInSuite extends PlanTest {
       testRelation
         .where(In(UnresolvedAttribute("a"), Seq(Literal(1), Literal(2))))
         .where(In(UnresolvedAttribute("b"),
-          Seq(UnresolvedAttribute("a"), Round(UnresolvedAttribute("a"), 0), Rand(0), Rand(0))))
+          Seq(UnresolvedAttribute("a"), UnresolvedAttribute("a"),
+            Round(UnresolvedAttribute("a"), 0), Round(UnresolvedAttribute("a"), 0),
+            Rand(0), Rand(0))))
         .analyze
 
     comparePlans(optimized, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -42,7 +42,7 @@ class OptimizeInSuite extends PlanTest {
 
   val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
 
-  test("RemoveRepetitionFromIn test") {
+  test("OptimizedIn test: Remove deterministic repetitions") {
     val originalQuery =
       testRelation
         .where(In(UnresolvedAttribute("a"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR improves `OptimizeIn` optimizer to remove the literal repetitions from SQL `IN` predicates. This optimizer prevents user mistakes and also can optimize some queries like [TPCDS-36](https://github.com/apache/spark/blob/master/sql/core/src/test/resources/tpcds/q36.sql#L19).

**Before**

``` scala
scala> sql("select state from (select explode(array('CA','TN')) state) where state in ('TN','TN','TN','TN','TN','TN','TN')").explain
== Physical Plan ==
*Filter state#6 IN (TN,TN,TN,TN,TN,TN,TN)
+- Generate explode([CA,TN]), false, false, [state#6]
   +- Scan OneRowRelation[]
```

**After**

``` scala
scala> sql("select state from (select explode(array('CA','TN')) state) where state in ('TN','TN','TN','TN','TN','TN','TN')").explain
== Physical Plan ==
*Filter state#6 IN (TN)
+- Generate explode([CA,TN]), false, false, [state#6]
   +- Scan OneRowRelation[]
```
## How was this patch tested?

Pass the Jenkins tests (including a new testcase).
