### PR TITLE
[SPARK-16665] python import pyspark fails

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -25,7 +25,7 @@ import threading
 from threading import RLock
 from tempfile import NamedTemporaryFile
 
-from pyspark import accumulators
+import pyspark.accumulators as accumulators
 from pyspark.accumulators import Accumulator
 from pyspark.broadcast import Broadcast
 from pyspark.conf import SparkConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix importing pyspark in python
## How was this patch tested?

manually tested

BEFORE patch error was:

import pyspark
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyspark/**init**.py", line 44, in <module>
    from pyspark.context import SparkContext
  File "pyspark/context.py", line 28, in <module>
    from pyspark import accumulators
ImportError: cannot import name accumulators
