### PR TITLE
[SPARK-16081][BUILD] Disallow using `l` as variable name

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -122,7 +122,7 @@ private[python] class JavaToWritableConverter extends Converter[Any, Writable] {
     obj match {
       case i: java.lang.Integer => new IntWritable(i)
       case d: java.lang.Double => new DoubleWritable(d)
-      case v: java.lang.Long => new LongWritable(v)
+      case i: java.lang.Long => new LongWritable(i)
       case f: java.lang.Float => new FloatWritable(f)
       case s: java.lang.String => new Text(s)
       case b: java.lang.Boolean => new BooleanWritable(b)

--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -122,7 +122,7 @@ private[python] class JavaToWritableConverter extends Converter[Any, Writable] {
     obj match {
       case i: java.lang.Integer => new IntWritable(i)
       case d: java.lang.Double => new DoubleWritable(d)
-      case l: java.lang.Long => new LongWritable(l)
+      case v: java.lang.Long => new LongWritable(v)
       case f: java.lang.Float => new FloatWritable(f)
       case s: java.lang.String => new Text(s)
       case b: java.lang.Boolean => new BooleanWritable(b)

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -88,7 +88,7 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
     val rddToFilter: RDD[P] = self.partitioner match {
       case Some(rp: RangePartitioner[K, V]) =>
         val partitionIndicies = (rp.getPartition(lower), rp.getPartition(upper)) match {
-          case (l, u) => Math.min(l, u) to Math.max(l, u)
+          case (lo, up) => Math.min(lo, up) to Math.max(lo, up)
         }
         PartitionPruningRDD.create(self, partitionIndicies.contains)
       case _ =>

--- a/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
@@ -297,7 +297,7 @@ private[spark] object SerializationDebugger extends Logging {
     override def writeBoolean(b: Boolean): Unit = {}
     override def writeBytes(s: String): Unit = {}
     override def writeChar(i: Int): Unit = {}
-    override def writeLong(l: Long): Unit = {}
+    override def writeLong(v: Long): Unit = {}
     override def writeByte(i: Int): Unit = {}
   }
 

--- a/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
@@ -297,7 +297,7 @@ private[spark] object SerializationDebugger extends Logging {
     override def writeBoolean(b: Boolean): Unit = {}
     override def writeBytes(s: String): Unit = {}
     override def writeChar(i: Int): Unit = {}
-    override def writeLong(v: Long): Unit = {}
+    override def writeLong(i: Long): Unit = {}
     override def writeByte(i: Int): Unit = {}
   }
 

--- a/core/src/main/scala/org/apache/spark/util/CollectionsUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/CollectionsUtils.scala
@@ -26,22 +26,25 @@ private[spark] object CollectionsUtils {
     // For primitive keys, we can use the natural ordering. Otherwise, use the Ordering comparator.
     classTag[K] match {
       case ClassTag.Float =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Float]], x.asInstanceOf[Float])
+        (list, x) =>
+          util.Arrays.binarySearch(list.asInstanceOf[Array[Float]], x.asInstanceOf[Float])
       case ClassTag.Double =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Double]], x.asInstanceOf[Double])
+        (list, x) =>
+          util.Arrays.binarySearch(list.asInstanceOf[Array[Double]], x.asInstanceOf[Double])
       case ClassTag.Byte =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Byte]], x.asInstanceOf[Byte])
+        (list, x) => util.Arrays.binarySearch(list.asInstanceOf[Array[Byte]], x.asInstanceOf[Byte])
       case ClassTag.Char =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Char]], x.asInstanceOf[Char])
+        (list, x) => util.Arrays.binarySearch(list.asInstanceOf[Array[Char]], x.asInstanceOf[Char])
       case ClassTag.Short =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Short]], x.asInstanceOf[Short])
+        (list, x) =>
+          util.Arrays.binarySearch(list.asInstanceOf[Array[Short]], x.asInstanceOf[Short])
       case ClassTag.Int =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Int]], x.asInstanceOf[Int])
+        (list, x) => util.Arrays.binarySearch(list.asInstanceOf[Array[Int]], x.asInstanceOf[Int])
       case ClassTag.Long =>
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[Long]], x.asInstanceOf[Long])
+        (list, x) => util.Arrays.binarySearch(list.asInstanceOf[Array[Long]], x.asInstanceOf[Long])
       case _ =>
         val comparator = implicitly[Ordering[K]].asInstanceOf[java.util.Comparator[Any]]
