### PR TITLE
[SPARK-16646][SQL] LEAST and GREATEST doesn't accept numeric arguments with different data types

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -216,7 +216,6 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     for (operator <- Seq[(Seq[Expression] => Expression)](Greatest, Least)) {
       assertError(operator(Seq('booleanField)), "requires at least 2 arguments")
       assertError(operator(Seq('intField, 'stringField)), "should all have the same type")
-      assertError(operator(Seq('intField, 'decimalField)), "should all have the same type")
       assertError(operator(Seq('mapField, 'mapField)), "does not support ordering")
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -344,6 +344,15 @@ class TypeCoercionSuite extends PlanTest {
           :: Cast(Literal(1), DecimalType(22, 0))
           :: Cast(Literal(new java.math.BigDecimal("1000000000000000000000")), DecimalType(22, 0))
           :: Nil))
+      ruleTest(TypeCoercion.FunctionArgumentConversion,
+        operator(Literal(1L)
+          :: Literal(1)
+          :: Literal(new java.math.BigDecimal("1.5"))
+          :: Nil),
+        operator(Cast(Literal(1L), DecimalType(21, 1))
+          :: Cast(Literal(1), DecimalType(21, 1))
+          :: Cast(Literal(new java.math.BigDecimal("1.5")), DecimalType(21, 1))
+          :: Nil))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes `LEAST` and `GREATEST` accept other numeric types (`Decimal`). This worked fine in `HiveContext` in 1.6 because , for example, `1.5` was `DoubleType` in there.

So, this finds a tightest common type from both `IntegerType` and `DoubleType` as `DoubleType`, then it works okay.

But currently it seems `1.5` is being treated as `DecimalType` for now. So, It casts 1.5 as decimal(2, 1). So, it fails to find a tightest common type from both `IntegerType` and `DecimalType(2, 1)`.

This PR introduces new function `findTightestCommonTypeToDecimal` dealing with decimals interacting with each other or with primitive types. This logic is borrowed from JSON schema inference.
## How was this patch tested?

Unit tests in `TypeCoercionSuite` and `DataFrameFunctionsSuite`.
