### PR TITLE
[SPARK-16217][SQL] Support SELECT INTO statement

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -338,7 +338,8 @@ querySpecification
        (RECORDREADER recordReader=STRING)?
        fromClause?
        (WHERE where=booleanExpression)?)
-    | ((kind=SELECT setQuantifier? namedExpressionSeq (intoClause? fromClause)?
+    | ((kind=SELECT setQuantifier? namedExpressionSeq fromClause?
+       |kind=SELECT setQuantifier? namedExpressionSeq intoClause? fromClause?
        | fromClause (kind=SELECT setQuantifier? namedExpressionSeq)?)
        lateralView*
        (WHERE where=booleanExpression)?

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -338,13 +338,17 @@ querySpecification
        (RECORDREADER recordReader=STRING)?
        fromClause?
        (WHERE where=booleanExpression)?)
-    | ((kind=SELECT setQuantifier? namedExpressionSeq fromClause?
+    | ((kind=SELECT setQuantifier? namedExpressionSeq (intoClause? fromClause)?
        | fromClause (kind=SELECT setQuantifier? namedExpressionSeq)?)
        lateralView*
        (WHERE where=booleanExpression)?
        aggregation?
        (HAVING having=booleanExpression)?
        windows?)
+    ;
+
+intoClause
+    : INTO tableIdentifier
     ;
 
 fromClause

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1757,95 +1757,75 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("select into(check relation)") {
-    val originalConf = sessionState.conf.convertCTAS
-
-    setConf(SQLConf.CONVERT_CTAS, true)
-
-    val defaultDataSource = sessionState.conf.defaultDataSourceName
-    try {
-      sql("DROP TABLE IF EXISTS si1")
-      sql("SELECT key, value INTO si1 FROM src ORDER BY key, value")
-      val message = intercept[AnalysisException] {
+    withSQLConf(SQLConf.CONVERT_CTAS.key -> "true") {
+      withTable("si1", "si2") {
+        val defaultDataSource = sessionState.conf.defaultDataSourceName
         sql("SELECT key, value INTO si1 FROM src ORDER BY key, value")
-      }.getMessage
-      assert(message.contains("already exists"))
-      checkRelation("si1", true, defaultDataSource)
-      sql("DROP TABLE si1")
+        val message = intercept[AnalysisException] {
+          sql("SELECT key, value INTO si1 FROM src ORDER BY key, value")
+        }.getMessage
+        assert(message.contains("already exists"))
+        checkRelation("si1", true, defaultDataSource)
 
-      // Specifying database name for query can be converted to data source write path
-      // is not allowed right now.
-      sql("SELECT key, value INTO default.si1 FROM src ORDER BY key, value")
-      checkRelation("si1", true, defaultDataSource)
-      sql("DROP TABLE si1")
-
-    } finally {
-      setConf(SQLConf.CONVERT_CTAS, originalConf)
-      sql("DROP TABLE IF EXISTS si1")
+        // Specifying database name for query can be converted to data source write path
+        // is not allowed right now.
+        sql("SELECT key, value INTO default.si2 FROM src ORDER BY key, value")
+        checkRelation("si2", true, defaultDataSource)
+      }
     }
   }
 
   test("select into(check answer)") {
-    sql("DROP TABLE IF EXISTS si1")
-    sql("DROP TABLE IF EXISTS si2")
-    sql("DROP TABLE IF EXISTS si3")
+    withTable("si1", "si2", "si3", "si4") {
+      sql("SELECT key, value INTO si1 FROM src")
+      checkAnswer(
+        sql("SELECT key, value FROM si1 ORDER BY key"),
+        sql("SELECT key, value FROM src ORDER BY key").collect().toSeq)
 
-    sql("SELECT key, value INTO si1 FROM src")
-    checkAnswer(
-      sql("SELECT key, value FROM si1 ORDER BY key"),
-      sql("SELECT key, value FROM src ORDER BY key").collect().toSeq)
+      sql("SELECT key k, value INTO si2 FROM src ORDER BY k,value").collect()
+      checkAnswer(
+        sql("SELECT k, value FROM si2 ORDER BY k, value"),
+        sql("SELECT key, value FROM src ORDER BY key, value").collect().toSeq)
 
-    sql("SELECT key k, value INTO si2 FROM src ORDER BY k,value").collect()
-    checkAnswer(
-      sql("SELECT k, value FROM si2 ORDER BY k, value"),
-      sql("SELECT key, value FROM src ORDER BY key, value").collect().toSeq)
+      sql("SELECT 1 AS key,value INTO si3 FROM src LIMIT 1").collect()
+      checkAnswer(
+        sql("SELECT key, value FROM si3 ORDER BY key, value"),
+        sql("SELECT key, value FROM si3 LIMIT 1").collect().toSeq)
 
-    sql("SELECT 1 AS key,value INTO si3 FROM src LIMIT 1").collect()
-    intercept[AnalysisException] {
-      sql("SELECT key, value INTO si3 FROM src ORDER BY key, value").collect()
+      sql("SELECT 1 INTO si4").collect()
+      checkAnswer(
+        sql("SELECT 1 FROM si4"),
+        sql("SELECT 1").collect().toSeq)
     }
-    checkAnswer(
-      sql("SELECT key, value FROM si3 ORDER BY key, value"),
-      sql("SELECT key, value FROM si3 LIMIT 1").collect().toSeq)
-
-    sql("DROP TABLE IF EXISTS si1")
-    sql("DROP TABLE IF EXISTS si2")
-    sql("DROP TABLE IF EXISTS si3")
   }
 
   test("select into(specifying the column list)") {
-    sql("DROP TABLE IF EXISTS mytable1")
-    sql("DROP TABLE IF EXISTS si4")
-    Seq((1, "111111"), (2, "222222")).toDF("key", "value").createOrReplaceTempView("mytable1")
+    withTable("mytable1", "si1") {
+      Seq((1, "111111"), (2, "222222")).toDF("key", "value").createOrReplaceTempView("mytable1")
 
-    sql("SELECT key as a,value as b INTO si4 FROM mytable1")
-    checkAnswer(
-      sql("SELECT a, b from si4"),
-      sql("select key, value from mytable1").collect())
-
-    sql("DROP TABLE IF EXISTS mytable1")
-    sql("DROP TABLE IF EXISTS si4")
+      sql("SELECT key as a,value as b INTO si1 FROM mytable1")
+      checkAnswer(
+        sql("SELECT a, b from si1"),
+        sql("select key, value from mytable1").collect())
+    }
   }
 
   test("select into(double nested data)") {
-    sql("DROP TABLE IF EXISTS nested")
-    sql("DROP TABLE IF EXISTS si5")
+    withTable("nested", "si1") {
+      sparkContext.parallelize(Nested1(Nested2(Nested3(1))) :: Nil)
+        .toDF().createOrReplaceTempView("nested")
+      checkAnswer(
+        sql("SELECT f1.f2.f3 FROM nested"),
+        Row(1))
 
-    sparkContext.parallelize(Nested1(Nested2(Nested3(1))) :: Nil)
-      .toDF().createOrReplaceTempView("nested")
-    checkAnswer(
-      sql("SELECT f1.f2.f3 FROM nested"),
-      Row(1))
+      sql("SELECT * INTO si1 FROM nested")
+      checkAnswer(
+        sql("SELECT * FROM si1"),
+        sql("SELECT * FROM nested").collect().toSeq)
 
-    sql("SELECT * INTO si5 FROM nested")
-    checkAnswer(
-      sql("SELECT * FROM si5"),
-      sql("SELECT * FROM nested").collect().toSeq)
-
-    intercept[AnalysisException] {
-      sql("SELECT * INTO si5 FROM notexists").collect()
+      intercept[AnalysisException] {
+        sql("SELECT * INTO si1 FROM notexists").collect()
+      }
     }
-
-    sql("DROP TABLE IF EXISTS nested")
-    sql("DROP TABLE IF EXISTS si5")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR implements the _SELECT INTO_ statement.

The _SELECT INTO_ statement selects data from one table and inserts it into a new table as follows.

```
SELECT column_name(s)
INTO newtable
FROM table1;
```

This statement is commonly used in SQL but not currently supported in SparkSQL.
We investigated the Catalyst and found that this statement can be implemented by improving the grammar and reusing the logical plan of _CTAS_.

The related JIRA is https://issues.apache.org/jira/browse/SPARK-16217
## How was this patch tested?

SQLQuerySuite.
