### PR TITLE
[SPARK-16558][Examples][MLlib] examples/mllib/LDAExample should use MLVector instead of MLlib Vector

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LDAExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LDAExample.scala
@@ -26,8 +26,7 @@ import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.feature.{CountVectorizer, CountVectorizerModel, RegexTokenizer, StopWordsRemover}
 import org.apache.spark.ml.linalg.{Vector => MLVector}
 import org.apache.spark.mllib.clustering.{DistributedLDAModel, EMLDAOptimizer, LDA, OnlineLDAOptimizer}
-import org.apache.spark.mllib.linalg.Vector
-import org.apache.spark.mllib.linalg.VectorImplicits
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
 
@@ -227,7 +226,7 @@ object LDAExample {
     val documents = model.transform(df)
       .select("features")
       .rdd
-      .map { case Row(features: MLVector) => VectorImplicits.mlVectorToMLlibVector(features) }
+      .map { case Row(features: MLVector) => Vectors.fromML(features) }
       .zipWithIndex()
       .map(_.swap)
 

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LDAExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LDAExample.scala
@@ -24,8 +24,10 @@ import scopt.OptionParser
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.feature.{CountVectorizer, CountVectorizerModel, RegexTokenizer, StopWordsRemover}
+import org.apache.spark.ml.linalg.{Vector => MLVector}
 import org.apache.spark.mllib.clustering.{DistributedLDAModel, EMLDAOptimizer, LDA, OnlineLDAOptimizer}
 import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.linalg.VectorImplicits
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
 
@@ -225,7 +227,7 @@ object LDAExample {
     val documents = model.transform(df)
       .select("features")
       .rdd
-      .map { case Row(features: Vector) => features }
+      .map { case Row(features: MLVector) => VectorImplicits.mlVectorToMLlibVector(features) }
       .zipWithIndex()
       .map(_.swap)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

mllib.LDAExample uses ML pipeline and MLlib LDA algorithm. The former transforms original data into MLVector format, while the latter uses MLlibVector format.
## How was this patch tested?

Test manually.
