### PR TITLE
[SPARK-16456][SQL] Reuse the uncorrelated scalar subqueries with the same logical plan in a query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -263,7 +263,9 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
    * All the subqueries of current plan.
    */
   def subqueries: Seq[PlanType] = {
-    expressions.flatMap(_.collect {case e: SubqueryExpression => e.plan.asInstanceOf[PlanType]})
+    expressions.flatMap(_.collect {
+      case e: SubqueryExpression => e
+    }).distinct.map(_.plan.asInstanceOf[PlanType])
   }
 
   override protected def innerChildren: Seq[QueryPlan[_]] = subqueries

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -158,9 +158,8 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    * Blocks the thread until all subqueries finish evaluation.
    */
   protected def waitForSubqueries(): Unit = synchronized {
-    allSubqueries.foreach { e =>
-      e.awaitSubqueryResult()
-    }
+    allSubqueries.foreach(_.awaitSubqueryResult())
+    allSubqueries.clear()
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.execution
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
 
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 import org.apache.spark.{broadcast, SparkEnv}
 import org.apache.spark.internal.Logging
@@ -138,51 +137,30 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   }
 
   /**
-   * List of (uncorrelated scalar subquery, future holding the subquery result) for this plan node.
+   * List of uncorrelated scalar subquery for this plan node.
    * This list is populated by [[prepareSubqueries]], which is called in [[prepare]].
    */
   @transient
