### PR TITLE
[SPARK-16545][SQL] Eliminate unnecessary rounds of physical planning in ForeachSink

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
@@ -21,6 +21,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Encoder, ForeachWriter}
 import org.apache.spark.sql.catalyst.plans.logical.CatalystSerde
+import org.apache.spark.sql.execution.SQLExecution
 
 /**
  * A [[Sink]] that forwards all data into [[ForeachWriter]] according to the contract defined by
@@ -47,15 +48,22 @@ class ForeachSink[T : Encoder](writer: ForeachWriter[T]) extends Sink with Seria
     // method supporting incremental planning. But in the long run, we should generally make newly
     // created Datasets use `IncrementalExecution` where necessary (which is SPARK-16264 tries to
     // resolve).
+    //
+    // Another thing worthy noting is, by introducing this `incrementalExecution`, we've also
+    // introduced one extra round of physical planning; refer to SPARK-16545 for details. Again,
+    // let's revisit this when SPARK-16264 is resolved.
 
     val datasetWithIncrementalExecution =
       new Dataset(data.sparkSession, data.logicalPlan, implicitly[Encoder[T]]) {
+
+        private var incrementalExecution: IncrementalExecution = _
+
         override lazy val rdd: RDD[T] = {
           val objectType = exprEnc.deserializer.dataType
           val deserialized = CatalystSerde.deserialize[T](logicalPlan)
 
           // was originally: sparkSession.sessionState.executePlan(deserialized) ...
-          val incrementalExecution = new IncrementalExecution(
+          incrementalExecution = new IncrementalExecution(
             this.sparkSession,
             deserialized,
             data.queryExecution.asInstanceOf[IncrementalExecution].outputMode,
@@ -65,7 +73,27 @@ class ForeachSink[T : Encoder](writer: ForeachWriter[T]) extends Sink with Seria
             rows.map(_.get(0, objectType))
           }.asInstanceOf[RDD[T]]
         }
+
+        /**
+         * This function's original implementation was:
+         * ```
+         *   def foreachPartition(f: Iterator[T] => Unit): Unit = withNewExecutionId {
+         *    rdd.foreachPartition(f)
+         *  }
+         * ```
+         *
+         * Below we overwrite it and provide `withNewExecutionId` with `this.incrementExecution`
+         * rather than with `this.queryExecution`; doing this would save one round of unnecessary
+         * physical planning. Refer to SPARK-16545 for details.
+         */
+        override def foreachPartition(f: Iterator[T] => Unit): Unit = {
+          rdd // call rdd first to set incrementalExecution properly
+          SQLExecution.withNewExecutionId(this.sparkSession, this.incrementalExecution) {
+            rdd.foreachPartition(f)
+          }
+        }
       }
+
     datasetWithIncrementalExecution.foreachPartition { iter =>
       if (writer.open(TaskContext.getPartitionId(), batchId)) {
         var isFailed = false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -366,9 +366,14 @@ class StreamExecution(
       checkpointFile("state"),
       currentBatchId)
 
-    lastExecution.executedPlan
-    val optimizerTime = (System.nanoTime() - optimizerStart).toDouble / 1000000
-    logDebug(s"Optimized batch in ${optimizerTime}ms")
+    // This if condition is to eliminate unnecessary physical planning for `ForeachSink`; refer to
+    // SPARK-16545 for details.
+    // TODO: remove this if condition after the full resolution of incremental execution
+    if (!sink.isInstanceOf[ForeachSink[_]]) {
+      lastExecution.executedPlan
+      val optimizerTime = (System.nanoTime() - optimizerStart).toDouble / 1000000
+      logDebug(s"Optimized batch in ${optimizerTime}ms")
+    }
 
     val nextBatch =
       new Dataset(sparkSession, lastExecution, RowEncoder(lastExecution.analyzed.schema))


### PR DESCRIPTION
## Problem

As reported by [SPARK-16545](https://issues.apache.org/jira/browse/SPARK-16545), in `ForeachSink` we have initialized 3 rounds of physical planning.

More specific:

[1] In `StreamExecution`, [lastExecution.executedPlan](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala#L369)

[2] In `ForeachSink`, [forearchPartition() calls withNewExecutionId(..., **_queryExection_**)](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala#L2145), which further calls [**_queryExecution_**.executedPlan](https://github.com/apache/spark/blob/9a5071996b968148f6b9aba12e0d3fe888d9acd8/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala#L55)

[3] In `ForeachSink`, [val rdd = { ... incrementalExecution = new IncrementalExecution ...}](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala#L53)
## What changes were proposed in this pull request?

[1] ~~should not be eliminated in general;~~ is eliminated for case `ForeachSink`;

**[2] is eliminated, by replacing the `queryExecution` with `incrementalExecution` provided by [3];**

[3] should be eliminated but can not be done at this stage; let's revisit it when SPARK-16264 is resolved.
## How was this patch tested?
- checked manually now there ~~are only 2 rounds~~ is only 1 round of physical planning in ForeachSink after this patch
- existing tests ensure it cause no regression
