### PR TITLE
[SPARK-16192][SQL] Add type checks in CollectSet

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.catalog.SimpleCatalogRelation
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, CollectSet}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types._
@@ -76,9 +76,6 @@ trait CheckAnalysis extends PredicateHelper {
             failAnalysis("grouping() can only be used with GroupingSets/Cube/Rollup")
           case g: GroupingID =>
             failAnalysis("grouping_id() can only be used with GroupingSets/Cube/Rollup")
-
-          case c: CollectSet if c.child.dataType.isInstanceOf[MapType] =>
-            failAnalysis("collect_set() cannot have map type data")
 
           case w @ WindowExpression(AggregateExpression(_, _, true, _), _) =>
             failAnalysis(s"Distinct window functions are not supported: $w")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.catalog.SimpleCatalogRelation
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, CollectSet}
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types._
@@ -73,9 +73,12 @@ trait CheckAnalysis extends PredicateHelper {
               s"invalid cast from ${c.child.dataType.simpleString} to ${c.dataType.simpleString}")
 
           case g: Grouping =>
-            failAnalysis(s"grouping() can only be used with GroupingSets/Cube/Rollup")
+            failAnalysis("grouping() can only be used with GroupingSets/Cube/Rollup")
           case g: GroupingID =>
-            failAnalysis(s"grouping_id() can only be used with GroupingSets/Cube/Rollup")
+            failAnalysis("grouping_id() can only be used with GroupingSets/Cube/Rollup")
+
+          case c: CollectSet if c.child.dataType.isInstanceOf[MapType] =>
+            failAnalysis("collect_set() cannot have map type data")
 
           case w @ WindowExpression(AggregateExpression(_, _, true, _), _) =>
             failAnalysis(s"Distinct window functions are not supported: $w")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import scala.collection.generic.Growable
 import scala.collection.mutable
 
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.catalyst.InternalRow
@@ -106,6 +107,14 @@ case class CollectSet(
     inputAggBufferOffset: Int = 0) extends Collect {
 
   def this(child: Expression) = this(child, 0, 0)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (!child.dataType.existsRecursively(_.isInstanceOf[MapType])) {
+      TypeCheckResult.TypeCheckSuccess
+    } else {
+      TypeCheckResult.TypeCheckFailure("collect_set() cannot have map type data")
+    }
+  }
 
   override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate =
     copy(mutableAggBufferOffset = newMutableAggBufferOffset)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -436,8 +436,8 @@ class AnalysisErrorSuite extends AnalysisTest {
   }
 
   test("we should fail analysis when we find map type data in collect_set") {
-    val dataType = MapType(StringType, IntegerType)
-    val plan =
+    def errorTest(dataType: DataType): Unit = {
+      val plan =
         Aggregate(
           AttributeReference("a", IntegerType)(exprId = ExprId(2)) :: Nil,
           Alias(CollectSet(AttributeReference("b", dataType)(exprId = ExprId(1)))
@@ -445,7 +445,11 @@ class AnalysisErrorSuite extends AnalysisTest {
           LocalRelation(
             AttributeReference("a", IntegerType)(exprId = ExprId(2)),
             AttributeReference("b", dataType)(exprId = ExprId(1))))
-    assertAnalysisError(plan, "collect_set() cannot have map type data" :: Nil)
+      assertAnalysisError(plan, "collect_set() cannot have map type data" :: Nil)
+    }
+
+    val mapType = MapType(StringType, IntegerType)
+    (mapType :: ArrayType(mapType) :: StructType(StructField("x", mapType) :: Nil) :: Nil)
   }
 
   test("Join can't work on binary and map types") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, CollectSet, Complete, Count}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Count}
 import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData, MapData}
@@ -433,23 +433,6 @@ class AnalysisErrorSuite extends AnalysisTest {
       plan,
       "It is not allowed to use an aggregate function in the argument of " +
         "another aggregate function." :: Nil)
-  }
-
-  test("we should fail analysis when we find map type data in collect_set") {
-    def errorTest(dataType: DataType): Unit = {
-      val plan =
-        Aggregate(
-          AttributeReference("a", IntegerType)(exprId = ExprId(2)) :: Nil,
-          Alias(CollectSet(AttributeReference("b", dataType)(exprId = ExprId(1)))
-            .toAggregateExpression(), "c")() :: Nil,
-          LocalRelation(
-            AttributeReference("a", IntegerType)(exprId = ExprId(2)),
-            AttributeReference("b", dataType)(exprId = ExprId(1))))
-      assertAnalysisError(plan, "collect_set() cannot have map type data" :: Nil)
-    }
-
-    val mapType = MapType(StringType, IntegerType)
-    (mapType :: ArrayType(mapType) :: StructType(StructField("x", mapType) :: Nil) :: Nil)
   }
 
   test("Join can't work on binary and map types") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -457,6 +457,16 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
     )
   }
 
+  test("collect_set functions cannot have maps") {
+    val df = Seq((1, 3, 0), (2, 3, 0), (3, 4, 1))
+      .toDF("a", "x", "y")
+      .select($"a", map($"x", $"y").as("b"))
+    val error = intercept[AnalysisException] {
+      df.select(collect_set($"a"), collect_set($"b"))
+    }
+    assert(error.message.contains("collect_set() cannot have map type data"))
+  }
+
   test("SPARK-14664: Decimal sum/avg over window should work.") {
     checkAnswer(
       spark.sql("select sum(a) over () from values 1.0, 2.0, 3.0 T(a)"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CollectSet` cannot have map-typed data because MapTypeData does not implement `equals`. 
So, this pr is to add type checks in `CheckAnalysis`.
## How was this patch tested?

Added tests to check failures when we found map-typed data in `CollectSet`.
