### PR TITLE
[SPARK-16686][SQL] Remove PushProjectThroughSample since it is handled by ColumnPruning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -156,13 +156,8 @@ object PushProjectThroughSample extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     // Push down projection into sample
     case p @ Project(projectList, Sample(lb, up, replace, seed, child))
-        if !hasNewOutput(projectList, p.child.output) =>
+        if p.outputSet.subsetOf(p.child.outputSet) =>
       Sample(lb, up, replace, seed, Project(projectList, child))()
-  }
-  private def hasNewOutput(
-      projectList: Seq[NamedExpression],
-      childOutput: Seq[Attribute]): Boolean = {
-    projectList.exists(p => !childOutput.exists(_.semanticEquals(p)))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -349,29 +349,16 @@ class ColumnPruningSuite extends PlanTest {
   test("push project down into sample") {
     val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
     val x = testRelation.subquery('x)
-    val originalQuery =
-      Sample(0.0, 0.6, false, 11L, x)().select('a)
 
-    val originalQueryAnalyzed = originalQuery.analyze
+    val query1 = Sample(0.0, 0.6, false, 11L, x)().select('a)
+    val optimized1 = Optimize.execute(query1.analyze)
+    val expected1 = Sample(0.0, 0.6, false, 11L, x.select('a))()
+    comparePlans(optimized1, expected1.analyze)
 
-    val optimized = Optimize.execute(originalQueryAnalyzed)
-
-    val correctAnswer =
-      Sample(0.0, 0.6, false, 11L, x.select('a))()
-
-    comparePlans(optimized, correctAnswer.analyze)
-
-    val originalQuery2 =
-      Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
-
-    val originalQueryAnalyzed2 = originalQuery2.analyze
-
-    val optimized2 = Optimize.execute(originalQueryAnalyzed2)
-
-    val correctAnswer2 =
-      Sample(0.0, 0.6, false, 11L, x.select('a))().select('a as 'aa)
-
-    comparePlans(optimized2, correctAnswer2.analyze)
+    val query2 = Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
+    val optimized2 = Optimize.execute(query2.analyze)
+    val expected2 = Sample(0.0, 0.6, false, 11L, x.select('a))().select('a as 'aa)
+    comparePlans(optimized2, expected2.analyze)
   }
 
   // todo: add more tests for column pruning

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.optimizer
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.sql.catalyst.analysis
-import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -353,8 +352,7 @@ class ColumnPruningSuite extends PlanTest {
     val originalQuery =
       Sample(0.0, 0.6, false, 11L, x)().select('a)
 
-    val originalQueryAnalyzed =
-      EliminateSubqueryAliases(analysis.SimpleAnalyzer.execute(originalQuery))
+    val originalQueryAnalyzed = originalQuery.analyze
 
     val optimized = Optimize.execute(originalQueryAnalyzed)
 
@@ -366,8 +364,7 @@ class ColumnPruningSuite extends PlanTest {
     val originalQuery2 =
       Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
 
-    val originalQueryAnalyzed2 =
-      EliminateSubqueryAliases(analysis.SimpleAnalyzer.execute(originalQuery2))
+    val originalQueryAnalyzed2 = originalQuery2.analyze
 
     val optimized2 = Optimize.execute(originalQueryAnalyzed2)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -601,6 +601,22 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer.analyze)
   }
 
+  test("don't push project down into sample if project brings new attributes") {
+    val x = testRelation.subquery('x)
+    val originalQuery =
+      Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
+
+    val originalQueryAnalyzed =
+      EliminateSubqueryAliases(analysis.SimpleAnalyzer.execute(originalQuery))
+
+    val optimized = Optimize.execute(originalQueryAnalyzed)
+
+    val correctAnswer =
+      Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
+
+    comparePlans(optimized, correctAnswer.analyze)
+  }
+
   test("aggregate: push down filter when filter on group by expression") {
     val originalQuery = testRelation
                         .groupBy('a)('a, count('b) as 'c)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -34,7 +34,6 @@ class FilterPushdownSuite extends PlanTest {
       Batch("Subqueries", Once,
         EliminateSubqueryAliases) ::
       Batch("Filter Pushdown", FixedPoint(10),
-        PushProjectThroughSample,
         CombineFilters,
         PushDownPredicate,
         BooleanSimplification,
@@ -583,38 +582,6 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery)
 
     comparePlans(optimized, originalQuery)
-  }
-
-  test("push project and filter down into sample") {
-    val x = testRelation.subquery('x)
-    val originalQuery =
-      Sample(0.0, 0.6, false, 11L, x)().select('a)
-
-    val originalQueryAnalyzed =
-      EliminateSubqueryAliases(analysis.SimpleAnalyzer.execute(originalQuery))
-
-    val optimized = Optimize.execute(originalQueryAnalyzed)
-
-    val correctAnswer =
-      Sample(0.0, 0.6, false, 11L, x.select('a))()
-
-    comparePlans(optimized, correctAnswer.analyze)
-  }
-
-  test("don't push project down into sample if project brings new attributes") {
-    val x = testRelation.subquery('x)
-    val originalQuery =
-      Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
-
-    val originalQueryAnalyzed =
-      EliminateSubqueryAliases(analysis.SimpleAnalyzer.execute(originalQuery))
-
-    val optimized = Optimize.execute(originalQueryAnalyzed)
-
-    val correctAnswer =
-      Sample(0.0, 0.6, false, 11L, x)().select('a as 'aa)
-
-    comparePlans(optimized, correctAnswer.analyze)
   }
 
   test("aggregate: push down filter when filter on group by expression") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -424,11 +424,8 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-16686: Dataset.sample with seed results shouldn't depend on downstream usage") {
     val udfOne = spark.udf.register("udfOne", (n: Int) => {
-      if (n == 1) {
-        throw new RuntimeException("udfOne shouldn't see swid=1!")
-      } else {
-        1
-      }
+      require(n != 1, "udfOne shouldn't see swid=1!")
+      1
     })
 
     val d = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -423,8 +423,8 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-16686: Dataset.sample with seed results shouldn't depend on downstream usage") {
-    val udfOne = udf((n: Int) => {
-      require(n != 1, "udfOne shouldn't see swid=1!")
+    val simpleUdf = udf((n: Int) => {
+      require(n != 1, "simpleUdf shouldn't see id=1!")
       1
     })
 
@@ -439,12 +439,12 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       (7, "string7"),
       (8, "string8"),
       (9, "string9")
-    ).toDF("swid", "stringData")
+    ).toDF("id", "stringData")
     val sampleDF = df.sample(false, 0.7, 50)
-    // After sampling, sampleDF doesn't contain swid=1.
-    assert(!sampleDF.select("swid").collect.contains(1))
-    // udfOne should not encounter swid=1.
-    checkAnswer(sampleDF.select(udfOne($"swid")), List.fill(sampleDF.count.toInt)(Row(1)))
+    // After sampling, sampleDF doesn't contain id=1.
+    assert(!sampleDF.select("id").collect.contains(1))
+    // simpleUdf should not encounter id=1.
+    checkAnswer(sampleDF.select(simpleUdf($"id")), List.fill(sampleDF.count.toInt)(Row(1)))
   }
 
   test("SPARK-11436: we should rebind right encoder when join 2 datasets") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -444,7 +444,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     // After sampling, sampleDF doesn't contain swid=1.
     assert(!sampleDF.select("swid").collect.contains(1))
     // udfOne should not encounter swid=1.
-    sampleDF.select(udfOne($"swid")).collect
+    checkAnswer(sampleDF.select(udfOne($"swid")), List.fill(sampleDF.count.toInt)(Row(1)))
   }
 
   test("SPARK-11436: we should rebind right encoder when join 2 datasets") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -423,12 +423,12 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-16686: Dataset.sample with seed results shouldn't depend on downstream usage") {
-    val udfOne = spark.udf.register("udfOne", (n: Int) => {
+    val udfOne = udf((n: Int) => {
       require(n != 1, "udfOne shouldn't see swid=1!")
       1
     })
 
-    val d = Seq(
+    val df = Seq(
       (0, "string0"),
       (1, "string1"),
       (2, "string2"),
@@ -439,8 +439,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       (7, "string7"),
       (8, "string8"),
       (9, "string9")
-    )
-    val df = spark.createDataFrame(d).toDF("swid", "stringData")
+    ).toDF("swid", "stringData")
     val sampleDF = df.sample(false, 0.7, 50)
     // After sampling, sampleDF doesn't contain swid=1.
     assert(!sampleDF.select("swid").collect.contains(1))


### PR DESCRIPTION
## What changes were proposed in this pull request?

We push down `Project` through `Sample` in `Optimizer` by the rule `PushProjectThroughSample`. However, if the projected columns produce new output, they will encounter whole data instead of sampled data. It will bring some inconsistency between original plan (Sample then Project) and optimized plan (Project then Sample). In the extreme case such as attached in the JIRA, if the projected column is an UDF which is supposed to not see the sampled out data, the result of UDF will be incorrect.

Since the rule `ColumnPruning` already handles general `Project` pushdown. We don't need  `PushProjectThroughSample` anymore. The rule `ColumnPruning` also avoids the described issue.
## How was this patch tested?

Jenkins tests.
