### PR TITLE
[SPARK-14351] [MLlib] [ML] Optimize findBestSplits method for decision trees (and random forest)

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
@@ -94,6 +94,16 @@ private[spark] class DTStatsAggregator(
     impurityAggregator.getCalculator(allStats, featureOffset + binIndex * statsSize)
   }
 
+  /**
+   * Calculate gain for a given (featureOffset, leftBin, parentBin).
+   *
+   * @param featureOffset  This is a pre-computed (node, feature) offset
+   *                           from [[getFeatureOffset]].
+   * @param leftBinIndex  Index of the leftChild in allStats
+   *                          Given by featureOffset + leftBinIndex * statsSize
+   * @param parentBinIndex  Index of the parent in allStats
+   *                            Given by featureOffset + parentBinIndex * statsSize
+   */
   def calculateGain(
       featureOffset: Int,
       leftBinIndex: Int,
@@ -115,6 +125,14 @@ private[spark] class DTStatsAggregator(
     gain
   }
 
+  /**
+   * Calculate gain for a given (featureOffset, leftBin).
+   * The stats of the parent are inferred from parentStats.
+   * @param featureOffset  This is a pre-computed (node, feature) offset
+   *                           from [[getFeatureOffset]].
+   * @param leftBinIndex  Index of the leftChild in allStats
+   *                          Given by featureOffset + leftBinIndex * statsSize
+   */
   def calculateGain(
       featureOffset: Int,
       leftBinIndex: Int): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
@@ -94,6 +94,27 @@ private[spark] class DTStatsAggregator(
     impurityAggregator.getCalculator(allStats, featureOffset + binIndex * statsSize)
   }
 
+  def calculateGain(
+      featureOffset: Int,
+      leftBinIndex: Int,
+      parentBinIndex: Int): Double = {
+    val leftChildOffset = featureOffset + leftBinIndex * statsSize
+    val parentOffset = featureOffset + parentBinIndex * statsSize
+    val gain = metadata.impurity match {
+      case Gini => Gini.calculateGain(
+        allStats, leftChildOffset, parentOffset, statsSize, metadata.minInstancesPerNode,
+        metadata.minInfoGain)
+      case Entropy => Entropy.calculateGain(
+        allStats, leftChildOffset, parentOffset, statsSize, metadata.minInstancesPerNode,
+        metadata.minInfoGain)
+      case Variance => Variance.calculateGain(
+        allStats, leftChildOffset, parentOffset, statsSize, metadata.minInstancesPerNode,
+        metadata.minInfoGain)
+      case _ => throw new IllegalArgumentException(s"Bad impurity parameter: ${metadata.impurity}")
+    }
+    gain
+  }
+
   /**
    * Get an [[ImpurityCalculator]] for the parent node.
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
@@ -102,13 +102,32 @@ private[spark] class DTStatsAggregator(
     val parentOffset = featureOffset + parentBinIndex * statsSize
     val gain = metadata.impurity match {
       case Gini => Gini.calculateGain(
-        allStats, leftChildOffset, parentOffset, statsSize, metadata.minInstancesPerNode,
+        allStats, leftChildOffset, allStats, parentOffset, statsSize,
+        metadata.minInstancesPerNode, metadata.minInfoGain)
+      case Entropy => Entropy.calculateGain(
+        allStats, leftChildOffset, allStats, parentOffset, statsSize,
+        metadata.minInstancesPerNode, metadata.minInfoGain)
+      case Variance => Variance.calculateGain(
+        allStats, leftChildOffset, allStats, parentOffset, statsSize,
+        metadata.minInstancesPerNode, metadata.minInfoGain)
+      case _ => throw new IllegalArgumentException(s"Bad impurity parameter: ${metadata.impurity}")
+    }
+    gain
+  }
+
+  def calculateGain(
+      featureOffset: Int,
+      leftBinIndex: Int): Double = {
+    val leftChildOffset = featureOffset + leftBinIndex * statsSize
+    val gain = metadata.impurity match {
+      case Gini => Gini.calculateGain(
+        allStats, leftChildOffset, parentStats, 0, statsSize, metadata.minInstancesPerNode,
         metadata.minInfoGain)
       case Entropy => Entropy.calculateGain(
-        allStats, leftChildOffset, parentOffset, statsSize, metadata.minInstancesPerNode,
+        allStats, leftChildOffset, parentStats, 0, statsSize, metadata.minInstancesPerNode,
         metadata.minInfoGain)
       case Variance => Variance.calculateGain(
-        allStats, leftChildOffset, parentOffset, statsSize, metadata.minInstancesPerNode,
+        allStats, leftChildOffset, parentStats, 0, statsSize, metadata.minInstancesPerNode,
         metadata.minInfoGain)
       case _ => throw new IllegalArgumentException(s"Bad impurity parameter: ${metadata.impurity}")
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -731,7 +731,7 @@ private[spark] object RandomForest extends Logging {
         } else if (binAggregates.metadata.isUnordered(featureIndex)) {
           // Unordered categorical feature
           val leftChildOffset = binAggregates.getFeatureOffset(featureIndexIdx)
-          val (bestFeatureSplitIndex, bestFeatureGainStats) =
+          val (temp, bestFeatureGainStats) =
             Range(0, numSplits).map { splitIndex =>
               val leftChildStats = binAggregates.getImpurityCalculator(leftChildOffset, splitIndex)
               val rightChildStats = binAggregates.getParentImpurityCalculator()
@@ -740,6 +740,11 @@ private[spark] object RandomForest extends Logging {
                 leftChildStats, rightChildStats, binAggregates.metadata)
               (splitIndex, gainAndImpurityStats)
             }.maxBy(_._2.gain)
+          val (bestFeatureSplitIndex, maxGain) =
+            Range(0, numSplits).map { case splitIdx =>
+              val gain = binAggregates.calculateGain(leftChildOffset, splitIdx)
+              (splitIdx, gain)
+            }.maxBy(_._2)
           (splits(featureIndex)(bestFeatureSplitIndex), bestFeatureGainStats)
         } else {
           // Ordered categorical feature

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -648,7 +648,7 @@ private[spark] object RandomForest extends Logging {
           }
           // Find best split.
           val (bestFeatureSplitIndex, maxGain) =
-            Range(0, numSplits).map { case splitIdx =>
+            Range(0, numSplits).map { splitIdx =>
               val gain = binAggregates.calculateGain(nodeFeatureOffset, splitIdx, numSplits)
               (splitIdx, gain)
             }.maxBy(_._2)
@@ -658,7 +658,7 @@ private[spark] object RandomForest extends Logging {
           // Unordered categorical feature
           val leftChildOffset = binAggregates.getFeatureOffset(featureIndexIdx)
           val (bestFeatureSplitIndex, maxGain) =
-            Range(0, numSplits).map { case splitIdx =>
+            Range(0, numSplits).map { splitIdx =>
               val gain = binAggregates.calculateGain(leftChildOffset, splitIdx)
               (splitIdx, gain)
             }.maxBy(_._2)
@@ -723,7 +723,7 @@ private[spark] object RandomForest extends Logging {
           val lastCategory = categoriesSortedByCentroid.last._1
           // Find best split.
           val (bestFeatureSplitIndex, maxGain) =
-            Range(0, numSplits).map { case splitIdx =>
+            Range(0, numSplits).map { splitIdx =>
               val featureValue = categoriesSortedByCentroid(splitIdx)._1
               val gain = binAggregates.calculateGain(nodeFeatureOffset, featureValue, lastCategory)
               (splitIdx, gain)

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
@@ -40,19 +40,7 @@ object Entropy extends Impurity {
    * information calculation for multiclass classification
    * @param counts Array[Double] with counts for each label
    * @param totalCount sum of counts for all labels
-   * @return information value, or 0 if totalCount = 0    var leftCount = 0.0
-    var totalCount = 0.0
-    var i = 0
-    while (i < statsSize) {
-      leftCount += allStats(leftChildOffset + i)
-      totalCount += allStats(parentOffset + i)
-    }
-    val rightCount = totalCount - leftCount
-
-    if ((leftCount < minInstancesPerNode) ||
-      (rightCount < minInstancesPerNode)) {
-      return Double.MinValue
-    }
+   * @return information value, or 0 if totalCount = 0
    */
   @Since("1.1.0")
   @DeveloperApi

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
@@ -27,14 +27,32 @@ import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
 @Experimental
 object Entropy extends Impurity {
 
-  private[tree] def log2(x: Double) = scala.math.log(x) / scala.math.log(2)
+  private[tree] def log2(x: Double): Double = {
+    if (x == 0) {
+      return 0.0
+    } else {
+      return scala.math.log(x) / scala.math.log(2)
+    }
+  }
 
   /**
    * :: DeveloperApi ::
    * information calculation for multiclass classification
    * @param counts Array[Double] with counts for each label
    * @param totalCount sum of counts for all labels
-   * @return information value, or 0 if totalCount = 0
+   * @return information value, or 0 if totalCount = 0    var leftCount = 0.0
+    var totalCount = 0.0
+    var i = 0
+    while (i < statsSize) {
+      leftCount += allStats(leftChildOffset + i)
+      totalCount += allStats(parentOffset + i)
+    }
+    val rightCount = totalCount - leftCount
+
+    if ((leftCount < minInstancesPerNode) ||
+      (rightCount < minInstancesPerNode)) {
+      return Double.MinValue
+    }
    */
   @Since("1.1.0")
   @DeveloperApi
@@ -47,10 +65,8 @@ object Entropy extends Impurity {
     var classIndex = 0
     while (classIndex < numClasses) {
       val classCount = counts(classIndex)
-      if (classCount != 0) {
-        val freq = classCount / totalCount
-        impurity -= freq * log2(freq)
-      }
+      val freq = classCount / totalCount
+      impurity -= freq * log2(freq)
       classIndex += 1
     }
     impurity
@@ -76,6 +92,56 @@ object Entropy extends Impurity {
   @Since("1.1.0")
   def instance: this.type = this
 
+  override def calculateGain(
+      allStats: Array[Double],
+      leftChildOffset: Int,
+      parentOffset: Int,
+      statsSize: Int,
+      minInstancesPerNode: Int,
+      minInfoGain: Double): Double = {
+    var leftCount = 0.0
+    var totalCount = 0.0
+    var i = 0
+    while (i < statsSize) {
+      leftCount += allStats(leftChildOffset + i)
+      totalCount += allStats(parentOffset + i)
+      i += 1
+    }
+    val rightCount = totalCount - leftCount
+
+    if ((leftCount < minInstancesPerNode) ||
+      (rightCount < minInstancesPerNode)) {
+      return Double.MinValue
+    }
+
+    var leftImpurity = 0.0
+    var rightImpurity = 0.0
+    var parentImpurity = 0.0
+
+    i = 0
+    while (i < statsSize) {
+      val leftStats = allStats(leftChildOffset + i)
+      val parentStats = allStats(parentOffset + i)
+
+      val leftFreq = leftStats / leftCount
+      val rightFreq = (parentStats - leftStats) / rightCount
+      val parentFreq = parentStats / totalCount
+
+      leftImpurity -= leftFreq * log2(leftFreq)
+      rightImpurity -= rightFreq * log2(rightFreq)
+      parentImpurity -= parentFreq * log2(parentFreq)
+
+      i += 1
+    }
+    val leftWeighted = leftCount / totalCount * leftImpurity
+    val rightWeighted = rightCount / totalCount * rightImpurity
+    val gain = parentImpurity - leftWeighted - rightWeighted
+
+    if (gain < minInfoGain) {
+      return Double.MinValue
+    }
+    gain
+  }
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
@@ -80,6 +80,21 @@ object Entropy extends Impurity {
   @Since("1.1.0")
   def instance: this.type = this
 
+  /**
+   * Information gain calculation.
+   * allStats(leftChildOffset: leftChildOffset + statsSize) contains the impurity
+   * information of the leftChild.
+   * parentsStats(parentOffset: parentOffset + statsSize) contains the impurity
+   * information of the parent.
+   * @param allStats  Flat stats array, with stats for this (node, feature, bin) contiguous.
+   * @param leftChildOffset  Start index of stats for the left child.
+   * @param parentStats  Flat stats array for impurity calculation of the parent.
+   * @param parentOffset  Start index of stats for the parent.
+   * @param statsSize  Size of the stats for the left child and the parent.
+   * @param minInstancePerNode  minimum no. of instances in the child nodes for non-zero gain.
+   * @param minInfoGain  return zero if gain < minInfoGain.
+   * @return information gain.
+   */
   override def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Entropy.scala
@@ -95,6 +95,7 @@ object Entropy extends Impurity {
   override def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,
+      parentStats: Array[Double],
       parentOffset: Int,
       statsSize: Int,
       minInstancesPerNode: Int,
@@ -104,7 +105,7 @@ object Entropy extends Impurity {
     var i = 0
     while (i < statsSize) {
       leftCount += allStats(leftChildOffset + i)
-      totalCount += allStats(parentOffset + i)
+      totalCount += parentStats(parentOffset + i)
       i += 1
     }
     val rightCount = totalCount - leftCount
@@ -121,11 +122,11 @@ object Entropy extends Impurity {
     i = 0
     while (i < statsSize) {
       val leftStats = allStats(leftChildOffset + i)
-      val parentStats = allStats(parentOffset + i)
+      val totalStats = parentStats(parentOffset + i)
 
       val leftFreq = leftStats / leftCount
-      val rightFreq = (parentStats - leftStats) / rightCount
-      val parentFreq = parentStats / totalCount
+      val rightFreq = (totalStats - leftStats) / rightCount
+      val parentFreq = totalStats / totalCount
 
       leftImpurity -= leftFreq * log2(leftFreq)
       rightImpurity -= rightFreq * log2(rightFreq)

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala
@@ -73,6 +73,21 @@ object Gini extends Impurity {
   @Since("1.1.0")
   def instance: this.type = this
 
+  /**
+   * Information gain calculation.
+   * allStats(leftChildOffset: leftChildOffset + statsSize) contains the impurity
+   * information of the leftChild.
+   * parentsStats(parentOffset: parentOffset + statsSize) contains the impurity
+   * information of the parent.
+   * @param allStats  Flat stats array, with stats for this (node, feature, bin) contiguous.
+   * @param leftChildOffset  Start index of stats for the left child.
+   * @param parentStats  Flat stats array for impurity calculation of the parent.
+   * @param parentOffset  Start index of stats for the parent.
+   * @param statsSize  Size of the stats for the left child and the parent.
+   * @param minInstancePerNode  minimum no. of instances in the child nodes for non-zero gain.
+   * @param minInfoGain  return zero if gain < minInfoGain.
+   * @return information gain.
+   */
   override def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala
@@ -76,6 +76,7 @@ object Gini extends Impurity {
   override def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,
+      parentStats: Array[Double],
       parentOffset: Int,
       statsSize: Int,
       minInstancesPerNode: Int,
@@ -86,7 +87,7 @@ object Gini extends Impurity {
     var i = 0
     while (i < statsSize) {
       leftCount += allStats(leftChildOffset + i)
-      totalCount += allStats(parentOffset + i)
+      totalCount += parentStats(parentOffset + i)
       i += 1
     }
     val rightCount = totalCount - leftCount
@@ -103,11 +104,11 @@ object Gini extends Impurity {
     i = 0
     while (i < statsSize) {
       val leftStats = allStats(leftChildOffset + i)
-      val parentStats = allStats(parentOffset + i)
+      val totalStats = parentStats(parentOffset + i)
 
       val leftFreq = leftStats / leftCount
-      val rightFreq = (parentStats - leftStats) / rightCount
-      val parentFreq = parentStats / totalCount
+      val rightFreq = (totalStats - leftStats) / rightCount
+      val parentFreq = totalStats / totalCount
 
       leftImpurity -= leftFreq * leftFreq
       rightImpurity -= rightFreq * rightFreq

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -52,6 +52,14 @@ trait Impurity extends Serializable {
   @Since("1.0.0")
   @DeveloperApi
   def calculate(count: Double, sum: Double, sumSquares: Double): Double
+
+  protected def calculateGain(
+      allStats: Array[Double],
+      leftChildOffset: Int,
+      parentOffset: Int,
+      statsSize: Int,
+      minInstancesPerNode: Int,
+      minInfoGain: Double): Double
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -53,6 +53,21 @@ trait Impurity extends Serializable {
   @DeveloperApi
   def calculate(count: Double, sum: Double, sumSquares: Double): Double
 
+  /**
+   * Information gain calculation.
+   * allStats(leftChildOffset: leftChildOffset + statsSize) contains the impurity
+   * information of the leftChild.
+   * parentsStats(parentOffset: parentOffset + statsSize) contains the impurity
+   * information of the parent.
+   * @param allStats Flat stats array, with stats for this (node, feature, bin) contiguous.
+   * @param leftChildOffset  Start index of stats for the left child.
+   * @param parentStats  Flat stats array for impurity calculation of the parent.
+   * @param parentOffset  Start index of stats for the parent.
+   * @param statsSize  Size of the stats for the left child and the parent.
+   * @param minInstancePerNode  minimum no. of instances in the child nodes for non-zero gain.
+   * @param minInfoGain  return zero if gain < minInfoGain.
+   * @return information gain.
+   */
   protected def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -56,6 +56,7 @@ trait Impurity extends Serializable {
   protected def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,
+      parentStats: Array[Double],
       parentOffset: Int,
       statsSize: Int,
       minInstancesPerNode: Int,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
@@ -64,6 +64,21 @@ object Variance extends Impurity {
   @Since("1.0.0")
   def instance: this.type = this
 
+  /**
+   * Information gain calculation.
+   * allStats(leftChildOffset: leftChildOffset + statsSize) contains the impurity
+   * information of the leftChild.
+   * parentsStats(parentOffset: parentOffset + statsSize) contains the impurity
+   * information of the parent.
+   * @param allStats  Flat stats array, with stats for this (node, feature, bin) contiguous.
+   * @param leftChildOffset  Start index of stats for the left child.
+   * @param parentStats  Flat stats array for impurity calculation of the parent.
+   * @param parentOffset  Start index of stats for the parent.
+   * @param statsSize  Size of the stats for the left child and the parent.
+   * @param minInstancePerNode  minimum no. of instances in the child nodes for non-zero gain.
+   * @param minInfoGain  return zero if gain < minInfoGain.
+   * @return information gain.
+   */
   override def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
@@ -106,11 +106,8 @@ object Variance extends Impurity {
     val rightSumSquares = parentSumSquares - leftSumSquares
 
     val parentImpurity = (parentSumSquares - (parentSum * parentSum) / totalCount) / totalCount
-    val leftImpurity = (leftSumSquares - (leftSum * leftSum) / leftCount) / leftCount
-    val rightImpurity = (rightSumSquares - (rightSum * rightSum) / rightCount) / leftCount
-
-    val leftWeighted = leftImpurity * leftCount / totalCount
-    val rightWeighted = rightImpurity * rightCount / totalCount
+    val leftWeighted = (leftSumSquares - (leftSum * leftSum) / leftCount) / totalCount
+    val rightWeighted = (rightSumSquares - (rightSum * rightSum) / rightCount) / totalCount
     val gain = parentImpurity - leftWeighted - rightWeighted
 
     if (gain < minInfoGain) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
@@ -67,6 +67,7 @@ object Variance extends Impurity {
   override def calculateGain(
       allStats: Array[Double],
       leftChildOffset: Int,
+      parentStats: Array[Double],
       parentOffset: Int,
       statsSize: Int,
       minInstancesPerNode: Int,
@@ -83,8 +84,8 @@ object Variance extends Impurity {
     val leftSum = allStats(leftChildOffset + 1)
     val leftSumSquares = allStats(leftChildOffset + 2)
 
-    val parentSum = allStats(parentOffset + 1)
-    val parentSumSquares = allStats(parentOffset + 2)
+    val parentSum = parentStats(parentOffset + 1)
+    val parentSumSquares = parentStats(parentOffset + 2)
 
     val rightSum = parentSum - leftSum
     val rightSumSquares = parentSumSquares - leftSumSquares

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Variance.scala
@@ -64,6 +64,46 @@ object Variance extends Impurity {
   @Since("1.0.0")
   def instance: this.type = this
 
+  override def calculateGain(
+      allStats: Array[Double],
+      leftChildOffset: Int,
+      parentOffset: Int,
+      statsSize: Int,
+      minInstancesPerNode: Int,
+      minInfoGain: Double): Double = {
+    val leftCount = allStats(leftChildOffset)
+    val totalCount = allStats(parentOffset)
+    val rightCount = totalCount - leftCount
+
+    if ((leftCount < minInstancesPerNode) ||
+      (rightCount < minInstancesPerNode)) {
+      return Double.MinValue
+    }
+
+    val leftSum = allStats(leftChildOffset + 1)
+    val leftSumSquares = allStats(leftChildOffset + 2)
+
+    val parentSum = allStats(parentOffset + 1)
+    val parentSumSquares = allStats(parentOffset + 2)
+
+    val rightSum = parentSum - leftSum
+    val rightSumSquares = parentSumSquares - leftSumSquares
+
+    val parentImpurity = (parentSumSquares - (parentSum * parentSum) / totalCount) / totalCount
+    val leftImpurity = (leftSumSquares - (leftSum * leftSum) / leftCount) / leftCount
+    val rightImpurity = (rightSumSquares - (rightSum * rightSum) / rightCount) / leftCount
+
+    val leftWeighted = leftImpurity * leftCount / totalCount
+    val rightWeighted = rightImpurity * rightCount / totalCount
+    val gain = parentImpurity - leftWeighted - rightWeighted
+
+    if (gain < minInfoGain) {
+      return Double.MinValue
+    }
+    gain
+
+  }
+
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current `findBestSplits` method creates an instance of `ImpurityCalculator` and `ImpurityStats` for every possible split and feature in the search for the bestSplit. Every instance of `ImpurityCalculator` creates an array of size `statsSize` which is unnecessary and take a non-negligible amount of time. This pull request tackles this problem by the following technique.
1. Remove the `impurityCalculator` instantiation for every possible split and feature. Replace this by a `calculateGain` method for each impurity that computes the gain directly from the `allStats` attribute of the `DTStatsAggregator` which holds all the necessary information. 
2. Replace returning an instance of `ImpurityStats` for every possible split and feature with just the information gain returned from the `calculateGain` method since the gain is sufficient to calculate the `bestSplit`. Just return an instance of `ImpurityStats` once for the `bestSplit` 
3. Remove the not-so-useful `calculateImpurityStats` method. 
## How was this patch tested?

Since this is a performance improvement, tests are necessary. Here are the improvements for a `RandomForestRegressor` with `maxDepth` set to 30, `subSamplingRate` set to 1 and `maxBins` set to 20 on synthetic data. The timings were calculated locally and the mean of 3 attempts were taken.

| n_trees | n_samples | n_features | time in master | total time in this branch |
| --- | :-: | --: | --: | --: |
| 1 | 10000 | 500 | 8.954 | 7.786 |
| 10 | 10000 | 500 | 9.44 | 6.825 |
| 100 | 10000 | 500 | 18.457 | 16.498 |
| 1 | 500 | 10000 | 8.718 | 6.783 |
| 10 | 500 | 10000 | 8.579 | 6.853 |
| 100 | 500 | 10000 | 17.593 | 15.905 |
| 1 | 1000 | 1000 | 8.323 | 6.456 |
| 10 | 1000 | 1000 | 8.841 | 6.633 |
| 100 | 1000 | 1000 | 17.834 | 16.077 |
| 500 | 1000 | 1000 | 64.3 | 58.94 |
