### PR TITLE
[MINOR] [BUILD] Download Maven 3.3.9 instead of 3.3.3 because the latter is no longer published on Apache mirrors

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -69,7 +69,7 @@ install_app() {
 
 # Install maven under the build/ folder
 install_mvn() {
-  local MVN_VERSION="3.3.3"
+  local MVN_VERSION="3.3.9"
 
   install_app \
     "https://www.apache.org/dyn/closer.lua?action=download&filename=/maven/maven-3/${MVN_VERSION}/binaries" \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Download Maven 3.3.9 instead of 3.3.3 because the latter is no longer published on Apache mirrors
## How was this patch tested?

Jenkins
