### PR TITLE
[SPARK-16500][ML][MLLib][Optimizer] add LBFGS convergence warning for all used place in MLLib

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -426,6 +426,11 @@ class LogisticRegression @Since("1.2.0") (
           throw new SparkException(msg)
         }
 
+        if (!state.actuallyConverged) {
+          logWarning("LogisticRegression training fininshed but the result " +
+            s"is not converged because: ${state.convergedReason.get.reason}")
+        }
+
         /*
            The coefficients are trained in the scaled space; we're converting them back to
            the original space.

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -245,6 +245,11 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
         throw new SparkException(msg)
       }
 
+      if (!state.actuallyConverged) {
+        logWarning("AFTSurvivalRegression training fininshed but the result " +
+          s"is not converged because: ${state.convergedReason.get.reason}")
+      }
+
       state.x.toArray.clone()
     }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -212,6 +212,12 @@ object LBFGS extends Logging {
       state = states.next()
     }
     lossHistory += state.value
+
+    if (!state.actuallyConverged) {
+      logWarning("LBFGS training fininshed but the result " +
+        s"is not converged because: ${state.convergedReason.get.reason}")
+    }
+
     val weights = Vectors.fromBreeze(state.x)
 
     val lossHistoryArray = lossHistory.result()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add warning_for the following case when LBFGS training not actually convergence:

1) LogisticRegression
2) AFTSurvivalRegression
3) LBFGS algorithm wrapper in mllib package
## How was this patch tested?

N/A
