### PR TITLE
[SPARK-16412][SQL][WIP] Generate Java code that gets an array in each column of CachedBatch when DataFrame.cache() is called

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.vectorized;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import org.apache.commons.lang.NotImplementedException;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.io.api.Binary;
@@ -529,7 +531,7 @@ public abstract class ColumnVector implements AutoCloseable {
   /**
    * Returns the array at rowid.
    */
-  public final Array getArray(int rowId) {
+  public ArrayData getArray(int rowId) {
     resultArray.length = getArrayLength(rowId);
     resultArray.offset = getArrayOffset(rowId);
     return resultArray;
@@ -552,7 +554,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * Returns the value for rowId.
    */
   private Array getByteArray(int rowId) {
-    Array array = getArray(rowId);
+    Array array = (Array)getArray(rowId);
     array.data.loadBytes(array);
     return array;
   }
@@ -996,6 +998,26 @@ public abstract class ColumnVector implements AutoCloseable {
       this.childColumns[1] = ColumnVector.allocate(capacity, DataTypes.LongType, memMode);
       this.resultArray = null;
       this.resultStruct = new ColumnarBatch.Row(this.childColumns);
+    } else {
+      this.childColumns = null;
+      this.resultArray = null;
+      this.resultStruct = null;
+    }
+  }
+
+  protected ColumnVector(int capacity, DataType type) {
+    this.capacity = capacity;
+    this.type = type;
+
+    if (type instanceof ArrayType || type instanceof BinaryType || type instanceof StringType
+            || DecimalType.isByteArrayDecimalType(type)) {
+      this.childColumns = null;
+      this.resultArray = new Array(null);
+      this.resultStruct = null;
+    } else if (type instanceof StructType) {
+      throw new NotImplementedException();
+    } else if (type instanceof CalendarIntervalType) {
+      throw new NotImplementedException();
     } else {
       this.childColumns = null;
       this.resultArray = null;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -95,6 +95,10 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
           s"$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder));"
         case NullType | StringType | BinaryType =>
           s"$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder));"
+        case ArrayType(_, _) =>
+          _isSupportColumnarCodeGen = true
+          s"""$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder),
+             (${dt.getClass.getName}) columnTypes[$index]);"""
         case other =>
           s"""$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder),
              (${dt.getClass.getName}) columnTypes[$index]);"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -53,7 +53,31 @@ private[sql] object InMemoryRelation {
  * @param stats The stat of columns
  */
 private[columnar]
-case class CachedBatch(numRows: Int, buffers: Array[Array[Byte]], stats: InternalRow)
+case class CachedBatch(numRows: Int, buffers: Array[Array[Byte]], stats: InternalRow) {
+  def column(columnarIterator: ColumnarIterator, index: Int): ColumnVector = {
+    val ordinal = columnarIterator.getColumnIndexes(index)
+    val dataType = columnarIterator.getColumnTypes(index)
+    val buffer = ByteBuffer.wrap(buffers(ordinal)).order(nativeOrder)
+    val accessor: BasicColumnAccessor[_] = dataType match {
+      case FloatType => new FloatColumnAccessor(buffer)
+      case DoubleType => new DoubleColumnAccessor(buffer)
+      case arrayType: ArrayType => new ArrayColumnAccessor(buffer, arrayType)
+      case _ => throw new UnsupportedOperationException(s"CachedBatch.column(): $dataType")
+    }
+
+    val (out, nullsBuffer) = if (accessor.isInstanceOf[NativeColumnAccessor[_]]) {
+      val nativeAccessor = accessor.asInstanceOf[NativeColumnAccessor[_]]
+      nativeAccessor.decompress(numRows);
+    } else {
+      val buffer = accessor.getByteBuffer
+      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
+      nullsBuffer.rewind()
+      (buffer, nullsBuffer)
+    }
+
+    ColumnVector.allocate(numRows, dataType, true, out, nullsBuffer)
+  }
+}
 
 private[sql] case class InMemoryRelation(
     output: Seq[Attribute],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -224,7 +224,6 @@ private[sql] object InMemoryTableScanExec {
        |
        |   while ($idx < $numRows) {
        |     int $rowidx = $idx++;
-       |     System.out.println("rowIdx="+$rowidx);
        |     ${codegen.consume(ctx, columns, null).trim}
        |     if (shouldStop()) return;
        |   }
@@ -243,12 +242,10 @@ private[sql] object InMemoryTableScanExec {
 
     s"""
       private void processBatch() throws java.io.IOException {
-        System.out.println("*** processBatch() ***");
         ${codeCol.trim}
       }
 
       private void processRow() throws java.io.IOException {
-        System.out.println("*** processRow() ***");
         ${codeRow.trim}
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -180,3 +180,91 @@ private[sql] case class InMemoryTableScanExec(
     }
   }
 }
+
+private[sql] object InMemoryTableScanExec {
+  private val columnarItrName = "columnar_itr"
+  private val columnarBatchIdxName = "columnar_batchIdx"
+
+  def enableColumnCodeGen(
+     sqlContext: SQLContext, ctx: CodegenContext, child: SparkPlan): Boolean = {
+    ctx.enableColumnCodeGen &&
+      sqlContext.getConf(SQLConf.COLUMN_VECTOR_CODEGEN.key).toBoolean &&
+      child.find(c => c.isInstanceOf[InMemoryTableScanExec]).isDefined &&
+      child.find(c => c.isInstanceOf[CodegenSupport] &&
+        c.asInstanceOf[CodegenSupport].useUnsafeRow).isEmpty
+  }
+
+  def produceColumnLoop(
+      ctx: CodegenContext, codegen: CodegenSupport, output: Seq[Attribute]): String = {
+    val idx = columnarBatchIdxName
+    val numRows = "columnar_numRows"
+    ctx.addMutableState("int", idx, s"$idx = 0;")
+    ctx.addMutableState("int", numRows, s"$numRows = 0;")
+    val rowidx = ctx.freshName("rowIdx")
+
+    val colVars = output.indices.map(i => ctx.freshName("col" + i))
+    val columnAssigns = colVars.zipWithIndex.map { case (name, i) =>
+      ctx.addMutableState("org.apache.spark.sql.execution.vectorized.ColumnVector",
+        name, s"$name = null;", s"$name = null;")
+      s"$name = ${columnarItrName}.getColumn($i);"
+    }
+    val columns = (output zip colVars).map { case (attr, colVar) =>
+      new ColumnVectorReference(colVar, rowidx, attr.dataType, attr.nullable).genCode(ctx) }
+
+    s"""
+       | while (true) {
+       |   if ($idx == 0) {
+       |     $numRows = ${columnarItrName}.initForColumnar();
+       |     if ($numRows < 0) {
+       |       cleanup();
+       |       break;
+       |     }
+       |     ${columnAssigns.mkString("", "\n", "")}
+       |   }
+       |
+       |   while ($idx < $numRows) {
+       |     int $rowidx = $idx++;
+       |     System.out.println("rowIdx="+$rowidx);
+       |     ${codegen.consume(ctx, columns, null).trim}
+       |     if (shouldStop()) return;
+       |   }
+       |   $idx = 0;
+       | }
+      """.stripMargin
+  }
+
+  def produceProcessNext(
+      ctx: CodegenContext, codegen: CodegenSupport, child: SparkPlan, codeRow: String): String = {
+    ctx.isRow = false
+    val codeCol = child.asInstanceOf[CodegenSupport].produce(ctx, codegen)
+    val columnarItrClz = "org.apache.spark.sql.execution.columnar.ColumnarIterator"
+    val colItr = columnarItrName
+    ctx.addMutableState(s"$columnarItrClz", colItr, s"$colItr = null;", s"$colItr = null;")
+
+    s"""
+      private void processBatch() throws java.io.IOException {
+        System.out.println("*** processBatch() ***");
+        ${codeCol.trim}
+      }
+
+      private void processRow() throws java.io.IOException {
+        System.out.println("*** processRow() ***");
+        ${codeRow.trim}
+      }
+
+      private void cleanup() {
+        ${ctx.cleanupMutableStates()}
+      }
+
+      protected void processNext() throws java.io.IOException {
+        if ((${columnarBatchIdxName} != 0) ||
+            (${ctx.iteratorInput} instanceof $columnarItrClz &&
+             ($colItr = ($columnarItrClz)${ctx.iteratorInput}).isSupportColumnarCodeGen())) {
+          processBatch();
+        } else {
+          processRow();
+        }
+      }
+     """.trim
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataFrameCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataFrameCacheSuite.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSQLContext
+
+class DataFrameCacheSuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  test("range/filter should be combined with column codegen") {
+    val df = sparkContext.parallelize(0 to 9, 1).map(i => i.toFloat).toDF().cache()
+      .filter("value = 1").selectExpr("value + 1")
+    assert(df.collect() === Array(Row(2.0)))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen).isDefined)
+  }
+
+  test("filters should be combined with column codegen") {
+    val df = sparkContext.parallelize(0 to 9, 1).map(i => i.toFloat).toDF().cache()
+      .filter("value % 2.0 == 0").filter("value % 3.0 == 0")
+    assert(df.collect() === Array(Row(0), Row(6.0)))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen).isDefined)
+  }
+
+  test("filter with null should be included in WholeStageCodegen with column codegen") {
+    val toFloat = udf[java.lang.Float, String] { s => if (s == "2") null else s.toFloat }
+    val df0 = sparkContext.parallelize(0 to 4, 1).map(i => i.toString).toDF()
+    val df = df0.withColumn("i", toFloat(df0("value"))).select("i").toDF().cache()
+      .filter("i % 2.0 == 0")
+    assert(df.collect() === Array(Row(0), Row(4.0)))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen).isDefined)
+  }
+
+  test("Aggregate should be included in WholeStageCodegen with column codegen") {
+    val df = sparkContext.parallelize(0 to 9, 1).map(i => i.toFloat).toDF().cache()
+      .groupBy().agg(max(col("value")), avg(col("value")))
+    assert(df.collect() === Array(Row(9, 4.5)))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen &&
+        p.asInstanceOf[WholeStageCodegenExec].child.isInstanceOf[HashAggregateExec]).isDefined)
+  }
+
+  test("Aggregate with grouping keys should be included in WholeStageCodegen with column codegen") {
+    val df = sparkContext.parallelize(0 to 2, 1).map(i => i.toFloat).toDF().cache()
+      .groupBy("value").count().orderBy("value")
+    assert(df.collect() === Array(Row(0.0, 1), Row(1.0, 1), Row(2.0, 1)))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen &&
+        p.asInstanceOf[WholeStageCodegenExec].child.isInstanceOf[HashAggregateExec]).isDefined)
+  }
+
+  test("Aggregate with columns should be included in WholeStageCodegen with column codegen") {
+    val df = sparkContext.parallelize(0 to 10, 1).map(i => (i, (i * 2).toDouble)).toDF("i", "d")
+      .cache().agg(sum("d"))
+    assert(df.collect() === Array(Row(110.0)))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen &&
+        p.asInstanceOf[WholeStageCodegenExec].child.isInstanceOf[HashAggregateExec]).isDefined)
+  }
+
+  test("Sort should be included in WholeStageCodegen without column codegen") {
+    val df = sparkContext.parallelize(Seq(3.toFloat, 2.toFloat, 1.toFloat), 1).toDF()
+      .sort(col("value"))
+    val plan = df.queryExecution.executedPlan
+    assert(df.collect() === Array(Row(1.0), Row(2.0), Row(3.0)))
+    assert(plan.find(p =>
+      p.isInstanceOf[WholeStageCodegenExec] &&
+        !p.asInstanceOf[WholeStageCodegenExec].enableColumnCodeGen &&
+        p.asInstanceOf[WholeStageCodegenExec].child.isInstanceOf[SortExec]).isDefined)
+  }
+
+  test("filter/selectExpr should be combined with column codegen for int array") {
+    val df = sparkContext.parallelize(0 to 9, 1).map(i => Array(i, i + 1)).toDF().cache()
+      .filter("value[0] > 4").selectExpr("value[1] + 1")
+    assert(df.collect() === Array(Row(7), Row(8), Row(9), Row(10), Row(11)))
+  }
+
+  test("filter/selectExpr should be combined with column codegen for double array") {
+    val df = sparkContext.parallelize(0 to 9, 1).map(i => Array(i.toDouble, (i + 1).toDouble))
+      .toDF().cache().filter("value[0] > 4.0").selectExpr("value[1] + 1")
+    assert(df.collect() === Array(Row(7.0), Row(8.0), Row(9.0), Row(10.0), Row(11.0)))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -401,26 +401,30 @@ class ColumnarBatchSuite extends SparkFunSuite {
       column.putArray(2, 2, 0)
       column.putArray(3, 3, 3)
 
-      val a1 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
-      val a2 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(1)).asInstanceOf[Array[Int]]
-      val a3 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(2)).asInstanceOf[Array[Int]]
-      val a4 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(3)).asInstanceOf[Array[Int]]
+      val a1 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(0).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
+      val a2 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(1).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
+      val a3 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(2).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
+      val a4 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(3).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
       assert(a1 === Array(0))
       assert(a2 === Array(1, 2))
       assert(a3 === Array.empty[Int])
       assert(a4 === Array(3, 4, 5))
 
       // Verify the ArrayData APIs
