### PR TITLE
Changes the numClasses check to !=2 (Line 306)

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -303,7 +303,7 @@ class LogisticRegression @Since("1.2.0") (
         throw new SparkException(msg)
       }
 
-      if (numClasses > 2) {
+      if (numClasses != 2) {
         val msg = s"Currently, LogisticRegression with ElasticNet in ML package only supports " +
           s"binary classification. Found $numClasses in the input dataset."
         logError(msg)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logistical Regression model gives Array Out Of Bounds exception is the numClasses parameter is less than 2 (equal to 1)
## How was this patch tested?

Tested using unit tests within another application

If numClasses is less than 2, it gives a array out of index error.
