### PR TITLE
[SPARK-12177][TEST] Removed test to avoid compilation issue in scala 2.10

### DIFF
--- a/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaConsumerStrategySuite.java
+++ b/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaConsumerStrategySuite.java
@@ -50,8 +50,8 @@ public class JavaConsumerStrategySuite implements Serializable {
       JavaConverters.mapAsScalaMapConverter(offsets).asScala();
 
     // make sure constructors can be called from java
-    final ConsumerStrategy<String, String> sub0 =
-      Subscribe.<String, String>apply(topics, kafkaParams, offsets);
+    // final ConsumerStrategy<String, String> sub0 =          // does not compile in Scala 2.10
+    //   Subscribe.<String, String>apply(topics, kafkaParams, offsets);
     final ConsumerStrategy<String, String> sub1 =
       Subscribe.<String, String>apply(sTopics, sKafkaParams, sOffsets);
     final ConsumerStrategy<String, String> sub2 =
@@ -65,8 +65,8 @@ public class JavaConsumerStrategySuite implements Serializable {
       sub1.executorKafkaParams().get("bootstrap.servers"),
       sub3.executorKafkaParams().get("bootstrap.servers"));
 
-    final ConsumerStrategy<String, String> asn0 =
-      Assign.<String, String>apply(parts, kafkaParams, offsets);
+    // final ConsumerStrategy<String, String> asn0 =          // does not compile in Scala 2.10
+    //   Assign.<String, String>apply(parts, kafkaParams, offsets);
     final ConsumerStrategy<String, String> asn1 =
       Assign.<String, String>apply(sParts, sKafkaParams, sOffsets);
     final ConsumerStrategy<String, String> asn2 =


### PR DESCRIPTION
## What changes were proposed in this pull request?

The commented lines failed scala 2.10 build. This is because of change in behavior of case classes between 2.10 and 2.11. In scala 2.10, if companion object of a case class has explicitly defined apply(), then the implicit apply method is not generated. In scala 2.11 it is generated. Hence, the lines compile fine in 2.11 but not in 2.10. 

This simply comments the tests to fix broken build. Correct solution is pending.
