### PR TITLE
SPARK-16478 graphX (added graph caching in strongly connected components)

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -117,15 +117,10 @@ object StronglyConnectedComponents {
         },
         (final1, final2) => final1 || final2)
 
-        // ensure sccGraph's rdd are marked as recently used
+        // ensure sccGraph's rdd are marked as recently used to not be evicted between iterations
         sccGraph.vertices.count()
         sccGraph.edges.count()
-        // sccGraph materialized so, unpersist can be done on previous
-        if(prevSccGraph != sccGraph)
-        {
-          prevSccGraph.unpersist(blocking = false)
-          prevSccGraph = sccGraph
-        }
+
     }
     sccGraph
   }

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -79,6 +79,8 @@ object StronglyConnectedComponents {
         sccWorkGraph = sccWorkGraph.subgraph(vpred = (vid, data) => !data._2).cache()
       } while (sccWorkGraph.numVertices < numVertices)
 
+      // if iter < numIter at this point sccGraph that is returned
+      // will not be recomputed and pregel executions are pointless
       if (iter < numIter) {
         sccWorkGraph = sccWorkGraph.mapVertices { case (vid, (color, isFinal)) => (vid, isFinal) }
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -116,11 +116,6 @@ object StronglyConnectedComponents {
           }
         },
         (final1, final2) => final1 || final2)
-
-        // ensure sccGraph's rdd are marked as recently used to not be evicted between iterations
-        sccGraph.vertices.count()
-        sccGraph.edges.count()
-
     }
     sccGraph
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added caching in every iteration for sccGraph that is returned in strongly connected components. Without this cache strongly connected components returned graph that needed to be computed from scratch when some intermediary caches didn't existed anymore. 
## How was this patch tested?

I tested it by running code similar to the one  [on databrics](https://databricks-prod-cloudfront.cloud.databricks.com/public/4027ec902e239c93eaaa8714f173bcfc/4889410027417133/3634650767364730/3117184429335832/latest.html). Basically I generated large graph  and computed strongly connected components with changed code, than simply run count on vertices and edges. Count after this update takes few seconds instead 20 minutes. 
# statement

contribution is my original work and I license the work to the project under the project's open source license.
