### PR TITLE
[TRIVIAL][PYSPARK] Clean up orc compression option as well

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -693,8 +693,7 @@ class DataFrameWriter(OptionUtils):
         self.mode(mode)
         if partitionBy is not None:
             self.partitionBy(partitionBy)
-        if compression is not None:
-            self.option("compression", compression)
+        self._set_opts(compression=compression)
         self._jwrite.orc(path)
 
     @since(1.4)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR corrects ORC compression option for PySpark as well. I think this was missed mistakenly in https://github.com/apache/spark/pull/13948.
## How was this patch tested?

N/A
