### PR TITLE
[SPARK-16587] [CORE] The annotation for the abstract Class 'BlockTransferMessage' missing several kind of messages.

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
@@ -35,6 +35,9 @@ import org.apache.spark.network.shuffle.protocol.mesos.ShuffleServiceHeartbeat;
  *     shuffle service. It returns a StreamHandle.
  *   - UploadBlock is only handled by the NettyBlockTransferService.
  *   - RegisterExecutor is only handled by the external shuffle service.
+ *   - StreamHandle is only handled by the OneForOneBlockFetcher.
+ *   - RegisterDriver is only handled by the MesosExternalShuffleService.
+ *   - HearBeat is only handled by the MesosExternalShuffleService.
  */
 public abstract class BlockTransferMessage implements Encodable {
   protected abstract Type type();


### PR DESCRIPTION
 **# What changes were proposed in this pull request?**
Currently, the Messages used by shuffle: OpenBlock, UploadBlock, RegisterExecutor has a simple introduction for the usage, while the other three (StreamHandle, RegisterDriver, HearBeat) haven' t. 
This PR added them.

**# How was this patch tested?**

Please let some commiters to review the added annotation to judge them.
