### PR TITLE
[SPARK-16274][SQL] Implement xpath_boolean

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.expressions.xml._
 import org.apache.spark.sql.catalyst.util.StringKeyHashMap
 
 
@@ -301,6 +302,7 @@ object FunctionRegistry {
     expression[UnBase64]("unbase64"),
     expression[Unhex]("unhex"),
     expression[Upper]("upper"),
+    expression[XPathBoolean]("xpath_boolean"),
 
     // datetime functions
     expression[AddMonths]("add_months"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathBoolean.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathBoolean.scala
@@ -37,7 +37,7 @@ case class XPathBoolean(xml: Expression, path: Expression)
     case _ => null
   }
 
-  override def simpleString: String = "xpath_boolean"
+  override def prettyName: String = "xpath_boolean"
 
   override def dataType: DataType = BooleanType
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathBoolean.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathBoolean.scala
@@ -31,7 +31,8 @@ case class XPathBoolean(xml: Expression, path: Expression)
 
   @transient private lazy val xpathUtil = new UDFXPathUtil
 
-  // We use these to avoid converting the path from UTF8String to String if it is a constant.
+  // If the path is a constant, cache the path string so that we don't need to convert path
+  // from UTF8String to String for every row.
   @transient lazy val pathLiteral: String = path match {
     case Literal(str: UTF8String, _) => str.toString
     case _ => null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathBoolean.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathBoolean.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.xml
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+
+@ExpressionDescription(
+  usage = "_FUNC_(xml, xpath) - Evaluates a boolean xpath expression.",
+  extended = "> SELECT _FUNC_('<a><b>1</b></a>','a/b');\ntrue")
+case class XPathBoolean(xml: Expression, path: Expression)
+  extends BinaryExpression with ExpectsInputTypes with CodegenFallback {
+
+  @transient private lazy val xpathUtil = new UDFXPathUtil
+
+  // We use these to avoid converting the path from UTF8String to String if it is a constant.
+  @transient private var lastPathUtf8: UTF8String = null
+  @transient private var lastPathString: String = null
+
+  override def simpleString: String = "xpath_boolean"
+
+  override def dataType: DataType = BooleanType
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
+
+  override def left: Expression = xml
+  override def right: Expression = path
+
+  override protected def nullSafeEval(xml: Any, path: Any): Any = {
+    val xmlString = xml.asInstanceOf[UTF8String].toString
+    val pathUtf8 = path.asInstanceOf[UTF8String]
+    if (pathUtf8 ne lastPathUtf8) {
+      lastPathUtf8 = pathUtf8
+      lastPathString = lastPathUtf8.toString
+    }
+    xpathUtil.evalBoolean(xmlString, lastPathString)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/NonFoldableLiteral.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/NonFoldableLiteral.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.types._
  * A literal value that is not foldable. Used in expression codegen testing to test code path
  * that behave differently based on foldable values.
  */
-case class NonFoldableLiteral(value: Any, dataType: DataType) extends LeafExpression {
+case class NonFoldableLiteral(var value: Any, dataType: DataType) extends LeafExpression {
 
   override def foldable: Boolean = false
   override def nullable: Boolean = true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/NonFoldableLiteral.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/NonFoldableLiteral.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.types._
  * A literal value that is not foldable. Used in expression codegen testing to test code path
  * that behave differently based on foldable values.
  */
-case class NonFoldableLiteral(var value: Any, dataType: DataType) extends LeafExpression {
+case class NonFoldableLiteral(value: Any, dataType: DataType) extends LeafExpression {
 
   override def foldable: Boolean = false
   override def nullable: Boolean = true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathExpressionSuite.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.catalyst.expressions.xml
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, Literal, NonFoldableLiteral}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, Literal}
 import org.apache.spark.sql.types.StringType
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Test suite for various xpath functions.
@@ -54,15 +54,8 @@ class XPathExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("xpath_boolean path cache invalidation") {
     // This is a test to ensure the expression is not reusing the path for different strings
-    val xml = NonFoldableLiteral("<a><b>b</b></a>")
-    val path = NonFoldableLiteral("a/b")
-    val expr = XPathBoolean(xml, path)
-
-    // Run evaluation once
-    assert(expr.eval(null) == true)
-
-    // Change the input path and make sure we don't screw up caching
-    path.value = UTF8String.fromString("a/c")
-    assert(expr.eval(null) == false)
+    val expr = XPathBoolean(Literal("<a><b>b</b></a>"), 'path.string.at(0))
+    checkEvaluation(expr, true, create_row("a/b"))
+    checkEvaluation(expr, false, create_row("a/c"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathExpressionSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.xml
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, Literal, NonFoldableLiteral}
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Test suite for various xpath functions.
+ */
+class XPathExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
+
+  private def testBoolean[T](xml: String, path: String, expected: T): Unit = {
+    checkEvaluation(
+      XPathBoolean(Literal.create(xml, StringType), Literal.create(path, StringType)),
+      expected)
+  }
+
+  test("xpath_boolean") {
+    testBoolean("<a><b>b</b></a>", "a/b", true)
+    testBoolean("<a><b>b</b></a>", "a/c", false)
+    testBoolean("<a><b>b</b></a>", "a/b = \"b\"", true)
+    testBoolean("<a><b>b</b></a>", "a/b = \"c\"", false)
+    testBoolean("<a><b>10</b></a>", "a/b < 10", false)
+    testBoolean("<a><b>10</b></a>", "a/b = 10", true)
+
+    // null input
+    testBoolean(null, null, null)
+    testBoolean(null, "a", null)
+    testBoolean("<a><b>10</b></a>", null, null)
+
+    // exception handling for invalid input
+    intercept[Exception] {
+      testBoolean("<a>/a>", "a", null)
+    }
+  }
+
+  test("xpath_boolean path cache invalidation") {
+    // This is a test to ensure the expression is not reusing the path for different strings
+    val xml = NonFoldableLiteral("<a><b>b</b></a>")
+    val path = NonFoldableLiteral("a/b")
+    val expr = XPathBoolean(xml, path)
+
+    // Run evaluation once
+    assert(expr.eval(null) == true)
+
+    // Change the input path and make sure we don't screw up caching
+    path.value = UTF8String.fromString("a/c")
+    assert(expr.eval(null) == false)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
@@ -23,11 +23,10 @@ import org.apache.spark.sql.test.SharedSQLContext
  * End-to-end tests for XML expressions.
  */
 class XmlFunctionsSuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
 
   test("xpath_boolean") {
-    val input = "<a><b>b</b></a>"
-    val path = "a/b"
-
-    checkAnswer(sql("select xpath_boolean('<a><b>b</b></a>', 'a/b')"), Row(true))
+    val df = Seq("<a><b>b</b></a>" -> "a/b").toDF("xml", "path")
+    checkAnswer(df.selectExpr("xpath_boolean(xml, path)"), Row(true))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.test.SharedSQLContext
+
+/**
+ * End-to-end tests for XML expressions.
+ */
+class XmlFunctionsSuite extends QueryTest with SharedSQLContext {
+
+  test("xpath_boolean") {
+    val input = "<a><b>b</b></a>"
+    val path = "a/b"
+
+    checkAnswer(sql("select xpath_boolean('<a><b>b</b></a>', 'a/b')"), Row(true))
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -227,7 +227,7 @@ private[sql] class HiveSessionCatalog(
     "elt", "hash", "java_method", "histogram_numeric",
     "map_keys", "map_values",
     "parse_url", "percentile", "percentile_approx", "reflect", "sentences", "stack", "str_to_map",
-    "xpath", "xpath_boolean", "xpath_double", "xpath_float", "xpath_int", "xpath_long",
+    "xpath", "xpath_double", "xpath_float", "xpath_int", "xpath_long",
     "xpath_number", "xpath_short", "xpath_string",
 
     // table generating function


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch implements xpath_boolean expression for Spark SQL, a xpath function that returns true or false. The implementation is modelled after Hive's xpath_boolean, except that how the expression handles null inputs. Hive throws a NullPointerException at runtime if either of the input is null. This implementation returns null if either of the input is null.
## How was this patch tested?

Created two new test suites. One for unit tests covering the expression, and the other for end-to-end test in SQL.
