### PR TITLE
[SPARK-16296][SQL] add null check for key when create map data in encoder

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
@@ -19,6 +19,11 @@ package org.apache.spark.sql.catalyst.util
 
 class ArrayBasedMapData(val keyArray: ArrayData, val valueArray: ArrayData) extends MapData {
   require(keyArray.numElements() == valueArray.numElements())
+  for (i <- 0 until keyArray.numElements()) {
+    if (keyArray.isNullAt(i)) {
+      throw new RuntimeException("Cannot use null as map key!")
+    }
+  }
 
   override def numElements(): Int = keyArray.numElements()
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -328,6 +328,12 @@ class ExpressionEncoderSuite extends PlanTest with AnalysisTest {
     }
   }
 
+  test("null check for map key") {
+    val encoder = ExpressionEncoder[Map[String, Int]]()
+    val e = intercept[RuntimeException](encoder.toRow(Map(("a", 1), (null, 2))))
+    assert(e.getMessage.contains("Cannot use null as map key"))
+  }
+
   private def encodeDecodeTest[T : ExpressionEncoder](
       input: T,
       testName: String): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The map type in Spark SQL can't put `null` as key. We already have key null check for `CreateMap`, but missed it when create map in encoder.  This PR fixes it.
## How was this patch tested?

new test in `ExpressionEncoderSuite`
