### PR TITLE
[Spark-16579][SparkR] add install.spark function

### DIFF
--- a/R/check-cran.sh
+++ b/R/check-cran.sh
@@ -47,6 +47,6 @@ $FWDIR/create-docs.sh
 
 VERSION=`grep Version $FWDIR/pkg/DESCRIPTION | awk '{print $NF}'`
 
-"$R_SCRIPT_PATH/"R CMD check --as-cran --no-tests SparkR_"$VERSION".tar.gz 
+"$R_SCRIPT_PATH/"R CMD check --as-cran SparkR_"$VERSION".tar.gz
 
 popd > /dev/null

--- a/R/check-cran.sh
+++ b/R/check-cran.sh
@@ -47,6 +47,6 @@ $FWDIR/create-docs.sh
 
 VERSION=`grep Version $FWDIR/pkg/DESCRIPTION | awk '{print $NF}'`
 
-"$R_SCRIPT_PATH/"R CMD check --as-cran --no-tests SparkR_"$VERSION".tar.gz 
+"$R_SCRIPT_PATH/"R CMD check --as-cran SparkR_"$VERSION".tar.gz 
 
 popd > /dev/null

--- a/R/check-cran.sh
+++ b/R/check-cran.sh
@@ -47,6 +47,6 @@ $FWDIR/create-docs.sh
 
 VERSION=`grep Version $FWDIR/pkg/DESCRIPTION | awk '{print $NF}'`
 
-"$R_SCRIPT_PATH/"R CMD check --as-cran SparkR_"$VERSION".tar.gz 
+"$R_SCRIPT_PATH/"R CMD check --as-cran --no-tests SparkR_"$VERSION".tar.gz 
 
 popd > /dev/null

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -31,6 +31,7 @@ Collate:
     'context.R'
     'deserialize.R'
     'functions.R'
+    'install.R'
     'mllib.R'
     'serialize.R'
     'sparkR.R'

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -7,7 +7,9 @@ Author: The Apache Software Foundation
 Maintainer: Shivaram Venkataraman <shivaram@cs.berkeley.edu>
 Depends:
     R (>= 3.0),
-    methods,
+    methods
+Imports:
+    rappdirs
 Suggests:
     testthat,
     e1071,

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -8,8 +8,6 @@ Maintainer: Shivaram Venkataraman <shivaram@cs.berkeley.edu>
 Depends:
     R (>= 3.0),
     methods
-Imports:
-    rappdirs
 Suggests:
     testthat,
     e1071,

--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -353,4 +353,4 @@ S3method(structField, jobj)
 S3method(structType, jobj)
 S3method(structType, structField)
 
-export("install_spark")
+export("install.spark")

--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -352,3 +352,5 @@ S3method(structField, character)
 S3method(structField, jobj)
 S3method(structType, jobj)
 S3method(structType, structField)
+
+export("install_spark")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -41,7 +41,7 @@
 #' @note install_spark since 2.1.0
 install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
                           local_dir = NULL) {
-  version <- paste0("spark-", spark_version_default())
+  version <- paste0("spark-", packageVersion("SparkR"))
   hadoop_version <- match.arg(hadoop_version, supported_versions_hadoop())
   packageName <- ifelse(hadoop_version == "without",
                         paste0(version, "-bin-without-hadoop"),
@@ -72,10 +72,12 @@ install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
       message("Remote URL not provided. Use Apache default.")
       mirror_url <- mirror_url_default()
     }
-    # This is temporary, should be removed when released
-    version <- "spark-releases/spark-2.0.0-rc4-bin"
-    packageRemotePath <- paste0(file.path(mirror_url, version, packageName),
-                                ".tgz")
+
+    version <- "spark-2.0.0-rc4-bin"
+    # When 2.0 released, remove the above line and
+    # change spark-releases to spark in the statement below
+    packageRemotePath <- paste0(
+      file.path(mirror_url, "spark-releases", version, packageName), ".tgz")
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n- %s",
                  "Installing to:\n- %s", sep = "\n")
@@ -138,7 +140,7 @@ spark_cache_path <- function() {
       path <- file.path(Sys.getenv("HOME"), "Library/Caches", "spark")
     } else {
       path <- file.path(
-        Sys.getenv("XDG_CACHE_HOME", file.path(Sys.getenv("HOME"), ".cache")), 
+        Sys.getenv("XDG_CACHE_HOME", file.path(Sys.getenv("HOME"), ".cache")),
         "spark")
     }
   } else {
@@ -149,12 +151,4 @@ spark_cache_path <- function() {
 
 mirror_url_csv <- function() {
   system.file("extdata", "spark_download.csv", package = "SparkR")
-}
-
-spark_version_default <- function() {
-  "2.0.0"
-}
-
-hadoop_version_default <- function() {
-  "2.7"
 }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -110,7 +110,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
     msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion),
                    packageRemotePath, packageLocalDir)
     message(msg)
-    
+
     tryCatch(download.file(packageRemotePath, packageLocalPath),
              error = function(e) {
                msg <- paste0("Fetch failed from ", mirrorUrl, ".",

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -70,7 +70,6 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
 
   packageLocalDir <- file.path(localDir, packageName)
 
-
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir)) {
     fmt <- "Spark %s for Hadoop %s has been installed."
@@ -108,19 +107,6 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
                             message(msg)
                             TRUE
                           })
-    if (fetchFail) {
-      message("Try the backup option.")
-      mirror_sites <- tryCatch(read.csv(mirror_url_csv()),
-                               error = function(e) stop("No csv file found."))
-      mirrorUrl <- mirror_sites$url[1]
-      packageRemotePath <- paste0(file.path(mirrorUrl, version, packageName),
-                                  ".tgz")
-      message(sprintf("Downloading from:\n- %s", packageRemotePath))
-      tryCatch(download.file(packageRemotePath, packageLocalPath),
-               error = function(e) {
-                 stop("Download failed. Please provide a valid mirrorUrl.")
-               })
-    }
   }
 
   untar(tarfile = packageLocalPath, exdir = localDir)
