### PR TITLE
[SPARK-16436][SQL] checkEvaluation should support NaN

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -41,12 +41,7 @@ trait ExpressionEvalHelper extends GeneratorDrivenPropertyChecks {
   }
 
   protected def checkEvaluation(
-      originalExpr: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {
-    val expression = originalExpr match {
-      case replaceable: RuntimeReplaceable => replaceable.replaced
-      case _ => originalExpr
-    }
-
+      expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {
     val catalystValue = CatalystTypeConverters.convertToCatalyst(expected)
     checkEvaluationWithoutCodegen(expression, catalystValue, inputRow)
     checkEvaluationWithGeneratedMutableProjection(expression, catalystValue, inputRow)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This small patch modifies ExpressionEvalHelper. checkEvaluation to support comparing NaN values for floating point comparisons.
## How was this patch tested?

This is a test harness change.
