### PR TITLE
Don't run over all numFeatures if debug log disabled

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -117,10 +117,12 @@ private[spark] object RandomForest extends Logging {
     timer.start("findSplits")
     val splits = findSplits(retaggedInput, metadata, seed)
     timer.stop("findSplits")
-    logDebug("numBins: feature: number of bins")
-    logDebug(Range(0, metadata.numFeatures).map { featureIndex =>
-      s"\t$featureIndex\t${metadata.numBins(featureIndex)}"
-    }.mkString("\n"))
+    if (log.isDebugEnabled) {
+      logDebug("numBins: feature: number of bins")
+      logDebug(Range(0, metadata.numFeatures).map { featureIndex =>
+        s"\t$featureIndex\t${metadata.numBins(featureIndex)}"
+      }.mkString("\n"))
+    }
 
     // Bin feature values (TreePoint representation).
     // Cache input RDD for speedup during multiple passes.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Very small changes that removes a lag on very big features vectors, when the machine prepare strings for debug log that may be disabled.
## How was this patch tested?

It's trivial changes.
