### PR TITLE
[SPARK-16471] [SQL] Remove Hive-specific CreateHiveTableAsSelectLogicalPlan [WIP]

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -137,14 +137,16 @@ case class CatalogTable(
     unsupportedFeatures: Seq[String] = Seq.empty) {
 
   // Verify that the provided columns are part of the schema
-  private val colNames = schema.map(_.name).toSet
-  private def requireSubsetOfSchema(cols: Seq[String], colType: String): Unit = {
-    require(cols.toSet.subsetOf(colNames), s"$colType columns (${cols.mkString(", ")}) " +
-      s"must be a subset of schema (${colNames.mkString(", ")}) in table '$identifier'")
-  }
-  requireSubsetOfSchema(partitionColumnNames, "partition")
-  requireSubsetOfSchema(sortColumnNames, "sort")
-  requireSubsetOfSchema(bucketColumnNames, "bucket")
+  // TODO: this restriction should be checked at the end of Analyzer. When building CatalogTable,
+  // the initial version might violate it.
+  // private val colNames = schema.map(_.name).toSet
+  // private def requireSubsetOfSchema(cols: Seq[String], colType: String): Unit = {
+  //   require(cols.toSet.subsetOf(colNames), s"$colType columns (${cols.mkString(", ")}) " +
+  //     s"must be a subset of schema (${colNames.mkString(", ")}) in table '$identifier'")
+  // }
+  // requireSubsetOfSchema(partitionColumnNames, "partition")
+  // requireSubsetOfSchema(sortColumnNames, "sort")
+  // requireSubsetOfSchema(bucketColumnNames, "bucket")
 
   /** Columns this table is partitioned by. */
   def partitionColumns: Seq[CatalogColumn] =

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.{CatalogColumn, CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.plans.logical.InsertIntoTable
-import org.apache.spark.sql.execution.datasources.{BucketSpec, CreateTableUsingAsSelect, DataSource, HadoopFsRelation}
+import org.apache.spark.sql.execution.datasources.{BucketSpec, CreateTableAsSelect, DataSource, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 
 /**
@@ -384,7 +384,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           properties = extraOptions.toMap)
 
         val cmd =
-          CreateTableUsingAsSelect(
+          CreateTableAsSelect(
             tableDesc,
             source,
             mode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -23,7 +23,8 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, Project}
+import org.apache.spark.sql.catalyst.catalog.{CatalogColumn, CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.InsertIntoTable
 import org.apache.spark.sql.execution.datasources.{BucketSpec, CreateTableUsingAsSelect, DataSource, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 
@@ -366,14 +367,27 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         throw new AnalysisException(s"Table $tableIdent already exists.")
 
       case _ =>
+        val bucketSpec = getBucketSpec
+        val sortColumnNames = bucketSpec.map(_.sortColumnNames).getOrElse(Seq.empty)
+        val bucketColumnNames = bucketSpec.map(_.bucketColumnNames).getOrElse(Seq.empty)
+        val numBuckets = bucketSpec.map(_.numBuckets).getOrElse(-1)
+
+        val tableDesc = CatalogTable(
+          identifier = tableIdent,
+          tableType = CatalogTableType.MANAGED,
+          storage = CatalogStorageFormat.empty,
+          schema = Seq.empty[CatalogColumn],
+          partitionColumnNames = partitioningColumns.getOrElse(Seq.empty[String]),
+          sortColumnNames = sortColumnNames,
+          bucketColumnNames = bucketColumnNames,
+          numBuckets = numBuckets,
+          properties = extraOptions.toMap)
+
         val cmd =
           CreateTableUsingAsSelect(
-            tableIdent,
+            tableDesc,
             source,
-            partitioningColumns.map(_.toArray).getOrElse(Array.empty[String]),
-            getBucketSpec,
             mode,
-            extraOptions.toMap,
             df.logicalPlan)
         df.sparkSession.sessionState.executePlan(cmd).toRdd
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.usePrettyExpression
 import org.apache.spark.sql.execution.{FileRelation, LogicalRDD, QueryExecution, SQLExecution}
 import org.apache.spark.sql.execution.command.{CreateViewCommand, ExplainCommand}
-import org.apache.spark.sql.execution.datasources.{CreateTableUsingAsSelect, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{CreateTableAsSelect, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.json.JacksonGenerator
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.streaming.{DataStreamWriter, StreamingQuery}
@@ -175,7 +175,7 @@ class Dataset[T] private[sql](
     def hasSideEffects(plan: LogicalPlan): Boolean = plan match {
       case _: Command |
            _: InsertIntoTable |
-           _: CreateTableUsingAsSelect => true
+           _: CreateTableAsSelect => true
       case _ => false
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1006,12 +1006,6 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
     selectQuery match {
       case Some(q) =>
-        // Just use whatever is projected in the select statement as our schema
-        if (schema.nonEmpty) {
-          operationNotAllowed(
-            "Schema may not be specified in a Create Table As Select (CTAS) statement",
-            ctx)
-        }
         // Hive does not allow to use a CTAS statement to create a partitioned table.
         if (tableDesc.partitionColumnNames.nonEmpty) {
           val errorMessage = "A Create Table As Select (CTAS) statement is not allowed to " +
@@ -1020,6 +1014,12 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
             "OPTIONS (...) PARTITIONED BY ...\" to create a partitioned table through a " +
             "CTAS statement."
           operationNotAllowed(errorMessage, ctx)
+        }
+        // Just use whatever is projected in the select statement as our schema
+        if (schema.nonEmpty) {
+          operationNotAllowed(
+            "Schema may not be specified in a Create Table As Select (CTAS) statement",
+            ctx)
         }
 
         val hasStorageProperties = (ctx.createFileFormat != null) || (ctx.rowFormat != null)
@@ -1035,7 +1035,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
           CreateTableUsingAsSelect(
             tableIdent = tableDesc.identifier,
             provider = conf.defaultDataSourceName,
-            partitionColumns = tableDesc.partitionColumnNames.toArray,
+            partitionColumns = Array.empty[String],
             bucketSpec = None,
             mode = mode,
             options = optionsWithPath,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -310,7 +310,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
   }
 
   /**
-   * Create a [[CreateTableUsing]] or a [[CreateTableUsingAsSelect]] logical plan.
+   * Create a [[CreateTableUsing]] or a [[CreateTableAsSelect]] logical plan.
    */
   override def visitCreateTableUsing(ctx: CreateTableUsingContext): LogicalPlan = withOrigin(ctx) {
     val (table, temp, ifNotExists, external) = visitCreateTableHeader(ctx.createTableHeader)
@@ -355,7 +355,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         numBuckets = numBuckets,
         properties = options)
 
-      CreateTableUsingAsSelect(
+      CreateTableAsSelect(
         tableDesc = tableDesc, provider = provider, mode = mode, child = query)
     } else {
       val struct = Option(ctx.colTypeList()).map(createStructType)
@@ -1047,7 +1047,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
           } else {
             Map.empty[String, String]
           }
-          CreateTableUsingAsSelect(
+          CreateTableAsSelect(
             tableDesc = tableDesc.copy(properties = tableProperties),
             provider = conf.defaultDataSourceName,
             mode = mode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1021,6 +1021,12 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
     selectQuery match {
       case Some(q) =>
+        // Just use whatever is projected in the select statement as our schema
+        if (schema.nonEmpty) {
+          operationNotAllowed(
+            "Schema may not be specified in a Create Table As Select (CTAS) statement",
+            ctx)
+        }
         // Hive does not allow to use a CTAS statement to create a partitioned table.
         if (tableDesc.partitionColumnNames.nonEmpty) {
           val errorMessage = "A Create Table As Select (CTAS) statement is not allowed to " +
@@ -1029,12 +1035,6 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
             "OPTIONS (...) PARTITIONED BY ...\" to create a partitioned table through a " +
             "CTAS statement."
           operationNotAllowed(errorMessage, ctx)
-        }
-        // Just use whatever is projected in the select statement as our schema
-        if (schema.nonEmpty) {
-          operationNotAllowed(
-            "Schema may not be specified in a Create Table As Select (CTAS) statement",
-            ctx)
         }
 
         val hasStorageProperties = (ctx.createFileFormat != null) || (ctx.rowFormat != null)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -444,7 +444,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         throw new AnalysisException(
           "allowExisting should be set to false when creating a temporary table.")
 
-      case c: CreateTableUsingAsSelect =>
+      case c: CreateTableAsSelect if c.provider != "hive" =>
         val cmd =
           CreateDataSourceTableAsSelectCommand(
             c.tableDesc,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -447,12 +447,9 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case c: CreateTableUsingAsSelect =>
         val cmd =
           CreateDataSourceTableAsSelectCommand(
-            c.tableIdent,
+            c.tableDesc,
             c.provider,
-            c.partitionColumns,
-            c.bucketSpec,
             c.mode,
-            c.options,
             c.child)
         ExecutedCommandExec(cmd) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -159,7 +159,9 @@ case class CreateDataSourceTableAsSelectCommand(
     var createMetastoreTable = false
     var isExternal = true
     val optionsWithPath =
-      if (!new CaseInsensitiveMap(tableDesc.properties).contains("path")) {
+      if (tableDesc.storage.locationUri.nonEmpty) {
+        tableDesc.properties + ("path" -> tableDesc.storage.locationUri.get)
+      } else if (!new CaseInsensitiveMap(tableDesc.properties).contains("path")) {
         isExternal = false
         tableDesc.properties +
           ("path" -> sessionState.catalog.defaultTablePath(tableDesc.identifier))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -33,28 +33,10 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogColumn, CatalogTable, Catal
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType._
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
-import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan, UnaryNode}
 import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
-
-case class CreateHiveTableAsSelectLogicalPlan(
-    tableDesc: CatalogTable,
-    child: LogicalPlan,
-    allowExisting: Boolean) extends UnaryNode with Command {
-
-  override def output: Seq[Attribute] = Seq.empty[Attribute]
-
-  override lazy val resolved: Boolean =
-    // This should be moved to Analyzer checking?
-    tableDesc.identifier.database.isDefined &&
-      tableDesc.schema.nonEmpty &&
-      tableDesc.storage.serde.isDefined &&
-      tableDesc.storage.inputFormat.isDefined &&
-      tableDesc.storage.outputFormat.isDefined &&
-      childrenResolved
-}
 
 /**
  * A command to create a table with the same definition of the given existing table.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -47,6 +47,7 @@ case class CreateHiveTableAsSelectLogicalPlan(
   override def output: Seq[Attribute] = Seq.empty[Attribute]
 
   override lazy val resolved: Boolean =
+    // This should be moved to Analyzer checking?
     tableDesc.identifier.database.isDefined &&
       tableDesc.schema.nonEmpty &&
       tableDesc.storage.serde.isDefined &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -54,7 +54,7 @@ case class CreateTableUsing(
  * analyzer can analyze the logical plan that will be used to populate the table.
  * So, [[PreWriteCheck]] can detect cases that are not allowed.
  */
-case class CreateTableUsingAsSelect(
+case class CreateTableAsSelect(
     tableDesc: CatalogTable,
     provider: String,
     mode: SaveMode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -54,12 +55,9 @@ case class CreateTableUsing(
  * So, [[PreWriteCheck]] can detect cases that are not allowed.
  */
 case class CreateTableUsingAsSelect(
-    tableIdent: TableIdentifier,
+    tableDesc: CatalogTable,
     provider: String,
-    partitionColumns: Array[String],
-    bucketSpec: Option[BucketSpec],
     mode: SaveMode,
-    options: Map[String, String],
     child: LogicalPlan) extends logical.UnaryNode {
   override def output: Seq[Attribute] = Seq.empty[Attribute]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -206,7 +206,7 @@ private[sql] case class PreWriteCheck(conf: SQLConf, catalog: SessionCatalog)
         // The relation in l is not an InsertableRelation.
         failAnalysis(s"$l does not allow insertion.")
 
-      case c: CreateTableUsingAsSelect =>
+      case c: CreateTableAsSelect =>
         // When the SaveMode is Overwrite, we need to check if the table is an input table of
         // the query. If so, we will throw an AnalysisException to let users know it is not allowed.
         if (c.mode == SaveMode.Overwrite && catalog.tableExists(c.tableDesc.identifier)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -206,7 +206,7 @@ private[sql] case class PreWriteCheck(conf: SQLConf, catalog: SessionCatalog)
         // The relation in l is not an InsertableRelation.
         failAnalysis(s"$l does not allow insertion.")
 
-      case c: CreateTableAsSelect =>
+      case c: CreateTableAsSelect if c.provider != "hive" =>
         // When the SaveMode is Overwrite, we need to check if the table is an input table of
         // the query. If so, we will throw an AnalysisException to let users know it is not allowed.
         if (c.mode == SaveMode.Overwrite && catalog.tableExists(c.tableDesc.identifier)) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.{CatalogColumn, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Generate, ScriptTransformation}
 import org.apache.spark.sql.execution.command._
+import org.apache.spark.sql.execution.datasources.CreateTableAsSelect
 import org.apache.spark.sql.hive.test.TestHive
 
 class HiveDDLCommandSuite extends PlanTest {
@@ -36,7 +37,8 @@ class HiveDDLCommandSuite extends PlanTest {
   private def extractTableDesc(sql: String): (CatalogTable, Boolean) = {
     parser.parsePlan(sql).collect {
       case c: CreateTableCommand => (c.table, c.ifNotExists)
-      case c: CreateHiveTableAsSelectLogicalPlan => (c.tableDesc, c.allowExisting)
+      case c: CreateTableAsSelect if c.provider == "hive" =>
+        (c.tableDesc, c.mode == SaveMode.Ignore)
       case c: CreateViewCommand => (c.tableDesc, c.allowExisting)
     }.head
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -625,35 +625,19 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("specifying the column list for CTAS") {
-    withTempTable("mytable1") {
-      Seq((1, "111111"), (2, "222222")).toDF("key", "value").createOrReplaceTempView("mytable1")
-      withTable("gen__tmp") {
-        sql("create table gen__tmp as select key as a, value as b from mytable1")
-        checkAnswer(
-          sql("SELECT a, b from gen__tmp"),
-          sql("select key, value from mytable1").collect())
-      }
+    Seq((1, "111111"), (2, "222222")).toDF("key", "value").createOrReplaceTempView("mytable1")
 
-      withTable("gen__tmp") {
-        val e = intercept[AnalysisException] {
-          sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
-        }.getMessage
-        assert(e.contains("Schema may not be specified in a Create Table As Select (CTAS)"))
-      }
+    sql("create table gen__tmp as select key as a, value as b from mytable1")
+    checkAnswer(
+      sql("SELECT a, b from gen__tmp"),
+      sql("select key, value from mytable1").collect())
+    sql("DROP TABLE gen__tmp")
 
-      withTable("gen__tmp") {
-        val e = intercept[AnalysisException] {
-          sql(
-            """
-              |CREATE TABLE gen__tmp
-              |PARTITIONED BY (key string)
-              |AS SELECT key, value FROM mytable1
-            """.stripMargin)
-        }.getMessage
-        assert(e.contains("A Create Table As Select (CTAS) statement is not allowed to " +
-          "create a partitioned table using Hive's file formats"))
-      }
+    intercept[AnalysisException] {
+      sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
     }
+
+    sql("drop table mytable1")
   }
 
   test("command substitution") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -625,19 +625,35 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("specifying the column list for CTAS") {
-    Seq((1, "111111"), (2, "222222")).toDF("key", "value").createOrReplaceTempView("mytable1")
+    withTempTable("mytable1") {
+      Seq((1, "111111"), (2, "222222")).toDF("key", "value").createOrReplaceTempView("mytable1")
+      withTable("gen__tmp") {
+        sql("create table gen__tmp as select key as a, value as b from mytable1")
+        checkAnswer(
+          sql("SELECT a, b from gen__tmp"),
+          sql("select key, value from mytable1").collect())
+      }
 
-    sql("create table gen__tmp as select key as a, value as b from mytable1")
-    checkAnswer(
-      sql("SELECT a, b from gen__tmp"),
-      sql("select key, value from mytable1").collect())
-    sql("DROP TABLE gen__tmp")
+      withTable("gen__tmp") {
+        val e = intercept[AnalysisException] {
+          sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
+        }.getMessage
+        assert(e.contains("Schema may not be specified in a Create Table As Select (CTAS)"))
+      }
 
-    intercept[AnalysisException] {
-      sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
+      withTable("gen__tmp") {
+        val e = intercept[AnalysisException] {
+          sql(
+            """
+              |CREATE TABLE gen__tmp
+              |PARTITIONED BY (key string)
+              |AS SELECT key, value FROM mytable1
+            """.stripMargin)
+        }.getMessage
+        assert(e.contains("A Create Table As Select (CTAS) statement is not allowed to " +
+          "create a partitioned table using Hive's file formats"))
+      }
     }
-
-    sql("drop table mytable1")
   }
 
   test("command substitution") {


### PR DESCRIPTION
#### What changes were proposed in this pull request?

`CreateHiveTableAsSelectLogicalPlan` is a Hive-specific logical node. This is not a good design. We need to consolidate it with `CreateTableUsingAsSelect` to build a unified logical node `CreateTableAsSelect`.

The first step is to make more general the signature of `CreateTableUsingAsSelect` by using `CatalogTable` as the input of Table metadata. The logical node is renamed to `CreateTableAsSelect`. The new interface will be like

``` Scala
case class CreateTableAsSelect(
    tableDesc: CatalogTable,
    provider: String,
    mode: SaveMode,
    child: LogicalPlan) extends logical.UnaryNode 
```

The second step is to convert `CreateHiveTableAsSelectLogicalPlan` into `CreateTableAsSelect`.  

This PR is based on the compare of the two interfaces. The details are described below.

Currently, the SQL interface is the only only entrance to `CreateHiveTableAsSelectLogicalPlan`. Below describes the correspondence between the SQL interface and `CreateHiveTableAsSelectLogicalPlan`

``` Scala
case class CreateHiveTableAsSelectLogicalPlan(
    tableDesc: CatalogTable,
    child: LogicalPlan,
    allowExisting: Boolean)
    extends UnaryNode with Command 
```

``` Scala
SQL:

When conf.convertCTAS == false || either [ROW FORMAT row_format] or [STORED AS file_format] is specified

  CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [db_name.]table_name
  [(col1[:] data_type [COMMENT col_comment], ...)]
  [COMMENT table_comment]
  [PARTITIONED BY (col2[:] data_type [COMMENT col_comment], ...)]
  [ROW FORMAT row_format]
  [STORED AS file_format]
  [LOCATION path]
  [TBLPROPERTIES (property_name=property_value, ...)]
  [AS select_statement];

  -->

  [TEMPORARY] is not allowed.

  allowExisting: Boolean = [IF NOT EXISTS]
  child: LogicalPlan = select_statement
  tableDesc: CatalogTable = CatalogTable(
    identifier = [db_name.]table_name,
    tableType = [EXTERNAL],
    storage = [ROW FORMAT row_format +
              [STORED AS file_format] +
              [LOCATION path],
    schema = Seq.empty,
    partitionColumnNames = Seq.empty,
    properties = [TBLPROPERTIES (property_name=property_value, ...)],
    comment = [COMMENT table_comment])
```

`CreateTableUsingAsSelect` has three entrances. Below is the the correspondence:

``` Scala
case class CreateTableUsingAsSelect(
    tableIdent: TableIdentifier,
    provider: String,
    partitionColumns: Array[String],
    bucketSpec: Option[BucketSpec],
    mode: SaveMode,
    options: Map[String, String],
    child: LogicalPlan) extends logical.UnaryNode 
```

``` Scala
SQL Interface I:

When conf.convertCTAS == true && [ROW FORMAT row_format] and [STORED AS file_format] are not specified

  CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [db_name.]table_name
  [(col1[:] data_type [COMMENT col_comment], ...)]
  [COMMENT table_comment]
  [PARTITIONED BY (col2[:] data_type [COMMENT col_comment], ...)]
  [ROW FORMAT row_format]
  [STORED AS file_format]
  [LOCATION path]
  [TBLPROPERTIES (property_name=property_value, ...)]
  [AS select_statement];

  --> 

  tableIdent: TableIdentifier = [db_name.]table_name,
  provider: String = conf.defaultDataSourceName,
  partitionColumns: Array[String] = Seq.empty,
  bucketSpec: Option[BucketSpec] = None,
  mode: SaveMode = [IF NOT EXISTS],
  options: Map[String, String] = [LOCATION path],
  child: LogicalPlan = [AS select_statement]
```

``` Scala
SQL Interface II:

  CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [db_name.]table_name
  [(col1[:] data_type [COMMENT col_comment], ...)]
  USING qualifiedName
  [OPTIONS tablePropertyList)]
  [PARTITIONED BY (col2[:] data_type [COMMENT col_comment], ...)]
  [CLUSTERED BY (col3, ...) (SORTED BY orderedIdentifierList)? INTO INTEGER_VALUE BUCKETS]
  [AS select_statement];

  -->

  [EXTERNAL] is not allowed.
  [TEMPORARY] is not allowed.

  tableIdent: TableIdentifier = [db_name.]table_name,
  provider: String = USING qualifiedName,
  partitionColumns: Array[String] = [PARTITIONED BY (col2[:] data_type [COMMENT col_comment], ...)],
  bucketSpec: Option[BucketSpec] = [CLUSTERED BY (col3, ...) (SORTED BY orderedIdentifierList)? INTO INTEGER_VALUE BUCKETS],
  mode: SaveMode = [IF NOT EXISTS],
  options: Map[String, String] = [OPTIONS tablePropertyList)],
  child: LogicalPlan = [AS select_statement]
```

``` Scala
DataFrameWriter Interface:

  tableIdent: TableIdentifier = tableIdent (from saveAsTable API),
  provider: String = source (from format API),
  partitionColumns: Array[String] = partitioningColumns (from partitionBy API),
  bucketSpec: Option[BucketSpec] = getBucketSpec function (from bucketBy API and sortBy API),
  mode: SaveMode = mode (from mode API),
  options: Map[String, String] = extraOptions (from option and options API),
  child: LogicalPlan = df.logicalPlan (from DataFrameWriter)
```
#### How was this patch tested?

The existing test cases cover the code refactoring
