### PR TITLE
[SPARK-16629] Allow comparisons between UDTs and Datatypes

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -622,10 +622,10 @@ class SQLTests(ReusedPySparkTestCase):
         rows = [Row(dollars=ExampleMoney(1.0)), Row(dollars=ExampleMoney(2.0)), , Row(dollars=ExampleMoney(3.0))]
         df = self.spark.createDataFrame(rows)
 
-        less_than = df['dollars < 2.0']
+        less_than = df.filter(df.dollars < 2.0)
         self.assertEqual(Row(dollars=ExampleMoney(1.0)), less_than.collect())
 
-        equal = df['dollars == 2.0']
+        equal = df.filter(df.dollars == 2.0)
         self.assertEqual(Row(dollars=ExampleMoney(2.0)), equal.collect())
 
         greater_than = df['dollars > 2.0']

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -619,7 +619,11 @@ class SQLTests(ReusedPySparkTestCase):
 
     def test_udt_with_predicates(self):
         from pyspark.sql.tests import ExampleMoney, ExampleMoneyUDT
-        rows = [Row(dollars=ExampleMoney(1.0)), Row(dollars=ExampleMoney(2.0)), , Row(dollars=ExampleMoney(3.0))]
+        rows = [
+            Row(dollars=ExampleMoney(1.0)),
+            Row(dollars=ExampleMoney(2.0)),
+            Row(dollars=ExampleMoney(3.0))
+        ]
         df = self.spark.createDataFrame(rows)
 
         less_than = df.filter(df.dollars < 2.0)
@@ -633,7 +637,11 @@ class SQLTests(ReusedPySparkTestCase):
 
     def test_udt_with_predicates_in_sql(self):
         from pyspark.sql.tests import ExampleMoney, ExampleMoneyUDT
-        rows = [Row(dollars=ExampleMoney(1.0)), Row(dollars=ExampleMoney(2.0)), , Row(dollars=ExampleMoney(3.0))]
+        rows = [
+            Row(dollars=ExampleMoney(1.0)),
+            Row(dollars=ExampleMoney(2.0)),
+            Row(dollars=ExampleMoney(3.0))
+        ]
         df = self.spark.createDataFrame(rows)
         df.createOrReplaceTempView("money_table")
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -94,6 +94,37 @@ class ExamplePointUDT(UserDefinedType):
         return ExamplePoint(datum[0], datum[1])
 
 
