### PR TITLE
[SPARK-16440][MLlib] Destroy broadcasted variables even on driver

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -434,9 +434,9 @@ class Word2Vec extends Serializable with Logging {
       bcSyn1Global.unpersist(false)
     }
     newSentences.unpersist()
-    expTable.unpersist()
-    bcVocab.unpersist()
-    bcVocabHash.unpersist()
+    expTable.destroy()
+    bcVocab.destroy()
+    bcVocabHash.destroy()
 
     val wordArray = vocab.map(_.word)
     new Word2VecModel(wordArray.zipWithIndex.toMap, syn0Global)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forgotten broadcasted variables were persisted into a previous #PR 14153). This PR turns those `unpersist()` into `destroy()` so that memory is freed even on the driver.
## How was this patch tested?

Unit Tests in Word2VecSuite were run locally.

This contribution is done on behalf of Criteo, according to the
terms of the Apache license 2.0.
