### PR TITLE
[SPARK-15889] [STREAMING] Follow-up fix to erroneous condition in StreamTest

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -189,7 +189,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with Timeouts {
     }
 
     def apply(message: String)(condition: StreamExecution => Unit): AssertOnQuery = {
-      new AssertOnQuery(s => { condition; true }, message)
+      new AssertOnQuery(s => { condition(s); true }, message)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A second form of AssertQuery now actually invokes the condition; avoids a build warning too
## How was this patch tested?

Jenkins; running StreamTest
