### PR TITLE
[SPARK-16536][SQL][PYSPARK][MINOR] Expose `sql` in PySpark Shell

### DIFF
--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -49,6 +49,7 @@ except TypeError:
     spark = SparkSession.builder.getOrCreate()
 
 sc = spark.sparkContext
+sql = spark.sql
 atexit.register(lambda: sc.stop())
 
 # for compatibility


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR exposes `sql` in PySpark Shell like Scala/R Shells for consistency.

**Background**
- Scala
  
  ``` scala
  scala> sql("select 1 a")
  res0: org.apache.spark.sql.DataFrame = [a: int]
  ```
- R
  
  ``` r
  > sql("select 1")
  SparkDataFrame[1:int]
  ```

**Before**
- Python
  
  ``` python
  >>> sql("select 1 a")
  Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  NameError: name 'sql' is not defined
  ```

**After**
- Python
  
  ``` python
  >>> sql("select 1 a")
  DataFrame[a: int]
  ```
## How was this patch tested?

Manual.
