### PR TITLE
[SPARK-16328][ML][MLLIB][PYSPARK] Add 'asML' and 'fromML' conversion methods to PySpark linalg

### DIFF
--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -423,12 +423,6 @@ class DenseVector(Vector):
         Convert this vector to the new mllib-local representation.
         This does NOT copy the data; it copies references.
 
-        >>> mllibDV = Vectors.dense([1, 2, 3])
-        >>> mlDV1 = newlinalg.Vectors.dense([1, 2, 3])
-        >>> mlDV2 = mllibDV.asML()
-        >>> mlDV2 == mlDV1
-        True
-
         :return: :py:class:`pyspark.ml.linalg.DenseVector`
 
         .. versionadded:: 2.0.0
@@ -769,12 +763,6 @@ class SparseVector(Vector):
         Convert this vector to the new mllib-local representation.
         This does NOT copy the data; it copies references.
 
-        >>> mllibSV = Vectors.sparse(4, {1: 1.0, 3: 5.5})
-        >>> mlSV1 = newlinalg.Vectors.sparse(4, {1: 1.0, 3: 5.5})
-        >>> mlSV2 = mllibSV.asML()
-        >>> mlSV2 == mlSV1
-        True
-
         :return: :py:class:`pyspark.ml.linalg.SparseVector`
 
         .. versionadded:: 2.0.0
@@ -895,19 +883,10 @@ class Vectors(object):
         Convert a vector from the new mllib-local representation.
         This does NOT copy the data; it copies references.
 
-        >>> mllibDV1 = Vectors.dense([1, 2, 3])
-        >>> mlDV = newlinalg.Vectors.dense([1, 2, 3])
-        >>> mllibDV2 = Vectors.fromML(mlDV)
-        >>> mllibDV1 == mllibDV2
-        True
-        >>> mllibSV1 = Vectors.sparse(4, {1: 1.0, 3: 5.5})
-        >>> mlSV = newlinalg.Vectors.sparse(4, {1: 1.0, 3: 5.5})
-        >>> mllibSV2 = Vectors.fromML(mlSV)
-        >>> mllibSV1 == mllibSV2
-        True
-
         :param vec: a :py:class:`pyspark.ml.linalg.Vector`
         :return: a :py:class:`pyspark.mllib.linalg.Vector`
