### PR TITLE
[SPARK-3723] [MLlib] Adding instrumentation to random forests

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/BaggedPoint.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/BaggedPoint.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.random.XORShiftRandom
  * particularly for bagging (e.g., for random forests).
  *
  * This holds one instance, as well as an array of weights which represent the (weighted)
- * number of times which this instance appears in each subsamplingRate.
+ * number of times which this instance appears in each subsample.
  * E.g., (datum, [1, 0, 4]) indicates that there are 3 subsamples of the dataset and that
  * this datum has 1 copy, 0 copies, and 4 copies in the 3 subsamples, respectively.
  *

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -215,7 +215,7 @@ private[spark] object RandomForest extends Logging {
     logInfo(s"Processed $numGroups groups of nodes")
     if (numGroups > 0) {
       logInfo(s"Max nodes per group: $maxNodesPerGroup")
-      logInfo(s"Min nodes per group: $minNodesPerGroup")      
+      logInfo(s"Min nodes per group: $minNodesPerGroup")
       logInfo(s"Average nodes per group: ${totalNodesProcessed / numGroups.toDouble}")
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -212,11 +212,11 @@ private[spark] object RandomForest extends Logging {
     logInfo(s"$timer")
 
     // Print out runtime statistics
-    logInfo(s"Max nodes per group $maxNodesPerGroup")
-    logInfo(s"Min nodes per group $minNodesPerGroup")
     logInfo(s"Processed $numGroups groups of nodes")
+    logInfo(s"Max nodes per group: $maxNodesPerGroup")
+    logInfo(s"Min nodes per group: $minNodesPerGroup")
     if (numGroups > 0) {
-      logInfo(s"Avg nodes per group ${totalNodesProcessed / numGroups.toDouble}")
+      logInfo(s"Average nodes per group: ${totalNodesProcessed / numGroups.toDouble}")
     }
 
     // Delete any remaining checkpoints used for node Id cache.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -213,9 +213,9 @@ private[spark] object RandomForest extends Logging {
 
     // Print out runtime statistics
     logInfo(s"Processed $numGroups groups of nodes")
-    logInfo(s"Max nodes per group: $maxNodesPerGroup")
-    logInfo(s"Min nodes per group: $minNodesPerGroup")
     if (numGroups > 0) {
+      logInfo(s"Max nodes per group: $maxNodesPerGroup")
+      logInfo(s"Min nodes per group: $minNodesPerGroup")      
       logInfo(s"Average nodes per group: ${totalNodesProcessed / numGroups.toDouble}")
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -173,11 +173,26 @@ private[spark] object RandomForest extends Logging {
 
     timer.stop("init")
 
+    // Variables used to keep track of runtime statistics (i.e. how many
+    // nodes get processed in each group/iteration on average)
+    var totalNodesProcessed = 0
+    var numGroups = 0
+    var minNodesPerGroup = Int.MaxValue
+    var maxNodesPerGroup = 0
+
     while (nodeQueue.nonEmpty) {
       // Collect some nodes to split, and choose features for each node (if subsampling).
       // Each group of nodes may come from one or multiple trees, and at multiple levels.
       val (nodesForGroup, treeToNodeToIndexInfo) =
         RandomForest.selectNodesToSplit(nodeQueue, maxMemoryUsage, metadata, rng)
+
+      // Update runtime statistics
+      val groupSize = nodesForGroup.values.map(_.length).sum
+      totalNodesProcessed += groupSize
+      numGroups += 1
+      minNodesPerGroup = Math.min(minNodesPerGroup, groupSize)
+      maxNodesPerGroup = Math.max(maxNodesPerGroup, groupSize)
+
       // Sanity check (should never occur):
       assert(nodesForGroup.nonEmpty,
         s"RandomForest selected empty nodesForGroup.  Error for unknown reason.")
@@ -195,6 +210,14 @@ private[spark] object RandomForest extends Logging {
 
     logInfo("Internal timing for DecisionTree:")
     logInfo(s"$timer")
+
+    // Print out runtime statistics
+    logInfo(s"Max nodes per group $maxNodesPerGroup")
+    logInfo(s"Min nodes per group $minNodesPerGroup")
+    logInfo(s"Processed $numGroups groups of nodes")
+    if (numGroups > 0) {
+      logInfo(s"Avg nodes per group ${totalNodesProcessed / numGroups.toDouble}")
+    }
 
     // Delete any remaining checkpoints used for node Id cache.
     if (nodeIdCache.nonEmpty) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In RandomForest.run(), added instrumentation for the number of node groups, along with the min, max, and average number of nodes per group.

Also fixed a typo in BaggedPoint.scala documentation.
## How was this patch tested?

Tested by running RandomForestClassifierSuite, checking the test output manually to make sure instrumentation information was present and reasonable.
