### PR TITLE
[SPARK-16662][PySpark][SQL] fix HiveContext warning bug

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -471,12 +471,11 @@ class HiveContext(SQLContext):
     .. note:: Deprecated in 2.0.0. Use SparkSession.builder.enableHiveSupport().getOrCreate().
     """
 
-    warnings.warn(
-        "HiveContext is deprecated in Spark 2.0.0. Please use " +
-        "SparkSession.builder.enableHiveSupport().getOrCreate() instead.",
-        DeprecationWarning)
-
     def __init__(self, sparkContext, jhiveContext=None):
+        warnings.warn(
+            "HiveContext is deprecated in Spark 2.0.0. Please use " +
+            "SparkSession.builder.enableHiveSupport().getOrCreate() instead.",
+            DeprecationWarning)
         if jhiveContext is None:
             sparkSession = SparkSession.builder.enableHiveSupport().getOrCreate()
         else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

move the `HiveContext` deprecate warning printing statement into `HiveContext` constructor.
so that this warning will appear only when we use `HiveContext`
otherwise this warning will always appear if we reference the pyspark.ml.context code file.
## How was this patch tested?

Manual.
