### PR TITLE
[SPARK-16674][SQL] Avoid per-record type dispatch in JDBC when reading

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -325,15 +325,15 @@ private[sql] class JDBCRDD(
   // A `JDBCValueSetter` is responsible for converting and setting a value from `ResultSet`
   // into a field for `MutableRow`. The last argument `Int` means the index for the
   // value to be set in the row and also used for the value to retrieve from `ResultSet`.
-  private type ValueSetter = (ResultSet, MutableRow, Int) => Unit
+  private type JDBCValueSetter = (ResultSet, MutableRow, Int) => Unit
 
   /**
    * Creates a StructType to setters for each type.
    */
-  def makeSetters(schema: StructType): Array[ValueSetter] =
+  def makeSetters(schema: StructType): Array[JDBCValueSetter] =
     schema.fields.map(sf => makeSetters(sf.dataType, sf.metadata))
 
-  private def makeSetters(dt: DataType, metadata: Metadata): ValueSetter = dt match {
+  private def makeSetters(dt: DataType, metadata: Metadata): JDBCValueSetter = dt match {
     case BooleanType =>
       (rs: ResultSet, row: MutableRow, pos: Int) =>
         row.setBoolean(pos, rs.getBoolean(pos + 1))
@@ -485,7 +485,7 @@ private[sql] class JDBCRDD(
     stmt.setFetchSize(fetchSize)
     val rs = stmt.executeQuery()
 
-    val setters: Array[ValueSetter] = makeSetters(schema)
+    val setters: Array[JDBCValueSetter] = makeSetters(schema)
     val mutableRow = new SpecificMutableRow(schema.fields.map(x => x.dataType))
 
     def getNext(): InternalRow = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -400,8 +400,7 @@ private[sql] class JDBCRDD(
       (rs: ResultSet, pos: Int) => rs.getBytes(pos)
 
     case ArrayType(et, _) =>
-      val elementConversion: ArrayElementConversion =
-        getArrayElementConversion(et, metadata)
+      val elementConversion: ArrayElementConversion = getArrayElementConversion(et, metadata)
       (rs: ResultSet, pos: Int) =>
         val array = rs.getArray(pos).getArray
         if (array != null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -328,12 +328,13 @@ private[sql] class JDBCRDD(
   private type JDBCValueSetter = (ResultSet, MutableRow, Int) => Unit
 
   /**
-   * Creates a StructType to setters for each type.
+   * Creates `JDBCValueSetter`s according to [[StructType]], which can set
+   * each value from `ResultSet` to each field of [[MutableRow]] correctly.
    */
   def makeSetters(schema: StructType): Array[JDBCValueSetter] =
-    schema.fields.map(sf => makeSetters(sf.dataType, sf.metadata))
+    schema.fields.map(sf => makeSetter(sf.dataType, sf.metadata))
 
-  private def makeSetters(dt: DataType, metadata: Metadata): JDBCValueSetter = dt match {
+  private def makeSetter(dt: DataType, metadata: Metadata): JDBCValueSetter = dt match {
     case BooleanType =>
       (rs: ResultSet, row: MutableRow, pos: Int) =>
         row.setBoolean(pos, rs.getBoolean(pos + 1))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -353,10 +353,10 @@ private[sql] class JDBCRDD(
     case DecimalType.Fixed(p, s) =>
       (rs: ResultSet, pos: Int) =>
         val decimalVal = rs.getBigDecimal(pos)
-        if (decimalVal == null) {
-          null
-        } else {
+        if (decimalVal != null) {
           Decimal(decimalVal, p, s)
+        } else {
+          null
         }
 
     case DoubleType =>
@@ -441,7 +441,8 @@ private[sql] class JDBCRDD(
           }
 
       case LongType if metadata.contains("binarylong") =>
-        throw new IllegalArgumentException(s"Unsupported array element conversion.")
+        throw new IllegalArgumentException(s"Unsupported array element " +
+          s"type ${dt.simpleString} based on binary")
 
       case ArrayType(_, _) =>
         throw new IllegalArgumentException("Nested arrays unsupported")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `JDBCRDD.compute` is doing type dispatch for each row to read appropriate values.
It might not have to be done like this because the schema is already kept in `JDBCRDD`.

So, appropriate converters can be created first according to the schema, and then apply them to each row.
## How was this patch tested?

Existing tests should cover this.
