### PR TITLE
[SPARK-16594] [SQL] Remove Physical Plan Differences when Table Scan Having Duplicate Columns

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -362,7 +362,6 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
     }
 
     if (projects.map(_.toAttribute) == projects &&
-        projectSet.size == projects.size &&
         filterSet.subsetOf(projectSet)) {
       // When it is possible to just use column pruning to get the right projection and
       // when the columns of this projection are enough to evaluate all filter conditions,


### PR DESCRIPTION
#### What changes were proposed in this pull request?

Currently, we keep two implementations for planning scans over data sources. There is one difference between two implementation when deciding whether a `Project` is needed or not. 
- Data Source Table Scan: https://github.com/apache/spark/blob/b1e5281c5cb429e338c3719c13c0b93078d7312a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala#L322-L395
  - `SELECT b, b FROM oneToTenPruned`: **_Add `ProjectExec`._**
- Hive Table Scan and In-memory Table Scan:
  https://github.com/apache/spark/blob/865ec32dd997e63aea01a871d1c7b4947f43c111/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala#L71-L99 
  - `SELECT b, b FROM oneToTenPruned`: **_No `ProjectExec` is added._** 

**Note.** When alias is being used, we will always add `ProjectExec` in all the scan types.
- `SELECT b as alias_b, b FROM oneToTenPruned`: **_Add `ProjectExec`._**

Because selecting the same column twice without adding `alias` is very weird, no clue why the code needs to behave differently here. This PR is to remove the differences. 
#### How was this patch tested?

Updated/added a test case
