### PR TITLE
[SPARK-15896][SQL] Clean up shuffle files just after jobs finished

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -258,6 +258,10 @@ class DAGScheduler(
     eventProcessLoop.post(TaskSetFailed(taskSet, reason, exception))
   }
 
+  def stageIdToShuffleId(stageInfo: StageInfo): Option[Int] = {
+    shuffleIdToMapStage.find(_._2.id == stageInfo.stageId).map(_._1)
+  }
+
   private[scheduler]
   def getCacheLocs(rdd: RDD[_]): IndexedSeq[Seq[TaskLocation]] = cacheLocs.synchronized {
     // Note: this doesn't use `getOrElse()` because this method is called O(num tasks) times

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
@@ -122,6 +122,10 @@ case class ShuffleExchange(
           val shuffleDependency = prepareShuffleDependency()
           preparePostShuffleRDD(shuffleDependency)
       }
+      // Register shuffle ids to clean up just after jobs finished
+      if (sqlContext.conf.shuffleCleanupEnabled) {
+        sqlContext.sessionState.shuffleIdsToCleanup.add(cachedShuffleRDD.dependency.shuffleId)
+      }
     }
     cachedShuffleRDD
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
@@ -23,6 +23,7 @@ import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection, UnsafeRow}
@@ -83,7 +84,7 @@ case class ShuffleExchange(
    */
   private[sql] def prepareShuffleDependency(): ShuffleDependency[Int, InternalRow, InternalRow] = {
     ShuffleExchange.prepareShuffleDependency(
-      child.execute(), child.output, newPartitioning, serializer)
+      child.execute(), child.output, newPartitioning, serializer, sqlContext)
   }
 
   /**
@@ -121,10 +122,6 @@ case class ShuffleExchange(
         case None =>
           val shuffleDependency = prepareShuffleDependency()
           preparePostShuffleRDD(shuffleDependency)
-      }
-      // Register shuffle ids to clean up just after jobs finished
-      if (sqlContext.conf.shuffleCleanupEnabled) {
-        sqlContext.sessionState.shuffleIdsToCleanup.add(cachedShuffleRDD.dependency.shuffleId)
       }
     }
     cachedShuffleRDD
@@ -202,7 +199,8 @@ object ShuffleExchange {
       rdd: RDD[InternalRow],
       outputAttributes: Seq[Attribute],
       newPartitioning: Partitioning,
-      serializer: Serializer): ShuffleDependency[Int, InternalRow, InternalRow] = {
+      serializer: Serializer,
+      sqlContext: SQLContext): ShuffleDependency[Int, InternalRow, InternalRow] = {
     val part: Partitioner = newPartitioning match {
       case RoundRobinPartitioning(numPartitions) => new HashPartitioner(numPartitions)
       case HashPartitioning(_, n) =>
@@ -267,6 +265,11 @@ object ShuffleExchange {
         rddWithPartitionIds,
         new PartitionIdPassthrough(part.numPartitions),
         serializer)
+
+    // Register shuffle ids to clean up just after jobs finished
+    if (sqlContext.conf.shuffleCleanupEnabled) {
+      sqlContext.sessionState.shuffleIdsToCleanup.add(dependency.shuffleId)
+    }
 
     dependency
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -41,7 +41,7 @@ case class CollectLimitExec(limit: Int, child: SparkPlan) extends UnaryExecNode 
   protected override def doExecute(): RDD[InternalRow] = {
     val shuffled = new ShuffledRowRDD(
       ShuffleExchange.prepareShuffleDependency(
-        child.execute(), child.output, SinglePartition, serializer))
+        child.execute(), child.output, SinglePartition, serializer, sqlContext))
     shuffled.mapPartitionsInternal(_.take(limit))
   }
 }
@@ -145,7 +145,7 @@ case class TakeOrderedAndProjectExec(
     }
     val shuffled = new ShuffledRowRDD(
       ShuffleExchange.prepareShuffleDependency(
-        localTopK, child.output, SinglePartition, serializer))
+        localTopK, child.output, SinglePartition, serializer, sqlContext))
     shuffled.mapPartitions { iter =>
       val topK = org.apache.spark.util.collection.Utils.takeOrdered(iter.map(_.copy()), limit)(ord)
       if (projectList.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -508,6 +508,12 @@ object SQLConf {
       .intConf
       .createWithDefault(40)
 
+  val SHUFFLE_CLEANUP_ENABLED =
+    SQLConfigBuilder("spark.sql.shuffle.cleanupEnabled")
+      .doc("Whether to remove shuffle files just after jobs finished.")
+      .booleanConf
+      .createWithDefault(true)
+
   val VECTORIZED_AGG_MAP_MAX_COLUMNS =
     SQLConfigBuilder("spark.sql.codegen.aggregate.map.columns.max")
       .internal()
@@ -689,6 +695,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def variableSubstituteEnabled: Boolean = getConf(VARIABLE_SUBSTITUTE_ENABLED)
 
   def variableSubstituteDepth: Int = getConf(VARIABLE_SUBSTITUTE_DEPTH)
+
+  def shuffleCleanupEnabled: Boolean = getConf(SHUFFLE_CLEANUP_ENABLED)
 
   def warehousePath: String = {
     getConf(WAREHOUSE_PATH).replace("${system:user.dir}", System.getProperty("user.dir"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since `ShuffleRDD` in a SQL query could not be reuse later, this pr is to remove the shuffle files after finish a query to free the disk space as soon as possible.
## How was this patch tested?

Manually checked all files were deleted just after jobs finished.
