### PR TITLE
[SPARK-16635] [WEBUI] [SQL] [WIP] Provide Session support in the Spark UI

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -73,6 +73,11 @@ public class SparkFirehoseListener implements SparkListenerInterface {
     }
 
     @Override
+    public final void onSessionUpdate(SparkListenerSessionUpdate sessionUpdate) {
+        onEvent(sessionUpdate);
+    }
+
+    @Override
     public final void onBlockManagerAdded(SparkListenerBlockManagerAdded blockManagerAdded) {
         onEvent(blockManagerAdded);
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -158,6 +158,8 @@ private[spark] class EventLoggingListener(
 
   override def onEnvironmentUpdate(event: SparkListenerEnvironmentUpdate): Unit = logEvent(event)
 
+  override def onSessionUpdate(event: SparkListenerSessionUpdate): Unit = logEvent(event)
+
   // Events that trigger a flush
   override def onStageCompleted(event: SparkListenerStageCompleted): Unit = {
     logEvent(event, flushLogger = true)

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -87,6 +87,10 @@ case class SparkListenerEnvironmentUpdate(environmentDetails: Map[String, Seq[(S
   extends SparkListenerEvent
 
 @DeveloperApi
+case class SparkListenerSessionUpdate(sessionDetails: Map[String, String])
+  extends SparkListenerEvent
+
+@DeveloperApi
 case class SparkListenerBlockManagerAdded(time: Long, blockManagerId: BlockManagerId, maxMem: Long)
   extends SparkListenerEvent
 
@@ -199,6 +203,11 @@ private[spark] trait SparkListenerInterface {
   def onEnvironmentUpdate(environmentUpdate: SparkListenerEnvironmentUpdate): Unit
 
   /**
+   * Called when session properties have been updated
+   */
+  def onSessionUpdate(sessionUpdate: SparkListenerSessionUpdate): Unit
+
+  /**
    * Called when a new block manager has joined
    */
   def onBlockManagerAdded(blockManagerAdded: SparkListenerBlockManagerAdded): Unit
@@ -274,6 +283,8 @@ abstract class SparkListener extends SparkListenerInterface {
   override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = { }
 
   override def onEnvironmentUpdate(environmentUpdate: SparkListenerEnvironmentUpdate): Unit = { }
+
+  override def onSessionUpdate(sessionUpdate: SparkListenerSessionUpdate): Unit = { }
 
   override def onBlockManagerAdded(blockManagerAdded: SparkListenerBlockManagerAdded): Unit = { }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -45,6 +45,8 @@ private[spark] trait SparkListenerBus
         listener.onTaskEnd(taskEnd)
       case environmentUpdate: SparkListenerEnvironmentUpdate =>
         listener.onEnvironmentUpdate(environmentUpdate)
+      case sessionUpdate: SparkListenerSessionUpdate =>
+        listener.onSessionUpdate(sessionUpdate)
       case blockManagerAdded: SparkListenerBlockManagerAdded =>
         listener.onBlockManagerAdded(blockManagerAdded)
       case blockManagerRemoved: SparkListenerBlockManagerRemoved =>

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -32,6 +32,7 @@ import org.apache.spark.ui.env.{EnvironmentListener, EnvironmentTab}
 import org.apache.spark.ui.exec.{ExecutorsListener, ExecutorsTab}
 import org.apache.spark.ui.jobs.{JobProgressListener, JobsTab, StagesTab}
 import org.apache.spark.ui.scope.RDDOperationGraphListener
+import org.apache.spark.ui.session.{SessionListener, SessionTab}
 import org.apache.spark.ui.storage.{StorageListener, StorageTab}
 import org.apache.spark.util.Utils
 
@@ -43,6 +44,7 @@ private[spark] class SparkUI private (
     val conf: SparkConf,
     securityManager: SecurityManager,
     val environmentListener: EnvironmentListener,
+    val sessionListener: SessionListener,
     val storageStatusListener: StorageStatusListener,
     val executorsListener: ExecutorsListener,
     val jobProgressListener: JobProgressListener,
@@ -69,6 +71,7 @@ private[spark] class SparkUI private (
     attachTab(stagesTab)
     attachTab(new StorageTab(this))
     attachTab(new EnvironmentTab(this))
+    attachTab(new SessionTab(this))
     attachTab(new ExecutorsTab(this))
     attachHandler(createStaticHandler(SparkUI.STATIC_RESOURCE_DIR, "/static"))
     attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
@@ -201,19 +204,21 @@ private[spark] object SparkUI {
     }
 
     val environmentListener = new EnvironmentListener
+    val sessionListener = new SessionListener
     val storageStatusListener = new StorageStatusListener(conf)
     val executorsListener = new ExecutorsListener(storageStatusListener, conf)
     val storageListener = new StorageListener(storageStatusListener)
     val operationGraphListener = new RDDOperationGraphListener(conf)
 
     listenerBus.addListener(environmentListener)
+    listenerBus.addListener(sessionListener)
     listenerBus.addListener(storageStatusListener)
     listenerBus.addListener(executorsListener)
     listenerBus.addListener(storageListener)
     listenerBus.addListener(operationGraphListener)
 
-    new SparkUI(sc, conf, securityManager, environmentListener, storageStatusListener,
-      executorsListener, _jobProgressListener, storageListener, operationGraphListener,
-      appName, basePath, startTime)
+    new SparkUI(sc, conf, securityManager, environmentListener, sessionListener,
+      storageStatusListener, executorsListener, _jobProgressListener, storageListener,
+      operationGraphListener, appName, basePath, startTime)
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/session/SessionPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/session/SessionPage.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.session
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.xml.Node
+
+import org.apache.spark.ui.{UIUtils, WebUIPage}
+
+private[ui] class SessionPage(parent: SessionTab) extends WebUIPage("") {
+  private val listener = parent.listener
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val sessionPropertiesTable = UIUtils.listingTable(
+      propertyHeader, propertyRow, listener.sessionDetails.toSeq.sorted, fixedWidth = true)
+    val content =
+      <span>
+        <h4>Session Properties</h4> {sessionPropertiesTable}
+      </span>
+
+    UIUtils.headerSparkPage("Session", content, parent)
+  }
+
+  private def propertyHeader = Seq("Name", "Value")
+  private def propertyRow(kv: (String, String)) = <tr><td>{kv._1}</td><td>{kv._2}</td></tr>
+}
+

--- a/core/src/main/scala/org/apache/spark/ui/session/SessionTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/session/SessionTab.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.session
+
+import scala.collection.Map
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.scheduler.{SparkListener, SparkListenerSessionUpdate, _}
+import org.apache.spark.ui.{SparkUI, SparkUITab, _}
+
+private[ui] class SessionTab(parent: SparkUI) extends SparkUITab(parent, "session") {
+  val listener = parent.sessionListener
+  attachPage(new SessionPage(this))
+}
+
+/**
+ * :: DeveloperApi ::
+ * A SparkListener that prepares information to be displayed on the SessionTab
+ */
+@DeveloperApi
+class SessionListener extends SparkListener {
+  var sessionDetails = Map[String, String]()
+
+  override def onSessionUpdate(sessionUpdate: SparkListenerSessionUpdate) {
+    synchronized {
+      sessionDetails = sessionUpdate.sessionDetails
+    }
+  }
+}
+

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -80,6 +80,8 @@ private[spark] object JsonProtocol {
         jobEndToJson(jobEnd)
       case environmentUpdate: SparkListenerEnvironmentUpdate =>
         environmentUpdateToJson(environmentUpdate)
+      case sessionUpdate: SparkListenerSessionUpdate =>
+        sessionUpdateToJson(sessionUpdate)
       case blockManagerAdded: SparkListenerBlockManagerAdded =>
         blockManagerAddedToJson(blockManagerAdded)
       case blockManagerRemoved: SparkListenerBlockManagerRemoved =>
@@ -175,6 +177,13 @@ private[spark] object JsonProtocol {
     ("Spark Properties" -> sparkProperties) ~
     ("System Properties" -> systemProperties) ~
     ("Classpath Entries" -> classpathEntries)
+  }
+
+  def sessionUpdateToJson(sessionUpdate: SparkListenerSessionUpdate): JValue = {
+    val sessionDetails = sessionUpdate.sessionDetails
+    val sessionConf = mapToJson(sessionDetails.toMap)
+    ("Event" -> Utils.getFormattedClassName(sessionUpdate)) ~
+    ("Session Properties" -> sessionConf)
   }
 
   def blockManagerAddedToJson(blockManagerAdded: SparkListenerBlockManagerAdded): JValue = {
@@ -491,6 +500,7 @@ private[spark] object JsonProtocol {
     val jobStart = Utils.getFormattedClassName(SparkListenerJobStart)
     val jobEnd = Utils.getFormattedClassName(SparkListenerJobEnd)
     val environmentUpdate = Utils.getFormattedClassName(SparkListenerEnvironmentUpdate)
+    val sessionUpdate = Utils.getFormattedClassName(SparkListenerSessionUpdate)
     val blockManagerAdded = Utils.getFormattedClassName(SparkListenerBlockManagerAdded)
     val blockManagerRemoved = Utils.getFormattedClassName(SparkListenerBlockManagerRemoved)
     val unpersistRDD = Utils.getFormattedClassName(SparkListenerUnpersistRDD)
@@ -510,6 +520,7 @@ private[spark] object JsonProtocol {
       case `jobStart` => jobStartFromJson(json)
       case `jobEnd` => jobEndFromJson(json)
       case `environmentUpdate` => environmentUpdateFromJson(json)
+      case `sessionUpdate` => sessionUpdateFromJson(json)
       case `blockManagerAdded` => blockManagerAddedFromJson(json)
       case `blockManagerRemoved` => blockManagerRemovedFromJson(json)
       case `unpersistRDD` => unpersistRDDFromJson(json)
@@ -588,6 +599,11 @@ private[spark] object JsonProtocol {
       "System Properties" -> mapFromJson(json \ "System Properties").toSeq,
       "Classpath Entries" -> mapFromJson(json \ "Classpath Entries").toSeq)
     SparkListenerEnvironmentUpdate(environmentDetails)
+  }
+
+  def sessionUpdateFromJson(json: JValue): SparkListenerSessionUpdate = {
+    val sessionDetails = mapFromJson(json \ "Session Properties")
+    SparkListenerSessionUpdate(sessionDetails)
   }
 
   def blockManagerAddedFromJson(json: JValue): SparkListenerBlockManagerAdded = {

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -209,6 +209,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
       SparkListenerBlockManagerAdded,
       SparkListenerExecutorAdded,
       SparkListenerEnvironmentUpdate,
+      SparkListenerSessionUpdate,
       SparkListenerJobStart,
       SparkListenerJobEnd,
       SparkListenerStageSubmitted,

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -130,7 +130,8 @@ class SparkSession private(
    *
    * @since 2.0.0
    */
-  @transient lazy val conf: RuntimeConfig = new RuntimeConfig(sessionState.conf)
+  @transient lazy val conf: RuntimeConfig = new RuntimeConfig(sessionState.conf,
+    Some(sparkContext.listenerBus))
 
   /**
    * :: Experimental ::
@@ -794,7 +795,7 @@ object SparkSession {
       // Get the session from current thread's active session.
       var session = activeThreadSession.get()
       if ((session ne null) && !session.sparkContext.isStopped) {
-        options.foreach { case (k, v) => session.conf.set(k, v) }
+        session.conf.setBatch(options)
         if (options.nonEmpty) {
           logWarning("Use an existing SparkSession, some configuration may not take effect.")
         }
@@ -806,7 +807,7 @@ object SparkSession {
         // If the current thread does not have an active session, get it from the global session.
         session = defaultSession.get()
         if ((session ne null) && !session.sparkContext.isStopped) {
-          options.foreach { case (k, v) => session.conf.set(k, v) }
+          session.conf.setBatch(options)
           if (options.nonEmpty) {
             logWarning("Use an existing SparkSession, some configuration may not take effect.")
           }
@@ -829,7 +830,7 @@ object SparkSession {
           sc
         }
         session = new SparkSession(sparkContext)
-        options.foreach { case (k, v) => session.conf.set(k, v) }
+        session.conf.setBatch(options)
         defaultSession.set(session)
 
         // Register a successfully instantiated context to the singleton. This should be at the


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a Session Tab and the related Session Page in the Spark UI.

The page could show all properties configured for the session. It could be updated to the latest configuration after refreshing, compared to the SparkContext configurations showed in the Environments Page which cannot be updated during runtime.
## How was this patch tested?

Manually tested and viewed, and unit tests.

When a `spark-shell` is opened, the Session page could be found at the related web UI (e.g. http://192.168.1.104:4040/session/), showing all the properties of the session.

First input lines below into the shell, a new row about "Property A" could be found at the Session page after refreshing.

``` scala
import org.apache.spark.sql.SparkSession
SparkSession.builder.config("Property A", "the value of Property A").getOrCreate()
```

Then input the line below, another row is shown.

``` scala
spark.conf.set("Property B", "the value of Property B")
```

Screenshot:
![sessionpage](https://cloud.githubusercontent.com/assets/5558370/17061954/88372d94-4ff6-11e6-84f5-2b8120911e09.png)