-      assert(column.getArray(0).length == 1)
+      assert(column.getArray(0).numElements() == 1)
       assert(column.getArray(0).getInt(0) == 0)
 
-      assert(column.getArray(1).length == 2)
+      assert(column.getArray(1).numElements() == 2)
       assert(column.getArray(1).getInt(0) == 1)
       assert(column.getArray(1).getInt(1) == 2)
 
-      assert(column.getArray(2).length == 0)
+      assert(column.getArray(2).numElements() == 0)
 
-      assert(column.getArray(3).length == 3)
+      assert(column.getArray(3).numElements() == 3)
       assert(column.getArray(3).getInt(0) == 3)
       assert(column.getArray(3).getInt(1) == 4)
       assert(column.getArray(3).getInt(2) == 5)
@@ -433,7 +437,8 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(data.capacity == array.length * 2)
       data.putInts(0, array.length, array, 0)
       column.putArray(0, 0, array.length)
-      assert(ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
+      assert(ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(0).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
         === array)
     }}
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Waiting #11956 to be merged.

This PR generates Java code to directly get an array of each column from `CachedBatch` when `DataFrame.cache()` is called. This is done in whole stage code generation.

When DataFrame.cache()`is called, data is stored as column-oriented storage (columnar cache) in`CachedBatch`. This PR avoid conversion from column-oriented storage to row-oriented storage. This PR handles an array type that is stored into a column. 

This PR generates code both for row-oriented storage and column-oriented storage only if
- `InMemoryColumnarTableScan` exists in a plan sub-tree. A decision is performed by checking an given iterator is `ColumnaIterator` at runtime
- Sort or join does not exist in a plan sub-tree. 

This PR generates Java code for columnar cache only if types in all columns, which are accessed in operations, are primitive or an array

I will add benchmark suites into  [here](https://github.com/kiszk/spark/blob/SPARK-14098/sql/core/src/test/scala/org/apache/spark/sql/DataFrameCacheBenchmark.scala)

Motivating example

``` java
val df = sc.parallelize(Seq(Array(1.0, 2.0), Array(3.0, 4.0)), 1).toDF
df.cache.filter("value[0] > 2.0").show
```

Generated code
Before applying this PR

``` java
/* 001 */ public Object generate(Object[] references) {
/* 002 */   return new GeneratedIterator(references);
/* 003 */ }
/* 004 */
/* 005 */ /**
 * Codegend pipeline for
 * Filter (value#1[0] > 2.0)
 * +- InMemoryTableScan [value#1], [(value#1[0] > 2.0)]
 *    :  +- InMemoryRelation [value#1], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
 *    :     :  +- Scan ExistingRDD[value#1]
 */