@@ -139,7 +125,7 @@ mirror_url_default <- function() {
 }
 
 supported_versions_hadoop <- function() {
-  c("2.7", "2.6", "2.4", "without")
+  c("without", "2.7", "2.6", "2.4")
 }
 
 spark_cache_path <- function() {
@@ -164,8 +150,4 @@ spark_cache_path <- function() {
     stop("Unknown OS")
   }
   normalizePath(path, mustWork = FALSE)
-}
-
-mirror_url_csv <- function() {
-  system.file("extdata", "spark_download.csv", package = "SparkR")
 }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -80,7 +80,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir) && !overwrite) {
-    fmt <- "Spark %s for Hadoop %s has been installed."
+    fmt <- "Spark %s for Hadoop %s is found."
     msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion))
     message(msg)
     return(invisible(packageLocalDir))

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -161,7 +161,6 @@ get_preferred_mirror <- function(version, packageName) {
   jsonUrl <- paste0("http://www.apache.org/dyn/closer.cgi?path=",
                         file.path("spark", version, packageName),
                         ".tgz&as_json=1")
-  # jsonUrl <- "http://www.apache.org/dyn/closer.cgi?as_json=1"
   textLines <- readLines(jsonUrl, warn = FALSE)
   rowNum <- grep("\"preferred\"", textLines)
   linePreferred <- textLines[rowNum]

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -42,7 +42,7 @@ install_spark <- function(hadoop_version = NULL, url = NULL, local_dir = NULL) {
   hadoop_version <- hadoop_version_default()
   packageName <- paste0(version, "-bin-hadoop", hadoop_version)
   if (is.null(local_dir)) {
-    local_dir <- getOption("spark.install.dir", 
+    local_dir <- getOption("spark.install.dir",
                            rappdirs::app_dir("spark"))$cache()
   }
   packageLocalDir <- file.path(local_dir, packageName)
@@ -61,7 +61,7 @@ install_spark <- function(hadoop_version = NULL, url = NULL, local_dir = NULL) {
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n %s",
                  "Installing to:\n %s", sep = "\n")
-    msg <- sprintf(fmt, version, hadoop_version, packageRemotePath, 
+    msg <- sprintf(fmt, version, hadoop_version, packageRemotePath,
                    packageLocalDir)
     message(msg)
     packageLocalPath <- paste0(packageLocalDir, ".tgz")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -65,7 +65,11 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
   if (is.null(localDir)) {
     localDir <- getOption("spark.install.dir", spark_cache_path())
   } else {
-    localDir <- normalizePath(localDir)
+    localDir <- normalizePath(localDir, mustWork = FALSE)
+  }
+
+  if (is.na(file.info(localDir)$isdir)) {
+    dir.create(localDir, recursive = TRUE)
   }
 
   packageLocalDir <- file.path(localDir, packageName)

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -39,8 +39,8 @@
 #'                      version number in the format of "int.int".
 #'                      If \code{hadoopVersion = "without"}, "Hadoop free" build is installed.
 #'                      See
-#'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}
-#'                      {"Hadoop Free" Build} for more information.
+#'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}{
+#'                      "Hadoop Free" Build} for more information.
 #'                      Other patched version names can also be used, e.g. \code{"cdh4"}
 #' @param mirrorUrl base URL of the repositories to use. The directory layout should follow
 #'                  \href{http://www.apache.org/dyn/closer.lua/spark/}{Apache mirrors}.
@@ -68,7 +68,7 @@
 #'}
 #' @note install.spark since 2.1.0
 #' @seealso See available Hadoop versions:
-#' \href{http://spark.apache.org/downloads.html}{Apache Spark}
+#'          \href{http://spark.apache.org/downloads.html}{Apache Spark}
 install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
                           localDir = NULL, overwrite = FALSE) {
   version <- paste0("spark-", packageVersion("SparkR"))
@@ -117,12 +117,12 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
   invisible(packageLocalDir)
 }
 
-robust_download_tar(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
+robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
   # step 1: use user-provided url
   if (!is.null(mirrorUrl)) {
     msg <- sprintf("Use user-provided mirror site: %s.", mirrorUrl)
     message(msg)
-    success <- direct_download_url(mirrorUrl, version, hadoopVersion,
+    success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
     if (success) return()
   } else {
@@ -133,7 +133,7 @@ robust_download_tar(mirrorUrl, version, hadoopVersion, packageName, packageLocal
   message("Looking for site suggested from apache website...")
   mirrorUrl <- get_preferred_mirror()
   if (!is.null(mirrorUrl)) {
-    success <- direct_download_url(mirrorUrl, version, hadoopVersion,
+    success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
     if (success) return()
   } else {
@@ -143,7 +143,7 @@ robust_download_tar(mirrorUrl, version, hadoopVersion, packageName, packageLocal
   # step 3: use backup option
   message("To use backup site...")
   mirrorUrl <- default_mirror_url()
-  success <- direct_download_url(mirrorUrl, version, hadoopVersion,
+  success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                  packageName, packageLocalPath)
   if (sucess) {
     return(packageLocalPath)
@@ -166,14 +166,14 @@ get_preferred_mirror <- function() {
     message(sprintf("Preferred mirror site found: %s", mirrorPreferred))
     startPos <- matchInfo + 1
     endPos <- startPos + attr(matchInfo, "match.length") - 2
-    mirrorPreferred <- linePreferred[startPos:endPos])
+    mirrorPreferred <- linePreferred[startPos:endPos]
   } else {
     mirrorPreferred <- NULL
   }
   mirrorPreferred
 }
 
-direct_download_tar(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
+direct_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
   packageRemotePath <- paste0(
     file.path(mirrorUrl, version, packageName), ".tgz")
   fmt <- paste("Downloading Spark %s for Hadoop %s from:\n- %s")
@@ -210,8 +210,8 @@ spark_cache_path <- function() {
     winAppPath <- Sys.getenv("%LOCALAPPDATA%", unset = NA)
     if (is.null(winAppPath)) {
       msg <- paste("%LOCALAPPDATA% not found.",
-                    "Please define the environment variable",
-                    "or restart and enter an installation path in localDir.")
+                   "Please define the environment variable",
+                   "or restart and enter an installation path in localDir.")
       stop(msg)
     } else {
       path <- file.path(winAppPath, "spark", "spark", "Cache")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -25,12 +25,23 @@
 #' Users can specify a desired Hadoop version, the remote mirror site, and
 #' the directory where the package is installed locally.
 #'
-#' @param hadoopVersion Version of Hadoop to install. Default is "without", Spark's
-#'                      "Hadoop free" build. See
-#'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}{
-#'                      "Hadoop Free" Build} for more information. It can also be version number
-#'                      in the format of "int.int", e.g. "2.7", or other patched version names, e.g.
-#'                      "cdh4"
+#' The full url of remote file is inferred from \code{mirrorUrl} and \code{hadoopVersion}.
+#' \code{mirrorUrl} specifies the remote path to a Spark folder. It is followed by a subfolder
+#' named after the Spark version (that corresponds to SparkR), and then the tar filename.
+#' The filename is composed of four parts, i.e. [Spark version]-bin-[Hadoop version].tgz.
+#' For example, the full path for a Spark 2.0.0 package for Hadoop 2.7 from
+#' \code{http://apache.osuosl.org} has path:
+#' \code{http://apache.osuosl.org/spark/spark-2.0.0/spark-2.0.0-bin-hadoop2.7.tgz}.
+#' For \code{hadoopVersion = "without"}, [Hadoop version] in the filename is then
+#' \code{without-hadoop}.
+#'
+#' @param hadoopVersion Version of Hadoop to install. Default is \code{"2.7"}. It can take other
+#'                      version number in the format of "int.int".
+#'                      If \code{hadoopVersion = "without"}, "Hadoop free" build is installed.
+#'                      See
+#'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}
+#'                      {"Hadoop Free" Build} for more information.
+#'                      Other patched version names can also be used, e.g. \code{"cdh4"}
 #' @param mirrorUrl base URL of the repositories to use. The directory layout should follow
 #'                  \href{http://www.apache.org/dyn/closer.lua/spark/}{Apache mirrors}.
 #' @param localDir a local directory where Spark is installed. The directory contains
@@ -58,7 +69,7 @@
 #' @note install.spark since 2.1.0
 #' @seealso See available Hadoop versions:
 #' \href{http://spark.apache.org/downloads.html}{Apache Spark}
-install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
+install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
                           localDir = NULL, overwrite = FALSE) {
   version <- paste0("spark-", packageVersion("SparkR"))
   hadoopVersion <- tolower(hadoopVersion)
@@ -100,7 +111,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
     }
 
     packageRemotePath <- paste0(
-      file.path(mirrorUrl, "spark", version, packageName), ".tgz")
+      file.path(mirrorUrl, version, packageName), ".tgz")
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n- %s",
                  "Installing to:\n- %s", sep = "\n")
@@ -127,7 +138,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
 }
 
 default_mirror_url <- function() {
-  "http://www.apache.org/dyn/closer.lua"
+  "http://www.apache.org/dyn/closer.lua/spark"
 }
 
 hadoop_version_name <- function(hadoopVersion) {

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -67,7 +67,6 @@ install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
   if (tarExists) {
     message("Tar file found. Installing...")
   } else {
-    dir.create(packageLocalDir, recursive = TRUE)
     if (is.null(mirror_url)) {
       message("Remote URL not provided. Use Apache default.")
       mirror_url <- mirror_url_default()

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -89,7 +89,7 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir) && !overwrite) {
-    fmt <- "Spark %s for Hadoop %s is found in %s"
+    fmt <- "Spark %s for Hadoop %s is found, and SPARK_HOME set to %s"
     msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion),
                    packageLocalDir)
     message(msg)
@@ -113,6 +113,7 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
   }
   message("DONE.")
   Sys.setenv(SPARK_HOME = packageLocalDir)
+  message(paste("SPARK_HOME set to", packageLocalDir))
   invisible(packageLocalDir)
 }
 

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -84,6 +84,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
     msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion),
                    packageLocalDir)
     message(msg)
+    Sys.setenv(SPARK_HOME = packageLocalDir)
     return(invisible(packageLocalDir))
   }
 
@@ -124,6 +125,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
     unlink(packageLocalPath)
   }
   message("Installation done.")
+  Sys.setenv(SPARK_HOME = packageLocalDir)
   invisible(packageLocalDir)
 }
 

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -25,7 +25,7 @@
 #' Users can specify a desired Hadoop version, the remote mirror site, and
 #' the directory where the package is installed locally.
 #'
