### PR TITLE
[SPARK-16261][EXAMPLES][ML] Fixed incorrect appNames in ML Examples

### DIFF
--- a/examples/src/main/python/ml/decision_tree_regression_example.py
+++ b/examples/src/main/python/ml/decision_tree_regression_example.py
@@ -31,7 +31,7 @@ from pyspark.sql import SparkSession
 if __name__ == "__main__":
     spark = SparkSession\
         .builder\
-        .appName("decision_tree_classification_example")\
+        .appName("DecisionTreeRegressionExample")\
         .getOrCreate()
 
     # $example on$

--- a/examples/src/main/python/ml/lda_example.py
+++ b/examples/src/main/python/ml/lda_example.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     # Creates a SparkSession
     spark = SparkSession \
         .builder \
-        .appName("PythonKMeansExample") \
+        .appName("LDAExample") \
         .getOrCreate()
 
     # $example on$

--- a/examples/src/main/python/ml/simple_params_example.py
+++ b/examples/src/main/python/ml/simple_params_example.py
@@ -33,7 +33,7 @@ Run with:
 if __name__ == "__main__":
     spark = SparkSession \
         .builder \
-        .appName("SimpleTextClassificationPipeline") \
+        .appName("SimpleParamsExample") \
         .getOrCreate()
 
     # prepare training data.

--- a/examples/src/main/scala/org/apache/spark/examples/ml/CountVectorizerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/CountVectorizerExample.scala
@@ -27,7 +27,7 @@ object CountVectorizerExample {
   def main(args: Array[String]) {
     val spark = SparkSession
       .builder
-      .appName("CounterVectorizerExample")
+      .appName("CountVectorizerExample")
       .getOrCreate()
 
     // $example on$


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some appNames in ML examples are incorrect, mostly in PySpark but one in Scala.  This corrects the names.
## How was this patch tested?

Style, local tests
