### PR TITLE
[SPARK-16562][SQL] Do not allow downcast in INT32 based types for normal Parquet reader

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.parquet.column.Dictionary
 import org.apache.parquet.io.api.{Binary, Converter, GroupConverter, PrimitiveConverter}
 import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType, Type}
-import org.apache.parquet.schema.OriginalType.{INT_32, LIST, UTF8}
+import org.apache.parquet.schema.OriginalType.{INT_16, INT_32, INT_8, LIST, UTF8}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.{BINARY, DOUBLE, FIXED_LEN_BYTE_ARRAY, INT32, INT64}
 
 import org.apache.spark.internal.Logging
@@ -215,13 +215,13 @@ private[parquet] class ParquetRowConverter(
       case BooleanType | IntegerType | LongType | FloatType | DoubleType | BinaryType =>
         new ParquetPrimitiveConverter(updater)
 
-      case ByteType =>
+      case ByteType if parquetType.asPrimitiveType.getOriginalType == INT_8 =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit =
             updater.setByte(value.asInstanceOf[ByteType#InternalType])
         }
 
-      case ShortType =>
+      case ShortType if parquetType.asPrimitiveType.getOriginalType == INT_16 =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit =
             updater.setShort(value.asInstanceOf[ShortType#InternalType])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -169,6 +169,19 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSQLContext {
     }
   }
 
+  test("SPARK-16562 Do not allow downcast in INT32 based types for normal Parquet reader") {
+    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+      withTempPath { file =>
+        (1 to 4).map(Tuple1(_)).toDF("a").write.parquet(file.getAbsolutePath)
+        val schema = StructType(StructField("a", ShortType, true) :: Nil)
+        val errorMessage = intercept[SparkException] {
+          spark.read.schema(schema).parquet(file.getAbsolutePath).collect()
+        }.toString
+        assert(errorMessage.contains("Unable to create Parquet converter for data type"))
+      }
+    }
+  }
+
   testStandardAndLegacyModes("map") {
     val data = (1 to 4).map(i => Tuple1(Map(i -> s"val_$i")))
     checkParquetFile(data)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -172,7 +172,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSQLContext {
   test("SPARK-16562 Do not allow downcast in INT32 based types for normal Parquet reader") {
     withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
       withTempPath { file =>
-        (1 to 4).map(Tuple1(_)).toDF("a").write.parquet(file.getAbsolutePath)
+        (1 to 4).toDF("a").write.parquet(file.getAbsolutePath)
         val schema = StructType(StructField("a", ShortType, true) :: Nil)
         val errorMessage = intercept[SparkException] {
           spark.read.schema(schema).parquet(file.getAbsolutePath).collect()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, INT32 based types, (`ShortType`, `ByteType`, `IntegerType`) can be downcasted in any combination. For example, the codes below:

``` scala
val path = "/tmp/test.parquet"
val data = (1 to 4).map(Tuple1(_.toInt))
data.toDF("a").write.parquet(path)
val schema = StructType(StructField("a", ShortType, true) :: Nil)
spark.read.schema(schema).parquet(path).show()
```

works fine. This should not be allowed.

This only happens when vectorized reader is disabled.
## How was this patch tested?

Unit test in `ParquetIOSuite`.
