### PR TITLE
[SPARK-16215][SQL] Reduce runtime overhead of a program that writes an primitive array in Dataframe/Dataset

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions.codegen;
 
+import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.array.ByteArrayMethods;
@@ -258,5 +259,110 @@ public class UnsafeArrayWriter {
 
     // move the cursor forward.
     holder.cursor += 16;
+  }
+
+  public void writePrimiviveBooleanArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // boolean[] intput = ((GenericBooleanArrayData)arrayData).primitiveArray();
+    boolean[] input = arrayData.toBooleanArray();
+    int length = input.length;
+    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
+  }
+
+  public void writePrimitiveByteArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // byte[] intput = ((GenericByteArrayData)arrayData).primitiveArray();
+    byte[] input = arrayData.toByteArray();
+    int length = input.length;
+    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
+  }
+
+  public void writePrimitiveShortArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // short[] input = ((GenericShortArrayData)arrayData).primitiveArray();
+    short[] input = arrayData.toShortArray();
+    int length = input.length * 2;
+    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal * 2) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
+  }
+
+  public void writePrimitiveIntArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // int[] input = ((GenericIntArrayData)arrayData).primitiveArray();
+    int[] input = arrayData.toIntArray();
+    int length = input.length * 4;
+    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal * 4) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
+  }
+
+  public void writePrimitiveLongArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // long[] input = ((GenericLongArrayData)arrayData).primitiveArray();
+    long[] input = arrayData.toLongArray();
+    int length = input.length * 8;
+    Platform.copyMemory(input, Platform.LONG_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal * 8) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
+  }
+
+  public void writePrimitiveFloatArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // float[] input = ((GenericFloatArrayData)arrayData).primitiveArray();
+    float[] input = arrayData.toFloatArray();
+    int length = input.length * 4;
+    Platform.copyMemory(input, Platform.FLOAT_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal * 4) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
+  }
+
+  public void writePrimitiveDoubleArray(ArrayData arrayData) {
+    // uncomment this if SPARK-16043 is merged
+    // double[] input = ((GenericDoubleArrayData)arrayData).primitiveArray();
+    double[] input = arrayData.toDoubleArray();
+    int length = input.length * 8;
+    Platform.copyMemory(input, Platform.DOUBLE_ARRAY_OFFSET,
+            holder.buffer, holder.cursor, length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < input.length; ordinal++) {
+      final int relativeOffset = (holder.cursor + ordinal * 8) - startingOffset;
+      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
+    }
+    holder.cursor += length;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -262,7 +262,7 @@ public class UnsafeArrayWriter {
   }
 
   private void writePrimitiveArray(Object input, int offset, int elementSize, int length)  {
-    Platform.copyMemory(input, offset, holder.buffer, holder.cursor, elementSize * length);
+    Platform.copyMemory(input, offset, holder.buffer, startingOffset + headerInBytes, elementSize * length);
     holder.cursor += elementSize * length;
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -261,7 +261,7 @@ public class UnsafeArrayWriter {
     holder.cursor += 16;
   }
 
-  public void writePrimiviveBooleanArray(ArrayData arrayData) {
+  public void writePrimitiveBooleanArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // boolean[] intput = ((GenericBooleanArrayData)arrayData).primitiveArray();
     boolean[] input = arrayData.toBooleanArray();

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -261,19 +261,26 @@ public class UnsafeArrayWriter {
     holder.cursor += 16;
   }
 
+  private void writePrimitiveArray(Object input, int offset, int elementSize, int length)  {
+    // uncomment this if SPARK-16043 is merged
+    // Platform.copyMemory(input, offset, holder.buffer, startingOffset + headerInBytes,
+    //   elementSize * length);
+    Platform.copyMemory(input, offset, holder.buffer, holder.cursor, elementSize * length);
+    // remove the followings if SPARK-15962 is merged
+    for (int ordinal = 0; ordinal < length; ordinal++) {
+      Platform.putInt(holder.buffer, getElementOffset(ordinal),
+        (holder.cursor + ordinal * elementSize) - startingOffset);
+    }
+    holder.cursor += elementSize * length;
+  }
+
   public void writePrimitiveBooleanArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // boolean[] intput = ((GenericBooleanArrayData)arrayData).primitiveArray();
     boolean[] input = arrayData.toBooleanArray();
     int length = input.length;
-    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int offset = Platform.BYTE_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 1, length);
   }
 
   public void writePrimitiveByteArray(ArrayData arrayData) {
@@ -281,88 +288,52 @@ public class UnsafeArrayWriter {
     // byte[] intput = ((GenericByteArrayData)arrayData).primitiveArray();
     byte[] input = arrayData.toByteArray();
     int length = input.length;
-    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int offset = Platform.BYTE_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 1, length);
   }
 
   public void writePrimitiveShortArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // short[] input = ((GenericShortArrayData)arrayData).primitiveArray();
     short[] input = arrayData.toShortArray();
-    int length = input.length * 2;
-    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal * 2) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int length = input.length;
+    int offset = Platform.SHORT_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 2, length);
   }
 
   public void writePrimitiveIntArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // int[] input = ((GenericIntArrayData)arrayData).primitiveArray();
     int[] input = arrayData.toIntArray();
