### PR TITLE
[SPARK-16515][SQL]set default record reader and writer for script transformation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1340,7 +1340,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         val name = conf.getConfString("hive.script.serde",
           "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
         val props = Seq("field.delim" -> "\t")
-        val recordHandler = defaultRecordHandler(configKey)
+        val recordHandler = Try(conf.getConfString(configKey, configValue)).toOption
         (Nil, Option(name), props, recordHandler)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1330,7 +1330,6 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         // SPARK-10310: Special cases LazySimpleSerDe
         val recordHandler = if (name == "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe") {
           Try(conf.getConfString(configKey, configValue)).toOption
-          defaultRecordHandler(configKey)
         } else {
           None
         }

--- a/sql/hive/src/test/resources/test_script.sh
+++ b/sql/hive/src/test/resources/test_script.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+while read line
+do
+  echo "$line" | sed 's/\t/_/'
+done < /dev/stdin


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `ScriptInputOutputSchema`, we read default `RecordReader` and `RecordWriter` from conf. Since Spark 2.0 has deleted those config keys from hive conf, we have to set default reader/writer class name by ourselves. Otherwise we will get `None` for `LazySimpleSerde`, the data written would not be able to read by script. The test case added worked fine with previous version of Spark, but would fail now.
## How was this patch tested?

added a test case in SQLQuerySuite.
