### PR TITLE
[SPARK-16648][SQL] Make ignoreNullsExpr a child expression of First and Last

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -45,6 +45,17 @@ case class First(child: Expression, ignoreNullsExpr: Expression) extends Declara
 
   override def children: Seq[Expression] = child :: Nil
 
+  // SPARK-16648: Default `TreeNode.withNewChildren` implementation doesn't work for `First` when
+  // both constructor arguments are the same, e.g.:
+  //
+  //   FIRST_VALUE(FALSE) // The 2nd argument defaults to FALSE
+  //   FIRST_VALUE(FALSE, FALSE)
+  //   FIRST_VALUE(TRUE, TRUE)
+  override def withNewChildren(newChildren: Seq[Expression]): Expression = {
+    val Seq(newChild) = newChildren
+    copy(child = newChild)
+  }
+
   override def nullable: Boolean = true
 
   // First is not a deterministic function.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -43,18 +43,7 @@ case class First(child: Expression, ignoreNullsExpr: Expression) extends Declara
       throw new AnalysisException("The second argument of First should be a boolean literal.")
   }
 
-  override def children: Seq[Expression] = child :: Nil
-
-  // SPARK-16648: Default `TreeNode.withNewChildren` implementation doesn't work for `First` when
-  // both constructor arguments are the same, e.g.:
-  //
-  //   FIRST_VALUE(FALSE) // The 2nd argument defaults to FALSE
-  //   FIRST_VALUE(FALSE, FALSE)
-  //   FIRST_VALUE(TRUE, TRUE)
-  override def withNewChildren(newChildren: Seq[Expression]): Expression = {
-    val Seq(newChild) = newChildren
-    copy(child = newChild)
-  }
+  override def children: Seq[Expression] = child :: ignoreNullsExpr :: Nil
 
   override def nullable: Boolean = true
 
@@ -65,7 +54,7 @@ case class First(child: Expression, ignoreNullsExpr: Expression) extends Declara
   override def dataType: DataType = child.dataType
 
   // Expected input data type.
-  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType, BooleanType)
 
   private lazy val first = AttributeReference("first", child.dataType)()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -42,6 +42,17 @@ case class Last(child: Expression, ignoreNullsExpr: Expression) extends Declarat
 
   override def children: Seq[Expression] = child :: Nil
 
+  // SPARK-16648: Default `TreeNode.withNewChildren` implementation doesn't work for `Last` when
+  // both constructor arguments are the same, e.g.:
+  //
+  //   LAST_VALUE(FALSE) // The 2nd argument defaults to FALSE
+  //   LAST_VALUE(FALSE, FALSE)
+  //   LAST_VALUE(TRUE, TRUE)
+  override def withNewChildren(newChildren: Seq[Expression]): Expression = {
+    val Seq(newChild) = newChildren
+    copy(child = newChild)
+  }
+
   override def nullable: Boolean = true
 
   // Last is not a deterministic function.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -40,18 +40,7 @@ case class Last(child: Expression, ignoreNullsExpr: Expression) extends Declarat
       throw new AnalysisException("The second argument of First should be a boolean literal.")
   }
 
-  override def children: Seq[Expression] = child :: Nil
-
-  // SPARK-16648: Default `TreeNode.withNewChildren` implementation doesn't work for `Last` when
-  // both constructor arguments are the same, e.g.:
-  //
-  //   LAST_VALUE(FALSE) // The 2nd argument defaults to FALSE
-  //   LAST_VALUE(FALSE, FALSE)
-  //   LAST_VALUE(TRUE, TRUE)
-  override def withNewChildren(newChildren: Seq[Expression]): Expression = {
-    val Seq(newChild) = newChildren
-    copy(child = newChild)
-  }
+  override def children: Seq[Expression] = child :: ignoreNullsExpr :: Nil
 
   override def nullable: Boolean = true
 
@@ -62,7 +51,7 @@ case class Last(child: Expression, ignoreNullsExpr: Expression) extends Declarat
   override def dataType: DataType = child.dataType
 
   // Expected input data type.
-  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType, BooleanType)
 
   private lazy val last = AttributeReference("last", child.dataType)()
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/WindowQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/WindowQuerySuite.scala
@@ -250,5 +250,13 @@ class WindowQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
   test("SPARK-16646: LAST_VALUE(FALSE) OVER ()") {
     checkAnswer(sql("SELECT LAST_VALUE(FALSE) OVER ()"), Row(false))
+    checkAnswer(sql("SELECT LAST_VALUE(FALSE, FALSE) OVER ()"), Row(false))
+    checkAnswer(sql("SELECT LAST_VALUE(TRUE, TRUE) OVER ()"), Row(true))
+  }
+
+  test("SPARK-16646: FIRST_VALUE(FALSE) OVER ()") {
+    checkAnswer(sql("SELECT FIRST_VALUE(FALSE) OVER ()"), Row(false))
+    checkAnswer(sql("SELECT FIRST_VALUE(FALSE, FALSE) OVER ()"), Row(false))
+    checkAnswer(sql("SELECT FIRST_VALUE(TRUE, TRUE) OVER ()"), Row(true))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/WindowQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/WindowQuerySuite.scala
@@ -247,4 +247,8 @@ class WindowQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         |from part
         """.stripMargin))
   }
+
+  test("SPARK-16646: LAST_VALUE(FALSE) OVER ()") {
+    checkAnswer(sql("SELECT LAST_VALUE(FALSE) OVER ()"), Row(false))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default `TreeNode.withNewChildren` implementation doesn't work for `Last` and when both constructor arguments are the same, e.g.:

``` sql
LAST_VALUE(FALSE) -- The 2nd argument defaults to FALSE
LAST_VALUE(FALSE, FALSE)
LAST_VALUE(TRUE, TRUE)
```

This is because although `Last` is a unary expression, both of its constructor arguments, `child` and `ignoreNullsExpr`, are `Expression`s. When they have the same value, `TreeNode.withNewChildren` treats both of them as child nodes by mistake. `First` is also affected by this issue in exactly the same way.

This PR fixes this issue by making `ignoreNullsExpr` a child expression of `First` and `Last`.
## How was this patch tested?

New test case added in `WindowQuerySuite`.
