### PR TITLE
[SPARK-16619] Add shuffle service metrics entry in monitoring docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -350,6 +350,7 @@ set of sinks to which metrics are reported. The following instances are currentl
 * `worker`: A Spark standalone worker process.
 * `executor`: A Spark executor.
 * `driver`: The Spark driver process (the process in which your SparkContext is created).
+* `shuffleService`: The Spark shuffle service
 
 Each instance can report to zero or more _sinks_. Sinks are contained in the
 `org.apache.spark.metrics.sink` package:


### PR DESCRIPTION
## What changes were proposed in this pull request?

After change [SPARK-16405](https://github.com/apache/spark/pull/14080), we need to update docs by adding shuffle service metrics entry in currently supporting metrics list.
## How was this patch tested?

existing test

JIRA link: https://issues.apache.org/jira/browse/SPARK-16619
