### PR TITLE
[SPARK-16299][SPARKR] Capture errors from R workers in daemon.R to avoid deletion of R session temporary directory.

### DIFF
--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -44,7 +44,7 @@ while (TRUE) {
     if (inherits(p, "masterProcess")) {
       close(inputCon)
       Sys.setenv(SPARKR_WORKER_PORT = port)
-      source(script)
+      try(source(script))
       # Set SIGUSR1 so that child can exit
       tools::pskill(Sys.getpid(), tools::SIGUSR1)
       parallel:::mcexit(0L)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Capture errors from R workers in daemon.R to avoid deletion of R session temporary directory. See detailed description at https://issues.apache.org/jira/browse/SPARK-16299
## How was this patch tested?

SparkR unit tests.
