### PR TITLE
[SPARK-16588][SQL] Missed API fix for a function name mismatched between FunctionRegistry and functions.scala

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -37,7 +37,7 @@ import org.apache.spark.mllib.linalg.MatrixImplicits._
 import org.apache.spark.mllib.linalg.VectorImplicits._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
-import org.apache.spark.sql.functions.{col, monotonicallyIncreasingId, udf}
+import org.apache.spark.sql.functions.{col, monotonically_increasing_id, udf}
 import org.apache.spark.sql.types.StructType
 
 
@@ -888,7 +888,7 @@ object LDA extends DefaultParamsReadable[LDA] {
        dataset: Dataset[_],
        featuresCol: String): RDD[(Long, OldVector)] = {
     dataset
-      .withColumn("docId", monotonicallyIncreasingId())
+      .withColumn("docId", monotonically_increasing_id())
       .select("docId", featuresCol)
       .rdd
       .map { case Row(docId: Long, features: Vector) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -977,7 +977,10 @@ object functions {
    *
    * @group normal_funcs
    * @since 1.4.0
+   * @deprecated As of 2.0.0, replaced by `monotonically_increasing_id`. This will be removed in
+   *            Spark 2.1.
    */
+  @deprecated("Use monotonically_increasing_id. This will be removed in Spark 2.1.", "2.0.0")
   def monotonicallyIncreasingId(): Column = monotonically_increasing_id()
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

It seems the function `monotonicallyIncreasingId` was missed in https://issues.apache.org/jira/browse/SPARK-10621 

The registered name is [monotonically_increasing_id](https://github.com/apache/spark/blob/56bd399a86c4e92be412d151200cb5e4a5f6a48a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala#L369) but [monotonicallyIncreasingId](https://github.com/apache/spark/blob/5f342049cce9102fb62b4de2d8d8fa691c2e8ac4/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L981) was still not deprecated and removed. 

So, this was also missed in https://issues.apache.org/jira/browse/SPARK-12600 (removing deprecated APIs).
## How was this patch tested?

N/A
