### PR TITLE
[SPARK-16301] [SQL] The analyzer rule for resolving using joins should respect the case sensitivity setting.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1836,11 +1836,11 @@ class Analyzer(
   }
 
   private def commonNaturalJoinProcessing(
-     left: LogicalPlan,
-     right: LogicalPlan,
-     joinType: JoinType,
-     joinNames: Seq[String],
-     condition: Option[Expression]) = {
+      left: LogicalPlan,
+      right: LogicalPlan,
+      joinType: JoinType,
+      joinNames: Seq[String],
+      condition: Option[Expression]) = {
     val leftKeys =
       joinNames.map(keyName => left.output.find(attr => resolver(attr.name, keyName)).get)
     val rightKeys =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1841,10 +1841,20 @@ class Analyzer(
       joinType: JoinType,
       joinNames: Seq[String],
       condition: Option[Expression]) = {
-    val leftKeys =
-      joinNames.map(keyName => left.output.find(attr => resolver(attr.name, keyName)).get)
-    val rightKeys =
-      joinNames.map(keyName => right.output.find(attr => resolver(attr.name, keyName)).get)
+    val leftKeys = joinNames.map { keyName =>
+      val joinColumn = left.output.find(attr => resolver(attr.name, keyName))
+      assert(
+        joinColumn.isDefined,
+        s"$keyName should exist in ${left.output.map(_.name).mkString(",")}")
+      joinColumn.get
+    }
+    val rightKeys = joinNames.map { keyName =>
+      val joinColumn = right.output.find(attr => resolver(attr.name, keyName))
+      assert(
+        joinColumn.isDefined,
+        s"$keyName should exist in ${right.output.map(_.name).mkString(",")}")
+      joinColumn.get
+    }
     val joinPairs = leftKeys.zip(rightKeys)
 
     val newCondition = (condition ++ joinPairs.map(EqualTo.tupled)).reduceOption(And)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1841,8 +1841,10 @@ class Analyzer(
      joinType: JoinType,
      joinNames: Seq[String],
      condition: Option[Expression]) = {
-    val leftKeys = joinNames.map(keyName => left.output.find(_.name == keyName).get)
-    val rightKeys = joinNames.map(keyName => right.output.find(_.name == keyName).get)
+    val leftKeys =
+      joinNames.map(keyName => left.output.find(attr => resolver(attr.name, keyName)).get)
+    val rightKeys =
+      joinNames.map(keyName => right.output.find(attr => resolver(attr.name, keyName)).get)
     val joinPairs = leftKeys.zip(rightKeys)
 
     val newCondition = (condition ++ joinPairs.map(EqualTo.tupled)).reduceOption(And)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The analyzer rule for resolving using joins should respect the case sensitivity setting.
## How was this patch tested?

New tests in ResolveNaturalJoinSuite
