### PR TITLE
[Minor][Core][1.6-backport] Fix display wrong free memory size in the log

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -393,7 +393,8 @@ private[spark] class MemoryStore(blockManager: BlockManager, memoryManager: Memo
         }
         val valuesOrBytes = if (deserialized) "values" else "bytes"
         logInfo("Block %s stored as %s in memory (estimated size %s, free %s)".format(
-          blockId, valuesOrBytes, Utils.bytesToString(size), Utils.bytesToString(blocksMemoryUsed)))
+          blockId, valuesOrBytes, Utils.bytesToString(size),
+          Utils.bytesToString(maxMemory - blocksMemoryUsed)))
       } else {
         // Tell the block manager that we couldn't put it in memory so that it can drop it to
         // disk if the block allows disk storage.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Free memory size displayed in the log is wrong (used memory), fix to make it correct. Backported to 1.6.
## How was this patch tested?

N/A
