### PR TITLE
[SPARK-16329] [SQL] Star Expansion over Table Containing No Column 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -215,43 +215,35 @@ abstract class Star extends LeafExpression with NamedExpression {
 case class UnresolvedStar(target: Option[Seq[String]]) extends Star with Unevaluable {
 
   override def expand(input: LogicalPlan, resolver: Resolver): Seq[NamedExpression] = {
-    // When the table does not have any column, the input LogicalPlan does not have any column
-    if (input.output.isEmpty) return Seq.empty[NamedExpression]
-
-    // First try to expand assuming it is table.*.
-    val expandedAttributes: Seq[Attribute] = target match {
+    if (target.isEmpty) {
       // If there is no table specified, use all input attributes.
-      case None => input.output
+      input.output
+    } else if (target.get.size == 1) {
       // If there is a table, pick out attributes that are part of this table.
-      case Some(t) => if (t.size == 1) {
-        input.output.filter(_.qualifier.exists(resolver(_, t.head)))
-      } else {
-        List()
-      }
-    }
-    if (expandedAttributes.nonEmpty) return expandedAttributes
-
-    // Try to resolve it as a struct expansion. If there is a conflict and both are possible,
-    // (i.e. [name].* is both a table and a struct), the struct path can always be qualified.
-    require(target.isDefined)
-    val attribute = input.resolve(target.get, resolver)
-    if (attribute.isDefined) {
-      // This target resolved to an attribute in child. It must be a struct. Expand it.
-      attribute.get.dataType match {
-        case s: StructType => s.zipWithIndex.map {
-          case (f, i) =>
-            val extract = GetStructField(attribute.get, i)
-            Alias(extract, f.name)()
-        }
-
-        case _ =>
-          throw new AnalysisException("Can only star expand struct data types. Attribute: `" +
-            target.get + "`")
-      }
+      input.output.filter(_.qualifier.exists(resolver(_, target.get.head)))
     } else {
-      val from = input.inputSet.map(_.name).mkString(", ")
-      val targetString = target.get.mkString(".")
-      throw new AnalysisException(s"cannot resolve '$targetString.*' give input columns '$from'")
+      // Try to resolve it as a struct expansion. If there is a conflict and both are possible,
+      // (i.e. [name].* is both a table and a struct), the struct path can always be qualified.
+      require(target.isDefined)
+      val attribute = input.resolve(target.get, resolver)
+      if (attribute.isDefined) {
+        // This target resolved to an attribute in child. It must be a struct. Expand it.
+        attribute.get.dataType match {
+          case s: StructType => s.zipWithIndex.map {
+            case (f, i) =>
+              val extract = GetStructField(attribute.get, i)
+              Alias(extract, f.name)()
+          }
+
+          case _ =>
+            throw new AnalysisException("Can only star expand struct data types. Attribute: `" +
+              target.get + "`")
+        }
+      } else {
+        val from = input.inputSet.map(_.name).mkString(", ")
+        val targetString = target.get.mkString(".")
+        throw new AnalysisException(s"cannot resolve '$targetString.*' give input columns '$from'")
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -215,6 +215,8 @@ abstract class Star extends LeafExpression with NamedExpression {
 case class UnresolvedStar(target: Option[Seq[String]]) extends Star with Unevaluable {
 
   override def expand(input: LogicalPlan, resolver: Resolver): Seq[NamedExpression] = {
+    // When the table does not have any column, the input LogicalPlan does not have any column
+    if (input.output.isEmpty) return Seq.empty[NamedExpression]
 
     // First try to expand assuming it is table.*.
     val expandedAttributes: Seq[Attribute] = target match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2117,8 +2117,8 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
 
   test("Star Expansion - table with zero column") {
     withTempTable("temp_table_no_cols") {
-      val rddNoCols = sqlContext.sparkContext.parallelize(1 to 10).map(_ => Row.empty)
-      val dfNoCols = sqlContext.createDataFrame(rddNoCols, StructType(Seq.empty))
+      val rddNoCols = sparkContext.parallelize(1 to 10).map(_ => Row.empty)
+      val dfNoCols = spark.createDataFrame(rddNoCols, StructType(Seq.empty))
       dfNoCols.createTempView("temp_table_no_cols")
 
       // ResolvedStar

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2132,10 +2132,17 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         sql("SELECT * FROM temp_table_no_cols"))
       checkAnswer(
         dfNoCols,
-        sql("SELECT a.* FROM temp_table_no_cols a"))
-      checkAnswer(
-        dfNoCols,
         dfNoCols.select($"*"))
+
+      var e = intercept[AnalysisException] {
+        sql("SELECT a.* FROM temp_table_no_cols a")
+      }.getMessage
+      assert(e.contains("cannot resolve 'a.*' give input columns ''"))
+
+      e = intercept[AnalysisException] {
+        dfNoCols.select($"b.*")
+      }.getMessage
+      assert(e.contains("cannot resolve 'b.*' give input columns ''"))
     }
   }
 


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Star expansion over a table containing zero column does not work since 1.6. However, it works in Spark 1.5.1. This PR is to fix the issue in the master branch.

For example, 

``` scala
val rddNoCols = sqlContext.sparkContext.parallelize(1 to 10).map(_ => Row.empty)
val dfNoCols = sqlContext.createDataFrame(rddNoCols, StructType(Seq.empty))
dfNoCols.registerTempTable("temp_table_no_cols")
sqlContext.sql("select * from temp_table_no_cols").show
```

Without the fix, users will get the following the exception:

```
java.lang.IllegalArgumentException: requirement failed
        at scala.Predef$.require(Predef.scala:221)
        at org.apache.spark.sql.catalyst.analysis.UnresolvedStar.expand(unresolved.scala:199)
```
#### How was this patch tested?

Tests are added
