### PR TITLE
[SPARK-16385][core] Catch correct exception when calling method via reflection.

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1813,7 +1813,7 @@ private[spark] object Utils extends Logging {
         .invoke(process, timeoutMs.asInstanceOf[java.lang.Long], TimeUnit.MILLISECONDS)
         .asInstanceOf[Boolean]
     } catch {
-      case _: NoSuchMethodError =>
+      case _: NoSuchMethodException =>
         // Otherwise implement it manually
         var terminated = false
         val startTime = System.currentTimeMillis


### PR DESCRIPTION
Using "Method.invoke" causes an exception to be thrown, not an error, so
Utils.waitForProcess() was always throwing an exception when run on Java 7.
