### PR TITLE
[SPARK-16689] [SQL] FileSourceStrategy: Pruning Partition Columns When No Partition Column Exist in Project

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -135,9 +135,17 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
         PUSHED_FILTERS -> pushedDownFilters.mkString("[", ", ", "]"),
         INPUT_PATHS -> fsRelation.location.paths.mkString(", "))
 
+      // If the required attributes does not have the partitioning columns, we do not need
+      // to scan the partitioning columns. If partitioning columns are selected, the column order
+      // of partitionColumns is fixed in rdd. Thus, we always scan all the partitioning columns.
+      val scannedColumns = if (requiredAttributes.intersect(partitionSet).nonEmpty) {
+        readDataColumns ++ partitionColumns
+      } else {
+        readDataColumns
+      }
       val scan =
         DataSourceScanExec.create(
-          readDataColumns ++ partitionColumns,
+          scannedColumns,
           rdd,
           fsRelation,
           meta,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -236,7 +236,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     val df = table.where("p1 = 1 AND (p1 + c1) = 2 AND c1 = 1")
     // Filter on data only are advisory so we have to reevaluate.
     assert(getPhysicalFilters(df) contains resolve(df, "c1 = 1"))
-    // Need to evalaute filters that are not pushed down.
+    // Need to evaluate filters that are not pushed down.
     assert(getPhysicalFilters(df) contains resolve(df, "(p1 + c1) = 2"))
     // Don't reevaluate partition only filters.
     assert(!(getPhysicalFilters(df) contains resolve(df, "p1 = 1")))
@@ -311,6 +311,76 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
 
         val fileScanRDD = getFileScanRDD(table)
         assert(partitions.flatMap(fileScanRDD.preferredLocations).length == 2)
+      }
+    }
+  }
+
+  test("Column pruning on partitioning columns") {
+    Seq("parquet", "json").foreach { fileFormat =>
+      withTempPath { path =>
+        val tempDir = path.getCanonicalPath
+        Seq(("val1_1", "val2_1", 1, 2, 3), ("val1_2", "val2_2", 1, 3, 3))
+          .toDF("value", "value2", "p1", "p2", "p3").write.format(fileFormat)
+          .partitionBy("p1", "p2", "p3").save(tempDir)
+
+        def verifyPruning(
+            projectList: Seq[String],
+            expectedScanList: Seq[String],
+            expectedResult: Seq[Row]): Unit = {
+          val df = spark.read.format(fileFormat).load(tempDir).selectExpr(projectList: _*)
+          assert(getDataSourceScanExec(df).output.map(_.name) == expectedScanList)
+          checkAnswer(df, expectedResult)
+        }
+
+        verifyPruning(
+          projectList = Seq("value", "p1", "p2", "p3"),
+          expectedScanList = Seq("value", "p1", "p2", "p3"),
+          Row("val1_1", 1, 2, 3) :: Row("val1_2", 1, 3, 3) :: Nil)
+
+        verifyPruning(
+          projectList = Seq("value2"),
+          expectedScanList = Seq("value2"),
+          Row("val2_1") :: Row("val2_2") :: Nil)
+
+        verifyPruning(
+          projectList = Seq("value2", "value"),
+          expectedScanList = Seq("value", "value2"),
+          Row("val2_1", "val1_1") :: Row("val2_2", "val1_2") :: Nil)
+
+        verifyPruning(
+          projectList = Seq("value"),
+          expectedScanList = Seq("value"),
+          Row("val1_1") :: Row("val1_2") :: Nil)
+
+        verifyPruning(
+          projectList = Seq("value", "value"),
+          expectedScanList = Seq("value"),
+          Row("val1_1", "val1_1") :: Row("val1_2", "val1_2") :: Nil)
+
+        verifyPruning(
+          projectList = Seq("value as v", "value"),
+          expectedScanList = Seq("value"),
+          Row("val1_1", "val1_1") :: Row("val1_2", "val1_2") :: Nil)
+
+        verifyPruning(
+          projectList = Seq("p2", "p2"),
+          expectedScanList = Seq("p1", "p2", "p3"),
+          Row(2, 2) :: Row(3, 3) :: Nil)
+
+        verifyPruning(
+          projectList = Seq("p2 as p", "p2"),
+          expectedScanList = Seq("p1", "p2", "p3"),
+          Row(2, 2) :: Row(3, 3) :: Nil)
+
+        verifyPruning(
+          projectList = Seq("p3", "value", "p2"),
+          expectedScanList = Seq("value", "p1", "p2", "p3"),
+          Row(3, "val1_2", 3) :: Row(3, "val1_1", 2) :: Nil)
+
+        verifyPruning(
+          projectList = Seq("p3", "p2", "value2"),
+          expectedScanList = Seq("value2", "p1", "p2", "p3"),
+          Row(3, 3, "val2_2") :: Row(3, 2, "val2_1") :: Nil)
       }
     }
   }
@@ -488,6 +558,14 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
         scan.rdd.asInstanceOf[FileScanRDD]
     }.headOption.getOrElse {
       fail(s"No FileScan in query\n${df.queryExecution}")
+    }
+  }
+
+  def getDataSourceScanExec(df: DataFrame): DataSourceScanExec = {
+    df.queryExecution.executedPlan.collect {
+      case scan: DataSourceScanExec => scan
+    }.headOption.getOrElse {
+      fail(s"No DataSourceScanExec in query\n${df.queryExecution}")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

For partitioned file sources, the current implementation always scans all the partition columns. However, this is not necessary when the projected column list does not include any partition column. In addition, we also can avoid the unnecessary `Project`.

Below is an example,

``` scala
spark
  .range(N)
  .selectExpr("id AS value1", "id AS value2", "id AS p1", "id AS p2", "id AS p3")
  .toDF("value", "value2", "p1", "p2", "p3").write.format("json")
  .partitionBy("p1", "p2", "p3").save(tempDir)
```

```
spark.read.format("json").load(tempDir).selectExpr("value")
```

**Before the PR changes**, the physical plan is like:

```
== Physical Plan ==
*Project [value#37L]
+- *Scan json [value#37L,p1#39,p2#40,p3#41] Format: JSON, InputPaths: file:/private/var/folders/4b/sgmfldk15js406vk7lw5llzw0000gn/T/spark-f7a4294a-2e1b-4f44-9ebb-1a5eb..., PushedFilters: [], ReadSchema: struct<value:bigint>
```

**After the PR changes**, the physical plan becomes:

```
== Physical Plan ==
*Scan json [value#147L] Format: JSON, InputPaths: file:/private/var/folders/4b/sgmfldk15js406vk7lw5llzw0000gn/T/spark-a5bcb14a-46c2-4c20-8f34-9662b..., PushedFilters: [], ReadSchema: struct<value:bigint>
```
### How was this patch tested?

Added a test case to verify the results.
