### PR TITLE
[SPARK-16547] [CORE] EventLoggingListener to auto create log base dir if it does not exist

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -90,8 +90,14 @@ private[spark] class EventLoggingListener(
    * Creates the log file in the configured log directory.
    */
   def start() {
-    if (!fileSystem.getFileStatus(new Path(logBaseDir)).isDirectory) {
-      throw new IllegalArgumentException(s"Log directory $logBaseDir does not exist.")
+    val logBaseDirPath = new Path(logBaseDir)
+    if (!fileSystem.exists(logBaseDirPath)) {
+      logError(s"Log directory $logBaseDir does not exist. Creating directory")
+      if (!fileSystem.mkdirs(logBaseDirPath)) {
+        throw new IOException(s"Unable to create log directory $logBaseDir")
+      }
+    } else if (!fileSystem.getFileStatus(logBaseDirPath).isDirectory) {
+      throw new IllegalArgumentException(s"Log directory $logBaseDir is not a directory")
     }
 
     val workingPath = logPath + IN_PROGRESS

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -268,6 +268,14 @@ private[spark] object Utils extends Logging {
   }
 
   /**
+   * Generates a temporary location
+   */
+  def generateTempLocation(root: String = System.getProperty("java.io.tmpdir"),
+                           namePrefix: String = "spark"): File = {
+    new File(root, namePrefix + "-" + UUID.randomUUID.toString)
+  }
+
+  /**
    * Create a directory inside the given parent directory. The directory is guaranteed to be
    * newly created, and is not marked for automatic deletion.
    */
@@ -282,7 +290,7 @@ private[spark] object Utils extends Logging {
           maxAttempts + " attempts!")
       }
       try {
-        dir = new File(root, namePrefix + "-" + UUID.randomUUID.toString)
+        dir = generateTempLocation(root, namePrefix)
         if (dir.exists() || !dir.mkdirs()) {
           dir = null
         }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -50,7 +50,11 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
   private var testDirPath: Path = _
 
   before {
-    testDir = Utils.createTempDir()
+    testDir = Utils.generateTempLocation()
+    if (testDir.exists()) {
+      testDir.delete()
+    }
+
     testDir.deleteOnExit()
     testDirPath = new Path(testDir.getAbsolutePath())
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the HDFS namenode gets changed or replaced, one has to manually create the `spark.eventLog.dir` dir. This PR would change Spark to auto-create that directory if its not present thus saving one manual step.
## How was this patch tested?

Changed the unit tests to not have the `spark.eventLog.dir` created as a pre-step. I have ensured that the modified version of tests fail without the fix.
