### PR TITLE
[SPARK-16613] [CORE] RDD.pipe returns values for empty partitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -718,9 +718,8 @@ abstract class RDD[T: ClassTag](
    * is computed by executing the given process once per partition. All elements
    * of each input partition are written to a process's stdin as lines of input separated
    * by a newline. The resulting partition consists of the process's stdout output, with
-   * each line of stdout resulting in one element of the output partition. Note that an empty
-   * partition results in an empty output partition, and no process is invoked for an empty
-   * partition.
+   * each line of stdout resulting in one element of the output partition. A process is invoked
+   * even for empty partitions.
    *
    * The print behavior can be customized by providing two functions.
    *

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -714,7 +714,14 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
-   * Return an RDD created by piping elements to a forked external process.
+   * Return an RDD created by piping elements to a forked external process. The resulting RDD
+   * is computed by executing the given process once per partition. All elements
+   * of each input partition are written to a process's stdin as lines of input separated
+   * by a newline. The resulting partition consists of the process's stdout output, with
+   * each line of stdout resulting in one element of the output partition. Note that an empty
+   * partition results in an empty output partition, and no process is invoked for an empty
+   * partition.
+   *
    * The print behavior can be customized by providing two functions.
    *
    * @param command command to run in forked process.

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -138,6 +138,12 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
     }
   }
 
+  test("pipe with empty partition") {
+    val data = sc.parallelize(Seq("foo", "bar"), 8)
+    val piped = data.pipe("wc")
+    assert(piped.count == 2)
+  }
+
   test("pipe with env variable") {
     if (testCommandAvailable("printenv")) {
       val nums = sc.makeRDD(Array(1, 2, 3, 4), 2)

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -139,9 +139,11 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   test("pipe with empty partition") {
-    val data = sc.parallelize(Seq("foo", "bar"), 8)
-    val piped = data.pipe("wc")
-    assert(piped.count == 2)
+    val data = sc.parallelize(Seq("foo", "bing"), 8)
+    val piped = data.pipe("wc -c")
+    assert(piped.count == 8)
+    val charCounts = piped.map(_.trim.toInt).collect().toSet
+    assert(Set(0, 4, 5) == charCounts)
   }
 
   test("pipe with env variable") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Document RDD.pipe semantics; don't execute process for empty input partitions.

Note this includes the fix in https://github.com/apache/spark/pull/14256 because it's necessary to even test this. One or the other will merge the fix.
## How was this patch tested?

Jenkins tests including new test.
