### PR TITLE
[SPARK-16583] [SQL] [WIP] Improve Partition Pruning in InMemoryTableScanExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.CollectionAccumulator
 
@@ -91,6 +92,9 @@ private[sql] case class InMemoryRelation(
       Statistics(sizeInBytes = sizeInBytes)
     }
   }
+
+  require(batchSize >= 1,
+    s"The minimal number of ${SQLConf.COLUMN_BATCH_SIZE.key} is 1, but got $batchSize")
 
   // If the cached column buffers were not passed in, we calculate them in the constructor.
   // As in Spark, the actual work of caching is lazy.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -161,7 +161,7 @@ private[sql] case class InMemoryTableScanExec(
                   val value = cachedBatch.stats.get(i, a.dataType)
                   s"${a.name}: $value"
               }.mkString(", ")
-              println(s"Skipping partition based on stats $statsString")
+              logInfo(s"Skipping partition based on stats $statsString")
               false
             } else {
               true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -64,18 +64,31 @@ private[sql] case class InMemoryTableScanExec(
       statsFor(a).lowerBound <= l && l <= statsFor(a).upperBound
     case EqualTo(l: Literal, a: AttributeReference) =>
       statsFor(a).lowerBound <= l && l <= statsFor(a).upperBound
+    case EqualTo(a: AttributeReference, b: AttributeReference) =>
+      statsFor(a).lowerBound <= statsFor(b).upperBound &&
+        statsFor(a).upperBound >= statsFor(b).lowerBound
 
-    case LessThan(a: AttributeReference, l: Literal) => statsFor(a).lowerBound < l
-    case LessThan(l: Literal, a: AttributeReference) => l < statsFor(a).upperBound
+    case LessThan(a: AttributeReference, l: Literal) =>
+      statsFor(a).lowerBound < l
+    case LessThan(l: Literal, a: AttributeReference) =>
+      l < statsFor(a).upperBound
+    case LessThan(a: AttributeReference, b: AttributeReference) =>
+      statsFor(a).lowerBound < statsFor(b).upperBound
 
     case LessThanOrEqual(a: AttributeReference, l: Literal) => statsFor(a).lowerBound <= l
     case LessThanOrEqual(l: Literal, a: AttributeReference) => l <= statsFor(a).upperBound
+    case LessThanOrEqual(a: AttributeReference, b: AttributeReference) =>
+      statsFor(a).lowerBound <= statsFor(b).upperBound
 
     case GreaterThan(a: AttributeReference, l: Literal) => l < statsFor(a).upperBound
     case GreaterThan(l: Literal, a: AttributeReference) => statsFor(a).lowerBound < l
+    case GreaterThan(a: AttributeReference, b: AttributeReference) =>
+      statsFor(a).upperBound > statsFor(b).lowerBound
 
     case GreaterThanOrEqual(a: AttributeReference, l: Literal) => l <= statsFor(a).upperBound
     case GreaterThanOrEqual(l: Literal, a: AttributeReference) => statsFor(a).lowerBound <= l
+    case GreaterThanOrEqual(a: AttributeReference, b: AttributeReference) =>
+      statsFor(a).upperBound >= statsFor(b).lowerBound
 
     case IsNull(a: Attribute) => statsFor(a).nullCount > 0
     case IsNotNull(a: Attribute) => statsFor(a).count - statsFor(a).nullCount > 0
@@ -148,7 +161,7 @@ private[sql] case class InMemoryTableScanExec(
                   val value = cachedBatch.stats.get(i, a.dataType)
                   s"${a.name}: $value"
               }.mkString(", ")
-              logInfo(s"Skipping partition based on stats $statsString")
+              println(s"Skipping partition based on stats $statsString")
               false
             } else {
               true

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -79,8 +79,8 @@ object SQLConf {
 
   val COLUMN_BATCH_SIZE = SQLConfigBuilder("spark.sql.inMemoryColumnarStorage.batchSize")
     .internal()
-    .doc("Controls the size of batches for columnar caching.  Larger batch sizes can improve " +
-      "memory utilization and compression, but risk OOMs when caching data.")
+    .doc("Controls the maximal number of rows per batches for columnar caching.  Larger batch " +
+      "sizes can improve memory utilization and compression, but risk OOMs when caching data.")
     .intConf
     .createWithDefault(10000)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
@@ -155,9 +155,16 @@ class PartitionBatchPruningSuite
     }
   }
 
-  test("illegal COLUMN_BATCH_SIZE") {
+  test("illegal values of COLUMN_BATCH_SIZE") {
     withSQLConf(SQLConf.COLUMN_BATCH_SIZE.key -> "0") {
-      sql("SELECT key FROM pruningData WHERE").show()
+      withTempTable("test") {
+        spark.sql("select key from pruningData").createOrReplaceTempView("test")
+        val e = intercept[IllegalArgumentException] {
+          spark.catalog.cacheTable("test")
+        }.getMessage
+        assert(e.contains(
+          "The minimal number of spark.sql.inMemoryColumnarStorage.batchSize is 1, but got 0"))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
@@ -142,17 +142,23 @@ class PartitionBatchPruningSuite
 
   // With disable IN_MEMORY_PARTITION_PRUNING option
   test("disable IN_MEMORY_PARTITION_PRUNING") {
-    spark.conf.set(SQLConf.IN_MEMORY_PARTITION_PRUNING.key, false)
+    withSQLConf(SQLConf.IN_MEMORY_PARTITION_PRUNING.key -> "false") {
+      val df = sql("SELECT key FROM pruningData WHERE key = 1")
+      val result = df.collect().map(_ (0)).toArray
+      assert(result.length === 1)
 
-    val df = sql("SELECT key FROM pruningData WHERE key = 1")
-    val result = df.collect().map(_(0)).toArray
-    assert(result.length === 1)
-
-    val (readPartitions, readBatches) = df.queryExecution.sparkPlan.collect {
+      val (readPartitions, readBatches) = df.queryExecution.sparkPlan.collect {
         case in: InMemoryTableScanExec => (in.readPartitions.value, in.readBatches.value)
       }.head
-    assert(readPartitions === 5)
-    assert(readBatches === 10)
+      assert(readPartitions === 5)
+      assert(readBatches === 10)
+    }
+  }
+
+  test("illegal COLUMN_BATCH_SIZE") {
+    withSQLConf(SQLConf.COLUMN_BATCH_SIZE.key -> "0") {
+      sql("SELECT key FROM pruningData WHERE").show()
+    }
   }
 
   def checkBatchPruning(


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Currently, column pruning in `InMemoryTableScanExec` only can utilize the predicates whose either left or right side is foldable expressions. We can further extend the existing framework to utilize the predicates in which both sides are attribute references. Through their maximal and minimal boundary values, we can prune the unnecessary partitions. The performance improvement depends on the data distribution and predicates. 

TODO: more examples here.
#### How was this patch tested?

TODO: added more test cases
