### PR TITLE
[SPARK-16497][SQL] Don't throw an exception if drop non-existent TABLE/VIEW/Function/Partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -151,6 +151,7 @@ case class DropFunctionCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
+    val ignoreIfNotExists = ifExists || sparkSession.sqlContext.conf.dropIgnoreNonExist
     if (isTemp) {
       if (databaseName.isDefined) {
         throw new AnalysisException(s"Specifying a database in DROP TEMPORARY FUNCTION " +
@@ -159,12 +160,12 @@ case class DropFunctionCommand(
       if (FunctionRegistry.builtin.functionExists(functionName)) {
         throw new AnalysisException(s"Cannot drop native function '$functionName'")
       }
-      catalog.dropTempFunction(functionName, ifExists)
+      catalog.dropTempFunction(functionName, ignoreIfNotExists)
     } else {
       // We are dropping a permanent function.
       catalog.dropFunction(
         FunctionIdentifier(functionName, databaseName),
-        ignoreIfNotExists = ifExists)
+        ignoreIfNotExists)
     }
     Seq.empty[Row]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -285,6 +285,12 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
+  val DROP_IGNORENONEXIST = SQLConfigBuilder("spark.sql.drop.ignorenonexistent")
+    .doc("When true, Do not throw an exception if DROP TABLE/VIEW/Index/Function specifies a " +
+      "non-existent table/view/index/function.")
+    .booleanConf
+    .createWithDefault(true)
+
   // This is used to set the default data source
   val DEFAULT_DATA_SOURCE_NAME = SQLConfigBuilder("spark.sql.sources.default")
     .doc("The default data source to use in input/output.")
@@ -630,6 +636,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def columnNameOfCorruptRecord: String = getConf(COLUMN_NAME_OF_CORRUPT_RECORD)
 
   def broadcastTimeout: Int = getConf(BROADCAST_TIMEOUT)
+
+  def dropIgnoreNonExist: Boolean = getConf(DROP_IGNORENONEXIST)
 
   def defaultDataSourceName: String = getConf(DEFAULT_DATA_SOURCE_NAME)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1426,17 +1426,13 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
         sql("ALTER TABLE tbl DROP PARTITION (part1 = 1)")
       }
       withSQLConf(SQLConf.DROP_IGNORENONEXIST.key -> "false") {
-        intercept[AnalysisException] {
-          sql("DROP TABLE nonExistTable")
-        }
-        intercept[AnalysisException] {
-          sql("DROP VIEW nonExistView")
-        }
-        intercept[AnalysisException] {
-          sql("DROP Function nonExistFunction")
-        }
-        intercept[AnalysisException] {
-          sql("ALTER TABLE tbl DROP PARTITION (part1 = 1)")
+        val doNotIgnoreNonExistentSqls = Seq(
+          "DROP TABLE nonExistTable",
+          "DROP VIEW nonExistView",
+          "DROP Function nonExistFunction",
+          "ALTER TABLE tbl DROP PARTITION (part1 = 1)")
+        doNotIgnoreNonExistentSqls.foreach { case q =>
+          intercept[AnalysisException] { sql(q) }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

from https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.exec.drop.ignorenonexistent, Hive use 'hive.exec.drop.ignorenonexistent'(default=true) to do not report an error if DROP TABLE/VIEW/PARTITION/INDEX/TEMPORARY FUNCTION specifies a non-existent table/view. So SparkSQL also should support it.
## How was this patch tested?

add unit tests.
