### PR TITLE
[SPARK-15857]Add caller context in Spark: invoke YARN/HDFS API to set…

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1015,7 +1015,7 @@ class DAGScheduler(
             val locs = taskIdToLocations(id)
             val part = stage.rdd.partitions(id)
             new ShuffleMapTask(stage.id, stage.latestInfo.attemptId,
-              taskBinary, part, locs, stage.latestInfo.taskMetrics, properties)
+              taskBinary, part, locs, stage.latestInfo.taskMetrics, properties, Option(jobId))
           }
 
         case stage: ResultStage =>
@@ -1024,7 +1024,7 @@ class DAGScheduler(
             val part = stage.rdd.partitions(p)
             val locs = taskIdToLocations(id)
             new ResultTask(stage.id, stage.latestInfo.attemptId,
-              taskBinary, part, locs, id, properties, stage.latestInfo.taskMetrics)
+              taskBinary, part, locs, id, properties, stage.latestInfo.taskMetrics, Option(jobId))
           }
       }
     } catch {

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -51,8 +51,9 @@ private[spark] class ResultTask[T, U](
     locs: Seq[TaskLocation],
     val outputId: Int,
     localProperties: Properties,
-    metrics: TaskMetrics)
-  extends Task[U](stageId, stageAttemptId, partition.index, metrics, localProperties)
+    metrics: TaskMetrics,
+    jobId: Option[Int] = None)
+  extends Task[U](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId)
   with Serializable {
 
   @transient private[this] val preferredLocs: Seq[TaskLocation] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -51,8 +51,9 @@ private[spark] class ShuffleMapTask(
     partition: Partition,
     @transient private var locs: Seq[TaskLocation],
     metrics: TaskMetrics,
-    localProperties: Properties)
-  extends Task[MapStatus](stageId, stageAttemptId, partition.index, metrics, localProperties)
+    localProperties: Properties,
+    jobId: Option[Int] = None)
+  extends Task[MapStatus](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId)
   with Logging {
 
   /** A constructor used only in test suites. This does not require passing in an RDD. */

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -53,7 +53,8 @@ private[spark] abstract class Task[T](
     val partitionId: Int,
     // The default value is only used in tests.
     val metrics: TaskMetrics = TaskMetrics.registered,
-    @transient var localProperties: Properties = new Properties) extends Serializable {
+    @transient var localProperties: Properties = new Properties,
+    val jobId: Option[Int] = None) extends Serializable {
 
   /**
    * Called by [[org.apache.spark.executor.Executor]] to run this task.
@@ -78,6 +79,12 @@ private[spark] abstract class Task[T](
       metrics)
     TaskContext.setTaskContext(context)
     taskThread = Thread.currentThread()
+
+    val callerContext =
+      s"JobId_${jobId.get}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
+        s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber} on Spark".stripMargin
+    Utils.setCallerContext(callerContext)
+
     if (_killed) {
       kill(interruptThread = false)
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -197,6 +197,9 @@ private[spark] class ApplicationMaster(
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
       }
 
+      val context = s"${System.getProperty("spark.app.name")} running on Spark"
+      Utils.setCallerContext(context)
+
       logInfo("ApplicationAttemptId: " + appAttemptId)
 
       val fs = FileSystem.get(yarnConf)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -49,7 +49,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException
 import org.apache.hadoop.yarn.util.Records
 
-import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
@@ -65,6 +65,9 @@ private[spark] class Client(
 
   import Client._
   import YarnSparkHadoopUtil._
+
+  val context: String = s"${sparkConf.get("spark.app.name")} running on Spark"
+  Utils.setCallerContext(context)
 
   def this(clientArgs: ClientArguments, spConf: SparkConf) =
     this(clientArgs, SparkHadoopUtil.get.newConfiguration(spConf), spConf)


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Pass 'jobId' to Task.
2. Add a new function 'setCallerContext' in Utils. 'setCallerContext' function will call APIs of 'org.apache.hadoop.ipc.CallerContext' to set up spark caller contexts, which will be written into HDFS hdfs-audit.log or Yarn resource manager log.
3. 'setCallerContext' function will be called in Yarn client, ApplicationMaster, and Task class.
   
   The Spark caller context written into HDFS log will be "JobID_stageID_stageAttemptId_taskID_attemptNumbe on Spark", and the Spark caller context written into Yarn log will be"{spark.app.name} running on Spark".
## How was this patch tested?

Manual Tests against some Spark applications in Yarn client mode and cluster mode. Need to check if spark caller contexts were written into HDFS hdfs-audit.log and Yarn resource manager log successfully. 

For example, run SparkKmeans on Spark:
In Yarn resource manager log, there will be a record with the spark caller context.
...
   2016-07-21 13:36:26,318 INFO org.apache.hadoop.yarn.server.resourcemanager.RMAuditLogger: USER=wyang        IP=127.0.0.1            OPERATION=Submit Application Request  TARGET=ClientRMService   RESULT=SUCCESS            APPID=application_1469125587135_0004   CALLERCONTEXT=SparkKMeans running on Spark
...

 In HDFS hdfs-audit.log, there will be records with spark caller contexts.
...
2016-07-21 13:38:30,799 INFO FSNamesystem.audit: allowed=true           ugi=wyang (auth:SIMPLE)    ip=/127.0.0.1   cmd=getfileinfo            src=/lr_big.txt/_spark_metadata          dst=null           perm=null        proto=rpc        callerContext=SparkKMeans running on Spark
...
2016-07-21 13:39:35,584 INFO FSNamesystem.audit: allowed=true           ugi=wyang (auth:SIMPLE)    ip=/127.0.0.1   cmd=open            src=/lr_big.txt  dst=null           perm=null        proto=rpc            callerContext=JobId_0_StageID_0_stageAttemptId_0_taskID_1_attemptNumber_0 on Spark
...

If the hadoop version on which Spark runs does not have CallerContext APIs, there will be no information of Spark caller context in those logs.

… up caller context
