### PR TITLE
[SPARK-16459][SQL] Prevent dropping current database

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -885,15 +885,14 @@ class SessionCatalog(
    * This is mainly used for tests.
    */
   private[sql] def reset(): Unit = synchronized {
-    val default = DEFAULT_DATABASE
-    setCurrentDatabase(default)
-    listDatabases().filter(_ != default).foreach { db =>
+    setCurrentDatabase(DEFAULT_DATABASE)
+    listDatabases().filter(_ != DEFAULT_DATABASE).foreach { db =>
       dropDatabase(db, ignoreIfNotExists = false, cascade = true)
     }
-    listTables(default).foreach { table =>
+    listTables(DEFAULT_DATABASE).foreach { table =>
       dropTable(table, ignoreIfNotExists = false)
     }
-    listFunctions(default).map(_._1).foreach { func =>
+    listFunctions(DEFAULT_DATABASE).map(_._1).foreach { func =>
       if (func.database.isDefined) {
         dropFunction(func, ignoreIfNotExists = false)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -148,8 +148,10 @@ class SessionCatalog(
 
   def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {
     val dbName = formatDatabaseName(db)
-    if (dbName == DEFAULT_DATABASE || dbName == getCurrentDatabase) {
-      throw new AnalysisException(s"Can not drop `${DEFAULT_DATABASE}` or current database")
+    if (dbName == DEFAULT_DATABASE) {
+      throw new AnalysisException(s"Can not drop default database")
+    } else if (dbName == getCurrentDatabase) {
+      throw new AnalysisException(s"Can not drop current database `${dbName}`")
     }
     externalCatalog.dropDatabase(dbName, ignoreIfNotExists, cascade)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -148,8 +148,8 @@ class SessionCatalog(
 
   def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {
     val dbName = formatDatabaseName(db)
-    if (dbName == DEFAULT_DATABASE) {
-      throw new AnalysisException(s"Can not drop default database")
+    if (dbName == DEFAULT_DATABASE || dbName == getCurrentDatabase) {
+      throw new AnalysisException(s"Can not drop `${DEFAULT_DATABASE}` or current database")
     }
     externalCatalog.dropDatabase(dbName, ignoreIfNotExists, cascade)
   }
@@ -881,6 +881,7 @@ class SessionCatalog(
    */
   private[sql] def reset(): Unit = synchronized {
     val default = DEFAULT_DATABASE
+    setCurrentDatabase(default)
     listDatabases().filter(_ != default).foreach { db =>
       dropDatabase(db, ignoreIfNotExists = false, cascade = true)
     }
@@ -904,7 +905,6 @@ class SessionCatalog(
       require(functionBuilder.isDefined, s"built-in function '$f' is missing function builder")
       functionRegistry.registerFunction(f, expressionInfo.get, functionBuilder.get)
     }
-    setCurrentDatabase(default)
   }
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -34,6 +34,10 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.util.StringUtils
 
+object SessionCatalog {
+  val DEFAULT_DATABASE = "default"
+}
+
 /**
  * An internal catalog that is used by a Spark Session. This internal catalog serves as a
  * proxy to the underlying metastore (e.g. Hive Metastore) and it also manages temporary
@@ -47,9 +51,8 @@ class SessionCatalog(
     functionRegistry: FunctionRegistry,
     conf: CatalystConf,
     hadoopConf: Configuration) extends Logging {
+  import SessionCatalog._
   import CatalogTypes.TablePartitionSpec
-
-  val DEFAULT_DATABASE = "default"
 
   // For testing only.
   def this(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -49,6 +49,8 @@ class SessionCatalog(
     hadoopConf: Configuration) extends Logging {
   import CatalogTypes.TablePartitionSpec
 
+  val DEFAULT_DATABASE = "default"
+
   // For testing only.
   def this(
       externalCatalog: ExternalCatalog,
@@ -77,7 +79,7 @@ class SessionCatalog(
   // the corresponding item in the current database.
   @GuardedBy("this")
   protected var currentDb = {
-    val defaultName = "default"
+    val defaultName = DEFAULT_DATABASE
     val defaultDbDefinition =
       CatalogDatabase(defaultName, "default database", conf.warehousePath, Map())
     // Initialize default database if it doesn't already exist
@@ -146,7 +148,7 @@ class SessionCatalog(
 
   def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {
     val dbName = formatDatabaseName(db)
-    if (dbName == "default") {
+    if (dbName == DEFAULT_DATABASE) {
       throw new AnalysisException(s"Can not drop default database")
     }
     externalCatalog.dropDatabase(dbName, ignoreIfNotExists, cascade)
@@ -878,7 +880,7 @@ class SessionCatalog(
    * This is mainly used for tests.
    */
   private[sql] def reset(): Unit = synchronized {
-    val default = "default"
+    val default = DEFAULT_DATABASE
     listDatabases().filter(_ != default).foreach { db =>
       dropDatabase(db, ignoreIfNotExists = false, cascade = true)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -93,7 +93,11 @@ case class DropDatabaseCommand(
   extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    sparkSession.sessionState.catalog.dropDatabase(databaseName, ifExists, cascade)
+    val catalog = sparkSession.sessionState.catalog
+    catalog.dropDatabase(databaseName, ifExists, cascade)
+    if (catalog.getCurrentDatabase == databaseName) {
+      catalog.setCurrentDatabase(catalog.DEFAULT_DATABASE)
+    }
     Seq.empty[Row]
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -93,11 +93,7 @@ case class DropDatabaseCommand(
   extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val catalog = sparkSession.sessionState.catalog
-    catalog.dropDatabase(databaseName, ifExists, cascade)
-    if (catalog.getCurrentDatabase == databaseName) {
-      catalog.setCurrentDatabase(catalog.DEFAULT_DATABASE)
-    }
+    sparkSession.sessionState.catalog.dropDatabase(databaseName, ifExists, cascade)
     Seq.empty[Row]
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1270,20 +1270,22 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
       "WITH SERDEPROPERTIES ('spark.sql.sources.me'='anything')")
   }
 
-  test("drop default or current database") {
+  test("drop current database") {
     sql("CREATE DATABASE temp")
     sql("USE temp")
     val m = intercept[AnalysisException] {
       sql("DROP DATABASE temp")
     }.getMessage
-    assert(m.contains("Can not drop `default` or current database"))
+    assert(m.contains("Can not drop current database `temp`"))
+  }
 
+  test("drop default database") {
     Seq("true", "false").foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive) {
         var message = intercept[AnalysisException] {
           sql("DROP DATABASE default")
         }.getMessage
-        assert(message.contains("Can not drop `default` or current database"))
+        assert(message.contains("Can not drop default database"))
 
         message = intercept[AnalysisException] {
           sql("DROP DATABASE DeFault")
@@ -1291,7 +1293,7 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
         if (caseSensitive == "true") {
           assert(message.contains("Database 'DeFault' not found"))
         } else {
-          assert(message.contains("Can not drop `default` or current database"))
+          assert(message.contains("Can not drop default database"))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -154,6 +154,7 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
 
             sql(s"CREATE DATABASE $dbName")
             val db1 = catalog.getDatabaseMetadata(dbNameWithoutBackTicks)
+            catalog.setCurrentDatabase(dbNameWithoutBackTicks)
             val expectedLocation =
               "file:" + appendTrailingSlash(path) + s"$dbNameWithoutBackTicks.db"
             assert(db1 == CatalogDatabase(
@@ -162,6 +163,7 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
               expectedLocation,
               Map.empty))
             sql(s"DROP DATABASE $dbName CASCADE")
+            assert(catalog.getCurrentDatabase != dbNameWithoutBackTicks)
             assert(!catalog.databaseExists(dbNameWithoutBackTicks))
           } finally {
             catalog.reset()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
@@ -93,6 +93,7 @@ class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEac
     hc.sql("DROP TABLE mee_table")
     val tables2 = hc.sql("SHOW TABLES IN mee_db").collect().map(_.getString(0))
     assert(tables2.isEmpty)
+    hc.sql("USE default")
     hc.sql("DROP DATABASE mee_db CASCADE")
     val databases3 = hc.sql("SHOW DATABASES").collect().map(_.getString(0))
     assert(databases3.toSeq == Seq("default"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -567,18 +567,14 @@ class HiveDDLSuite
         var message = intercept[AnalysisException] {
           sql("DROP DATABASE default")
         }.getMessage
-        assert(message.contains("Can not drop `default` or current database"))
+        assert(message.contains("Can not drop default database"))
 
         // SQLConf.CASE_SENSITIVE does not affect the result
         // because the Hive metastore is not case sensitive.
         message = intercept[AnalysisException] {
           sql("DROP DATABASE DeFault")
         }.getMessage
-        if (caseSensitive == "true") {
-          assert(message.contains("Can not drop default database"))
-        } else {
-          assert(message.contains("Can not drop `default` or current database"))
-        }
+        assert(message.contains("Can not drop default database"))
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR prevents dropping the current database to avoid errors like the followings.

``` scala
scala> sql("create database delete_db")
scala> sql("use delete_db")
scala> sql("drop database delete_db")
scala> sql("create table t as select 1")
org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException: Database `delete_db` not found;
```
## How was this patch tested?

Pass the Jenkins tests including an updated testcase.
