### PR TITLE
[SPARK-16376] [WEBUI] [Spark web UI]:HTTP ERROR 500 when using rest api "/applications/[app-id]/jobs" if array "stageIds" is empty

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/AllJobsResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/AllJobsResource.scala
@@ -68,7 +68,12 @@ private[v1] object AllJobsResource {
       listener: JobProgressListener,
       includeStageDetails: Boolean): JobData = {
     listener.synchronized {
-      val lastStageInfo = listener.stageIdToInfo.get(job.stageIds.max)
+      val lastStageInfo =
+        if (job.stageIds.isEmpty) {
+          None
+        } else {
+          listener.stageIdToInfo.get(job.stageIds.max)
+        }
       val lastStageData = lastStageInfo.flatMap { s =>
         listener.stageIdToData.get((s.stageId, s.attemptId))
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid error finding max of empty Seq when stageIds is empty. It does fix the immediate problem; I don't know if it results in meaningful output, but not an error at least.
## How was this patch tested?

Jenkins tests
