### PR TITLE
[SPARK-15923][YARN] Spark Application rest api returns 'no such app: …

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -225,9 +225,9 @@ for the history server, they would typically be accessible at `http://<server-ur
 for a running application, at `http://localhost:4040/api/v1`.
 
 In the API, an application is referenced by its application ID, `[app-id]`.
-When running on YARN, each application may have multiple attempts; each identified by their `[attempt-id]`.
+When running on YARN cluster mode, each application may have multiple attempts; each identified by their `[attempt-id]`.
 In the API listed below, `[app-id]` will actually be `[base-app-id]/[attempt-id]`,
-where `[base-app-id]` is the YARN application ID.
+where `[base-app-id]` is the YARN application ID. However, in yarn client mode, there will be no `[attempt-id]`.
 
 <table class="table">
   <tr><th>Endpoint</th><th>Meaning</th></tr>

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -101,10 +101,10 @@ private[spark] abstract class YarnSchedulerBackend(
    * attempts. Applications run in client mode will not have attempt IDs.
    * This attempt ID only includes attempt counter, like "1", "2".
    *
-   * @return The application attempt id, if available.
+   * @return The application attempt id, if not available, will return "1".
    */
   override def applicationAttemptId(): Option[String] = {
-    attemptId.map(_.getAttemptId.toString)
+    Some(attemptId.map(_.getAttemptId.toString).getOrElse("1"))
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Updated the monitoring.md doc.
2. In YarnSchedulerBackend.scala: make applications run in Yarn cluster mode have attemptID "1" by default.
## How was this patch tested?

Manual tests passed.

…<appId>'
