### PR TITLE
[SPARK-16209] [SQL] Convert Hive Tables in PARQUET/ORC to Data Source Tables for CREATE TABLE AS SELECT

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -17,12 +17,22 @@
 
 package org.apache.spark.sql.internal
 
+import org.apache.hadoop.mapred.InputFormat
+
 case class HiveSerDe(
   inputFormat: Option[String] = None,
   outputFormat: Option[String] = None,
   serde: Option[String] = None)
 
 object HiveSerDe {
+  val parquetInputFormat = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+  val parquetOutputFormat = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+  val parquetSerde = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+
+  val orcInputFormat = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"
+  val orcOutputFormat = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"
+  val orcSerde = "org.apache.hadoop.hive.ql.io.orc.OrcSerde"
+
   /**
    * Get the Hive SerDe information from the data source abbreviation string or classname.
    *
@@ -47,15 +57,15 @@ object HiveSerDe {
 
       "orc" ->
         HiveSerDe(
-          inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
-          outputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"),
-          serde = Option("org.apache.hadoop.hive.ql.io.orc.OrcSerde")),
+          inputFormat = Option(orcInputFormat),
+          outputFormat = Option(orcOutputFormat),
+          serde = Option(orcSerde)),
 
       "parquet" ->
         HiveSerDe(
-          inputFormat = Option("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"),
-          outputFormat = Option("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"),
-          serde = Option("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")),
+          inputFormat = Option(parquetInputFormat),
+          outputFormat = Option(parquetOutputFormat),
+          serde = Option(parquetSerde)),
 
       "textfile" ->
         HiveSerDe(
@@ -78,5 +88,23 @@ object HiveSerDe {
     }
 
     serdeMap.get(key)
+  }
+
+  def isParquet(
+      inputFormat: Option[String],
+      outputFormat: Option[String],
+      serde: Option[String]): Boolean = {
+    inputFormat == Option(parquetInputFormat) &&
+      outputFormat == Option(parquetOutputFormat) &&
+      serde == Option(parquetSerde)
+  }
+
+  def isOrc(
+      inputFormat: Option[String],
+      outputFormat: Option[String],
+      serde: Option[String]): Boolean = {
+    inputFormat == Option(orcInputFormat) &&
+      outputFormat == Option(orcOutputFormat) &&
+      serde == Option(orcSerde)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.internal
 
-import org.apache.hadoop.mapred.InputFormat
-
 case class HiveSerDe(
   inputFormat: Option[String] = None,
   outputFormat: Option[String] = None,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -395,7 +395,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
   def checkRelation(
       tableName: String,
-      isDataSourceParquet: Boolean,
+      isDataSourceTable: Boolean,
       format: String,
       userSpecifiedLocation: Option[String] = None): Unit = {
     val relation = EliminateSubqueryAliases(
@@ -404,7 +404,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
     relation match {
       case LogicalRelation(r: HadoopFsRelation, _, _) =>
-        if (!isDataSourceParquet) {
+        if (!isDataSourceTable) {
           fail(
             s"${classOf[MetastoreRelation].getCanonicalName} is expected, but found " +
               s"${HadoopFsRelation.getClass.getCanonicalName}.")
@@ -418,7 +418,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
           catalogTable.properties(CreateDataSourceTableUtils.DATASOURCE_PROVIDER) === format)
 
       case r: MetastoreRelation =>
-        if (isDataSourceParquet) {
+        if (isDataSourceTable) {
           fail(
             s"${HadoopFsRelation.getClass.getCanonicalName} is expected, but found " +
               s"${classOf[MetastoreRelation].getCanonicalName}.")
@@ -479,11 +479,11 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sql("DROP TABLE ctas1")
 
       sql("CREATE TABLE ctas1 stored as orc AS SELECT key k, value FROM src ORDER BY k, value")
-      checkRelation("ctas1", false, "orc")
+      checkRelation("ctas1", true, "orc")
       sql("DROP TABLE ctas1")
 
       sql("CREATE TABLE ctas1 stored as parquet AS SELECT key k, value FROM src ORDER BY k, value")
-      checkRelation("ctas1", false, "parquet")
+      checkRelation("ctas1", true, "parquet")
       sql("DROP TABLE ctas1")
     } finally {
       setConf(SQLConf.CONVERT_CTAS, originalConf)


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Currently, the following created tables will be Hive Table.

``` SQL
CREATE TABLE t STORED AS parquet SELECT 1 as a, 1 as b
```

``` SQL
CREATE TABLE t1
ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
STORED AS
INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
SELECT col1, col2 from t3
```

When users create table as query with `STORED AS` or `ROW FORMAT` and `spark.sql.hive.convertCTAS` is set to `true`, we will not convert them to data source tables. Actually, for parquet and orc formats, we still can convert them to data source table even if the users use `STORED AS` or `ROW FORMAT`.
#### How was this patch tested?

Added test cases for both ORC and PARQUET
