### PR TITLE
[SPARK-5847][CORE] Allow for configuring MetricsSystem's use of app ID to namespace all metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -108,4 +108,9 @@ package object config {
     ConfigBuilder("spark.scheduler.listenerbus.eventqueue.size")
       .intConf
       .createWithDefault(10000)
+
+  // This property sets the root namespace for metrics reporting
+  private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
+    .stringConf
+    .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -33,10 +33,10 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
   private val DEFAULT_PREFIX = "*"
   private val INSTANCE_REGEX = "^(\\*|[a-zA-Z]+)\\.(.+)".r
   private val DEFAULT_METRICS_CONF_FILENAME = "metrics.properties"
-  // This is intetionally made to not fall the prefix (spark.metrics.conf) because it's not
+  // This is intetionally made to not fall in the prefix (spark.metrics.conf) because it's not
   // intended to be a _real_ metrics property, for example, its first part before the dot
   // doesn't represent the instance (master, worker, etc.). Instead, it's used to configure the
-  // metrics systems. Where accessed, this should be namespace property should be directly accessed
+  // metrics systems. Where accessed, this namespace property should be directly accessed
   // from SparkConf using its full name, represented here.
   private val NAMESPACE_CONFIG_PROPERTY = "spark.metrics.namespace"
 
@@ -71,8 +71,8 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
 
     // Now, let's populate a list of sub-properties per instance, instance being the prefix that
     // appears before the first dot in the property name.
-    // Add to the sub-properties per instance, the default properties (those with prefix "*"), as
-    // as they don't have a more specific sub-property already defined.
+    // Add to the sub-properties per instance, the default properties (those with prefix "*"), if
+    // they don't have that exact same sub-property already defined.
     //
     // For example, if properties has ("*.class"->"default_class", "*.path"->"default_path,
     // "driver.path"->"driver_path"), for driver specific sub-properties, we'd like the output to be
