### PR TITLE
[SPARK-8971][ML] Add stratified sampling to ML CrossValidator and TrainValidationSplit

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -288,8 +288,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   def sampleByKeyExact(
       withReplacement: Boolean,
       fractions: Map[K, Double],
-      seed: Long = Utils.random.nextLong,
-      complement: Boolean = false): RDD[(K, V)] = self.withScope {
+      seed: Long = Utils.random.nextLong): RDD[(K, V)] = self.withScope {
 
     require(fractions.values.forall(v => v >= 0.0), "Negative sampling rates.")
 
@@ -307,14 +306,14 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * with each split containing exactly math.ceil(numItems * samplingRate) for each stratum.
    *
    * This method differs from [[sampleByKey]] and [[sampleByKeyExact]] in that it provides random
-   * splits (and their complements) instead of just a subsample of the data. This requires segmenting
-   * random keys into ranges with upper and lower bounds instead of segmenting the keys into a high/low
-   * bisection of the entire dataset.
+   * splits (and their complements) instead of just a subsample of the data. This requires
+   * segmenting random keys into ranges with upper and lower bounds instead of segmenting the keys
+   * into a high/low bisection of the entire dataset.
    *
-   * @param weights array of maps of specific keys to sampling rates for each split, normalized by key to sum to 1
+   * @param weights array of maps of (key -> samplingRate) pairs for each split, normed by key
    * @param exact boolean specifying whether to use exact subsampling
    * @param seed seed for the random number generator
-   * @return Array of tuples containing the subsample and complement RDDs for each split
+   * @return array of tuples containing the subsample and complement RDDs for each split
    */
   @Experimental
   def randomSplitByKey(
@@ -323,36 +322,47 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
      seed: Long = Utils.random.nextLong): Array[(RDD[(K, V)], RDD[(K, V)])] = self.withScope {
 
     require(weights.flatMap(_.values).forall(v => v >= 0.0), "Negative sampling rates.")
+    if (weights.length > 1) {
+      require(weights.map(m => m.keys.toSet).sliding(2).forall(t => t(0) == t(1)),
+        "Inconsistent keys between splits.")
+    }
+
+    // maps of sampling threshold boundaries at 0.0 and 1.0
+    val leftBoundary = weights(0).map(x => (x._1, 0.0))
+    val rightBoundary = weights(0).map(x => (x._1, 1.0))
 
     // normalize and cumulative sum
-    val baseFold = weights(0).map(x => (x._1, 0.0))
-    val cumWeightsByKey = weights.scanLeft(baseFold){ case (accMap, iterMap) =>
+    val cumWeightsByKey = weights.scanLeft(leftBoundary) { case (accMap, iterMap) =>
       accMap.map { case (k, v) => (k, v + iterMap(k)) }
     }.drop(1)
 
     val weightSumsByKey = cumWeightsByKey.last
-    val normalizedCumWeightsByKey = cumWeightsByKey.dropRight(1).map(_.map { case (key, threshold) =>
-      (key, threshold / weightSumsByKey(key))
+    val normedCumWeightsByKey = cumWeightsByKey.dropRight(1).map(_.map { case (key, threshold) =>
+      val keyWeightSum = weightSumsByKey(key)
+      val norm = if (keyWeightSum > 0.0) keyWeightSum else 1.0
+      (key, threshold / norm)
     })
 
     // compute exact thresholds for each stratum if required
-    val splitArray = if (exact) {
-      normalizedCumWeightsByKey.map { fractions =>
-        val finalResult = StratifiedSamplingUtils.getAcceptanceResults(self, false, fractions, None, seed)
-        StratifiedSamplingUtils.computeThresholdByKey(finalResult, fractions)
+    val splitPoints = if (exact) {
+      normedCumWeightsByKey.map { w =>
+        val finalResult = StratifiedSamplingUtils.getAcceptanceResults(self, false, w, None, seed)
+        StratifiedSamplingUtils.computeThresholdByKey(finalResult, w)
       }
-    } else normalizedCumWeightsByKey
+    } else {
+      normedCumWeightsByKey
+    }
 
-    // get the exact threshold for each segment
-    val totalSplitArray = weights(0).map(x => (x._1, 0.0)) +: splitArray :+ weights(0).map(x => (x._1, 1.0))
-    totalSplitArray.sliding(2).map { x =>
-      (randomSampleByKeyWithRange(x(0), x(1), seed), randomSampleByKeyWithRange(x(0), x(1), seed, complement = true))
+    val splitsPointsAndBounds = leftBoundary +: splitPoints :+ rightBoundary
+    splitsPointsAndBounds.sliding(2).map { x =>
+        (randomSampleByKeyWithRange(x(0), x(1), seed),
+          randomSampleByKeyWithRange(x(0), x(1), seed, complement = true))
     }.toArray
   }
 
   /**
-   * Internal method exposed for Stratified Random Splits in DataFrames. Samples an RDD given probability
-   * bounds for each stratum.
+   * Internal method exposed for Stratified Random Splits in DataFrames. Samples an RDD given
+   * probability bounds for each stratum.
    *
    * @param lb map of lower bound for each key to use for the Bernoulli cell sampler
    * @param ub map of upper bound for each key to use for the Bernoulli cell sampler
@@ -364,7 +374,8 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       ub: Map[K, Double],
       seed: Long,
       complement: Boolean = false): RDD[(K, V)] = {
-    val samplingFunc = StratifiedSamplingUtils.getBernoulliCellSamplingFunction(self, lb, ub, seed, complement)
+    val samplingFunc = StratifiedSamplingUtils.getBernoulliCellSamplingFunction(self,
+      lb, ub, seed, complement)
     self.mapPartitionsWithIndex(samplingFunc, preservesPartitioning = true)
   }
 

--- a/core/src/main/scala/org/apache/spark/util/random/StratifiedSamplingUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/StratifiedSamplingUtils.scala
@@ -216,7 +216,10 @@ private[spark] object StratifiedSamplingUtils extends Logging {
   }
 
   /**
-   * WIP sample with range
+   * Return the per partition sampling function used for partitioning a dataset without
+   * replacement.
+   *
+   * The sampling function has a unique seed per partition.
    */
   def getBernoulliCellSamplingFunction[K, V](rdd: RDD[(K, V)],
       lb: Map[K, Double],
@@ -226,17 +229,16 @@ private[spark] object StratifiedSamplingUtils extends Logging {
     (idx: Int, iter: Iterator[(K, V)]) => {
       val rng = new RandomDataGenerator()
       rng.reSeed(seed + idx)
-      // Must use the same invoke pattern on the rng as in getSeqOp for without replacement
-      // in order to generate the same sequence of random numbers when creating the sample
+
       if (complement) {
-        iter.filter { t =>
+        iter.filter { case(k, _) =>
           val x = rng.nextUniform()
-          (x < lb(t._1)) || (x >= ub(t._1))
+          (x < lb(k)) || (x >= ub(k))
         }
       } else {
-        iter.filter { t =>
+        iter.filter { case(k, _) =>
           val x = rng.nextUniform()
-          (x >= lb(t._1)) && (x < ub(t._1))
+          (x >= lb(k)) && (x < ub(k))
         }
       }
     }

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -168,6 +168,118 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     }
   }
 
+  test("randomSplitByKey exact") {
+    val defaultSeed = 1L
+
+    // vary RDD size
+    for (n <- List(100, 1000, 10000)) {
+      val data = sc.parallelize(1 to n, 2)
+      val fractionPositive = 0.3
+      val stratifiedData = data.keyBy(StratifiedAuxiliary.stratifier(fractionPositive))
+      val keys = stratifiedData.keys.distinct().collect()
+      val splitWeights = Array(0.3, 0.2, 0.5)
+      val weights: Array[scala.collection.Map[String, Double]] =
+        splitWeights.map(w => keys.map(k => (k, w)).toMap)
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, defaultSeed, n, true)
+    }
+
+    // vary fractionPositive
+    for (fractionPositive <- List(0.1, 0.3, 0.5, 0.7, 0.9)) {
+      val n = 100
+      val data = sc.parallelize(1 to n, 2)
+      val stratifiedData = data.keyBy(StratifiedAuxiliary.stratifier(fractionPositive))
+      val keys = stratifiedData.keys.distinct().collect()
+      val splitWeights = Array(0.3, 0.2, 0.5)
+      val weights: Array[scala.collection.Map[String, Double]] =
+        splitWeights.map(w => keys.map(k => (k, w)).toMap)
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, defaultSeed, n, true)
+    }
+
+    // use same data for remaining tests
+    val n = 100
+    val fractionPositive = 0.3
+    val data = sc.parallelize(1 to n, 2)
+    val stratifiedData = data.keyBy(StratifiedAuxiliary.stratifier(fractionPositive))
+    val keys = stratifiedData.keys.distinct().collect()
+
+    // use different weights for each key in the split
+    val unevenWeights: Array[scala.collection.Map[String, Double]] =
+      Array(Map("0" -> 0.2, "1" -> 0.3), Map("0" -> 0.1, "1" -> 0.4), Map("0" -> 0.7, "1" -> 0.3))
+    StratifiedAuxiliary.testSplits(stratifiedData, unevenWeights, defaultSeed, n, true)
+
+    // vary the seed
+    val splitWeights = Array(0.3, 0.2, 0.5)
+    val weights: Array[scala.collection.Map[String, Double]] =
+      splitWeights.map(w => keys.map(k => (k, w)).toMap)
+    for (seed <- defaultSeed to defaultSeed + 3L) {
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, seed, n, true)
+    }
+
+    // vary the number of splits
+    for (numSplits <- 1 to 3) {
+      val splitWeights = (1 to numSplits).map(n => 1.toDouble).toArray // check normalization too
+      val weights: Array[scala.collection.Map[String, Double]] =
+        splitWeights.map(w => keys.map(k => (k, w)).toMap)
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, defaultSeed, n, true)
+    }
+  }
+
+  test("randomSplitByKey") {
+    val defaultSeed = 1L
+
+    // vary RDD size
+    for (n <- List(100, 1000, 10000)) {
+      val data = sc.parallelize(1 to n, 2)
+      val fractionPositive = 0.3
+      val stratifiedData = data.keyBy(StratifiedAuxiliary.stratifier(fractionPositive))
+      val keys = stratifiedData.keys.distinct().collect()
+      val splitWeights = Array(0.3, 0.2, 0.5)
+      val weights: Array[scala.collection.Map[String, Double]] =
+        splitWeights.map(w => keys.map(k => (k, w)).toMap)
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, defaultSeed, n, false)
+    }
+
+    // vary fractionPositive
+    for (fractionPositive <- List(0.1, 0.3, 0.5, 0.7, 0.9)) {
+      val n = 100
+      val data = sc.parallelize(1 to n, 2)
+      val stratifiedData = data.keyBy(StratifiedAuxiliary.stratifier(fractionPositive))
+      val keys = stratifiedData.keys.distinct().collect()
+      val splitWeights = Array(0.3, 0.2, 0.5)
+      val weights: Array[scala.collection.Map[String, Double]] =
+        splitWeights.map(w => keys.map(k => (k, w)).toMap)
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, defaultSeed, n, false)
+    }
+
+    // use same data for remaining tests
+    val n = 100
+    val fractionPositive = 0.3
+    val data = sc.parallelize(1 to n, 2)
+    val stratifiedData = data.keyBy(StratifiedAuxiliary.stratifier(fractionPositive))
+    val keys = stratifiedData.keys.distinct().collect()
+
+    // use different weights for each key in the split
+    val unevenWeights: Array[scala.collection.Map[String, Double]] =
+      Array(Map("0" -> 0.2, "1" -> 0.3), Map("0" -> 0.1, "1" -> 0.4), Map("0" -> 0.7, "1" -> 0.3))
+    StratifiedAuxiliary.testSplits(stratifiedData, unevenWeights, defaultSeed, n, false)
+
+    // vary the seed
+    val splitWeights = Array(0.3, 0.2, 0.5)
+    val weights: Array[scala.collection.Map[String, Double]] =
+      splitWeights.map(w => keys.map(k => (k, w)).toMap)
+    for (seed <- defaultSeed to defaultSeed + 5L) {
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, seed, n, false)
+    }
+
+    // vary the number of splits
+    for (numSplits <- 1 to 5) {
+      val splitWeights = (1 to numSplits).map(n => 1.toDouble).toArray // check normalization too
+      val weights: Array[scala.collection.Map[String, Double]] =
+        splitWeights.map(w => keys.map(k => (k, w)).toMap)
+      StratifiedAuxiliary.testSplits(stratifiedData, weights, defaultSeed, n, false)
+    }
+  }
+
   test("reduceByKey") {
     val pairs = sc.parallelize(Array((1, 1), (1, 2), (1, 3), (1, 1), (2, 1)))
     val sums = pairs.reduceByKey(_ + _).collect()
@@ -646,6 +758,19 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
       }
     }
 
