### PR TITLE
[SPARK-16366][SPARKR] Fix time comparison failures in SparkR unit tests.

### DIFF
--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1258,10 +1258,12 @@ test_that("date functions on a DataFrame", {
   df2 <- createDataFrame(l2)
   expect_equal(collect(select(df2, minute(df2$b)))[, 1], c(34, 24))
   expect_equal(collect(select(df2, second(df2$b)))[, 1], c(0, 34))
-  expect_equal(collect(select(df2, from_utc_timestamp(df2$b, "JST")))[, 1],
-               c(as.POSIXlt("2012-12-13 21:34:00 UTC"), as.POSIXlt("2014-12-15 10:24:34 UTC")))
-  expect_equal(collect(select(df2, to_utc_timestamp(df2$b, "JST")))[, 1],
-               c(as.POSIXlt("2012-12-13 03:34:00 UTC"), as.POSIXlt("2014-12-14 16:24:34 UTC")))
+  t <- c(as.POSIXlt("2012-12-13 21:34:00 UTC"), as.POSIXlt("2014-12-15 10:24:34 UTC"))
+  attr(t, "tzone") <- NULL
+  expect_equal(collect(select(df2, from_utc_timestamp(df2$b, "JST")))[, 1], t)
+  t <- c(as.POSIXlt("2012-12-13 03:34:00 UTC"), as.POSIXlt("2014-12-14 16:24:34 UTC"))
+  attr(t, "tzone") <- NULL
+  expect_equal(collect(select(df2, to_utc_timestamp(df2$b, "JST")))[, 1], t)
   expect_gt(collect(select(df2, unix_timestamp()))[1, 1], 0)
   expect_gt(collect(select(df2, unix_timestamp(df2$b)))[1, 1], 0)
   expect_gt(collect(select(df2, unix_timestamp(lit("2015-01-01"), "yyyy-MM-dd")))[1, 1], 0)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix time comparison failures in SparkR unit tests. For details, refer to https://issues.apache.org/jira/browse/SPARK-16366.
## How was this patch tested?

SparkR unit tests.
