### PR TITLE
[WIP][SPARK-16638][ML][Optimizer] fix L2 reg computation in linearRegression when standarlization is false

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -986,7 +986,7 @@ private class LeastSquaresCostFun(
               // perform this reverse standardization by penalizing each component
               // differently to get effectively the same objective function when
               // the training dataset is not standardized.
-              val temp = value / (featuresStd(index) * featuresStd(index))
+              val temp = value * (featuresStd(index) * featuresStd(index))
               totalGradientArray(index) += effectiveL2regParam * temp
               value * temp
             } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

when `standardization == false`
update L2 reg computation
from
`0.5 * effectiveL2regParam * sigma( ( wi / featuresStd(i) )^2 )`
to
`0.5 * effectiveL2regParam * sigma( ( wi * featuresStd(i) )^2 )`
## How was this patch tested?

Existing test.
