### PR TITLE
[SPARK-16250][PYSPARK] Can't use escapeQuotes option in DataFrameWriter.csv()

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -744,7 +744,7 @@ class DataFrameWriter(object):
         if nullValue is not None:
             self.option("nullValue", nullValue)
         if escapeQuotes is not None:
-            self.option("escapeQuotes", nullValue)
+            self.option("escapeQuotes", escapeQuotes)
         self._jwrite.csv(path)
 
     @since(1.5)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR corrects `DataFrameWriter.csv()` to use correct value for the option, `escapeQuotes`. This is using `nullValue` for this.
## How was this patch tested?

N/A
