### PR TITLE
[SPARK-16658][GRAPHX] Add EdgePartition.withVertexAttributes

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartition.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartition.scala
@@ -82,6 +82,13 @@ class EdgePartition[
       Some(activeSet))
   }
 
+  /** Return a new `EdgePartition` with the specified vertex attributes. */
+  def withVertexAttributes[VD2: ClassTag](newVertexAttrs: Array[VD2]): EdgePartition[ED, VD2] = {
+    new EdgePartition(
+      localSrcIds, localDstIds, data, index, global2local, local2global, newVertexAttrs,
+      activeSet)
+  }
+
   /** Return a new `EdgePartition` with updates to vertex attributes specified in `iter`. */
   def updateVertices(iter: Iterator[(VertexId, VD)]): EdgePartition[ED, VD] = {
     val newVertexAttrs = new Array[VD](vertexAttrs.length)


### PR DESCRIPTION
## What changes were proposed in this pull request?

I'm using cloudml/zen, which has forked graphx. I'd like to see their changes upstreamed, so that they can go back to using the upstream graphx instead of having a fork.

[Their implementation of withVertexAttributes](https://github.com/cloudml/zen/blob/94ba7d7f216feb2bff910eec7285dd7caf9440f0/ml/src/main/scala/org/apache/spark/graphx2/impl/EdgePartition.scala)
[Their usage of this method](https://github.com/cloudml/zen/blob/8a64a141685d6637a993c3cc6d1788f414d6c3cf/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDADefines.scala)
## How was this patch tested?

[Because this method is used in the cloudml/zen code](https://github.com/cloudml/zen/blob/8a64a141685d6637a993c3cc6d1788f414d6c3cf/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDADefines.scala) it has seen a decent amount of use.
