### PR TITLE
[SPARK-16307] [ML] Add test to verify the predicted variances of a DT on toy data

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -44,14 +44,6 @@ class DecisionTreeRegressorSuite
 
     categoricalDataPointsRDD =
       sc.parallelize(OldDecisionTreeSuite.generateCategoricalDataPoints().map(_.asML))
-    toyData = sc.parallelize(Seq(
-      LabeledPoint(1.0, Vectors.dense(Array(0.0))),
-      LabeledPoint(2.0, Vectors.dense(Array(1.0))),
-      LabeledPoint(3.0, Vectors.dense(Array(2.0))),
-      LabeledPoint(10.0, Vectors.dense(Array(3.0))),
-      LabeledPoint(12.0, Vectors.dense(Array(4.0))),
-      LabeledPoint(14.0, Vectors.dense(Array(5.0))))
-    )
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -109,12 +101,14 @@ class DecisionTreeRegressorSuite
         s"Expected variance $expectedVariance but got $variance.")
     }
 
-    val toyDF = TreeTests.setMetadata(toyData, Map.empty[Int, Int], 0)
+
+    val varianceData: RDD[LabeledPoint] = TreeTests.varianceData(sc)
+    val varianceDF = TreeTests.setMetadata(varianceData, Map.empty[Int, Int], 0)
     dt.setMaxDepth(1)
       .setMaxBins(6)
       .setSeed(0)
-    val transformToyDF = dt.fit(toyDF).transform(toyDF)
-    val calculatedVariances = transformToyDF.select(dt.getVarianceCol).collect().map {
+    val transformVarDF = dt.fit(varianceDF).transform(varianceDF)
+    val calculatedVariances = transformVarDF.select(dt.getVarianceCol).collect().map {
       case Row(variance: Double) => variance
     }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -37,11 +37,8 @@ class DecisionTreeRegressorSuite
 
   private var categoricalDataPointsRDD: RDD[LabeledPoint] = _
 
-  private var toyData: RDD[LabeledPoint] = _
-
   override def beforeAll() {
     super.beforeAll()
-
     categoricalDataPointsRDD =
       sc.parallelize(OldDecisionTreeSuite.generateCategoricalDataPoints().map(_.asML))
   }
@@ -100,7 +97,6 @@ class DecisionTreeRegressorSuite
       assert(variance === expectedVariance,
         s"Expected variance $expectedVariance but got $variance.")
     }
-
 
     val varianceData: RDD[LabeledPoint] = TreeTests.varianceData(sc)
     val varianceDF = TreeTests.setMetadata(varianceData, Map.empty[Int, Int], 0)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -113,8 +113,10 @@ class DecisionTreeRegressorSuite
     dt.setMaxDepth(1)
       .setMaxBins(6)
       .setSeed(0)
-    val calculatedVariances = dt.fit(toyDF).transform(toyDF).select("variance").collect().map {
-      case Row(variance: Double) => variance }
+    val transformToyDF = dt.fit(toyDF).transform(toyDF)
+    val calculatedVariances = transformToyDF.select(dt.getVarianceCol).collect().map {
+      case Row(variance: Double) => variance
+    }
 
     // Since max depth is set to 1, the best split point is that which splits the data
     // into (0.0, 1.0, 2.0) and (10.0, 12.0, 14.0). The predicted variance for each

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -113,10 +113,17 @@ class DecisionTreeRegressorSuite
     dt.setMaxDepth(1)
       .setMaxBins(6)
       .setSeed(0)
-    val expectVariances = dt.fit(toyDF).transform(toyDF).select("variance").collect().map {
+    val calculatedVariances = dt.fit(toyDF).transform(toyDF).select("variance").collect().map {
       case Row(variance: Double) => variance }
-    val trueVariances = Array(0.667, 0.667, 0.667, 2.667, 2.667, 2.667)
-    trueVariances.zip(expectVariances).foreach(x => x._1 ~== x._2 absTol 1e-3)
+
+    // Since max depth is set to 1, the best split point is that which splits the data
+    // into (0.0, 1.0, 2.0) and (10.0, 12.0, 14.0). The predicted variance for each
+    // data point in the left node is 0.667 and for each data point in the right node
+    // is 2.667
+    val expectedVariances = Array(0.667, 0.667, 0.667, 2.667, 2.667, 2.667)
+    calculatedVariances.zip(expectedVariances).foreach { case (actual, expected) =>
+      assert(actual ~== expected absTol 1e-3)
+    }
   }
 
   test("Feature importance with toy data") {

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -183,6 +183,18 @@ private[ml] object TreeTests extends SparkFunSuite {
   ))
 
   /**
+   * Create some toy data for testing correctness of variance.
+   */
+  def varianceData(sc: SparkContext): RDD[LabeledPoint] = sc.parallelize(Seq(
+    new LabeledPoint(1.0, Vectors.dense(Array(0.0))),
+    new LabeledPoint(2.0, Vectors.dense(Array(1.0))),
+    new LabeledPoint(3.0, Vectors.dense(Array(2.0))),
+    new LabeledPoint(10.0, Vectors.dense(Array(3.0))),
+    new LabeledPoint(12.0, Vectors.dense(Array(4.0))),
+    new LabeledPoint(14.0, Vectors.dense(Array(5.0)))
+  ))
+
+  /**
    * Mapping from all Params to valid settings which differ from the defaults.
    * This is useful for tests which need to exercise all Params, such as save/load.
    * This excludes input columns to simplify some tests.


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current tests assumes that `impurity.calculate()` returns the variance correctly. It should be better to make the tests independent of this assumption. In other words verify that the variance computed equals the variance computed manually on a small tree.
## How was this patch tested?

The patch is a test....
