### PR TITLE
[SPARK-16304] LinkageError should not crash Spark executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -406,7 +406,7 @@ private[spark] class Executor(
 
           // Don't forcibly exit unless the exception was inherently fatal, to avoid
           // stopping other tasks unnecessarily.
-          if (Utils.isFatalError(t) && !Utils.isLinkageError(t)) {
+          if (Utils.isFatalError(t)) {
             SparkUncaughtExceptionHandler.uncaughtException(t)
           }
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -406,7 +406,7 @@ private[spark] class Executor(
 
           // Don't forcibly exit unless the exception was inherently fatal, to avoid
           // stopping other tasks unnecessarily.
-          if (Utils.isFatalError(t)) {
+          if (Utils.isFatalError(t) && !Utils.isLinkageError(t)) {
             SparkUncaughtExceptionHandler.uncaughtException(t)
           }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1865,17 +1865,15 @@ private[spark] object Utils extends Logging {
   /** Returns true if the given exception was fatal. See docs for scala.util.control.NonFatal. */
   def isFatalError(e: Throwable): Boolean = {
     e match {
-      case NonFatal(_) | _: InterruptedException | _: NotImplementedError | _: ControlThrowable =>
+      case NonFatal(_) |
+           _: InterruptedException |
+           _: NotImplementedError |
+           _: ControlThrowable |
+           _: LinkageError =>
         false
       case _ =>
         true
     }
-  }
-
-  /** Returns true if the given exception is a linkage error. */
-  def isLinkageError(e: Throwable): Boolean = e match {
-    case _: java.lang.LinkageError => true
-    case _ => false
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1872,6 +1872,12 @@ private[spark] object Utils extends Logging {
     }
   }
 
+  /** Returns true if the given exception is a linkage error. */
+  def isLinkageError(e: Throwable): Boolean = e match {
+    case _: java.lang.LinkageError => true
+    case _ => false
+  }
+
   /**
    * Return a well-formed URI for the file described by a user input string.
    *

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -253,6 +253,15 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
     rdd.count()
   }
 
+  test("SPARK-16304: Link error should not crash executor") {
+    sc = new SparkContext("local[1,2]", "test")
+    intercept[SparkException] {
+      sc.parallelize(1 to 2).foreach { i =>
+        throw new LinkageError()
+      }
+    }
+  }
+
   // TODO: Need to add tests with shuffle fetch failures.
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch updates the failure handling logic so Spark executor does not crash when seeing LinkageError.
## How was this patch tested?

Added an end-to-end test in FailureSuite.