-#' @param hadoopVersion Version of Hadoop to install. Default is \code{"without"}, Spark's
+#' @param hadoopVersion Version of Hadoop to install. Default is "without", Spark's
 #'                      "Hadoop free" build. See
 #'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}{
 #'                      "Hadoop Free" Build} for more information. It can also be version number

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -25,8 +25,8 @@
 #' specify a desired Hadoop version, the remote site, and the directory where
 #' the package is installed locally.
 #'
-#' @param hadoop_version Version of Hadoop to install. 2.3, 2.4, 2.6,
-#'        and 2.7 (default)
+#' @param hadoop_version Version of Hadoop to install, 2.4, 2.6,
+#'        2.7 (default) and without
 #' @param mirror_url the base URL of the repositories to use
 #' @param local_dir local directory that Spark is installed to
 #' @return \code{install_spark} returns the local directory 
@@ -135,9 +135,11 @@ spark_cache_path <- function() {
     }
   } else if (.Platform$OS.type == "unix") {
     if (Sys.info()["sysname"] == "Darwin") {
-      path <- file.path("~/Library/Caches", "spark")
+      path <- file.path(Sys.getenv("HOME"), "Library/Caches", "spark")
     } else {
-      path <- file.path(Sys.getenv("XDG_CACHE_HOME", "~/.cache"), "spark")
+      path <- file.path(
+        Sys.getenv("XDG_CACHE_HOME", file.path(Sys.getenv("HOME"), ".cache")), 
+        "spark")
     }
   } else {
     stop("Unknown OS")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -77,7 +77,8 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir)) {
     fmt <- "Spark %s for Hadoop %s has been installed."
-    msg <- sprintf(fmt, version, hadoopVersion)
+    msg <- sprintf(fmt, ifelse(version == "without", "Free build", version),
+                   hadoopVersion)
     message(msg)
     return(invisible(packageLocalDir))
   }
@@ -101,8 +102,8 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n- %s",
                  "Installing to:\n- %s", sep = "\n")
-    msg <- sprintf(fmt, version, hadoopVersion, packageRemotePath,
-                   packageLocalDir)
+    msg <- sprintf(fmt, ifelse(version == "without", "Free build", version),
+                   hadoopVersion, packageRemotePath, packageLocalDir)
     message(msg)
 
     fetchFail <- tryCatch(download.file(packageRemotePath, packageLocalPath),

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -80,8 +80,9 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir) && !overwrite) {
-    fmt <- "Spark %s for Hadoop %s is found."
-    msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion))
+    fmt <- "Spark %s for Hadoop %s is found in %s"
+    msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion),
+                   packageLocalDir)
     message(msg)
     return(invisible(packageLocalDir))
   }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -54,7 +54,9 @@ install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
 
   packageLocalDir <- file.path(local_dir, packageName)
 
-  if (dir.exists(packageLocalDir)) {
+
+  # can use dir.exists(packageLocalDir) under R 3.2.0 or later
+  if (!is.na(file.info(packageLocalDir)$isdir)) {
     fmt <- "Spark %s for Hadoop %s has been installed."
     msg <- sprintf(fmt, version, hadoop_version)
     message(msg)

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -47,7 +47,7 @@ install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
                         paste0(version, "-bin-without-hadoop"),
                         paste0(version, "-bin-hadoop", hadoop_version))
   if (is.null(local_dir)) {
-    local_dir <- getOption("spark.install.dir",spark_cache_path())
+    local_dir <- getOption("spark.install.dir", spark_cache_path())
   } else {
     local_dir <- normalizePath(local_dir)
   }
@@ -77,8 +77,8 @@ install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
     packageRemotePath <- paste0(file.path(mirror_url, version, packageName),
                                 ".tgz")
     fmt <- paste("Installing Spark %s for Hadoop %s.",
-                 "Downloading from:\n %s",
-                 "Installing to:\n %s", sep = "\n")
+                 "Downloading from:\n- %s",
+                 "Installing to:\n- %s", sep = "\n")
     msg <- sprintf(fmt, version, hadoop_version, packageRemotePath,
                    packageLocalDir)
     message(msg)
@@ -96,7 +96,7 @@ install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
       mirror_url <- mirror_sites$url[1]
       packageRemotePath <- paste0(file.path(mirror_url, version, packageName),
                                   ".tgz")