+    def checkSplitSize(exact: Boolean,
+        expected: Long,
+        actual: Long,
+        p: Double): Boolean = {
+      if (exact) {
+        // all splits will not be exact, but must be within 1 of expected size
+        return math.abs(expected - actual) <= 1
+      }
+      val stdev = math.sqrt(expected * p * (1 - p))
+      // Very forgiving margin since we're dealing with very small sample sizes most of the time
+      math.abs(actual - expected) <= 6 * stdev
+    }
+
     def testSampleExact(stratifiedData: RDD[(String, Int)],
         samplingRate: Double,
         seed: Long,
@@ -660,6 +785,64 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
         n: Long): Unit = {
       testBernoulli(stratifiedData, false, samplingRate, seed, n)
       testPoisson(stratifiedData, false, samplingRate, seed, n)
+    }
+
+    def testSplits(stratifiedData: RDD[(String, Int)],
+        weights: Array[scala.collection.Map[String, Double]],
+        seed: Long,
+        n: Int,
+        exact: Boolean): Unit = {
+      val baseFold = weights(0).map(x => (x._1, 0.0))
+      val totalWeightByKey = weights.foldLeft(baseFold) { case (accMap, iterMap) =>
+        accMap.map { case (k, v) => (k, v + iterMap(k)) }
+      }
+      val normedWeights = weights.map(m => m.map { case(k, v) => (k, v / totalWeightByKey(k))})
+
+      val splits = stratifiedData.randomSplitByKey(weights, exact, seed)
+      val stratCounts = stratifiedData.countByKey()
+
+
+      val expectedSampleSizes = normedWeights.map { m =>
+        stratCounts.map { case (key, count) =>
+          (key, math.ceil(count * m(key)).toLong)
+        }.toMap
+      }
+      val expectedComplementSizes = normedWeights.map { m =>
+        stratCounts.map { case (key, count) =>
+          (key, math.ceil(count * (1 - m(key))).toLong)
+        }.toMap
+      }
+
+      val samples = splits.map{ case(subsample, complement) => subsample.collect()}
+      val complements = splits.map{ case(subsample, complement) => complement.collect()}
+
+      // check for the correct sample size for each split by key
+      (samples.map(_.groupBy(_._1).map(x => (x._1, x._2.length))) zip expectedSampleSizes)
+        .zipWithIndex.foreach { case ((actual, expected), idx) =>
+          actual.foreach { case (k, v) =>
+            checkSplitSize(exact, expected(k), v, normedWeights(idx)(k))
+          }
+        }
+      (complements.map(_.groupBy(_._1).map(x => (x._1, x._2.length))) zip expectedComplementSizes)
+        .zipWithIndex.foreach { case ((actual, expected), idx) =>
+          actual.foreach{ case (k, v) =>
+            checkSplitSize(exact, expected(k), v, normedWeights(idx)(k))
+          }
+        }
+
+      // make sure samples ++ complements equals the original set
+      (samples zip complements).foreach { case (sample, complement) =>
+        assert((sample ++ complement).sortBy(_._2).toList == stratifiedData.collect().toList)
+      }
+
+      // make sure the elements are members of the original set
+      samples.map(sample => sample.map(x => assert(x._2 >= 1 && x._2 <= n)))
+
+      // make sure no duplicates in each sample
+      samples.map(sample => assert(sample.length == sample.toSet.size))
+
+      // make sure that union of all samples equals the original set
+      assert(samples.flatMap(x => x).sortBy(_._2).toList == stratifiedData.collect().toList)
     }
 
     // Without replacement validation

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -52,7 +52,6 @@ private[ml] trait CrossValidatorParams extends ValidatorParams {
   def getNumFolds: Int = $(numFolds)
 
   setDefault(numFolds -> 3)
-
 }
 
 /**
@@ -89,7 +88,7 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
   def setSeed(value: Long): this.type = set(seed, value)
 
   /** @group setParam */
