### PR TITLE
[SPARK-15467][build] update janino version to 3.0.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -79,7 +79,7 @@ jackson-databind-2.6.5.jar
 jackson-mapper-asl-1.9.13.jar
 jackson-module-paranamer-2.6.5.jar
 jackson-module-scala_2.11-2.6.5.jar
-janino-2.7.8.jar
+janino-3.0.0.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -81,7 +81,7 @@ jackson-databind-2.6.5.jar
 jackson-mapper-asl-1.9.13.jar
 jackson-module-paranamer-2.6.5.jar
 jackson-module-scala_2.11-2.6.5.jar
-janino-2.7.8.jar
+janino-3.0.0.jar
 java-xmlbuilder-1.0.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -81,7 +81,7 @@ jackson-databind-2.6.5.jar
 jackson-mapper-asl-1.9.13.jar
 jackson-module-paranamer-2.6.5.jar
 jackson-module-scala_2.11-2.6.5.jar
-janino-2.7.8.jar
+janino-3.0.0.jar
 java-xmlbuilder-1.0.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -89,7 +89,7 @@ jackson-mapper-asl-1.9.13.jar
 jackson-module-paranamer-2.6.5.jar
 jackson-module-scala_2.11-2.6.5.jar
 jackson-xc-1.9.13.jar
-janino-2.7.8.jar
+janino-3.0.0.jar
 java-xmlbuilder-1.0.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -89,7 +89,7 @@ jackson-mapper-asl-1.9.13.jar
 jackson-module-paranamer-2.6.5.jar
 jackson-module-scala_2.11-2.6.5.jar
 jackson-xc-1.9.13.jar
-janino-2.7.8.jar
+janino-3.0.0.jar
 java-xmlbuilder-1.0.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <!-- org.apache.commons/commons-lang3/-->
     <commons-lang3.version>3.3.2</commons-lang3.version>
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
-    <janino.version>2.7.8</janino.version>
+    <janino.version>3.0.0</janino.version>
     <jersey.version>2.22.2</jersey.version>
     <joda.version>2.9.3</joda.version>
     <jodd.version>3.5.2</jodd.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR updates version of Janino compiler from 2.7.8 to 3.0.0. This version fixes [an Janino issue](https://github.com/janino-compiler/janino/issues/1) that fixes [an issue](https://issues.apache.org/jira/browse/SPARK-15467), which throws Java exception, in Spark.
## How was this patch tested?

Manually tested using a program in [the JIRA entry](https://issues.apache.org/jira/browse/SPARK-15467)