/* 006 */ final class GeneratedIterator extends org.apache.spark.sql.execution.BufferedRowIterator {
/* 007 */   private Object[] references;
/* 008 */   private scala.collection.Iterator inputadapter_input;
/* 009 */   private org.apache.spark.sql.execution.metric.SQLMetric filter_numOutputRows;
/* 010 */   private UnsafeRow filter_result;
/* 011 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder filter_holder;
/* 012 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter filter_rowWriter;
/* 013 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter filter_arrayWriter;
/* 014 */
/* 015 */   public GeneratedIterator(Object[] references) {
/* 016 */     this.references = references;
/* 017 */   }
/* 018 */
/* 019 */   public void init(int index, scala.collection.Iterator inputs[]) {
/* 020 */     partitionIndex = index;
/* 021 */     inputadapter_input = inputs[0];
/* 022 */     this.filter_numOutputRows = (org.apache.spark.sql.execution.metric.SQLMetric) references[0];
/* 023 */     filter_result = new UnsafeRow(1);
/* 024 */     this.filter_holder = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(filter_result, 32);
/* 025 */     this.filter_rowWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(filter_holder, 1);
/* 026 */     this.filter_arrayWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter();
/* 027 */   }
/* 028 */
/* 029 */   protected void processNext() throws java.io.IOException {
/* 030 */     // PRODUCE: Filter (value#1[0] > 2.0)
/* 031 */     // PRODUCE: InputAdapter
/* 032 */     while (inputadapter_input.hasNext()) {
/* 033 */       InternalRow inputadapter_row = (InternalRow) inputadapter_input.next();
/* 034 */       // CONSUME: Filter (value#1[0] > 2.0)
/* 035 */       // input[0, array<double>, true]
/* 036 */       boolean inputadapter_isNull = inputadapter_row.isNullAt(0);
/* 037 */       ArrayData inputadapter_value = inputadapter_isNull ? null : (inputadapter_row.getArray(0));
/* 038 */
/* 039 */       // (input[0, array<double>, true][0] > 2.0)
/* 040 */       boolean filter_isNull = true;
/* 041 */       boolean filter_value = false;
/* 042 */       // input[0, array<double>, true][0]
/* 043 */       boolean filter_isNull1 = true;
/* 044 */       double filter_value1 = -1.0;
/* 045 */
/* 046 */       if (!inputadapter_isNull) {
/* 047 */         filter_isNull1 = false; // resultCode could change nullability.
/* 048 */
/* 049 */         final int filter_index = (int) 0;
/* 050 */         if (filter_index >= inputadapter_value.numElements() || filter_index < 0 || inputadapter_value.isNullAt(filter_index)) {
/* 051 */           filter_isNull1 = true;
/* 052 */         } else {
/* 053 */           filter_value1 = inputadapter_value.getDouble(filter_index);
/* 054 */         }
/* 055 */
/* 056 */       }
/* 057 */       if (!filter_isNull1) {
/* 058 */         filter_isNull = false; // resultCode could change nullability.
/* 059 */         filter_value = org.apache.spark.util.Utils.nanSafeCompareDoubles(filter_value1, 2.0D) > 0;
/* 060 */
/* 061 */       }
/* 062 */       if (filter_isNull || !filter_value) continue;
/* 063 */
/* 064 */       filter_numOutputRows.add(1);
/* 065 */
/* 066 */       // CONSUME: WholeStageCodegen
/* 067 */       filter_holder.reset();
/* 068 */
/* 069 */       filter_rowWriter.zeroOutNullBytes();
/* 070 */
/* 071 */       if (inputadapter_isNull) {
/* 072 */         filter_rowWriter.setNullAt(0);
/* 073 */       } else {
/* 074 */         // Remember the current cursor so that we can calculate how many bytes are
/* 075 */         // written later.
/* 076 */         final int filter_tmpCursor = filter_holder.cursor;
/* 077 */
/* 078 */         if (inputadapter_value instanceof UnsafeArrayData) {
/* 079 */           final int filter_sizeInBytes = ((UnsafeArrayData) inputadapter_value).getSizeInBytes();
/* 080 */           // grow the global buffer before writing data.
/* 081 */           filter_holder.grow(filter_sizeInBytes);
/* 082 */           ((UnsafeArrayData) inputadapter_value).writeToMemory(filter_holder.buffer, filter_holder.cursor);
/* 083 */           filter_holder.cursor += filter_sizeInBytes;
/* 084 */
/* 085 */         } else {
/* 086 */           final int filter_numElements = inputadapter_value.numElements();
/* 087 */           filter_arrayWriter.initialize(filter_holder, filter_numElements, 8);
/* 088 */
/* 089 */           for (int filter_index1 = 0; filter_index1 < filter_numElements; filter_index1++) {
/* 090 */             if (inputadapter_value.isNullAt(filter_index1)) {
/* 091 */               filter_arrayWriter.setNullAt(filter_index1);
/* 092 */             } else {
/* 093 */               final double filter_element = inputadapter_value.getDouble(filter_index1);
/* 094 */               filter_arrayWriter.write(filter_index1, filter_element);
/* 095 */             }
/* 096 */           }
/* 097 */         }
/* 098 */
/* 099 */         filter_rowWriter.setOffsetAndSize(0, filter_tmpCursor, filter_holder.cursor - filter_tmpCursor);
/* 100 */         filter_rowWriter.alignToWords(filter_holder.cursor - filter_tmpCursor);
/* 101 */       }
/* 102 */       filter_result.setTotalSize(filter_holder.totalSize());
/* 103 */       append(filter_result);
/* 104 */       if (shouldStop()) return;
/* 105 */     }
/* 106 */   }
/* 107 */
/* 108 */ }
```

After applying this PR

``` java
/* 001 */ public Object generate(Object[] references) {
/* 002 */   return new GeneratedIterator(references);
/* 003 */ }
/* 004 */
/* 005 */ /**
 * Codegend pipeline for
 * Filter (value#1[0] > 2.0)
 * +- InMemoryTableScan [value#1], [(value#1[0] > 2.0)]
 *    :  +- InMemoryRelation [value#1], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
 *    :     :  +- Scan ExistingRDD[value#1]
 */