-  @Since("2.0.0")
+  @Since("2.1.0")
   def setStratifiedCol(value: String): this.type = set(stratifiedCol, value)
   setDefault(stratifiedCol -> "")
 
@@ -107,7 +106,7 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
     val splits = if ($(stratifiedCol).nonEmpty) {
       val stratifiedColIndex = schema.fieldNames.indexOf($(stratifiedCol))
       val pairData = dataset.toDF.rdd.map(row => (row(stratifiedColIndex), row))
-      val splitsWithKeys = MLUtils.kFoldStratified(pairData, $(numFolds), 0)
+      val splitsWithKeys = MLUtils.kFoldStratified(pairData, $(numFolds), $(seed))
       splitsWithKeys.map { case (training, validation) => (training.values, validation.values)}
     } else {
       MLUtils.kFold(dataset.toDF.rdd, $(numFolds), $(seed))

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -88,6 +88,8 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
   @Since("2.0.0")
   def setSeed(value: Long): this.type = set(seed, value)
 
+  /** @group setParam */
+  @Since("2.1.0")
   def setStratifiedCol(value: String): this.type = set(stratifiedCol, value)
   setDefault(stratifiedCol -> "")
 
@@ -109,13 +111,13 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
         val keys = pairData.keys.distinct.collect()
         val weights: Array[scala.collection.Map[Any, Double]] =
           Array(keys.map((_, $(trainRatio))).toMap, keys.map((_, 1 - $(trainRatio))).toMap)
-        val splitsWithKeys = pairData.randomSplitByKey(weights, exact = true, 0)
+        val splitsWithKeys = pairData.randomSplitByKey(weights, exact = true, $(seed))
         val Array(training, validation) =
           splitsWithKeys.map { case (subsample, complement) => subsample.values }
         Array(sparkSession.createDataFrame(training, schema),
           sparkSession.createDataFrame(validation, schema))
       } else {
-        dataset.randomSplit(Array($(trainRatio), 1 - $(trainRatio)))
+        dataset.randomSplit(Array($(trainRatio), 1 - $(trainRatio)), $(seed))
       }
 
     trainingDataset.cache()

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
@@ -67,6 +67,17 @@ private[ml] trait ValidatorParams extends HasSeed with Params {
   /** @group getParam */
   def getEvaluator: Evaluator = $(evaluator)
 
+  /**
+   * Param for stratified sampling column name
+   * Default: empty
+   * @group param
+   */
+  val stratifiedCol: Param[String] = new Param[String](this, "stratifiedCol",
+    "stratified column name")
+
+  /** @group getParam */
+  def getStratifiedCol: String = $(stratifiedCol)
+
   protected def transformSchemaImpl(schema: StructType): StructType = {
     require($(estimatorParamMaps).nonEmpty, s"Validator requires non-empty estimatorParamMaps")
     val firstEstimatorParamMap = $(estimatorParamMaps).head

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -27,9 +27,9 @@ import org.apache.spark.ml.linalg.{MatrixUDT => MLMatrixUDT, VectorUDT => MLVect
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.BLAS.dot
 import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD}
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, udf}
-import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD, PairRDDFunctions}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.random.BernoulliCellSampler
 
