### PR TITLE
[SPARK-16269][SQL] Support null handling for vectorized hashmap during hash aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -262,8 +262,8 @@ class CodegenContext {
   }
 
   /**
-    * Returns the specialized code to access if null is set at `ordinal` from a `inputRow`.
-    */
+   * Returns the specialized code to access if null is set at `ordinal` from a `inputRow`.
+   */
   def getIsNull(input: String, ordinal: String): String = {
       s"$input.isNullAt($ordinal)"
   }
@@ -377,8 +377,8 @@ class CodegenContext {
   }
 
   /**
-    * Returns the specialized code to access if null is set at `ordinal` from a column vector.
-    */
+   * Returns the specialized code to access if null is set at `ordinal` from a column vector.
+   */
   def getIsNull(batch: String, row: String, ordinal: Int): String = {
     s"$batch.column($ordinal).isNullAt($row)"
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -262,6 +262,13 @@ class CodegenContext {
   }
 
   /**
+    * Returns the specialized code to access if null is set at `ordinal` from a `inputRow`.
+    */
+  def getIsNull(input: String, ordinal: String): String = {
+      s"$input.isNullAt($ordinal)"
+  }
+
+  /**
    * Returns the code to update a column in Row for a given DataType.
    */
   def setColumn(row: String, dataType: DataType, ordinal: Int, value: String): String = {
@@ -367,6 +374,13 @@ class CodegenContext {
       case _ =>
         throw new IllegalArgumentException(s"cannot generate code for unsupported type: $dataType")
     }
+  }
+
+  /**
+    * Returns the specialized code to access if null is set at `ordinal` from a column vector.
+    */
+  def getIsNull(batch: String, row: String, ordinal: Int): String = {
+    s"$batch.column($ordinal).isNullAt($row)"
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -652,6 +652,10 @@ case class HashAggregateExec(
              |  if (${vectorizedRowKeys.map("!" + _.isNull).mkString(" && ")}) {
              |    $vectorizedRowBuffer = $vectorizedHashMapTerm.findOrInsert(
              |        ${vectorizedRowKeys.map(_.value).mkString(", ")});
+             |  } else {
+             |    $vectorizedRowBuffer = $vectorizedHashMapTerm.findOrInsert(
+             |        ${vectorizedRowKeys.map(_.value).mkString(", ")},
+             |        ${vectorizedRowKeys.map(_.isNull).mkString(", ")});
              |  }
              |}
          """.stripMargin)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -379,7 +379,8 @@ class VectorizedHashMapGenerator(
     s"""
        |public org.apache.spark.sql.execution.vectorized.ColumnarBatch.Row findOrInsert(
        |  ${groupingKeySignature}, ${groupingKeyIsNullSignature}) {
-       |  long h = hash(${groupingKeys.map(_.name).mkString(", ")});
+       |  long h = hash(${groupingKeys.map(_.name).mkString(", ")},
+       |                ${groupingKeys.map(_.isNullName).mkString(", ")});
        |  int step = 0;
        |  int idx = (int) h & (numBuckets - 1);
        |  while (step < maxSteps) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -182,9 +182,9 @@ class VectorizedHashMapGenerator(
   }
 
   /**
-    * Similar to generateHashFunction(), but generate hash() with a different signature
-    * to deal with nullable keys
-    */
+   * Similar to generateHashFunction(), but generate hash() with a different signature
+   * to deal with nullable keys
+   */
   private def generateHashFunctionWithNullable(): String = {
     val hash = ctx.freshName("hash")
 
@@ -239,9 +239,9 @@ class VectorizedHashMapGenerator(
 
 
   /**
-    * Similar to generateEquals(), but generate equals() with a different signature
-    * to deal with nullable keys
-    */
+   * Similar to generateEquals(), but generate equals() with a different signature
+   * to deal with nullable keys
+   */
   private def generateEqualsWithNullable(): String = {
 
     def genEqualsForKeys(groupingKeys: Seq[Buffer]): String = {
@@ -350,14 +350,14 @@ class VectorizedHashMapGenerator(
   }
 
   /**
-    * Similar to generateFindOrInsert(), but generate a findOrInsertWithNullable() that
-    * deals with nullable types.
-    *
-    * We generate both versions of findOrInsert(), one can deal with nulls (this one), one cannot.
-    * We could always go with this findOrInsert() but the null dealing logic in this generated
-    * method adds noticeable overhead (observed 40% degradation for some cases) if actual values
-    * are not null for the currently processed record, which could only be known during runtime.
-    */
+   * Similar to generateFindOrInsert(), but generate a findOrInsertWithNullable() that
+   * deals with nullable types.
+   *
+   * We generate both versions of findOrInsert(), one can deal with nulls (this one), one cannot.
+   * We could always go with this findOrInsert() but the null dealing logic in this generated
+   * method adds noticeable overhead (observed 40% degradation for some cases) if actual values
+   * are not null for the currently processed record, which could only be known during runtime.
+   */
   private def generateFindOrInsertWithNullable(): String = {
 
     def genCodeToSetKeys(groupingKeys: Seq[Buffer]): Seq[String] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -225,8 +225,10 @@ class VectorizedHashMapGenerator(
 
     def genEqualsForKeys(groupingKeys: Seq[Buffer]): String = {
       groupingKeys.zipWithIndex.map { case (key: Buffer, ordinal: Int) =>
+        s"""((${ctx.genEqual(BooleanType, ctx.getIsNull("batch", "buckets[idx]", ordinal),
+          "false")})&&""" +
         s"""(${ctx.genEqual(key.dataType, ctx.getValue("batch", "buckets[idx]",
-          key.dataType, ordinal), key.name)})"""
+          key.dataType, ordinal), key.name)}))"""
       }.mkString(" && ")
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AggregateBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AggregateBenchmark.scala
@@ -160,14 +160,14 @@ class AggregateBenchmark extends BenchmarkBase {
 
 
     /*
-      Java HotSpot(TM) 64-Bit Server VM 1.8.0_91-b14 on Mac OS X 10.11.5
-      Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
+    Java HotSpot(TM) 64-Bit Server VM 1.8.0_91-b14 on Mac OS X 10.11.5
+    Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
 
-      Aggregate with null keys:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-      ------------------------------------------------------------------------------------------------
-      codegen = F                                   4369 / 4562         19.2          52.1       1.0X
-      codegen = T hashmap = F                       1835 / 1929         45.7          21.9       2.4X
-      codegen = T hashmap = T                        712 /  923        117.8           8.5       6.1X
+    Aggregate with null keys:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ------------------------------------------------------------------------------------------------
+    codegen = F                                   4369 / 4562         19.2          52.1       1.0X
+    codegen = T hashmap = F                       1835 / 1929         45.7          21.9       2.4X
+    codegen = T hashmap = T                        712 /  923        117.8           8.5       6.1X
     */
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current impl of vectorized hashmap does not support null-value keys for nullable data types.  This patch fix the problem by adding `generateFindOrInsertWithNullable()` method in `VectorizedHashMapGenerator.scala`, which code-generates another version of `findOrInsert` that handles null-value keys. 

We need null support so the aggregate logic does not have to fallback to BytesToBytesMap. This would also us to remove BytesToBytesMap completely.

**Note that this patch does degrade query performance when there are no nulls.** Because the vectorized hashmap now contains null-value keys, we need to perform more null checks when comparing key values, i.e., in `equals`. In the future, we might use two levels of vectorized hashmap, with the first level only dealing non-null values, and second level dealing any values.
## How was this patch tested?

No additional test is added. A simple benchmark test is included to show the performance gain.