-      message(sprintf("Downloading from:\n %s", packageRemotePath))
+      message(sprintf("Downloading from:\n- %s", packageRemotePath))
       tryCatch(download.file(packageRemotePath, packageLocalPath),
                error = function(e) {
                  stop("Download failed. Please provide a valid mirror_url.")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -86,7 +86,7 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
   } else {
     if (is.null(mirrorUrl)) {
       message("Remote URL not provided. Use Apache default.")
-      mirrorUrl <- mirror_url_default()
+      mirrorUrl <- default_mirror_url()
     }
 
     version <- "spark-2.0.0-rc4-bin"
@@ -117,7 +117,7 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
   invisible(packageLocalDir)
 }
 
-mirror_url_default <- function() {
+default_mirror_url <- function() {
   # change to http://www.apache.org/dyn/closer.lua
   # when released
 

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -77,8 +77,9 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir)) {
     fmt <- "Spark %s for Hadoop %s has been installed."
-    msg <- sprintf(fmt, ifelse(version == "without", "Free build", version),
-                   hadoopVersion)
+    msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without",
+                                        "Free build", hadoopVersion)
+                  )
     message(msg)
     return(invisible(packageLocalDir))
   }
@@ -102,8 +103,9 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n- %s",
                  "Installing to:\n- %s", sep = "\n")
