### PR TITLE
[SPARK-16649][SQL] Push partition predicates down into metastore for OptimizeMetadataOnlyQuery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
+import org.apache.spark.sql.catalyst.expressions.Expression
 
 
 /**
@@ -166,6 +167,21 @@ abstract class ExternalCatalog {
       db: String,
       table: String,
       partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition]
+
+  /**
+   * Returns partitions filtered by predicates for the given table, It just work for Hive.
+   *
+   * The filters Expressions may optionally be provided to filter the partitions returned.
+   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
+   * then the filters (a='1') will return the first two only.
+   * @param db database name
+   * @param table table name
+   * @param filters The filters used to prune which partitions are returned.
+   */
+  def listPartitionsByFilter(
+      db: String,
+      table: String,
+      filters: Seq[Expression]): Seq[CatalogTablePartition]
 
   // --------------------------------------------------------------------------
   // Functions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -169,11 +169,12 @@ abstract class ExternalCatalog {
       partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition]
 
   /**
-   * Returns partitions filtered by predicates for the given table, It just work for Hive.
+   * Returns partitions filtered by predicates for the given table, It just works for Hive.
    *
    * The filters Expressions may optionally be provided to filter the partitions returned.
    * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
    * then the filters (a='1') will return the first two only.
+   *
    * @param db database name
    * @param table table name
    * @param filters The filters used to prune which partitions are returned.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.StringUtils
 
 /**
@@ -458,6 +459,14 @@ class InMemoryCatalog(hadoopConfig: Configuration = new Configuration) extends E
       throw new UnsupportedOperationException(
         "listPartition with partial partition spec is not implemented")
     }
+    catalog(db).tables(table).partitions.values.toSeq
+  }
+
+  override def listPartitionsByFilter(
+    db: String,
+    table: String,
+    filters: Seq[Expression]): Seq[CatalogTablePartition] = synchronized {
+    requireTableExists(db, table)
     catalog(db).tables(table).partitions.values.toSeq
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -632,7 +632,7 @@ class SessionCatalog(
   }
 
   /**
-   * Returns partitions filtered by predicates for the given table, It just work for Hive.
+   * Returns partitions filtered by predicates for the given table, It just works for Hive.
    *
    * The filters Expressions may optionally be provided to filter the partitions returned.
    * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -632,6 +632,23 @@ class SessionCatalog(
   }
 
   /**
+   * Returns partitions filtered by predicates for the given table, It just work for Hive.
+   *
+   * The filters Expressions may optionally be provided to filter the partitions returned.
+   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
+   * then the filters (a='1') will return the first two only.
+   */
+  def listPartitionsByFilter(
+    tableName: TableIdentifier,
+    filters: Seq[Expression]): Seq[CatalogTablePartition] = {
+    val db = formatDatabaseName(tableName.database.getOrElse(getCurrentDatabase))
+    val table = formatTableName(tableName.table)
+    requireDbExists(db)
+    requireTableExists(TableIdentifier(table, Option(db)))
+    externalCatalog.listPartitionsByFilter(db, table, filters)
+  }
+
+  /**
    * Verify if the input partition spec exactly matches the existing defined partition spec
    * The columns must be the same but the orders could be different.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -841,6 +841,15 @@ class SessionCatalogSuite extends SparkFunSuite {
     assert(catalog.listPartitions(TableIdentifier("tbl2")).toSet == Set(part1, part2))
   }
 
+  test("list partitions by filter") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    assert(catalog.listPartitionsByFilter(
+      TableIdentifier("tbl2", Some("db2")), Nil).toSet == Set(part1, part2))
+    // List partitions without explicitly specifying database
+    catalog.setCurrentDatabase("db2")
+    assert(catalog.listPartitionsByFilter(TableIdentifier("tbl2"), Nil).toSet == Set(part1, part2))
+  }
+
   test("list partitions when database/table does not exist") {
     val catalog = new SessionCatalog(newBasicCatalog())
     intercept[NoSuchDatabaseException] {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -30,6 +30,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.hive.client.HiveClient
 
 
@@ -332,6 +333,17 @@ private[spark] class HiveExternalCatalog(client: HiveClient, hadoopConf: Configu
       table: String,
       partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition] = withClient {
     client.getPartitions(db, table, partialSpec)
+  }
+
+  /**
+   * Returns the partition names filtered by filters from hive metastore for a given table in a
+   * database.
+   */
+  override def listPartitionsByFilter(
+    db: String,
+    table: String,
+    filters: Seq[Expression]): Seq[CatalogTablePartition] = withClient {
+    client.getPartitionsByFilter(db, table, filters)
   }
 
   // --------------------------------------------------------------------------

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -186,6 +186,14 @@ private[hive] trait HiveClient {
 
   /** Returns partitions filtered by predicates for the given table. */
   def getPartitionsByFilter(
+    db: String,
+    table: String,
+    predicates: Seq[Expression]): Seq[CatalogTablePartition] = {
+    getPartitionsByFilter(getTable(db, table), predicates)
+  }
+
+  /** Returns partitions filtered by predicates for the given table. */
+  def getPartitionsByFilter(
       table: CatalogTable,
       predicates: Seq[Expression]): Seq[CatalogTablePartition]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-6910 has supported for pushing partition predicates down into the metastore for table scan. So it also should push partition predicates down into metastore for OptimizeMetadataOnlyQuery.
## How was this patch tested?

add unit tests.
