### PR TITLE
[SPARK-16622][SQL] Fix NullPointerException when the returned value of the called method in Invoke is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -138,7 +138,10 @@ case class Invoke(
     val funcValIsNull = ctx.freshName("funcValIsNull")
     val callFunc = if (method.isDefined && method.get.getReturnType.isPrimitive) {
       s"""
-        $javaType $funcVal = ${obj.value}.$functionName($argString);
+        $javaType $funcVal = ${ctx.defaultValue(dataType)};
+        if (!${ev.isNull}) {
+          $funcVal = ${obj.value}.$functionName($argString);
+        }
         boolean $funcValIsNull = false;
       """
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -27,7 +27,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("SPARK-16622: The returned value of the called method in Invoke can be null") {
     val inputRow = InternalRow.fromSeq(Seq((false, null)))
-    val cls = classOf[Tuple2[Boolean, Int]]
+    val cls = classOf[Tuple2[Boolean, java.lang.Integer]]
     val inputObject = BoundReference(0, ObjectType(cls), nullable = true)
     val invoke = Invoke(inputObject, "_2", IntegerType)
     checkEvaluationWithGeneratedMutableProjection(invoke, null, inputRow)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
+import org.apache.spark.sql.types.{IntegerType, ObjectType}
+
+
+class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
+
+  test("SPARK-16622: The returned value of the called method in Invoke can be null") {
+    val inputRow = InternalRow.fromSeq(Seq((false, null)))
+    val cls = classOf[Tuple2[Boolean, Int]]
+    val inputObject = BoundReference(0, ObjectType(cls), nullable = true)
+    val invoke = Invoke(inputObject, "_2", IntegerType)
+    checkEvaluationWithGeneratedMutableProjection(invoke, null, inputRow)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -136,35 +136,6 @@ object NullResultAgg extends Aggregator[AggData, AggData, AggData] {
   override def outputEncoder: Encoder[AggData] = Encoders.product[AggData]
 }
 
-class ReduceAgg[T](func: (T, T) => T, encoder: ExpressionEncoder[T])
-    extends Aggregator[T, (Boolean, T), T] {
-
-  override def zero: (Boolean, T) = (false, null.asInstanceOf[T])
-
-  override def bufferEncoder: Encoder[(Boolean, T)] =
-    ExpressionEncoder.tuple(ExpressionEncoder[Boolean](), encoder)
-
-  override def outputEncoder: Encoder[T] = encoder
-  override def reduce(b: (Boolean, T), a: T): (Boolean, T) = {
-    if (b._1) {
-      (true, func(b._2, a))
-    } else {
-      (true, a)
-    }
-  }
-  override def merge(b1: (Boolean, T), b2: (Boolean, T)): (Boolean, T) = {
-    if (!b1._1) {
-      b2
-    } else if (!b2._1) {
-      b1
-    } else {
-      (true, func(b1._2, b2._2))
-    }
-  }
-  override def finish(reduction: (Boolean, T)): T = {
-    reduction._2
-  }
-}
 
 class DatasetAggregatorSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -342,15 +313,5 @@ class DatasetAggregatorSuite extends QueryTest with SharedSQLContext {
     assert(ds2.select(SeqAgg.toColumn).schema.head.nullable === true)
     val ds3 = sql("SELECT 'Some String' AS b, 1279869254 AS a").as[AggData]
     assert(ds3.select(NameAgg.toColumn).schema.head.nullable === true)
-  }
-
-  test("Aggregator on empty dataset") {
-    val func: (Int, Int) => Int = (v1: Int, v2: Int) => v1 + v2
-    val intEncoder: ExpressionEncoder[Int] = ExpressionEncoder()
-    val aggregator: TypedColumn[Int, Int] = new ReduceAgg(func, intEncoder).toColumn
-
-    val ds = Seq[Int]().toDS()
-    val agged = ds.groupByKey(_ => 1).agg(aggregator)
-    assert(agged.collect === Seq())
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we don't check the value returned by called method in `Invoke`. When the returned value is null and is assigned to a variable of primitive type, `NullPointerException` will be thrown.
## How was this patch tested?

Jenkins tests.