-  private val subqueryResults = new ArrayBuffer[(ScalarSubquery, Future[Array[InternalRow]])]
+  private var allSubqueries = new ArrayBuffer[ScalarSubquery]
 
   /**
    * Finds scalar subquery expressions in this plan node and starts evaluating them.
-   * The list of subqueries are added to [[subqueryResults]].
+   * The list of subqueries are added to [[allSubqueries]].
    */
   protected def prepareSubqueries(): Unit = {
-    val allSubqueries = expressions.flatMap(_.collect {
-      case e: ScalarSubquery if !e.isExecuted => e
-    }).distinct
-    allSubqueries.asInstanceOf[Seq[ScalarSubquery]].foreach { e =>
-      e.updateExecutedState()
-      val futureResult = Future {
-        // Each subquery should return only one row (and one column). We take two here and throws
-        // an exception later if the number of rows is greater than one.
-        e.executedPlan.executeTake(2)
-      }(SparkPlan.subqueryExecutionContext)
-      subqueryResults += e -> futureResult
+    expressions.flatMap(_.collect { case e: ScalarSubquery => e }).distinct.foreach { e =>
+      e.submitSubqueryEvaluated()
+      allSubqueries += e
     }
   }
 
   /**
-   * Blocks the thread until all subqueries finish evaluation and update the results.
+   * Blocks the thread until all subqueries finish evaluation.
    */
   protected def waitForSubqueries(): Unit = synchronized {
-    // fill in the result of subqueries
-    subqueryResults.foreach { case (e, futureResult) =>
-      val rows = ThreadUtils.awaitResult(futureResult, Duration.Inf)
-      if (rows.length > 1) {
-        sys.error(s"more than one row returned by a subquery used as an expression:\n${e.plan}")
-      }
-      if (rows.length == 1) {
-        assert(rows(0).numFields == 1,
-          s"Expects 1 field, but got ${rows(0).numFields}; something went wrong in analysis")
-        e.updateResult(rows(0).get(0, e.dataType))
-      } else {
-        // If there is no rows returned, the result should be null.
-        e.updateResult(null)
-      }
+    allSubqueries.foreach { e =>
+      e.awaitSubqueryResult()
     }
-    subqueryResults.clear()
   }
 
   /**
@@ -391,11 +369,6 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     }
     newOrdering(order, Seq.empty)
   }
-}
-
-object SparkPlan {
-  private[execution] val subqueryExecutionContext = ExecutionContext.fromExecutorService(
-    ThreadUtils.newDaemonCachedThreadPool("subquery", 16))
 }
 
 private[sql] trait LeafExecNode extends SparkPlan {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -56,8 +56,8 @@ case class ScalarSubquery(
   // the first column in first row from `query`.
   @volatile private var result: Any = null
   @volatile private var updated: Boolean = false
-  @volatile private var evaluated: Boolean = false
-  @volatile private var futureResult: Future[Array[InternalRow]] = _
+  @transient private var evaluated: Boolean = false
+  @transient private var futureResult: Future[Array[InternalRow]] = _
 
   private def updateResult(v: Any): Unit = {
     result = v

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -94,7 +94,7 @@ case class ReusedScalarSubquery(
     child: ScalarSubquery) extends UnaryExpression {
 
   override def dataType: DataType = child.dataType
-  override def toString: String = s"ReusedSubquery#${exprId.id} ($child)"
+  override def toString: String = s"ReusedSubquery#${exprId.id}($child)"
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
     defineCodeGen(ctx, ev, c => c)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -54,10 +54,10 @@ case class ScalarSubquery(
   override def toString: String = s"subquery#${exprId.id}"
 
   // the first column in first row from `query`.
-  @volatile private var result: Any = null
-  @volatile private var updated: Boolean = false
-  @transient private var evaluated: Boolean = false
-  @transient private var futureResult: Future[Array[InternalRow]] = _
+  @volatile private[this] var result: Any = null
+  @volatile private[this] var updated: Boolean = false
+  @transient private[this] var evaluated: Boolean = false
+  @transient private[this] var futureResult: Future[Array[InternalRow]] = _
 
   private def updateResult(v: Any): Unit = {
     result = v

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2896,4 +2896,31 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql(s"SELECT '$literal' AS DUMMY"),
       Row(s"$expected") :: Nil)
   }
+
+  test("SPARK-16456: Reuse the uncorrelated scalar subqueries with the same logical plan") {
+    withTempTable("t1", "t2", "t3") {
+      val df = (1 to 3).map(i => (i, i)).toDF("key", "value")
+      df.createOrReplaceTempView("t1")
+      df.createOrReplaceTempView("t2")
+      df.createOrReplaceTempView("t3")
+      checkAnswer(
+        sql(
+          """
+            |WITH max_test AS
+            |(
+            | SELECT max(key) as max_key FROM t1
+            |),
+            |max_test2 AS
+            |(
+            | SELECT max(key) as max_key FROM t1
+            |)
+            |SELECT key FROM t2
+            |WHERE key = (SELECT max_key FROM max_test) and value = (SELECT max_key FROM max_test)
+            |UNION ALL
+            |SELECT key FROM t3
+            |WHERE key = (SELECT max_key FROM max_test) and value = (SELECT max_key FROM max_test2)
+          """.stripMargin
+        ), Row(3) :: Row(3) :: Nil)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -571,4 +571,31 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
       Row(1.0, false) :: Row(1.0, false) :: Row(2.0, true) :: Row(2.0, true) ::
         Row(3.0, false) :: Row(5.0, true) :: Row(null, false) :: Row(null, true) :: Nil)
   }
+
+  test("SPARK-16456: Reuse the uncorrelated scalar subqueries with the same logical plan") {
+    withTempTable("t1", "t2", "t3") {
+      val df = (1 to 3).map(i => (i, i)).toDF("key", "value")
+      df.createOrReplaceTempView("t1")
+      df.createOrReplaceTempView("t2")
+      df.createOrReplaceTempView("t3")
+      checkAnswer(
+        sql(
+          """
+            |WITH max_test AS
+            |(
+            | SELECT max(key) as max_key FROM t1
+            |),
+            |max_test2 AS
+            |(
+            | SELECT max(key) as max_key FROM t1
+            |)
+            |SELECT key FROM t2
+            |WHERE key = (SELECT max_key FROM max_test) and value = (SELECT max_key FROM max_test)
+            |UNION ALL
+            |SELECT key FROM t3
+            |WHERE key = (SELECT max_key FROM max_test) and value = (SELECT max_key FROM max_test2)
+          """.stripMargin
+        ), Row(3) :: Row(3) :: Nil)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [TPCDS-Q14](https://github.com/apache/spark/blob/master/sql/core/src/test/resources/tpcds/q14a.sql) the same physical plan of uncorrelated scalar subqueries from a CTE could be executed multiple times, we should re-use the same result to avoid the duplicated computing.
**Before**

```
scala> (1 to 3).map(i => (i, i)).toDF("key", "value").createOrReplaceTempView("t1")
scala> sql("WITH max_test AS( SELECT max(key) as max_key FROM t ) SELECT key FROM t1 WHERE key = (SELECT max_key FROM max_test) and value = (SELECT max_key FROM max_test)").explain
== Physical Plan ==
*Project [_1#200 AS key#203]
+- *Filter ((_1#200 = subquery#209) && (_2#201 = subquery#210))
   :  :- Subquery subquery#209
   :  :  +- *HashAggregate(keys=[], functions=[max(key#203)], output=[max_key#211])
   :  :     +- Exchange SinglePartition
   :  :        +- *HashAggregate(keys=[], functions=[partial_max(key#203)], output=[max#217])
   :  :           +- LocalTableScan [key#203]
   :  +- Subquery subquery#210
   :     +- *HashAggregate(keys=[], functions=[max(key#203)], output=[max_key#211])
   :        +- Exchange SinglePartition
   :           +- *HashAggregate(keys=[], functions=[partial_max(key#203)], output=[max#219])
   :              +- LocalTableScan [key#203]
   +- LocalTableScan [_1#200, _2#201]
```

**After**

```
scala> (1 to 3).map(i => (i, i)).toDF("key", "value").createOrReplaceTempView("t1")
scala> sql("WITH max_test AS( SELECT max(key) as max_key FROM t ) SELECT key FROM t1 WHERE key = (SELECT max_key FROM max_test) and value = (SELECT max_key FROM max_test)").explain
== Physical Plan ==
*Project [_1#200 AS key#203]
+- *Filter ((_1#200 = subquery#209) && (_2#201 = ReusedSubquery#210(subquery#209)))
   :  +- Subquery subquery#209
   :     +- *HashAggregate(keys=[], functions=[max(key#203)], output=[max_key#211])
   :        +- Exchange SinglePartition
   :           +- *HashAggregate(keys=[], functions=[partial_max(key#203)], output=[max#217])
   :              +- LocalTableScan [key#203]
   +- LocalTableScan [_1#200, _2#201]
```
## How was this patch tested?

Pass the Jenkins tests (including a new testcase).
