### PR TITLE
[SPARK-16431] [ML] Add a unified method that accepts single instances to feature transformers and predictors

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -194,4 +194,6 @@ abstract class PredictionModel[FeaturesType, M <: PredictionModel[FeaturesType, 
    * This internal method is used to implement [[transform()]] and output [[predictionCol]].
    */
   protected def predict(features: FeaturesType): Double
+
+  def transformInstance(features: FeaturesType): Double = {predict(features)}
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
@@ -95,6 +95,8 @@ abstract class UnaryTransformer[IN, OUT, T <: UnaryTransformer[IN, OUT, T]]
    */
   protected def createTransformFunc: IN => OUT
 
+  def transformInstance(input: IN) : OUT = {this.createTransformFunc(input)}
+
   /**
    * Returns the data type of the output column.
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -569,7 +569,7 @@ class LogisticRegressionModel private[spark] (
    * Predict label for the given feature vector.
    * The behavior of this can be adjusted using [[thresholds]].
    */
-  override protected def predict(features: Vector): Double = {
+  override def predict(features: Vector): Double = {
     // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
     if (score(features) > getThreshold) 1 else 0
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -569,7 +569,7 @@ class LogisticRegressionModel private[spark] (
    * Predict label for the given feature vector.
    * The behavior of this can be adjusted using [[thresholds]].
    */
-  override def predict(features: Vector): Double = {
+  override protected def predict(features: Vector): Double = {
     // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
     if (score(features) > getThreshold) 1 else 0
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Binarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Binarizer.scala
@@ -76,25 +76,9 @@ final class Binarizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     val outputSchema = transformSchema(dataset.schema, logging = true)
     val schema = dataset.schema
     val inputType = schema($(inputCol)).dataType
-    val td = $(threshold)
-
-    val binarizerDouble = udf { in: Double => if (in > td) 1.0 else 0.0 }
-    val binarizerVector = udf { (data: Vector) =>
-      val indices = ArrayBuilder.make[Int]
-      val values = ArrayBuilder.make[Double]
-
-      data.foreachActive { (index, value) =>
-        if (value > td) {
-          indices += index
-          values +=  1.0
-        }
-      }
-
-      Vectors.sparse(data.size, indices.result(), values.result()).compressed
-    }
-
+    val binarizerDouble = udf{(x: Double) => transformInstance(x)}
+    val binarizerVector = udf{(x: Vector) => transformInstance(x)}
     val metadata = outputSchema($(outputCol)).metadata
-
     inputType match {
       case DoubleType =>
         dataset.select(col("*"), binarizerDouble(col($(inputCol))).as($(outputCol), metadata))
@@ -102,6 +86,22 @@ final class Binarizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
         dataset.select(col("*"), binarizerVector(col($(inputCol))).as($(outputCol), metadata))
     }
   }
+
+  def transformInstance(in: Double): Double = {if (in > $(threshold)) 1.0 else 0.0}
+
+  def transformInstance(data: Vector): Vector = {
+    val indices = ArrayBuilder.make[Int]
+    val values = ArrayBuilder.make[Double]
+    val td = $(threshold)
+    data.foreachActive { (index, value) =>
+      if (value > td) {
+        indices += index
+        values +=  1.0
+      }
+    }
+    Vectors.sparse(data.size, indices.result(), values.result()).compressed
+  }
+
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -78,13 +78,14 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema)
-    val bucketizer = udf { feature: Double =>
-      Bucketizer.binarySearchForBuckets($(splits), feature)
-    }
+    val bucketizer = udf { transformInstance _ }
     val newCol = bucketizer(dataset($(inputCol)))
     val newField = prepOutputField(dataset.schema)
     dataset.withColumn($(outputCol), newCol, newField.metadata)
   }
+
+  def transformInstance(feature: Double): Double =
+    {Bucketizer.binarySearchForBuckets($(splits), feature)}
 
   private def prepOutputField(schema: StructType): StructField = {
     val buckets = $(splits).sliding(2).map(bucket => bucket.mkString(", ")).toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -148,12 +148,13 @@ final class ChiSqSelectorModel private[ml] (
   override def transform(dataset: Dataset[_]): DataFrame = {
     val transformedSchema = transformSchema(dataset.schema, logging = true)
     val newField = transformedSchema.last
-
-    // TODO: Make the transformer natively in ml framework to avoid extra conversion.
-    val transformer: Vector => Vector = v => chiSqSelector.transform(OldVectors.fromML(v)).asML
-
-    val selector = udf(transformer)
+    val selector = udf(transformInstance _)
     dataset.withColumn($(outputCol), selector(col($(featuresCol))), newField.metadata)
+  }
+
+  def transformInstance(v: Vector): Vector = {
+    // TODO: Make the transformer natively in ml framework to avoid extra conversion.
+    chiSqSelector.transform(OldVectors.fromML(v)).asML
   }
 
   @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -109,7 +109,7 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     dataset.select(col("*"), t(col($(inputCol))).as($(outputCol), metadata))
   }
 
-  /** Used by transformInstance - Reinitialized by the setters */
+  /** Updated by the setters when parameters change */
   private var hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
 
   def transformInstance(terms: Seq[_]): Vector = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ml.feature
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.util._
@@ -82,7 +83,11 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
   /** @group setParam */
   @Since("1.2.0")
-  def setNumFeatures(value: Int): this.type = set(numFeatures, value)
+  def setNumFeatures(value: Int): this.type = {
+    set(numFeatures, value)
+    hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
+    this
+  }
 
   /** @group getParam */
   @Since("2.0.0")
@@ -90,16 +95,26 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
   /** @group setParam */
   @Since("2.0.0")
-  def setBinary(value: Boolean): this.type = set(binary, value)
+  def setBinary(value: Boolean): this.type = {
+    set(binary, value)
+    hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
+    this
+  }
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema)
-    val hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
-    // TODO: Make the hashingTF.transform natively in ml framework to avoid extra conversion.
-    val t = udf { terms: Seq[_] => hashingTF.transform(terms).asML }
+    val t = udf { transformInstance _ }
     val metadata = outputSchema($(outputCol)).metadata
     dataset.select(col("*"), t(col($(inputCol))).as($(outputCol), metadata))
+  }
+
+  /** Used by transformInstance - Reinitialized by the setters */
+  private var hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
+
+  def transformInstance(terms: Seq[_]): Vector = {
+    // TODO: Make the hashingTF.transform natively in ml framework to avoid extra conversion.
+    hashingTF.transform(terms).asML
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
@@ -133,10 +133,13 @@ class IDFModel private[ml] (
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    // TODO: Make the idfModel.transform natively in ml framework to avoid extra conversion.
-    val idf = udf { vec: Vector => idfModel.transform(OldVectors.fromML(vec)).asML }
+    val idf = udf { transformInstance _ }
     dataset.withColumn($(outputCol), idf(col($(inputCol))))
   }
+
+  def transformInstance(vec: Vector) : Vector = {
+    // TODO: Make the idfModel.transform natively in ml framework to avoid extra conversion.
+    idfModel.transform(OldVectors.fromML(vec)).asML}
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -173,25 +173,24 @@ class MinMaxScalerModel private[ml] (
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
+    val reScale = udf { transformInstance _ }
+    dataset.withColumn($(outputCol), reScale(col($(inputCol))))
+  }
+
+  def transformInstance(vector: Vector): Vector = {
     val originalRange = (originalMax.asBreeze - originalMin.asBreeze).toArray
     val minArray = originalMin.toArray
-
-    val reScale = udf { (vector: Vector) =>
-      val scale = $(max) - $(min)
-
-      // 0 in sparse vector will probably be rescaled to non-zero
-      val values = vector.toArray
-      val size = values.length
-      var i = 0
-      while (i < size) {
-        val raw = if (originalRange(i) != 0) (values(i) - minArray(i)) / originalRange(i) else 0.5
-        values(i) = raw * scale + $(min)
-        i += 1
-      }
-      Vectors.dense(values)
+    val scale = $(max) - $(min)
+    // 0 in sparse vector will probably be rescaled to non-zero
+    val values = vector.toArray
+    val size = values.length
+    var i = 0
+    while (i < size) {
+      val raw = if (originalRange(i) != 0) (values(i) - minArray(i)) / originalRange(i) else 0.5
+      values(i) = raw * scale + $(min)
+      i += 1
     }
-
-    dataset.withColumn($(outputCol), reScale(col($(inputCol))))
+    Vectors.dense(values)
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -165,15 +165,7 @@ class StringIndexerModel (
       return dataset.toDF
     }
     validateAndTransformSchema(dataset.schema)
-
-    val indexer = udf { label: String =>
-      if (labelToIndex.contains(label)) {
-        labelToIndex(label)
-      } else {
-        throw new SparkException(s"Unseen label: $label.")
-      }
-    }
-
+    val indexer = udf { transformInstance _ }
     val metadata = NominalAttribute.defaultAttr
       .withName($(outputCol)).withValues(labels).toMetadata()
     // If we are skipping invalid records, filter them out.
@@ -187,6 +179,15 @@ class StringIndexerModel (
     }
     filteredDataset.select(col("*"),
       indexer(dataset($(inputCol)).cast(StringType)).as($(outputCol), metadata))
+  }
+
+  def transformInstance(label: String): Double = {
+    // Throws an exception if the label is unseen before
+    if (labelToIndex.contains(label)) {
+      labelToIndex(label)
+    } else {
+      throw new SparkException(s"Unseen label: $label.")
+    }
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -97,7 +97,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
     // Data transformation.
     val assembleFunc = udf { r: Row =>
-      VectorAssembler.assemble(r.toSeq: _*)
+      transformInstance(r.toSeq)
     }
     val args = $(inputCols).map { c =>
       schema(c).dataType match {
@@ -109,6 +109,9 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
     dataset.select(col("*"), assembleFunc(struct(args: _*)).as($(outputCol), metadata))
   }
+
+  /** Takes a sequence of values or vectors and assembles them into a single vector */
+  def transformInstance(seq: Seq[Any]): Vector = {VectorAssembler.assemble(seq: _*)}
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
@@ -363,10 +363,12 @@ class VectorIndexerModel private[ml] (
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
     val newField = prepOutputField(dataset.schema)
-    val transformUDF = udf { (vector: Vector) => transformFunc(vector) }
+    val transformUDF = udf { transformInstance _ }
     val newCol = transformUDF(dataset($(inputCol)))
     dataset.withColumn($(outputCol), newCol, newField.metadata)
   }
+
+  def transformInstance(vector: Vector): Vector = {transformFunc(vector)}
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {


### PR DESCRIPTION
## Summary

Add a new transformation method `transformInstance` that operates on single instances. This method can reduce the latency of predictions by 200x for typical ML tasks which facilitates serving models in production. See the [JIRA ticket](https://issues.apache.org/jira/browse/SPARK-16431) for details.
## What changes were proposed in this pull request?

Current feature transformers in spark.ml can only operate on DataFrames and don't have a method that accepts single instances. A typical transformer has a User-Defined Function (udf) in its `transform` method which includes a set of operations on the features of a single instance:

```
val column_operation = udf {operations on single instance}
```

Adding a new method called `transformInstance` that operates directly on single instances and using it in the udf instead can be useful:

```
def transformInstance(features: featuresType): OutputType = {operations on single instance}

val column_operation = udf {transformInstance}
```

Predictors also don't have a public method that does predictions on single instances. `transformInstance` can be easily added to predictors by acting as a wrapper for the internal method predict (which takes features as input).

The proposed method in this change is added to all predictors and feature transformers except OnehotEncoder, VectorSlicer, and Word2Vec, which might require bigger changes due to dependencies on the dataset's schema (they can be fixed using simple hacks but this needs to be discussed)
## How was this patch tested?

The current tests for transformers and predictors, which invoke `transformInstance` internally, passed. 