-    msg <- sprintf(fmt, ifelse(version == "without", "Free build", version),
-                   hadoopVersion, packageRemotePath, packageLocalDir)
+    msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without",
+                                        "Free build", hadoopVersion),
+                   packageRemotePath, packageLocalDir)
     message(msg)
 
     fetchFail <- tryCatch(download.file(packageRemotePath, packageLocalPath),

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -36,7 +36,7 @@
 #' \code{without-hadoop}.
 #'
 #' @param hadoopVersion Version of Hadoop to install. Default is \code{"2.7"}. It can take other
-#'                      version number in the format of "int.int".
+#'                      version number in the format of "x.y" where x and y are integer.
 #'                      If \code{hadoopVersion = "without"}, "Hadoop free" build is installed.
 #'                      See
 #'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}{
@@ -50,11 +50,9 @@
 #'                 \itemize{
 #'                   \item Mac OS X: \file{~/Library/Caches/spark}
 #'                   \item Unix: \env{$XDG_CACHE_HOME} if defined, otherwise \file{~/.cache/spark}
-#'                   \item Win XP:
-#'                         \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application
-#'                         Data\\spark\\spark\\Cache}
-#'                   \item Win Vista:
-#'                         \file{C:\\Users\\<username>\\AppData\\Local\\spark\\spark\\Cache}
+#'                   \item Windows: \file{\%LOCALAPPDATA\%\\spark\\spark\\Cache}. See
+#'                         \href{https://www.microsoft.com/security/portal/mmpc/shared/variables.aspx}{
+#'                         Windows Common Folder Variables} about \%LOCALAPPDATA\%
 #'                 }
 #' @param overwrite If \code{TRUE}, download and overwrite the existing tar file in localDir
 #'                  and force re-install Spark (in case the local directory or file is corrupted)
@@ -210,7 +208,7 @@ hadoop_version_name <- function(hadoopVersion) {
 spark_cache_path <- function() {
   if (.Platform$OS.type == "windows") {
     winAppPath <- Sys.getenv("%LOCALAPPDATA%", unset = NA)
-    if (is.null(winAppPath)) {
+    if (is.na(winAppPath)) {
       msg <- paste("%LOCALAPPDATA% not found.",
                    "Please define the environment variable",
                    "or restart and enter an installation path in localDir.")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -138,7 +138,7 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
 }
 
 default_mirror_url <- function() {
-  "http://www.apache.org/dyn/closer.lua/spark"
+  "http://apache.osuosl.org/spark"
 }
 
 hadoop_version_name <- function(hadoopVersion) {

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -29,6 +29,8 @@
 #'        and 2.7 (default)
 #' @param url the base URL of the repositories to use
 #' @param local_dir local directory that Spark is installed to
+#' @return \code{install_spark} returns the local directory 
+#'         where Spark is found or installed
 #' @rdname install_spark
 #' @name install_spark
 #' @export
@@ -69,6 +71,7 @@ install_spark <- function(hadoop_version = NULL, url = NULL, local_dir = NULL) {
     untar(tarfile = packageLocalPath, exdir = local_dir)
     unlink(packageLocalPath)
   }
+  packageLocalDir
 }
 
 mirror_csv_url <- function() {

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -20,32 +20,34 @@
 
 #' Download and Install Apache Spark to a Local Directory
 #' 
-#' \code{install.spark} downloads and installs Spark to local directory if
+#' \code{install.spark} downloads and installs Spark to a local directory if
 #' it is not found. The Spark version we use is the same as the SparkR version.
-#' Users can specify a desired Hadoop version, the remote site, and
+#' Users can specify a desired Hadoop version, the remote mirror site, and
 #' the directory where the package is installed locally.
 #'
-#' @param hadoopVersion Version of Hadoop to install. Default is "without", Spark's "Hadoop free"
-#'                      build. See
+#' @param hadoopVersion Version of Hadoop to install. Default is \code{"without"}, Spark's
+#'                      "Hadoop free" build. See
 #'                      \href{http://spark.apache.org/docs/latest/hadoop-provided.html}{
-#'                      "Hadoop Free" Build} for more information. It can be in format of
-#'                      "int.int" (for example, "2.7") or "cdh4"
+#'                      "Hadoop Free" Build} for more information. It can also be version number
+#'                      in the format of "int.int", e.g. "2.7", or other patched version names, e.g.
+#'                      "cdh4"
 #' @param mirrorUrl base URL of the repositories to use. The directory layout should follow
 #'                  \href{http://www.apache.org/dyn/closer.lua/spark/}{Apache mirrors}.
-#' @param localDir a local directory where Spark is installed. Default path to the cache directory:
+#' @param localDir a local directory where Spark is installed. The directory contains
+#'                 version-specific folders of Spark packages. Default is path to
+#'                 the cache directory:
 #'                 \itemize{
 #'                   \item Mac OS X: \file{~/Library/Caches/spark}
 #'                   \item Unix: \env{$XDG_CACHE_HOME} if defined, otherwise \file{~/.cache/spark}
 #'                   \item Win XP:
-#                          \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application
+#'                         \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application
 #'                         Data\\spark\\spark\\Cache}
 #'                   \item Win Vista:
 #'                         \file{C:\\Users\\<username>\\AppData\\Local\\spark\\spark\\Cache}
 #'                 }
-#' @param overwrite If \code{TRUE}, download and overwrite the existing tar file and force
-#'                  re-install Spark (in case the local directory or file is corrupted)
-#' @return \code{install.spark} returns the local directory
-#'         where Spark is found or installed
+#' @param overwrite If \code{TRUE}, download and overwrite the existing tar file in localDir
+#'                  and force re-install Spark (in case the local directory or file is corrupted)
+#' @return \code{install.spark} returns the local directory where Spark is found or installed
 #' @rdname install.spark
 #' @name install.spark
 #' @export
@@ -72,7 +74,8 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
   packageLocalDir <- file.path(localDir, packageName)
 
   if (overwrite) {
-    message("Overwrite = TRUE: download and overwrite the Spark directory if it exists.")
+    message("Overwrite = TRUE: download and overwrite the tar file and Spark package directory
+            if they exist.")
   }
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
@@ -87,7 +90,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
   tarExists <- file.exists(packageLocalPath)
 
   if (tarExists && !overwrite) {
-    message("Tar file found. Installing...")
+    message("tar file found. Installing...")
   } else {
     if (is.null(mirrorUrl)) {
       mirrorUrl <- default_mirror_url()
@@ -132,8 +135,7 @@ default_mirror_url <- function() {
 hadoop_version_name <- function(hadoopVersion) {
   if (hadoopVersion == "without") {
     "without-hadoop"
-  }
-  if (grepl("^[0-9]+\\.[0-9]+$", hadoopVersion, perl = TRUE)) {
+  } else if (grepl("^[0-9]+\\.[0-9]+$", hadoopVersion, perl = TRUE)) {
     paste0("hadoop", hadoopVersion)
   } else {
     hadoopVersion

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -99,11 +99,8 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
       message(sprintf("Remote URL not provided. Use Apache default: %s", mirrorUrl))
     }
 
-    version <- "spark-2.0.0-rc4-bin"
-    # When 2.0 released, remove the above line and
-    # change spark-releases to spark in the statement below
     packageRemotePath <- paste0(
-      file.path(mirrorUrl, "spark-releases", version, packageName), ".tgz")
+      file.path(mirrorUrl, "spark", version, packageName), ".tgz")
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n- %s",
                  "Installing to:\n- %s", sep = "\n")
@@ -130,9 +127,7 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
 }
 
 default_mirror_url <- function() {
-  # change to http://www.apache.org/dyn/closer.lua
-  # when released
-  "http://people.apache.org/~pwendell"
+  "http://www.apache.org/dyn/closer.lua"
 }
 
 hadoop_version_name <- function(hadoopVersion) {

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -132,12 +132,16 @@ supported_versions_hadoop <- function() {
   c("without", "2.7", "2.6", "2.4")
 }
 
+# This function adapts the implementation of the cache function in
+# https://github.com/hadley/rappdirs/blob/master/R/cache.r
+# to Spark context.
 spark_cache_path <- function() {
   if (.Platform$OS.type == "windows") {
     winAppPath <- Sys.getenv("%LOCALAPPDATA%", unset = NA)
     if (is.null(winAppPath)) {
       msg <- paste("%LOCALAPPDATA% not found.",
-                    "Please define or enter an installation path in loc_dir.")
+                    "Please define the environment variable",
+                    "or restart and enter an installation path in localDir.")
       stop(msg)
     } else {
       path <- file.path(winAppPath, "spark", "spark", "Cache")

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -151,7 +151,7 @@ spark_cache_path <- function() {
         "spark")
     }
   } else {
-    stop("Unknown OS")
+    stop(sprintf("Unknown OS: %s", .Platform$OS.type))
   }
   normalizePath(path, mustWork = FALSE)
 }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -103,16 +103,17 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
   tarExists <- file.exists(packageLocalPath)
 
   if (tarExists && !overwrite) {
-    message("tar file found. Installing...")
+    message("tar file found.")
   } else {
     robust_download_tar(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath)
   }
 
+  message(sprintf("Installing to %s", localDir))
   untar(tarfile = packageLocalPath, exdir = localDir)
   if (!tarExists || overwrite) {
     unlink(packageLocalPath)
   }
-  message("Installation Done.")
+  message("DONE.")
   Sys.setenv(SPARK_HOME = packageLocalDir)
   invisible(packageLocalDir)
 }
@@ -149,7 +150,7 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
     return(packageLocalPath)
   } else {
     msg <- sprintf(paste("Unable to download Spark %s for Hadoop %s.",
-                         "Please network connection, Hadoop version,",
+                         "Please check network connection, Hadoop version,",
                          "or provide other mirror sites."),
                    version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion))
     stop(msg)

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -147,7 +147,7 @@ spark_cache_path <- function() {
   } else {
     stop("Unknown OS")
   }
-  normalizePath(path, mustWork = TRUE)
+  normalizePath(path, mustWork = FALSE)
 }
 
 mirror_url_csv <- function() {

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -74,8 +74,8 @@ install.spark <- function(hadoopVersion = "without", mirrorUrl = NULL,
   packageLocalDir <- file.path(localDir, packageName)
 
   if (overwrite) {
-    message("Overwrite = TRUE: download and overwrite the tar file and Spark package directory
-            if they exist.")
+    message(paste0("Overwrite = TRUE: download and overwrite the tar file",
+                   "and Spark package directory if they exist."))
   }
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -126,7 +126,6 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
     success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
     if (success) return()
-    }
   } else {
     message("Mirror site not provided.")
   }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -62,11 +62,8 @@ install.spark <- function(hadoopVersion = NULL, mirrorUrl = NULL,
   packageName <- ifelse(hadoopVersion == "without",
                         paste0(version, "-bin-without-hadoop"),
                         paste0(version, "-bin-hadoop", hadoopVersion))
-  if (is.null(localDir)) {
-    localDir <- getOption("spark.install.dir", spark_cache_path())
-  } else {
-    localDir <- normalizePath(localDir, mustWork = FALSE)
-  }
+  localDir <- ifelse(is.null(localDir), spark_cache_path(),
+                     normalizePath(localDir, mustWork = FALSE))
 
   if (is.na(file.info(localDir)$isdir)) {
     dir.create(localDir, recursive = TRUE)

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Functions to install Spark in case the user directly downloads SparkR
+# from CRAN.
+
+#' Download and Install Spark to Local Directory
+#' 
+#' \code{install_spark} downloads and installs Spark to local directory if
+#' it is not found. The Spark version we use is 2.0.0 (preview). Users can
+#' specify a desired Hadoop version, the remote site, and the directory where
+#' the package is installed locally.
+#'
+#' @param hadoop_version Version of Hadoop to install. 2.3, 2.4, 2.6,
+#'        and 2.7 (default)
+#' @param url the base URL of the repositories to use
+#' @param local_dir local directory that Spark is installed to
+#' @rdname install_spark
+#' @name install_spark
+#' @export
+#' @examples
+#'\dontrun{
+#' install_spark()
+#'}
+#' @note install_spark since 2.1.0
+install_spark <- function(hadoop_version = NULL, url = NULL, local_dir = NULL) {
+  version <- paste0("spark-", spark_version_default())
+  hadoop_version <- hadoop_version_default()
+  packageName <- paste0(version, "-bin-hadoop", hadoop_version)
+  if (is.null(local_dir)) {
+    local_dir <- getOption("spark.install.dir", 
+                           rappdirs::app_dir("spark"))$cache()
+  }
+  packageLocalDir <- file.path(local_dir, packageName)
+  if (dir.exists(packageLocalDir)) {
+    fmt <- "Spark %s for Hadoop %s has been installed."
+    msg <- sprintf(fmt, version, hadoop_version)
+    message(msg)
+  } else {
+    dir.create(packageLocalDir, recursive = TRUE)
+    if (is.null(url)) {
+      mirror_sites <- read.csv(mirror_csv_url())
+      url <- mirror_sites$url[1]
+    }
+    packageRemotePath <- paste0(file.path(url, "spark", version, packageName),
+                                ".tgz")
+    fmt <- paste("Installing Spark %s for Hadoop %s.",
+                 "Downloading from:\n %s",
+                 "Installing to:\n %s", sep = "\n")
+    msg <- sprintf(fmt, version, hadoop_version, packageRemotePath, 
+                   packageLocalDir)
+    message(msg)
+    packageLocalPath <- paste0(packageLocalDir, ".tgz")
+    download.file(packageRemotePath, packageLocalPath)
+    untar(tarfile = packageLocalPath, exdir = local_dir)
+    unlink(packageLocalPath)
+  }
+}
+
+mirror_csv_url <- function() {
+  system.file("extdata", "spark_download.csv", package = "SparkR")
+}
+
+spark_version_default <- function() {
+  "2.0.0-preview"
+}
+
+hadoop_version_default <- function() {
+  "2.7"
+}

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -145,7 +145,7 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
   mirrorUrl <- default_mirror_url()
   success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                  packageName, packageLocalPath)
-  if (sucess) {
+  if (success) {
     return(packageLocalPath)
   } else {
     msg <- sprintf(paste("Unable to download Spark %s for Hadoop %s.",
@@ -163,10 +163,11 @@ get_preferred_mirror <- function() {
   linePreferred <- textLines[rowNum]
   matchInfo <- regexpr("\"[A-Za-z][A-Za-z0-9+-.]*://.+\"", linePreferred)
   if (matchInfo != -1) {
-    message(sprintf("Preferred mirror site found: %s", mirrorPreferred))
     startPos <- matchInfo + 1
-    endPos <- startPos + attr(matchInfo, "match.length") - 2
-    mirrorPreferred <- linePreferred[startPos:endPos]
+    endPos <- matchInfo + attr(matchInfo, "match.length") - 2
+    mirrorPreferred <- base::substr(linePreferred, startPos, endPos)
+    mirrorPreferred <- paste0(mirrorPreferred, "spark")
+    message(sprintf("Preferred mirror site found: %s", mirrorPreferred))
   } else {
     mirrorPreferred <- NULL
   }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -19,7 +19,7 @@
 # from CRAN.
 
 #' Download and Install Apache Spark to a Local Directory
-#' 
+#'
 #' \code{install.spark} downloads and installs Spark to a local directory if
 #' it is not found. The Spark version we use is the same as the SparkR version.
 #' Users can specify a desired Hadoop version, the remote mirror site, and
@@ -59,6 +59,7 @@
 #' @return \code{install.spark} returns the local directory where Spark is found or installed
 #' @rdname install.spark
 #' @name install.spark
+#' @aliases install.spark
 #' @export
 #' @examples
 #'\dontrun{
@@ -131,7 +132,7 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
 
   # step 2: use url suggested from apache website
   message("Looking for site suggested from apache website...")
-  mirrorUrl <- get_preferred_mirror()
+  mirrorUrl <- get_preferred_mirror(version, packageName)
   if (!is.null(mirrorUrl)) {
     success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
@@ -156,8 +157,11 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
   }
 }
 
-get_preferred_mirror <- function() {
-  jsonUrl <- "http://www.apache.org/dyn/closer.cgi?as_json=1"
+get_preferred_mirror <- function(version, packageName) {
+  jsonUrl <- paste0("http://www.apache.org/dyn/closer.cgi?path=",
+                        file.path("spark", version, packageName),
+                        ".tgz&as_json=1")
+  # jsonUrl <- "http://www.apache.org/dyn/closer.cgi?as_json=1"
   textLines <- readLines(jsonUrl, warn = FALSE)
   rowNum <- grep("\"preferred\"", textLines)
   linePreferred <- textLines[rowNum]
@@ -185,6 +189,7 @@ direct_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
   isFail <- tryCatch(download.file(packageRemotePath, packageLocalPath),
                      error = function(e) {
                        message(sprintf("Fetch failed from %s", mirrorUrl))
+                       print(e)
                        TRUE
                      })
   !isFail

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -18,7 +18,7 @@
 # Functions to install Spark in case the user directly downloads SparkR
 # from CRAN.
 
-#' Download and Install Spark to Local Directory
+#' Download and Install Spark Core to Local Directory
 #' 
 #' \code{install_spark} downloads and installs Spark to local directory if
 #' it is not found. The Spark version we use is 2.0.0 (preview). Users can
@@ -27,7 +27,7 @@
 #'
 #' @param hadoop_version Version of Hadoop to install. 2.3, 2.4, 2.6,
 #'        and 2.7 (default)
-#' @param url the base URL of the repositories to use
+#' @param mirror_url the base URL of the repositories to use
 #' @param local_dir local directory that Spark is installed to
 #' @return \code{install_spark} returns the local directory 
 #'         where Spark is found or installed
@@ -39,26 +39,42 @@
 #' install_spark()
 #'}
 #' @note install_spark since 2.1.0
-install_spark <- function(hadoop_version = NULL, url = NULL, local_dir = NULL) {
+install_spark <- function(hadoop_version = NULL, mirror_url = NULL,
+                          local_dir = NULL) {
   version <- paste0("spark-", spark_version_default())
-  hadoop_version <- hadoop_version_default()
-  packageName <- paste0(version, "-bin-hadoop", hadoop_version)
+  hadoop_version <- match.arg(hadoop_version, supported_versions_hadoop())
+  packageName <- ifelse(hadoop_version == "without",
+                        paste0(version, "-bin-without-hadoop"),
+                        paste0(version, "-bin-hadoop", hadoop_version))
   if (is.null(local_dir)) {
-    local_dir <- getOption("spark.install.dir",
-                           rappdirs::app_dir("spark"))$cache()
+    local_dir <- getOption("spark.install.dir",spark_cache_path())
+  } else {
+    local_dir <- normalizePath(local_dir)
   }
+
   packageLocalDir <- file.path(local_dir, packageName)
+
   if (dir.exists(packageLocalDir)) {
     fmt <- "Spark %s for Hadoop %s has been installed."
     msg <- sprintf(fmt, version, hadoop_version)
     message(msg)
+    return(invisible(packageLocalDir))
+  }
+
+  packageLocalPath <- paste0(packageLocalDir, ".tgz")
+  tarExists <- file.exists(packageLocalPath)
+
+  if (tarExists) {
+    message("Tar file found. Installing...")
   } else {
     dir.create(packageLocalDir, recursive = TRUE)
-    if (is.null(url)) {
-      mirror_sites <- read.csv(mirror_csv_url())
-      url <- mirror_sites$url[1]
+    if (is.null(mirror_url)) {
+      message("Remote URL not provided. Use Apache default.")
+      mirror_url <- mirror_url_default()
     }
-    packageRemotePath <- paste0(file.path(url, "spark", version, packageName),
+    # This is temporary, should be removed when released
+    version <- "spark-releases/spark-2.0.0-rc4-bin"
+    packageRemotePath <- paste0(file.path(mirror_url, version, packageName),
                                 ".tgz")
     fmt <- paste("Installing Spark %s for Hadoop %s.",
                  "Downloading from:\n %s",
@@ -66,20 +82,75 @@ install_spark <- function(hadoop_version = NULL, url = NULL, local_dir = NULL) {
     msg <- sprintf(fmt, version, hadoop_version, packageRemotePath,
                    packageLocalDir)
     message(msg)
-    packageLocalPath <- paste0(packageLocalDir, ".tgz")
-    download.file(packageRemotePath, packageLocalPath)
-    untar(tarfile = packageLocalPath, exdir = local_dir)
+
+    fetchFail <- tryCatch(download.file(packageRemotePath, packageLocalPath),
+                          error = function(e) {
+                            msg <- paste0("Fetch failed from ", mirror_url, ".")
+                            message(msg)
+                            TRUE
+                          })
+    if (fetchFail) {
+      message("Try the backup option.")
+      mirror_sites <- tryCatch(read.csv(mirror_url_csv()),
+                               error = function(e) stop("No csv file found."))
+      mirror_url <- mirror_sites$url[1]
+      packageRemotePath <- paste0(file.path(mirror_url, version, packageName),
+                                  ".tgz")
+      message(sprintf("Downloading from:\n %s", packageRemotePath))
+      tryCatch(download.file(packageRemotePath, packageLocalPath),
+               error = function(e) {
+                 stop("Download failed. Please provide a valid mirror_url.")
+               })
+    }
+  }
+
+  untar(tarfile = packageLocalPath, exdir = local_dir)
+  if (!tarExists) {
     unlink(packageLocalPath)
   }
-  packageLocalDir
+  message("Installation done.")
+  invisible(packageLocalDir)
 }
 
-mirror_csv_url <- function() {
+mirror_url_default <- function() {
+  # change to http://www.apache.org/dyn/closer.lua
+  # when released
+
+  "http://people.apache.org/~pwendell"
+}
+
+supported_versions_hadoop <- function() {
+  c("2.7", "2.6", "2.4", "without")
+}
+
+spark_cache_path <- function() {
+  if (.Platform$OS.type == "windows") {
+    winAppPath <- Sys.getenv("%LOCALAPPDATA%", unset = NA)
+    if (is.null(winAppPath)) {
+      msg <- paste("%LOCALAPPDATA% not found.",
+                    "Please define or enter an installation path in loc_dir.")
+      stop(msg)
+    } else {
+      path <- file.path(winAppPath, "spark", "spark", "Cache")
+    }
+  } else if (.Platform$OS.type == "unix") {
+    if (Sys.info()["sysname"] == "Darwin") {
+      path <- file.path("~/Library/Caches", "spark")
+    } else {
+      path <- file.path(Sys.getenv("XDG_CACHE_HOME", "~/.cache"), "spark")
+    }
+  } else {
+    stop("Unknown OS")
+  }
+  normalizePath(path, mustWork = TRUE)
+}
+
+mirror_url_csv <- function() {
   system.file("extdata", "spark_download.csv", package = "SparkR")
 }
 
 spark_version_default <- function() {
-  "2.0.0-preview"
+  "2.0.0"
 }
 
 hadoop_version_default <- function() {

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -126,6 +126,7 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
     success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
     if (success) return()
+    }
   } else {
     message("Mirror site not provided.")
   }
@@ -185,7 +186,7 @@ direct_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
 
   isFail <- tryCatch(download.file(packageRemotePath, packageLocalPath),
                      error = function(e) {
-                       message("Fetch failed.")
+                       message(sprintf("Fetch failed from %s", mirrorUrl))
                        TRUE
                      })
   !isFail

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -365,7 +365,7 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
-  if (!nzchar(master) || master_is_local(master)) {
+  if (!nzchar(master) || is_master_local(master)) {
     if (!is.na(file.info(sparkHome)$isdir)) {
       fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
                    "Search in the cache directory. ",

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -365,19 +365,21 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
-  if (!nzchar(master) || is_master_local(master)) {
-    if (!is.na(file.info(sparkHome)$isdir)) {
-      fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
-                   "Search in the cache directory. ",
-                   "It will be installed if not found.")
-      msg <- sprintf(fmt, sparkHome)
-      message(msg)
-      packageLocalDir <- install.spark()
-      sparkHome <- packageLocalDir
-    } else {
-      fmt <- "Make sure that Spark is installed in SPARK_HOME: %s"
-      msg <- sprintf(fmt, sparkHome)
-      message(msg)
+  if (!grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)) {
+    if (!nzchar(master) || is_master_local(master)) {
+      if (is.na(file.info(sparkHome)$isdir)) {
+        fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
+                      "Search in the cache directory. ",
+                      "It will be installed if not found.")
+        msg <- sprintf(fmt, sparkHome)
+        message(msg)
+        packageLocalDir <- install.spark()
+        sparkHome <- packageLocalDir
+      } else {
+        fmt <- "Spark package is found in SPARK_HOME: %s"
+        msg <- sprintf(fmt, sparkHome)
+        message(msg)
+      }
     }
   }
 

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -366,6 +366,12 @@ sparkR.session <- function(
     overrideEnvs(sparkConfigMap, paramMap)
   }
 
+#  if (master_is_local(master) && (!nzchar(sparkHome) || !dir.exists(sparkHome))) {
+#    message("Spark is not found in local directory. It will be installed in a cache dir.")
+#    packageLocalDir <- install_spark()
+#    sparkHome <- packageLocalDir
+#  }
+  
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
     sparkExecutorEnvMap <- new.env()
     sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorEnvMap,

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -366,7 +366,7 @@ sparkR.session <- function(
     overrideEnvs(sparkConfigMap, paramMap)
   }
   if (!nzchar(master) || master_is_local(master)) {
-    if (!dir.exists(sparkHome)) {
+    if (!is.na(file.info(sparkHome)$isdir)) {
       fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
                    "Search in the cache directory. ",
                    "It will be installed if not found.")

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -365,19 +365,19 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
+  # do not download if it is run in the sparkR shell
   if (!grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)) {
     if (!nzchar(master) || is_master_local(master)) {
       if (is.na(file.info(sparkHome)$isdir)) {
-        fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
-                      "To search in the cache directory. ",
+        msg <- paste0("Spark not found in SPARK_HOME: ",
+                      sparkHome,
+                      " .\nTo search in the cache directory. ",
                       "Installation will start if not found.")
-        msg <- sprintf(fmt, sparkHome)
         message(msg)
         packageLocalDir <- install.spark()
         sparkHome <- packageLocalDir
       } else {
-        fmt <- "Spark package is found in SPARK_HOME: %s"
-        msg <- sprintf(fmt, sparkHome)
+        msg <- paste0("Spark package is found in SPARK_HOME: ", sparkHome)
         message(msg)
       }
     }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -372,7 +372,7 @@ sparkR.session <- function(
                    "It will be installed if not found.")
       msg <- sprintf(fmt, sparkHome)
       message(msg)
-      packageLocalDir <- install_spark()
+      packageLocalDir <- install.spark()
       sparkHome <- packageLocalDir
     } else {
       fmt <- "Make sure that Spark is installed in SPARK_HOME: %s"

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -365,12 +365,17 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
-
-#  if (master_is_local(master) && (!nzchar(sparkHome) || !dir.exists(sparkHome))) {
-#    message("Spark is not found in local directory. It will be installed in a cache dir.")
-#    packageLocalDir <- install_spark()
-#    sparkHome <- packageLocalDir
-#  }
+  if (!nzchar(master) || master_is_local(master)) {
+    if (!nzchar(sparkHome) || !dir.exists(sparkHome)) {
+      message("Spark is not found in SPARK_HOME. Redirect to the cache directory.")
+      packageLocalDir <- install_spark()
+      sparkHome <- packageLocalDir
+    } else {
+      fmt <- "Make sure that Spark is installed in SPARK_HOME: %s"
+      msg <- sprintf(fmt, sparkHome)
+      message(msg)
+    }
+  }
   
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
     sparkExecutorEnvMap <- new.env()

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -369,7 +369,7 @@ sparkR.session <- function(
     if (!nzchar(master) || is_master_local(master)) {
       if (is.na(file.info(sparkHome)$isdir)) {
         fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
-                      "Search in the cache directory. ",
+                      "To search in the cache directory. ",
                       "It will be installed if not found.")
         msg <- sprintf(fmt, sparkHome)
         message(msg)

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -366,8 +366,8 @@ sparkR.session <- function(
     overrideEnvs(sparkConfigMap, paramMap)
   }
   # do not download if it is run in the sparkR shell
-  if (!grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)) {
-    if (!nzchar(master) || is_master_local(master)) {
+  if (!nzchar(master) || is_master_local(master)) {
+    if (!is_sparkR_shell()) {
       if (is.na(file.info(sparkHome)$isdir)) {
         msg <- paste0("Spark not found in SPARK_HOME: ",
                       sparkHome,

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -366,8 +366,12 @@ sparkR.session <- function(
     overrideEnvs(sparkConfigMap, paramMap)
   }
   if (!nzchar(master) || master_is_local(master)) {
-    if (!nzchar(sparkHome) || !dir.exists(sparkHome)) {
-      message("Spark is not found in SPARK_HOME. Redirect to the cache directory.")
+    if (!dir.exists(sparkHome)) {
+      fmt <- paste("Spark not found in SPARK_HOME: %s.\n",
+                   "Search in the cache directory.",
+                   "It will be installed if not found.")
+      msg <- sprintf(fmt, sparkHome)
+      message(msg)
       packageLocalDir <- install_spark()
       sparkHome <- packageLocalDir
     } else {
@@ -376,7 +380,7 @@ sparkR.session <- function(
       message(msg)
     }
   }
-  
+
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
     sparkExecutorEnvMap <- new.env()
     sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorEnvMap,

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -370,7 +370,7 @@ sparkR.session <- function(
       if (is.na(file.info(sparkHome)$isdir)) {
         fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
                       "To search in the cache directory. ",
-                      "It will be installed if not found.")
+                      "Installation will start if not found.")
         msg <- sprintf(fmt, sparkHome)
         message(msg)
         packageLocalDir <- install.spark()

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -367,8 +367,8 @@ sparkR.session <- function(
   }
   if (!nzchar(master) || master_is_local(master)) {
     if (!dir.exists(sparkHome)) {
-      fmt <- paste("Spark not found in SPARK_HOME: %s.\n",
-                   "Search in the cache directory.",
+      fmt <- paste0("Spark not found in SPARK_HOME: %s.\n",
+                   "Search in the cache directory. ",
                    "It will be installed if not found.")
       msg <- sprintf(fmt, sparkHome)
       message(msg)

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -691,5 +691,5 @@ getSparkContext <- function() {
 }
 
 is_master_local <- function(master) {
-  grepl("^local(\\[[0-9\\*]*\\])?$", master, perl = TRUE)
+  grepl("^local(\\[[0-9\\*]+\\])?$", master, perl = TRUE)
 }

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -691,5 +691,5 @@ getSparkContext <- function() {
 }
 
 is_master_local <- function(master) {
-  grepl("^local(\\[[0-9\\*]+\\])?$", master, perl = TRUE)
+  grepl("^local(\\[([0-9]+|\\*)\\])?$", master, perl = TRUE)
 }

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -690,6 +690,6 @@ getSparkContext <- function() {
   sc
 }
 
-master_is_local <- function(master) {
+is_master_local <- function(master) {
   grepl("^local(\\[[0-9\\*]*\\])?$", master, perl = TRUE)
 }

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -693,3 +693,7 @@ getSparkContext <- function() {
 is_master_local <- function(master) {
   grepl("^local(\\[([0-9]+|\\*)\\])?$", master, perl = TRUE)
 }
+
+is_sparkR_shell <- function() {
+  grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
+}

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -689,3 +689,7 @@ getSparkContext <- function() {
   sc <- get(".sparkRjsc", envir = .sparkREnv)
   sc
 }
+
+master_is_local <- function(master) {
+  grepl("^local(\\[[0-9\\*]*\\])?$", master, perl = TRUE)
+}

--- a/R/pkg/inst/extdata/spark_download.csv
+++ b/R/pkg/inst/extdata/spark_download.csv
@@ -1,2 +1,0 @@
-"url","default"
-"http://apache.osuosl.org",TRUE

--- a/R/pkg/inst/extdata/spark_download.csv
+++ b/R/pkg/inst/extdata/spark_download.csv
@@ -1,0 +1,2 @@
+"url","default"
+"http://apache.osuosl.org",TRUE

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1824,11 +1824,11 @@ test_that("describe() and summarize() on a DataFrame", {
   expect_equal(collect(stats)[2, "age"], "24.5")
   expect_equal(collect(stats)[3, "age"], "7.7781745930520225")
   stats <- describe(df)
-  expect_equal(collect(stats)[4, "name"], "Andy")
+  expect_equal(collect(stats)[4, "summary"], "min")
   expect_equal(collect(stats)[5, "age"], "30")
 
   stats2 <- summary(df)
-  expect_equal(collect(stats2)[4, "name"], "Andy")
+  expect_equal(collect(stats2)[4, "summary"], "min")
   expect_equal(collect(stats2)[5, "age"], "30")
 
   # SPARK-16425: SparkR summary() fails on column of type logical

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1824,11 +1824,11 @@ test_that("describe() and summarize() on a DataFrame", {
   expect_equal(collect(stats)[2, "age"], "24.5")
   expect_equal(collect(stats)[3, "age"], "7.7781745930520225")
   stats <- describe(df)
-  expect_equal(collect(stats)[4, "summary"], "min")
+  expect_equal(collect(stats)[4, "name"], "Andy")
   expect_equal(collect(stats)[5, "age"], "30")
 
   stats2 <- summary(df)
-  expect_equal(collect(stats2)[4, "summary"], "min")
+  expect_equal(collect(stats2)[4, "name"], "Andy")
   expect_equal(collect(stats2)[5, "age"], "30")
 
   # SPARK-16425: SparkR summary() fails on column of type logical


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add an install_spark function to the SparkR package. User can run `install_spark()` to install Spark to a local directory within R. 

Updates:

Several changes have been made:
- `install.spark()`
  - check existence of tar file in the cache folder, and download only if not found
  - trial priority of mirror_url look-up: user-provided -> preferred mirror site from apache website -> hardcoded backup option
  - use 2.0.0
- `sparkR.session()`
  - can install spark when not found in `SPARK_HOME`
## How was this patch tested?

Manual tests, running the check-cran.sh script added in #14173.
