### PR TITLE
[SPARK-16656] [SQL] Try to make CreateTableAsSelectSuite more stable

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -37,6 +37,7 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSQLContext with
   override def beforeAll(): Unit = {
     super.beforeAll()
     path = Utils.createTempDir()
+    path.delete()
     val rdd = sparkContext.parallelize((1 to 10).map(i => s"""{"a":$i, "b":"str${i}"}"""))
     spark.read.json(rdd).createOrReplaceTempView("jt")
   }
@@ -44,18 +45,14 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSQLContext with
   override def afterAll(): Unit = {
     try {
       spark.catalog.dropTempView("jt")
-      if (path.exists()) {
-        Utils.deleteRecursively(path)
-      }
+      Utils.deleteRecursively(path)
     } finally {
       super.afterAll()
     }
   }
 
   before {
-    if (path.exists()) {
-      Utils.deleteRecursively(path)
-    }
+    Utils.deleteRecursively(path)
   }
 
   test("CREATE TABLE USING AS SELECT") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.sources
 
 import java.io.File
 
-import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -29,15 +29,16 @@ import org.apache.spark.sql.execution.datasources.BucketSpec
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
-class CreateTableAsSelectSuite extends DataSourceTest with SharedSQLContext with BeforeAndAfter {
+class CreateTableAsSelectSuite
+  extends DataSourceTest
+  with SharedSQLContext
+  with BeforeAndAfterEach {
 
   protected override lazy val sql = spark.sql _
   private var path: File = null
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    path = Utils.createTempDir()
-    path.delete()
     val rdd = sparkContext.parallelize((1 to 10).map(i => s"""{"a":$i, "b":"str${i}"}"""))
     spark.read.json(rdd).createOrReplaceTempView("jt")
   }
@@ -51,8 +52,15 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSQLContext with
     }
   }
 
-  before {
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    path = Utils.createTempDir()
+    path.delete()
+  }
+
+  override def afterEach(): Unit = {
     Utils.deleteRecursively(path)
+    super.afterEach()
   }
 
   test("CREATE TABLE USING AS SELECT") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/62593/testReport/junit/org.apache.spark.sql.sources/CreateTableAsSelectSuite/create_a_table__drop_it_and_create_another_one_with_the_same_name/ shows that `create a table, drop it and create another one with the same name` failed. But other runs were good. Seems it is a flaky test. This PR tries to make this test more stable.