@@ -92,9 +92,9 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
   }
 
   /**
-   * Take a simple set of properties and a regex that the property names have to conform to.
-   * And, return a map of the first order prefix (before the first dot) to the subproperties under
-   * that prefix.
+   * Take a simple set of properties and a regex that the instance names (part before the first dot)
+   * have to conform to. And, return a map of the first order prefix (before the first dot) to the
+   * sub-properties under that prefix.
    *
    * For example, if the properties sent were Properties("*.sink.servlet.class"->"class1",
    * "*.sink.servlet.path"->"path1"), the returned map would be

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -33,16 +33,9 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
   private val DEFAULT_PREFIX = "*"
   private val INSTANCE_REGEX = "^(\\*|[a-zA-Z]+)\\.(.+)".r
   private val DEFAULT_METRICS_CONF_FILENAME = "metrics.properties"
-  // This is intetionally made to not fall in the prefix (spark.metrics.conf) because it's not
-  // intended to be a _real_ metrics property, for example, its first part before the dot
-  // doesn't represent the instance (master, worker, etc.). Instead, it's used to configure the
-  // metrics systems. Where accessed, this namespace property should be directly accessed
-  // from SparkConf using its full name, represented here.
-  private val NAMESPACE_CONFIG_PROPERTY = "spark.metrics.namespace"
 
   private[metrics] val properties = new Properties()
   private[metrics] var perInstanceSubProperties: mutable.HashMap[String, Properties] = null
-  private[metrics] var metricsNamespace: String = null
 
   private def setDefaultProperties(prop: Properties) {
     prop.setProperty("*.sink.servlet.class", "org.apache.spark.metrics.sink.MetricsServlet")
@@ -88,7 +81,6 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
         prop.put(k, v)
       }
     }
-    metricsNamespace = conf.getOption(NAMESPACE_CONFIG_PROPERTY).getOrElse("spark.app.id")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -32,24 +32,24 @@ import org.apache.spark.metrics.source.{Source, StaticSources}
 import org.apache.spark.util.Utils
 
 /**
- * Spark Metrics System, created by specific "instance", combined by source,
- * sink, periodically poll source metrics data to sink destinations.
+ * Spark Metrics System, created by a specific "instance", combined by source,
+ * sink, periodically polls source metrics data to sink destinations.
  *
- * "instance" specify "who" (the role) use metrics system. In spark there are several roles
- * like master, worker, executor, client driver, these roles will create metrics system
- * for monitoring. So instance represents these roles. Currently in Spark, several instances
+ * "instance" specifies "who" (the role) uses the metrics system. In Spark, there are several roles
+ * like master, worker, executor, client driver. These roles will create metrics system
+ * for monitoring. So, "instance" represents these roles. Currently in Spark, several instances
  * have already implemented: master, worker, executor, driver, applications.
  *
- * "source" specify "where" (source) to collect metrics data. In metrics system, there exists
+ * "source" specifies "where" (source) to collect metrics data from. In metrics system, there exists
  * two kinds of source:
  *   1. Spark internal source, like MasterSource, WorkerSource, etc, which will collect
  *   Spark component's internal state, these sources are related to instance and will be
- *   added after specific metrics system is created.
+ *   added after a specific metrics system is created.
  *   2. Common source, like JvmSource, which will collect low level state, is configured by
  *   configuration and loaded through reflection.
  *
- * "sink" specify "where" (destination) to output metrics data to. Several sinks can be
- * coexisted and flush metrics to all these sinks.
+ * "sink" specifies "where" (destination) to output metrics data to. Several sinks can
+ * coexist and metrics can be flushed to all these sinks.
  *
  * Metrics configuration format is like below:
  * [instance].[sink|source].[name].[options] = xxxx
@@ -62,9 +62,9 @@ import org.apache.spark.util.Utils
  * [sink|source] means this property belongs to source or sink. This field can only be
  * source or sink.
  *
- * [name] specify the name of sink or source, it is custom defined.
+ * [name] specify the name of sink or source, if it is custom defined.
  *
- * [options] is the specific property of this source or sink.
+ * [options] represent the specific property of this source or sink.
  */
 private[spark] class MetricsSystem private (
     val instance: String,
@@ -125,19 +125,23 @@ private[spark] class MetricsSystem private (
    *         application, executor/driver and metric source.
    */
   private[spark] def buildRegistryName(source: Source): String = {
-    val appId = conf.getOption("spark.app.id")
+    val metricsNamespace = conf.getOption(metricsConfig.metricsNamespace)
     val executorId = conf.getOption("spark.executor.id")
     val defaultName = MetricRegistry.name(source.sourceName)
 
     if (instance == "driver" || instance == "executor") {
-      if (appId.isDefined && executorId.isDefined) {
-        MetricRegistry.name(appId.get, executorId.get, source.sourceName)
+      if (metricsNamespace.isDefined && executorId.isDefined) {
+        MetricRegistry.name(metricsNamespace.get, executorId.get, source.sourceName)
       } else {
         // Only Driver and Executor set spark.app.id and spark.executor.id.
         // Other instance types, e.g. Master and Worker, are not related to a specific application.
-        val warningMsg = s"Using default name $defaultName for source because %s is not set."
-        if (appId.isEmpty) { logWarning(warningMsg.format("spark.app.id")) }
-        if (executorId.isEmpty) { logWarning(warningMsg.format("spark.executor.id")) }
+        val warningMsgFormat = s"Using default name $defaultName for source because %s is not set."
+        if (metricsNamespace.isEmpty) {
+          logWarning(warningMsgFormat.format(metricsConfig.metricsNamespace))
+        }
+        if (executorId.isEmpty) {
+          logWarning(warningMsgFormat.format("spark.executor.id"))
+        }
         defaultName
       }
     } else { defaultName }

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -126,8 +126,7 @@ private[spark] class MetricsSystem private (
    *         application, executor/driver and metric source.
    */
   private[spark] def buildRegistryName(source: Source): String = {
-    val metricsNamespace = conf.get(METRICS_NAMESPACE).map(Some(_))
-      .getOrElse(conf.getOption("spark.app.id"))
+    val metricsNamespace = conf.get(METRICS_NAMESPACE).orElse(conf.getOption("spark.app.id"))
 
     val executorId = conf.getOption("spark.executor.id")
     val defaultName = MetricRegistry.name(source.sourceName)

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsConfigSuite.scala
@@ -37,6 +37,7 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
 
     assert(conf.properties.size() === 4)
     assert(conf.properties.getProperty("test-for-dummy") === null)
+    assert(conf.metricsNamespace === "spark.app.id")
 
     val property = conf.getInstance("random")
     assert(property.size() === 2)
@@ -70,6 +71,8 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(workerProp.getProperty("sink.servlet.class") ===
       "org.apache.spark.metrics.sink.MetricsServlet")
     assert(workerProp.getProperty("sink.servlet.path") === "/metrics/json")
+
+    assert(conf.metricsNamespace === "spark.app.id")
   }
 
   test("MetricsConfig with properties set from a Spark configuration") {
@@ -101,6 +104,8 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(workerProp.getProperty("sink.servlet.class") ===
       "org.apache.spark.metrics.sink.MetricsServlet")
     assert(workerProp.getProperty("sink.servlet.path") === "/metrics/json")
+
+    assert(conf.metricsNamespace === "spark.app.id")
   }
 
   test("MetricsConfig with properties set from a file and a Spark configuration") {
@@ -131,6 +136,8 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(workerProp.getProperty("sink.servlet.class") ===
       "org.apache.spark.metrics.sink.MetricsServlet")
     assert(workerProp.getProperty("sink.servlet.path") === "/metrics/json")
+
+    assert(conf.metricsNamespace === "spark.app.id")
   }
 
   test("MetricsConfig with subProperties") {
@@ -139,7 +146,7 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     val conf = new MetricsConfig(sparkConf)
     conf.initialize()
 
-    val propCategories = conf.propertyCategories
+    val propCategories = conf.perInstanceSubProperties
     assert(propCategories.size === 3)
 
     val masterProp = conf.getInstance("master")
@@ -157,6 +164,15 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
 
     val servletProps = sinkProps("servlet")
     assert(servletProps.size() === 2)
+  }
+
+  test("MetricsConfig with alternate namespace set") {
+    val sparkConf = new SparkConf(loadDefaults = false)
+    sparkConf.set("spark.metrics.conf", filePath)
+    sparkConf.set("spark.metrics.namespace", "spark.app.name")
+    val conf = new MetricsConfig(sparkConf)
+    conf.initialize()
+    assert(conf.metricsNamespace == "spark.app.name")
   }
 
   private def setMetricsProperty(conf: SparkConf, name: String, value: String): Unit = {

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsConfigSuite.scala
@@ -37,7 +37,6 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
 
     assert(conf.properties.size() === 4)
     assert(conf.properties.getProperty("test-for-dummy") === null)
-    assert(conf.metricsNamespace === "spark.app.id")
 
     val property = conf.getInstance("random")
     assert(property.size() === 2)
@@ -71,8 +70,6 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(workerProp.getProperty("sink.servlet.class") ===
       "org.apache.spark.metrics.sink.MetricsServlet")
     assert(workerProp.getProperty("sink.servlet.path") === "/metrics/json")
-
-    assert(conf.metricsNamespace === "spark.app.id")
   }
 
   test("MetricsConfig with properties set from a Spark configuration") {
@@ -104,8 +101,6 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(workerProp.getProperty("sink.servlet.class") ===
       "org.apache.spark.metrics.sink.MetricsServlet")
     assert(workerProp.getProperty("sink.servlet.path") === "/metrics/json")
-
-    assert(conf.metricsNamespace === "spark.app.id")
   }
 
   test("MetricsConfig with properties set from a file and a Spark configuration") {
@@ -136,8 +131,6 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(workerProp.getProperty("sink.servlet.class") ===
       "org.apache.spark.metrics.sink.MetricsServlet")
     assert(workerProp.getProperty("sink.servlet.path") === "/metrics/json")
-
-    assert(conf.metricsNamespace === "spark.app.id")
   }
 
   test("MetricsConfig with subProperties") {
@@ -164,15 +157,6 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
 
     val servletProps = sinkProps("servlet")
     assert(servletProps.size() === 2)
-  }
-
-  test("MetricsConfig with alternate namespace set") {
-    val sparkConf = new SparkConf(loadDefaults = false)
-    sparkConf.set("spark.metrics.conf", filePath)
-    sparkConf.set("spark.metrics.namespace", "spark.app.name")
-    val conf = new MetricsConfig(sparkConf)
-    conf.initialize()
-    assert(conf.metricsNamespace == "spark.app.name")
   }
 
   private def setMetricsProperty(conf: SparkConf, name: String, value: String): Unit = {

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -222,7 +222,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
 
     val metricName = driverMetricsSystem.buildRegistryName(source)
     // If the user set the spark.metrics.namespace property to an expansion of another property
-    // (say ${spark.doesnotexist}, the unresolved name (i.e. litterally ${spark.doesnot})
+    // (say ${spark.doesnotexist}, the unresolved name (i.e. literally ${spark.doesnotexist})
     // is used as the root logger name.
     assert(metricName === s"$namespaceToResolve.$executorId.${source.sourceName}")
   }

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -206,7 +206,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     assert(metricName === s"$appName.$executorId.${source.sourceName}")
   }
 
-  test("MetricsSystem with Executor instance and custom namespace which is not set") {
+  test("MetricsSystem with Executor instance, custom namespace which is not set") {
     val source = new Source {
       override val sourceName = "dummySource"
       override val metricRegistry = new MetricRegistry()
@@ -227,8 +227,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     assert(metricName === s"$namespaceToResolve.$executorId.${source.sourceName}")
   }
 
-  test("MetricsSystem with Executor instance and custom namespace and spark.executor.id is not " +
-    "set") {
+  test("MetricsSystem with Executor instance, custom namespace, spark.executor.id not set") {
     val source = new Source {
       override val sourceName = "dummySource"
       override val metricRegistry = new MetricRegistry()
@@ -245,7 +244,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     assert(metricName === source.sourceName)
   }
 
-  test("MetricsSystem with instance which is neither Driver nor Executor and custom namespace") {
+  test("MetricsSystem with non-driver, non-executor instance with custom namespace") {
     val source = new Source {
       override val sourceName = "dummySource"
       override val metricRegistry = new MetricRegistry()

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -255,7 +255,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     val executorId = "dummyExecutorId"
     conf.set("spark.app.id", appId)
     conf.set("spark.app.name", appName)
-    conf.set("spark.metrics.namespace", "${spark.app.name}")
+    conf.set(METRICS_NAMESPACE, "${spark.app.name}")
     conf.set("spark.executor.id", executorId)
 
     val instanceName = "testInstance"

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -183,4 +183,85 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     assert(metricName != s"$appId.$executorId.${source.sourceName}")
     assert(metricName === source.sourceName)
   }
+
+  test("MetricsSystem with Executor instance, with custom namespace") {
+    val source = new Source {
+      override val sourceName = "dummySource"
+      override val metricRegistry = new MetricRegistry()
+    }
+
+    val appId = "testId"
+    val appName = "testName"
+    val executorId = "1"
+    conf.set("spark.app.id", appId)
+    conf.set("spark.app.name", appName)
+    conf.set("spark.executor.id", executorId)
+    conf.set("spark.metrics.namespace", "spark.app.name")
+
+    val instanceName = "executor"
+    val driverMetricsSystem = MetricsSystem.createMetricsSystem(instanceName, conf, securityMgr)
+
+    val metricName = driverMetricsSystem.buildRegistryName(source)
+    assert(metricName === s"$appName.$executorId.${source.sourceName}")
+  }
+
+  test("MetricsSystem with Executor instance and custom namespace which is not set") {
+    val source = new Source {
+      override val sourceName = "dummySource"
+      override val metricRegistry = new MetricRegistry()
+    }
+
+    val executorId = "1"
+    conf.set("spark.executor.id", executorId)
+    conf.set("spark.metrics.namespace", "spark.app.name")
+
+    val instanceName = "executor"
+    val driverMetricsSystem = MetricsSystem.createMetricsSystem(instanceName, conf, securityMgr)
+
+    val metricName = driverMetricsSystem.buildRegistryName(source)
+    assert(metricName === source.sourceName)
+  }
+
+  test("MetricsSystem with Executor instance and custom namespace and spark.executor.id is not " +
+    "set") {
+    val source = new Source {
+      override val sourceName = "dummySource"
+      override val metricRegistry = new MetricRegistry()
+    }
+
+    val appId = "testId"
+    conf.set("spark.app.name", appId)
+    conf.set("spark.metrics.namespace", "spark.app.name")
+
+    val instanceName = "executor"
+    val driverMetricsSystem = MetricsSystem.createMetricsSystem(instanceName, conf, securityMgr)
+
+    val metricName = driverMetricsSystem.buildRegistryName(source)
+    assert(metricName === source.sourceName)
+  }
+
+  test("MetricsSystem with instance which is neither Driver nor Executor and custom namespace") {
+    val source = new Source {
+      override val sourceName = "dummySource"
+      override val metricRegistry = new MetricRegistry()
+    }
+
+    val appId = "testId"
+    val appName = "testName"
+    val executorId = "dummyExecutorId"
+    conf.set("spark.app.id", appId)
+    conf.set("spark.app.name", appName)
+    conf.set("spark.metrics.namespace", "spark.app.name")
+    conf.set("spark.executor.id", executorId)
+
+    val instanceName = "testInstance"
+    val driverMetricsSystem = MetricsSystem.createMetricsSystem(instanceName, conf, securityMgr)
+
+    val metricName = driverMetricsSystem.buildRegistryName(source)
+
+    // Even if spark.app.id and spark.executor.id are set, they are not used for the metric name.
+    assert(metricName != s"$appId.$executorId.${source.sourceName}")
+    assert(metricName === source.sourceName)
+  }
+
 }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -346,17 +346,17 @@ This allows users to report Spark metrics to a variety of sinks including HTTP, 
 files. The metrics system is configured via a configuration file that Spark expects to be present
 at `$SPARK_HOME/conf/metrics.properties`. A custom file location can be specified via the
 `spark.metrics.conf` [configuration property](configuration.html#spark-properties).
-Also, a custom namespace can be specified to report metrics using `spark.metrics.namespace` 
-configuration property. By default, the root namespace used for driver or executor metrics is 
+By default, the root namespace used for driver or executor metrics is 
 the value of `spark.app.id`. However, often times, users want to be able to track the metrics 
-across apps for driver and executor metrics, which is hard to do with application ID 
+across apps for driver and executors, which is hard to do with application ID 
 (i.e. `spark.app.id`) since it changes with every invocation of the app. For such use cases,
-users can set the `spark.metrics.namespace` property to another spark configuration key like
-`spark.app.name` which is then used to populate the root namespace of the metrics system 
-(with the app name in our example). `spark.metrics.namespace` property can be set to any 
-arbitrary spark property key, whose value would be used to set the root namespace of the 
-metrics system. Non driver and executor metrics are never prefixed with `spark.app.id`, nor
-does the `spark.metrics.namespace` property have any such affect on such metrics.
+a custom namespace can be specified for metrics reporting using `spark.metrics.namespace`
+configuration property. 
+If, say, users wanted to set the metrics namespace to the name of the application, they
+can set the `spark.metrics.namespace` property to a value like `${spark.app.name}`. This value is
+then expanded appropriately by Spark and is used as the root namespace of the metrics system. 
+Non driver and executor metrics are never prefixed with `spark.app.id`, nor does the 
+`spark.metrics.namespace` property have any such affect on such metrics.
 
 Spark's metrics are decoupled into different
 _instances_ corresponding to Spark components. Within each instance, you can configure a

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -346,6 +346,18 @@ This allows users to report Spark metrics to a variety of sinks including HTTP, 
 files. The metrics system is configured via a configuration file that Spark expects to be present
 at `$SPARK_HOME/conf/metrics.properties`. A custom file location can be specified via the
 `spark.metrics.conf` [configuration property](configuration.html#spark-properties).
+Also, a custom namespace can be specified to report metrics using `spark.metrics.namespace` 
+configuration property. By default, the root namespace used for driver or executor metrics is 
+the value of `spark.app.id`. However, often times, users want to be able to track the metrics 
+across apps for driver and executor metrics, which is hard to do with application ID 
+(i.e. `spark.app.id`) since it changes with every invocation of the app. For such use cases,
+users can set the `spark.metrics.namespace` property to another spark configuration key like
+`spark.app.name` which is then used to populate the root namespace of the metrics system 
+(with the app name in our example). `spark.metrics.namespace` property can be set to any 
+arbitrary spark property key, whose value would be used to set the root namespace of the 
+metrics system. Non driver and executor metrics are never prefixed with `spark.app.id`, nor
+does the `spark.metrics.namespace` property have any such affect on such metrics.
+
 Spark's metrics are decoupled into different
 _instances_ corresponding to Spark components. Within each instance, you can configure a
 set of sinks to which metrics are reported. The following instances are currently supported:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a new property to SparkConf called spark.metrics.namespace that allows users to
set a custom namespace for executor and driver metrics in the metrics systems.

By default, the root namespace used for driver or executor metrics is
the value of `spark.app.id`. However, often times, users want to be able to track the metrics
across apps for driver and executor metrics, which is hard to do with application ID
(i.e. `spark.app.id`) since it changes with every invocation of the app. For such use cases,
users can set the `spark.metrics.namespace` property to another spark configuration key like
`spark.app.name` which is then used to populate the root namespace of the metrics system
(with the app name in our example). `spark.metrics.namespace` property can be set to any
arbitrary spark property key, whose value would be used to set the root namespace of the
metrics system. Non driver and executor metrics are never prefixed with `spark.app.id`, nor
does the `spark.metrics.namespace` property have any such affect on such metrics.
## How was this patch tested?

Added new unit tests, modified existing unit tests.
