### PR TITLE
[SPARK-16278][SPARK-16279][SQL] Implement map_keys/map_values SQL functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -171,6 +171,8 @@ object FunctionRegistry {
     expression[IsNotNull]("isnotnull"),
     expression[Least]("least"),
     expression[CreateMap]("map"),
+    expression[MapKeys]("map_keys"),
+    expression[MapValues]("map_values"),
     expression[CreateNamedStruct]("named_struct"),
     expression[NaNvl]("nanvl"),
     expression[NullIf]("nullif"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -56,8 +56,6 @@ case class MapKeys(child: Expression)
 
   override def dataType: DataType = ArrayType(child.dataType.asInstanceOf[MapType].keyType)
 
-  override def foldable: Boolean = child.foldable
-
   override def nullSafeEval(map: Any): Any = {
     map.asInstanceOf[MapData].keyArray()
   }
@@ -81,8 +79,6 @@ case class MapValues(child: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(MapType)
 
   override def dataType: DataType = ArrayType(child.dataType.asInstanceOf[MapType].valueType)
-
-  override def foldable: Boolean = child.foldable
 
   override def nullSafeEval(map: Any): Any = {
     map.asInstanceOf[MapData].valueArray()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -44,6 +44,56 @@ case class Size(child: Expression) extends UnaryExpression with ExpectsInputType
 }
 
 /**
+ * Returns an unordered array containing the keys of the map.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(map) - Returns an unordered array containing the keys of the map.")
+case class MapKeys(child: Expression)
+  extends UnaryExpression with ExpectsInputTypes {
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(MapType)
+
+  override def dataType: DataType = ArrayType(child.dataType.asInstanceOf[MapType].keyType)
+
+  override def foldable: Boolean = child.foldable
+
+  override def nullSafeEval(map: Any): Any = {
+    map.asInstanceOf[MapData].keyArray().copy()
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    nullSafeCodeGen(ctx, ev, c => s"${ev.value} = ($c).keyArray().copy();")
+  }
+
+  override def prettyName: String = "map_keys"
+}
+
+/**
+ * Returns an unordered array containing the values of the map.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(map) - Returns an unordered array containing the values of the map.")
+case class MapValues(child: Expression)
+  extends UnaryExpression with ExpectsInputTypes {
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(MapType)
+
+  override def dataType: DataType = ArrayType(child.dataType.asInstanceOf[MapType].valueType)
+
+  override def foldable: Boolean = child.foldable
+
+  override def nullSafeEval(map: Any): Any = {
+    map.asInstanceOf[MapData].valueArray().copy()
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    nullSafeCodeGen(ctx, ev, c => s"${ev.value} = ($c).valueArray().copy();")
+  }
+
+  override def prettyName: String = "map_values"
+}
+
+/**
  * Sorts the input array in ascending / descending order according to the natural ordering of
  * the array elements and returns it.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -47,7 +47,8 @@ case class Size(child: Expression) extends UnaryExpression with ExpectsInputType
  * Returns an unordered array containing the keys of the map.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(map) - Returns an unordered array containing the keys of the map.")
+  usage = "_FUNC_(map) - Returns an unordered array containing the keys of the map.",
+  extended = " > SELECT _FUNC_(map(1, 'a', 2, 'b'));\n [1,2]")
 case class MapKeys(child: Expression)
   extends UnaryExpression with ExpectsInputTypes {
 
@@ -58,11 +59,11 @@ case class MapKeys(child: Expression)
   override def foldable: Boolean = child.foldable
 
   override def nullSafeEval(map: Any): Any = {
-    map.asInstanceOf[MapData].keyArray().copy()
+    map.asInstanceOf[MapData].keyArray()
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    nullSafeCodeGen(ctx, ev, c => s"${ev.value} = ($c).keyArray().copy();")
+    nullSafeCodeGen(ctx, ev, c => s"${ev.value} = ($c).keyArray();")
   }
 
   override def prettyName: String = "map_keys"
@@ -72,7 +73,8 @@ case class MapKeys(child: Expression)
  * Returns an unordered array containing the values of the map.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(map) - Returns an unordered array containing the values of the map.")
+  usage = "_FUNC_(map) - Returns an unordered array containing the values of the map.",
+  extended = " > SELECT _FUNC_(map(1, 'a', 2, 'b'));\n [\"a\",\"b\"]")
 case class MapValues(child: Expression)
   extends UnaryExpression with ExpectsInputTypes {
 
@@ -83,11 +85,11 @@ case class MapValues(child: Expression)
   override def foldable: Boolean = child.foldable
 
   override def nullSafeEval(map: Any): Any = {
-    map.asInstanceOf[MapData].valueArray().copy()
+    map.asInstanceOf[MapData].valueArray()
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    nullSafeCodeGen(ctx, ev, c => s"${ev.value} = ($c).valueArray().copy();")
+    nullSafeCodeGen(ctx, ev, c => s"${ev.value} = ($c).valueArray();")
   }
 
   override def prettyName: String = "map_values"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
@@ -44,6 +44,16 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Literal.create(null, ArrayType(StringType)), null)
   }
 
+  test("MapKeys/MapValues") {
+    val m0 = Literal.create(Map("a" -> "1", "b" -> "2"), MapType(StringType, StringType))
+    val m1 = Literal.create(Map[String, String](), MapType(StringType, StringType))
+
+    checkEvaluation(MapKeys(m0), Seq("a", "b"))
+    checkEvaluation(MapValues(m0), Seq("1", "2"))
+    checkEvaluation(MapKeys(m1), Seq())
+    checkEvaluation(MapValues(m1), Seq())
+  }
+
   test("Sort Array") {
     val a0 = Literal.create(Seq(2, 1, 3), ArrayType(IntegerType))
     val a1 = Literal.create(Seq[Integer](), ArrayType(IntegerType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
@@ -47,11 +47,14 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("MapKeys/MapValues") {
     val m0 = Literal.create(Map("a" -> "1", "b" -> "2"), MapType(StringType, StringType))
     val m1 = Literal.create(Map[String, String](), MapType(StringType, StringType))
+    val m2 = Literal.create(null, MapType(StringType, StringType))
 
     checkEvaluation(MapKeys(m0), Seq("a", "b"))
     checkEvaluation(MapValues(m0), Seq("1", "2"))
     checkEvaluation(MapKeys(m1), Seq())
     checkEvaluation(MapValues(m1), Seq())
+    checkEvaluation(MapKeys(m2), null)
+    checkEvaluation(MapValues(m2), null)
   }
 
   test("Sort Array") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2761,22 +2761,6 @@ object functions {
   def size(e: Column): Column = withExpr { Size(e.expr) }
 
   /**
-   * Returns the key array of the map.
-   *
-   * @group collection_funcs
-   * @since 2.1.0
-   */
-  def map_keys(e: Column): Column = withExpr { MapKeys(e.expr) }
-
-  /**
-   * Returns the key array of the map.
-   *
-   * @group collection_funcs
-   * @since 2.1.0
-   */
-  def map_values(e: Column): Column = withExpr { MapValues(e.expr) }
-
-  /**
    * Sorts the input array for the given column in ascending order,
    * according to the natural ordering of the array elements.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2761,6 +2761,22 @@ object functions {
   def size(e: Column): Column = withExpr { Size(e.expr) }
 
   /**
+   * Returns the key array of the map.
+   *
+   * @group collection_funcs
+   * @since 2.1.0
+   */
+  def map_keys(e: Column): Column = withExpr { MapKeys(e.expr) }
+
+  /**
+   * Returns the key array of the map.
+   *
+   * @group collection_funcs
+   * @since 2.1.0
+   */
+  def map_values(e: Column): Column = withExpr { MapValues(e.expr) }
+
+  /**
    * Sorts the input array for the given column in ascending order,
    * according to the natural ordering of the array elements.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -352,6 +352,30 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     )
   }
 
+  test("map_keys/map_values function") {
+    val df = Seq(
+      (Map[Int, Int](1 -> 100, 2 -> 200), "x"),
+      (Map[Int, Int](), "y"),
+      (Map[Int, Int](1 -> 100, 2 -> 200, 3 -> 300), "z")
+    ).toDF("a", "b")
+    checkAnswer(
+      df.select(map_keys($"a")),
+      Seq(Row(Seq(1, 2)), Row(Seq.empty), Row(Seq(1, 2, 3)))
+    )
+    checkAnswer(
+      df.selectExpr("map_keys(a)"),
+      Seq(Row(Seq(1, 2)), Row(Seq.empty), Row(Seq(1, 2, 3)))
+    )
+    checkAnswer(
+      df.select(map_values($"a")),
+      Seq(Row(Seq(100, 200)), Row(Seq.empty), Row(Seq(100, 200, 300)))
+    )
+    checkAnswer(
+      df.selectExpr("map_values(a)"),
+      Seq(Row(Seq(100, 200)), Row(Seq.empty), Row(Seq(100, 200, 300)))
+    )
+  }
+
   test("array contains function") {
     val df = Seq(
       (Seq[Int](1, 2), "x"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -359,16 +359,8 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       (Map[Int, Int](1 -> 100, 2 -> 200, 3 -> 300), "z")
     ).toDF("a", "b")
     checkAnswer(
-      df.select(map_keys($"a")),
-      Seq(Row(Seq(1, 2)), Row(Seq.empty), Row(Seq(1, 2, 3)))
-    )
-    checkAnswer(
       df.selectExpr("map_keys(a)"),
       Seq(Row(Seq(1, 2)), Row(Seq.empty), Row(Seq(1, 2, 3)))
-    )
-    checkAnswer(
-      df.select(map_values($"a")),
-      Seq(Row(Seq(100, 200)), Row(Seq.empty), Row(Seq(100, 200, 300)))
     )
     checkAnswer(
       df.selectExpr("map_values(a)"),

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -239,7 +239,6 @@ private[sql] class HiveSessionCatalog(
   // str_to_map, windowingtablefunction.
   private val hiveFunctions = Seq(
     "hash", "java_method", "histogram_numeric",
-    "map_keys", "map_values",
     "parse_url", "percentile", "percentile_approx", "reflect", "sentences", "stack", "str_to_map",
     "xpath", "xpath_double", "xpath_float", "xpath_int", "xpath_long",
     "xpath_number", "xpath_short", "xpath_string",


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds `map_keys` and `map_values` SQL functions in order to remove Hive fallback.
## How was this patch tested?

Pass the Jenkins tests including new testcases.
