### PR TITLE
[GIT] add pydev & Rstudio project file to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .idea/
 .idea_modules/
 .project
+.pydevproject
 .scala_dependencies
 .settings
 /lib/
@@ -78,3 +79,6 @@ spark-warehouse/
 .RData
 .RHistory
 .Rhistory
+*.Rproj
+*.Rproj.*
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Pydev & Rstudio project file to gitignore list, I think the two IEDs are used by many developers.
so that won't need personal gitignore_global config.
## How was this patch tested?

N/A