/* 006 */ final class GeneratedIterator extends org.apache.spark.sql.execution.BufferedRowIterator {
/* 007 */   private Object[] references;
/* 008 */   private scala.collection.Iterator inputadapter_input;
/* 009 */   private org.apache.spark.sql.execution.metric.SQLMetric filter_numOutputRows;
/* 010 */   private UnsafeRow filter_result;
/* 011 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder filter_holder;
/* 012 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter filter_rowWriter;
/* 013 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter filter_arrayWriter;
/* 014 */   private scala.collection.Iterator inputadapter_input1;
/* 015 */   private int columnar_batchIdx;
/* 016 */   private int columnar_numRows;
/* 017 */   private org.apache.spark.sql.execution.vectorized.ColumnVector inputadapter_col0;
/* 018 */   private UnsafeRow inputadapter_result;
/* 019 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder inputadapter_holder;
/* 020 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter inputadapter_rowWriter;
/* 021 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter inputadapter_arrayWriter;
/* 022 */   private org.apache.spark.sql.execution.metric.SQLMetric filter_numOutputRows1;
/* 023 */   private UnsafeRow filter_result1;
/* 024 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder filter_holder1;
/* 025 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter filter_rowWriter1;
/* 026 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter filter_arrayWriter1;
/* 027 */   private org.apache.spark.sql.execution.columnar.ColumnarIterator columnar_itr;
/* 028 */
/* 029 */   public GeneratedIterator(Object[] references) {
/* 030 */     this.references = references;
/* 031 */   }
/* 032 */
/* 033 */   public void init(int index, scala.collection.Iterator inputs[]) {
/* 034 */     partitionIndex = index;
/* 035 */     inputadapter_input = inputs[0];
/* 036 */     this.filter_numOutputRows = (org.apache.spark.sql.execution.metric.SQLMetric) references[0];
/* 037 */     filter_result = new UnsafeRow(1);
/* 038 */     this.filter_holder = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(filter_result, 32);
/* 039 */     this.filter_rowWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(filter_holder, 1);
/* 040 */     this.filter_arrayWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter();
/* 041 */     inputadapter_input1 = inputs[0];
/* 042 */     columnar_batchIdx = 0;
/* 043 */     columnar_numRows = 0;
/* 044 */     inputadapter_col0 = null;
/* 045 */     inputadapter_result = new UnsafeRow(1);
/* 046 */     this.inputadapter_holder = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(inputadapter_result, 32);
/* 047 */     this.inputadapter_rowWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(inputadapter_holder, 1);
/* 048 */     this.inputadapter_arrayWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter();
/* 049 */     this.filter_numOutputRows1 = (org.apache.spark.sql.execution.metric.SQLMetric) references[1];
/* 050 */     filter_result1 = new UnsafeRow(1);
/* 051 */     this.filter_holder1 = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(filter_result1, 32);
/* 052 */     this.filter_rowWriter1 = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(filter_holder1, 1);
/* 053 */     this.filter_arrayWriter1 = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter();
/* 054 */     columnar_itr = null;
/* 055 */   }
/* 056 */
/* 057 */   private void processBatch() throws java.io.IOException {
/* 058 */     // PRODUCE: Filter (value#1[0] > 2.0)
/* 059 */     // PRODUCE: InputAdapter
/* 060 */     while (true) {
/* 061 */       if (columnar_batchIdx == 0) {
/* 062 */         columnar_numRows = columnar_itr.initForColumnar();
/* 063 */         if (columnar_numRows < 0) {
/* 064 */           cleanup();
/* 065 */           break;
/* 066 */         }
/* 067 */         inputadapter_col0 = columnar_itr.getColumn(0);
/* 068 */       }
/* 069 */
/* 070 */       while (columnar_batchIdx < columnar_numRows) {
/* 071 */         int inputadapter_rowIdx = columnar_batchIdx++;
/* 072 */         // CONSUME: Filter (value#1[0] > 2.0)
/* 073 */         // columnVector[inputadapter_col0, inputadapter_rowIdx, array<double>]
/* 074 */         boolean inputadapter_isNull1 = inputadapter_col0.isNullAt(inputadapter_rowIdx);
/* 075 */         ArrayData inputadapter_value1 = inputadapter_isNull1 ? null : (inputadapter_col0.getArray(inputadapter_rowIdx));
/* 076 */
/* 077 */         // (input[0, array<double>, true][0] > 2.0)
/* 078 */         boolean filter_isNull6 = true;
/* 079 */         boolean filter_value6 = false;
/* 080 */         // input[0, array<double>, true][0]
/* 081 */         boolean filter_isNull7 = true;
/* 082 */         double filter_value7 = -1.0;
/* 083 */
/* 084 */         if (!inputadapter_isNull1) {
/* 085 */           filter_isNull7 = false; // resultCode could change nullability.
/* 086 */
/* 087 */           final int filter_index2 = (int) 0;
/* 088 */           if (filter_index2 >= inputadapter_value1.numElements() || filter_index2 < 0 || inputadapter_value1.isNullAt(filter_index2)) {
/* 089 */             filter_isNull7 = true;
/* 090 */           } else {
/* 091 */             filter_value7 = inputadapter_value1.getDouble(filter_index2);
/* 092 */           }
/* 093 */
/* 094 */         }
/* 095 */         if (!filter_isNull7) {
/* 096 */           filter_isNull6 = false; // resultCode could change nullability.
/* 097 */           filter_value6 = org.apache.spark.util.Utils.nanSafeCompareDoubles(filter_value7, 2.0D) > 0;
/* 098 */
/* 099 */         }
/* 100 */         if (filter_isNull6 || !filter_value6) continue;
/* 101 */
/* 102 */         filter_numOutputRows1.add(1);
/* 103 */
/* 104 */         // CONSUME: WholeStageCodegen
/* 105 */         filter_holder1.reset();
/* 106 */
/* 107 */         filter_rowWriter1.zeroOutNullBytes();
/* 108 */
/* 109 */         if (inputadapter_isNull1) {
/* 110 */           filter_rowWriter1.setNullAt(0);
/* 111 */         } else {
/* 112 */           // Remember the current cursor so that we can calculate how many bytes are
/* 113 */           // written later.
/* 114 */           final int filter_tmpCursor1 = filter_holder1.cursor;
/* 115 */
/* 116 */           if (inputadapter_value1 instanceof UnsafeArrayData) {
/* 117 */             final int filter_sizeInBytes1 = ((UnsafeArrayData) inputadapter_value1).getSizeInBytes();
/* 118 */             // grow the global buffer before writing data.
/* 119 */             filter_holder1.grow(filter_sizeInBytes1);
/* 120 */             ((UnsafeArrayData) inputadapter_value1).writeToMemory(filter_holder1.buffer, filter_holder1.cursor);
/* 121 */             filter_holder1.cursor += filter_sizeInBytes1;
/* 122 */
/* 123 */           } else {
/* 124 */             final int filter_numElements1 = inputadapter_value1.numElements();
/* 125 */             filter_arrayWriter1.initialize(filter_holder1, filter_numElements1, 8);
/* 126 */
/* 127 */             for (int filter_index3 = 0; filter_index3 < filter_numElements1; filter_index3++) {
/* 128 */               if (inputadapter_value1.isNullAt(filter_index3)) {
/* 129 */                 filter_arrayWriter1.setNullAt(filter_index3);
/* 130 */               } else {
/* 131 */                 final double filter_element1 = inputadapter_value1.getDouble(filter_index3);
/* 132 */                 filter_arrayWriter1.write(filter_index3, filter_element1);
/* 133 */               }
/* 134 */             }
/* 135 */           }
/* 136 */
/* 137 */           filter_rowWriter1.setOffsetAndSize(0, filter_tmpCursor1, filter_holder1.cursor - filter_tmpCursor1);
/* 138 */           filter_rowWriter1.alignToWords(filter_holder1.cursor - filter_tmpCursor1);
/* 139 */         }
/* 140 */         filter_result1.setTotalSize(filter_holder1.totalSize());
/* 141 */         append(filter_result1);
/* 142 */         if (shouldStop()) return;
/* 143 */       }
/* 144 */       columnar_batchIdx = 0;
/* 145 */     }
/* 146 */   }
/* 147 */
/* 148 */   private void processRow() throws java.io.IOException {
/* 149 */     // PRODUCE: Filter (value#1[0] > 2.0)
/* 150 */     // PRODUCE: InputAdapter
/* 151 */     while (inputadapter_input.hasNext()) {
/* 152 */       InternalRow inputadapter_row = (InternalRow) inputadapter_input.next();
/* 153 */       // CONSUME: Filter (value#1[0] > 2.0)
/* 154 */       // input[0, array<double>, true]
/* 155 */       boolean inputadapter_isNull = inputadapter_row.isNullAt(0);
/* 156 */       ArrayData inputadapter_value = inputadapter_isNull ? null : (inputadapter_row.getArray(0));
/* 157 */
/* 158 */       // (input[0, array<double>, true][0] > 2.0)
/* 159 */       boolean filter_isNull = true;
/* 160 */       boolean filter_value = false;
/* 161 */       // input[0, array<double>, true][0]
/* 162 */       boolean filter_isNull1 = true;
/* 163 */       double filter_value1 = -1.0;
/* 164 */
/* 165 */       if (!inputadapter_isNull) {
/* 166 */         filter_isNull1 = false; // resultCode could change nullability.
/* 167 */
/* 168 */         final int filter_index = (int) 0;
/* 169 */         if (filter_index >= inputadapter_value.numElements() || filter_index < 0 || inputadapter_value.isNullAt(filter_index)) {
/* 170 */           filter_isNull1 = true;
/* 171 */         } else {
/* 172 */           filter_value1 = inputadapter_value.getDouble(filter_index);
/* 173 */         }
/* 174 */
/* 175 */       }
/* 176 */       if (!filter_isNull1) {
/* 177 */         filter_isNull = false; // resultCode could change nullability.
/* 178 */         filter_value = org.apache.spark.util.Utils.nanSafeCompareDoubles(filter_value1, 2.0D) > 0;
/* 179 */
/* 180 */       }
/* 181 */       if (filter_isNull || !filter_value) continue;
/* 182 */
/* 183 */       filter_numOutputRows.add(1);
/* 184 */
/* 185 */       // CONSUME: WholeStageCodegen
/* 186 */       filter_holder.reset();
/* 187 */
/* 188 */       filter_rowWriter.zeroOutNullBytes();
/* 189 */
/* 190 */       if (inputadapter_isNull) {
/* 191 */         filter_rowWriter.setNullAt(0);
/* 192 */       } else {
/* 193 */         // Remember the current cursor so that we can calculate how many bytes are
/* 194 */         // written later.
/* 195 */         final int filter_tmpCursor = filter_holder.cursor;
/* 196 */
/* 197 */         if (inputadapter_value instanceof UnsafeArrayData) {
/* 198 */           final int filter_sizeInBytes = ((UnsafeArrayData) inputadapter_value).getSizeInBytes();
/* 199 */           // grow the global buffer before writing data.
/* 200 */           filter_holder.grow(filter_sizeInBytes);
/* 201 */           ((UnsafeArrayData) inputadapter_value).writeToMemory(filter_holder.buffer, filter_holder.cursor);
/* 202 */           filter_holder.cursor += filter_sizeInBytes;
/* 203 */
/* 204 */         } else {
/* 205 */           final int filter_numElements = inputadapter_value.numElements();
/* 206 */           filter_arrayWriter.initialize(filter_holder, filter_numElements, 8);
/* 207 */
/* 208 */           for (int filter_index1 = 0; filter_index1 < filter_numElements; filter_index1++) {
/* 209 */             if (inputadapter_value.isNullAt(filter_index1)) {
/* 210 */               filter_arrayWriter.setNullAt(filter_index1);
/* 211 */             } else {
/* 212 */               final double filter_element = inputadapter_value.getDouble(filter_index1);
/* 213 */               filter_arrayWriter.write(filter_index1, filter_element);
/* 214 */             }
/* 215 */           }
/* 216 */         }
/* 217 */
/* 218 */         filter_rowWriter.setOffsetAndSize(0, filter_tmpCursor, filter_holder.cursor - filter_tmpCursor);
/* 219 */         filter_rowWriter.alignToWords(filter_holder.cursor - filter_tmpCursor);
/* 220 */       }
/* 221 */       filter_result.setTotalSize(filter_holder.totalSize());
/* 222 */       append(filter_result);
/* 223 */       if (shouldStop()) return;
/* 224 */     }
/* 225 */   }
/* 226 */
/* 227 */   private void cleanup() {
/* 228 */     inputadapter_col0 = null;
/* 229 */
/* 230 */     columnar_itr = null;
/* 231 */   }
/* 232 */
/* 233 */   protected void processNext() throws java.io.IOException {
/* 234 */     if ((columnar_batchIdx != 0) ||
/* 235 */       (inputadapter_input1 instanceof org.apache.spark.sql.execution.columnar.ColumnarIterator &&
/* 236 */         (columnar_itr = (org.apache.spark.sql.execution.columnar.ColumnarIterator)inputadapter_input1).isSupportColumnarCodeGen())) {
/* 237 */       processBatch();
/* 238 */     } else {
/* 239 */       processRow();
/* 240 */     }
/* 241 */   }
/* 242 */ }
```
## How was this patch tested?

Added new tests into `DataFrameCacheSuite.scala`
