### PR TITLE
[SPARK-16589][PYTHON] Chained cartesian produces incorrect number of records

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -684,10 +684,19 @@ class RDD(object):
         >>> sorted(rdd.cartesian(rdd).collect())
         [(1, 1), (1, 2), (2, 1), (2, 2)]
         """
+        def reserialize_if_cartesian(rdd):
+            if isinstance(rdd._jrdd_deserializer, CartesianDeserializer):
+                return rdd._reserialize(self.ctx.serializer)
+            else:
+                return rdd
+
+        this = reserialize_if_cartesian(self)
+        other = reserialize_if_cartesian(other)
+
         # Due to batching, we can't use the Java cartesian method.
-        deserializer = CartesianDeserializer(self._jrdd_deserializer,
+        deserializer = CartesianDeserializer(this._jrdd_deserializer,
                                              other._jrdd_deserializer)
-        return RDD(self._jrdd.cartesian(other._jrdd), self.ctx, deserializer)
+        return RDD(this._jrdd.cartesian(other._jrdd), self.ctx, deserializer)
 
     def groupBy(self, f, numPartitions=None, partitionFunc=portable_hash):
         """

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1036,6 +1036,12 @@ class RDDTests(ReusedPySparkTestCase):
         self.assertRaises(Py4JJavaError, rdd.pipe('grep 4', checkCode=True).collect)
         self.assertEqual([], rdd.pipe('grep 4').collect())
 
+    def test_cartesian_chaining(self):
+        # Tests for SPARK-16589
+        rdd = self.sc.parallelize(range(10), 2)
+        self.assertEqual(rdd.cartesian(rdd).cartesian(rdd).count(), 1000)
+        self.assertEqual(rdd.cartesian(rdd.cartesian(rdd)).count(), 1000)
+
 
 class ProfilerTests(PySparkTestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1039,8 +1039,15 @@ class RDDTests(ReusedPySparkTestCase):
     def test_cartesian_chaining(self):
         # Tests for SPARK-16589
         rdd = self.sc.parallelize(range(10), 2)
-        self.assertEqual(rdd.cartesian(rdd).cartesian(rdd).count(), 1000)
-        self.assertEqual(rdd.cartesian(rdd.cartesian(rdd)).count(), 1000)
+        self.assertSetEqual(
+            set(rdd.cartesian(rdd).cartesian(rdd).collect()),
+            set([((x, y), z) for x in range(10) for y in range(10) for z in range(10)])
+        )
+
+        self.assertSetEqual(
+            set(rdd.cartesian(rdd.cartesian(rdd)).collect()),
+            set([(x, (y, z)) for x in range(10) for y in range(10) for z in range(10)])
+        )
 
 
 class ProfilerTests(PySparkTestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

If either self or other is serialized using `CartesianSerializer` it is reserialized with default serializer before executing `_jrdd.cartesian`.
## How was this patch tested?

Using existing unit tests as well as additional test case to address  SPARK-16589.
