### PR TITLE
[SPARK-16397][SQL] make CatalogTable more general and less hive specific

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -53,7 +53,7 @@ statement
         (PARTITIONED BY partitionColumnNames=identifierList)?
         bucketSpec? AS? query                                          #createTableUsing
     | createTableHeader ('(' columns=colTypeList ')')?
-        (COMMENT STRING)?
+        (COMMENT comment=STRING)?
         (PARTITIONED BY '(' partitionColumns=colTypeList ')')?
         bucketSpec? skewSpec?
         rowFormat?  createFileFormat? locationSpec?

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -398,7 +398,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       assert(oldPart2.storage.locationUri != Some(newLocation))
       // alter other storage information
       catalog.alterPartitions("db2", "tbl2", Seq(
-        oldPart1.copy(storage = storageFormat.withSerde(newSerde)),
+        oldPart1.copy(storage = storageFormat.withSerde(Some(newSerde))),
         oldPart2.copy(storage = storageFormat.copy(properties = newSerdeProps))))
       val newPart1b = catalog.getPartition("db2", "tbl2", part1.spec)
       val newPart2b = catalog.getPartition("db2", "tbl2", part2.spec)
@@ -569,7 +569,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       tableType = CatalogTableType.EXTERNAL,
       storage = CatalogStorageFormat(
         Some(Utils.createTempDir().getAbsolutePath),
-        None, Map.empty),
+        Map.empty),
       schema = Seq(CatalogColumn("a", "int"), CatalogColumn("b", "string"))
     )
     catalog.createTable("db1", externalTable, ignoreIfExists = false)
@@ -609,7 +609,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       Map("a" -> "7", "b" -> "8"),
       CatalogStorageFormat(
         Some(Utils.createTempDir().getAbsolutePath),
-        None, Map.empty)
+        Map.empty)
     )
     catalog.createPartitions("db1", "tbl", Seq(externalPartition), ignoreIfExists = false)
     assert(!exists(databaseDir, "tbl", "a=7", "b=8"))
@@ -629,8 +629,8 @@ abstract class CatalogTestUtils {
 
   // These fields must be lazy because they rely on fields that are not implemented yet
   lazy val storageFormat = CatalogStorageFormat.empty
-    .withInputFormat(tableInputFormat)
-    .withOutputFormat(tableOutputFormat)
+    .withInputFormat(Some(tableInputFormat))
+    .withOutputFormat(Some(tableOutputFormat))
   lazy val part1 = CatalogTablePartition(Map("a" -> "1", "b" -> "2"), storageFormat)
   lazy val part2 = CatalogTablePartition(Map("a" -> "3", "b" -> "4"), storageFormat)
   lazy val part3 = CatalogTablePartition(Map("a" -> "5", "b" -> "6"), storageFormat)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -398,12 +398,12 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       assert(oldPart2.storage.locationUri != Some(newLocation))
       // alter other storage information
       catalog.alterPartitions("db2", "tbl2", Seq(
-        oldPart1.copy(storage = storageFormat.copy(serde = Some(newSerde))),
-        oldPart2.copy(storage = storageFormat.copy(serdeProperties = newSerdeProps))))
+        oldPart1.copy(storage = storageFormat.withSerde(newSerde)),
+        oldPart2.copy(storage = storageFormat.copy(properties = newSerdeProps))))
       val newPart1b = catalog.getPartition("db2", "tbl2", part1.spec)
       val newPart2b = catalog.getPartition("db2", "tbl2", part2.spec)
-      assert(newPart1b.storage.serde == Some(newSerde))
-      assert(newPart2b.storage.serdeProperties == newSerdeProps)
+      assert(newPart1b.storage.getSerde == Some(newSerde))
+      assert(newPart2b.storage.getProperties == newSerdeProps)
       // alter but change spec, should fail because new partition specs do not exist yet
       val badPart1 = part1.copy(spec = Map("a" -> "v1", "b" -> "v2"))
       val badPart2 = part2.copy(spec = Map("a" -> "v3", "b" -> "v4"))
@@ -550,7 +550,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     val table = CatalogTable(
       identifier = TableIdentifier("my_table", Some("db1")),
       tableType = CatalogTableType.MANAGED,
-      storage = CatalogStorageFormat(None, None, None, None, false, Map.empty),
+      storage = CatalogStorageFormat.empty,
       schema = Seq(CatalogColumn("a", "int"), CatalogColumn("b", "string"))
     )
 
@@ -569,7 +569,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       tableType = CatalogTableType.EXTERNAL,
       storage = CatalogStorageFormat(
         Some(Utils.createTempDir().getAbsolutePath),
-        None, None, None, false, Map.empty),
+        None, Map.empty),
       schema = Seq(CatalogColumn("a", "int"), CatalogColumn("b", "string"))
     )
     catalog.createTable("db1", externalTable, ignoreIfExists = false)
@@ -582,7 +582,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     val table = CatalogTable(
       identifier = TableIdentifier("tbl", Some("db1")),
       tableType = CatalogTableType.MANAGED,
-      storage = CatalogStorageFormat(None, None, None, None, false, Map.empty),
+      storage = CatalogStorageFormat.empty,
       schema = Seq(
         CatalogColumn("col1", "int"),
         CatalogColumn("col2", "string"),
@@ -609,7 +609,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       Map("a" -> "7", "b" -> "8"),
       CatalogStorageFormat(
         Some(Utils.createTempDir().getAbsolutePath),
-        None, None, None, false, Map.empty)
+        None, Map.empty)
     )
     catalog.createPartitions("db1", "tbl", Seq(externalPartition), ignoreIfExists = false)
     assert(!exists(databaseDir, "tbl", "a=7", "b=8"))
