### PR TITLE
[SPARK-16455] Add a new hook in CoarseGrainedSchedulerBackend in order to stop scheduling new tasks when cluster is restarting

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -209,6 +209,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Make fake resource offers on all executors
     private def makeOffers() {
+      if (!isClusterAvailableForNewOffers()) {
+        return
+      }
       // Filter out executors under killing
       val activeExecutors = executorDataMap.filterKeys(executorIsAlive)
       val workOffers = activeExecutors.map { case (id, executorData) =>
@@ -227,6 +230,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Make fake resource offers on just one executor
     private def makeOffers(executorId: String) {
+      if (!isClusterAvailableForNewOffers()) {
+        return
+      }
       // Filter out executors under killing
       if (executorIsAlive(executorId)) {
         val executorData = executorDataMap(executorId)
@@ -235,6 +241,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         launchTasks(scheduler.resourceOffers(workOffers))
       }
     }
+
+    // A hook to decide the availability for new resource offers
+    def isClusterAvailableForNewOffers(): Boolean = true
 
     private def executorIsAlive(executorId: String): Boolean = synchronized {
       !executorsPendingToRemove.contains(executorId) &&

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -242,9 +242,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       }
     }
 
-    // A hook to decide the availability for new resource offers
-    def isClusterAvailableForNewOffers(): Boolean = true
-
     private def executorIsAlive(executorId: String): Boolean = synchronized {
       !executorsPendingToRemove.contains(executorId) &&
         !executorsPendingLossReason.contains(executorId)
@@ -353,6 +350,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     // TODO (prashant) send conf instead of properties
     driverEndpoint = createDriverEndpointRef(properties)
   }
+
+  def isClusterAvailableForNewOffers(): Boolean = true
 
   protected def createDriverEndpointRef(
       properties: ArrayBuffer[(String, String)]): RpcEndpointRef = {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -209,6 +209,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Make fake resource offers on all executors
     private def makeOffers() {
+      // Avoid making offers when cluster is not available for new offers
       if (!isClusterAvailableForNewOffers()) {
         return
       }
@@ -230,6 +231,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Make fake resource offers on just one executor
     private def makeOffers(executorId: String) {
+      // Avoid making offers when cluster is not available for new offersgit add .
       if (!isClusterAvailableForNewOffers()) {
         return
       }
@@ -351,6 +353,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     driverEndpoint = createDriverEndpointRef(properties)
   }
 
+  /**
+   * The hook to check if the cluster is running well or temporarily down.
+   *
+   * @return Whether cluster is available for new offers
+   */
   def isClusterAvailableForNewOffers(): Boolean = true
 
   protected def createDriverEndpointRef(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -231,7 +231,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Make fake resource offers on just one executor
     private def makeOffers(executorId: String) {
-      // Avoid making offers when cluster is not available for new offersgit add .
+      // Avoid making offers when cluster is not available for new offers
       if (!isClusterAvailableForNewOffers()) {
         return
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In our case, we are implementing a new mechanism which will let driver survive when cluster is temporarily down and restarting. So when the service provided by cluster is not available, scheduler should stop scheduling new tasks. I added a hook inside CoarseGrainedSchedulerBackend class, in order to avoid new task scheduling when it's necessary.

JIRA link: https://issues.apache.org/jira/browse/SPARK-16455
