### PR TITLE
[SPARK-14974][SQL]delete temporary folder after insert hive table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -292,6 +292,10 @@ case class InsertIntoHiveTable(
         holdDDLTime)
     }
 
+    // delete temporary folder after insert
+    val fileSystem = outputPath.getFileSystem(jobConf)
+    fileSystem.delete(outputPath.getParent, true)
+
     // Invalidate the cache.
     sqlContext.sharedState.cacheManager.invalidateCache(table)
     sqlContext.sessionState.catalog.refreshTable(table.catalogTable.identifier)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modify the code of InsertIntoHiveTable.scala.  To fix  https://issues.apache.org/jira/browse/SPARK-14974
## How was this patch tested?

I think this patch can be tested  manually.
