### PR TITLE
[MINOR][SQL][TEST] checkAnswer does not print the rows being compared in a correct order

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -434,9 +434,9 @@ object QueryTest {
          |== Results ==
          |${sideBySide(
         s"== Correct Answer - ${expectedAnswer.size} ==" +:
-         prepareAnswer(expectedAnswer, isSorted).map(_.toString()),
+         expectedAnswer.map(_.toString()),
         s"== Spark Answer - ${sparkAnswer.size} ==" +:
-         prepareAnswer(sparkAnswer, isSorted).map(_.toString())).mkString("\n")}
+         sparkAnswer.map(_.toString())).mkString("\n")}
         """.stripMargin
       return Some(errorMessage)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR corrects the order of rows being printed in `checkAnswer()` function. For example,

``` scala
val a = Seq("foo", "bar", "bla", "blabla").toDF()
val b = Seq("fooo","barr", "bla", "blabla").toDF()
checkAnswer(a, b)
```

The codes above print the error message as below:

```
== Results ==
!== Correct Answer - 4 ==   == Spark Answer - 4 ==
![barr]                     [bar]
 [bla]                      [bla]
 [blabla]                   [blabla]
![fooo]                     [foo]
```

I understand it compares after sorting the rows but the error message seems not sensible. 

This PR corrects the order as it is rather than sorts the rows as below:

```
== Results ==
!== Correct Answer - 4 ==   == Spark Answer - 4 ==
![fooo]                     [foo]
![barr]                     [bar]
 [bla]                      [bla]
 [blabla]                   [blabla]
```

**This PR does not change the actual comparison but just the contents being printed.**
## How was this patch tested?

Manually tested.
