### PR TITLE
[SPARK-10614][CORE] Change SystemClock to derive time from System.nanoTime() instead of System.currentTimeMillis()

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Clock.scala
+++ b/core/src/main/scala/org/apache/spark/util/Clock.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util
 
+import java.util.concurrent.TimeUnit
+
 /**
  * An interface to represent clocks, so that they can be mocked out in unit tests.
  */
@@ -26,6 +28,7 @@ private[spark] trait Clock {
 
   /**
    * Wait until a clock's view of current time reaches the specified target time.
+   *
    * @param targetTime block until the current time is at least this value
    * @return clock's view of current time when the wait has completed
    */
@@ -42,8 +45,7 @@ private[spark] class SystemClock extends Clock {
   /**
    * @return the same time in milliseconds as is derived from `System.nanoTime()`
    */
-  def getTimeMillis(): Long = System.nanoTime() / (1000 * 1000)
-
+  def getTimeMillis(): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
 
   /**
    * @param targetTime block until the current time is at least this value


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change SystemClock to derive time from System.nanoTime() instead of System.currentTimeMillis(). This is because using System.currentTimeMillis() makes waitTillTime() routine brittle against systems like VMs where time can go forward and backwards.

Shout out to @steveloughran for doing a good chunk of research and a previous PR (#8766) on this in 2015.
## How was this patch tested?

Build is green, I am running unit tests, they are looking green, but are also taking a while. So, filing this PR a little proactively.