-        (l, x) => util.Arrays.binarySearch(l.asInstanceOf[Array[AnyRef]], x, comparator)
+        (list, x) => util.Arrays.binarySearch(list.asInstanceOf[Array[AnyRef]], x, comparator)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -664,7 +664,7 @@ private[spark] object JsonProtocol {
     val numTasks = (json \ "Number of Tasks").extract[Int]
     val rddInfos = (json \ "RDD Info").extract[List[JValue]].map(rddInfoFromJson)
     val parentIds = Utils.jsonOption(json \ "Parent IDs")
-      .map { ids => ids.extract[List[JValue]].map(_.extract[Int]) }
+      .map(_.extract[List[JValue]].map(_.extract[Int]))
       .getOrElse(Seq.empty)
     val details = (json \ "Details").extractOpt[String].getOrElse("")
     val submissionTime = Utils.jsonOption(json \ "Submission Time").map(_.extract[Long])
@@ -900,7 +900,7 @@ private[spark] object JsonProtocol {
       .map(RDDOperationScope.fromJson)
     val callsite = Utils.jsonOption(json \ "Callsite").map(_.extract[String]).getOrElse("")
     val parentIds = Utils.jsonOption(json \ "Parent IDs")
-      .map { ids => ids.extract[List[JValue]].map(_.extract[Int]) }
+      .map(_.extract[List[JValue]].map(_.extract[Int]))
       .getOrElse(Seq.empty)
     val storageLevel = storageLevelFromJson(json \ "Storage Level")
     val numPartitions = (json \ "Number of Partitions").extract[Int]

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -664,7 +664,7 @@ private[spark] object JsonProtocol {
     val numTasks = (json \ "Number of Tasks").extract[Int]
     val rddInfos = (json \ "RDD Info").extract[List[JValue]].map(rddInfoFromJson)
     val parentIds = Utils.jsonOption(json \ "Parent IDs")
-      .map { l => l.extract[List[JValue]].map(_.extract[Int]) }
+      .map { ids => ids.extract[List[JValue]].map(_.extract[Int]) }
       .getOrElse(Seq.empty)
     val details = (json \ "Details").extractOpt[String].getOrElse("")
     val submissionTime = Utils.jsonOption(json \ "Submission Time").map(_.extract[Long])
@@ -900,7 +900,7 @@ private[spark] object JsonProtocol {
       .map(RDDOperationScope.fromJson)
     val callsite = Utils.jsonOption(json \ "Callsite").map(_.extract[String]).getOrElse("")
     val parentIds = Utils.jsonOption(json \ "Parent IDs")
-      .map { l => l.extract[List[JValue]].map(_.extract[Int]) }
+      .map { ids => ids.extract[List[JValue]].map(_.extract[Int]) }
       .getOrElse(Seq.empty)
     val storageLevel = storageLevelFromJson(json \ "Storage Level")
     val numPartitions = (json \ "Number of Partitions").extract[Int]

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2095,8 +2095,8 @@ private[spark] object Utils extends Logging {
   /**
    * configure a new log4j level
    */
-  def setLogLevel(l: org.apache.log4j.Level) {
-    org.apache.log4j.Logger.getRootLogger().setLevel(l)
+  def setLogLevel(level: org.apache.log4j.Level) {
+    org.apache.log4j.Logger.getRootLogger().setLevel(level)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
@@ -32,7 +32,7 @@ private[spark] object Utils {
    */
   def takeOrdered[T](input: Iterator[T], num: Int)(implicit ord: Ordering[T]): Iterator[T] = {
     val ordering = new GuavaOrdering[T] {
-      override def compare(l: T, r: T): Int = ord.compare(l, r)
+      override def compare(left: T, right: T): Int = ord.compare(left, right)
     }
     ordering.leastOf(input.asJava, num).iterator.asScala
   }

--- a/core/src/main/scala/org/apache/spark/util/random/SamplingUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/SamplingUtils.scala
@@ -52,17 +52,17 @@ private[spark] object SamplingUtils {
       (trimReservoir, i)
     } else {
       // If input size > k, continue the sampling process.
-      var l = i.toLong
+      var size = i.toLong
       val rand = new XORShiftRandom(seed)
       while (input.hasNext) {
         val item = input.next()
-        val replacementIndex = (rand.nextDouble() * l).toLong
+        val replacementIndex = (rand.nextDouble() * size).toLong
         if (replacementIndex < k) {
           reservoir(replacementIndex.toInt) = item
         }
-        l += 1
+        size += 1
       }
-      (reservoir, l)
+      (reservoir, size)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -348,7 +348,7 @@ class TestCreateNullValue {
     val b: Byte = 1
     val s: Short = 1
     val i: Int = 1
-    val v: Long = 1
+    val long: Long = 1
     val f: Float = 1
     val d: Double = 1
 
@@ -363,7 +363,7 @@ class TestCreateNullValue {
         println(b)
         println(s)
         println(i)
-        println(v)
+        println(long)
         println(f)
         println(d)
       }

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -348,7 +348,7 @@ class TestCreateNullValue {
     val b: Byte = 1
     val s: Short = 1
     val i: Int = 1
-    val l: Long = 1
+    val v: Long = 1
     val f: Float = 1
     val d: Double = 1
 
@@ -363,7 +363,7 @@ class TestCreateNullValue {
         println(b)
         println(s)
         println(i)
-        println(l)
+        println(v)
         println(f)
         println(d)
       }

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite2.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite2.scala
@@ -415,9 +415,9 @@ class ClosureCleanerSuite2 extends SparkFunSuite with BeforeAndAfterAll with Pri
         (1 to x).map { y => y + localValue } // 2 levels
       }
     }
-    val closure3 = (k: Int, l: Int, m: Int) => {
+    val closure3 = (k: Int, v: Int, m: Int) => {
       (1 to k).flatMap(closure2) ++ // 4 levels
-      (1 to l).flatMap(closure1) ++ // 3 levels
+      (1 to v).flatMap(closure1) ++ // 3 levels
       (1 to m).map { x => x + 1 } // 2 levels
     }
     val closure1r = closure1(1)
@@ -443,7 +443,7 @@ class ClosureCleanerSuite2 extends SparkFunSuite with BeforeAndAfterAll with Pri
     val closure2 = (j: Int) => { (1 to j).map { x => x + someSerializableMethod() } }
     val closure4 = (k: Int) => { (1 to k).map { x => x + localSerializableMethod() } }
     // This closure references a local non-serializable value
-    val closure3 = (l: Int) => { (1 to l).map { x => localNonSerializableValue } }
+    val closure3 = (i: Int) => { (1 to i).map { x => localNonSerializableValue } }
     // This is non-serializable no matter how many levels we nest it
     val closure5 = (m: Int) => {
       (1 to m).foreach { x =>

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite2.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite2.scala
@@ -415,10 +415,10 @@ class ClosureCleanerSuite2 extends SparkFunSuite with BeforeAndAfterAll with Pri
         (1 to x).map { y => y + localValue } // 2 levels
       }
     }
-    val closure3 = (k: Int, v: Int, m: Int) => {
+    val closure3 = (k: Int, m: Int, n: Int) => {
       (1 to k).flatMap(closure2) ++ // 4 levels
-      (1 to v).flatMap(closure1) ++ // 3 levels
-      (1 to m).map { x => x + 1 } // 2 levels
+      (1 to m).flatMap(closure1) ++ // 3 levels
+      (1 to n).map { x => x + 1 } // 2 levels
     }
     val closure1r = closure1(1)
     val closure2r = closure2(2)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/IsotonicRegressionExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/IsotonicRegressionExample.scala
@@ -55,7 +55,9 @@ object IsotonicRegressionExample {
     }
 
     // Calculate mean squared error between predicted and real labels.
-    val meanSquaredError = predictionAndLabel.map { case (p, la) => math.pow((p - la), 2) }.mean()
+    val meanSquaredError = predictionAndLabel.map {
+      case (pred, label) => math.pow((pred - label), 2)
+    }.mean()
     println("Mean Squared Error = " + meanSquaredError)
 
     // Save and load model

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/IsotonicRegressionExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/IsotonicRegressionExample.scala
@@ -55,7 +55,7 @@ object IsotonicRegressionExample {
     }
 
     // Calculate mean squared error between predicted and real labels.
-    val meanSquaredError = predictionAndLabel.map { case (p, l) => math.pow((p - l), 2) }.mean()
+    val meanSquaredError = predictionAndLabel.map { case (p, la) => math.pow((p - la), 2) }.mean()
     println("Mean Squared Error = " + meanSquaredError)
 
     // Save and load model

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LinearRegression.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LinearRegression.scala
@@ -125,8 +125,8 @@ object LinearRegression {
     val prediction = model.predict(test.map(_.features))
     val predictionAndLabel = prediction.zip(test.map(_.label))
 
-    val loss = predictionAndLabel.map { case (p, la) =>
-      val err = p - la
+    val loss = predictionAndLabel.map { case (pred, label) =>
+      val err = pred - label
       err * err
     }.reduce(_ + _)
     val rmse = math.sqrt(loss / numTest)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LinearRegression.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LinearRegression.scala
@@ -125,8 +125,8 @@ object LinearRegression {
     val prediction = model.predict(test.map(_.features))
     val predictionAndLabel = prediction.zip(test.map(_.label))
 
-    val loss = predictionAndLabel.map { case (p, l) =>
-      val err = p - l
+    val loss = predictionAndLabel.map { case (p, la) =>
+      val err = p - la
       err * err
     }.reduce(_ + _)
     val rmse = math.sqrt(loss / numTest)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/MulticlassMetricsExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/MulticlassMetricsExample.scala
@@ -65,23 +65,23 @@ object MulticlassMetricsExample {
 
     // Precision by label
     val labels = metrics.labels
-    labels.foreach { l =>
-      println(s"Precision($l) = " + metrics.precision(l))
+    labels.foreach { label =>
+      println(s"Precision($label) = " + metrics.precision(label))
     }
 
     // Recall by label
-    labels.foreach { l =>
-      println(s"Recall($l) = " + metrics.recall(l))
+    labels.foreach { label =>
+      println(s"Recall($label) = " + metrics.recall(label))
     }
 
     // False positive rate by label
-    labels.foreach { l =>
-      println(s"FPR($l) = " + metrics.falsePositiveRate(l))
+    labels.foreach { label =>
+      println(s"FPR($label) = " + metrics.falsePositiveRate(label))
     }
 
     // F-measure by label
-    labels.foreach { l =>
-      println(s"F1-Score($l) = " + metrics.fMeasure(l))
+    labels.foreach { label =>
+      println(s"F1-Score($label) = " + metrics.fMeasure(label))
     }
 
     // Weighted stats

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaCluster.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaCluster.scala
@@ -94,8 +94,8 @@ class KafkaCluster(val kafkaParams: Map[String, String]) extends Serializable {
         tm.partitionsMetadata.flatMap { pm: PartitionMetadata =>
           val tp = TopicAndPartition(tm.topic, pm.partitionId)
           if (topicAndPartitions(tp)) {
-            pm.leader.map { l =>
-              tp -> (l.host -> l.port)
+            pm.leader.map { leader =>
+              tp -> (leader.host -> leader.port)
             }
           } else {
             None

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -200,7 +200,7 @@ private[ml] object WeightedLeastSquares {
      * Adds an instance.
      */
     def add(instance: Instance): this.type = {
-      val Instance(l, w, f) = instance
+      val Instance(label, w, f) = instance
       val ak = f.size
       if (!initialized) {
         init(ak)
@@ -209,10 +209,10 @@ private[ml] object WeightedLeastSquares {
       count += 1L
       wSum += w
       wwSum += w * w
-      bSum += w * l
-      bbSum += w * l * l
+      bSum += w * label
+      bbSum += w * label * label
       BLAS.axpy(w, f, aSum)
-      BLAS.axpy(w * l, f, abSum)
+      BLAS.axpy(w * label, f, abSum)
       BLAS.spr(w, f, aaSum)
       this
     }
@@ -294,9 +294,9 @@ private[ml] object WeightedLeastSquares {
       var j = 2
       val aaValues = aaSum.values
       while (i < triK) {
-        val l = j - 2
-        val aw = aSum(l) / wSum
-        variance(l) = aaValues(i) / wSum - aw * aw
+        val k = j - 2
+        val aw = aSum(k) / wSum
+        variance(k) = aaValues(i) / wSum - aw * aw
         i += j
         j += 1
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -200,20 +200,20 @@ private[ml] object WeightedLeastSquares {
      * Adds an instance.
      */
     def add(instance: Instance): this.type = {
-      val Instance(label, w, f) = instance
-      val ak = f.size
+      val Instance(label, weight, feature) = instance
+      val ak = feature.size
       if (!initialized) {
         init(ak)
       }
       assert(ak == k, s"Dimension mismatch. Expect vectors of size $k but got $ak.")
       count += 1L
-      wSum += w
-      wwSum += w * w
-      bSum += w * label
-      bbSum += w * label * label
-      BLAS.axpy(w, f, aSum)
-      BLAS.axpy(w * label, f, abSum)
-      BLAS.spr(w, f, aaSum)
+      wSum += weight
+      wwSum += weight * weight
+      bSum += weight * label
+      bbSum += weight * label * label
+      BLAS.axpy(weight, feature, aSum)
+      BLAS.axpy(weight * label, feature, abSum)
+      BLAS.spr(weight, feature, aaSum)
       this
     }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -155,7 +155,7 @@ object HashingTF {
       case b: Byte => hashInt(b, seed)
       case s: Short => hashInt(s, seed)
       case i: Int => hashInt(i, seed)
-      case l: Long => hashLong(l, seed)
+      case v: Long => hashLong(v, seed)
       case f: Float => hashInt(java.lang.Float.floatToIntBits(f), seed)
       case d: Double => hashLong(java.lang.Double.doubleToLongBits(d), seed)
       case s: String =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -155,7 +155,7 @@ object HashingTF {
       case b: Byte => hashInt(b, seed)
       case s: Short => hashInt(s, seed)
       case i: Int => hashInt(i, seed)
-      case v: Long => hashLong(v, seed)
+      case i: Long => hashLong(i, seed)
       case f: Float => hashInt(java.lang.Float.floatToIntBits(f), seed)
       case d: Double => hashLong(java.lang.Double.doubleToLongBits(d), seed)
       case s: String =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -616,14 +616,14 @@ class RowMatrix @Since("1.0.0") (
               val i = indices(k)
               val iVal = scaled(k)
               if (iVal != 0 && rand.nextDouble() < p(i)) {
-                var l = k + 1
-                while (l < nnz) {
-                  val j = indices(l)
-                  val jVal = scaled(l)
+                var index = k + 1
+                while (index < nnz) {
+                  val j = indices(index)
+                  val jVal = scaled(index)
                   if (jVal != 0 && rand.nextDouble() < p(j)) {
                     buf += (((i, j), iVal * jVal))
                   }
-                  l += 1
+                  index += 1
                 }
               }
               buf

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/GradientDescent.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/GradientDescent.scala
@@ -241,8 +241,8 @@ object GradientDescent extends Logging {
         .treeAggregate((BDV.zeros[Double](n), 0.0, 0L))(
           seqOp = (c, v) => {
             // c: (grad, loss, count), v: (label, features)
-            val l = gradient.compute(v._2, v._1, bcWeights.value, Vectors.fromBreeze(c._1))
-            (c._1, c._2 + l, c._3 + 1)
+            val loss = gradient.compute(v._2, v._1, bcWeights.value, Vectors.fromBreeze(c._1))
+            (c._1, c._2 + loss, c._3 + 1)
           },
           combOp = (c1, c2) => {
             // c: (grad, loss, count)

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -242,9 +242,8 @@ object LBFGS extends Logging {
 
       val (gradientSum, lossSum) = data.treeAggregate((Vectors.zeros(n), 0.0))(
           seqOp = (c, v) => (c, v) match { case ((grad, loss), (label, features)) =>
-            val l = localGradient.compute(
-              features, label, bcW.value, grad)
-            (grad, loss + l)
+            val localLoss = localGradient.compute(features, label, bcW.value, grad)
+            (grad, loss + localLoss)
           },
           combOp = (c1, c2) => (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>
             axpy(1.0, grad2, grad1)

--- a/mllib/src/test/scala/org/apache/spark/ml/ann/ANNSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/ann/ANNSuite.scala
@@ -49,8 +49,8 @@ class ANNSuite extends SparkFunSuite with MLlibTestSparkContext {
     val predictionAndLabels = rddData.map { case (input, label) =>
       (model.predict(input)(0), label(0))
     }.collect()
-    predictionAndLabels.foreach { case (p, l) =>
-      assert(math.round(p) === l)
+    predictionAndLabels.foreach { case (p, label) =>
+      assert(math.round(p) === label)
     }
   }
 
@@ -84,8 +84,8 @@ class ANNSuite extends SparkFunSuite with MLlibTestSparkContext {
     val predictionAndLabels = rddData.map { case (input, label) =>
       (model.predict(input), label)
     }.collect()
-    predictionAndLabels.foreach { case (p, l) =>
-      assert(p ~== l absTol 0.5)
+    predictionAndLabels.foreach { case (p, label) =>
+      assert(p ~== label absTol 0.5)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/ann/ANNSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/ann/ANNSuite.scala
@@ -49,8 +49,8 @@ class ANNSuite extends SparkFunSuite with MLlibTestSparkContext {
     val predictionAndLabels = rddData.map { case (input, label) =>
       (model.predict(input)(0), label(0))
     }.collect()
-    predictionAndLabels.foreach { case (p, label) =>
-      assert(math.round(p) === label)
+    predictionAndLabels.foreach { case (pred, label) =>
+      assert(math.round(pred) === label)
     }
   }
 
@@ -84,8 +84,8 @@ class ANNSuite extends SparkFunSuite with MLlibTestSparkContext {
     val predictionAndLabels = rddData.map { case (input, label) =>
       (model.predict(input), label)
     }.collect()
-    predictionAndLabels.foreach { case (p, label) =>
-      assert(p ~== label absTol 0.5)
+    predictionAndLabels.foreach { case (pred, label) =>
+      assert(pred ~== label absTol 0.5)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -74,8 +74,8 @@ class MultilayerPerceptronClassifierSuite
     val model = trainer.fit(dataset)
     val result = model.transform(dataset)
     val predictionAndLabels = result.select("prediction", "label").collect()
-    predictionAndLabels.foreach { case Row(p: Double, l: Double) =>
-      assert(p == l)
+    predictionAndLabels.foreach { case Row(p: Double, label: Double) =>
+      assert(p == label)
     }
   }
 
@@ -129,7 +129,7 @@ class MultilayerPerceptronClassifierSuite
     val numFeatures = dataFrame.select("features").first().getAs[Vector](0).size
     assert(model.numFeatures === numFeatures)
     val mlpPredictionAndLabels = model.transform(dataFrame).select("prediction", "label").rdd.map {
-      case Row(p: Double, l: Double) => (p, l)
+      case Row(p: Double, label: Double) => (p, label)
     }
     // train multinomial logistic regression
     val lr = new LogisticRegressionWithLBFGS()

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -74,8 +74,8 @@ class MultilayerPerceptronClassifierSuite
     val model = trainer.fit(dataset)
     val result = model.transform(dataset)
     val predictionAndLabels = result.select("prediction", "label").collect()
-    predictionAndLabels.foreach { case Row(p: Double, label: Double) =>
-      assert(p == label)
+    predictionAndLabels.foreach { case Row(pred: Double, label: Double) =>
+      assert(pred == label)
     }
   }
 
@@ -129,7 +129,7 @@ class MultilayerPerceptronClassifierSuite
     val numFeatures = dataFrame.select("features").first().getAs[Vector](0).size
     assert(model.numFeatures === numFeatures)
     val mlpPredictionAndLabels = model.transform(dataFrame).select("prediction", "label").rdd.map {
-      case Row(p: Double, label: Double) => (p, label)
+      case Row(pred: Double, label: Double) => (pred, label)
     }
     // train multinomial logistic regression
     val lr = new LogisticRegressionWithLBFGS()

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -210,9 +210,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
   /////////////////////////////////////////////////////////////////////////////
 
   test("extract categories from a number for multiclass classification") {
-    val l = RandomForest.extractMultiClassCategories(13, 10)
-    assert(l.length === 3)
-    assert(Seq(3.0, 2.0, 0.0) === l)
+    val categories = RandomForest.extractMultiClassCategories(13, 10)
+    assert(categories.length === 3)
+    assert(Seq(3.0, 2.0, 0.0) === categories)
   }
 
   test("Avoid aggregation on the last level") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/rdd/RDDFunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/rdd/RDDFunctionsSuite.scala
@@ -31,7 +31,7 @@ class RDDFunctionsSuite extends SparkFunSuite with MLlibTestSparkContext {
         for (step <- 1 to 3) {
           val sliding = rdd.sliding(windowSize, step).collect().map(_.toList).toList
           val expected = data.sliding(windowSize, step)
-            .map(_.toList).toList.filter(l => l.size == windowSize)
+            .map(_.toList).toList.filter(list => list.size == windowSize)
           assert(sliding === expected)
         }
       }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -250,6 +250,14 @@ This file is divided into 3 sections:
     <customMessage>Omit braces in case clauses.</customMessage>
   </check>
 
+  <!-- SPARK-16081: Disallow using "l" as variable name -->
+  <check customId="DisallowMisleadingVariableName"  level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+    <parameters>
+      <parameter name="regex">^l$</parameter>
+    </parameters>
+    <customMessage>Disallow misleading variable names like `l`</customMessage>
+  </check>
+
   <!-- ================================================================================ -->
   <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
   <!-- ================================================================================ -->

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -43,7 +43,7 @@ class AnalysisException protected[sql] (
   }
 
   override def getMessage: String = {
-    val lineAnnotation = line.map(l => s" line $l").getOrElse("")
+    val lineAnnotation = line.map(li => s" line $li").getOrElse("")
     val positionAnnotation = startPosition.map(p => s" pos $p").getOrElse("")
     s"$message;$lineAnnotation$positionAnnotation"
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -43,7 +43,7 @@ class AnalysisException protected[sql] (
   }
 
   override def getMessage: String = {
-    val lineAnnotation = line.map(li => s" line $li").getOrElse("")
+    val lineAnnotation = line.map(" line " + _).getOrElse("")
     val positionAnnotation = startPosition.map(p => s" pos $p").getOrElse("")
     s"$message;$lineAnnotation$positionAnnotation"
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -82,9 +82,9 @@ trait CheckAnalysis extends PredicateHelper {
 
           case w @ WindowExpression(_: OffsetWindowFunction, WindowSpecDefinition(_, order,
                SpecifiedWindowFrame(frame,
-                 FrameBoundary(l),
-                 FrameBoundary(h))))
-             if order.isEmpty || frame != RowFrame || l != h =>
+                 FrameBoundary(start),
+                 FrameBoundary(end))))
+             if order.isEmpty || frame != RowFrame || start != end =>
             failAnalysis("An offset window function can only be evaluated in an ordered " +
               s"row-based window frame with a single offset: $w")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -501,17 +501,17 @@ object TypeCoercion {
           case None => g
         }
 
-      case l @ Least(children) if !haveSameType(children) =>
+      case le @ Least(children) if !haveSameType(children) =>
         val types = children.map(_.dataType)
         findTightestCommonType(types) match {
           case Some(finalDataType) => Least(children.map(Cast(_, finalDataType)))
-          case None => l
+          case None => le
         }
 
-      case NaNvl(l, r) if l.dataType == DoubleType && r.dataType == FloatType =>
-        NaNvl(l, Cast(r, DoubleType))
-      case NaNvl(l, r) if l.dataType == FloatType && r.dataType == DoubleType =>
-        NaNvl(Cast(l, DoubleType), r)
+      case NaNvl(left, right) if left.dataType == DoubleType && right.dataType == FloatType =>
+        NaNvl(left, Cast(right, DoubleType))
+      case NaNvl(left, right) if left.dataType == FloatType && right.dataType == DoubleType =>
+        NaNvl(Cast(left, DoubleType), right)
 
       case e: RuntimeReplaceable => e.replaceForTypeCoercion()
     }
@@ -599,12 +599,12 @@ object TypeCoercion {
       // Skip nodes who's children have not been resolved yet.
       case e if !e.childrenResolved => e
 
-      case Add(l @ CalendarIntervalType(), r) if acceptedTypes.contains(r.dataType) =>
-        Cast(TimeAdd(r, l), r.dataType)
-      case Add(l, r @ CalendarIntervalType()) if acceptedTypes.contains(l.dataType) =>
-        Cast(TimeAdd(l, r), l.dataType)
-      case Subtract(l, r @ CalendarIntervalType()) if acceptedTypes.contains(l.dataType) =>
-        Cast(TimeSub(l, r), l.dataType)
+      case Add(left @ CalendarIntervalType(), right) if acceptedTypes.contains(right.dataType) =>
+        Cast(TimeAdd(right, left), right.dataType)
+      case Add(left, right @ CalendarIntervalType()) if acceptedTypes.contains(left.dataType) =>
+        Cast(TimeAdd(left, right), left.dataType)
+      case Subtract(left, right @ CalendarIntervalType()) if acceptedTypes.contains(left.dataType)
+        => Cast(TimeSub(left, right), left.dataType)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -124,7 +124,7 @@ package object dsl {
     implicit def byteToLiteral(b: Byte): Literal = Literal(b)
     implicit def shortToLiteral(s: Short): Literal = Literal(s)
     implicit def intToLiteral(i: Int): Literal = Literal(i)
-    implicit def longToLiteral(v: Long): Literal = Literal(v)
+    implicit def longToLiteral(i: Long): Literal = Literal(i)
     implicit def floatToLiteral(f: Float): Literal = Literal(f)
     implicit def doubleToLiteral(d: Double): Literal = Literal(d)
     implicit def stringToLiteral(s: String): Literal = Literal(s)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -124,7 +124,7 @@ package object dsl {
     implicit def byteToLiteral(b: Byte): Literal = Literal(b)
     implicit def shortToLiteral(s: Short): Literal = Literal(s)
     implicit def intToLiteral(i: Int): Literal = Literal(i)
-    implicit def longToLiteral(l: Long): Literal = Literal(l)
+    implicit def longToLiteral(v: Long): Literal = Literal(v)
     implicit def floatToLiteral(f: Float): Literal = Literal(f)
     implicit def doubleToLiteral(d: Double): Literal = Literal(d)
     implicit def stringToLiteral(s: String): Literal = Literal(s)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
@@ -59,26 +59,26 @@ object Canonicalize extends {
 
   /** Rearrange expressions that are commutative or associative. */
   private def expressionReorder(e: Expression): Expression = e match {
-    case a: Add => orderCommutative(a, { case Add(l, r) => Seq(l, r) }).reduce(Add)
-    case m: Multiply => orderCommutative(m, { case Multiply(l, r) => Seq(l, r) }).reduce(Multiply)
+    case a: Add => orderCommutative(a, { case Add(a, b) => Seq(a, b) }).reduce(Add)
+    case m: Multiply => orderCommutative(m, { case Multiply(a, b) => Seq(a, b) }).reduce(Multiply)
 
-    case EqualTo(l, r) if l.hashCode() > r.hashCode() => EqualTo(r, l)
-    case EqualNullSafe(l, r) if l.hashCode() > r.hashCode() => EqualNullSafe(r, l)
+    case EqualTo(a, b) if a.hashCode() > b.hashCode() => EqualTo(b, a)
+    case EqualNullSafe(a, b) if a.hashCode() > b.hashCode() => EqualNullSafe(b, a)
 
-    case GreaterThan(l, r) if l.hashCode() > r.hashCode() => LessThan(r, l)
-    case LessThan(l, r) if l.hashCode() > r.hashCode() => GreaterThan(r, l)
+    case GreaterThan(a, b) if a.hashCode() > b.hashCode() => LessThan(b, a)
+    case LessThan(a, b) if a.hashCode() > b.hashCode() => GreaterThan(b, a)
 
-    case GreaterThanOrEqual(l, r) if l.hashCode() > r.hashCode() => LessThanOrEqual(r, l)
-    case LessThanOrEqual(l, r) if l.hashCode() > r.hashCode() => GreaterThanOrEqual(r, l)
+    case GreaterThanOrEqual(a, b) if a.hashCode() > b.hashCode() => LessThanOrEqual(b, a)
+    case LessThanOrEqual(a, b) if a.hashCode() > b.hashCode() => GreaterThanOrEqual(b, a)
 
-    case Not(GreaterThan(l, r)) if l.hashCode() > r.hashCode() => GreaterThan(r, l)
-    case Not(GreaterThan(l, r)) => LessThanOrEqual(l, r)
-    case Not(LessThan(l, r)) if l.hashCode() > r.hashCode() => LessThan(r, l)
-    case Not(LessThan(l, r)) => GreaterThanOrEqual(l, r)
-    case Not(GreaterThanOrEqual(l, r)) if l.hashCode() > r.hashCode() => GreaterThanOrEqual(r, l)
-    case Not(GreaterThanOrEqual(l, r)) => LessThan(l, r)
-    case Not(LessThanOrEqual(l, r)) if l.hashCode() > r.hashCode() => LessThanOrEqual(r, l)
-    case Not(LessThanOrEqual(l, r)) => GreaterThan(l, r)
+    case Not(GreaterThan(a, b)) if a.hashCode() > b.hashCode() => GreaterThan(b, a)
+    case Not(GreaterThan(a, b)) => LessThanOrEqual(a, b)
+    case Not(LessThan(a, b)) if a.hashCode() > b.hashCode() => LessThan(b, a)
+    case Not(LessThan(a, b)) => GreaterThanOrEqual(a, b)
+    case Not(GreaterThanOrEqual(a, b)) if a.hashCode() > b.hashCode() => GreaterThanOrEqual(b, a)
+    case Not(GreaterThanOrEqual(a, b)) => LessThan(a, b)
+    case Not(LessThanOrEqual(a, b)) if a.hashCode() > b.hashCode() => LessThanOrEqual(b, a)
+    case Not(LessThanOrEqual(a, b)) => GreaterThan(a, b)
 
     case _ => e
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -184,7 +184,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0)
     case LongType =>
-      buildCast[Long](_, v => longToTimestamp(v))
+      buildCast[Long](_, i => longToTimestamp(i))
     case IntegerType =>
       buildCast[Int](_, i => longToTimestamp(i.toLong))
     case ShortType =>
@@ -664,7 +664,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 
   private[this] def decimalToTimestampCode(d: String): String =
     s"($d.toBigDecimal().bigDecimal().multiply(new java.math.BigDecimal(1000000L))).longValue()"
-  private[this] def longToTimeStampCode(v: String): String = s"$v * 1000000L"
+  private[this] def longToTimeStampCode(i: String): String = s"$i * 1000000L"
   private[this] def timestampToIntegerCode(ts: String): String =
     s"java.lang.Math.floor((double) $ts / 1000000L)"
   private[this] def timestampToDoubleCode(ts: String): String = s"$ts / 1000000.0"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -184,7 +184,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0)
     case LongType =>
-      buildCast[Long](_, l => longToTimestamp(l))
+      buildCast[Long](_, v => longToTimestamp(v))
     case IntegerType =>
       buildCast[Int](_, i => longToTimestamp(i.toLong))
     case ShortType =>
@@ -664,7 +664,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 
   private[this] def decimalToTimestampCode(d: String): String =
     s"($d.toBigDecimal().bigDecimal().multiply(new java.math.BigDecimal(1000000L))).longValue()"
-  private[this] def longToTimeStampCode(l: String): String = s"$l * 1000000L"
+  private[this] def longToTimeStampCode(v: String): String = s"$v * 1000000L"
   private[this] def timestampToIntegerCode(ts: String): String =
     s"java.lang.Math.floor((double) $ts / 1000000L)"
   private[this] def timestampToDoubleCode(ts: String): String = s"$ts / 1000000.0"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -134,7 +134,7 @@ object TimeWindow {
   private def parseExpression(expr: Expression): Long = expr match {
     case NonNullLiteral(s, StringType) => getIntervalInMicroSeconds(s.toString)
     case IntegerLiteral(i) => i.toLong
-    case NonNullLiteral(v, LongType) => v.toString.toLong
+    case NonNullLiteral(i, LongType) => i.toString.toLong
     case _ => throw new AnalysisException("The duration and time inputs to window must be " +
       "an integer, long or string literal.")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -134,7 +134,7 @@ object TimeWindow {
   private def parseExpression(expr: Expression): Long = expr match {
     case NonNullLiteral(s, StringType) => getIntervalInMicroSeconds(s.toString)
     case IntegerLiteral(i) => i.toLong
-    case NonNullLiteral(l, LongType) => l.toString.toLong
+    case NonNullLiteral(v, LongType) => v.toString.toLong
     case _ => throw new AnalysisException("The duration and time inputs to window must be " +
       "an integer, long or string literal.")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeFormatter.scala
@@ -42,8 +42,8 @@ object CodeFormatter {
   def stripExtraNewLines(input: String): String = {
     val code = new StringBuilder
     var lastLine: String = "dummy"
-    input.split('\n').foreach { l =>
-      val line = l.trim()
+    input.split('\n').foreach { li =>
+      val line = li.trim()
       val skip = line == "" && (lastLine == "" || lastLine.endsWith("{") || lastLine.endsWith("*/"))
       if (!skip) {
         code.append(line)
@@ -67,8 +67,8 @@ object CodeFormatter {
     }
 
     var lastLine: String = "dummy"
-    codeAndComment.body.split('\n').foreach { l =>
-      val line = l.trim()
+    codeAndComment.body.split('\n').foreach { li =>
+      val line = li.trim()
 
       val skip = getComment(lastLine).zip(getComment(line)).exists {
         case (lastComment, currentComment) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -832,8 +832,8 @@ case class MonthsBetween(date1: Expression, date2: Expression)
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
-    defineCodeGen(ctx, ev, (l, r) => {
-      s"""$dtu.monthsBetween($l, $r)"""
+    defineCodeGen(ctx, ev, (a, b) => {
+      s"""$dtu.monthsBetween($a, $b)"""
     })
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -36,7 +36,7 @@ object Literal {
 
   def apply(v: Any): Literal = v match {
     case i: Int => Literal(i, IntegerType)
-    case v: Long => Literal(v, LongType)
+    case i: Long => Literal(i, LongType)
     case d: Double => Literal(d, DoubleType)
     case f: Float => Literal(f, FloatType)
     case b: Byte => Literal(b, ByteType)
@@ -186,7 +186,7 @@ case class Literal protected (value: Any, dataType: DataType)
     val jsonValue = (value, dataType) match {
       case (null, _) => JNull
       case (i: Int, DateType) => JString(DateTimeUtils.toJavaDate(i).toString)
-      case (v: Long, TimestampType) => JString(DateTimeUtils.toJavaTimestamp(v).toString)
+      case (i: Long, TimestampType) => JString(DateTimeUtils.toJavaTimestamp(i).toString)
       case (other, _) => JString(other.toString)
     }
     ("value" -> jsonValue) :: ("dataType" -> dataType.jsonValue) :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -36,7 +36,7 @@ object Literal {
 
   def apply(v: Any): Literal = v match {
     case i: Int => Literal(i, IntegerType)
-    case l: Long => Literal(l, LongType)
+    case v: Long => Literal(v, LongType)
     case d: Double => Literal(d, DoubleType)
     case f: Float => Literal(f, FloatType)
     case b: Byte => Literal(b, ByteType)
@@ -186,7 +186,7 @@ case class Literal protected (value: Any, dataType: DataType)
     val jsonValue = (value, dataType) match {
       case (null, _) => JNull
       case (i: Int, DateType) => JString(DateTimeUtils.toJavaDate(i).toString)
-      case (l: Long, TimestampType) => JString(DateTimeUtils.toJavaTimestamp(l).toString)
+      case (v: Long, TimestampType) => JString(DateTimeUtils.toJavaTimestamp(v).toString)
       case (other, _) => JString(other.toString)
     }
     ("value" -> jsonValue) :: ("dataType" -> dataType.jsonValue) :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -648,7 +648,7 @@ case class ShiftLeft(left: Expression, right: Expression)
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
     input1 match {
-      case l: jl.Long => l << input2.asInstanceOf[jl.Integer]
+      case v: jl.Long => v << input2.asInstanceOf[jl.Integer]
       case i: jl.Integer => i << input2.asInstanceOf[jl.Integer]
     }
   }
@@ -678,7 +678,7 @@ case class ShiftRight(left: Expression, right: Expression)
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
     input1 match {
-      case l: jl.Long => l >> input2.asInstanceOf[jl.Integer]
+      case v: jl.Long => v >> input2.asInstanceOf[jl.Integer]
       case i: jl.Integer => i >> input2.asInstanceOf[jl.Integer]
     }
   }
@@ -708,7 +708,7 @@ case class ShiftRightUnsigned(left: Expression, right: Expression)
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
     input1 match {
-      case l: jl.Long => l >>> input2.asInstanceOf[jl.Integer]
+      case v: jl.Long => v >>> input2.asInstanceOf[jl.Integer]
       case i: jl.Integer => i >>> input2.asInstanceOf[jl.Integer]
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -648,7 +648,7 @@ case class ShiftLeft(left: Expression, right: Expression)
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
     input1 match {
-      case v: jl.Long => v << input2.asInstanceOf[jl.Integer]
+      case i: jl.Long => i << input2.asInstanceOf[jl.Integer]
       case i: jl.Integer => i << input2.asInstanceOf[jl.Integer]
     }
   }
@@ -678,7 +678,7 @@ case class ShiftRight(left: Expression, right: Expression)
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
     input1 match {
-      case v: jl.Long => v >> input2.asInstanceOf[jl.Integer]
+      case i: jl.Long => i >> input2.asInstanceOf[jl.Integer]
       case i: jl.Integer => i >> input2.asInstanceOf[jl.Integer]
     }
   }
@@ -708,7 +708,7 @@ case class ShiftRightUnsigned(left: Expression, right: Expression)
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
     input1 match {
-      case v: jl.Long => v >>> input2.asInstanceOf[jl.Integer]
+      case i: jl.Long => i >>> input2.asInstanceOf[jl.Integer]
       case i: jl.Integer => i >>> input2.asInstanceOf[jl.Integer]
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -284,7 +284,7 @@ abstract class HashExpression[E] extends Expression {
     val hasher = hasherClassName
 
     def hashInt(i: String): String = s"$result = $hasher.hashInt($i, $result);"
-    def hashLong(l: String): String = s"$result = $hasher.hashLong($l, $result);"
+    def hashLong(v: String): String = s"$result = $hasher.hashLong($v, $result);"
     def hashBytes(b: String): String =
       s"$result = $hasher.hashUnsafeBytes($b, Platform.BYTE_ARRAY_OFFSET, $b.length, $result);"
 
@@ -354,7 +354,7 @@ abstract class HashExpression[E] extends Expression {
 abstract class InterpretedHashFunction {
   protected def hashInt(i: Int, seed: Long): Long
 
-  protected def hashLong(l: Long, seed: Long): Long
+  protected def hashLong(v: Long, seed: Long): Long
 
   protected def hashUnsafeBytes(base: AnyRef, offset: Long, length: Int, seed: Long): Long
 
@@ -365,7 +365,7 @@ abstract class InterpretedHashFunction {
       case b: Byte => hashInt(b, seed)
       case s: Short => hashInt(s, seed)
       case i: Int => hashInt(i, seed)
-      case l: Long => hashLong(l, seed)
+      case v: Long => hashLong(v, seed)
       case f: Float => hashInt(java.lang.Float.floatToIntBits(f), seed)
       case d: Double => hashLong(java.lang.Double.doubleToLongBits(d), seed)
       case d: Decimal =>
@@ -458,8 +458,8 @@ object Murmur3HashFunction extends InterpretedHashFunction {
     Murmur3_x86_32.hashInt(i, seed.toInt)
   }
 
-  override protected def hashLong(l: Long, seed: Long): Long = {
-    Murmur3_x86_32.hashLong(l, seed.toInt)
+  override protected def hashLong(v: Long, seed: Long): Long = {
+    Murmur3_x86_32.hashLong(v, seed.toInt)
   }
 
   override protected def hashUnsafeBytes(base: AnyRef, offset: Long, len: Int, seed: Long): Long = {
@@ -540,7 +540,7 @@ case class XxHash64(children: Seq[Expression], seed: Long) extends HashExpressio
 object XxHash64Function extends InterpretedHashFunction {
   override protected def hashInt(i: Int, seed: Long): Long = XXH64.hashInt(i, seed)
 
-  override protected def hashLong(l: Long, seed: Long): Long = XXH64.hashLong(l, seed)
+  override protected def hashLong(v: Long, seed: Long): Long = XXH64.hashLong(v, seed)
 
   override protected def hashUnsafeBytes(base: AnyRef, offset: Long, len: Int, seed: Long): Long = {
     XXH64.hashUnsafeBytes(base, offset, len, seed)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -284,7 +284,7 @@ abstract class HashExpression[E] extends Expression {
     val hasher = hasherClassName
 
     def hashInt(i: String): String = s"$result = $hasher.hashInt($i, $result);"
-    def hashLong(v: String): String = s"$result = $hasher.hashLong($v, $result);"
+    def hashLong(i: String): String = s"$result = $hasher.hashLong($i, $result);"
     def hashBytes(b: String): String =
       s"$result = $hasher.hashUnsafeBytes($b, Platform.BYTE_ARRAY_OFFSET, $b.length, $result);"
 
@@ -354,7 +354,7 @@ abstract class HashExpression[E] extends Expression {
 abstract class InterpretedHashFunction {
   protected def hashInt(i: Int, seed: Long): Long
 
-  protected def hashLong(v: Long, seed: Long): Long
+  protected def hashLong(i: Long, seed: Long): Long
 
   protected def hashUnsafeBytes(base: AnyRef, offset: Long, length: Int, seed: Long): Long
 
@@ -365,7 +365,7 @@ abstract class InterpretedHashFunction {
       case b: Byte => hashInt(b, seed)
       case s: Short => hashInt(s, seed)
       case i: Int => hashInt(i, seed)
-      case v: Long => hashLong(v, seed)
+      case i: Long => hashLong(i, seed)
       case f: Float => hashInt(java.lang.Float.floatToIntBits(f), seed)
       case d: Double => hashLong(java.lang.Double.doubleToLongBits(d), seed)
       case d: Decimal =>
@@ -458,8 +458,8 @@ object Murmur3HashFunction extends InterpretedHashFunction {
     Murmur3_x86_32.hashInt(i, seed.toInt)
   }
 
-  override protected def hashLong(v: Long, seed: Long): Long = {
-    Murmur3_x86_32.hashLong(v, seed.toInt)
+  override protected def hashLong(i: Long, seed: Long): Long = {
+    Murmur3_x86_32.hashLong(i, seed.toInt)
   }
 
   override protected def hashUnsafeBytes(base: AnyRef, offset: Long, len: Int, seed: Long): Long = {
@@ -540,7 +540,7 @@ case class XxHash64(children: Seq[Expression], seed: Long) extends HashExpressio
 object XxHash64Function extends InterpretedHashFunction {
   override protected def hashInt(i: Int, seed: Long): Long = XXH64.hashInt(i, seed)
 
-  override protected def hashLong(v: Long, seed: Long): Long = XXH64.hashLong(v, seed)
+  override protected def hashLong(i: Long, seed: Long): Long = XXH64.hashLong(i, seed)
 
   override protected def hashUnsafeBytes(base: AnyRef, offset: Long, len: Int, seed: Long): Long = {
     XXH64.hashUnsafeBytes(base, offset, len, seed)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -123,7 +123,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate
   override def inputTypes: Seq[AbstractDataType] = value.dataType +: list.map(_.dataType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (list.exists(l => l.dataType != value.dataType)) {
+    if (list.exists(i => i.dataType != value.dataType)) {
       TypeCheckResult.TypeCheckFailure(
         "Arguments must be same type")
     } else {
@@ -401,8 +401,8 @@ private[sql] object BinaryComparison {
 /** An extractor that matches both standard 3VL equality and null-safe equality. */
 private[sql] object Equality {
   def unapply(e: BinaryComparison): Option[(Expression, Expression)] = e match {
-    case EqualTo(l, r) => Some((l, r))
-    case EqualNullSafe(l, r) => Some((l, r))
+    case EqualTo(left, right) => Some((left, right))
+    case EqualNullSafe(left, right) => Some((left, right))
     case _ => None
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -141,7 +141,7 @@ trait BaseGenericInternalRow extends InternalRow {
             case b: Byte => b.toInt
             case s: Short => s.toInt
             case i: Int => i
-            case l: Long => (l ^ (l >>> 32)).toInt
+            case v: Long => (v ^ (v >>> 32)).toInt
             case f: Float => java.lang.Float.floatToIntBits(f)
             case d: Double =>
               val b = java.lang.Double.doubleToLongBits(d)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -141,7 +141,7 @@ trait BaseGenericInternalRow extends InternalRow {
             case b: Byte => b.toInt
             case s: Short => s.toInt
             case i: Int => i
-            case v: Long => (v ^ (v >>> 32)).toInt
+            case i: Long => (i ^ (i >>> 32)).toInt
             case f: Float => java.lang.Float.floatToIntBits(f)
             case d: Double =>
               val b = java.lang.Double.doubleToLongBits(d)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -176,10 +176,10 @@ class ParseException(
     val builder = new StringBuilder
     builder ++= "\n" ++= message
     start match {
-      case Origin(Some(l), Some(p)) =>
-        builder ++= s"(line $l, pos $p)\n"
+      case Origin(Some(line), Some(p)) =>
+        builder ++= s"(line $line, pos $p)\n"
         command.foreach { cmd =>
-          val (above, below) = cmd.split("\n").splitAt(l)
+          val (above, below) = cmd.split("\n").splitAt(line)
           builder ++= "\n== SQL ==\n"
           above.foreach(builder ++= _ += '\n')
           builder ++= (0 until p).map(_ => "-").mkString("") ++= "^^^\n"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -112,22 +112,22 @@ object ExtractEquiJoinKeys extends Logging with PredicateHelper {
       // as join keys.
       val predicates = condition.map(splitConjunctivePredicates).getOrElse(Nil)
       val joinKeys = predicates.flatMap {
-        case EqualTo(l, r) if canEvaluate(l, left) && canEvaluate(r, right) => Some((l, r))
-        case EqualTo(l, r) if canEvaluate(l, right) && canEvaluate(r, left) => Some((r, l))
+        case EqualTo(le, ri) if canEvaluate(le, left) && canEvaluate(ri, right) => Some((le, ri))
+        case EqualTo(le, ri) if canEvaluate(le, right) && canEvaluate(ri, left) => Some((ri, le))
         // Replace null with default value for joining key, then those rows with null in it could
         // be joined together
-        case EqualNullSafe(l, r) if canEvaluate(l, left) && canEvaluate(r, right) =>
-          Some((Coalesce(Seq(l, Literal.default(l.dataType))),
-            Coalesce(Seq(r, Literal.default(r.dataType)))))
-        case EqualNullSafe(l, r) if canEvaluate(l, right) && canEvaluate(r, left) =>
-          Some((Coalesce(Seq(r, Literal.default(r.dataType))),
-            Coalesce(Seq(l, Literal.default(l.dataType)))))
+        case EqualNullSafe(le, ri) if canEvaluate(le, left) && canEvaluate(ri, right) =>
+          Some((Coalesce(Seq(le, Literal.default(le.dataType))),
+            Coalesce(Seq(ri, Literal.default(ri.dataType)))))
+        case EqualNullSafe(le, ri) if canEvaluate(le, right) && canEvaluate(ri, left) =>
+          Some((Coalesce(Seq(ri, Literal.default(ri.dataType))),
+            Coalesce(Seq(le, Literal.default(le.dataType)))))
         case other => None
       }
       val otherPredicates = predicates.filterNot {
-        case EqualTo(l, r) =>
-          canEvaluate(l, left) && canEvaluate(r, right) ||
-            canEvaluate(l, right) && canEvaluate(r, left)
+        case EqualTo(le, ri) =>
+          canEvaluate(le, left) && canEvaluate(ri, right) ||
+            canEvaluate(le, right) && canEvaluate(ri, left)
         case other => false
       }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -75,12 +75,12 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
   private def inferAdditionalConstraints(constraints: Set[Expression]): Set[Expression] = {
     var inferredConstraints = Set.empty[Expression]
     constraints.foreach {
-      case eq @ EqualTo(l: Attribute, r: Attribute) =>
+      case eq @ EqualTo(left: Attribute, right: Attribute) =>
         inferredConstraints ++= (constraints - eq).map(_ transform {
-          case a: Attribute if a.semanticEquals(l) => r
+          case a: Attribute if a.semanticEquals(left) => right
         })
         inferredConstraints ++= (constraints - eq).map(_ transform {
-          case a: Attribute if a.semanticEquals(r) => l
+          case a: Attribute if a.semanticEquals(right) => left
         })
       case _ => // No inference
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -148,7 +148,7 @@ case class Intersect(left: LogicalPlan, right: LogicalPlan) extends SetOperation
   override lazy val resolved: Boolean =
     childrenResolved &&
       left.output.length == right.output.length &&
-      left.output.zip(right.output).forall { case (l, r) => l.dataType == r.dataType } &&
+      left.output.zip(right.output).forall { case (le, ri) => le.dataType == ri.dataType } &&
       duplicateResolved
 
   override def maxRows: Option[Long] = {
@@ -181,7 +181,7 @@ case class Except(left: LogicalPlan, right: LogicalPlan) extends SetOperation(le
   override lazy val resolved: Boolean =
     childrenResolved &&
       left.output.length == right.output.length &&
-      left.output.zip(right.output).forall { case (l, r) => l.dataType == r.dataType } &&
+      left.output.zip(right.output).forall { case (le, ri) => le.dataType == ri.dataType } &&
       duplicateResolved
 
   override lazy val statistics: Statistics = {
@@ -218,7 +218,7 @@ case class Union(children: Seq[LogicalPlan]) extends LogicalPlan {
         child.output.length == children.head.output.length &&
         // compare the data types with the first child
         child.output.zip(children.head.output).forall {
-          case (l, r) => l.dataType == r.dataType }
+          case (left, right) => left.dataType == right.dataType }
       )
 
     children.length > 1 && childrenResolved && allChildrenCompatible

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -607,7 +607,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case b: Byte => JInt(b.toInt)
     case s: Short => JInt(s.toInt)
     case i: Int => JInt(i)
-    case v: Long => JInt(v)
+    case i: Long => JInt(i)
     case f: Float => JDouble(f)
     case d: Double => JDouble(d)
     case b: BigInt => JInt(b)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -105,7 +105,9 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
    */
   def find(f: BaseType => Boolean): Option[BaseType] = f(this) match {
     case true => Some(this)
-    case false => children.foldLeft(Option.empty[BaseType]) { (l, r) => l.orElse(r.find(f)) }
+    case false => children.foldLeft(Option.empty[BaseType]) {
+      (left, right) => left.orElse(right.find(f))
+    }
   }
 
   /**
@@ -165,7 +167,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
   def collectFirst[B](pf: PartialFunction[BaseType, B]): Option[B] = {
     val lifted = pf.lift
     lifted(this).orElse {
-      children.foldLeft(Option.empty[B]) { (l, r) => l.orElse(r.collectFirst(pf)) }
+      children.foldLeft(Option.empty[B]) { (left, right) => left.orElse(right.collectFirst(pf)) }
     }
   }
 
@@ -605,7 +607,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case b: Byte => JInt(b.toInt)
     case s: Short => JInt(s.toInt)
     case i: Int => JInt(i)
-    case l: Long => JInt(l)
+    case v: Long => JInt(v)
     case f: Float => JDouble(f)
     case d: Double => JDouble(d)
     case b: BigInt => JInt(b)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericArrayData.scala
@@ -127,7 +127,7 @@ class GenericArrayData(val array: Array[Any]) extends ArrayData {
             case b: Byte => b.toInt
             case s: Short => s.toInt
             case i: Int => i
-            case v: Long => (v ^ (v >>> 32)).toInt
+            case i: Long => (i ^ (i >>> 32)).toInt
             case f: Float => java.lang.Float.floatToIntBits(f)
             case d: Double =>
               val b = java.lang.Double.doubleToLongBits(d)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericArrayData.scala
@@ -127,7 +127,7 @@ class GenericArrayData(val array: Array[Any]) extends ArrayData {
             case b: Byte => b.toInt
             case s: Short => s.toInt
             case i: Int => i
-            case l: Long => (l ^ (l >>> 32)).toInt
+            case v: Long => (v ^ (v >>> 32)).toInt
             case f: Float => java.lang.Float.floatToIntBits(f)
             case d: Double =>
               val b = java.lang.Double.doubleToLongBits(d)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -110,7 +110,7 @@ package object util {
     val rightPadded = right ++ Seq.fill(math.max(left.size - right.size, 0))("")
 
     leftPadded.zip(rightPadded).map {
-      case (l, r) => (if (l == r) " " else "!") + l + (" " * ((maxLeftSize - l.length) + 3)) + r
+      case (a, b) => (if (a == b) " " else "!") + a + (" " * ((maxLeftSize - a.length) + 3)) + b
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -203,10 +203,10 @@ object DataType {
           equalsIgnoreNullability(leftValueType, rightValueType)
       case (StructType(leftFields), StructType(rightFields)) =>
         leftFields.length == rightFields.length &&
-          leftFields.zip(rightFields).forall { case (l, r) =>
-            l.name == r.name && equalsIgnoreNullability(l.dataType, r.dataType)
+          leftFields.zip(rightFields).forall { case (le, ri) =>
+            le.name == ri.name && equalsIgnoreNullability(le.dataType, ri.dataType)
           }
-      case (l, r) => l == r
+      case (le, ri) => le == ri
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -415,7 +415,7 @@ object Decimal {
       case j: java.math.BigDecimal => apply(j)
       case d: BigDecimal => apply(d)
       case k: scala.math.BigInt => apply(k)
-      case l: java.math.BigInteger => apply(l)
+      case i: java.math.BigInteger => apply(i)
       case d: Decimal => d
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -73,11 +73,11 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
     val plan =
       Union(Project(Seq(Alias(left, "l")()), relation),
         Project(Seq(Alias(right, "r")()), relation))
-    val (l, r) = analyzer.execute(plan).collect {
+    val (a, b) = analyzer.execute(plan).collect {
       case Union(Seq(child1, child2)) => (child1.output.head, child2.output.head)
     }.head
-    assert(l.dataType === expectedType)
-    assert(r.dataType === expectedType)
+    assert(a.dataType === expectedType)
+    assert(b.dataType === expectedType)
   }
 
   test("basic operations") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -66,7 +66,7 @@ case class RepeatedData(
     mapFieldNull: scala.collection.Map[Int, java.lang.Long],
     structField: PrimitiveData)
 
-case class SpecificCollection(l: List[Int])
+case class SpecificCollection(list: List[Int])
 
 /** For testing Kryo serialization based encoder. */
 class KryoSerializable(val value: Int) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -78,7 +78,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     def generateCase(n: Int): (Expression, Expression) = {
       val condition = (1 to clauses)
         .map(c => EqualTo(BoundReference(0, StringType, false), Literal(s"$c:$n")))
-        .reduceLeft[Expression]((l, r) => Or(l, r))
+        .reduceLeft[Expression]((left, right) => Or(left, right))
       (condition, Literal(n))
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -188,8 +188,8 @@ trait ExpressionEvalHelper extends GeneratorDrivenPropertyChecks {
   def checkConsistencyBetweenInterpretedAndCodegen(
       c: Expression => Expression,
       dataType: DataType): Unit = {
-    forAll (LiteralGenerator.randomGen(dataType)) { (l: Literal) =>
-      cmpInterpretWithCodegen(EmptyRow, c(l))
+    forAll (LiteralGenerator.randomGen(dataType)) { (literal: Literal) =>
+      cmpInterpretWithCodegen(EmptyRow, c(literal))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -62,7 +62,7 @@ object LiteralGenerator {
     for { i <- Arbitrary.arbInt.arbitrary } yield Literal.create(i, IntegerType)
 
   lazy val longLiteralGen: Gen[Literal] =
-    for { l <- Arbitrary.arbLong.arbitrary } yield Literal.create(l, LongType)
+    for { v <- Arbitrary.arbLong.arbitrary } yield Literal.create(v, LongType)
 
   lazy val floatLiteralGen: Gen[Literal] =
     for {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -62,7 +62,7 @@ object LiteralGenerator {
     for { i <- Arbitrary.arbInt.arbitrary } yield Literal.create(i, IntegerType)
 
   lazy val longLiteralGen: Gen[Literal] =
-    for { v <- Arbitrary.arbLong.arbitrary } yield Literal.create(v, LongType)
+    for { i <- Arbitrary.arbLong.arbitrary } yield Literal.create(i, LongType)
 
   lazy val floatLiteralGen: Gen[Literal] =
     for {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -32,8 +32,8 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     truthTable: Seq[(Any, Any, Any)]) {
     test(s"3VL $name") {
       truthTable.foreach {
-        case (l, r, answer) =>
-          val expr = op(Literal.create(l, BooleanType), Literal.create(r, BooleanType))
+        case (left, right, answer) =>
+          val expr = op(Literal.create(left, BooleanType), Literal.create(right, BooleanType))
           checkEvaluation(expr, answer)
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
@@ -37,8 +37,8 @@ abstract class PlanTest extends SparkFunSuite with PredicateHelper {
         s.copy(exprId = ExprId(0))
       case e: Exists =>
         e.copy(exprId = ExprId(0))
-      case l: ListQuery =>
-        l.copy(exprId = ExprId(0))
+      case list: ListQuery =>
+        list.copy(exprId = ExprId(0))
       case p: PredicateSubquery =>
         p.copy(exprId = ExprId(0))
       case a: AttributeReference =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -71,7 +71,7 @@ class TreeNodeSuite extends SparkFunSuite {
 
   test("collect") {
     val tree = Add(Literal(1), Add(Literal(2), Add(Literal(3), Literal(4))))
-    val literals = tree collect {case l: Literal => l}
+    val literals = tree collect {case literal: Literal => literal}
 
     assert(literals.size === 4)
     (1 to 4).foreach(i => assert(literals contains Literal(i)))
@@ -83,7 +83,7 @@ class TreeNodeSuite extends SparkFunSuite {
     val expression = Add(Literal(1), Multiply(Literal(2), Subtract(Literal(3), Literal(4))))
     expression transformDown {
       case b: BinaryOperator => actual.append(b.symbol); b
-      case l: Literal => actual.append(l.toString); l
+      case literal: Literal => actual.append(literal.toString); literal
     }
 
     assert(expected === actual)
@@ -95,7 +95,7 @@ class TreeNodeSuite extends SparkFunSuite {
     val expression = Add(Literal(1), Multiply(Literal(2), Subtract(Literal(3), Literal(4))))
     expression transformUp {
       case b: BinaryOperator => actual.append(b.symbol); b
-      case l: Literal => actual.append(l.toString); l
+      case literal: Literal => actual.append(literal.toString); literal
     }
 
     assert(expected === actual)
@@ -135,7 +135,7 @@ class TreeNodeSuite extends SparkFunSuite {
     val expression = Add(Literal(1), Multiply(Literal(2), Subtract(Literal(3), Literal(4))))
     expression foreachUp {
       case b: BinaryOperator => actual.append(b.symbol);
-      case l: Literal => actual.append(l.toString);
+      case literal: Literal => actual.append(literal.toString);
     }
 
     assert(expected === actual)
@@ -201,7 +201,7 @@ class TreeNodeSuite extends SparkFunSuite {
     // Collect the first children.
     {
       val actual = expression.collectFirst {
-        case l @ Literal(1, IntegerType) => l
+        case literal @ Literal(1, IntegerType) => literal
       }
       val expected = Some(Literal(1))
       assert(expected === actual)
@@ -219,7 +219,7 @@ class TreeNodeSuite extends SparkFunSuite {
     // Collect a leaf node.
     {
       val actual = expression.collectFirst {
-        case l @ Literal(3, IntegerType) => l
+        case literal @ Literal(3, IntegerType) => literal
       }
       val expected = Some(Literal(3))
       assert(expected === actual)
@@ -228,7 +228,7 @@ class TreeNodeSuite extends SparkFunSuite {
     // Collect nothing.
     {
       val actual = expression.collectFirst {
-        case l @ Literal(100, IntegerType) => l
+        case literal @ Literal(100, IntegerType) => literal
       }
       val expected = None
       assert(expected === actual)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/SQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/SQLBuilder.scala
@@ -519,10 +519,10 @@ class SQLBuilder(logicalPlan: LogicalPlan) extends Logging {
         case PredicateSubquery(query, conditions, true, exprId) =>
           val (in, correlated) = conditions.partition(_.isInstanceOf[EqualTo])
           val (outer, inner) = in.zipWithIndex.map {
-            case (EqualTo(l, r), i) if query.outputSet.intersect(r.references).nonEmpty =>
-              (l, Alias(r, s"_c$i")())
-            case (EqualTo(r, l), i) =>
-              (l, Alias(r, s"_c$i")())
+            case (EqualTo(a, b), i) if query.outputSet.intersect(b.references).nonEmpty =>
+              (a, Alias(b, s"_c$i")())
+            case (EqualTo(b, a), i) =>
+              (a, Alias(b, s"_c$i")())
           }.unzip
           val wrapped = addSubqueryIfNeeded(query)
           val filtered = if (correlated.nonEmpty) {
@@ -566,8 +566,8 @@ class SQLBuilder(logicalPlan: LogicalPlan) extends Logging {
 
   object ExtractSQLTable {
     def unapply(plan: LogicalPlan): Option[SQLTable] = plan match {
-      case l @ LogicalRelation(_, _, Some(TableIdentifier(table, Some(database)))) =>
-        Some(SQLTable(database, table, l.output.map(_.withQualifier(None))))
+      case lr @ LogicalRelation(_, _, Some(TableIdentifier(table, Some(database)))) =>
+        Some(SQLTable(database, table, lr.output.map(_.withQualifier(None))))
 
       case relation: CatalogRelation =>
         val m = relation.catalogTable

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -309,8 +309,8 @@ class VectorizedHashMapGenerator(
       input: String,
       dataType: DataType,
       result: String): String = {
-    def hashInt(i: String): String = s"int $result = $i;"
-    def hashLong(l: String): String = s"long $result = $l;"
+    def hashInt(value: String): String = s"int $result = $value;"
+    def hashLong(value: String): String = s"long $result = $value;"
     def hashBytes(b: String): String = {
       val hash = ctx.freshName("hash")
       s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -60,29 +60,31 @@ private[sql] case class InMemoryTableScanExec(
       if buildFilter.isDefinedAt(lhs) && buildFilter.isDefinedAt(rhs) =>
       buildFilter(lhs) || buildFilter(rhs)
 
-    case EqualTo(a: AttributeReference, l: Literal) =>
-      statsFor(a).lowerBound <= l && l <= statsFor(a).upperBound
-    case EqualTo(l: Literal, a: AttributeReference) =>
-      statsFor(a).lowerBound <= l && l <= statsFor(a).upperBound
+    case EqualTo(a: AttributeReference, value: Literal) =>
+      statsFor(a).lowerBound <= value && value <= statsFor(a).upperBound
+    case EqualTo(value: Literal, a: AttributeReference) =>
+      statsFor(a).lowerBound <= value && value <= statsFor(a).upperBound
 
-    case LessThan(a: AttributeReference, l: Literal) => statsFor(a).lowerBound < l
-    case LessThan(l: Literal, a: AttributeReference) => l < statsFor(a).upperBound
+    case LessThan(a: AttributeReference, value: Literal) => statsFor(a).lowerBound < value
+    case LessThan(value: Literal, a: AttributeReference) => value < statsFor(a).upperBound
 
-    case LessThanOrEqual(a: AttributeReference, l: Literal) => statsFor(a).lowerBound <= l
-    case LessThanOrEqual(l: Literal, a: AttributeReference) => l <= statsFor(a).upperBound
+    case LessThanOrEqual(a: AttributeReference, value: Literal) => statsFor(a).lowerBound <= value
+    case LessThanOrEqual(value: Literal, a: AttributeReference) => value <= statsFor(a).upperBound
 
-    case GreaterThan(a: AttributeReference, l: Literal) => l < statsFor(a).upperBound
-    case GreaterThan(l: Literal, a: AttributeReference) => statsFor(a).lowerBound < l
+    case GreaterThan(a: AttributeReference, value: Literal) => value < statsFor(a).upperBound
+    case GreaterThan(value: Literal, a: AttributeReference) => statsFor(a).lowerBound < value
 
-    case GreaterThanOrEqual(a: AttributeReference, l: Literal) => l <= statsFor(a).upperBound
-    case GreaterThanOrEqual(l: Literal, a: AttributeReference) => statsFor(a).lowerBound <= l
+    case GreaterThanOrEqual(a: AttributeReference, value: Literal) =>
+      value <= statsFor(a).upperBound
+    case GreaterThanOrEqual(value: Literal, a: AttributeReference) =>
+      statsFor(a).lowerBound <= value
 
     case IsNull(a: Attribute) => statsFor(a).nullCount > 0
     case IsNotNull(a: Attribute) => statsFor(a).count - statsFor(a).nullCount > 0
 
     case In(a: AttributeReference, list: Seq[Expression]) if list.forall(_.isInstanceOf[Literal]) =>
-      list.map(l => statsFor(a).lowerBound <= l.asInstanceOf[Literal] &&
-        l.asInstanceOf[Literal] <= statsFor(a).upperBound).reduce(_ || _)
+      list.map(value => statsFor(a).lowerBound <= value.asInstanceOf[Literal] &&
+        value.asInstanceOf[Literal] <= statsFor(a).upperBound).reduce(_ || _)
   }
 
   val partitionFilters: Seq[Expression] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -196,9 +196,9 @@ case class CreateDataSourceTableAsSelectCommand(
 
           EliminateSubqueryAliases(
             sessionState.catalog.lookupRelation(tableIdent)) match {
-            case l @ LogicalRelation(_: InsertableRelation | _: HadoopFsRelation, _, _) =>
+            case lr @ LogicalRelation(_: InsertableRelation | _: HadoopFsRelation, _, _) =>
               // check if the file formats match
-              l.relation match {
+              lr.relation match {
                 case r: HadoopFsRelation if r.fileFormat.getClass != dataSource.providingClass =>
                   throw new AnalysisException(
                     s"The file format of the existing table $tableIdent is " +
@@ -206,12 +206,12 @@ case class CreateDataSourceTableAsSelectCommand(
                       s"format `$provider`")
                 case _ =>
               }
-              if (query.schema.size != l.schema.size) {
+              if (query.schema.size != lr.schema.size) {
                 throw new AnalysisException(
-                  s"The column number of the existing schema[${l.schema}] " +
+                  s"The column number of the existing schema[${lr.schema}] " +
                     s"doesn't match the data schema[${query.schema}]'s")
               }
-              existingSchema = Some(l.schema)
+              existingSchema = Some(lr.schema)
             case s: SimpleCatalogRelation if DDLUtils.isDatasourceTable(s.metadata) =>
               existingSchema = DDLUtils.getSchemaFromTableProperties(s.metadata)
             case o =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -52,7 +52,8 @@ case class LogicalRelation(
 
   // Logical Relations are distinct if they have different output for the sake of transformations.
   override def equals(other: Any): Boolean = other match {
-    case l @ LogicalRelation(otherRelation, _, _) => relation == otherRelation && output == l.output
+    case lr @ LogicalRelation(otherRelation, _, _) =>
+      relation == otherRelation && output == lr.output
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -387,8 +387,8 @@ private[sql] object PartitioningUtils {
       if (topType == NullType) StringType else topType
     }
 
-    literals.map { case l @ Literal(_, dataType) =>
-      Literal.create(Cast(l, desiredType).eval(), desiredType)
+    literals.map { case literal @ Literal(_, dataType) =>
+      Literal.create(Cast(literal, desiredType).eval(), desiredType)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
@@ -188,8 +188,8 @@ case class BroadcastNestedLoopJoinExec(
       val joinedRow = new JoinedRow
 
       if (condition.isDefined) {
-        streamedIter.filter(l =>
-          buildRows.exists(r => boundCondition(joinedRow(l, r))) == exists
+        streamedIter.filter(left =>
+          buildRows.exists(right => boundCondition(joinedRow(left, right))) == exists
         )
       } else if (buildRows.nonEmpty == exists) {
         streamedIter

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -341,10 +341,10 @@ case class SortMergeJoinExec(
   }
 
   private def genComparision(ctx: CodegenContext, a: Seq[ExprCode], b: Seq[ExprCode]): String = {
-    val comparisons = a.zip(b).zipWithIndex.map { case ((l, r), i) =>
+    val comparisons = a.zip(b).zipWithIndex.map { case ((left, right), i) =>
       s"""
          |if (comp == 0) {
-         |  comp = ${ctx.genComp(leftKeys(i).dataType, l.value, r.value)};
+         |  comp = ${ctx.genComp(leftKeys(i).dataType, left.value, right.value)};
          |}
        """.stripMargin.trim
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/LongOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/LongOffset.scala
@@ -23,7 +23,7 @@ package org.apache.spark.sql.execution.streaming
 case class LongOffset(offset: Long) extends Offset {
 
   override def compareTo(other: Offset): Int = other match {
-    case l: LongOffset => offset.compareTo(l.offset)
+    case lo: LongOffset => offset.compareTo(lo.offset)
     case _ =>
       throw new IllegalArgumentException(s"Invalid comparison of $getClass with ${other.getClass}")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1237,7 +1237,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def atan2(l: Column, r: Column): Column = withExpr { Atan2(l.expr, r.expr) }
+  def atan2(left: Column, right: Column): Column = withExpr { Atan2(left.expr, right.expr) }
 
   /**
    * Returns the angle theta from the conversion of rectangular coordinates (x, y) to
@@ -1246,7 +1246,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def atan2(l: Column, rightName: String): Column = atan2(l, Column(rightName))
+  def atan2(left: Column, rightName: String): Column = atan2(left, Column(rightName))
 
   /**
    * Returns the angle theta from the conversion of rectangular coordinates (x, y) to
@@ -1274,7 +1274,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def atan2(l: Column, r: Double): Column = atan2(l, lit(r))
+  def atan2(left: Column, right: Double): Column = atan2(left, lit(right))
 
   /**
    * Returns the angle theta from the conversion of rectangular coordinates (x, y) to
@@ -1292,7 +1292,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def atan2(l: Double, r: Column): Column = atan2(lit(l), r)
+  def atan2(left: Double, right: Column): Column = atan2(lit(left), right)
 
   /**
    * Returns the angle theta from the conversion of rectangular coordinates (x, y) to
@@ -1301,7 +1301,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def atan2(l: Double, rightName: String): Column = atan2(l, Column(rightName))
+  def atan2(left: Double, rightName: String): Column = atan2(left, Column(rightName))
 
   /**
    * An expression that returns the string representation of the binary value of the given long
@@ -1499,7 +1499,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def hypot(l: Column, r: Column): Column = withExpr { Hypot(l.expr, r.expr) }
+  def hypot(left: Column, right: Column): Column = withExpr { Hypot(left.expr, right.expr) }
 
   /**
    * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
@@ -1507,7 +1507,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def hypot(l: Column, rightName: String): Column = hypot(l, Column(rightName))
+  def hypot(left: Column, rightName: String): Column = hypot(left, Column(rightName))
 
   /**
    * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
@@ -1532,7 +1532,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def hypot(l: Column, r: Double): Column = hypot(l, lit(r))
+  def hypot(left: Column, right: Double): Column = hypot(left, lit(right))
 
   /**
    * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
@@ -1540,7 +1540,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def hypot(leftName: String, r: Double): Column = hypot(Column(leftName), r)
+  def hypot(leftName: String, right: Double): Column = hypot(Column(leftName), right)
 
   /**
    * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
@@ -1548,7 +1548,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def hypot(l: Double, r: Column): Column = hypot(lit(l), r)
+  def hypot(left: Double, right: Column): Column = hypot(lit(left), right)
 
   /**
    * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
@@ -1556,7 +1556,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def hypot(l: Double, rightName: String): Column = hypot(l, Column(rightName))
+  def hypot(left: Double, rightName: String): Column = hypot(left, Column(rightName))
 
   /**
    * Returns the least value of the list of values, skipping null values.
@@ -1669,7 +1669,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def pow(l: Column, r: Column): Column = withExpr { Pow(l.expr, r.expr) }
+  def pow(left: Column, right: Column): Column = withExpr { Pow(left.expr, right.expr) }
 
   /**
    * Returns the value of the first argument raised to the power of the second argument.
@@ -1677,7 +1677,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def pow(l: Column, rightName: String): Column = pow(l, Column(rightName))
+  def pow(left: Column, rightName: String): Column = pow(left, Column(rightName))
 
   /**
    * Returns the value of the first argument raised to the power of the second argument.
@@ -1701,7 +1701,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def pow(l: Column, r: Double): Column = pow(l, lit(r))
+  def pow(left: Column, right: Double): Column = pow(left, lit(right))
 
   /**
    * Returns the value of the first argument raised to the power of the second argument.
@@ -1717,7 +1717,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def pow(l: Double, r: Column): Column = pow(lit(l), r)
+  def pow(left: Double, right: Column): Column = pow(lit(left), right)
 
   /**
    * Returns the value of the first argument raised to the power of the second argument.
@@ -1725,7 +1725,7 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def pow(l: Double, rightName: String): Column = pow(l, Column(rightName))
+  def pow(left: Double, rightName: String): Column = pow(left, Column(rightName))
 
   /**
    * Returns the positive value of dividend mod divisor.
@@ -2128,7 +2128,9 @@ object functions {
    * @group string_funcs
    * @since 1.5.0
    */
-  def levenshtein(l: Column, r: Column): Column = withExpr { Levenshtein(l.expr, r.expr) }
+  def levenshtein(left: Column, right: Column): Column = withExpr {
+    Levenshtein(left.expr, right.expr)
+  }
 
   /**
    * Locate the position of the first occurrence of substr.

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -528,7 +528,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
 
   test("upper") {
     checkAnswer(
-      lowerCaseData.select(upper('l)),
+      lowerCaseData.select(upper('s)),
       ('a' to 'd').map(c => Row(c.toString.toUpperCase))
     )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -677,11 +677,11 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("runtime null check for RowEncoder") {
     val schema = new StructType().add("i", IntegerType, nullable = false)
-    val df = spark.range(10).map(l => {
-      if (l % 5 == 0) {
+    val df = spark.range(10).map(v => {
+      if (v % 5 == 0) {
         Row(null)
       } else {
-        Row(l)
+        Row(v)
       }
     })(RowEncoder(schema))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -677,13 +677,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("runtime null check for RowEncoder") {
     val schema = new StructType().add("i", IntegerType, nullable = false)
-    val df = spark.range(10).map(v => {
+    val df = spark.range(10).map(v =>
       if (v % 5 == 0) {
         Row(null)
       } else {
         Row(v)
       }
-    })(RowEncoder(schema))
+    )(RowEncoder(schema))
 
     val message = intercept[Exception] {
       df.collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -260,7 +260,7 @@ class JoinSuite extends QueryTest with SharedSQLContext {
           Row(6, "F", null, null) :: Nil)
 
       checkAnswer(
-        upperCaseData.join(lowerCaseData, $"n" === $"N" && $"l" > $"L", "left"),
+        upperCaseData.join(lowerCaseData, $"n" === $"N" && $"s" > $"L", "left"),
         Row(1, "A", 1, "a") ::
           Row(2, "B", 2, "b") ::
           Row(3, "C", 3, "c") ::
@@ -323,7 +323,7 @@ class JoinSuite extends QueryTest with SharedSQLContext {
           Row(null, null, 5, "E") ::
           Row(null, null, 6, "F") :: Nil)
       checkAnswer(
-        lowerCaseData.join(upperCaseData, $"n" === $"N" && $"l" > $"L", "right"),
+        lowerCaseData.join(upperCaseData, $"n" === $"N" && $"s" > $"L", "right"),
         Row(1, "a", 1, "A") ::
           Row(2, "b", 2, "B") ::
           Row(3, "c", 3, "C") ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -140,9 +140,9 @@ abstract class QueryTest extends PlanTest {
     case (null, _) => false
     case (_, null) => false
     case (a: Array[_], b: Array[_]) =>
-      a.length == b.length && a.zip(b).forall { case (l, r) => compare(l, r)}
+      a.length == b.length && a.zip(b).forall { case (left, right) => compare(left, right)}
     case (a: Iterable[_], b: Iterable[_]) =>
-      a.size == b.size && a.zip(b).forall { case (l, r) => compare(l, r)}
+      a.size == b.size && a.zip(b).forall { case (left, right) => compare(left, right)}
     case (a, b) => a == b
   }
 
@@ -275,10 +275,10 @@ abstract class QueryTest extends PlanTest {
     val localRelations = new ArrayDeque[LocalRelation]()
     val inMemoryRelations = new ArrayDeque[InMemoryRelation]()
     def collectData: (LogicalPlan => Unit) = {
-      case l: LogicalRDD =>
-        logicalRDDs.offer(l)
-      case l: LocalRelation =>
-        localRelations.offer(l)
+      case lrdd: LogicalRDD =>
+        logicalRDDs.offer(lrdd)
+      case lr: LocalRelation =>
+        localRelations.offer(lr)
       case i: InMemoryRelation =>
         inMemoryRelations.offer(i)
       case p =>
@@ -307,21 +307,21 @@ abstract class QueryTest extends PlanTest {
     }
 
     def renormalize: PartialFunction[LogicalPlan, LogicalPlan] = {
-      case l: LogicalRDD =>
+      case lrdd: LogicalRDD =>
         val origin = logicalRDDs.pop()
-        LogicalRDD(l.output, origin.rdd)(spark)
-      case l: LocalRelation =>
+        LogicalRDD(lrdd.output, origin.rdd)(spark)
+      case lr: LocalRelation =>
         val origin = localRelations.pop()
-        l.copy(data = origin.data)
-      case l: InMemoryRelation =>
+        lr.copy(data = origin.data)
+      case i: InMemoryRelation =>
         val origin = inMemoryRelations.pop()
         InMemoryRelation(
-          l.output,
-          l.useCompression,
-          l.batchSize,
-          l.storageLevel,
+          i.output,
+          i.useCompression,
+          i.batchSize,
+          i.storageLevel,
           origin.child,
-          l.tableName)(
+          i.tableName)(
           origin.cachedColumnBuffers,
           origin.batchStats)
       case p =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -985,7 +985,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
 
   test("system function upper()") {
     checkAnswer(
-      sql("SELECT n,UPPER(l) FROM lowerCaseData"),
+      sql("SELECT n,UPPER(s) FROM lowerCaseData"),
       Seq(
         Row(1, "A"),
         Row(2, "B"),
@@ -1036,7 +1036,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   test("UNION with column mismatches") {
     // Column name mismatches are allowed.
     checkAnswer(
-      sql("SELECT n,l FROM lowerCaseData UNION SELECT N as x1, L as x2 FROM upperCaseData"),
+      sql("SELECT n,s FROM lowerCaseData UNION SELECT N as x1, L as x2 FROM upperCaseData"),
       Row(1, "A") :: Row(1, "a") :: Row(2, "B") :: Row(2, "b") :: Row(3, "C") :: Row(3, "c") ::
       Row(4, "D") :: Row(4, "d") :: Row(5, "E") :: Row(6, "F") :: Nil)
     // Column type mismatches are not allowed, forcing a type coercion.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -26,7 +26,7 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
 
   val row = identity[(java.lang.Integer, java.lang.Double)](_)
 
-  lazy val l = Seq(
+  lazy val left = Seq(
     row(1, 2.0),
     row(1, 2.0),
     row(2, 1.0),
@@ -36,7 +36,7 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     row(null, 5.0),
     row(6, null)).toDF("a", "b")
 
-  lazy val r = Seq(
+  lazy val right = Seq(
     row(2, 3.0),
     row(2, 3.0),
     row(3, 2.0),
@@ -45,12 +45,12 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     row(null, 5.0),
     row(6, null)).toDF("c", "d")
 
-  lazy val t = r.filter($"c".isNotNull && $"d".isNotNull)
+  lazy val t = right.filter($"c".isNotNull && $"d".isNotNull)
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
-    l.createOrReplaceTempView("l")
-    r.createOrReplaceTempView("r")
+    left.createOrReplaceTempView("l")
+    right.createOrReplaceTempView("r")
     t.createOrReplaceTempView("t")
   }
 
@@ -158,7 +158,7 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     val df = sql("select a, sum(b) as s from l group by a having a > (select avg(a) from l)")
     val expected = Row(3, 2.0, 3, 3.0) :: Row(6, null, 6, null) :: Nil
     (1 to 10).foreach { _ =>
-      checkAnswer(r.join(df, $"c" === $"a"), expected)
+      checkAnswer(right.join(df, $"c" === $"a"), expected)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -472,8 +472,8 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
 
     if (buckets > 0) {
       val bucketed = df.queryExecution.analyzed transform {
-        case l @ LogicalRelation(r: HadoopFsRelation, _, _) =>
-          l.copy(relation =
+        case lr @ LogicalRelation(r: HadoopFsRelation, _, _) =>
+          lr.copy(relation =
             r.copy(bucketSpec = Some(BucketSpec(numBuckets = buckets, "c1" :: Nil, Nil))))
       }
       Dataset.ofRows(spark, bucketed)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -50,7 +50,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       Row(3, "c"),
       Row(4, "d"),
       Row(null, "e")
-    )), new StructType().add("n", IntegerType).add("l", StringType))
+    )), new StructType().add("n", IntegerType).add("s", StringType))
 
   private lazy val myTestData1 = Seq(
     (1, 1),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/stat/ApproxQuantileSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/stat/ApproxQuantileSuite.scala
@@ -87,8 +87,8 @@ class ApproxQuantileSuite extends SparkFunSuite {
   } {
 
     val (data1, data2) = {
-      val l = data.size
-      data.take(l / 2) -> data.drop(l / 2)
+      val size = data.size
+      data.take(size / 2) -> data.drop(size / 2)
     }
 
     test(s"Merging ordered lists with epsi=$epsi and seq=$seq_name, compression=$compression") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -298,7 +298,7 @@ private[sql] object SQLTestData {
   case class DecimalData(a: BigDecimal, b: BigDecimal)
   case class BinaryData(a: Array[Byte], b: Int)
   case class UpperCaseData(N: Int, L: String)
-  case class LowerCaseData(n: Int, l: String)
+  case class LowerCaseData(n: Int, s: String)
   case class ArrayData(data: Seq[Int], nestedData: Seq[Seq[Int]])
   case class MapData(data: scala.collection.Map[Int, String])
   case class StringData(s: String)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -348,9 +348,9 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
           var counter = 0
           try {
             while (!out.checkError() && driver.getResults(res)) {
-              res.asScala.foreach { l =>
+              res.asScala.foreach { line =>
                 counter += 1
-                out.println(l)
+                out.println(line)
               }
               res.clear()
             }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -576,8 +576,8 @@ private[hive] trait HiveInspectors {
         data: Any => {
           if (data != null) {
             Option(li.getList(data))
-              .map { l =>
-                val values = l.asScala.map(unwrapper).toArray
+              .map { list =>
+                val values = list.asScala.map(unwrapper).toArray
                 new GenericArrayData(values)
               }
               .orNull
@@ -880,7 +880,8 @@ private[hive] trait HiveInspectors {
         types.StructField(
           f.getFieldName, inspectorToDataType(f.getFieldObjectInspector), nullable = true)
       ))
-    case l: ListObjectInspector => ArrayType(inspectorToDataType(l.getListElementObjectInspector))
+    case loi: ListObjectInspector =>
+      ArrayType(inspectorToDataType(loi.getListElementObjectInspector))
     case m: MapObjectInspector =>
       MapType(
         inspectorToDataType(m.getMapKeyObjectInspector),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ErrorPositionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ErrorPositionSuite.scala
@@ -142,7 +142,7 @@ class ErrorPositionSuite extends QueryTest with TestHiveSingleton with BeforeAnd
       assert(!error.getMessage.contains("List("))
 
       val (line, expectedLineNum) = query.split("\n").zipWithIndex.collect {
-        case (l, i) if l.contains(token) => (l, i + 1)
+        case (line, i) if line.contains(token) => (line, i + 1)
       }.headOption.getOrElse(sys.error(s"Invalid test. Token $token not in $query"))
       val actualLine = error.line.getOrElse {
         fail(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -549,7 +549,7 @@ class HiveDDLCommandSuite extends PlanTest {
   test("load data") {
     val v1 = "LOAD DATA INPATH 'path' INTO TABLE table1"
     val (table, path, isLocal, isOverwrite, partition) = parser.parsePlan(v1).collect {
-      case LoadDataCommand(t, path, l, o, partition) => (t, path, l, o, partition)
+      case LoadDataCommand(t, path, local, o, partition) => (t, path, local, o, partition)
     }.head
     assert(table.database.isEmpty)
     assert(table.table == "table1")
@@ -560,7 +560,7 @@ class HiveDDLCommandSuite extends PlanTest {
 
     val v2 = "LOAD DATA LOCAL INPATH 'path' OVERWRITE INTO TABLE table1 PARTITION(c='1', d='2')"
     val (table2, path2, isLocal2, isOverwrite2, partition2) = parser.parsePlan(v2).collect {
-      case LoadDataCommand(t, path, l, o, partition) => (t, path, l, o, partition)
+      case LoadDataCommand(t, path, local, o, partition) => (t, path, local, o, partition)
     }.head
     assert(table2.database.isEmpty)
     assert(table2.table == "table1")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -259,7 +259,7 @@ abstract class HiveComparisonTest
       logDebug(s"=== HIVE TEST: $testCaseName ===")
 
       val sqlWithoutComment =
-        sql.split("\n").filterNot(l => l.matches("--.*(?<=[^\\\\]);")).mkString("\n")
+        sql.split("\n").filterNot(line => line.matches("--.*(?<=[^\\\\]);")).mkString("\n")
       val allQueries =
         sqlWithoutComment.split("(?<=[^\\\\]);").map(_.trim).filterNot(q => q == "").toSeq
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -251,7 +251,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
 
     sql(s"CREATE TEMPORARY FUNCTION testUDFListString AS '${classOf[UDFListString].getName}'")
     checkAnswer(
-      sql("SELECT testUDFListString(l) FROM listStringTable"),
+      sql("SELECT testUDFListString(ls) FROM listStringTable"),
       Seq(Row("a,b,c"), Row("d,e")))
     sql("DROP TEMPORARY FUNCTION IF EXISTS testUDFListString")
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -40,7 +40,7 @@ case class Fields(f1: Int, f2: Int, f3: Int, f4: Int, f5: Int)
 case class IntegerCaseClass(i: Int)
 case class ListListIntCaseClass(lli: Seq[(Int, Int, Int)])
 case class StringCaseClass(s: String)
-case class ListStringCaseClass(l: Seq[String])
+case class ListStringCaseClass(ls: Seq[String])
 
 /**
  * A test suite for Hive custom UDFs.

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingSource.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingSource.scala
@@ -31,7 +31,7 @@ private[streaming] class StreamingSource(ssc: StreamingContext) extends Source {
   private def registerGauge[T](name: String, f: StreamingJobProgressListener => T,
       defaultValue: T): Unit = {
     registerGaugeWithOption[T](name,
-      (l: StreamingJobProgressListener) => Option(f(streamingListener)), defaultValue)
+      (_: StreamingJobProgressListener) => Option(f(streamingListener)), defaultValue)
   }
 
   private def registerGaugeWithOption[T](

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverSchedulingPolicySuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverSchedulingPolicySuite.scala
@@ -108,9 +108,9 @@ class ReceiverSchedulingPolicySuite extends SparkFunSuite {
     // There should be 1 receiver running on each executor and each receiver has two executors
     scheduledLocations.foreach { case (receiverId, locations) =>
       assert(locations.size == 2)
-      locations.foreach { l =>
-        assert(l.isInstanceOf[ExecutorCacheTaskLocation])
-        numReceiversOnExecutor(l) = numReceiversOnExecutor.getOrElse(l, 0) + 1
+      locations.foreach { location =>
+        assert(location.isInstanceOf[ExecutorCacheTaskLocation])
+        numReceiversOnExecutor(location) = numReceiversOnExecutor.getOrElse(location, 0) + 1
       }
     }
     assert(numReceiversOnExecutor === executors.map(_ -> 1).toMap)
@@ -128,9 +128,9 @@ class ReceiverSchedulingPolicySuite extends SparkFunSuite {
     // There should be 1 receiver running on each executor and each receiver has 1 executor
     scheduledLocations.foreach { case (receiverId, executors) =>
       assert(executors.size == 1)
-      executors.foreach { l =>
-        assert(l.isInstanceOf[ExecutorCacheTaskLocation])
-        numReceiversOnExecutor(l) = numReceiversOnExecutor.getOrElse(l, 0) + 1
+      executors.foreach { location =>
+        assert(location.isInstanceOf[ExecutorCacheTaskLocation])
+        numReceiversOnExecutor(location) = numReceiversOnExecutor.getOrElse(location, 0) + 1
       }
     }
     assert(numReceiversOnExecutor === executors.map(_ -> 1).toMap)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a ScalaStyle custom rule, `DisallowMisleadingVariableName`, by using `TokenChecker` rule with regex `^l$`.
-  90 files changed, 372 insertions(+), 350 deletions(-)

Actually, this rule prevents the potential misleading `l` as a token.
## How was this patch tested?

Manual and pass the Jenkins tests.