@@ -628,13 +628,9 @@ abstract class CatalogTestUtils {
   def newEmptyCatalog(): ExternalCatalog
 
   // These fields must be lazy because they rely on fields that are not implemented yet
-  lazy val storageFormat = CatalogStorageFormat(
-    locationUri = None,
-    inputFormat = Some(tableInputFormat),
-    outputFormat = Some(tableOutputFormat),
-    serde = None,
-    compressed = false,
-    serdeProperties = Map.empty)
+  lazy val storageFormat = CatalogStorageFormat.empty
+    .withInputFormat(tableInputFormat)
+    .withOutputFormat(tableOutputFormat)
   lazy val part1 = CatalogTablePartition(Map("a" -> "1", "b" -> "2"), storageFormat)
   lazy val part2 = CatalogTablePartition(Map("a" -> "3", "b" -> "4"), storageFormat)
   lazy val part3 = CatalogTablePartition(Map("a" -> "5", "b" -> "6"), storageFormat)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -401,7 +401,7 @@ object CreateDataSourceTableUtils extends Logging {
       assert(relation.partitionSchema.isEmpty)
 
       var storage = CatalogStorageFormat(
-        locationUri = None,
+        locationUri = Some(relation.location.paths.map(_.toUri.toString).head),
         provider = Some("hive"),
         properties = options)
       serde.inputFormat.foreach(inFmt => storage = storage.withInputFormat(inFmt))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -388,7 +388,6 @@ object CreateDataSourceTableUtils extends Logging {
         schema = Nil,
         storage = CatalogStorageFormat(
           locationUri = None,
-          provider = None,
           properties = options
         ),
         properties = tableProperties.toMap)
@@ -400,18 +399,18 @@ object CreateDataSourceTableUtils extends Logging {
       assert(partitionColumns.isEmpty)
       assert(relation.partitionSchema.isEmpty)
 
-      var storage = CatalogStorageFormat(
+      val storage = CatalogStorageFormat(
         locationUri = Some(relation.location.paths.map(_.toUri.toString).head),
-        provider = Some("hive"),
         properties = options)
-      serde.inputFormat.foreach(inFmt => storage = storage.withInputFormat(inFmt))
-      serde.outputFormat.foreach(outFmt => storage = storage.withOutputFormat(outFmt))
-      serde.serde.foreach(sd => storage = storage.withSerde(sd))
+        .withInputFormat(serde.inputFormat)
+        .withOutputFormat(serde.outputFormat)
+        .withSerde(serde.serde)
 
       CatalogTable(
         identifier = tableIdent,
         tableType = tableType,
         storage = storage,
+        provider = Some("hive"),
         schema = relation.schema.map { f =>
           CatalogColumn(f.name, f.dataType.catalogString)
         },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -49,9 +49,9 @@ case class CreateHiveTableAsSelectLogicalPlan(
   override lazy val resolved: Boolean =
     tableDesc.identifier.database.isDefined &&
       tableDesc.schema.nonEmpty &&
-      tableDesc.storage.serde.isDefined &&
-      tableDesc.storage.inputFormat.isDefined &&
-      tableDesc.storage.outputFormat.isDefined &&
+      tableDesc.storage.getSerde.isDefined &&
+      tableDesc.storage.getInputFormat.isDefined &&
+      tableDesc.storage.getOutputFormat.isDefined &&
       childrenResolved
 }
 
@@ -80,11 +80,13 @@ case class CreateTableLikeCommand(
         s"Source table in CREATE TABLE LIKE cannot be temporary: '$sourceTable'")
     }
 
-    val tableToCreate = catalog.getTableMetadata(sourceTable).copy(
+    val sourceTableMeta = catalog.getTableMetadata(sourceTable)
+    val tableToCreate = sourceTableMeta.copy(
       identifier = targetTable,
       tableType = CatalogTableType.MANAGED,
       createTime = System.currentTimeMillis,
-      lastAccessTime = -1).withNewStorage(locationUri = None)
+      lastAccessTime = -1,
+      storage = sourceTableMeta.storage.copy(locationUri = None))
 
     catalog.createTable(tableToCreate, ifNotExists)
     Seq.empty[Row]
@@ -120,7 +122,7 @@ case class CreateTableCommand(table: CatalogTable, ifNotExists: Boolean) extends
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     DDLUtils.verifyTableProperties(table.properties.keys.toSeq, "CREATE TABLE")
-    DDLUtils.verifyTableProperties(table.storage.serdeProperties.keys.toSeq, "CREATE TABLE")
+    DDLUtils.verifyTableProperties(table.storage.properties.keys.toSeq, "CREATE TABLE")
     sparkSession.sessionState.catalog.createTable(table, ifNotExists)
     Seq.empty[Row]
   }
@@ -166,8 +168,9 @@ case class AlterTableRenameCommand(
       val table = catalog.getTableMetadata(oldName)
       if (DDLUtils.isDatasourceTable(table) && table.tableType == CatalogTableType.MANAGED) {
         val newPath = catalog.defaultTablePath(newName)
-        val newTable = table.withNewStorage(
-          serdeProperties = table.storage.serdeProperties ++ Map("path" -> newPath))
+        val newTable = table.copy(
+          storage = table.storage.copy(
+            properties = table.storage.properties + ("path" -> newPath)))
         catalog.alterTable(newTable)
       }
       // Invalidate the table last, otherwise uncaching the table would load the logical plan
@@ -349,7 +352,7 @@ case class TruncateTableCommand(
     }
     val locations =
       if (isDatasourceTable) {
-        Seq(table.storage.serdeProperties.get("path"))
+        Seq(table.storage.properties.get("path"))
       } else if (table.partitionColumnNames.isEmpty) {
         Seq(table.storage.locationUri)
       } else {
@@ -487,15 +490,15 @@ case class DescribeTableCommand(table: TableIdentifier, isExtended: Boolean, isF
   private def describeStorageInfo(metadata: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
     append(buffer, "", "", "")
     append(buffer, "# Storage Information", "", "")
-    metadata.storage.serde.foreach(serdeLib => append(buffer, "SerDe Library:", serdeLib, ""))
-    metadata.storage.inputFormat.foreach(format => append(buffer, "InputFormat:", format, ""))
-    metadata.storage.outputFormat.foreach(format => append(buffer, "OutputFormat:", format, ""))
-    append(buffer, "Compressed:", if (metadata.storage.compressed) "Yes" else "No", "")
+
+    metadata.storage.getSerde.foreach(serdeLib => append(buffer, "SerDe Library:", serdeLib, ""))
+    metadata.storage.getInputFormat.foreach(format => append(buffer, "InputFormat:", format, ""))
+    metadata.storage.getOutputFormat.foreach(format => append(buffer, "OutputFormat:", format, ""))
     describeBucketingInfo(metadata, buffer)
 
     append(buffer, "Storage Desc Parameters:", "", "")
-    metadata.storage.serdeProperties.foreach { case (key, value) =>
-      append(buffer, s"  $key", value, "")
+    metadata.storage.getProperties.foreach {
+      case (key, value) => append(buffer, s"  $key", value, "")
     }
   }
 
@@ -821,10 +824,10 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
   private def showHiveTableStorageInfo(metadata: CatalogTable, builder: StringBuilder): Unit = {
     val storage = metadata.storage
 
-    storage.serde.foreach { serde =>
+    storage.getSerde.foreach { serde =>
       builder ++= s"ROW FORMAT SERDE '$serde'\n"
 
-      val serdeProps = metadata.storage.serdeProperties.map {
+      val serdeProps = metadata.storage.getProperties.map {
         case (key, value) =>
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
@@ -832,14 +835,14 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
       builder ++= serdeProps.mkString("WITH SERDEPROPERTIES (\n  ", ",\n  ", "\n)\n")
     }
 
-    if (storage.inputFormat.isDefined || storage.outputFormat.isDefined) {
+    if (storage.getInputFormat.isDefined || storage.getOutputFormat.isDefined) {
       builder ++= "STORED AS\n"
 
-      storage.inputFormat.foreach { format =>
+      storage.getInputFormat.foreach { format =>
         builder ++= s"  INPUTFORMAT '${escapeSingleQuotedString(format)}'\n"
       }
 
-      storage.outputFormat.foreach { format =>
+      storage.getOutputFormat.foreach { format =>
         builder ++= s"  OUTPUTFORMAT '${escapeSingleQuotedString(format)}'\n"
       }
     }
@@ -894,7 +897,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
 
     builder ++= s"USING ${props(CreateDataSourceTableUtils.DATASOURCE_PROVIDER)}\n"
 
-    val dataSourceOptions = metadata.storage.serdeProperties.filterNot {
+    val dataSourceOptions = metadata.storage.properties.filterNot {
       case (key, value) =>
         // If it's a managed table, omit PATH option. Spark SQL always creates external table
         // when the table creation DDL contains the PATH option.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -43,6 +43,7 @@ case class CreateHiveTableAsSelectLogicalPlan(
     tableDesc: CatalogTable,
     child: LogicalPlan,
     allowExisting: Boolean) extends UnaryNode with Command {
+  assert(tableDesc.storage.provider == Some("hive"))
 
   override def output: Seq[Attribute] = Seq.empty[Attribute]
 
@@ -119,6 +120,7 @@ case class CreateTableLikeCommand(
  * }}}
  */
 case class CreateTableCommand(table: CatalogTable, ifNotExists: Boolean) extends RunnableCommand {
+  assert(table.storage.provider == Some("hive"))
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     DDLUtils.verifyTableProperties(table.properties.keys.toSeq, "CREATE TABLE")
@@ -446,6 +448,7 @@ case class DescribeTableCommand(table: TableIdentifier, isExtended: Boolean, isF
         partCols.foreach(col => append(buffer, col, "", ""))
       }
     } else {
+      assert(table.storage.provider == Some("hive"))
       describeSchema(table.schema, buffer)
 
       if (table.partitionColumns.nonEmpty) {
@@ -744,6 +747,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
     val stmt = if (DDLUtils.isDatasourceTable(tableMetadata)) {
       showCreateDataSourceTable(tableMetadata)
     } else {
+      assert(tableMetadata.storage.provider == Some("hive"))
       showCreateHiveTable(tableMetadata)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -214,7 +214,7 @@ private[sql] class FindDataSourceTable(sparkSession: SparkSession) extends Rule[
 
     val bucketSpec = DDLUtils.getBucketSpecFromTableProperties(table)
 
-    val options = table.storage.serdeProperties
+    val options = table.storage.properties
     val dataSource =
       DataSource(
         sparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -214,7 +214,7 @@ private[sql] class FindDataSourceTable(sparkSession: SparkSession) extends Rule[
 
     val bucketSpec = DDLUtils.getBucketSpecFromTableProperties(table)
 
-    val options = table.storage.properties
+    val options = table.storage.getProperties
     val dataSource =
       DataSource(
         sparkSession,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -246,9 +246,9 @@ class DDLCommandSuite extends PlanTest {
       val ct = parseAs[CreateTableCommand](query)
       val hiveSerde = HiveSerDe.sourceToSerDe(s, new SQLConf)
       assert(hiveSerde.isDefined)
-      assert(ct.table.storage.serde == hiveSerde.get.serde)
-      assert(ct.table.storage.inputFormat == hiveSerde.get.inputFormat)
-      assert(ct.table.storage.outputFormat == hiveSerde.get.outputFormat)
+      assert(ct.table.storage.getSerde == hiveSerde.get.serde)
+      assert(ct.table.storage.getInputFormat == hiveSerde.get.inputFormat)
+      assert(ct.table.storage.getOutputFormat == hiveSerde.get.outputFormat)
     }
   }
 
@@ -260,13 +260,13 @@ class DDLCommandSuite extends PlanTest {
 
     // No conflicting serdes here, OK
     val parsed1 = parseAs[CreateTableCommand](query1)
-    assert(parsed1.table.storage.serde == Some("anything"))
-    assert(parsed1.table.storage.inputFormat == Some("inputfmt"))
-    assert(parsed1.table.storage.outputFormat == Some("outputfmt"))
+    assert(parsed1.table.storage.getSerde == Some("anything"))
+    assert(parsed1.table.storage.getInputFormat == Some("inputfmt"))
+    assert(parsed1.table.storage.getOutputFormat == Some("outputfmt"))
     val parsed2 = parseAs[CreateTableCommand](query2)
-    assert(parsed2.table.storage.serde.isEmpty)
-    assert(parsed2.table.storage.inputFormat == Some("inputfmt"))
-    assert(parsed2.table.storage.outputFormat == Some("outputfmt"))
+    assert(parsed2.table.storage.getSerde.isEmpty)
+    assert(parsed2.table.storage.getInputFormat == Some("inputfmt"))
+    assert(parsed2.table.storage.getOutputFormat == Some("outputfmt"))
   }
 
   test("create table - row format serde and generic file format") {
@@ -279,9 +279,9 @@ class DDLCommandSuite extends PlanTest {
         val ct = parseAs[CreateTableCommand](query)
         val hiveSerde = HiveSerDe.sourceToSerDe(s, new SQLConf)
         assert(hiveSerde.isDefined)
-        assert(ct.table.storage.serde == Some("anything"))
-        assert(ct.table.storage.inputFormat == hiveSerde.get.inputFormat)
-        assert(ct.table.storage.outputFormat == hiveSerde.get.outputFormat)
+        assert(ct.table.storage.getSerde == Some("anything"))
+        assert(ct.table.storage.getInputFormat == hiveSerde.get.inputFormat)
+        assert(ct.table.storage.getOutputFormat == hiveSerde.get.outputFormat)
       } else {
         assertUnsupported(query, Seq("row format serde", "incompatible", s))
       }
@@ -298,9 +298,9 @@ class DDLCommandSuite extends PlanTest {
         val ct = parseAs[CreateTableCommand](query)
         val hiveSerde = HiveSerDe.sourceToSerDe(s, new SQLConf)
         assert(hiveSerde.isDefined)
-        assert(ct.table.storage.serde == hiveSerde.get.serde)
-        assert(ct.table.storage.inputFormat == hiveSerde.get.inputFormat)
-        assert(ct.table.storage.outputFormat == hiveSerde.get.outputFormat)
+        assert(ct.table.storage.getSerde == hiveSerde.get.serde)
+        assert(ct.table.storage.getInputFormat == hiveSerde.get.inputFormat)
+        assert(ct.table.storage.getOutputFormat == hiveSerde.get.outputFormat)
       } else {
         assertUnsupported(query, Seq("row format delimited", "only compatible with 'textfile'", s))
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -80,11 +80,8 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     val storage =
       CatalogStorageFormat(
         locationUri = Some(catalog.defaultTablePath(name)),
-        inputFormat = None,
-        outputFormat = None,
-        serde = None,
-        compressed = false,
-        serdeProperties = Map())
+        provider = None,
+        properties = Map.empty)
     CatalogTable(
       identifier = name,
       tableType = CatalogTableType.EXTERNAL,
@@ -107,7 +104,7 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
       spec: TablePartitionSpec,
       tableName: TableIdentifier): Unit = {
     val part = CatalogTablePartition(
-      spec, CatalogStorageFormat(None, None, None, None, false, Map()))
+      spec, CatalogStorageFormat.empty)
     catalog.createPartitions(tableName, Seq(part), ignoreIfExists = false)
   }
 
@@ -891,9 +888,9 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
       convertToDatasourceTable(catalog, tableIdent)
     }
     assert(catalog.getTableMetadata(tableIdent).storage.locationUri.isDefined)
-    assert(catalog.getTableMetadata(tableIdent).storage.serdeProperties.isEmpty)
+    assert(catalog.getTableMetadata(tableIdent).storage.getProperties.isEmpty)
     assert(catalog.getPartition(tableIdent, partSpec).storage.locationUri.isEmpty)
-    assert(catalog.getPartition(tableIdent, partSpec).storage.serdeProperties.isEmpty)
+    assert(catalog.getPartition(tableIdent, partSpec).storage.getProperties.isEmpty)
     // Verify that the location is set to the expected string
     def verifyLocation(expected: String, spec: Option[TablePartitionSpec] = None): Unit = {
       val storageFormat = spec
@@ -901,10 +898,10 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
         .getOrElse { catalog.getTableMetadata(tableIdent).storage }
       if (isDatasourceTable) {
         if (spec.isDefined) {
-          assert(storageFormat.serdeProperties.isEmpty)
+          assert(storageFormat.getProperties.isEmpty)
           assert(storageFormat.locationUri.isEmpty)
         } else {
-          assert(storageFormat.serdeProperties.get("path") === Some(expected))
+          assert(storageFormat.properties.get("path") === Some(expected))
           assert(storageFormat.locationUri === Some(expected))
         }
       } else {
@@ -946,8 +943,8 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     if (isDatasourceTable) {
       convertToDatasourceTable(catalog, tableIdent)
     }
-    assert(catalog.getTableMetadata(tableIdent).storage.serde.isEmpty)
-    assert(catalog.getTableMetadata(tableIdent).storage.serdeProperties.isEmpty)
+    assert(catalog.getTableMetadata(tableIdent).storage.getSerde.isEmpty)
+    assert(catalog.getTableMetadata(tableIdent).storage.getProperties.isEmpty)
     // set table serde and/or properties (should fail on datasource tables)
     if (isDatasourceTable) {
       val e1 = intercept[AnalysisException] {
@@ -961,22 +958,22 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
       assert(e2.getMessage.contains("datasource"))
     } else {
       sql("ALTER TABLE dbx.tab1 SET SERDE 'org.apache.jadoop'")
-      assert(catalog.getTableMetadata(tableIdent).storage.serde == Some("org.apache.jadoop"))
-      assert(catalog.getTableMetadata(tableIdent).storage.serdeProperties.isEmpty)
+      assert(catalog.getTableMetadata(tableIdent).storage.getSerde == Some("org.apache.jadoop"))
+      assert(catalog.getTableMetadata(tableIdent).storage.getProperties.isEmpty)
       sql("ALTER TABLE dbx.tab1 SET SERDE 'org.apache.madoop' " +
         "WITH SERDEPROPERTIES ('k' = 'v', 'kay' = 'vee')")
-      assert(catalog.getTableMetadata(tableIdent).storage.serde == Some("org.apache.madoop"))
-      assert(catalog.getTableMetadata(tableIdent).storage.serdeProperties ==
+      assert(catalog.getTableMetadata(tableIdent).storage.getSerde == Some("org.apache.madoop"))
+      assert(catalog.getTableMetadata(tableIdent).storage.getProperties ==
         Map("k" -> "v", "kay" -> "vee"))
     }
     // set serde properties only
     sql("ALTER TABLE dbx.tab1 SET SERDEPROPERTIES ('k' = 'vvv', 'kay' = 'vee')")
-    assert(catalog.getTableMetadata(tableIdent).storage.serdeProperties ==
+    assert(catalog.getTableMetadata(tableIdent).storage.getProperties ==
       Map("k" -> "vvv", "kay" -> "vee"))
     // set things without explicitly specifying database
     catalog.setCurrentDatabase("dbx")
     sql("ALTER TABLE tab1 SET SERDEPROPERTIES ('kay' = 'veee')")
-    assert(catalog.getTableMetadata(tableIdent).storage.serdeProperties ==
+    assert(catalog.getTableMetadata(tableIdent).storage.getProperties ==
       Map("k" -> "vvv", "kay" -> "veee"))
     // table to alter does not exist
     intercept[AnalysisException] {
@@ -1002,8 +999,8 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     if (isDatasourceTable) {
       convertToDatasourceTable(catalog, tableIdent)
     }
-    assert(catalog.getPartition(tableIdent, spec).storage.serde.isEmpty)
-    assert(catalog.getPartition(tableIdent, spec).storage.serdeProperties.isEmpty)
+    assert(catalog.getPartition(tableIdent, spec).storage.getSerde.isEmpty)
+    assert(catalog.getPartition(tableIdent, spec).storage.getProperties.isEmpty)
     // set table serde and/or properties (should fail on datasource tables)
     if (isDatasourceTable) {
       val e1 = intercept[AnalysisException] {
@@ -1017,26 +1014,26 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
       assert(e2.getMessage.contains("datasource"))
     } else {
       sql("ALTER TABLE dbx.tab1 PARTITION (a=1, b=2) SET SERDE 'org.apache.jadoop'")
-      assert(catalog.getPartition(tableIdent, spec).storage.serde == Some("org.apache.jadoop"))
-      assert(catalog.getPartition(tableIdent, spec).storage.serdeProperties.isEmpty)
+      assert(catalog.getPartition(tableIdent, spec).storage.getSerde == Some("org.apache.jadoop"))
+      assert(catalog.getPartition(tableIdent, spec).storage.getProperties.isEmpty)
       sql("ALTER TABLE dbx.tab1 PARTITION (a=1, b=2) SET SERDE 'org.apache.madoop' " +
         "WITH SERDEPROPERTIES ('k' = 'v', 'kay' = 'vee')")
-      assert(catalog.getPartition(tableIdent, spec).storage.serde == Some("org.apache.madoop"))
-      assert(catalog.getPartition(tableIdent, spec).storage.serdeProperties ==
+      assert(catalog.getPartition(tableIdent, spec).storage.getSerde == Some("org.apache.madoop"))
+      assert(catalog.getPartition(tableIdent, spec).storage.getProperties ==
         Map("k" -> "v", "kay" -> "vee"))
     }
     // set serde properties only
     maybeWrapException(isDatasourceTable) {
       sql("ALTER TABLE dbx.tab1 PARTITION (a=1, b=2) " +
         "SET SERDEPROPERTIES ('k' = 'vvv', 'kay' = 'vee')")
-      assert(catalog.getPartition(tableIdent, spec).storage.serdeProperties ==
+      assert(catalog.getPartition(tableIdent, spec).storage.getProperties ==
         Map("k" -> "vvv", "kay" -> "vee"))
     }
     // set things without explicitly specifying database
     catalog.setCurrentDatabase("dbx")
     maybeWrapException(isDatasourceTable) {
       sql("ALTER TABLE tab1 PARTITION (a=1, b=2) SET SERDEPROPERTIES ('kay' = 'veee')")
-      assert(catalog.getPartition(tableIdent, spec).storage.serdeProperties ==
+      assert(catalog.getPartition(tableIdent, spec).storage.getProperties ==
         Map("k" -> "vvv", "kay" -> "veee"))
     }
     // table to alter does not exist

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -80,7 +80,6 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     val storage =
       CatalogStorageFormat(
         locationUri = Some(catalog.defaultTablePath(name)),
-        provider = None,
         properties = Map.empty)
     CatalogTable(
       identifier = name,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -179,9 +179,7 @@ private[spark] class HiveExternalCatalog(client: HiveClient, hadoopConf: Configu
 
       try {
         client.createTable(
-          tableDefinition.copy(storage = tableDefinition.storage.copy(
-            locationUri = Some(tempPath.toString)
-          )),
+          tableDefinition.mapStorage(_.copy(locationUri = Some(tempPath.toString))),
           ignoreIfExists)
       } finally {
         FileSystem.get(tempPath.toUri, hadoopConf).delete(tempPath, true)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -179,7 +179,9 @@ private[spark] class HiveExternalCatalog(client: HiveClient, hadoopConf: Configu
 
       try {
         client.createTable(
-          tableDefinition.withNewStorage(locationUri = Some(tempPath.toString)),
+          tableDefinition.copy(storage = tableDefinition.storage.copy(
+            locationUri = Some(tempPath.toString)
+          )),
           ignoreIfExists)
       } finally {
         FileSystem.get(tempPath.toUri, hadoopConf).delete(tempPath, true)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -119,7 +119,7 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           BucketSpec(n.toInt, getColumnNames("bucket"), getColumnNames("sort"))
         }
 
-        val options = table.storage.properties
+        val options = table.storage.getProperties
         val dataSource =
           DataSource(
             sparkSession,
@@ -443,8 +443,7 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
       case p @ CreateHiveTableAsSelectLogicalPlan(table, child, allowExisting) =>
         val desc = if (table.storage.getSerde.isEmpty) {
           // add default serde
-          table.copy(storage =
-            table.storage.withSerde("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
+          table.mapStorage(_.withSerde(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")))
         } else {
           table
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -119,7 +119,7 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           BucketSpec(n.toInt, getColumnNames("bucket"), getColumnNames("sort"))
         }
 
-        val options = table.storage.serdeProperties
+        val options = table.storage.properties
         val dataSource =
           DataSource(
             sparkSession,
@@ -441,10 +441,10 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
       case p: LogicalPlan if p.resolved => p
 
       case p @ CreateHiveTableAsSelectLogicalPlan(table, child, allowExisting) =>
-        val desc = if (table.storage.serde.isEmpty) {
+        val desc = if (table.storage.getSerde.isEmpty) {
           // add default serde
-          table.withNewStorage(
-            serde = Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
+          table.copy(storage =
+            table.storage.withSerde("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
         } else {
           table
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
@@ -84,28 +84,13 @@ private[hive] case class MetastoreRelation(
       case CatalogTableType.VIEW => HiveTableType.VIRTUAL_VIEW.toString
     })
 
-    val sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor()
-    tTable.setSd(sd)
-
     // Note: In Hive the schema and partition columns must be disjoint sets
     val (partCols, schema) = catalogTable.schema.map(toHiveColumn).partition { c =>
       catalogTable.partitionColumnNames.contains(c.getName)
     }
-    sd.setCols(schema.asJava)
+    val sd = toHiveStorage(catalogTable.storage, schema)
+    tTable.setSd(sd)
     tTable.setPartitionKeys(partCols.asJava)
-
-    catalogTable.storage.locationUri.foreach(sd.setLocation)
-    catalogTable.storage.inputFormat.foreach(sd.setInputFormat)
-    catalogTable.storage.outputFormat.foreach(sd.setOutputFormat)
-
-    val serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo
-    catalogTable.storage.serde.foreach(serdeInfo.setSerializationLib)
-    sd.setSerdeInfo(serdeInfo)
-
-    val serdeParameters = new java.util.HashMap[String, String]()
-    catalogTable.storage.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
-    serdeInfo.setParameters(serdeParameters)
-
     new HiveTable(tTable)
   }
 
@@ -160,25 +145,28 @@ private[hive] case class MetastoreRelation(
       tPartition.setTableName(tableName)
       tPartition.setValues(partitionKeys.map(a => p.spec(a.name)).asJava)
 
-      val sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor()
+      val sd = toHiveStorage(p.storage, catalogTable.schema.map(toHiveColumn))
       tPartition.setSd(sd)
-      sd.setCols(catalogTable.schema.map(toHiveColumn).asJava)
-      p.storage.locationUri.foreach(sd.setLocation)
-      p.storage.inputFormat.foreach(sd.setInputFormat)
-      p.storage.outputFormat.foreach(sd.setOutputFormat)
-
-      val serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo
-      sd.setSerdeInfo(serdeInfo)
-      // maps and lists should be set only after all elements are ready (see HIVE-7975)
-      p.storage.serde.foreach(serdeInfo.setSerializationLib)
-
-      val serdeParameters = new java.util.HashMap[String, String]()
-      catalogTable.storage.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
-      p.storage.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
-      serdeInfo.setParameters(serdeParameters)
-
       new Partition(hiveQlTable, tPartition)
     }
+  }
+
+  private def toHiveStorage(storage: CatalogStorageFormat, schema: Seq[FieldSchema]) = {
+    val sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor()
+    sd.setCols(schema.asJava)
+    catalogTable.storage.locationUri.foreach(sd.setLocation)
+    catalogTable.storage.getInputFormat.foreach(sd.setInputFormat)
+    catalogTable.storage.getOutputFormat.foreach(sd.setOutputFormat)
+
+    val serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo
+    sd.setSerdeInfo(serdeInfo)
+    // maps and lists should be set only after all elements are ready (see HIVE-7975)
+    catalogTable.storage.getSerde.foreach(serdeInfo.setSerializationLib)
+
+    val serdeParameters = new java.util.HashMap[String, String]()
+    catalogTable.storage.getProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
+    serdeInfo.setParameters(serdeParameters)
+    sd
   }
 
   /** Only compare database and tablename, not alias. */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
@@ -154,17 +154,17 @@ private[hive] case class MetastoreRelation(
   private def toHiveStorage(storage: CatalogStorageFormat, schema: Seq[FieldSchema]) = {
     val sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor()
     sd.setCols(schema.asJava)
-    catalogTable.storage.locationUri.foreach(sd.setLocation)
-    catalogTable.storage.getInputFormat.foreach(sd.setInputFormat)
-    catalogTable.storage.getOutputFormat.foreach(sd.setOutputFormat)
+    storage.locationUri.foreach(sd.setLocation)
+    storage.getInputFormat.foreach(sd.setInputFormat)
+    storage.getOutputFormat.foreach(sd.setOutputFormat)
 
     val serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo
     sd.setSerdeInfo(serdeInfo)
     // maps and lists should be set only after all elements are ready (see HIVE-7975)
-    catalogTable.storage.getSerde.foreach(serdeInfo.setSerializationLib)
+    storage.getSerde.foreach(serdeInfo.setSerializationLib)
 
     val serdeParameters = new java.util.HashMap[String, String]()
-    catalogTable.storage.getProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
+    storage.getProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
     serdeInfo.setParameters(serdeParameters)
     sd
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -69,9 +69,9 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.viewText.isEmpty)
     assert(desc.viewOriginalText.isEmpty)
     assert(desc.partitionColumns == Seq.empty[CatalogColumn])
-    assert(desc.storage.inputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileInputFormat"))
-    assert(desc.storage.outputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileOutputFormat"))
-    assert(desc.storage.serde ==
+    assert(desc.storage.getInputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileInputFormat"))
+    assert(desc.storage.getOutputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileOutputFormat"))
+    assert(desc.storage.getSerde ==
       Some("org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe"))
     assert(desc.properties == Map(("p1", "v1"), ("p2", "v2")))
   }
@@ -100,10 +100,10 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.viewText.isEmpty)
     assert(desc.viewOriginalText.isEmpty)
     assert(desc.partitionColumns == Seq.empty[CatalogColumn])
-    assert(desc.storage.serdeProperties == Map())
-    assert(desc.storage.inputFormat == Some("parquet.hive.DeprecatedParquetInputFormat"))
-    assert(desc.storage.outputFormat == Some("parquet.hive.DeprecatedParquetOutputFormat"))
-    assert(desc.storage.serde == Some("parquet.hive.serde.ParquetHiveSerDe"))
+    assert(desc.storage.getProperties == Map())
+    assert(desc.storage.getInputFormat == Some("parquet.hive.DeprecatedParquetInputFormat"))
+    assert(desc.storage.getOutputFormat == Some("parquet.hive.DeprecatedParquetOutputFormat"))
+    assert(desc.storage.getSerde == Some("parquet.hive.serde.ParquetHiveSerDe"))
     assert(desc.properties == Map(("p1", "v1"), ("p2", "v2")))
   }
 
@@ -118,11 +118,11 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.schema == Seq.empty[CatalogColumn])
     assert(desc.viewText == None) // TODO will be SQLText
     assert(desc.viewOriginalText.isEmpty)
-    assert(desc.storage.serdeProperties == Map())
-    assert(desc.storage.inputFormat == Some("org.apache.hadoop.mapred.TextInputFormat"))
-    assert(desc.storage.outputFormat ==
+    assert(desc.storage.getProperties == Map())
+    assert(desc.storage.getInputFormat == Some("org.apache.hadoop.mapred.TextInputFormat"))
+    assert(desc.storage.getOutputFormat ==
       Some("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"))
-    assert(desc.storage.serde.isEmpty)
+    assert(desc.storage.getSerde.isEmpty)
     assert(desc.properties == Map())
   }
 
@@ -154,10 +154,10 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.schema == Seq.empty[CatalogColumn])
     assert(desc.viewText == None) // TODO will be SQLText
     assert(desc.viewOriginalText.isEmpty)
-    assert(desc.storage.serdeProperties == Map(("serde_p1" -> "p1"), ("serde_p2" -> "p2")))
-    assert(desc.storage.inputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileInputFormat"))
-    assert(desc.storage.outputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileOutputFormat"))
-    assert(desc.storage.serde == Some("org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"))
+    assert(desc.storage.getProperties == Map(("serde_p1" -> "p1"), ("serde_p2" -> "p2")))
+    assert(desc.storage.getInputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileInputFormat"))
+    assert(desc.storage.getOutputFormat == Some("org.apache.hadoop.hive.ql.io.RCFileOutputFormat"))
+    assert(desc.storage.getSerde == Some("org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"))
     assert(desc.properties == Map(("tbl_p1" -> "p11"), ("tbl_p2" -> "p22")))
   }
 
@@ -300,12 +300,12 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.viewText.isEmpty)
     assert(desc.viewOriginalText.isEmpty)
     assert(desc.storage.locationUri.isEmpty)
-    assert(desc.storage.inputFormat ==
+    assert(desc.storage.getInputFormat ==
       Some("org.apache.hadoop.mapred.TextInputFormat"))
-    assert(desc.storage.outputFormat ==
+    assert(desc.storage.getOutputFormat ==
       Some("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"))
-    assert(desc.storage.serde.isEmpty)
-    assert(desc.storage.serdeProperties.isEmpty)
+    assert(desc.storage.getSerde.isEmpty)
+    assert(desc.storage.getProperties.isEmpty)
     assert(desc.properties.isEmpty)
     assert(desc.comment.isEmpty)
   }
@@ -390,11 +390,11 @@ class HiveDDLCommandSuite extends PlanTest {
     val (desc1, _) = extractTableDesc(query1)
     val (desc2, _) = extractTableDesc(query2)
     val (desc3, _) = extractTableDesc(query3)
-    assert(desc1.storage.serde == Some("org.apache.poof.serde.Baff"))
-    assert(desc1.storage.serdeProperties.isEmpty)
-    assert(desc2.storage.serde == Some("org.apache.poof.serde.Baff"))
-    assert(desc2.storage.serdeProperties == Map("k1" -> "v1"))
-    assert(desc3.storage.serdeProperties == Map(
+    assert(desc1.storage.getSerde == Some("org.apache.poof.serde.Baff"))
+    assert(desc1.storage.getProperties.isEmpty)
+    assert(desc2.storage.getSerde == Some("org.apache.poof.serde.Baff"))
+    assert(desc2.storage.getProperties == Map("k1" -> "v1"))
+    assert(desc3.storage.getProperties == Map(
       "field.delim" -> "x",
       "escape.delim" -> "y",
       "serialization.format" -> "x",
@@ -409,12 +409,13 @@ class HiveDDLCommandSuite extends PlanTest {
     val query2 = s"$baseQuery ORC"
     val (desc1, _) = extractTableDesc(query1)
     val (desc2, _) = extractTableDesc(query2)
-    assert(desc1.storage.inputFormat == Some("winput"))
-    assert(desc1.storage.outputFormat == Some("wowput"))
-    assert(desc1.storage.serde.isEmpty)
-    assert(desc2.storage.inputFormat == Some("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"))
-    assert(desc2.storage.outputFormat == Some("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"))
-    assert(desc2.storage.serde == Some("org.apache.hadoop.hive.ql.io.orc.OrcSerde"))
+    assert(desc1.storage.getInputFormat == Some("winput"))
+    assert(desc1.storage.getOutputFormat == Some("wowput"))
+    assert(desc1.storage.getSerde.isEmpty)
+    assert(desc2.storage.getInputFormat == Some("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"))
+    assert(desc2.storage.getOutputFormat ==
+      Some("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"))
+    assert(desc2.storage.getSerde == Some("org.apache.hadoop.hive.ql.io.orc.OrcSerde"))
   }
 
   test("create table - storage handler") {
@@ -460,10 +461,10 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.viewText.isEmpty)
     assert(desc.viewOriginalText.isEmpty)
     assert(desc.storage.locationUri == Some("/path/to/mercury"))
-    assert(desc.storage.inputFormat == Some("winput"))
-    assert(desc.storage.outputFormat == Some("wowput"))
-    assert(desc.storage.serde == Some("org.apache.poof.serde.Baff"))
-    assert(desc.storage.serdeProperties == Map("k1" -> "v1"))
+    assert(desc.storage.getInputFormat == Some("winput"))
+    assert(desc.storage.getOutputFormat == Some("wowput"))
+    assert(desc.storage.getSerde == Some("org.apache.poof.serde.Baff"))
+    assert(desc.storage.getProperties == Map("k1" -> "v1"))
     assert(desc.properties == Map("k1" -> "v1", "k2" -> "v2"))
     assert(desc.comment == Some("no comment"))
   }
@@ -479,10 +480,10 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.schema == Seq.empty[CatalogColumn])
     assert(desc.viewText == Option("SELECT * FROM tab1"))
     assert(desc.viewOriginalText == Option("SELECT * FROM tab1"))
-    assert(desc.storage.serdeProperties == Map())
-    assert(desc.storage.inputFormat.isEmpty)
-    assert(desc.storage.outputFormat.isEmpty)
-    assert(desc.storage.serde.isEmpty)
+    assert(desc.storage.getProperties == Map())
+    assert(desc.storage.getInputFormat.isEmpty)
+    assert(desc.storage.getOutputFormat.isEmpty)
+    assert(desc.storage.getSerde.isEmpty)
     assert(desc.properties == Map())
   }
 
@@ -505,10 +506,10 @@ class HiveDDLCommandSuite extends PlanTest {
         CatalogColumn("col3", null, nullable = true, None) :: Nil)
     assert(desc.viewText == Option("SELECT * FROM tab1"))
     assert(desc.viewOriginalText == Option("SELECT * FROM tab1"))
-    assert(desc.storage.serdeProperties == Map())
-    assert(desc.storage.inputFormat.isEmpty)
-    assert(desc.storage.outputFormat.isEmpty)
-    assert(desc.storage.serde.isEmpty)
+    assert(desc.storage.getProperties == Map())
+    assert(desc.storage.getInputFormat.isEmpty)
+    assert(desc.storage.getOutputFormat.isEmpty)
+    assert(desc.storage.getSerde.isEmpty)
     assert(desc.properties == Map("prop1Key" -> "prop1Val"))
     assert(desc.comment == Option("BLABLA"))
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -93,9 +93,9 @@ class DataSourceWithHiveMetastoreCatalogSuite
         }
 
         val hiveTable = sessionState.catalog.getTableMetadata(TableIdentifier("t", Some("default")))
-        assert(hiveTable.storage.inputFormat === Some(inputFormat))
-        assert(hiveTable.storage.outputFormat === Some(outputFormat))
-        assert(hiveTable.storage.serde === Some(serde))
+        assert(hiveTable.storage.getInputFormat === Some(inputFormat))
+        assert(hiveTable.storage.getOutputFormat === Some(outputFormat))
+        assert(hiveTable.storage.getSerde === Some(serde))
 
         assert(hiveTable.partitionColumnNames.isEmpty)
         assert(hiveTable.tableType === CatalogTableType.MANAGED)
@@ -125,9 +125,9 @@ class DataSourceWithHiveMetastoreCatalogSuite
 
           val hiveTable =
             sessionState.catalog.getTableMetadata(TableIdentifier("t", Some("default")))
-          assert(hiveTable.storage.inputFormat === Some(inputFormat))
-          assert(hiveTable.storage.outputFormat === Some(outputFormat))
-          assert(hiveTable.storage.serde === Some(serde))
+          assert(hiveTable.storage.getInputFormat === Some(inputFormat))
+          assert(hiveTable.storage.getOutputFormat === Some(outputFormat))
+          assert(hiveTable.storage.getSerde === Some(serde))
 
           assert(hiveTable.tableType === CatalogTableType.EXTERNAL)
           assert(hiveTable.storage.locationUri ===
@@ -157,9 +157,9 @@ class DataSourceWithHiveMetastoreCatalogSuite
 
           val hiveTable =
             sessionState.catalog.getTableMetadata(TableIdentifier("t", Some("default")))
-          assert(hiveTable.storage.inputFormat === Some(inputFormat))
-          assert(hiveTable.storage.outputFormat === Some(outputFormat))
-          assert(hiveTable.storage.serde === Some(serde))
+          assert(hiveTable.storage.getInputFormat === Some(inputFormat))
+          assert(hiveTable.storage.getOutputFormat === Some(outputFormat))
+          assert(hiveTable.storage.getSerde === Some(serde))
 
           assert(hiveTable.partitionColumnNames.isEmpty)
           assert(hiveTable.tableType === CatalogTableType.EXTERNAL)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -729,11 +729,8 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         schema = Seq.empty,
         storage = CatalogStorageFormat(
           locationUri = None,
-          inputFormat = None,
-          outputFormat = None,
-          serde = None,
-          compressed = false,
-          serdeProperties = Map(
+          provider = None,
+          properties = Map(
             "path" -> sessionState.catalog.hiveDefaultTableFilePath(TableIdentifier(tableName)))
         ),
         properties = Map(
@@ -1171,8 +1168,8 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         checkAnswer(table("t"), Seq(Row(1, 2, 3), Row(2, 3, 4)))
         val catalogTable = sharedState.externalCatalog.getTable("default", "t")
         // there should not be a lowercase key 'path' now
-        assert(catalogTable.storage.serdeProperties.get("path").isEmpty)
-        assert(catalogTable.storage.serdeProperties.get("PATH").isDefined)
+        assert(catalogTable.storage.properties.get("path").isEmpty)
+        assert(catalogTable.storage.properties.get("PATH").isDefined)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -729,7 +729,6 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         schema = Seq.empty,
         storage = CatalogStorageFormat(
           locationUri = None,
-          provider = None,
           properties = Map(
             "path" -> sessionState.catalog.hiveDefaultTableFilePath(TableIdentifier(tableName)))
         ),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MultiDatabaseSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MultiDatabaseSuite.scala
@@ -29,7 +29,7 @@ class MultiDatabaseSuite extends QueryTest with SQLTestUtils with TestHiveSingle
     val expectedPath =
       spark.sharedState.externalCatalog.getDatabase(dbName).locationUri + "/" + tableName
 
-    assert(metastoreTable.storage.serdeProperties("path") === expectedPath)
+    assert(metastoreTable.storage.properties("path") === expectedPath)
   }
 
   private def getTableNames(dbName: Option[String] = None): Array[String] = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -148,9 +148,9 @@ class VersionsSuite extends SparkFunSuite with Logging {
         tableType = CatalogTableType.MANAGED,
         schema = Seq(CatalogColumn("key", "int")),
         storage = CatalogStorageFormat.empty
-          .withInputFormat(classOf[TextInputFormat].getName)
-          .withOutputFormat(classOf[HiveIgnoreKeyTextOutputFormat[_, _]].getName)
-          .withSerde(classOf[LazySimpleSerDe].getName))
+          .withInputFormat(Some(classOf[TextInputFormat].getName))
+          .withOutputFormat(Some(classOf[HiveIgnoreKeyTextOutputFormat[_, _]].getName))
+          .withSerde(Some(classOf[LazySimpleSerDe].getName)))
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -358,7 +358,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
       val newLocation = Utils.createTempDir().getPath()
       val storage = storageFormat.copy(locationUri = Some(newLocation))
         // needed for 0.12 alter partitions
-        .withSerde("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
+        .withSerde(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
       val partition = CatalogTablePartition(spec, storage)
       client.alterPartitions("default", "src_part", Seq(partition))
       assert(client.getPartition("default", "src_part", spec)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -147,14 +147,10 @@ class VersionsSuite extends SparkFunSuite with Logging {
         identifier = TableIdentifier(tableName, Some(database)),
         tableType = CatalogTableType.MANAGED,
         schema = Seq(CatalogColumn("key", "int")),
-        storage = CatalogStorageFormat(
-          locationUri = None,
-          inputFormat = Some(classOf[TextInputFormat].getName),
-          outputFormat = Some(classOf[HiveIgnoreKeyTextOutputFormat[_, _]].getName),
-          serde = Some(classOf[LazySimpleSerDe].getName()),
-          compressed = false,
-          serdeProperties = Map.empty
-        ))
+        storage = CatalogStorageFormat.empty
+          .withInputFormat(classOf[TextInputFormat].getName)
+          .withOutputFormat(classOf[HiveIgnoreKeyTextOutputFormat[_, _]].getName)
+          .withSerde(classOf[LazySimpleSerDe].getName))
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -269,13 +265,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
     // Partition related API
     ///////////////////////////////////////////////////////////////////////////
 
-    val storageFormat = CatalogStorageFormat(
-      locationUri = None,
-      inputFormat = None,
-      outputFormat = None,
-      serde = None,
-      compressed = false,
-      serdeProperties = Map.empty)
+    val storageFormat = CatalogStorageFormat.empty
 
     test(s"$version: sql create partitioned table") {
       client.runSqlHive("CREATE TABLE src_part (value INT) PARTITIONED BY (key1 INT, key2 INT)")
@@ -366,10 +356,9 @@ class VersionsSuite extends SparkFunSuite with Logging {
     test(s"$version: alterPartitions") {
       val spec = Map("key1" -> "1", "key2" -> "2")
       val newLocation = Utils.createTempDir().getPath()
-      val storage = storageFormat.copy(
-        locationUri = Some(newLocation),
+      val storage = storageFormat.copy(locationUri = Some(newLocation))
         // needed for 0.12 alter partitions
-        serde = Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
+        .withSerde("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
       val partition = CatalogTablePartition(spec, storage)
       client.alterPartitions("default", "src_part", Seq(partition))
       assert(client.getPartition("default", "src_part", spec)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -355,16 +355,16 @@ class HiveDDLSuite
     val expectedSerdePropsString =
       expectedSerdeProps.map { case (k, v) => s"'$k'='$v'" }.mkString(", ")
     val oldPart = catalog.getPartition(TableIdentifier("boxes"), Map("width" -> "4"))
-    assume(oldPart.storage.serde != Some(expectedSerde), "bad test: serde was already set")
-    assume(oldPart.storage.serdeProperties.filterKeys(expectedSerdeProps.contains) !=
+    assume(oldPart.storage.getSerde != Some(expectedSerde), "bad test: serde was already set")
+    assume(oldPart.storage.getProperties.filterKeys(expectedSerdeProps.contains) !=
       expectedSerdeProps, "bad test: serde properties were already set")
     sql(s"""ALTER TABLE boxes PARTITION (width=4)
       |    SET SERDE '$expectedSerde'
       |    WITH SERDEPROPERTIES ($expectedSerdePropsString)
       |""".stripMargin)
     val newPart = catalog.getPartition(TableIdentifier("boxes"), Map("width" -> "4"))
-    assert(newPart.storage.serde == Some(expectedSerde))
-    assume(newPart.storage.serdeProperties.filterKeys(expectedSerdeProps.contains) ==
+    assert(newPart.storage.getSerde == Some(expectedSerde))
+    assume(newPart.storage.getProperties.filterKeys(expectedSerdeProps.contains) ==
       expectedSerdeProps)
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -434,7 +434,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
           case None => // OK.
         }
         // Also make sure that the format is the desired format.
-        assert(catalogTable.storage.inputFormat.get.toLowerCase.contains(format))
+        assert(catalogTable.storage.getInputFormat.get.toLowerCase.contains(format))
     }
 
     // When a user-specified location is defined, the table type needs to be EXTERNAL.


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CatalogTable` is an internal interface to represent table metadata in Spark SQL, and should be able to express both hive serde table and data source table. Due to some hive hacks, data source table only use table properties to store its information, and the `CatalogStorageFormat` is very hive specific as it's only used by hive serde table currently.

However this is not a good design, the `CatalogTable` is not general enough to express data source table if we remove hive hacks in the future.

This PR is trying to make `CatalogStorageFormat` general enough to handle all types of tables in Spark SQL.
## How was this patch tested?

existing tests.
