### PR TITLE
[SPARK-16265][SUBMIT] Addition of --driver-jre Flag to SparkSubmit

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -25,7 +25,7 @@ commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
 commons-compiler-2.7.6.jar
-commons-compress-1.4.1.jar
+commons-compress-1.12.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar
 commons-digester-1.8.jar
@@ -161,5 +161,4 @@ univocity-parsers-2.1.1.jar
 validation-api-1.1.0.Final.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
-xz-1.0.jar
 zookeeper-3.4.5.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -28,7 +28,7 @@ commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
 commons-compiler-2.7.6.jar
-commons-compress-1.4.1.jar
+commons-compress-1.12.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar
 commons-digester-1.8.jar
@@ -169,5 +169,4 @@ univocity-parsers-2.1.1.jar
 validation-api-1.1.0.Final.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
-xz-1.0.jar
 zookeeper-3.4.5.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -28,7 +28,7 @@ commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
 commons-compiler-2.7.6.jar
-commons-compress-1.4.1.jar
+commons-compress-1.12.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar
 commons-digester-1.8.jar
@@ -169,5 +169,4 @@ univocity-parsers-2.1.1.jar
 validation-api-1.1.0.Final.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
-xz-1.0.jar
 zookeeper-3.4.5.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -32,7 +32,7 @@ commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
 commons-compiler-2.7.6.jar
-commons-compress-1.4.1.jar
+commons-compress-1.12.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar
 commons-digester-1.8.jar
@@ -178,5 +178,4 @@ validation-api-1.1.0.Final.jar
 xbean-asm5-shaded-4.4.jar
 xercesImpl-2.9.1.jar
 xmlenc-0.52.jar
-xz-1.0.jar
 zookeeper-3.4.6.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -32,7 +32,7 @@ commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
 commons-compiler-2.7.6.jar
-commons-compress-1.4.1.jar
+commons-compress-1.12.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar
 commons-digester-1.8.jar
@@ -179,5 +179,4 @@ validation-api-1.1.0.Final.jar
 xbean-asm5-shaded-4.4.jar
 xercesImpl-2.9.1.jar
 xmlenc-0.52.jar
-xz-1.0.jar
 zookeeper-3.4.6.jar

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -39,6 +39,7 @@ import static org.apache.spark.launcher.CommandBuilderUtils.*;
 abstract class AbstractCommandBuilder {
 
   boolean verbose;
+  boolean driverJre;
   String appName;
   String appResource;
   String deployMode;

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -359,6 +359,16 @@ public class SparkLauncher {
   }
 
   /**
+   * Enables shipping of driver JRE to the YARN cluster nodes.
+   *
+   * This ensures that all executors run with the same version of the JRE as the client.
+   */
+  public SparkLauncher withDriverJre() {
+    builder.driverJre = true;
+    return this;
+  }
+
+  /**
    * Launches a sub-process that will start the configured Spark application.
    * <p>
    * The {@link #startApplication(SparkAppHandle.Listener...)} method is preferred when launching

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -42,6 +42,7 @@ class SparkSubmitOptionParser {
   protected final String DRIVER_CLASS_PATH = "--driver-class-path";
   protected final String DRIVER_CORES = "--driver-cores";
   protected final String DRIVER_JAVA_OPTIONS =  "--driver-java-options";
+  protected final String DRIVER_JRE = "--driver-jre";
   protected final String DRIVER_LIBRARY_PATH = "--driver-library-path";
   protected final String DRIVER_MEMORY = "--driver-memory";
   protected final String EXECUTOR_MEMORY = "--executor-memory";
@@ -121,6 +122,7 @@ class SparkSubmitOptionParser {
    * List of switches (command line options that do not take parameters) recognized by spark-submit.
    */
   final String[][] switches = {
+    { DRIVER_JRE },
     { HELP, "-h" },
     { SUPERVISE },
     { USAGE_ERROR },

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,8 @@
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
     <commons-lang3.version>3.3.2</commons-lang3.version>
+    <!-- org.apache.commons/commons-compress/-->
+    <commons-compress.version>1.12</commons-compress.version>
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
     <janino.version>2.7.8</janino.version>
     <jersey.version>2.22.2</jersey.version>
@@ -379,6 +381,11 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${commons-lang2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Addition of `--driver-jre` flag to `SparkSubmitArguments`
2. Now when `--driver-jre` is specified to `SparkSubmit` and it is connecting to a YARN master, the driver will zip up a copy of its in-use JRE and ship it to the YARN cluster as part of `spark.yarn.dist.archives`. Then by setting `spark.executorEnv.JAVA_HOME` and `spark.appMasterEnv.JAVA_HOME` to point to their local copies, use of specific versions of Java can be had even on YARN clusters that do not have those versions pre-installed.
## How was this patch tested?

Compiled the Spark examples with Java 8, did a Java 8 `spark-submit --driver-jre` of `SparkPi`  to a Java 7 YARN cluster, executors and AM used Java 8 without issue. Running without shipping the JRE results in errors due to Java version differences.
