### PR TITLE
SPARK-16178: Remove unnecessary Hive partition check.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -171,14 +171,6 @@ case class InsertIntoHiveTable(
     val partitionColumns = fileSinkConf.getTableInfo.getProperties.getProperty("partition_columns")
     val partitionColumnNames = Option(partitionColumns).map(_.split("/")).getOrElse(Array.empty)
 
-    // By this time, the partition map must match the table's partition columns
-    if (partitionColumnNames.toSet != partition.keySet) {
-      throw new SparkException(
-        s"""Requested partitioning does not match the ${table.tableName} table:
-           |Requested partitions: ${partition.keys.mkString(",")}
-           |Table partitions: ${table.partitionKeys.map(_.name).mkString(",")}""".stripMargin)
-    }
-
     // Validate partition spec if there exist any dynamic partitions
     if (numDynamicPartitions > 0) {
       // Report error if dynamic partitioning is not enabled


### PR DESCRIPTION
## What changes were proposed in this pull request?

This removes a check that partition names match from the Hive write path, which was added as a sanity check in [SPARK-14459](https://issues.apache.org/jira/browse/SPARK-14459). The sanity check is incorrect because `partitionBy` could be used to explicitly set columns with names that don't match.

This is also no longer exercised because of changes in SPARK-16032. Now, Hive's `partition` metadata is derived from the table partitions during the analysis phase and will always match.
