### PR TITLE
[SPARK-16503] SparkSession should provide Spark version

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -234,6 +234,12 @@ class SparkSession(object):
 
     @property
     @since(2.0)
+    def version(self):
+        """The version of Spark on which this application is running."""
+        return self._jsparkSession.version()
+
+    @property
+    @since(2.0)
     def conf(self):
         """Runtime configuration interface for Spark.
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
 
-import org.apache.spark.{SparkConf, SparkContext, SPARK_VERSION}
+import org.apache.spark.{SPARK_VERSION, SparkConf, SparkContext}
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.internal.Logging

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext, SPARK_VERSION}
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.internal.Logging
@@ -78,6 +78,9 @@ class SparkSession private(
   }
 
   sparkContext.assertNotStopped()
+
+  /** The version of Spark on which this application is running. */
+  def version: String = SPARK_VERSION
 
   /* ----------------------- *
    |  Session-related state  |

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -79,7 +79,11 @@ class SparkSession private(
 
   sparkContext.assertNotStopped()
 
-  /** The version of Spark on which this application is running. */
+  /**
+   * The version of Spark on which this application is running.
+   *
+   * @since 2.0.0
+   */
   def version: String = SPARK_VERSION
 
   /* ----------------------- *


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch enables SparkSession to provide spark version.
## How was this patch tested?

Manual test:

```
scala> sc.version
res0: String = 2.1.0-SNAPSHOT

scala> spark.version
res1: String = 2.1.0-SNAPSHOT
```

```
>>> sc.version
u'2.1.0-SNAPSHOT'
>>> spark.version
u'2.1.0-SNAPSHOT'
```