+class ExampleMoneyUDT(UserDefinedType):
+
+    @classmethod
+    def sqlType(self):
+        return DecimalType()
+
+    @classmethod
+    def module(cls):
+        return 'pyspark.sql.tests'
+
+    def serialize(self, obj):
+        return obj
+
+    def deserialize(self, datum):
+        return datum
+
+
+class ExampleMoney:
+
+    __UDT__ = ExampleMoneyUDT()
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return "$%s" % self.value
+
+    def __eq__(self, other):
+        return self.value == other.value
+
+
 class ExamplePoint:
     """
     An example class to demonstrate UDT in Scala, Java, and Python.
@@ -585,6 +616,35 @@ class SQLTests(ReusedPySparkTestCase):
         self.spark.catalog.registerFunction("udf", myudf, PythonOnlyUDT())
         rows = [r[0] for r in df.selectExpr("udf(id)").take(2)]
         self.assertEqual(rows, [None, PythonOnlyPoint(1, 1)])
+
+    def test_udt_with_predicates(self):
+        from pyspark.sql.tests import ExampleMoney, ExampleMoneyUDT
+        rows = [Row(dollars=ExampleMoney(1.0)), Row(dollars=ExampleMoney(2.0)), , Row(dollars=ExampleMoney(3.0))]
+        df = self.spark.createDataFrame(rows)
+
+        less_than = df['dollars < 2.0']
+        self.assertEqual(Row(dollars=ExampleMoney(1.0)), less_than.collect())
+
+        equal = df['dollars == 2.0']
+        self.assertEqual(Row(dollars=ExampleMoney(2.0)), equal.collect())
+
+        greater_than = df['dollars > 2.0']
+        self.assertEqual(Row(dollars=ExampleMoney(3.0)), greater_than.collect())
+
+    def test_udt_with_predicates_in_sql(self):
+        from pyspark.sql.tests import ExampleMoney, ExampleMoneyUDT
+        rows = [Row(dollars=ExampleMoney(1.0)), Row(dollars=ExampleMoney(2.0)), , Row(dollars=ExampleMoney(3.0))]
+        df = self.spark.createDataFrame(rows)
+        df.createOrReplaceTempView("money_table")
+
+        less_than = self.spark.sql("SELECT dollars FROM money_table WHERE dollars < 2.0")
+        self.assertEqual(Row(dollars=ExampleMoney(1.0)), less_than.collect())
+
+        equal = self.spark.sql("SELECT dollars FROM money_table WHERE dollars = 2.0")
+        self.assertEqual(Row(dollars=ExampleMoney(2.0)), equal.collect())
+
+        greater_than = self.spark.sql("SELECT dollars FROM money_table WHERE dollars > 2.0")
+        self.assertEqual(Row(dollars=ExampleMoney(3.0)), greater_than.collect())
 
     def test_infer_schema_with_udt(self):
         from pyspark.sql.tests import ExamplePoint, ExamplePointUDT

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -65,6 +65,8 @@ object TypeUtils {
       case i: AtomicType => i.ordering.asInstanceOf[Ordering[Any]]
       case a: ArrayType => a.interpretedOrdering.asInstanceOf[Ordering[Any]]
       case s: StructType => s.interpretedOrdering.asInstanceOf[Ordering[Any]]
+      case u: UserDefinedType[_] => u.interpretedOrdering
+      case p: PythonUserDefinedType => p.interpretedOrdering
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -66,7 +66,6 @@ object TypeUtils {
       case a: ArrayType => a.interpretedOrdering.asInstanceOf[Ordering[Any]]
       case s: StructType => s.interpretedOrdering.asInstanceOf[Ordering[Any]]
       case u: UserDefinedType[_] => u.interpretedOrdering
-      case p: PythonUserDefinedType => p.interpretedOrdering
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -206,6 +206,7 @@ object DataType {
           leftFields.zip(rightFields).forall { case (l, r) =>
             l.name == r.name && equalsIgnoreNullability(l.dataType, r.dataType)
           }
+      case (l: DataType, r: UserDefinedType[_]) => r.acceptsType(l)
       case (l, r) => l == r
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -23,6 +23,7 @@ import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.catalyst.util.TypeUtils
 
 /**
  * The data type for User Defined Types (UDTs).
@@ -42,6 +43,10 @@ import org.apache.spark.annotation.DeveloperApi
  */
 private[spark]
 abstract class UserDefinedType[UserType >: Null] extends DataType with Serializable {
+
+  final def interpretedOrdering: Ordering[Any] = {
+    TypeUtils.getInterpretedOrdering(this.sqlType)
+  }
 
   /** Underlying storage type for this UDT */
   def sqlType: DataType
@@ -121,6 +126,11 @@ private[sql] class PythonUserDefinedType(
       ("pyClass" -> pyUDT) ~
       ("serializedClass" -> serializedPyClass) ~
       ("sqlType" -> sqlType.jsonValue)
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: DataType => this.acceptsType(that)
+    case _ => false
   }
 
   override def hashCode(): Int = Objects.hashCode(pyUDT)

--- a/sql/core/src/main/scala/org/apache/spark/sql/test/ExampleMoneyUDT.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/test/ExampleMoneyUDT.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test
+
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
+import org.apache.spark.sql.types._
+
+/**
+ * An example class to demonstrate UDT in Scala, Java, and Python.
+ * @param value x coordinate
+ */
+@SQLUserDefinedType(udt = classOf[ExampleMoneyUDT])
+private[sql] class ExampleMoney(val value: Double) extends Serializable {
+
+  override def hashCode(): Int = 31 * (31 * value.hashCode())
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ExampleMoney => this.value == that.value
+    case _ => false
+  }
+}
+
+/**
+ * User-defined type for [[ExampleMoney]].
+ */
+private[sql] class ExampleMoneyUDT extends UserDefinedType[ExampleMoney] {
+
+  override def sqlType: DataType = DoubleType
+
+  override def pyUDT: String = "pyspark.sql.tests.ExampleMoneyUDT"
+
+  override def serialize(p: ExampleMoney): Double = {
+    p.value
+  }
+
+  override def deserialize(datum: Any): ExampleMoney = {
+    datum match {
+      case value: Double =>
+        new ExampleMoney(value)
+    }
+  }
+
+  override def userClass: Class[ExampleMoney] = classOf[ExampleMoney]
+
+  private[spark] override def asNullable: ExampleMoneyUDT = this
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchange}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, ExampleMoney, ExampleMoneyUDT, SharedSQLContext}
+import org.apache.spark.sql.test.{ExampleMoney, ExampleMoneyUDT, ExamplePoint, ExamplePointUDT, SharedSQLContext}
 import org.apache.spark.sql.test.SQLTestData.TestData2
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -111,7 +111,9 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("test filtering with predicates on UDT columns") {
-    val rowRDD = sparkContext.parallelize(Seq(Row(new ExampleMoney(1.0)), Row(new ExampleMoney(2.0)), Row(new ExampleMoney(3.0))))
+    val rowRDD = sparkContext.parallelize(
+      Seq(Row(new ExampleMoney(1.0)), Row(new ExampleMoney(2.0)), Row(new ExampleMoney(3.0)))
+    )
     val schema = StructType(Array(StructField("dollar", new ExampleMoneyUDT(), false)))
     val df = spark.createDataFrame(rowRDD, schema)
 
@@ -122,7 +124,9 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("test filtering with predicates on UDT columns in spark sql") {
-    val rowRDD = sparkContext.parallelize(Seq(Row(new ExampleMoney(1.0)), Row(new ExampleMoney(2.0)), Row(new ExampleMoney(3.0))))
+    val rowRDD = sparkContext.parallelize(
+      Seq(Row(new ExampleMoney(1.0)), Row(new ExampleMoney(2.0)), Row(new ExampleMoney(3.0)))
+    )
     val schema = StructType(Array(StructField("dollar", new ExampleMoneyUDT(), false)))
     val df = spark.createDataFrame(rowRDD, schema)
     df.createOrReplaceTempView("udtData")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchange}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSQLContext}
+import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, ExampleMoney, ExampleMoneyUDT, SharedSQLContext}
 import org.apache.spark.sql.test.SQLTestData.TestData2
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -108,6 +108,28 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       df1.union(df2).orderBy("label"),
       Seq(Row(1, new ExamplePoint(1.0, 2.0)), Row(2, new ExamplePoint(3.0, 4.0)))
     )
+  }
+
+  test("test filtering with predicates on UDT columns") {
+    val rowRDD = sparkContext.parallelize(Seq(Row(new ExampleMoney(1.0)), Row(new ExampleMoney(2.0)), Row(new ExampleMoney(3.0))))
+    val schema = StructType(Array(StructField("dollar", new ExampleMoneyUDT(), false)))
+    val df = spark.createDataFrame(rowRDD, schema)
+
+    checkAnswer(df.filter(df("dollar") < 2.0), Seq(Row(new ExampleMoney(1.0))))
+    checkAnswer(df.filter(df("dollar") === 2.0), Seq(Row(new ExampleMoney(2.0))))
+    checkAnswer(df.filter(df("dollar") > 2.0), Seq(Row(new ExampleMoney(3.0)))
+    )
+  }
+
+  test("test filtering with predicates on UDT columns in spark sql") {
+    val rowRDD = sparkContext.parallelize(Seq(Row(new ExampleMoney(1.0)), Row(new ExampleMoney(2.0)), Row(new ExampleMoney(3.0))))
+    val schema = StructType(Array(StructField("dollar", new ExampleMoneyUDT(), false)))
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.createOrReplaceTempView("udtData")
+
+    checkAnswer(sql("SELECT dollar FROM udtData WHERE dollar < 2.0"), Row(new ExampleMoney(1.0)))
+    checkAnswer(sql("SELECT dollar FROM udtData WHERE dollar = 2.0"), Row(new ExampleMoney(2.0)))
+    checkAnswer(sql("SELECT dollar FROM udtData WHERE dollar > 2.0"), Row(new ExampleMoney(3.0)))
   }
 
   test("empty data frame") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes https://issues.apache.org/jira/browse/SPARK-16629

Currently UDTs can not be compared to Datatypes even if their sqlTypes match. this leads to errors like this 

```

In [12]: filtered = df.filter(df['udt_time'] > threshold)
---------------------------------------------------------------------------
AnalysisException                         Traceback (most recent call last)
/Users/franklyndsouza/dev/starscream/bin/starscream in <module>()
----> 1 thresholded = df.filter(df['udt_time'] > threshold)

AnalysisException: u"cannot resolve '(`udt_time` > TIMESTAMP('2015-10-20 01:00:00.0'))' due to data typ mismatch: '(`udt_time` > TIMESTAMP('2015-10-20 01:00:00.0'))' requires (boolean or tinyint or smallint or int or bigint or float or double or decimal or timestamp or date or string or binary) type, not pythonuserdefined"

```

This PR adds some methods that allow UDTs to be correctly compared to a Datatype.
## How was this patch tested?

Built locally and tested in the pyspark repl.

@angelini @davies @rxin 
