### PR TITLE
[SPARK-14702][SUBMIT] Expose SparkLauncher's ProcessBuilder for user flexibility

### DIFF
--- a/core/src/test/scala/org/apache/spark/launcher/LauncherBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/launcher/LauncherBackendSuite.scala
@@ -17,15 +17,16 @@
 
 package org.apache.spark.launcher
 
+
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.Matchers
 
-import org.apache.spark._
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 
 class LauncherBackendSuite extends SparkFunSuite with Matchers {
 
@@ -36,6 +37,10 @@ class LauncherBackendSuite extends SparkFunSuite with Matchers {
   tests.foreach { case (name, master) =>
     test(s"$name: launcher handle") {
       testWithMaster(master)
+    }
+
+    test(s"$name: launcher handler process builder") {
+      testWithMasterWithProcessBuilder(master)
     }
   }
 
@@ -59,7 +64,40 @@ class LauncherBackendSuite extends SparkFunSuite with Matchers {
 
       handle.stop()
 
+      eventually(timeout(30 seconds), interval(1000 millis)) {
+        handle.getState() should be (SparkAppHandle.State.KILLED)
+      }
+    } finally {
+      handle.kill()
+    }
+  }
+
+  private def testWithMasterWithProcessBuilder(master: String): Unit = {
+    val env = new java.util.HashMap[String, String]()
+    env.put("SPARK_PRINT_LAUNCH_COMMAND", "1")
+    // Note: this is NOT necessarily how the API is meant to be used, the user can pass in
+    // an arbitrary ProcessBuilder to startApplication and it should launch it, we however
+    // want to use a ProcessBuilder that will create a Spark application.
+    val procBuilder = new SparkLauncher(env)
+      .setSparkHome(sys.props("spark.test.home"))
+      .setConf(SparkLauncher.DRIVER_EXTRA_CLASSPATH, System.getProperty("java.class.path"))
+      .setConf("spark.ui.enabled", "false")
+      .setConf(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, s"-Dtest.appender=console")
+      .setMaster(master)
+      .setAppResource(SparkLauncher.NO_RESOURCE)
+      .setMainClass(TestApp.getClass.getName().stripSuffix("$"))
+      .createProcessBuilder()
+    val handle = new SparkLauncher()
+      .startApplication("TestApp", procBuilder)
+
+    try {
       eventually(timeout(30 seconds), interval(100 millis)) {
+        handle.getAppId() should not be (null)
+      }
+
+      handle.stop()
+
+      eventually(timeout(40 seconds), interval(100 millis)) {
         handle.getState() should be (SparkAppHandle.State.KILLED)
       }
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expose the `ProcessBuilder` in `SparkLauncher`, as well as opening up `SparkLauncher#startApplication` to allow accepting arbitrary ProcessBuilders.

For more info see [https://issues.apache.org/jira/browse/SPARK-16511](this JIRA ticket)

Also covers [https://issues.apache.org/jira/browse/SPARK-14702](SPARK-14702)
## How was this patch tested?

Unit tests + spark shell
