### PR TITLE
[SPARK-16236] [SQL] [FOLLOWUP] Add Path Option back to Load API in DataFrameReader

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -143,7 +143,9 @@ class DataFrameReader(OptionUtils):
         if schema is not None:
             self.schema(schema)
         self.options(**options)
-        if path is not None:
+        if isinstance(path, basestring):
+            return self._df(self._jreader.load(path))
+        elif path is not None:
             if type(path) != list:
                 path = [path]
             return self._df(self._jreader.load(self._spark._sc._jvm.PythonUtils.toSeq(path)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -244,7 +244,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def json(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    option("path", path).json(Seq.empty: _*)
+    json(Seq(path): _*)
   }
 
   /**
@@ -337,7 +337,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def csv(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    option("path", path).csv(Seq.empty: _*)
+    csv(Seq(path): _*)
   }
 
   /**
@@ -406,7 +406,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def parquet(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    option("path", path).parquet(Seq.empty: _*)
+    parquet(Seq(path): _*)
   }
 
   /**
@@ -434,7 +434,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def orc(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    option("path", path).orc(Seq.empty: _*)
+    orc(Seq(path): _*)
   }
 
   /**
@@ -467,7 +467,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def text(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    option("path", path).text(Seq.empty: _*)
+    text(Seq(path): _*)
   }
 
   /**
@@ -496,7 +496,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def textFile(path: String): Dataset[String] = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    option("path", path).textFile(Seq.empty: _*)
+    textFile(Seq(path): _*)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -244,7 +244,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def json(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    json(Seq(path): _*)
+    option("path", path).json(Seq.empty: _*)
   }
 
   /**
@@ -337,7 +337,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def csv(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    csv(Seq(path): _*)
+    option("path", path).csv(Seq.empty: _*)
   }
 
   /**
@@ -406,7 +406,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def parquet(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    parquet(Seq(path): _*)
+    option("path", path).parquet(Seq.empty: _*)
   }
 
   /**
@@ -434,7 +434,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def orc(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    orc(Seq(path): _*)
+    option("path", path).orc(Seq.empty: _*)
   }
 
   /**
@@ -467,7 +467,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def text(path: String): DataFrame = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    text(Seq(path): _*)
+    option("path", path).text(Seq.empty: _*)
   }
 
   /**
@@ -496,7 +496,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def textFile(path: String): Dataset[String] = {
     // This method ensures that calls that explicit need single argument works, see SPARK-16009
-    textFile(Seq(path): _*)
+    option("path", path).textFile(Seq.empty: _*)
   }
 
   /**


### PR DESCRIPTION
#### What changes were proposed in this pull request?

In Python API, we have the same issue. Thanks for identifying this issue, @zsxwing ! Below is an example:

``` Python
spark.read.format('json').load('python/test_support/sql/people.json')
```
#### How was this patch tested?

Existing test cases cover the changes by this PR