+
+        .. versionadded:: 2.0.0
         """
         if isinstance(vec, newlinalg.DenseVector):
             return DenseVector(vec.array)
@@ -1127,17 +1106,6 @@ class DenseMatrix(Matrix):
         Convert this matrix to the new mllib-local representation.
         This does NOT copy the data; it copies references.
 
-        >>> mllibDM = Matrices.dense(2, 2, [0, 1, 2, 3])
-        >>> mlDM1 = newlinalg.Matrices.dense(2, 2, [0, 1, 2, 3])
-        >>> mlDM2 = mllibDM.asML()
-        >>> mlDM2 == mlDM1
-        True
-        >>> mllibDMt = DenseMatrix(2, 2, [0, 1, 2, 3], True)
-        >>> mlDMt1 = newlinalg.DenseMatrix(2, 2, [0, 1, 2, 3], True)
-        >>> mlDMt2 = mllibDMt.asML()
-        >>> mlDMt2 == mlDMt1
-        True
-
         :return: :py:class:`pyspark.ml.linalg.DenseMatrix`
 
         .. versionadded:: 2.0.0
@@ -1321,17 +1289,6 @@ class SparseMatrix(Matrix):
         Convert this matrix to the new mllib-local representation.
         This does NOT copy the data; it copies references.
 
-        >>> mllibSM = Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
-        >>> mlSM1 = newlinalg.Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
-        >>> mlSM2 = mllibSM.asML()
-        >>> mlSM2 == mlSM1
-        True
-        >>> mllibSMt = SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
-        >>> mlSMt1 = newlinalg.SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
-        >>> mlSMt2 = mllibSMt.asML()
-        >>> mlSMt2 == mlSMt1
-        True
-
         :return: :py:class:`pyspark.ml.linalg.SparseMatrix`
 
         .. versionadded:: 2.0.0
@@ -1365,29 +1322,10 @@ class Matrices(object):
         Convert a matrix from the new mllib-local representation.
         This does NOT copy the data; it copies references.
 
-        >>> mllibDM1 = Matrices.dense(2, 2, [1, 2, 3, 4])
-        >>> mlDM = newlinalg.Matrices.dense(2, 2, [1, 2, 3, 4])
-        >>> mllibDM2 = Matrices.fromML(mlDM)
-        >>> mllibDM1 == mllibDM2
-        True
-        >>> mllibDMt1 = DenseMatrix(2, 2, [1, 2, 3, 4], True)
-        >>> mlDMt = newlinalg.DenseMatrix(2, 2, [1, 2, 3, 4], True)
-        >>> mllibDMt2 = Matrices.fromML(mlDMt)
-        >>> mllibDMt1 == mllibDMt2
-        True
-        >>> mllibSM1 = Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
-        >>> mlSM = newlinalg.Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
-        >>> mllibSM2 = Matrices.fromML(mlSM)
-        >>> mllibSM1 == mllibSM2
-        True
-        >>> mllibSMt1 = SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
-        >>> mlSMt = newlinalg.SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
-        >>> mllibSMt2 = Matrices.fromML(mlSMt)
-        >>> mllibSMt1 == mllibSMt2
-        True
-
-        :param vec: a :py:class:`pyspark.ml.linalg.Matrix`
+        :param mat: a :py:class:`pyspark.ml.linalg.Matrix`
         :return: a :py:class:`pyspark.mllib.linalg.Matrix`
+
+        .. versionadded:: 2.0.0
         """
         if isinstance(mat, newlinalg.DenseMatrix):
             return DenseMatrix(mat.numRows, mat.numCols, mat.values, mat.isTransposed)

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -909,9 +909,9 @@ class Vectors(object):
         :param vec: a :py:class:`pyspark.ml.linalg.Vector`
         :return: a :py:class:`pyspark.mllib.linalg.Vector`
         """
-        if type(vec) == newlinalg.DenseVector:
+        if isinstance(vec, newlinalg.DenseVector):
             return DenseVector(vec.array)
-        elif type(vec) == newlinalg.SparseVector:
+        elif isinstance(vec, newlinalg.SparseVector):
             return SparseVector(vec.size, vec.indices, vec.values)
         else:
             raise TypeError("Unsupported vector type %s" % type(vec))
@@ -1389,9 +1389,9 @@ class Matrices(object):
         :param vec: a :py:class:`pyspark.ml.linalg.Matrix`
         :return: a :py:class:`pyspark.mllib.linalg.Matrix`
         """
-        if type(mat) == newlinalg.DenseMatrix:
+        if isinstance(mat, newlinalg.DenseMatrix):
             return DenseMatrix(mat.numRows, mat.numCols, mat.values, mat.isTransposed)
-        elif type(mat) == newlinalg.SparseMatrix:
+        elif isinstance(mat, newlinalg.SparseMatrix):
             return SparseMatrix(mat.numRows, mat.numCols, mat.colPtrs, mat.rowIndices,
                                 mat.values, mat.isTransposed)
         else:

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -49,6 +49,7 @@ else:
     import unittest
 
 from pyspark import SparkContext
+import pyspark.ml.linalg as newlinalg
 from pyspark.mllib.common import _to_java_object_rdd
 from pyspark.mllib.clustering import StreamingKMeans, StreamingKMeansModel
 from pyspark.mllib.linalg import Vector, SparseVector, DenseVector, VectorUDT, _convert_to_vector,\
@@ -422,6 +423,74 @@ class VectorTests(MLlibTestCase):
 
         tmp = SparseVector(4, [0, 2], [3, 0])
         self.assertEqual(tmp.numNonzeros(), 1)
