### PR TITLE
[SPARK-16433][SQL]Improve StreamingQuery.explain when no data arrives

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -477,7 +477,7 @@ class StreamExecution(
   /** Expose for tests */
   def explainInternal(extended: Boolean): String = {
     if (lastExecution == null) {
-      "N/A"
+      "No physical plan. Waiting for data."
     } else {
       val explain = ExplainCommand(lastExecution.logical, extended = extended)
       sparkSession.sessionState.executePlan(explain).executedPlan.executeCollect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -596,8 +596,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       val q = df.writeStream.queryName("file_explain").format("memory").start()
         .asInstanceOf[StreamExecution]
       try {
-        assert("N/A" === q.explainInternal(false))
-        assert("N/A" === q.explainInternal(true))
+        assert("No physical plan. Waiting for data." === q.explainInternal(false))
+        assert("No physical plan. Waiting for data." === q.explainInternal(true))
 
         val tempFile = Utils.tempFileWith(new File(tmp, "text"))
         val finalFile = new File(src, tempFile.getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -251,8 +251,8 @@ class StreamSuite extends StreamTest {
     val q = df.writeStream.queryName("memory_explain").format("memory").start()
       .asInstanceOf[StreamExecution]
     try {
-      assert("N/A" === q.explainInternal(false))
-      assert("N/A" === q.explainInternal(true))
+      assert("No physical plan. Waiting for data." === q.explainInternal(false))
+      assert("No physical plan. Waiting for data." === q.explainInternal(true))
 
       inputData.addData("abc")
       q.processAllAvailable()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Display `No physical plan. Waiting for data.` instead of `N/A`  for StreamingQuery.explain when no data arrives because `N/A` doesn't provide meaningful information.
## How was this patch tested?

Existing unit tests.
