### PR TITLE
[SPARK-16699][SQL] Fix performance bug in hash aggregate on long string keys

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -313,10 +313,12 @@ class VectorizedHashMapGenerator(
     def hashLong(l: String): String = s"long $result = $l;"
     def hashBytes(b: String): String = {
       val hash = ctx.freshName("hash")
+      val bytes = ctx.freshName("bytes")
       s"""
          |int $result = 0;
-         |for (int i = 0; i < $b.length; i++) {
-         |  ${genComputeHash(ctx, s"$b[i]", ByteType, hash)}
+         |byte[] $bytes = $b;
+         |for (int i = 0; i < $bytes.length; i++) {
+         |  ${genComputeHash(ctx, s"$bytes[i]", ByteType, hash)}
          |  $result = ($result ^ (0x9e3779b9)) + $hash + ($result << 6) + ($result >>> 2);
          |}
        """.stripMargin


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the following code in `VectorizedHashMapGenerator.scala`:

```
    def hashBytes(b: String): String = {
      val hash = ctx.freshName("hash")
      s"""
         |int $result = 0;
         |for (int i = 0; i < $b.length; i++) {
         |  ${genComputeHash(ctx, s"$b[i]", ByteType, hash)}
         |  $result = ($result ^ (0x9e3779b9)) + $hash + ($result << 6) + ($result >>> 2);
         |}
       """.stripMargin
    }

```

when b=input.getBytes(), the current 2.0 code results in getBytes() being called n times, n being length of input. getBytes() involves memory copy is thus expensive and causes a performance degradation.
Fix is to evaluate getBytes() before the for loop.
## How was this patch tested?

Performance bug, no additional test added.
