### PR TITLE
[SPARK-11857] [Mesos] Deprecate fine grained

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -237,7 +237,7 @@ conf.set("spark.mesos.coarse", "false")
 
 You may also make use of `spark.mesos.constraints` to set
 attribute-based constraints on Mesos resource offers. By default, all
-resource offers will be accepted.
+offers will be accepted.
 
 {% highlight scala %}
 conf.set("spark.mesos.constraints", "os:centos7;us-east-1:false")

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -237,7 +237,7 @@ conf.set("spark.mesos.coarse", "false")
 
 You may also make use of `spark.mesos.constraints` to set
 attribute-based constraints on Mesos resource offers. By default, all
-offers will be accepted.
+resource offers will be accepted.
 
 {% highlight scala %}
 conf.set("spark.mesos.constraints", "os:centos7;us-east-1:false")

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -181,7 +181,7 @@ Note that jars or python files that are passed to spark-submit should be URIs re
 # Mesos Run Modes
 
 Spark can run over Mesos in two modes: "coarse-grained" (default) and
-"fine-grained".
+"fine-grained" (deprecated).
 
 ## Coarse-Grained
 
@@ -213,7 +213,12 @@ the application.  To configure your job to dynamically adjust to its
 resource requirements, look into
 [Dynamic Allocation](#dynamic-resource-allocation-with-mesos).
 
-## Fine-Grained
+## Fine-Grained (deprecated)
+
+**NOTE:** Fine-grained is deprecated as of Spark 2.0.0.  Consider using
+ [Dynamic Allocation](#dynamic-resource-allocation-with-mesos) for
+ some of the benefits of fine-grained mode.  For a full explanation
+ see [SPARK-11857](https://issues.apache.org/jira/browse/SPARK-11857)
 
 In "fine-grained" mode, each Spark task inside the Spark executor runs
 as a separate Mesos task. This allows multiple instances of Spark (and

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -215,10 +215,10 @@ resource requirements, look into
 
 ## Fine-Grained (deprecated)
 
-**NOTE:** Fine-grained is deprecated as of Spark 2.0.0.  Consider using
- [Dynamic Allocation](#dynamic-resource-allocation-with-mesos) for
- some of the benefits of fine-grained mode.  For a full explanation
- see [SPARK-11857](https://issues.apache.org/jira/browse/SPARK-11857)
+**NOTE:** Fine-grained mode is deprecated as of Spark 2.0.0.  Consider
+ using [Dynamic Allocation](#dynamic-resource-allocation-with-mesos)
+ for some of the benefits.  For a full explanation see
+ [SPARK-11857](https://issues.apache.org/jira/browse/SPARK-11857)
 
 In "fine-grained" mode, each Spark task inside the Spark executor runs
 as a separate Mesos task. This allows multiple instances of Spark (and


### PR DESCRIPTION
## What changes were proposed in this pull request?

Documentation changes to indicate that fine-grained mode is now deprecated.  No code changes were made, and all fine-grained mode instructions were left in place.  We can remove all of that once the deprecation cycle completes (Does Spark have a standard deprecation cycle?  One major version?)

Blocked on https://github.com/apache/spark/pull/14059
## How was this patch tested?

Viewed in Github
