### PR TITLE
[SPARK-16698][SQL] Field names having dots should be allowed for datasources based on FileFormat

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -127,7 +127,7 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
    */
   def resolve(schema: StructType, resolver: Resolver): Seq[Attribute] = {
     schema.map { field =>
-      resolveQuoted(field.name, resolver).map {
+      resolve(field.name :: Nil, resolver).map {
         case a: AttributeReference => a
         case other => sys.error(s"can not handle nested schema yet...  plan $this")
       }.getOrElse {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2991,9 +2991,9 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         .format("parquet")
         .partitionBy("part.col1", "part.col2")
         .save(path.getCanonicalPath)
-      val copyData = spark.read.format("parquet").load(path.getCanonicalPath)
+      val readBack = spark.read.format("parquet").load(path.getCanonicalPath)
       checkAnswer(
-        copyData.selectExpr("`part.col1`", "`col.1`"),
+        readBack.selectExpr("`part.col1`", "`col.1`"),
         data.selectExpr("`part.col1`", "`col.1`"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2982,4 +2982,19 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         """.stripMargin), Nil)
     }
   }
+
+  test("SPARK-16674: field names containing dots for both fields and partitioned fields") {
+    withTempPath { path =>
+      val data = (1 to 10).map(i => (i, s"data-$i", i % 2, if ((i % 2) == 0) "a" else "b"))
+        .toDF("col.1", "col.2", "part.col1", "part.col2")
+      data.write
+        .format("parquet")
+        .partitionBy("part.col1", "part.col2")
+        .save(path.getCanonicalPath)
+      val copyData = spark.read.format("parquet").load(path.getCanonicalPath)
+      checkAnswer(
+        copyData.selectExpr("`part.col1`", "`col.1`"),
+        data.selectExpr("`part.col1`", "`col.1`"))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -242,22 +242,6 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     assert(!(getPhysicalFilters(df) contains resolve(df, "p1 = 1")))
   }
 
-  test("field names containing dots for both fields and partitioned fields") {
-    val table =
-      createTable(
-        files = Seq(
-          "p.1=1/file1" -> 10,
-          "p.1=2/file2" -> 10))
-
-    val df = table.where("`p.1` = 1 AND (`p.1` + c1) = 2 AND `c.3` = 1")
-    // Filter on data only are advisory so we have to reevaluate.
-    assert(getPhysicalFilters(df) contains resolve(df, "`c.3` = 1"))
-    // Need to evalaute filters that are not pushed down.
-    assert(getPhysicalFilters(df) contains resolve(df, "(`p.1` + c1) = 2"))
-    // Don't reevaluate partition only filters.
-    assert(!(getPhysicalFilters(df) contains resolve(df, "`p.1` = 1")))
-  }
-
   test("bucketed table") {
     val table =
       createTable(
@@ -533,8 +517,7 @@ class TestFileFormat extends TextBasedFileFormat {
     Some(
       StructType(Nil)
           .add("c1", IntegerType)
-          .add("c2", IntegerType)
-          .add("c.3", IntegerType))
+          .add("c2", IntegerType))
 
   /**
    * Prepares a write job and returns an [[OutputWriterFactory]].  Client side job preparation can

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -242,6 +242,22 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     assert(!(getPhysicalFilters(df) contains resolve(df, "p1 = 1")))
   }
 
+  test("field names containing dots for both fields and partitioned fields") {
+    val table =
+      createTable(
+        files = Seq(
+          "p.1=1/file1" -> 10,
+          "p.1=2/file2" -> 10))
+
+    val df = table.where("`p.1` = 1 AND (`p.1` + c1) = 2 AND `c.3` = 1")
+    // Filter on data only are advisory so we have to reevaluate.
+    assert(getPhysicalFilters(df) contains resolve(df, "`c.3` = 1"))
+    // Need to evalaute filters that are not pushed down.
+    assert(getPhysicalFilters(df) contains resolve(df, "(`p.1` + c1) = 2"))
+    // Don't reevaluate partition only filters.
+    assert(!(getPhysicalFilters(df) contains resolve(df, "`p.1` = 1")))
+  }
+
   test("bucketed table") {
     val table =
       createTable(
@@ -517,7 +533,8 @@ class TestFileFormat extends TextBasedFileFormat {
     Some(
       StructType(Nil)
           .add("c1", IntegerType)
-          .add("c2", IntegerType))
+          .add("c2", IntegerType)
+          .add("c.3", IntegerType))
 
   /**
    * Prepares a write job and returns an [[OutputWriterFactory]].  Client side job preparation can


### PR DESCRIPTION
## What changes were proposed in this pull request?

It seems this is a regression assuming from https://issues.apache.org/jira/browse/SPARK-16698.

Field name having dots throws an exception. For example the codes below:

``` scala
val path = "/tmp/path"
val json =""" {"a.b":"data"}"""
spark.sparkContext
  .parallelize(json :: Nil)
  .saveAsTextFile(path)
spark.read.json(path).collect()
```

throws an exception as below:

```
Unable to resolve a.b given [a.b];
org.apache.spark.sql.AnalysisException: Unable to resolve a.b given [a.b];
    at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan$$anonfun$resolve$1$$anonfun$apply$5.apply(LogicalPlan.scala:134)
    at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan$$anonfun$resolve$1$$anonfun$apply$5.apply(LogicalPlan.scala:134)
    at scala.Option.getOrElse(Option.scala:121)
```

This problem was introduced in https://github.com/apache/spark/commit/17eec0a71ba8713c559d641e3f43a1be726b037c#diff-27c76f96a7b2733ecfd6f46a1716e153R121

When extracting the data columns, it does not count that it can contain dots in field names. Actually, it seems the fields name are not expected as quoted. So, It does not have to consider whether this is wrapped with quotes because the actual schema (inferred or user-given schema) would not have the quotes for fields. 

For example, this throws an exception. (**Loading JSON from RDD is fine**)

``` scala
val json =""" {"a.b":"data"}"""
val rdd = spark.sparkContext.parallelize(json :: Nil)
spark.read.schema(StructType(Seq(StructField("`a.b`", StringType, true))))
  .json(rdd).select("`a.b`").printSchema()
```

as below:

``````
cannot resolve '```a.b```' given input columns: [`a.b`];
org.apache.spark.sql.AnalysisException: cannot resolve '```a.b```' given input columns: [`a.b`];
    at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
``````
## How was this patch tested?

Unit tests in `FileSourceStrategySuite`.
