### PR TITLE
 [SPARK-11976][SPARKR] Support "." character in DataFrame column name

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -345,11 +345,6 @@ setMethod("colnames<-",
               stop("Column names cannot be NA.")
             }
 
-            # Check if the column names have . in it
-            if (any(regexec(".", value, fixed = TRUE)[[1]][1] != -1)) {
-              stop("Colum names cannot contain the '.' symbol.")
-            }
-
             sdf <- callJMethod(x@sdf, "toDF", as.list(value))
             dataFrame(sdf)
           })

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -230,16 +230,6 @@ createDataFrame.default <- function(data, schema = NULL, samplingRatio = 1.0) {
       })
     }
 
-    # SPAKR-SQL does not support '.' in column name, so replace it with '_'
-    # TODO(davies): remove this once SPARK-2775 is fixed
-    names <- lapply(names, function(n) {
-      nn <- gsub("[.]", "_", n)
-      if (nn != n) {
-        warning(paste("Use", nn, "instead of", n, " as column name"))
-      }
-      nn
-    })
-
     types <- lapply(row, infer_type)
     fields <- lapply(1:length(row), function(i) {
       structField(names[[i]], types[[i]], TRUE)

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -23,24 +23,24 @@ context("MLlib functions")
 sparkSession <- sparkR.session(enableHiveSupport = FALSE)
 
 test_that("formula of spark.glm", {
-  training <- suppressWarnings(createDataFrame(iris))
+  training <- createDataFrame(iris)
   # directly calling the spark API
   # dot minus and intercept vs native glm
-  model <- spark.glm(training, Sepal_Width ~ . - Species + 0)
+  model <- spark.glm(training, Sepal.Width ~ . - Species + 0)
   vals <- collect(select(predict(model, training), "prediction"))
   rVals <- predict(glm(Sepal.Width ~ . - Species + 0, data = iris), iris)
   expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
 
   # feature interaction vs native glm
-  model <- spark.glm(training, Sepal_Width ~ Species:Sepal_Length)
+  model <- spark.glm(training, Sepal.Width ~ Species:Sepal.Length)
   vals <- collect(select(predict(model, training), "prediction"))
   rVals <- predict(glm(Sepal.Width ~ Species:Sepal.Length, data = iris), iris)
   expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
 
   # glm should work with long formula
-  training <- suppressWarnings(createDataFrame(iris))
-  training$LongLongLongLongLongName <- training$Sepal_Width
-  training$VeryLongLongLongLonLongName <- training$Sepal_Length
+  training <- createDataFrame(iris)
+  training$LongLongLongLongLongName <- training$Sepal.Width
+  training$VeryLongLongLongLonLongName <- training$Sepal.Length
   training$AnotherLongLongLongLongName <- training$Species
   model <- spark.glm(training, LongLongLongLongLongName ~ VeryLongLongLongLonLongName +
     AnotherLongLongLongLongName)
@@ -50,9 +50,9 @@ test_that("formula of spark.glm", {
 })
 
 test_that("spark.glm and predict", {
-  training <- suppressWarnings(createDataFrame(iris))
+  training <- createDataFrame(iris)
   # gaussian family
-  model <- spark.glm(training, Sepal_Width ~ Sepal_Length + Species)
+  model <- spark.glm(training, Sepal.Width ~ Sepal.Length + Species)
   prediction <- predict(model, training)
   expect_equal(typeof(take(select(prediction, "prediction"), 1)$prediction), "double")
   vals <- collect(select(prediction, "prediction"))
@@ -60,7 +60,7 @@ test_that("spark.glm and predict", {
   expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
 
   # poisson family
-  model <- spark.glm(training, Sepal_Width ~ Sepal_Length + Species,
+  model <- spark.glm(training, Sepal.Width ~ Sepal.Length + Species,
   family = poisson(link = identity))
   prediction <- predict(model, training)
   expect_equal(typeof(take(select(prediction, "prediction"), 1)$prediction), "double")
@@ -77,8 +77,8 @@ test_that("spark.glm and predict", {
 
 test_that("spark.glm summary", {
   # gaussian family
-  training <- suppressWarnings(createDataFrame(iris))
-  stats <- summary(spark.glm(training, Sepal_Width ~ Sepal_Length + Species))
+  training <- createDataFrame(iris)
+  stats <- summary(spark.glm(training, Sepal.Width ~ Sepal.Length + Species))
 
   rStats <- summary(glm(Sepal.Width ~ Sepal.Length + Species, data = iris))
 
@@ -87,7 +87,7 @@ test_that("spark.glm summary", {
   expect_true(all(abs(rCoefs - coefs) < 1e-4))
   expect_true(all(
     rownames(stats$coefficients) ==
-    c("(Intercept)", "Sepal_Length", "Species_versicolor", "Species_virginica")))
+    c("(Intercept)", "Sepal.Length", "Species_versicolor", "Species_virginica")))
   expect_equal(stats$dispersion, rStats$dispersion)
   expect_equal(stats$null.deviance, rStats$null.deviance)
   expect_equal(stats$deviance, rStats$deviance)
@@ -96,9 +96,9 @@ test_that("spark.glm summary", {
   expect_equal(stats$aic, rStats$aic)
 
   # binomial family
-  df <- suppressWarnings(createDataFrame(iris))
+  df <- createDataFrame(iris)
   training <- df[df$Species %in% c("versicolor", "virginica"), ]
-  stats <- summary(spark.glm(training, Species ~ Sepal_Length + Sepal_Width,
+  stats <- summary(spark.glm(training, Species ~ Sepal.Length + Sepal.Width,
     family = binomial(link = "logit")))
 
   rTraining <- iris[iris$Species %in% c("versicolor", "virginica"), ]
@@ -110,7 +110,7 @@ test_that("spark.glm summary", {
   expect_true(all(abs(rCoefs - coefs) < 1e-4))
   expect_true(all(
     rownames(stats$coefficients) ==
-    c("(Intercept)", "Sepal_Length", "Sepal_Width")))
+    c("(Intercept)", "Sepal.Length", "Sepal.Width")))
   expect_equal(stats$dispersion, rStats$dispersion)
   expect_equal(stats$null.deviance, rStats$null.deviance)
   expect_equal(stats$deviance, rStats$deviance)
@@ -125,8 +125,8 @@ test_that("spark.glm summary", {
 })
 
 test_that("spark.glm save/load", {
-  training <- suppressWarnings(createDataFrame(iris))
-  m <- spark.glm(training, Sepal_Width ~ Sepal_Length + Species)
+  training <- createDataFrame(iris)
+  m <- spark.glm(training, Sepal.Width ~ Sepal.Length + Species)
   s <- summary(m)
 
   modelPath <- tempfile(pattern = "spark-glm", fileext = ".tmp")
@@ -154,23 +154,23 @@ test_that("spark.glm save/load", {
 
 
 test_that("formula of glm", {
-  training <- suppressWarnings(createDataFrame(iris))
+  training <- createDataFrame(iris)
   # dot minus and intercept vs native glm
-  model <- glm(Sepal_Width ~ . - Species + 0, data = training)
+  model <- glm(Sepal.Width ~ . - Species + 0, data = training)
   vals <- collect(select(predict(model, training), "prediction"))
   rVals <- predict(glm(Sepal.Width ~ . - Species + 0, data = iris), iris)
   expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
 
   # feature interaction vs native glm
-  model <- glm(Sepal_Width ~ Species:Sepal_Length, data = training)
+  model <- glm(Sepal.Width ~ Species:Sepal.Length, data = training)
   vals <- collect(select(predict(model, training), "prediction"))
   rVals <- predict(glm(Sepal.Width ~ Species:Sepal.Length, data = iris), iris)
   expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
 
   # glm should work with long formula
-  training <- suppressWarnings(createDataFrame(iris))
-  training$LongLongLongLongLongName <- training$Sepal_Width
-  training$VeryLongLongLongLonLongName <- training$Sepal_Length
+  training <- createDataFrame(iris)
+  training$LongLongLongLongLongName <- training$Sepal.Width
+  training$VeryLongLongLongLonLongName <- training$Sepal.Length
   training$AnotherLongLongLongLongName <- training$Species
   model <- glm(LongLongLongLongLongName ~ VeryLongLongLongLonLongName + AnotherLongLongLongLongName,
                data = training)
@@ -180,9 +180,9 @@ test_that("formula of glm", {
 })
 
 test_that("glm and predict", {
-  training <- suppressWarnings(createDataFrame(iris))
+  training <- createDataFrame(iris)
   # gaussian family
-  model <- glm(Sepal_Width ~ Sepal_Length + Species, data = training)
+  model <- glm(Sepal.Width ~ Sepal.Length + Species, data = training)
   prediction <- predict(model, training)
   expect_equal(typeof(take(select(prediction, "prediction"), 1)$prediction), "double")
   vals <- collect(select(prediction, "prediction"))
@@ -190,7 +190,7 @@ test_that("glm and predict", {
   expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
 
   # poisson family
-  model <- glm(Sepal_Width ~ Sepal_Length + Species, data = training,
+  model <- glm(Sepal.Width ~ Sepal.Length + Species, data = training,
                family = poisson(link = identity))
   prediction <- predict(model, training)
   expect_equal(typeof(take(select(prediction, "prediction"), 1)$prediction), "double")
@@ -207,8 +207,8 @@ test_that("glm and predict", {
 
 test_that("glm summary", {
   # gaussian family
-  training <- suppressWarnings(createDataFrame(iris))
-  stats <- summary(glm(Sepal_Width ~ Sepal_Length + Species, data = training))
+  training <- createDataFrame(iris)
+  stats <- summary(glm(Sepal.Width ~ Sepal.Length + Species, data = training))
 
   rStats <- summary(glm(Sepal.Width ~ Sepal.Length + Species, data = iris))
 
@@ -217,7 +217,7 @@ test_that("glm summary", {
   expect_true(all(abs(rCoefs - coefs) < 1e-4))
   expect_true(all(
     rownames(stats$coefficients) ==
-    c("(Intercept)", "Sepal_Length", "Species_versicolor", "Species_virginica")))
+    c("(Intercept)", "Sepal.Length", "Species_versicolor", "Species_virginica")))
   expect_equal(stats$dispersion, rStats$dispersion)
   expect_equal(stats$null.deviance, rStats$null.deviance)
   expect_equal(stats$deviance, rStats$deviance)
@@ -226,9 +226,9 @@ test_that("glm summary", {
   expect_equal(stats$aic, rStats$aic)
 
   # binomial family
-  df <- suppressWarnings(createDataFrame(iris))
+  df <- createDataFrame(iris)
   training <- df[df$Species %in% c("versicolor", "virginica"), ]
-  stats <- summary(glm(Species ~ Sepal_Length + Sepal_Width, data = training,
+  stats <- summary(glm(Species ~ Sepal.Length + Sepal.Width, data = training,
     family = binomial(link = "logit")))
 
   rTraining <- iris[iris$Species %in% c("versicolor", "virginica"), ]
@@ -240,7 +240,7 @@ test_that("glm summary", {
   expect_true(all(abs(rCoefs - coefs) < 1e-4))
   expect_true(all(
     rownames(stats$coefficients) ==
-    c("(Intercept)", "Sepal_Length", "Sepal_Width")))
+    c("(Intercept)", "Sepal.Length", "Sepal.Width")))
   expect_equal(stats$dispersion, rStats$dispersion)
   expect_equal(stats$null.deviance, rStats$null.deviance)
   expect_equal(stats$deviance, rStats$deviance)
@@ -255,8 +255,8 @@ test_that("glm summary", {
 })
 
 test_that("glm save/load", {
-  training <- suppressWarnings(createDataFrame(iris))
-  m <- glm(Sepal_Width ~ Sepal_Length + Species, data = training)
+  training <- createDataFrame(iris)
+  m <- glm(Sepal.Width ~ Sepal.Length + Species, data = training)
   s <- summary(m)
 
   modelPath <- tempfile(pattern = "glm", fileext = ".tmp")
@@ -284,7 +284,7 @@ test_that("glm save/load", {
 test_that("spark.kmeans", {
   newIris <- iris
   newIris$Species <- NULL
-  training <- suppressWarnings(createDataFrame(newIris))
+  training <- createDataFrame(newIris)
 
   take(training, 1)
 
@@ -362,12 +362,12 @@ test_that("spark.naiveBayes", {
 
   t <- as.data.frame(Titanic)
   t1 <- t[t$Freq > 0, -5]
-  df <- suppressWarnings(createDataFrame(t1))
+  df <- createDataFrame(t1)
   m <- spark.naiveBayes(df, Survived ~ ., smoothing = 0.0)
   s <- summary(m)
   expect_equal(as.double(s$apriori[1, "Yes"]), 0.5833333, tolerance = 1e-6)
   expect_equal(sum(s$apriori), 1)
-  expect_equal(as.double(s$tables["Yes", "Age_Adult"]), 0.5714286, tolerance = 1e-6)
+  expect_equal(as.double(s$tables["Yes", "Age.Adult"]), 0.5714286, tolerance = 1e-6)
   p <- collect(select(predict(m, df), "prediction"))
   expect_equal(p$prediction, c("Yes", "Yes", "Yes", "Yes", "No", "No", "Yes", "Yes", "No", "No",
                                "Yes", "Yes", "Yes", "Yes", "Yes", "Yes", "Yes", "Yes", "No", "No",

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -769,8 +769,6 @@ test_that("names() colnames() set the column names", {
   colnames(df) <- c("col3", "col4")
   expect_equal(names(df)[1], "col3")
 
-  expect_error(colnames(df) <- c("sepal.length", "sepal_width"),
-               "Colum names cannot contain the '.' symbol.")
   expect_error(colnames(df) <- c(1, 2), "Invalid column names.")
   expect_error(colnames(df) <- c("a"),
                "Column names must have the same length as the number of columns in the dataset.")
@@ -778,7 +776,7 @@ test_that("names() colnames() set the column names", {
 
   # Note: if this test is broken, remove check for "." character on colnames<- method
   irisDF <- suppressWarnings(createDataFrame(iris))
-  expect_equal(names(irisDF)[1], "Sepal_Length")
+  expect_equal(names(irisDF)[1], "Sepal.Length")
 
   # Test base::colnames base::names
   m2 <- cbind(1, 1:4)
@@ -2067,11 +2065,11 @@ test_that("attach() on a DataFrame", {
 })
 
 test_that("with() on a DataFrame", {
-  df <- suppressWarnings(createDataFrame(iris))
-  expect_error(Sepal_Length)
-  sum1 <- with(df, list(summary(Sepal_Length), summary(Sepal_Width)))
-  expect_equal(collect(sum1[[1]])[1, "Sepal_Length"], "150")
-  sum2 <- with(df, distinct(Sepal_Length))
+  df <- createDataFrame(iris)
+  expect_error(Sepal.Length)
+  sum1 <- with(df, list(summary(Sepal.Length), summary(Sepal.Width)))
+  expect_equal(collect(sum1[[1]])[1, "Sepal.Length"], "150")
+  sum2 <- with(df, distinct(Sepal.Length))
   expect_equal(nrow(sum2), 35)
 })
 
@@ -2117,17 +2115,17 @@ test_that("Method coltypes() to get and set R's data types of a DataFrame", {
 test_that("Method str()", {
   # Structure of Iris
   iris2 <- iris
-  colnames(iris2) <- c("Sepal_Length", "Sepal_Width", "Petal_Length", "Petal_Width", "Species")
+  colnames(iris2) <- c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
   iris2$col <- TRUE
   irisDF2 <- createDataFrame(iris2)
 
   out <- capture.output(str(irisDF2))
   expect_equal(length(out), 7)
   expect_equal(out[1], "'SparkDataFrame': 6 variables:")
-  expect_equal(out[2], " $ Sepal_Length: num 5.1 4.9 4.7 4.6 5 5.4")
-  expect_equal(out[3], " $ Sepal_Width : num 3.5 3 3.2 3.1 3.6 3.9")
-  expect_equal(out[4], " $ Petal_Length: num 1.4 1.4 1.3 1.5 1.4 1.7")
-  expect_equal(out[5], " $ Petal_Width : num 0.2 0.2 0.2 0.2 0.2 0.4")
+  expect_equal(out[2], " $ Sepal.Length: num 5.1 4.9 4.7 4.6 5 5.4")
+  expect_equal(out[3], " $ Sepal.Width : num 3.5 3 3.2 3.1 3.6 3.9")
+  expect_equal(out[4], " $ Petal.Length: num 1.4 1.4 1.3 1.5 1.4 1.7")
+  expect_equal(out[5], " $ Petal.Width : num 0.2 0.2 0.2 0.2 0.2 0.4")
   expect_equal(out[6], paste0(" $ Species     : chr \"setosa\" \"setosa\" \"",
                               "setosa\" \"setosa\" \"setosa\" \"setosa\""))
   expect_equal(out[7], " $ col         : logi TRUE TRUE TRUE TRUE TRUE TRUE")
@@ -2149,7 +2147,7 @@ test_that("Histogram", {
 
   # Basic histogram test with colname
   expect_equal(
-    all(histogram(irisDF, "Petal_Width", 8) ==
+    all(histogram(irisDF, "Petal.Width", 8) ==
         data.frame(bins = seq(0, 7),
                    counts = c(48, 2, 7, 21, 24, 19, 15, 14),
                    centroids = seq(0, 7) * 0.3 + 0.25)),
@@ -2157,7 +2155,7 @@ test_that("Histogram", {
 
   # Basic histogram test with Column
   expect_equal(
-    all(histogram(irisDF, irisDF$Petal_Width, 8) ==
+    all(histogram(irisDF, irisDF$Petal.Width, 8) ==
           data.frame(bins = seq(0, 7),
                      counts = c(48, 2, 7, 21, 24, 19, 15, 14),
                      centroids = seq(0, 7) * 0.3 + 0.25)),
@@ -2165,26 +2163,26 @@ test_that("Histogram", {
 
   # Basic histogram test with derived column
   expect_equal(
-    all(round(histogram(irisDF, irisDF$Petal_Width + 1, 8), 2) ==
+    all(round(histogram(irisDF, irisDF$Petal.Width + 1, 8), 2) ==
           data.frame(bins = seq(0, 7),
                      counts = c(48, 2, 7, 21, 24, 19, 15, 14),
                      centroids = seq(0, 7) * 0.3 + 1.25)),
     TRUE)
 
   # Missing nbins
-  expect_equal(length(histogram(irisDF, "Petal_Width")$counts), 10)
+  expect_equal(length(histogram(irisDF, "Petal.Width")$counts), 10)
 
   # Wrong colname
   expect_error(histogram(irisDF, "xxx"),
                "Specified colname does not belong to the given SparkDataFrame.")
 
   # Invalid nbins
-  expect_error(histogram(irisDF, "Petal_Width", nbins = 0),
+  expect_error(histogram(irisDF, "Petal.Width", nbins = 0),
                "The number of bins must be a positive integer number greater than 1.")
 
   # Test against R's hist
   expect_equal(all(hist(iris$Sepal.Width)$counts ==
-                   histogram(irisDF, "Sepal_Width", 12)$counts), T)
+                   histogram(irisDF, "Sepal.Width", 12)$counts), T)
 
   # Test when there are zero counts
   df <- as.DataFrame(data.frame(x = c(1, 2, 3, 4, 100)))
@@ -2352,23 +2350,23 @@ test_that("gapply() and gapplyCollect() on a DataFrame", {
   actual <- df3Collect[order(df3Collect$a), ]
   expect_identical(actual$avg, expected$avg)
 
-  irisDF <- suppressWarnings(createDataFrame (iris))
-  schema <-  structType(structField("Sepal_Length", "double"), structField("Avg", "double"))
-  # Groups by `Sepal_Length` and computes the average for `Sepal_Width`
+  irisDF <- createDataFrame (iris)
+  schema <-  structType(structField("Sepal.Length", "double"), structField("Avg", "double"))
+  # Groups by `Sepal.Length` and computes the average for `Sepal.Width`
   df4 <- gapply(
-    cols = "Sepal_Length",
+    cols = "Sepal.Length",
     irisDF,
     function(key, x) {
-      y <- data.frame(key, mean(x$Sepal_Width), stringsAsFactors = FALSE)
+      y <- data.frame(key, mean(x$Sepal.Width), stringsAsFactors = FALSE)
     },
     schema)
   actual <- collect(df4)
-  actual <- actual[order(actual$Sepal_Length), ]
+  actual <- actual[order(actual$Sepal.Length), ]
   rownames(actual) <- NULL
   agg_local_df <- data.frame(aggregate(iris$Sepal.Width, by = list(iris$Sepal.Length), FUN = mean),
                     stringsAsFactors = FALSE)
-  colnames(agg_local_df) <- c("Sepal_Length", "Avg")
-  expected <-  agg_local_df[order(agg_local_df$Sepal_Length), ]
+  colnames(agg_local_df) <- c("Sepal.Length", "Avg")
+  expected <-  agg_local_df[order(agg_local_df$Sepal.Length), ]
   rownames(expected) <- NULL
   expect_identical(actual, expected)
 })

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -201,6 +201,8 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
       attribute: Attribute): Option[(Attribute, List[String])] = {
     if (!attribute.isGenerated && resolver(attribute.name, nameParts.head)) {
       Option((attribute.withName(nameParts.head), nameParts.tail.toList))
+    } else if (!attribute.isGenerated && resolver(attribute.name, nameParts.mkString("."))) {
+      Option((attribute.withName(nameParts.mkString(".")), Nil))
     } else {
       None
     }


### PR DESCRIPTION
```
## What changes were proposed in this pull request?
- Add support "." character in DataFrame column name
- Remove R code in "createDataFrame()" that replaces "." with "_"
- Remove warning suppression in createDataFrame() for iris dataset (introduced in SPARK-12034)

## How was this patch tested?
SparkR unit tests and manual testing with the R script described in SPARK-11976
```
