### PR TITLE
[SPARK-16509][SPARKR] Rename window.partitionBy and window.orderBy to windowPartitionBy and windowOrderBy.

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -341,5 +341,5 @@ export("partitionBy",
        "rowsBetween",
        "rangeBetween")
 
-export("window.partitionBy",
-       "window.orderBy")
+export("windowPartitionBy",
+       "windowOrderBy")

--- a/R/pkg/R/WindowSpec.R
+++ b/R/pkg/R/WindowSpec.R
@@ -22,10 +22,10 @@ NULL
 
 #' S4 class that represents a WindowSpec
 #'
-#' WindowSpec can be created by using window.partitionBy() or window.orderBy()
+#' WindowSpec can be created by using windowPartitionBy() or windowOrderBy()
 #'
 #' @rdname WindowSpec
-#' @seealso \link{window.partitionBy}, \link{window.orderBy}
+#' @seealso \link{windowPartitionBy}, \link{windowOrderBy}
 #'
 #' @param sws A Java object reference to the backing Scala WindowSpec
 #' @export

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -779,13 +779,13 @@ setGeneric("rowsBetween", function(x, start, end) { standardGeneric("rowsBetween
 #' @export
 setGeneric("rangeBetween", function(x, start, end) { standardGeneric("rangeBetween") })
 
-#' @rdname window.partitionBy
+#' @rdname windowPartitionBy
 #' @export
-setGeneric("window.partitionBy", function(col, ...) { standardGeneric("window.partitionBy") })
+setGeneric("windowPartitionBy", function(col, ...) { standardGeneric("windowPartitionBy") })
 
-#' @rdname window.orderBy
+#' @rdname windowOrderBy
 #' @export
-setGeneric("window.orderBy", function(col, ...) { standardGeneric("window.orderBy") })
+setGeneric("windowOrderBy", function(col, ...) { standardGeneric("windowOrderBy") })
 
 ###################### Expression Function Methods ##########################
 

--- a/R/pkg/R/window.R
+++ b/R/pkg/R/window.R
@@ -17,23 +17,23 @@
 
 # window.R - Utility functions for defining window in DataFrames
 
-#' window.partitionBy
+#' windowPartitionBy
 #'
 #' Creates a WindowSpec with the partitioning defined.
 #'
-#' @rdname window.partitionBy
-#' @name window.partitionBy
+#' @rdname windowPartitionBy
+#' @name windowPartitionBy
 #' @export
 #' @examples
 #' \dontrun{
-#'   ws <- window.partitionBy("key1", "key2")
+#'   ws <- windowPartitionBy("key1", "key2")
 #'   df1 <- select(df, over(lead("value", 1), ws))
 #'
-#'   ws <- window.partitionBy(df$key1, df$key2)
+#'   ws <- windowPartitionBy(df$key1, df$key2)
 #'   df1 <- select(df, over(lead("value", 1), ws))
 #' }
-#' @note window.partitionBy(character) since 2.0.0
-setMethod("window.partitionBy",
+#' @note windowPartitionBy(character) since 2.0.0
+setMethod("windowPartitionBy",
           signature(col = "character"),
           function(col, ...) {
             windowSpec(
@@ -43,11 +43,11 @@ setMethod("window.partitionBy",
                           list(...)))
           })
 
-#' @rdname window.partitionBy
-#' @name window.partitionBy
+#' @rdname windowPartitionBy
+#' @name windowPartitionBy
 #' @export
-#' @note window.partitionBy(Column) since 2.0.0
-setMethod("window.partitionBy",
+#' @note windowPartitionBy(Column) since 2.0.0
+setMethod("windowPartitionBy",
           signature(col = "Column"),
           function(col, ...) {
             jcols <- lapply(list(col, ...), function(c) {
@@ -59,23 +59,23 @@ setMethod("window.partitionBy",
                           jcols))
           })
 
-#' window.orderBy
+#' windowOrderBy
 #'
 #' Creates a WindowSpec with the ordering defined.
 #'
-#' @rdname window.orderBy
-#' @name window.orderBy
+#' @rdname windowOrderBy
+#' @name windowOrderBy
 #' @export
 #' @examples
 #' \dontrun{
-#'   ws <- window.orderBy("key1", "key2")
+#'   ws <- windowOrderBy("key1", "key2")
 #'   df1 <- select(df, over(lead("value", 1), ws))
 #'
-#'   ws <- window.orderBy(df$key1, df$key2)
+#'   ws <- windowOrderBy(df$key1, df$key2)
 #'   df1 <- select(df, over(lead("value", 1), ws))
 #' }
-#' @note window.orderBy(character) since 2.0.0
-setMethod("window.orderBy",
+#' @note windowOrderBy(character) since 2.0.0
+setMethod("windowOrderBy",
           signature(col = "character"),
           function(col, ...) {
             windowSpec(
@@ -85,11 +85,11 @@ setMethod("window.orderBy",
                           list(...)))
           })
 
-#' @rdname window.orderBy
-#' @name window.orderBy
+#' @rdname windowOrderBy
+#' @name windowOrderBy
 #' @export
-#' @note window.orderBy(Column) since 2.0.0
-setMethod("window.orderBy",
+#' @note windowOrderBy(Column) since 2.0.0
+setMethod("windowOrderBy",
           signature(col = "Column"),
           function(col, ...) {
             jcols <- lapply(list(col, ...), function(c) {

--- a/R/pkg/R/window.R
+++ b/R/pkg/R/window.R
@@ -21,6 +21,11 @@
 #'
 #' Creates a WindowSpec with the partitioning defined.
 #'
+#' @param col A column name or Column by which rows are partitioned to 
+#'            windows.
+#' @param ... Optional column names or Columns in addition to col, by 
+#'            which rows are partitioned to windows.
+#'
 #' @rdname windowPartitionBy
 #' @name windowPartitionBy
 #' @export
@@ -62,6 +67,11 @@ setMethod("windowPartitionBy",
 #' windowOrderBy
 #'
 #' Creates a WindowSpec with the ordering defined.
+#'
+#' @param col A column name or Column by which rows are ordered within 
+#'            windows.
+#' @param ... Optional column names or Columns in addition to col, by 
+#'            which rows are ordered within windows.
 #'
 #' @rdname windowOrderBy
 #' @name windowOrderBy

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2376,7 +2376,7 @@ test_that("gapply() and gapplyCollect() on a DataFrame", {
 test_that("Window functions on a DataFrame", {
   df <- createDataFrame(list(list(1L, "1"), list(2L, "2"), list(1L, "1"), list(2L, "2")),
                         schema = c("key", "value"))
-  ws <- orderBy(window.partitionBy("key"), "value")
+  ws <- orderBy(windowPartitionBy("key"), "value")
   result <- collect(select(df, over(lead("key", 1), ws), over(lead("value", 1), ws)))
   names(result) <- c("key", "value")
   expected <- data.frame(key = c(1L, NA, 2L, NA),
@@ -2384,17 +2384,17 @@ test_that("Window functions on a DataFrame", {
                        stringsAsFactors = FALSE)
   expect_equal(result, expected)
 
-  ws <- orderBy(window.partitionBy(df$key), df$value)
+  ws <- orderBy(windowPartitionBy(df$key), df$value)
   result <- collect(select(df, over(lead("key", 1), ws), over(lead("value", 1), ws)))
   names(result) <- c("key", "value")
   expect_equal(result, expected)
 
-  ws <- partitionBy(window.orderBy("value"), "key")
+  ws <- partitionBy(windowOrderBy("value"), "key")
   result <- collect(select(df, over(lead("key", 1), ws), over(lead("value", 1), ws)))
   names(result) <- c("key", "value")
   expect_equal(result, expected)
 
-  ws <- partitionBy(window.orderBy(df$value), df$key)
+  ws <- partitionBy(windowOrderBy(df$value), df$key)
   result <- collect(select(df, over(lead("key", 1), ws), over(lead("value", 1), ws)))
   names(result) <- c("key", "value")
   expect_equal(result, expected)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename window.partitionBy and window.orderBy to windowPartitionBy and windowOrderBy to pass CRAN package check.
## How was this patch tested?

SparkR unit tests.
