### PR TITLE
[SPARK-16370][SQL] Union queries should not be executed eagerly

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.usePrettyExpression
 import org.apache.spark.sql.execution.{FileRelation, LogicalRDD, QueryExecution, SQLExecution}
 import org.apache.spark.sql.execution.command.{CreateViewCommand, ExplainCommand}
-import org.apache.spark.sql.execution.datasources.{CreateTableUsingAsSelect, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{CreateTableUsingAsSelect, InsertIntoHadoopFsRelationCommand, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.json.JacksonGenerator
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.streaming.{DataStreamWriter, StreamingQuery}
@@ -183,7 +183,8 @@ class Dataset[T] private[sql](
       // to happen right away to let these side effects take place eagerly.
       case p if hasSideEffects(p) =>
         LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
-      case Union(children) if children.forall(_.isInstanceOf[InsertIntoTable]) =>
+      case Union(children) if children.forall(x =>
+          x.isInstanceOf[InsertIntoTable] || x.isInstanceOf[InsertIntoHadoopFsRelationCommand]) =>
         LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
       case _ =>
         queryExecution.analyzed

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -183,9 +183,7 @@ class Dataset[T] private[sql](
       // to happen right away to let these side effects take place eagerly.
       case p if hasSideEffects(p) =>
         LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
-      case Union(children) if children.exists(hasSideEffects) =>
-        LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
-      case Distinct(Union(children)) if children.exists(hasSideEffects) =>
+      case Union(children) if children.forall(_.isInstanceOf[InsertIntoTable]) =>
         LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
       case _ =>
         queryExecution.analyzed

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2896,23 +2896,4 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql(s"SELECT '$literal' AS DUMMY"),
       Row(s"$expected") :: Nil)
   }
-
-  test("SPARK-16370: Union queries with side effects should be executed eagerly") {
-    withTable("tbl") {
-      withTempTable("empty") {
-        spark.emptyDataFrame.createOrReplaceTempView("empty")
-        sql("CREATE TABLE tbl(i INT) USING PARQUET")
-        sql("INSERT INTO tbl VALUES(1)")
-        checkAnswer(sql("SELECT * FROM tbl"), Seq(1).map(Row(_)))
-        sql("INSERT INTO tbl VALUES(2)")
-        checkAnswer(sql("SELECT * FROM tbl"), (1 to 2).map(Row(_)))
-        sql("(INSERT INTO tbl VALUES(3)) UNION ALL (INSERT INTO tbl VALUES(4))")
-        checkAnswer(sql("SELECT * FROM tbl"), (1 to 4).map(Row(_)))
-        sql("(INSERT INTO tbl VALUES(5)) UNION ALL (SELECT * FROM empty)")
-        checkAnswer(sql("SELECT * FROM tbl"), (1 to 5).map(Row(_)))
-        sql("(INSERT INTO tbl VALUES(6)) UNION (SELECT * FROM empty)")
-        checkAnswer(sql("SELECT * FROM tbl"), (1 to 6).map(Row(_)))
-      }
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2896,4 +2896,23 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql(s"SELECT '$literal' AS DUMMY"),
       Row(s"$expected") :: Nil)
   }
+
+  test("SPARK-16370: Union queries with side effects should be executed eagerly") {
+    withTable("tbl") {
+      withTempTable("empty") {
+        spark.emptyDataFrame.createOrReplaceTempView("empty")
+        sql("CREATE TABLE tbl(i INT) USING PARQUET")
+        sql("INSERT INTO tbl VALUES(1)")
+        checkAnswer(sql("SELECT * FROM tbl"), Seq(1).map(Row(_)))
+        sql("INSERT INTO tbl VALUES(2)")
+        checkAnswer(sql("SELECT * FROM tbl"), (1 to 2).map(Row(_)))
+        sql("(INSERT INTO tbl VALUES(3)) UNION ALL (INSERT INTO tbl VALUES(4))")
+        checkAnswer(sql("SELECT * FROM tbl"), (1 to 4).map(Row(_)))
+        sql("(INSERT INTO tbl VALUES(5)) UNION ALL (SELECT * FROM empty)")
+        checkAnswer(sql("SELECT * FROM tbl"), (1 to 5).map(Row(_)))
+        sql("(INSERT INTO tbl VALUES(6)) UNION (SELECT * FROM empty)")
+        checkAnswer(sql("SELECT * FROM tbl"), (1 to 6).map(Row(_)))
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark eagerly executes some queries with side effects like `Command`, `InsertIntoTable`, and `CreateTableUsingAsSelect`. However, it matches `UNION` queries **mistakenly** and executes **inconsistently**. This PR prevents **`UNION`** query eager execution to prevent inconsistency.

``` scala
scala> spark.emptyDataFrame.createOrReplaceTempView("empty")

scala> sql("CREATE TABLE tbl(i INT) USING PARQUET")

scala> sql("(INSERT INTO tbl VALUES(1)) UNION ALL (INSERT INTO tbl VALUES(2))") // Executed.

scala> sql("select * from tbl").collect()
res4: Array[org.apache.spark.sql.Row] = Array([1], [2])  // Inserted

scala> sql("(INSERT INTO tbl VALUES(5)) UNION ALL (SELECT * FROM empty)") // Not executed.

scala> sql("select * from tbl").collect()
res6: Array[org.apache.spark.sql.Row] = Array([1], [2])  // Not inserted.
```
## How was this patch tested?

Pass the Jenkins tests.
