### PR TITLE
[SPARK-16202] [SQL] [DOC] Correct The Description of CreatableRelationProvider's createRelation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -148,9 +148,9 @@ trait StreamSinkProvider {
 @DeveloperApi
 trait CreatableRelationProvider {
   /**
-   * Creates a relation with the given parameters based on the contents of the given
-   * DataFrame. The mode specifies the expected behavior of createRelation when
-   * data already exists.
+   * Save the DataFrame to the destination and return a relation with the given parameters based on
+   * the contents of the given DataFrame. The mode specifies the expected behavior of createRelation
+   * when data already exists.
    * Right now, there are three modes, Append, Overwrite, and ErrorIfExists.
    * Append mode means that when saving a DataFrame to a data source, if data already exists,
    * contents of the DataFrame are expected to be appended to existing data.


### PR DESCRIPTION
#### What changes were proposed in this pull request?

The API description of `createRelation` in `CreatableRelationProvider` is misleading. The current description only expects users to return the relation. 

``` Scala
trait CreatableRelationProvider {
  def createRelation(
      sqlContext: SQLContext,
      mode: SaveMode,
      parameters: Map[String, String],
      data: DataFrame): BaseRelation
}
```

However, the major goal of this API should also include saving the `DataFrame`.

Since this API is critical for Data Source API developers, this PR is to correct the description. 
#### How was this patch tested?

N/A
