### PR TITLE
[SPARK-16566][MLLib] sort sparseVector's indices before doing multiplication

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -618,26 +618,25 @@ private[spark] object BLAS extends Serializable with Logging {
       beta: Double,
       y: DenseVector): Unit = {
     
-    def isSorted(l:Array[Int]): Boolean = {
+    def isSorted(array: Array[Int]): Boolean = {
       var index = 1
-      while(index < l.length){
-        val prevElement = l(index - 1)
-        val currentElement = l(index)
-        
-        if(prevElement > currentElement) return false
+      while (index < array.length) {
+        if (array(index - 1) > array(index)) {
+          return false
+        }
         index += 1
       }
-      return true
+      true
     }
     
-    val (xValues,xIndices) = isSorted(x.indices) match{
-      case false => {
-        val xValuesAndIndices = (x.values zip x.indices).sortBy(_._2)
-        (xValuesAndIndices.map(l => l._1), xValuesAndIndices.map(l => l._2))
+    val (xValues, xIndices) =
+      if (isSorted(x.indices)) {
+        (x.values, x.indices)
+      } else {
+        val (xValues,xIndices) = x.values.zip(x.indices).sortBy(_._2).unzip
+        (xValues.toArray, xIndices.toArray)
       }
-      case _     => (x.values, x.indices)
-    }
-    
+        
     val xNnz = xIndices.length
 
     val yValues = y.values

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -618,7 +618,17 @@ private[spark] object BLAS extends Serializable with Logging {
       beta: Double,
       y: DenseVector): Unit = {
     
-    def isSorted(l:Iterable[Int]) = l.isEmpty || l.view.zip(l.tail).forall(x => x._1 <= x._2)
+    def isSorted(l:Array[Int]): Boolean = {
+      var index = 1
+      while(index < l.length){
+        val prevElement = l(index - 1)
+        val currentElement = l(index)
+        
+        if(prevElement > currentElement) return false
+        index += 1
+      }
+      return true
+    }
     
     val xValuesAndIndices = isSorted(x.indices) match{
       case false => (x.values zip x.indices).sortBy(_._2)

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -617,7 +617,14 @@ private[spark] object BLAS extends Serializable with Logging {
       x: SparseVector,
       beta: Double,
       y: DenseVector): Unit = {
-    val xValuesAndIndices = (x.values zip x.indices).sortBy(_._2)
+    
+    def isSorted(l:Iterable[Int]) = l.isEmpty || l.view.zip(l.tail).forall(x => x._1 <= x._2)
+    
+    val xValuesAndIndices = isSorted(x.indices) match{
+      case false => (x.values zip x.indices).sortBy(_._2)
+      case _     => (x.values zip x.indices)
+    }
+    
     val xValues = xValuesAndIndices.map(l => l._1)
     val xIndices = xValuesAndIndices.map(l => l._2)
     val xNnz = xIndices.length

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -617,8 +617,9 @@ private[spark] object BLAS extends Serializable with Logging {
       x: SparseVector,
       beta: Double,
       y: DenseVector): Unit = {
-    val xValues = x.values
-    val xIndices = x.indices
+    val xValuesAndIndices = (x.values zip x.indices).sortBy(_._2)
+    val xValues = xValuesAndIndices.map(l => l._1)
+    val xIndices = xValuesAndIndices.map(l => l._2)
     val xNnz = xIndices.length
 
     val yValues = y.values

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -32,7 +32,7 @@ private[spark] object BLAS extends Serializable with Logging {
 
   /**
    * check whether the array is sorted, 
-   * mainly used for checking sparseVector's indices
+   * mainly used for checking SparseVector's indices
    */
   private def isSorted(array: Array[Int]): Boolean = {
     var index = 1

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -151,8 +151,8 @@ private[spark] object BLAS extends Serializable with Logging {
    */
   private def dot(x: SparseVector, y: SparseVector): Double = {
     
-    val (xIndices, xValues) = x.getSortedIndicesAndValues()
-    val (yIndices, yValues) = y.getSortedIndicesAndValues()
+    val (xIndices, xValues) = (x.sortedIndicesAndValues._1, x.sortedIndicesAndValues._2)
+    val (yIndices, yValues) = (y.sortedIndicesAndValues._1, y.sortedIndicesAndValues._2)
     val nnzx = xIndices.length
     val nnzy = yIndices.length
 
@@ -617,7 +617,7 @@ private[spark] object BLAS extends Serializable with Logging {
       beta: Double,
       y: DenseVector): Unit = {
    
-    val (xIndices, xValues) = x.getSortedIndicesAndValues()
+    val (xIndices, xValues) = (x.sortedIndicesAndValues._1, x.sortedIndicesAndValues._2)
     val xNnz = xIndices.length
 
     val yValues = y.values

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -630,13 +630,14 @@ private[spark] object BLAS extends Serializable with Logging {
       return true
     }
     
-    val xValuesAndIndices = isSorted(x.indices) match{
-      case false => (x.values zip x.indices).sortBy(_._2)
-      case _     => (x.values zip x.indices)
+    val (xValues,xIndices) = isSorted(x.indices) match{
+      case false => {
+        val xValuesAndIndices = (x.values zip x.indices).sortBy(_._2)
+        (xValuesAndIndices.map(l => l._1), xValuesAndIndices.map(l => l._2))
+      }
+      case _     => (x.values, x.indices)
     }
     
-    val xValues = xValuesAndIndices.map(l => l._1)
-    val xIndices = xValuesAndIndices.map(l => l._2)
     val xNnz = xIndices.length
 
     val yValues = y.values

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -750,6 +750,27 @@ class SparseVector @Since("1.0.0") (
   require(indices.length <= size, s"You provided ${indices.length} indices and values, " +
     s"which exceeds the specified vector size ${size}.")
 
+  lazy val sortedIndicesAndValues: (Array[Int], Array[Double]) = {
+    def isSorted(array: Array[Int]): Boolean = {
+      var index = 1
+      while (index < array.length) {
+        if (array(index - 1) > array(index)) {
+          return false
+        }
+        index += 1
+      }
+      true
+    }
+    
+    if (isSorted(this.indices)) {
+        (this.indices, this.values)
+      } else {
+        val (indices, values) = this.indices.zip(this.values).sortBy(_._1).unzip
+        println("gg")
+        (indices.toArray, values.toArray)
+      }
+  }
+    
   override def toString: String =
     s"($size,${indices.mkString("[", ",", "]")},${values.mkString("[", ",", "]")})"
 
@@ -886,26 +907,6 @@ class SparseVector @Since("1.0.0") (
     }
   }
 
-  def getSortedIndicesAndValues(): (Array[Int], Array[Double]) = {
-    def isSorted(array: Array[Int]): Boolean = {
-      var index = 1
-      while (index < array.length) {
-        if (array(index - 1) > array(index)) {
-          return false
-        }
-        index += 1
-      }
-      true
-    }
-    
-    if (isSorted(this.indices)) {
-        (this.indices, this.values)
-      } else {
-        val (indices, values) = this.indices.zip(this.values).sortBy(_._1).unzip
-        (indices.toArray, values.toArray)
-      }
-  }
-  
   /**
    * Create a slice of this vector based on the given indices.
    * @param selectedIndices Unsorted list of indices into the vector.

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -766,7 +766,6 @@ class SparseVector @Since("1.0.0") (
         (this.indices, this.values)
       } else {
         val (indices, values) = this.indices.zip(this.values).sortBy(_._1).unzip
-        println("gg")
         (indices.toArray, values.toArray)
       }
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -886,6 +886,26 @@ class SparseVector @Since("1.0.0") (
     }
   }
 
+  def getSortedIndicesAndValues(): (Array[Int], Array[Double]) = {
+    def isSorted(array: Array[Int]): Boolean = {
+      var index = 1
+      while (index < array.length) {
+        if (array(index - 1) > array(index)) {
+          return false
+        }
+        index += 1
+      }
+      true
+    }
+    
+    if (isSorted(this.indices)) {
+        (this.indices, this.values)
+      } else {
+        val (indices, values) = this.indices.zip(this.values).sortBy(_._1).unzip
+        (indices.toArray, values.toArray)
+      }
+  }
+  
   /**
    * Create a slice of this vector based on the given indices.
    * @param selectedIndices Unsorted list of indices into the vector.


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-16566

sort sparseVector's indices before doing multiplication to make sure the result returned correctly
## How was this patch tested?

manual and existing tests