-    int length = input.length * 4;
-    Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal * 4) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int length = input.length;
+    int offset = Platform.INT_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 4, length);
   }
 
   public void writePrimitiveLongArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // long[] input = ((GenericLongArrayData)arrayData).primitiveArray();
     long[] input = arrayData.toLongArray();
-    int length = input.length * 8;
-    Platform.copyMemory(input, Platform.LONG_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal * 8) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int length = input.length;
+    int offset = Platform.LONG_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 8, length);
   }
 
   public void writePrimitiveFloatArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // float[] input = ((GenericFloatArrayData)arrayData).primitiveArray();
     float[] input = arrayData.toFloatArray();
-    int length = input.length * 4;
-    Platform.copyMemory(input, Platform.FLOAT_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal * 4) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int length = input.length;
+    int offset = Platform.FLOAT_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 4, length);
   }
 
   public void writePrimitiveDoubleArray(ArrayData arrayData) {
     // uncomment this if SPARK-16043 is merged
     // double[] input = ((GenericDoubleArrayData)arrayData).primitiveArray();
     double[] input = arrayData.toDoubleArray();
-    int length = input.length * 8;
-    Platform.copyMemory(input, Platform.DOUBLE_ARRAY_OFFSET,
-            holder.buffer, holder.cursor, length);
-    // remove the followings if SPARK-15962 is merged
-    for (int ordinal = 0; ordinal < input.length; ordinal++) {
-      final int relativeOffset = (holder.cursor + ordinal * 8) - startingOffset;
-      Platform.putInt(holder.buffer, getElementOffset(ordinal), relativeOffset);
-    }
-    holder.cursor += length;
+    int length = input.length;
+    int offset = Platform.DOUBLE_ARRAY_OFFSET;
+    writePrimitiveArray(input, offset, 8, length);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -263,7 +263,6 @@ public class UnsafeArrayWriter {
 
   private void writePrimitiveArray(Object input, int offset, int elementSize, int length)  {
     Platform.copyMemory(input, offset, holder.buffer, startingOffset + headerInBytes, elementSize * length);
-    holder.cursor += elementSize * length;
   }
 
   public void writePrimitiveBooleanArray(ArrayData arrayData) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -262,11 +262,7 @@ public class UnsafeArrayWriter {
   }
 
   private void writePrimitiveArray(Object input, int offset, int elementSize, int length)  {
-    // uncomment this if SPARK-16043 is merged
-    // Platform.copyMemory(input, offset, holder.buffer, startingOffset + headerInBytes,
-    //   elementSize * length);
     Platform.copyMemory(input, offset, holder.buffer, holder.cursor, elementSize * length);
-    // remove the followings if SPARK-15962 is merged
     for (int ordinal = 0; ordinal < length; ordinal++) {
       Platform.putInt(holder.buffer, getElementOffset(ordinal),
         (holder.cursor + ordinal * elementSize) - startingOffset);
@@ -275,8 +271,6 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveBooleanArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // boolean[] intput = ((GenericBooleanArrayData)arrayData).primitiveArray();
     boolean[] input = arrayData.toBooleanArray();
     int length = input.length;
     int offset = Platform.BYTE_ARRAY_OFFSET;
@@ -284,8 +278,6 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveByteArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // byte[] intput = ((GenericByteArrayData)arrayData).primitiveArray();
     byte[] input = arrayData.toByteArray();
     int length = input.length;
     int offset = Platform.BYTE_ARRAY_OFFSET;
@@ -293,8 +285,6 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveShortArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // short[] input = ((GenericShortArrayData)arrayData).primitiveArray();
     short[] input = arrayData.toShortArray();
     int length = input.length;
     int offset = Platform.SHORT_ARRAY_OFFSET;
@@ -302,8 +292,6 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveIntArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // int[] input = ((GenericIntArrayData)arrayData).primitiveArray();
     int[] input = arrayData.toIntArray();
     int length = input.length;
     int offset = Platform.INT_ARRAY_OFFSET;
@@ -311,8 +299,6 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveLongArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // long[] input = ((GenericLongArrayData)arrayData).primitiveArray();
     long[] input = arrayData.toLongArray();
     int length = input.length;
     int offset = Platform.LONG_ARRAY_OFFSET;
@@ -320,8 +306,6 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveFloatArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // float[] input = ((GenericFloatArrayData)arrayData).primitiveArray();
     float[] input = arrayData.toFloatArray();
     int length = input.length;
     int offset = Platform.FLOAT_ARRAY_OFFSET;
@@ -329,11 +313,126 @@ public class UnsafeArrayWriter {
   }
 
   public void writePrimitiveDoubleArray(ArrayData arrayData) {
-    // uncomment this if SPARK-16043 is merged
-    // double[] input = ((GenericDoubleArrayData)arrayData).primitiveArray();
     double[] input = arrayData.toDoubleArray();
     int length = input.length;
     int offset = Platform.DOUBLE_ARRAY_OFFSET;
     writePrimitiveArray(input, offset, 8, length);
   }
+
+/** uncomment this if SPARK-16043 is merged
+
+  // remove this method if SPARK-15962 is merged
+  private void updateIndex(int elementSize, int length)  {
+    for (int ordinal = 0; ordinal < length; ordinal++) {
+      Platform.putInt(holder.buffer, getElementOffset(ordinal),
+              (holder.cursor + ordinal * elementSize) - startingOffset);
+    }
+    holder.cursor += elementSize * length;
+  }
+
+  public void writePrimitiveBooleanArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericBooleanArrayData) {
+      boolean[] input = ((GenericBooleanArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.BOOLEAN_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putBoolean(holder.buffer, holder.cursor + i, arrayData.getBoolean(i));
+      }
+      updateIndex(1, length);
+    }
+  }
+
+  public void writePrimitiveByteArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericByteArrayData) {
+      byte[] input = ((GenericByteArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.BYTE_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putByte(holder.buffer, holder.cursor + i, arrayData.getByte(i));
+      }
+      updateIndex(1, length);
+    }
+  }
+
+  public void writePrimitiveShortArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericShortArrayData) {
+      short[] input = ((GenericShortArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.SHORT_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putShort(holder.buffer, holder.cursor + i, arrayData.getShort(i));
+      }
+      updateIndex(2, length);
+    }
+  }
+
+  public void writePrimitiveIntArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericIntArrayData) {
+      int[] input = ((GenericIntArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.INT_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putInt(holder.buffer, holder.cursor + i, arrayData.getInt(i));
+      }
+      updateIndex(4, length);
+    }
+  }
+
+  public void writePrimitiveLongArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericLongArrayData) {
+      long[] input = ((GenericLongArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.LONG_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putLong(holder.buffer, holder.cursor + i, arrayData.getLong(i));
+      }
+      updateIndex(8, length);
+    }
+  }
+
+  public void writePrimitiveFloatArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericFloatArrayData) {
+      float[] input = ((GenericFloatArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.FLOAT_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putFloat(holder.buffer, holder.cursor + i, arrayData.getFloat(i));
+      }
+      updateIndex(4, length);
+    }
+  }
+
+  public void writePrimitiveDoubleArray(ArrayData arrayData) {
+    if (arrayData instanceof GenericDoubleArrayData) {
+      double[] input = ((GenericDoubleArrayData)arrayData).primitiveArray();
+      int length = input.length;
+      Platform.copyMemory(input, Platform.DOUBLE_ARRAY_OFFSET,
+              holder.buffer, startingOffset + headerInBytes, length);
+    } else {
+      int length = arrayData.numElements();
+      for (int i = 0; i < length; i++) {
+        Platform.putFloat(holder.buffer, holder.cursor + i, arrayData.getFloat(i));
+      }
+      updateIndex(8, length);
+    }
+  }
+*/
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -263,10 +263,6 @@ public class UnsafeArrayWriter {
 
   private void writePrimitiveArray(Object input, int offset, int elementSize, int length)  {
     Platform.copyMemory(input, offset, holder.buffer, holder.cursor, elementSize * length);
-    for (int ordinal = 0; ordinal < length; ordinal++) {
-      Platform.putInt(holder.buffer, getElementOffset(ordinal),
-        (holder.cursor + ordinal * elementSize) - startingOffset);
-    }
     holder.cursor += elementSize * length;
   }
 
@@ -321,15 +317,6 @@ public class UnsafeArrayWriter {
 
 /** uncomment this if SPARK-16043 is merged
 
-  // remove this method if SPARK-15962 is merged
-  private void updateIndex(int elementSize, int length)  {
-    for (int ordinal = 0; ordinal < length; ordinal++) {
-      Platform.putInt(holder.buffer, getElementOffset(ordinal),
-              (holder.cursor + ordinal * elementSize) - startingOffset);
-    }
-    holder.cursor += elementSize * length;
-  }
-
   public void writePrimitiveBooleanArray(ArrayData arrayData) {
     if (arrayData instanceof GenericBooleanArrayData) {
       boolean[] input = ((GenericBooleanArrayData)arrayData).primitiveArray();
@@ -341,7 +328,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putBoolean(holder.buffer, holder.cursor + i, arrayData.getBoolean(i));
       }
-      updateIndex(1, length);
     }
   }
 
@@ -356,7 +342,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putByte(holder.buffer, holder.cursor + i, arrayData.getByte(i));
       }
-      updateIndex(1, length);
     }
   }
 
@@ -371,7 +356,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putShort(holder.buffer, holder.cursor + i, arrayData.getShort(i));
       }
-      updateIndex(2, length);
     }
   }
 
@@ -386,7 +370,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putInt(holder.buffer, holder.cursor + i, arrayData.getInt(i));
       }
-      updateIndex(4, length);
     }
   }
 
@@ -401,7 +384,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putLong(holder.buffer, holder.cursor + i, arrayData.getLong(i));
       }
-      updateIndex(8, length);
     }
   }
 
@@ -416,7 +398,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putFloat(holder.buffer, holder.cursor + i, arrayData.getFloat(i));
       }
-      updateIndex(4, length);
     }
   }
 
@@ -431,7 +412,6 @@ public class UnsafeArrayWriter {
       for (int i = 0; i < length; i++) {
         Platform.putFloat(holder.buffer, holder.cursor + i, arrayData.getFloat(i));
       }
-      updateIndex(8, length);
     }
   }
 */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -206,7 +206,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       case a @ ArrayType(et, cn) =>
         s"""
           final int $tmpCursor = $bufferHolder.cursor;
-          ${writeArrayToBuffer(ctx, element, et, bufferHolder)}
+          ${writeArrayToBuffer(ctx, element, et, cn, bufferHolder)}
           $arrayWriter.setOffsetAndSize($index, $tmpCursor, $bufferHolder.cursor - $tmpCursor);
         """
 
@@ -289,7 +289,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
         // Remember the current cursor so that we can write numBytes of key array later.
         final int $tmpCursor = $bufferHolder.cursor;
 
-        ${writeArrayToBuffer(ctx, keys, keyType, bufferHolder)}
+        ${writeArrayToBuffer(ctx, keys, keyType, false, bufferHolder)}
         // Write the numBytes of key array into the first 8 bytes.
         Platform.putLong($bufferHolder.buffer, $tmpCursor - 8, $bufferHolder.cursor - $tmpCursor);
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -225,11 +225,12 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       case _ => s"$arrayWriter.write($index, $element);"
     }
 
+    val typeName = if (ctx.isPrimitiveType(jt)) ctx.primitiveTypeName(et) else ""
     val storeElements = if (containsNull) {
       s"""
       for (int $index = 0; $index < $numElements; $index++) {
         if ($input.isNullAt($index)) {
-          $arrayWriter.setNullAt($index);
+          $arrayWriter.setNull${typeName}($index);
         } else {
           final $jt $element = ${ctx.getValue(input, et, index)};
           $writeElement
@@ -237,8 +238,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       }
       """
     } else {
-      if (ctx.isPrimitiveType(et)) {
-        val typeName = ctx.primitiveTypeName(et)
+      if (ctx.isPrimitiveType(jt)) {
         s"$arrayWriter.writePrimitive${typeName}Array($input);"
       } else {
         s"""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.catalyst.expressions.codegen
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.catalyst.expressions.{UnsafeArrayData, UnsafeRow}
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.unsafe.Platform
 
 class BufferHolderSuite extends SparkFunSuite {
 
@@ -35,5 +37,201 @@ class BufferHolderSuite extends SparkFunSuite {
       holder.grow(Integer.MAX_VALUE)
     }
     assert(e.getMessage.contains("exceeds size limitation"))
+  }
+
+  def performUnsafeArrayWriter(length: Int, elementSize: Int, f: (UnsafeArrayWriter) => Unit):
+  UnsafeArrayData = {
+    val unsafeRow = new UnsafeRow(1)
+    val unsafeArrayWriter = new UnsafeArrayWriter
+    val bufferHolder = new BufferHolder(unsafeRow, 32)
+    bufferHolder.reset()
+    val cursor = bufferHolder.cursor
+    unsafeArrayWriter.initialize(bufferHolder, length, elementSize)
+    // execute UnsafeArrayWriter.foo() in f()
+    f(unsafeArrayWriter)
+
+    val unsafeArray = new UnsafeArrayData
+    unsafeArray.pointTo(bufferHolder.buffer, cursor.toLong, bufferHolder.cursor - cursor)
+    assert(unsafeArray.numElements() == length)
+    unsafeArray
+  }
+
+  def initializeUnsafeArrayData(data: Seq[Any], elementSize: Int):
+  UnsafeArrayData = {
+    val length = data.length
+    val unsafeArray = new UnsafeArrayData
+    // uncomment this if SPARK-15962 is merged
+    // val headerSize = calculateHeaderPortionInBytes(length)
+    val headerSize = 4 + 4 * length
+    val size = headerSize + elementSize * length
+    val buffer = new Array[Byte](size)
+    Platform.putInt(buffer, Platform.BYTE_ARRAY_OFFSET, length)
+    unsafeArray.pointTo(buffer, Platform.BYTE_ARRAY_OFFSET, size)
+    // remove this if SPARK-15962 is merged
+    (0 until length).map(ordinal =>
+      Platform.putInt(buffer, Platform.BYTE_ARRAY_OFFSET + 4 + ordinal * 4,
+        headerSize + ordinal * elementSize)
+    )
+    assert(unsafeArray.numElements == length)
+    data.zipWithIndex.map { case (e, i) =>
+      val offset = Platform.BYTE_ARRAY_OFFSET + headerSize + elementSize * i
+      e match {
+        case _ : Boolean => Platform.putBoolean(buffer, offset, e.asInstanceOf[Boolean])
+        case _ : Byte => Platform.putByte(buffer, offset, e.asInstanceOf[Byte])
+        case _ : Short => Platform.putShort(buffer, offset, e.asInstanceOf[Short])
+        case _ : Int => Platform.putInt(buffer, offset, e.asInstanceOf[Int])
+        case _ : Long => Platform.putLong(buffer, offset, e.asInstanceOf[Long])
+        case _ : Float => Platform.putFloat(buffer, offset, e.asInstanceOf[Float])
+        case _ : Double => Platform.putDouble(buffer, offset, e.asInstanceOf[Double])
+        case _ => throw new UnsupportedOperationException()
+      }
+    }
+    unsafeArray
+  }
+
+  val booleanData = Seq(true, false)
+  val byteData = Seq(0.toByte, 1.toByte, Byte.MaxValue, Byte.MinValue)
+  val shortData = Seq(0.toShort, 1.toShort, Short.MaxValue, Short.MinValue)
+  val intData = Seq(0, 1, -1, Int.MaxValue, Int.MinValue)
+  val longData = Seq(0.toLong, 1.toLong, -1.toLong, Long.MaxValue, Long.MinValue)
+  val floatData = Seq(0.toFloat, 1.1.toFloat, -1.1.toFloat, Float.MaxValue, Float.MinValue)
+  val doubleData = Seq(0.toDouble, 1.1.toDouble, -1.1.toDouble, Double.MaxValue, Double.MinValue)
+
+  test("UnsafeArrayDataWriter write") {
+    val boolUnsafeArray = performUnsafeArrayWriter(booleanData.length, 1,
+      (writer: UnsafeArrayWriter) => booleanData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    booleanData.zipWithIndex.map { case (e, i) => assert(boolUnsafeArray.getBoolean(i) == e) }
+
+    val byteUnsafeArray = performUnsafeArrayWriter(byteData.length, 1,
+      (writer: UnsafeArrayWriter) => byteData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    byteData.zipWithIndex.map { case (e, i) => assert(byteUnsafeArray.getByte(i) == e) }
+
+    val shortUnsafeArray = performUnsafeArrayWriter(shortData.length, 2,
+      (writer: UnsafeArrayWriter) => shortData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    shortData.zipWithIndex.map { case (e, i) => assert(shortUnsafeArray.getShort(i) == e) }
+
+    val intUnsafeArray = performUnsafeArrayWriter(intData.length, 4,
+      (writer: UnsafeArrayWriter) => intData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    intData.zipWithIndex.map { case (e, i) => assert(intUnsafeArray.getInt(i) == e) }
+
+    val longUnsafeArray = performUnsafeArrayWriter(longData.length, 8,
+      (writer: UnsafeArrayWriter) => longData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    longData.zipWithIndex.map { case (e, i) => assert(longUnsafeArray.getLong(i) == e) }
+
+    val floatUnsafeArray = performUnsafeArrayWriter(floatData.length, 8,
+      (writer: UnsafeArrayWriter) => floatData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    floatData.zipWithIndex.map { case (e, i) => assert(floatUnsafeArray.getFloat(i) == e) }
+
+    val doubleUnsafeArray = performUnsafeArrayWriter(doubleData.length, 8,
+      (writer: UnsafeArrayWriter) => doubleData.zipWithIndex.map {
+        case (e, i) => writer.write(i, e) })
+    doubleData.zipWithIndex.map { case (e, i) => assert(doubleUnsafeArray.getDouble(i) == e) }
+  }
+
+  test("toPrimitiveArray") {
+    val booleanUnsafeArray = initializeUnsafeArrayData(booleanData, 1)
+    booleanUnsafeArray.toBooleanArray().
+      zipWithIndex.map { case (e, i) => assert(e == booleanData(i)) }
+
+    val byteUnsafeArray = initializeUnsafeArrayData(byteData, 1)
+    byteUnsafeArray.toByteArray().zipWithIndex.map { case (e, i) => assert(e == byteData(i)) }
+
+    val shortUnsafeArray = initializeUnsafeArrayData(shortData, 2)
+    shortUnsafeArray.toShortArray().zipWithIndex.map { case (e, i) => assert(e == shortData(i)) }
+
+    val intUnsafeArray = initializeUnsafeArrayData(intData, 4)
+    intUnsafeArray.toIntArray().zipWithIndex.map { case (e, i) => assert(e == intData(i)) }
+
+    val longUnsafeArray = initializeUnsafeArrayData(longData, 8)
+    longUnsafeArray.toLongArray().zipWithIndex.map { case (e, i) => assert(e == longData(i)) }
+
+    val floatUnsafeArray = initializeUnsafeArrayData(floatData, 4)
+    floatUnsafeArray.toFloatArray().zipWithIndex.map { case (e, i) => assert(e == floatData(i)) }
+
+    val doubleUnsafeArray = initializeUnsafeArrayData(doubleData, 8)
+    doubleUnsafeArray.toDoubleArray().
+      zipWithIndex.map { case (e, i) => assert(e == doubleData(i)) }
+  }
+
+  test("fromPrimitiveArray") {
+    // uncomment this if SPARK-15962 is merged
+/*
+    val booleanArray = booleanData.toArray
+    val booleanUnsafeArray = UnsafeArrayData.fromPrimitiveArray(booleanArray)
+    booleanArray.zipWithIndex.map { case (e, i) => assert(booleanUnsafeArray.getBoolean(i) == e) }
+
+    val byteArray = byteData.toArray
+    val byteUnsafeArray = UnsafeArrayData.fromPrimitiveArray(byteArray)
+    byteArray.zipWithIndex.map { case (e, i) => assert(byteUnsafeArray.getByte(i) == e) }
+
+    val shortArray = shortData.toArray
+    val shortUnsafeArray = UnsafeArrayData.fromPrimitiveArray(shortArray)
+    shortArray.zipWithIndex.map { case (e, i) => assert(shortUnsafeArray.getShort(i) == e) }
+*/
+    val intArray = intData.toArray
+    val intUnsafeArray = UnsafeArrayData.fromPrimitiveArray(intArray)
+    intArray.zipWithIndex.map { case (e, i) => assert(intUnsafeArray.getInt(i) == e) }
+
+/*
+    val longArray = longData.toArray
+    val longUnsafeArray = UnsafeArrayData.fromPrimitiveArray(longArray)
+    longArray.zipWithIndex.map { case (e, i) => assert(longUnsafeArray.getLong(i) == e) }
+
+    val floatArray = floatData.toArray
+    val floatUnsafeArray = UnsafeArrayData.fromPrimitiveArray(floatArray)
+    floatArray.zipWithIndex.map { case (e, i) => assert(floatUnsafeArray.getFloat(i) == e) }
+*/
+    val doubleArray = doubleData.toArray
+    val doubleUnsafeArray = UnsafeArrayData.fromPrimitiveArray(doubleArray)
+    doubleArray.zipWithIndex.map { case (e, i) => assert(doubleUnsafeArray.getDouble(i) == e) }
+  }
+
+  test("writePrimitiveArray") {
+    val booleanArray = booleanData.toArray
+    val booleanUnsafeArray = performUnsafeArrayWriter(booleanArray.length, 4,
+      (writer: UnsafeArrayWriter) =>
+        writer.writePrimitiveBooleanArray(new GenericArrayData(booleanArray)))
+    booleanArray.zipWithIndex.map { case (e, i) => assert(booleanUnsafeArray.getBoolean(i) == e) }
+
+    val byteArray = byteData.toArray
+    val byteUnsafeArray = performUnsafeArrayWriter(byteArray.length, 4,
+      (writer: UnsafeArrayWriter) =>
+        writer.writePrimitiveByteArray(new GenericArrayData(byteArray)))
+    byteArray.zipWithIndex.map { case (e, i) => assert(byteUnsafeArray.getByte(i) == e) }
+
+    val shortArray = shortData.toArray
+    val shortUnsafeArray = performUnsafeArrayWriter(shortArray.length, 4,
+      (writer: UnsafeArrayWriter) =>
+        writer.writePrimitiveShortArray(new GenericArrayData(shortArray)))
+    shortArray.zipWithIndex.map { case (e, i) => assert(shortUnsafeArray.getShort(i) == e) }
+
+    val intArray = intData.toArray
+    val intUnsafeArray = performUnsafeArrayWriter(intArray.length, 4,
+      (writer: UnsafeArrayWriter) => writer.writePrimitiveIntArray(new GenericArrayData(intArray)))
+    intArray.zipWithIndex.map { case (e, i) => assert(intUnsafeArray.getInt(i) == e) }
+
+    val longArray = longData.toArray
+    val longUnsafeArray = performUnsafeArrayWriter(longArray.length, 8,
+      (writer: UnsafeArrayWriter) =>
+        writer.writePrimitiveLongArray(new GenericArrayData(longArray)))
+    longArray.zipWithIndex.map { case (e, i) => assert(longUnsafeArray.getLong(i) == e) }
+
+    val floatArray = floatData.toArray
+    val floatUnsafeArray = performUnsafeArrayWriter(floatArray.length, 4,
+      (writer: UnsafeArrayWriter) =>
+        writer.writePrimitiveFloatArray(new GenericArrayData(floatArray)))
+    floatArray.zipWithIndex.map { case (e, i) => assert(floatUnsafeArray.getFloat(i) == e) }
+
+    val doubleArray = doubleData.toArray
+    val doubleUnsafeArray = performUnsafeArrayWriter(doubleArray.length, 8,
+      (writer: UnsafeArrayWriter) =>
+        writer.writePrimitiveDoubleArray(new GenericArrayData(doubleArray)))
+    doubleArray.zipWithIndex.map { case (e, i) => assert(doubleUnsafeArray.getDouble(i) == e) }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
@@ -60,18 +60,11 @@ class BufferHolderSuite extends SparkFunSuite {
   UnsafeArrayData = {
     val length = data.length
     val unsafeArray = new UnsafeArrayData
-    // uncomment this if SPARK-15962 is merged
-    // val headerSize = calculateHeaderPortionInBytes(length)
-    val headerSize = 4 + 4 * length
+    val headerSize = UnsafeArrayData.calculateHeaderPortionInBytes(length)
     val size = headerSize + elementSize * length
     val buffer = new Array[Byte](size)
     Platform.putInt(buffer, Platform.BYTE_ARRAY_OFFSET, length)
     unsafeArray.pointTo(buffer, Platform.BYTE_ARRAY_OFFSET, size)
-    // remove this if SPARK-15962 is merged
-    (0 until length).map(ordinal =>
-      Platform.putInt(buffer, Platform.BYTE_ARRAY_OFFSET + 4 + ordinal * 4,
-        headerSize + ordinal * elementSize)
-    )
     assert(unsafeArray.numElements == length)
     data.zipWithIndex.map { case (e, i) =>
       val offset = Platform.BYTE_ARRAY_OFFSET + headerSize + elementSize * i
@@ -160,8 +153,6 @@ class BufferHolderSuite extends SparkFunSuite {
   }
 
   test("fromPrimitiveArray") {
-    // uncomment this if SPARK-15962 is merged
-/*
     val booleanArray = booleanData.toArray
     val booleanUnsafeArray = UnsafeArrayData.fromPrimitiveArray(booleanArray)
     booleanArray.zipWithIndex.map { case (e, i) => assert(booleanUnsafeArray.getBoolean(i) == e) }
@@ -173,12 +164,11 @@ class BufferHolderSuite extends SparkFunSuite {
     val shortArray = shortData.toArray
     val shortUnsafeArray = UnsafeArrayData.fromPrimitiveArray(shortArray)
     shortArray.zipWithIndex.map { case (e, i) => assert(shortUnsafeArray.getShort(i) == e) }
-*/
+
     val intArray = intData.toArray
     val intUnsafeArray = UnsafeArrayData.fromPrimitiveArray(intArray)
     intArray.zipWithIndex.map { case (e, i) => assert(intUnsafeArray.getInt(i) == e) }
 
-/*
     val longArray = longData.toArray
     val longUnsafeArray = UnsafeArrayData.fromPrimitiveArray(longArray)
     longArray.zipWithIndex.map { case (e, i) => assert(longUnsafeArray.getLong(i) == e) }
@@ -186,7 +176,7 @@ class BufferHolderSuite extends SparkFunSuite {
     val floatArray = floatData.toArray
     val floatUnsafeArray = UnsafeArrayData.fromPrimitiveArray(floatArray)
     floatArray.zipWithIndex.map { case (e, i) => assert(floatUnsafeArray.getFloat(i) == e) }
-*/
+
     val doubleArray = doubleData.toArray
     val doubleUnsafeArray = UnsafeArrayData.fromPrimitiveArray(doubleArray)
     doubleArray.zipWithIndex.map { case (e, i) => assert(doubleUnsafeArray.getDouble(i) == e) }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -27,6 +27,25 @@ import org.apache.spark.sql.test.SharedSQLContext
 class DataFrameComplexTypeSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
 
+  test("primitive type on array") {
+    val rows = sparkContext.parallelize(Seq(1, 2), 1).toDF("v").
+      selectExpr("Array(v + 2, v + 3)")
+    checkAnswer(rows, Seq(Row(Array(3, 4)), Row(Array(4, 5))))
+  }
+
+  test("primitive type and null on array") {
+    val rows = sparkContext.parallelize(Seq(1, 2), 1).toDF("v").
+      selectExpr("Array(v + 2, null, v + 3)")
+    checkAnswer(rows, Seq(Row(Array(3, null, 4)), Row(Array(4, null, 5))))
+  }
+
+  test("array with null on array") {
+    val rows = sparkContext.parallelize(Seq(1, 2), 1).toDF("v").
+      selectExpr("Array(Array(v, v + 1)," +
+                 "null," +
+                 "Array(v, v - 1))").collect
+  }
+
   test("UDF on struct") {
     val f = udf((a: String) => a)
     val df = sparkContext.parallelize(Seq((1, 1))).toDF("a", "b")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR optimize generate code of projection for an primitive type array. While we know primitive type array does not require null check and has contigious data region, current generated code performs null checks and performs copy for each element (at Lines 075-082 at Generated code before applying this PR)
1. Eliminate null checks for each array element
2. Perform bulk data copy by using `Platform.copy`
3. Eliminate primitive array allocation in `GenericArrayData` when https://github.com/apache/spark/pull/13758 is merged
4. Eliminate setting sparse index for `UnsafeArrayData` when https://github.com/apache/spark/pull/13680 is merged

They are done in a [helper method](https://github.com/apache/spark/pull/13911/files#diff-85658ffc242280699a331c90530f54baR271) `UnsafeArrayWrite.writePrimitive<PrimitiveType>Array()` (at Line 075 at Generated code after applying this PR).

For now, 3 and 4 are not currently enabled. But, code are ready.

Benchmark program

``` java
  def writeArray(iters: Int): Unit = {
    import sparkSession.implicits._

    val iters = 5
    val n = 1024 * 1024
    val rows = 15

    val benchmark = new Benchmark("Read primitive array", n)

    val intDF = sparkSession.sparkContext.parallelize(0 until rows, 1)
      .map(i => Array.tabulate(n)(i => i)).toDF()
    intDF.count() // force to create df

    benchmark.addCase(s"Write int array in DataFrame", numIters = iters)(iter => {
      intDF.selectExpr("value as a").collect
    })

    val doubleDF = sparkSession.sparkContext.parallelize(0 until rows, 1)
      .map(i => Array.tabulate(n)(i => i.toDouble)).toDF()
    doubleDF.count() // force to create df

    benchmark.addCase(s"Write double array in DataFrame", numIters = iters)(iter => {
      doubleDF.selectExpr("value as a").collect
    })

    benchmark.run()
  }

  test("Write an array in DataFrame") {
    writeArray(1)
  }
```

An example program

``` java
val df = sparkContext.parallelize(Seq(0.0d, 1.0d), 1).toDF
df.selectExpr("Array(value + 1.1d, value + 2.2d)").collect
```

Generated code before applying this PR

``` java
/* 028 */   protected void processNext() throws java.io.IOException {
/* 029 */     while (inputadapter_input.hasNext()) {
/* 030 */       InternalRow inputadapter_row = (InternalRow) inputadapter_input.next();
/* 031 */       double inputadapter_value = inputadapter_row.getDouble(0);
/* 032 */
/* 033 */       final boolean project_isNull = false;
/* 034 */       this.project_values = new Object[2];
/* 035 */       double project_value1 = -1.0;
/* 036 */       project_value1 = inputadapter_value + 1.1D;
/* 037 */       if (false) {
/* 038 */         project_values[0] = null;
/* 039 */       } else {
/* 040 */         project_values[0] = project_value1;
/* 041 */       }
/* 042 */
/* 043 */       double project_value4 = -1.0;
/* 044 */       project_value4 = inputadapter_value + 2.2D;
/* 045 */       if (false) {
/* 046 */         project_values[1] = null;
/* 047 */       } else {
/* 048 */         project_values[1] = project_value4;
/* 049 */       }
/* 050 */
/* 051 */       final ArrayData project_value = new org.apache.spark.sql.catalyst.util.GenericArrayData(project_values);
/* 052 */       this.project_values = null;
/* 053 */       project_holder.reset();
/* 054 */
/* 055 */       project_rowWriter.zeroOutNullBytes();
/* 056 */
/* 057 */       if (project_isNull) {
/* 058 */         project_rowWriter.setNullAt(0);
/* 059 */       } else {
/* 060 */         // Remember the current cursor so that we can calculate how many bytes are
/* 061 */         // written later.
/* 062 */         final int project_tmpCursor = project_holder.cursor;
/* 063 */
/* 064 */         if (project_value instanceof UnsafeArrayData) {
/* 065 */           final int project_sizeInBytes = ((UnsafeArrayData) project_value).getSizeInBytes();
/* 066 */           // grow the global buffer before writing data.
/* 067 */           project_holder.grow(project_sizeInBytes);
/* 068 */           ((UnsafeArrayData) project_value).writeToMemory(project_holder.buffer, project_holder.cursor);
/* 069 */           project_holder.cursor += project_sizeInBytes;
/* 070 */
/* 071 */         } else {
/* 072 */           final int project_numElements = project_value.numElements();
/* 073 */           project_arrayWriter.initialize(project_holder, project_numElements, 8);
/* 074 */
/* 075 */           for (int project_index = 0; project_index < project_numElements; project_index++) {
/* 076 */             if (project_value.isNullAt(project_index)) {
/* 077 */               project_arrayWriter.setNullAt(project_index);
/* 078 */             } else {
/* 079 */               final double project_element = project_value.getDouble(project_index);
/* 080 */               project_arrayWriter.write(project_index, project_element);
/* 081 */             }
/* 082 */           }
/* 083 */
/* 084 */         }
/* 085 */
/* 086 */         project_rowWriter.setOffsetAndSize(0, project_tmpCursor, project_holder.cursor - project_tmpCursor);
/* 087 */         project_rowWriter.alignToWords(project_holder.cursor - project_tmpCursor);
/* 088 */       }
/* 089 */       project_result.setTotalSize(project_holder.totalSize());
/* 090 */       append(project_result);
/* 091 */       if (shouldStop()) return;
/* 092 */     }
/* 093 */   }
/* 094 */ }
```

Generated code after applying this PR

``` java
/* 028 */   protected void processNext() throws java.io.IOException {
/* 029 */     while (inputadapter_input.hasNext()) {
/* 030 */       InternalRow inputadapter_row = (InternalRow) inputadapter_input.next();
/* 031 */       double inputadapter_value = inputadapter_row.getDouble(0);
/* 032 */
/* 033 */       final boolean project_isNull = false;
/* 034 */       this.project_values = new Object[2];
/* 035 */       double project_value1 = -1.0;
/* 036 */       project_value1 = inputadapter_value + 1.1D;
/* 037 */       if (false) {
/* 038 */         project_values[0] = null;
/* 039 */       } else {
/* 040 */         project_values[0] = project_value1;
/* 041 */       }
/* 042 */
/* 043 */       double project_value4 = -1.0;
/* 044 */       project_value4 = inputadapter_value + 2.2D;
/* 045 */       if (false) {
/* 046 */         project_values[1] = null;
/* 047 */       } else {
/* 048 */         project_values[1] = project_value4;
/* 049 */       }
/* 050 */
/* 051 */       final ArrayData project_value = new org.apache.spark.sql.catalyst.util.GenericArrayData(project_values);
/* 052 */       this.project_values = null;
/* 053 */       project_holder.reset();
/* 054 */
/* 055 */       project_rowWriter.zeroOutNullBytes();
/* 056 */
/* 057 */       if (project_isNull) {
/* 058 */         project_rowWriter.setNullAt(0);
/* 059 */       } else {
/* 060 */         // Remember the current cursor so that we can calculate how many bytes are
/* 061 */         // written later.
/* 062 */         final int project_tmpCursor = project_holder.cursor;
/* 063 */
/* 064 */         if (project_value instanceof UnsafeArrayData) {
/* 065 */           final int project_sizeInBytes = ((UnsafeArrayData) project_value).getSizeInBytes();
/* 066 */           // grow the global buffer before writing data.
/* 067 */           project_holder.grow(project_sizeInBytes);
/* 068 */           ((UnsafeArrayData) project_value).writeToMemory(project_holder.buffer, project_holder.cursor);
/* 069 */           project_holder.cursor += project_sizeInBytes;
/* 070 */
/* 071 */         } else {
/* 072 */           final int project_numElements = project_value.numElements();
/* 073 */           project_arrayWriter.initialize(project_holder, project_numElements, 8);
/* 074 */
/* 075 */           project_arrayWriter.writePrimitiveDoubleArray(project_value);
/* 076 */         }
/* 077 */
/* 078 */         project_rowWriter.setOffsetAndSize(0, project_tmpCursor, project_holder.cursor - project_tmpCursor);
/* 079 */         project_rowWriter.alignToWords(project_holder.cursor - project_tmpCursor);
/* 080 */       }
/* 081 */       project_result.setTotalSize(project_holder.totalSize());
/* 082 */       append(project_result);
/* 083 */       if (shouldStop()) return;
/* 084 */     }
/* 085 */   }
```
## How was this patch tested?

Added test suites into `DataFrameComplexTypeSuite`
