### PR TITLE
[SPARK-16251][CORE][wip] Fix Flaky test - LocalCheckpointSuite's - missing checkpoint block…

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -224,8 +224,7 @@ class BlockManagerMasterEndpoint(
         val blockManager = blockManagerInfo.get(blockManagerId)
         if (blockManager.isDefined) {
           // Remove the block from the slave's BlockManager.
-          // Doesn't actually wait for a confirmation and the message might get lost.
-          // If message loss becomes frequent, we should add retry logic here.
+          // wait for confirmation.
           blockManager.get.slaveEndpoint.askWithRetry[Boolean](RemoveBlock(blockId))
         }
       }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -226,7 +226,7 @@ class BlockManagerMasterEndpoint(
           // Remove the block from the slave's BlockManager.
           // Doesn't actually wait for a confirmation and the message might get lost.
           // If message loss becomes frequent, we should add retry logic here.
-          blockManager.get.slaveEndpoint.ask[Boolean](RemoveBlock(blockId))
+          blockManager.get.slaveEndpoint.askWithRetry[Boolean](RemoveBlock(blockId))
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On running LocalCheckpointSuite repeatedly 3-4 times, following test fails:

```
Collect should have failed if local checkpoint block is removed... (LocalCheckpointSuite.scala:173)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions$class.newAssertionFailedException(Assertions.scala:495)
```

One such instance at jenkins https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/61354/consoleFull

This test is flaky because, there is a time delay between remove block is requested 
at BlockManagerMasterEndpoint.scala:229 and it actually get's removed at slave. 

One drawback of the change is time required to run the test will increase.
## How was this patch tested?

Existing tests.