+
+    def test_ml_mllib_vector_conversion(self):
+        # to ml
+        # dense
+        mllibDV = Vectors.dense([1, 2, 3])
+        mlDV1 = newlinalg.Vectors.dense([1, 2, 3])
+        mlDV2 = mllibDV.asML()
+        self.assertEqual(mlDV2, mlDV1)
+        # sparse
+        mllibSV = Vectors.sparse(4, {1: 1.0, 3: 5.5})
+        mlSV1 = newlinalg.Vectors.sparse(4, {1: 1.0, 3: 5.5})
+        mlSV2 = mllibSV.asML()
+        self.assertEqual(mlSV2, mlSV1)
+        # from ml
+        # dense
+        mllibDV1 = Vectors.dense([1, 2, 3])
+        mlDV = newlinalg.Vectors.dense([1, 2, 3])
+        mllibDV2 = Vectors.fromML(mlDV)
+        self.assertEqual(mllibDV1, mllibDV2)
+        # sparse
+        mllibSV1 = Vectors.sparse(4, {1: 1.0, 3: 5.5})
+        mlSV = newlinalg.Vectors.sparse(4, {1: 1.0, 3: 5.5})
+        mllibSV2 = Vectors.fromML(mlSV)
+        self.assertEqual(mllibSV1, mllibSV2)
+
+    def test_ml_mllib_matrix_conversion(self):
+        # to ml
+        # dense
+        mllibDM = Matrices.dense(2, 2, [0, 1, 2, 3])
+        mlDM1 = newlinalg.Matrices.dense(2, 2, [0, 1, 2, 3])
+        mlDM2 = mllibDM.asML()
+        self.assertEqual(mlDM2, mlDM1)
+        # transposed
+        mllibDMt = DenseMatrix(2, 2, [0, 1, 2, 3], True)
+        mlDMt1 = newlinalg.DenseMatrix(2, 2, [0, 1, 2, 3], True)
+        mlDMt2 = mllibDMt.asML()
+        self.assertEqual(mlDMt2, mlDMt1)
+        # sparse
+        mllibSM = Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
+        mlSM1 = newlinalg.Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
+        mlSM2 = mllibSM.asML()
+        self.assertEqual(mlSM2, mlSM1)
+        # transposed
+        mllibSMt = SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
+        mlSMt1 = newlinalg.SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
+        mlSMt2 = mllibSMt.asML()
+        self.assertEqual(mlSMt2, mlSMt1)
+        # from ml
+        # dense
+        mllibDM1 = Matrices.dense(2, 2, [1, 2, 3, 4])
+        mlDM = newlinalg.Matrices.dense(2, 2, [1, 2, 3, 4])
+        mllibDM2 = Matrices.fromML(mlDM)
+        self.assertEqual(mllibDM1, mllibDM2)
+        # transposed
+        mllibDMt1 = DenseMatrix(2, 2, [1, 2, 3, 4], True)
+        mlDMt = newlinalg.DenseMatrix(2, 2, [1, 2, 3, 4], True)
+        mllibDMt2 = Matrices.fromML(mlDMt)
+        self.assertEqual(mllibDMt1, mllibDMt2)
+        # sparse
+        mllibSM1 = Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
+        mlSM = newlinalg.Matrices.sparse(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4])
+        mllibSM2 = Matrices.fromML(mlSM)
+        self.assertEqual(mllibSM1, mllibSM2)
+        # transposed
+        mllibSMt1 = SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
+        mlSMt = newlinalg.SparseMatrix(2, 2, [0, 2, 3], [0, 1, 1], [2, 3, 4], True)
+        mllibSMt2 = Matrices.fromML(mlSMt)
+        self.assertEqual(mllibSMt1, mllibSMt2)
 
 
 class ListTests(MLlibTestCase):


### PR DESCRIPTION
The move to `ml.linalg` created `asML`/`fromML` utility methods in Scala/Java for converting between representations. These are missing in Python, this PR adds them.
## How was this patch tested?

New doctests.
