### PR TITLE
[SPARK-16628][SQL] Don't convert Orc Metastore tables to datasource tables if metastore schema does not match schema stored in the files

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
@@ -450,6 +450,40 @@ class OrcQuerySuite extends QueryTest with BeforeAndAfterAll with OrcTest {
     }
   }
 
+  test("No ORC conversion when metastore schema does not match schema stored in ORC files") {
+    withTempTable("single") {
+      val singleRowDF = Seq((0, "foo")).toDF("key", "value")
+      singleRowDF.createOrReplaceTempView("single")
+
+      withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> "true") {
+        withTable("dummy_orc") {
+          withTempPath { dir =>
+            val path = dir.getCanonicalPath
+            singleRowDF.write.partitionBy("key").orc(path)
+
+            // Create a Metastore ORC table with different schema.
+            spark.sql(
+              s"""
+                 |CREATE TABLE dummy_orc(value STRING, value2 STRING)
+                 |PARTITIONED BY (key INT)
+                 |STORED AS ORC
+                 |LOCATION '$path'
+               """.stripMargin)
+
+            val df = spark.sql("SELECT key, value FROM dummy_orc WHERE key=0")
+            val queryExecution = df.queryExecution
+            queryExecution.analyzed.collectFirst {
+              case _: MetastoreRelation => ()
+            }.getOrElse {
+              fail(s"Expecting no conversion from orc to data sources, " +
+                s"but got:\n$queryExecution")
+            }
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-14962 Produce correct results on array type with isnotnull") {
     withSQLConf(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       val data = (0 until 10).map(i => Tuple1(Array(i)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

We will convert Metastore Orc tables (represented by `MetastoreRelation`) to datasource tables (represented by `HadoopFsRelation`) if `spark.sql.hive.convertMetastoreOrc` is enabled for better performance.

However, due to a Hive issue, an Orc table created by Hive does not store column name correctly in the Orc files. For these Orc tables, we can't do the conversion.

This PR tries to compare the inferred schema of Orc files with Metastore schema. If they don't match, we skip the conversion and continue to use `MetastoreRelation`.

As Parquet will have similar conversion, this PR does the same checking for it too.
## How was this patch tested?

Jenkins tests.
