### PR TITLE
[SPARK-16531][SQL][TEST] Remove timezone setting from DataFrameTimeWindowingSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala
@@ -29,16 +29,6 @@ class DataFrameTimeWindowingSuite extends QueryTest with SharedSQLContext with B
 
   import testImplicits._
 
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-  }
-
-  override def afterEach(): Unit = {
-    super.beforeEach()
-    TimeZone.setDefault(null)
-  }
-
   test("tumbling window groupBy statement") {
     val df = Seq(
       ("2016-03-27 19:39:34", 1, "a"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's unnecessary. `QueryTest` already sets it.
