### PR TITLE
[SPARK-11977][SQL] Support accessing a column contains "." without backticks

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -201,6 +201,8 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
       attribute: Attribute): Option[(Attribute, List[String])] = {
     if (!attribute.isGenerated && resolver(attribute.name, nameParts.head)) {
       Option((attribute.withName(nameParts.head), nameParts.tail.toList))
+    } else if (!attribute.isGenerated && resolver(attribute.name, nameParts.mkString("."))) {
+      Option((attribute.withName(nameParts.mkString(".")), Nil))
     } else {
       None
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Add support for accessing a dataframe column that contains "." in its name without backticks
- Add a testcase for this in DataFrameSuite
## How was this patch tested?

Spark SQL unit test and manual testing
