### PR TITLE
[SPARK-16470][ML][Optimizer] Check linear regression training whether actually reach convergence and add warning if not

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -327,6 +327,11 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
         throw new SparkException(msg)
       }
 
+      if (!state.actuallyConverged) {
+        logWarning("LinearRegression training fininshed but the result is not converged, " +
+          "the reason is: " + state.convergedReason.get.reason)
+      }
+
       /*
          The coefficients are trained in the scaled space; we're converting them back to
          the original space.

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -328,8 +328,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
       }
 
       if (!state.actuallyConverged) {
-        logWarning("LinearRegression training fininshed but the result is not converged, " +
-          "the reason is: " + state.convergedReason.get.reason)
+        logWarning("LinearRegression training fininshed but the result " +
+          s"is not converged because: ${state.convergedReason.get.reason}")
       }
 
       /*


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `ml.regression.LinearRegression`, it use breeze `LBFGS` and `OWLQN` optimizer to do data training, but do not check whether breeze's optimizer returned result actually reached convergence.

The `LBFGS` and `OWLQN` optimizer in breeze finish iteration may result the following situations:

1) reach max iteration number
2) function reach value convergence
3) objective function stop improving
4) gradient reach convergence
5) search failed(due to some internal numerical error)

I add warning printing code so that
if the iteration result is (1) or (3) or (5) in above, it will print a warning with respective reason string.
## How was this patch tested?

Manual.