@@ -239,6 +239,16 @@ object MLUtils extends Logging {
       rdd: RDD[(K, V)],
       numFolds: Int,
       seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {
+    kFoldStratified(rdd, numFolds, seed.toLong)
+  }
+
+  /**
+   * Version of [[kFoldStratified()]] taking a Long seed.
+   */
+  def kFoldStratified[K: ClassTag, V: ClassTag](
+      rdd: RDD[(K, V)],
+      numFolds: Int,
+      seed: Long): Array[(RDD[(K, V)], RDD[(K, V)])] = {
     val keys = rdd.keys.distinct().collect()
     val weights: Array[scala.collection.Map[K, Double]] = (1 to numFolds).map {
       n => keys.map(k => (k, 1 / numFolds.toDouble)).toMap

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -235,7 +235,8 @@ object MLUtils extends Logging {
    * ratios in the original data are maintained in each stratum of the train and validation
    * data.
    */
-  def kFoldStratified[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
+  def kFoldStratified[K: ClassTag, V: ClassTag](
+      rdd: RDD[(K, V)],
       numFolds: Int,
       seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {
     val keys = rdd.keys.distinct().collect()

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -26,12 +26,21 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.{MatrixUDT => MLMatrixUDT, VectorUDT => MLVectorUDT}
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.BLAS.dot
+
 import org.apache.spark.mllib.regression.LabeledPoint
-import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD}
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD, PairRDDFunctions}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.random.BernoulliCellSampler
+
+// My changes
+import scala.util.Random
+import org.apache.spark.util.random.StratifiedSamplingUtils
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import org.apache.spark.util.random.XORShiftRandom
+
 
 /**
  * Helper methods to load, save and pre-process data used in ML Lib.
@@ -225,6 +234,20 @@ object MLUtils extends Logging {
       val training = new PartitionwiseSampledRDD(rdd, sampler.cloneComplement(), true, seed)
       (training, validation)
     }.toArray
+  }
+
+  /**
+   * Seth Code
+   */
+  @Experimental
+  def kFoldStrat[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
+      numFolds: Int,
+      seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {
+    val keys: Array[K] = rdd.keys.collect().distinct
+    val weights: Array[scala.collection.Map[K, Double]] = (1 to numFolds).map {
+      n => keys.map(k => (k, 1 / numFolds.toDouble)).toMap
+    }.toArray
+    rdd.randomSplitByKey(weights, exact = true, seed)
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/CrossValidatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/CrossValidatorSuite.scala
@@ -55,6 +55,7 @@ class CrossValidatorSuite
       .setEstimatorParamMaps(lrParamMaps)
       .setEvaluator(eval)
       .setNumFolds(3)
+      .setStratifiedCol("label")
     val cvModel = cv.fit(dataset)
 
     // copied model must have the same paren.
@@ -109,6 +110,8 @@ class CrossValidatorSuite
       .setEstimator(est)
       .setEstimatorParamMaps(paramMaps)
       .setEvaluator(eval)
+      .setNumFolds(3)
+      .setStratifiedCol("label")
 
     cv.transformSchema(new StructType()) // This should pass.
 

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/CrossValidatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/CrossValidatorSuite.scala
@@ -22,15 +22,12 @@ import org.apache.spark.ml.{Estimator, Model, Pipeline}
 import org.apache.spark.ml.classification.{LogisticRegression, LogisticRegressionModel}
 import org.apache.spark.ml.classification.LogisticRegressionSuite.generateLogisticInput
 import org.apache.spark.ml.evaluation.{BinaryClassificationEvaluator, Evaluator, RegressionEvaluator}
-import org.apache.spark.ml.feature.HashingTF
+import org.apache.spark.ml.feature.{HashingTF, LabeledPoint}
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{ParamMap, ParamPair}
 import org.apache.spark.ml.param.shared.HasInputCol
 import org.apache.spark.ml.regression.LinearRegression
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
-import org.apache.spark.mllib.classification.LogisticRegressionSuite.generateLogisticInput
-import org.apache.spark.mllib.linalg.Vectors
-import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.{LinearDataGenerator, MLlibTestSparkContext}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
@@ -68,34 +65,6 @@ class CrossValidatorSuite
     assert(parent.getRegParam === 0.001)
     assert(parent.getMaxIter === 10)
     assert(cvModel.avgMetrics.length === lrParamMaps.length)
-  }
-
-  test("strat") {
-    val numFolds = 10
-    // generate imbalanced data
-    val data = Seq.tabulate(100) { i =>
-      if (i >= numFolds) {
-        LabeledPoint(0.0, Vectors.dense(1.0))
-      } else {
-        LabeledPoint(1.0, Vectors.dense(1.0))
-      }
-    }
-    val df = sqlContext.createDataFrame(data)
-    val lr = new LogisticRegression
-    val lrParamMaps = new ParamGridBuilder()
-      .addGrid(lr.maxIter, Array(0, 10))
-      .build()
-    val eval = new BinaryClassificationEvaluator
-    val cv = new CrossValidator()
-      .setEstimator(lr)
-      .setEstimatorParamMaps(lrParamMaps)
-      .setEvaluator(eval)
-      .setNumFolds(numFolds)
-      .setStratifiedCol("label")
-    val cvModel = cv.fit(df)
-    // without stratified sampling, there is a 99.964% that one of the splits has
-    // no negative examples, so some of the metrics will be < 0.5, bringing down the avg metrics.
-    assert(cvModel.avgMetrics.forall(_ === 0.5))
   }
 
   test("cross validation with linear regression") {
@@ -151,6 +120,36 @@ class CrossValidatorSuite
     intercept[IllegalArgumentException] {
       cv.transformSchema(new StructType())
     }
+  }
+
+  test("stratified vs. not stratified cross validation") {
+    val numFolds = 10
+    val data = Seq.tabulate(100) { i =>
+      if (i >= numFolds) {
+        LabeledPoint(0.0, Vectors.dense(1.0)) // 1 per split
+      } else {
+        LabeledPoint(1.0, Vectors.dense(1.0))
+      }
+    }
+    val df = spark.createDataFrame(data)
+    val lr = new LogisticRegression
+    val lrParamMaps = new ParamGridBuilder()
+      .addGrid(lr.maxIter, Array(2))
+      .build()
+    val eval = new BinaryClassificationEvaluator
+    val cv = new CrossValidator()
+      .setEstimator(lr)
+      .setEstimatorParamMaps(lrParamMaps)
+      .setEvaluator(eval)
+      .setNumFolds(numFolds)
+      .setSeed(42L)
+    val notStratifiedModel = cv.fit(df)
+    cv.setStratifiedCol("label")
+    val stratifiedModel = cv.fit(df)
+    // without stratified sampling some of the splits will not contain both examples
+    // so some of the metrics will be < 0.5, bringing down the avg metrics.
+    assert(stratifiedModel.avgMetrics.forall(_ === 0.5))
+    assert(notStratifiedModel.avgMetrics.exists(_ != 0.5))
   }
 
   test("read/write: CrossValidator with simple estimator") {

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
@@ -49,6 +49,8 @@ class TrainValidationSplitSuite
       .setEvaluator(eval)
       .setTrainRatio(0.5)
       .setSeed(42L)
+      .setStratifiedCol("label")
+
     val cvModel = cv.fit(dataset)
     val parent = cvModel.bestModel.parent.asInstanceOf[LogisticRegression]
     assert(cv.getTrainRatio === 0.5)
@@ -102,6 +104,7 @@ class TrainValidationSplitSuite
       .setEstimatorParamMaps(paramMaps)
       .setEvaluator(eval)
       .setTrainRatio(0.5)
+      .setStratifiedCol("label")
     cv.transformSchema(new StructType()) // This should pass.
 
     val invalidParamMaps = paramMaps :+ ParamMap(est.inputCol -> "")

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
@@ -19,9 +19,10 @@ package org.apache.spark.ml.tuning
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.classification.{LogisticRegression, LogisticRegressionModel}
+import org.apache.spark.ml.classification.{DecisionTreeClassifier, LogisticRegression, LogisticRegressionModel}
 import org.apache.spark.ml.classification.LogisticRegressionSuite.generateLogisticInput
-import org.apache.spark.ml.evaluation.{BinaryClassificationEvaluator, Evaluator, RegressionEvaluator}
+import org.apache.spark.ml.evaluation.{BinaryClassificationEvaluator, Evaluator, MulticlassClassificationEvaluator, RegressionEvaluator}
+import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.param.shared.HasInputCol
@@ -57,6 +58,39 @@ class TrainValidationSplitSuite
     assert(parent.getRegParam === 0.001)
     assert(parent.getMaxIter === 10)
     assert(cvModel.validationMetrics.length === lrParamMaps.length)
+  }
+
+  test("stratified") {
+    val data = Seq(
+      List.fill(20)(LabeledPoint(0.0, Vectors.dense(0.0))),
+      List.fill(20)(LabeledPoint(1.0, Vectors.dense(1.0))),
+      List.fill(2)(LabeledPoint(2.0, Vectors.dense(2.0)))
+    ).flatten
+    val df = spark.createDataFrame(data)
+    val trainer = new DecisionTreeClassifier()
+    val dtParamMaps = new ParamGridBuilder()
+      .addGrid(trainer.maxDepth, Array(2))
+      .build()
+    val eval = new MulticlassClassificationEvaluator()
+    val cv = new TrainValidationSplit()
+      .setEstimator(trainer)
+      .setEstimatorParamMaps(dtParamMaps)
+      .setEvaluator(eval)
+      .setTrainRatio(0.5)
+    val nTrials = 5
+    val notStratifiedTrials = (0 until nTrials).map { i =>
+      cv.setSeed(42L + i)
+      val cvModel = cv.fit(df)
+      cvModel.validationMetrics.head
+    }
+    val stratifiedTrials = (0 until nTrials).map { i =>
+      cv.setSeed(42L + i).setStratifiedCol("label")
+      val cvModel = cv.fit(df)
+      cvModel.validationMetrics.head
+    }
+
+    assert(!stratifiedTrials.exists(metric => math.abs(metric - 1.0) > 1e-6))
+    assert(notStratifiedTrials.exists(metric => math.abs(metric - 1.0) > 1e-6))
   }
 
   test("train validation with linear regression") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -210,6 +210,37 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     }
   }
 
+  test("kFoldStratified") {
+    /**
+     * Most of the functionality of [[kFoldStratified]] is tested in the PairRDD function
+     * `randomSplitByKey`. All that needs to be checked here is that the folds are even
+     * splits for each key.
+     */
+    val defaultSeed = 1
+    val n = 100
+    val data = sc.parallelize(1 to n, 2)
+    val fractionPositive = 0.3
+    val keys = Array("0", "1")
+    val stratifiedData = data.map { x =>
+      if (x > n*fractionPositive) ("0", x) else ("1", x)
+    }
+    val counts = stratifiedData.countByKey()
+    for (numFolds <- 1 to 3) {
+      val folds = kFoldStratified(stratifiedData, numFolds, defaultSeed)
+      val expectedSize = keys.map(k => (k, counts(k) / numFolds.toDouble)).toMap
+      for ((sample, complement) <- folds) {
+        val sampleCounts = sample.countByKey()
+        val complementCounts = complement.countByKey()
+        sampleCounts.foreach { case(key, count) =>
+          assert(math.abs(count - expectedSize(key)) <= 1)
+        }
+        complementCounts.foreach { case(key, count) =>
+          assert(math.abs(count - (counts(key) - expectedSize(key))) <= 1)
+        }
+      }
+    }
+  }
+
   test("loadVectors") {
     val vectors = sc.parallelize(Seq(
       Vectors.dense(1.0, 2.0),

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -211,7 +211,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("kFoldStratified") {
-    /**
+    /*
      * Most of the functionality of [[kFoldStratified]] is tested in the PairRDD function
      * `randomSplitByKey`. All that needs to be checked here is that the folds are even
      * splits for each key.
@@ -222,7 +222,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     val fractionPositive = 0.3
     val keys = Array("0", "1")
     val stratifiedData = data.map { x =>
-      if (x > n*fractionPositive) ("0", x) else ("1", x)
+      if (x > n * fractionPositive) ("0", x) else ("1", x)
     }
     val counts = stratifiedData.countByKey()
     for (numFolds <- 1 to 3) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds the ability to do stratified sampling in cross validation for ML pipelines. This is accomplished by modifying some of the methods in `StratifiedSamplingUtils` to support multiple _splits_ instead of a single subsample of the data. A method is added to `PairRDDFunctions` to support `randomSplitByKey`. Please see the detailed explanation below.
## How was this patch tested?

Unit tests were added to `PairRDDFunctionsSuite`, `MLUtilsSuite`, `CrossValidatorSuite`, and `TrainValidationSuite`.
## Algorithm changes

Currently, Spark implements a stratified sampling function on PairRDDs using the method `sampleByKeyExact` and `sampleByKey`. This method calls a stratified sampling routine that is implemented in `StratifiedSamplingUtils`. The underlying algorithm is described [here](http://jmlr.org/proceedings/papers/v28/meng13a.pdf) in the paper by Xiangrui Meng. When exact samples stratified samples are required, the algorithm makes an extra pass through the data. Each sample is mapped on to the interval [0, 1](for sampling without replacement), and we expect that, say for a 50% sample, we will split the interval at 0.5 and accept the samples which fell below that threshold. Items near 0 are highly likely to be accepted, while items near 1 are highly unlikely to be accepted. Items near 0.5 are uncertain, and are added to a waitlist on the first pass. The items in the waitlist will be sorted and used to determine the exact split point which produces 50/50 sample. 

![image](https://cloud.githubusercontent.com/assets/7275795/17071720/2f90bd14-5018-11e6-91c2-2c1dc2191213.png)

This patch modifies the routine to produce multiple splits by generating multiple waitlists on the first pass. Each waitlist is sorted to determine the exact split points and then we can sample as normal. 

![image](https://cloud.githubusercontent.com/assets/7275795/17071744/4f3b6d76-5018-11e6-8591-857eaaf288f9.png)

One potential concern is that if this is used for a large number of splits, it may degrade to the point where sorting the entire dataset would be quicker, as the waitlists get closer and closer together. It could potentially cause OOM errors on the driver if there are too many waitlists collected. Still, before this patch there was not a way to actually take a single _split_ of the data, as `sampleByKey` does not return the complement of the sample. This patch fixes this as well.
## ML API

This patch also allows users to specify a stratified column in the `CrossValidator` and `TrainValidationSplit` estimators. This is done by converting the input dataframe to a PairRDD and calling the `randomSplitByKey` method. This is exposed via a `setStratifiedCol` parameter which, if set, will use _exact_ stratified splits for cross validation. 
## Future considerations

This can be implemented as a function on dataframes in the future, if there is interest. It is somewhat inconvient to convert the dataframe to a pair rdd, perform sampling, and then convert back to a dataframe. 
