### PR TITLE
[SPARK-15382][SQL] Fix a rule to push down projects beneath Sample 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -154,7 +154,7 @@ object PushProjectThroughSample extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     // Push down projection into sample
     case proj @ Project(projectList, Sample(lb, up, replace, seed, child)) =>
-      if (up - lb <= 1.0 && !projectList.exists(_.find(!_.deterministic).nonEmpty)) {
+      if (!projectList.exists(_.find(!_.deterministic).nonEmpty)) {
         Sample(lb, up, replace, seed, Project(projectList, child))()
       } else {
         proj

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -154,7 +154,7 @@ object PushProjectThroughSample extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     // Push down projection into sample
     case proj @ Project(projectList, Sample(lb, up, replace, seed, child)) =>
-      if (!projectList.exists(_.find(!_.deterministic).nonEmpty)) {
+      if (!replace || !projectList.exists(_.find(!_.deterministic).nonEmpty)) {
         Sample(lb, up, replace, seed, Project(projectList, child))()
       } else {
         proj

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -154,7 +154,7 @@ object PushProjectThroughSample extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     // Push down projection into sample
     case proj @ Project(projectList, Sample(lb, up, replace, seed, child)) =>
-      if (up - lb < 1.0 && !projectList.exists(_.find(!_.deterministic).nonEmpty)) {
+      if (up - lb <= 1.0 && !projectList.exists(_.find(!_.deterministic).nonEmpty)) {
         Sample(lb, up, replace, seed, Project(projectList, child))()
       } else {
         proj

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1534,15 +1534,15 @@ class Dataset[T] private[sql](
    * Returns a new Dataset by sampling a fraction of rows.
    *
    * @param withReplacement Sample with replacement or not.
-   * @param fraction Fraction of rows to generate and the range is 0.0 < `fraction` < 1.0.
+   * @param fraction Fraction of rows to generate and the range is 0.0 <= `fraction` <= 1.0.
    * @param seed Seed for sampling.
    *
    * @group typedrel
    * @since 1.6.0
    */
   def sample(withReplacement: Boolean, fraction: Double, seed: Long): Dataset[T] = {
-    require(fraction >= 0,
-      s"Fraction must be nonnegative, but got ${fraction}")
+    require(fraction >= 0 && fraction <= 1.0,
+      s"Fraction range must be 0.0 <= `fraction` <= 1.0, but got ${fraction}")
 
     withTypedPlan {
       Sample(0.0, fraction, withReplacement, seed, logicalPlan)()
@@ -1553,7 +1553,7 @@ class Dataset[T] private[sql](
    * Returns a new Dataset by sampling a fraction of rows, using a random seed.
    *
    * @param withReplacement Sample with replacement or not.
-   * @param fraction Fraction of rows to generate and the range is 0.0 < `fraction` < 1.0.
+   * @param fraction Fraction of rows to generate and the range is 0.0 <= `fraction` <= 1.0.
    *
    * @group typedrel
    * @since 1.6.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1534,7 +1534,7 @@ class Dataset[T] private[sql](
    * Returns a new Dataset by sampling a fraction of rows.
    *
    * @param withReplacement Sample with replacement or not.
-   * @param fraction Fraction of rows to generate.
+   * @param fraction Fraction of rows to generate and the range is 0.0 < `fraction` < 1.0.
    * @param seed Seed for sampling.
    *
    * @group typedrel
@@ -1553,7 +1553,7 @@ class Dataset[T] private[sql](
    * Returns a new Dataset by sampling a fraction of rows, using a random seed.
    *
    * @param withReplacement Sample with replacement or not.
-   * @param fraction Fraction of rows to generate.
+   * @param fraction Fraction of rows to generate and the range is 0.0 < `fraction` < 1.0.
    *
    * @group typedrel
    * @since 1.6.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -266,6 +266,7 @@ case class SampleExec(
     if (withReplacement) {
       val samplerClass = classOf[PoissonSampler[UnsafeRow]].getName
       val initSampler = ctx.freshName("initSampler")
+      ctx.copyResult = true
       ctx.addMutableState(s"$samplerClass<UnsafeRow>", sampler,
         s"$initSampler();")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -266,10 +266,7 @@ case class SampleExec(
     if (withReplacement) {
       val samplerClass = classOf[PoissonSampler[UnsafeRow]].getName
       val initSampler = ctx.freshName("initSampler")
-      if (upperBound - lowerBound > 1.0) {
-        // In case input rows are possibly sampled twice, we need to copy the rows
-        ctx.copyResult = true
-      }
+      ctx.copyResult = true
       ctx.addMutableState(s"$samplerClass<UnsafeRow>", sampler,
         s"$initSampler();")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -266,7 +266,10 @@ case class SampleExec(
     if (withReplacement) {
       val samplerClass = classOf[PoissonSampler[UnsafeRow]].getName
       val initSampler = ctx.freshName("initSampler")
-      ctx.copyResult = true
+      if (upperBound - lowerBound > 1.0) {
+        // In case input rows are possibly sampled twice, we need to copy the rows
+        ctx.copyResult = true
+      }
       ctx.addMutableState(s"$samplerClass<UnsafeRow>", sampler,
         s"$initSampler();")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1595,7 +1595,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       val e = intercept[AnalysisException] {
         Seq((1, 0), (2, 0), (3, 0)).toDF("a", "b").sample(true, 2.0)
       }
-      assert(e.getMessage.startsWith("`fraction` must be greater than 0.0 and less than 1.0"))
+      assert(e.getMessage.startsWith("A valid range is 0.0 < `fraction` <= 1.0"))
     }
     checkException(1.1)
     checkException(-1.2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `X` > 1.0 in `Dataset#sample`, `sample(true, X).withColumn("x", monotonically_increasing_id)` cannot have unique ids. This pr fixes this bug.
## How was this patch tested?

Added tests in `DataFrameSuite`.
