### PR TITLE
[SPARK-15440] [Core] [Deploy] Add CSRF Filter for REST APIs to Spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestCsrfPreventionFilter.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestCsrfPreventionFilter.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.rest
+
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+/**
+ * This filter provides protection against cross site request forgery (CSRF)
+ * attacks for REST APIs. Enabling this filter on an endpoint results in the
+ * requirement of all client to send a particular HTTP header (X-XSRF-HEADER)
+ * with every request. In the absense of this header the filter will reject the
+ * attempt as a bad request.
+ */
+private[spark] class RestCsrfPreventionFilter extends Filter {
+
+  import RestCsrfPreventionFilter._
+
+  def init(filterConfig: FilterConfig): Unit = {}
+
+  def doFilter(
+      servletRequest: ServletRequest,
+      servletResponse: ServletResponse,
+      filterChain: FilterChain): Unit = {
+    val httpReq = servletRequest.asInstanceOf[HttpServletRequest]
+    if(ignoreMethods.contains(httpReq.getMethod) || httpReq.getHeader(X_XSRF_HEADER).nonEmpty) {
+      filterChain.doFilter(servletRequest, servletResponse)
+    } else {
+      servletResponse.asInstanceOf[HttpServletResponse].sendError(
+        HttpServletResponse.SC_BAD_REQUEST, "Missing Required Header for CSRF protection.")
+    }
+  }
+
+  def destroy(): Unit = {}
+}
+
+private[spark] object RestCsrfPreventionFilter {
+
+  val X_XSRF_HEADER = "X-XSRF-HEADER"
+  val ignoreMethods = Array("GET", "OPTIONS", "HEAD", "TRACE")
+}

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionClient.scala
@@ -199,6 +199,8 @@ private[spark] class RestSubmissionClient(master: String) extends Logging {
     logDebug(s"Sending POST request to server at $url.")
     val conn = url.openConnection().asInstanceOf[HttpURLConnection]
     conn.setRequestMethod("POST")
+    // Add CSRF protection header
+    conn.setRequestProperty(RestCsrfPreventionFilter.X_XSRF_HEADER, "true")
     readResponse(conn)
   }
 
@@ -209,6 +211,8 @@ private[spark] class RestSubmissionClient(master: String) extends Logging {
     conn.setRequestMethod("POST")
     conn.setRequestProperty("Content-Type", "application/json")
     conn.setRequestProperty("charset", "utf-8")
+    // Add CSRF protection header
+    conn.setRequestProperty(RestCsrfPreventionFilter.X_XSRF_HEADER, "true")
     conn.setDoOutput(true)
     try {
       val out = new DataOutputStream(conn.getOutputStream)

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.deploy.rest
 
+import javax.servlet.DispatcherType
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import scala.io.Source
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import org.eclipse.jetty.server.{Server, ServerConnector}
-import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
+import org.eclipse.jetty.servlet.{FilterHolder, ServletContextHandler, ServletHolder}
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -93,6 +94,13 @@ private[spark] abstract class RestSubmissionServer(
     contextToServlet.foreach { case (prefix, servlet) =>
       mainHandler.addServlet(new ServletHolder(servlet), prefix)
     }
+    // Add a filter for CSRF protection.
+    val csrfFilterHolder: FilterHolder = new FilterHolder()
+    csrfFilterHolder.setHeldClass(classOf[RestCsrfPreventionFilter])
+    mainHandler.addFilter(csrfFilterHolder, "/*", java.util.EnumSet.of(
+      DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.FORWARD,
+      DispatcherType.INCLUDE, DispatcherType.REQUEST))
+
     server.setHandler(mainHandler)
     server.start()
     val boundPort = connector.getLocalPort

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -94,13 +94,14 @@ private[spark] abstract class RestSubmissionServer(
     contextToServlet.foreach { case (prefix, servlet) =>
       mainHandler.addServlet(new ServletHolder(servlet), prefix)
     }
-    // Add a filter for CSRF protection.
-    val csrfFilterHolder: FilterHolder = new FilterHolder()
-    csrfFilterHolder.setHeldClass(classOf[RestCsrfPreventionFilter])
-    mainHandler.addFilter(csrfFilterHolder, "/*", java.util.EnumSet.of(
-      DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.FORWARD,
-      DispatcherType.INCLUDE, DispatcherType.REQUEST))
-
+    if(masterConf.getBoolean("spark.rest.csrf.enable", false)) {
+      // Add a filter for CSRF protection.
+      val csrfFilterHolder: FilterHolder = new FilterHolder()
+      csrfFilterHolder.setHeldClass(classOf[RestCsrfPreventionFilter])
+      mainHandler.addFilter(csrfFilterHolder, "/*", java.util.EnumSet.of(
+        DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.FORWARD,
+        DispatcherType.INCLUDE, DispatcherType.REQUEST))
+    }
     server.setHandler(mainHandler)
     server.start()
     val boundPort = connector.getLocalPort

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -495,6 +495,8 @@ class StandaloneRestSubmitSuite extends SparkFunSuite with BeforeAndAfterEach {
       body: String = ""): HttpURLConnection = {
     val conn = new URL(url).openConnection().asInstanceOf[HttpURLConnection]
     conn.setRequestMethod(method)
+    // Add CSRF protection header
+    conn.setRequestProperty(RestCsrfPreventionFilter.X_XSRF_HEADER, "true")
     if (body.nonEmpty) {
       conn.setDoOutput(true)
       val out = new DataOutputStream(conn.getOutputStream)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR replaced #13218.
CSRF prevention for REST APIs can be provided through a common servlet filter. This filter would check for the existence of an custom HTTP header - such as `X-XSRF-Header`.
The fact that CSRF attacks are entirely browser based means that the above approach can ensure that requests are coming from either: applications served by the same origin as the REST API or that there is explicit policy configuration that allows the setting of a header on XmlHttpRequest from another origin.
We have done similar work for Hadoop (https://issues.apache.org/jira/browse/HADOOP-12691) and other components.
## How was this patch tested?

Unit test.
