### PR TITLE
[SPARK-16408][SQL] SparkSQL Added file get Exception: is a directory …

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
@@ -113,8 +113,9 @@ case class AddFile(path: String) extends RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val hiveContext = sqlContext.asInstanceOf[HiveContext]
+    val recursive = sqlContext.sparkContext.getConf.getBoolean("spark.input.dir.recursive", false)
     hiveContext.runSqlHive(s"ADD FILE $path")
-    hiveContext.sparkContext.addFile(path)
+    hiveContext.sparkContext.addFile(path, recursive)
     Seq.empty[Row]
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is for adding an parameter (spark.input.dir.recursive) to control the value of recursive in SparkContext#addFile, so we can support "add file hdfs://dir/path" cmd in SparkSQL 
## How was this patch tested?

manual tests:
set the conf: --conf spark.input.dir.recursive=true, and run spark-sql -e "add file hdfs://dir/path"
