### PR TITLE
[SPARK-16534][Streaming][Kafka] Add Python API support for Kafka 0.10 connector

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -337,6 +337,7 @@ def build_spark_sbt(hadoop_version):
     build_profiles = get_hadoop_profiles(hadoop_version) + modules.root.build_profile_flags
     sbt_goals = ["test:package",  # Build test jars as some tests depend on them
                  "streaming-kafka-0-8-assembly/assembly",
+                 "streaming-kafka-0-10-assembly/assembly",
                  "streaming-flume-assembly/assembly",
                  "streaming-kinesis-asl-assembly/assembly"]
     profiles_and_goals = build_profiles + sbt_goals

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -359,6 +359,7 @@ pyspark_streaming = Module(
     python_test_goals=[
         "pyspark.streaming.util",
         "pyspark.streaming.tests",
+        "pyspark.streaming.kafka010_tests",
     ]
 )
 

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
@@ -17,19 +17,26 @@
 
 package org.apache.spark.streaming.kafka010
 
-import java.{ util => ju }
+import java.{util => ju}
+import java.io.OutputStream
+import java.lang.{Integer => JInt, Long => JLong}
+import java.nio.charset.StandardCharsets
 
+import scala.collection.JavaConverters._
+
+import net.razorvine.pickle.{IObjectPickler, Opcodes, Pickler}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.api.java.{ JavaRDD, JavaSparkContext }
-import org.apache.spark.api.java.function.{ Function0 => JFunction0 }
+import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
+import org.apache.spark.api.python.SerDeUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.StreamingContext
-import org.apache.spark.streaming.api.java.{ JavaInputDStream, JavaStreamingContext }
+import org.apache.spark.streaming.api.java.{JavaDStream, JavaInputDStream, JavaStreamingContext}
 import org.apache.spark.streaming.dstream._
 
 /**
@@ -43,6 +50,7 @@ object KafkaUtils extends Logging {
    * Scala constructor for a batch-oriented interface for consuming from Kafka.
    * Starting and ending offsets are specified in advance,
    * so that you can control exactly-once semantics.
+   *
    * @param kafkaParams Kafka
    * <a href="http://kafka.apache.org/documentation.html#newconsumerconfigs">
    * configuration parameters</a>. Requires "bootstrap.servers" to be set
@@ -80,8 +88,7 @@ object KafkaUtils extends Logging {
    * Java constructor for a batch-oriented interface for consuming from Kafka.
    * Starting and ending offsets are specified in advance,
    * so that you can control exactly-once semantics.
-   * @param keyClass Class of the keys in the Kafka records
-   * @param valueClass Class of the values in the Kafka records
+   *
    * @param kafkaParams Kafka
    * <a href="http://kafka.apache.org/documentation.html#newconsumerconfigs">
    * configuration parameters</a>. Requires "bootstrap.servers" to be set
@@ -130,8 +137,6 @@ object KafkaUtils extends Logging {
    * :: Experimental ::
    * Java constructor for a DStream where
    * each given Kafka topic/partition corresponds to an RDD partition.
-   * @param keyClass Class of the keys in the Kafka records
-   * @param valueClass Class of the values in the Kafka records
    * @param locationStrategy In most cases, pass in LocationStrategies.preferConsistent,
    *   see [[LocationStrategies]] for more details.
    * @param consumerStrategy In most cases, pass in ConsumerStrategies.subscribe,
@@ -174,6 +179,175 @@ object KafkaUtils extends Logging {
     if (null == rbb || rbb.asInstanceOf[java.lang.Integer] < 65536) {
       logWarning(s"overriding ${ConsumerConfig.RECEIVE_BUFFER_CONFIG} to 65536 see KAFKA-3135")
       kafkaParams.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, 65536: java.lang.Integer)
+    }
+  }
+}
+
+private[kafka010] class KafkaUtilsPythonHelper extends Logging {
+  import KafkaUtilsPythonHelper._
+
+  def createDirectStream(
+      jssc: JavaStreamingContext,
+      locationStrategy: LocationStrategy,
+      consumerStrategy: ConsumerStrategy[Array[Byte], Array[Byte]]
+    ): JavaDStream[Array[Byte]] = {
+    fixKafkaParams(consumerStrategy.executorKafkaParams)
+    val stream = KafkaUtils.createDirectStream(jssc.ssc, locationStrategy, consumerStrategy)
+      .map { r =>
+        PythonConsumerRecord(r.topic(), r.partition(), r.offset(), r.timestamp(),
+          r.timestampType().toString, r.checksum(), r.serializedKeySize(), r.serializedValueSize(),
+            r.key(), r.value())
+      }.mapPartitions(picklerIterator)
+    new JavaDStream(stream)
+  }
+
+  def createRDD(
+      jsc: JavaSparkContext,
+      kafkaParams: ju.Map[String, Object],
+      offsetRanges: ju.List[OffsetRange],
+      locationStrategy: LocationStrategy
+    ): JavaRDD[Array[Byte]] = {
+    fixKafkaParams(kafkaParams)
+    val rdd = KafkaUtils.createRDD[Array[Byte], Array[Byte]](
+      jsc.sc,
+      kafkaParams,
+      offsetRanges.toArray(new Array[OffsetRange](offsetRanges.size())),
+      locationStrategy)
+        .map { r =>
+          PythonConsumerRecord(r.topic(), r.partition(), r.offset(), r.timestamp(),
+            r.timestampType().toString, r.checksum(), r.serializedKeySize(),
+              r.serializedValueSize(), r.key(), r.value())
+        }.mapPartitions(picklerIterator)
+    new JavaRDD(rdd)
+  }
+
+  private def fixKafkaParams(kafkaParams: ju.Map[String, Object]): Unit = {
+    val decoder = classOf[ByteArrayDeserializer].getCanonicalName
+
+    val keyDecoder = kafkaParams.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG)
+    if (keyDecoder != null && keyDecoder != decoder) {
+      logWarning(s"${ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG} $keyDecoder is not supported " +
+        s"for python Kafka API, overriding with $decoder")
+    }
+    kafkaParams.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, decoder)
+
+    val valueDecoder = kafkaParams.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG)
+    if (valueDecoder != null && valueDecoder != decoder) {
+      logWarning(s"${ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG} $valueDecoder is not " +
+        s"supported for python Kafka API, overriding with $decoder")
+    }
+    kafkaParams.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, decoder)
+  }
+
+  // Helper functions to convert Python object to Java object
+  def createOffsetRange(topic: String, partition: JInt, fromOffset: JLong, untilOffset: JLong
+      ): OffsetRange = OffsetRange.create(topic, partition, fromOffset, untilOffset)
+
+  def createPreferBrokers(): LocationStrategy = LocationStrategies.PreferBrokers
+
+  def createPreferConsistent(): LocationStrategy = LocationStrategies.PreferConsistent
+
+  def createPreferFixed(hostMap: ju.Map[TopicPartition, String]): LocationStrategy = {
+    LocationStrategies.PreferFixed(hostMap)
+  }
+
+  def createTopicPartition(topic: String, partition: JInt): TopicPartition =
+    new TopicPartition(topic, partition)
+
+  def createSubscribe(
+      topics: ju.Set[String],
+      kafkaParams: ju.Map[String, Object],
+      offsets: ju.Map[TopicPartition, JLong]): ConsumerStrategy[Array[Byte], Array[Byte]] =
+    ConsumerStrategies.Subscribe(topics, kafkaParams, offsets)
+
+  def createSubscribePattern(
+      pattern: String,
+      kafkaParams: ju.Map[String, Object],
+      offsets: ju.Map[TopicPartition, JLong]): ConsumerStrategy[Array[Byte], Array[Byte]] = {
+    ConsumerStrategies.SubscribePattern(ju.regex.Pattern.compile(pattern), kafkaParams, offsets)
+  }
+
+  def createAssign(
+      topicPartitions: ju.Set[TopicPartition],
+      kafkaParams: ju.Map[String, Object],
+      offsets: ju.Map[TopicPartition, JLong]): ConsumerStrategy[Array[Byte], Array[Byte]] = {
+    ConsumerStrategies.Assign(topicPartitions, kafkaParams, offsets)
+  }
+
+  def offsetRangesOfKafkaRDD(rdd: RDD[_]): ju.List[OffsetRange] = {
+    val parentRDDs = rdd.getNarrowAncestors
+    val kafkaRDDs = parentRDDs.filter(rdd => rdd.isInstanceOf[KafkaRDD[_, _]])
+
+    require(
+      kafkaRDDs.length == 1,
+      "Cannot get offset ranges, as there may be multiple Kafka RDDs or no Kafka RDD associated" +
+        "with this RDD, please call this method only on a Kafka RDD.")
+
+    val kafkaRDD = kafkaRDDs.head.asInstanceOf[KafkaRDD[_, _]]
+    kafkaRDD.offsetRanges.toSeq.asJava
+  }
+}
+
+private object KafkaUtilsPythonHelper {
+  private var initialized = false
+
+  def initialize(): Unit = {
+    SerDeUtil.initialize()
+    synchronized {
+      if (!initialized) {
+        new PythonConsumerRecordPickler().register()
+        initialized = true
+      }
+    }
+  }
+
+  initialize()
+
+  def picklerIterator(iter: Iterator[Any]): Iterator[Array[Byte]] = {
+    new SerDeUtil.AutoBatchedPickler(iter)
+  }
+
+  case class PythonConsumerRecord(
+      topic: String,
+      partition: JInt,
+      offset: JLong,
+      timestamp: JLong,
+      timestampType: String,
+      checksum: JLong,
+      serializedKeySize: JInt,
+      serializedValueSize: JInt,
+      key: Array[Byte],
+      value: Array[Byte])
+
+  class PythonConsumerRecordPickler extends IObjectPickler {
+    private val module = "pyspark.streaming.kafka010"
+
+    def register(): Unit = {
+      Pickler.registerCustomPickler(classOf[PythonConsumerRecord], this)
+      Pickler.registerCustomPickler(this.getClass, this)
+    }
+
+    def pickle(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
+      if (obj == this) {
+        out.write(Opcodes.GLOBAL)
+        out.write(s"$module\nKafkaConsumerRecord\n".getBytes(StandardCharsets.UTF_8))
+      } else {
+        pickler.save(this)
+        val consumerRecord = obj.asInstanceOf[PythonConsumerRecord]
+        out.write(Opcodes.MARK)
+        pickler.save(consumerRecord.topic)
+        pickler.save(consumerRecord.partition)
+        pickler.save(consumerRecord.offset)
+        pickler.save(consumerRecord.timestamp)
+        pickler.save(consumerRecord.timestampType)
+        pickler.save(consumerRecord.checksum)
+        pickler.save(consumerRecord.serializedKeySize)
+        pickler.save(consumerRecord.serializedValueSize)
+        pickler.save(consumerRecord.key)
+        pickler.save(consumerRecord.value)
+        out.write(Opcodes.TUPLE)
+        out.write(Opcodes.REDUCE)
+      }
     }
   }
 }

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -252,8 +252,11 @@ class OffsetRange(object):
         return not self.__eq__(other)
 
     def __str__(self):
-        return "OffsetRange(topic: %s, partition: %d, range: [%d -> %d]" \
+        return "OffsetRange(topic: %s, partition: %d, range: [%d -> %d])" \
                % (self.topic, self.partition, self.fromOffset, self.untilOffset)
+
+    def __repr__(self):
+        return self.__str__()
 
     def _jOffsetRange(self, helper):
         return helper.createOffsetRange(self.topic, self.partition, self.fromOffset,
@@ -262,7 +265,7 @@ class OffsetRange(object):
 
 class TopicAndPartition(object):
     """
-    Represents a specific top and partition for Kafka.
+    Represents a specific topic and partition for Kafka.
     """
 
     def __init__(self, topic, partition):

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -25,8 +25,8 @@ from pyspark.streaming import DStream
 from pyspark.streaming.dstream import TransformedDStream
 from pyspark.streaming.util import TransformFunction
 
-__all__ = ['Broker', 'KafkaMessageAndMetadata', 'KafkaUtils', 'OffsetRange',
-           'TopicAndPartition', 'utf8_decoder']
+__all__ = ['Broker', 'KafkaMessageAndMetadata', 'KafkaUtils', 'KafkaDStream', 'KafkaRDD',
+           'OffsetRange', 'TopicAndPartition', 'utf8_decoder']
 
 
 def utf8_decoder(s):

--- a/python/pyspark/streaming/kafka010.py
+++ b/python/pyspark/streaming/kafka010.py
@@ -1,0 +1,249 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.rdd import RDD
+from pyspark.serializers import AutoBatchedSerializer, PickleSerializer
+from pyspark.streaming import DStream
+from pyspark.streaming.kafka import KafkaDStream, KafkaRDD, OffsetRange
+
+__all__ = ['Assign', 'KafkaConsumerRecord', 'KafkaUtils', 'PreferBrokers', 'PreferConsistent',
+           'PreferFixed', 'Subscribe', 'SubscribePattern', 'TopicPartition']
+
+
+def utf8_decoder(s):
+    """ Decode the unicode as UTF-8 """
+    if s is None:
+        return None
+    return s.decode('utf-8')
+
+
+class KafkaUtils(object):
+
+    @staticmethod
+    def createDirectStream(ssc, locationStrategy, consumerStrategy,
+                           keyDecoder=utf8_decoder, valueDecoder=utf8_decoder):
+        helper = KafkaUtils._get_helper(ssc._sc)
+        ser = AutoBatchedSerializer(PickleSerializer())
+
+        jlocationStrategy = locationStrategy._jLocationStrategy(helper)
+        jconsumerStrategy = consumerStrategy._jConsumerStrategy(helper)
+
+        jstream = helper.createDirectStream(ssc._jssc, jlocationStrategy, jconsumerStrategy)
+
+        def func(m):
+            m._set_key_deserializer(keyDecoder)
+            m._set_value_deserializer(valueDecoder)
+            return m
+
+        stream = DStream(jstream, ssc, ser).map(func)
+
+        return KafkaDStream(stream._jdstream, ssc, stream._jrdd_deserializer)
+
+    @staticmethod
+    def createRDD(sc, kafkaParams, offsetRanges, locationStrategy,
+                  keyDecoder=utf8_decoder, valueDecoder=utf8_decoder):
+
+        if not isinstance(kafkaParams, dict):
+            raise TypeError("kafkaParams should be dict")
+
+        helper = KafkaUtils._get_helper(sc)
+        joffsetRanges = [o._jOffsetRange(helper) for o in offsetRanges]
+        jlocationStrategy = locationStrategy._jLocationStrategy(helper)
+
+        jrdd = helper.createRDD(sc._jsc, kafkaParams, joffsetRanges, jlocationStrategy)
+
+        def func(m):
+            m._set_key_deserializer(keyDecoder)
+            m._set_value_deserializer(valueDecoder)
+            return m
+
+        rdd = RDD(jrdd, sc).map(func)
+
+        return KafkaRDD(rdd._jrdd, sc, rdd._jrdd_deserializer)
+
+    @staticmethod
+    def _get_helper(sc):
+        try:
+            return sc._jvm.org.apache.spark.streaming.kafka010.KafkaUtilsPythonHelper()
+        except TypeError as e:
+            if str(e) == "'JavaPackage' object is not callable":
+                KafkaUtils._printErrorMsg(sc)
+            raise
+
+    @staticmethod
+    def _printErrorMsg(sc):
+        print("""
+________________________________________________________________________________________________
+
+  Spark Streaming's Kafka libraries not found in class path. Try one of the following.
+
+  1. Include the Kafka library and its dependencies with in the
+     spark-submit command as
+
+     $ bin/spark-submit --packages org.apache.spark:spark-streaming-kafka-0-10:%s ...
+
+  2. Download the JAR of the artifact from Maven Central http://search.maven.org/,
+     Group Id = org.apache.spark, Artifact Id = spark-streaming-kafka-0-10-assembly, Version = %s.
+     Then, include the jar in the spark-submit command as
+
+     $ bin/spark-submit --jars <spark-streaming-kafka-0-10-assembly.jar> ...
+
+________________________________________________________________________________________________
+
+""" % (sc.version, sc.version))
+
+
+class LocationStrategy(object):
+
+    def _jLocationStrategy(self, helper):
+        pass
+
+
+class PreferBrokers(LocationStrategy):
+
+    def _jLocationStrategy(self, helper):
+        return helper.createPreferBrokers()
+
+
+class PreferConsistent(LocationStrategy):
+
+    def _jLocationStrategy(self, helper):
+        return helper.createPreferConsistent()
+
+
+class PreferFixed(LocationStrategy):
+
+    def __init__(self, hostMap):
+        self.hostMap = hostMap
+
+    def _jLocationStrategy(self, helper):
+        jhostMap = dict([(k._jTopicPartition(helper), v) for (k, v) in self.hostMap.items()])
+        return helper.createPreferFixed(jhostMap)
+
+
+class ConsumerStrategy(object):
+
+    def _jConsumerStrategy(self, helper):
+        pass
+
+
+class Subscribe(ConsumerStrategy):
+
+    def __init__(self, topics, kafkaParams, offsets=None):
+        self.topics = set(topics)
+        self.kafkaParams = kafkaParams
+        self.offsets = dict() if offsets is None else offsets
+
+    def _jConsumerStrategy(self, helper):
+        jOffsets = dict([k._jTopicPartition(helper), v] for (k, v) in self.offsets.items())
+        return helper.createSubscribe(self.topics, self.kafkaParams, jOffsets)
+
+
+class SubscribePattern(ConsumerStrategy):
+
+    def __init__(self, pattern, kafkaParams, offsets=None):
+        self.pattern = pattern
+        self.kafkaParams = kafkaParams
+        self.offsets = dict() if offsets is None else offsets
+
+    def _jConsumerStrategy(self, helper):
+        jOffsets = dict([k._jTopicPartition(helper), v] for (k, v) in self.offsets.items())
+        return helper.createSubscribePattern(self.pattern, self.kafkaParams, jOffsets)
+
+
+class Assign(ConsumerStrategy):
+
+    def __init__(self, topicPartitions, kafkaParams, offsets=None):
+        self.topicPartitions = set(topicPartitions)
+        self.kafkaParams = kafkaParams
+        self.offsets = dict() if offsets is None else offsets
+
+    def _jConsumerStrategy(self, helper):
+        jOffsets = dict([k._jTopicPartition(helper), v] for (k, v) in self.offsets.items())
+        return helper.createAssign(self.topicPartitions, self.kafkaParams, jOffsets)
+
+
+class TopicPartition(object):
+    """
+    Represents a specific top and partition for Kafka.
+    """
+
+    def __init__(self, topic, partition):
+        """
+        Create a Python TopicPartition to map to the Java related object
+        :param topic: Kafka topic name.
+        :param partition: Kafka partition id.
+        """
+        self._topic = topic
+        self._partition = partition
+
+    def _jTopicPartition(self, helper):
+        return helper.createTopicPartition(self._topic, self._partition)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (self._topic == other._topic
+                    and self._partition == other._partition)
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class KafkaConsumerRecord(object):
+
+    def __init__(self, topic, partition, offset, timestamp, timestampType, checksum,
+                 serializedKeySize, serializedValueSize, key, value):
+        self.topic = topic
+        self.partition = partition
+        self.offset = offset
+        self.timestamp = timestamp
+        self.timestampType = timestampType
+        self.checksum = checksum
+        self.serializedKeySize = serializedKeySize
+        self.serializedValueSize = serializedValueSize
+        self._rawKey = key
+        self._rawValue = value
+        self._keyDecoder = utf8_decoder
+        self._valueDecoder = utf8_decoder
+
+    def __str__(self):
+        return "Kafka ConsumerRecords(topic: %s, partition: %d, offset: %d, timestamp: %d, " \
+               "key and value...)" % (self.topic, self.partition, self.offset, self.timestamp)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __reduce__(self):
+        return (self.__class__, (self.topic, self.partition, self.offset, self.timestamp,
+            self.timestampType, self.checksum, self.serializedKeySize, self.serializedValueSize,
+                self._rawKey, self._rawValue))
+
+    def _set_key_deserializer(self, decoder):
+        self._keyDecoder = decoder
+
+    def _set_value_deserializer(self, decoder):
+        self._valueDecoder = decoder
+
+    @property
+    def key(self):
+        return self._keyDecoder(self._rawKey)
+
+    @property
+    def value(self):
+        return self._valueDecoder(self._rawValue)

--- a/python/pyspark/streaming/kafka010.py
+++ b/python/pyspark/streaming/kafka010.py
@@ -319,6 +319,9 @@ class TopicPartition(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash(self._topic) ^ hash(self._partition)
+
 
 class KafkaConsumerRecord(object):
     """

--- a/python/pyspark/streaming/kafka010_tests.py
+++ b/python/pyspark/streaming/kafka010_tests.py
@@ -1,0 +1,294 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+from itertools import chain
+import random
+
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
+from pyspark.streaming.kafka import OffsetRange
+from pyspark.streaming.kafka010 import Assign, KafkaUtils, PreferBrokers, PreferConsistent, \
+    PreferFixed, Subscribe, SubscribePattern, TopicPartition
+from pyspark.streaming.tests import PySparkStreamingTestCase, search_jar
+
+
+class Kafka010StreamTests(PySparkStreamingTestCase):
+    timeout = 20  # seconds
+    duration = 1
+
+    @classmethod
+    def setUpClass(cls):
+        super(Kafka010StreamTests, cls).setUpClass()
+        cls._kafkaTestUtils = cls.sc._jvm.org.apache.spark.streaming.kafka010.KafkaTestUtils()
+        cls._kafkaTestUtils.setup()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(Kafka010StreamTests, cls).tearDownClass()
+
+        if cls._kafkaTestUtils is not None:
+            cls._kafkaTestUtils.teardown()
+            cls._kafkaTestUtils = None
+
+    def _randomTopic(self):
+        return "topic-%d" % random.randint(0, 100000)
+
+    def _randomGroupId(self):
+        return "test-consumer-%d" % random.randint(0, 100000)
+
+    def _validateStreamResult(self, sendData, stream):
+        result = {}
+        for i in chain.from_iterable(self._collect(stream.map(lambda x: x[1]),
+                                                   sum(sendData.values()))):
+            result[i] = result.get(i, 0) + 1
+
+        self.assertEqual(sendData, result)
+
+    def _validateRddResult(self, sendData, rdd):
+        result = {}
+        for i in rdd.map(lambda x: x[1]).collect():
+            result[i] = result.get(i, 0) + 1
+        self.assertEqual(sendData, result)
+
+    def _with_strategy(self, topic, locationStrategy, consumerStrategy):
+        sendData = {"a": 3, "b": 5, "c": 10}
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
+
+        stream = KafkaUtils.createDirectStream(
+            self.ssc, locationStrategy, consumerStrategy) \
+            .map(lambda c: (c.key, c.value))
+        self._validateStreamResult(sendData, stream)
+
+    def test_kafka_direct_stream_prefer_brokers(self):
+        """Test the Python Kafka direct stream API with PreferBrokers strategy."""
+        topic = self._randomTopic()
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+        consumerStrategy = Subscribe([topic], kafkaParams)
+
+        self._with_strategy(topic, PreferBrokers(), consumerStrategy)
+
+    def test_kafka_direct_stream_prefer_consistent(self):
+        """Test the Python Kafka direct stream API with PreferConsistent strategy"""
+        topic = self._randomTopic()
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+        consumerStrategy = Subscribe([topic], kafkaParams)
+
+        self._with_strategy(topic, PreferConsistent(), consumerStrategy)
+
+    def test_kafka_direct_stream_prefer_fixed(self):
+        """Test the Python Kafka direct stream API with PreferFixed strategy"""
+        topic = self._randomTopic()
+        hostMap = {TopicPartition(topic, 0): "localhost"}
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+        consumerStrategy = Subscribe([topic], kafkaParams)
+
+        self._with_strategy(topic, PreferFixed(hostMap), consumerStrategy)
+
+    def test_kafka_direct_stream_subscribe_pattern(self):
+        """Test the Python Kafka direct stream API with SubscribePattern strategy"""
+        topic = self._randomTopic()
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+        consumerStrategy = SubscribePattern(topic, kafkaParams)
+
+        self._with_strategy(topic, PreferConsistent(), consumerStrategy)
+
+    def test_kafka_direct_stream_assign(self):
+        """Test the Python Kafka direct stream API with Assign strategy"""
+        topic = self._randomTopic()
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+        consumerStrategy = Assign([TopicPartition(topic, 0)], kafkaParams)
+
+        self._with_strategy(topic, PreferConsistent(), consumerStrategy)
+
+    @unittest.skipIf(sys.version >= "3", "long type not support")
+    def test_kafka_direct_stream_specify_offset(self):
+        """Test the Python direct Kafka stream API with start offset specified."""
+        topic = self._randomTopic()
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "group.id": self._randomGroupId()}
+        consumerStrategy = Subscribe([topic], kafkaParams, {TopicPartition(topic, 0): long(0)})
+
+        self._with_strategy(topic, PreferConsistent(), consumerStrategy)
+
+    def _with_location_strategy(self, topic, locationStrategy):
+        sendData = {"a": 1, "b": 2}
+        offsetRanges = [OffsetRange(topic, 0, long(0), long(sum(sendData.values())))]
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "group.id": self._randomGroupId()}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
+        rdd = KafkaUtils.createRDD(self.sc, kafkaParams, offsetRanges, locationStrategy) \
+            .map(lambda x: (x.key, x.value))
+        self._validateRddResult(sendData, rdd)
+
+    @unittest.skipIf(sys.version >= "3", "long type not support")
+    def test_kafka_rdd_prefer_consistent(self):
+        """Test the Python direct Kafka RDD API with PreferConsistent strategy."""
+        topic = self._randomTopic()
+        self._with_location_strategy(topic, PreferConsistent())
+
+    @unittest.skipIf(sys.version >= "3", "long type not support")
+    def test_kafka_rdd_prefer_fixed(self):
+        """Test the Python direct Kafka RDD API with PreferFixed strategy."""
+        topic = self._randomTopic()
+        hostMap = {TopicPartition(topic, 0): "localhost"}
+        self._with_location_strategy(topic, PreferFixed(hostMap))
+
+    @unittest.skipIf(sys.version >= "3", "long type not support")
+    def test_kafka_rdd_get_offsetRanges(self):
+        """Test Python direct Kafka RDD get OffsetRanges."""
+        topic = self._randomTopic()
+        sendData = {"a": 3, "b": 4, "c": 5}
+        offsetRanges = [OffsetRange(topic, 0, long(0), long(sum(sendData.values())))]
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "group.id": self._randomGroupId()}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
+        rdd = KafkaUtils.createRDD(self.sc, kafkaParams, offsetRanges, PreferConsistent())
+        self.assertEqual(offsetRanges, rdd.offsetRanges())
+
+    @unittest.skipIf(sys.version >= "3", "long type not support")
+    def test_kafka_direct_stream_foreach_get_offsetRanges(self):
+        """Test the Python direct Kafka stream foreachRDD get offsetRanges."""
+        topic = self._randomTopic()
+        sendData = {"a": 1, "b": 2, "c": 3}
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
+
+        stream = KafkaUtils.createDirectStream(self.ssc, PreferConsistent(),
+                                               Subscribe([topic], kafkaParams))
+
+        offsetRanges = []
+
+        def getOffsetRanges(_, rdd):
+            for o in rdd.offsetRanges():
+                offsetRanges.append(o)
+
+        stream.foreachRDD(getOffsetRanges)
+        self.ssc.start()
+        self.wait_for(offsetRanges, 1)
+
+        self.assertEqual(offsetRanges, [OffsetRange(topic, 0, long(0), long(6))])
+
+    @unittest.skipIf(sys.version >= "3", "long type not support")
+    def test_kafka_direct_stream_transform_get_offsetRanges(self):
+        """Test the Python direct Kafka stream transform get offsetRanges."""
+        topic = self._randomTopic()
+        sendData = {"a": 1, "b": 2, "c": 3}
+        kafkaParams = {"bootstrap.servers": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "earliest",
+                       "group.id": self._randomGroupId()}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
+
+        stream = KafkaUtils.createDirectStream(self.ssc, PreferConsistent(),
+                                               Subscribe([topic], kafkaParams))
+
+        offsetRanges = []
+
+        def transformWithOffsetRanges(rdd):
+            for o in rdd.offsetRanges():
+                offsetRanges.append(o)
+            return rdd
+
+        # Test whether it is ok mixing KafkaTransformedDStream and TransformedDStream together,
+        # only the TransformedDstreams can be folded together.
+        stream.transform(transformWithOffsetRanges).count().pprint()
+        self.ssc.start()
+        self.wait_for(offsetRanges, 1)
+
+        self.assertEqual(offsetRanges, [OffsetRange(topic, 0, long(0), long(6))])
+
+    def test_topic_partition_equality(self):
+        topic_partition_a = TopicPartition("foo", 0)
+        topic_partition_b = TopicPartition("foo", 0)
+        topic_partition_c = TopicPartition("bar", 0)
+        topic_partition_d = TopicPartition("foo", 1)
+
+        self.assertEqual(topic_partition_a, topic_partition_b)
+        self.assertNotEqual(topic_partition_a, topic_partition_c)
+        self.assertNotEqual(topic_partition_a, topic_partition_d)
+
+
+# Search jar in the project dir using the jar name_prefix for both sbt build and maven build because
+# the artifact jars are in different directories.
+def search_kafka010_assembly_jar():
+    SPARK_HOME = os.environ["SPARK_HOME"]
+    kafka_assembly_dir = os.path.join(SPARK_HOME, "external/kafka-0-10-assembly")
+    jars = search_jar(kafka_assembly_dir, "spark-streaming-kafka-0-10-assembly")
+    if not jars:
+        raise Exception(
+            ("Failed to find Spark Streaming kafka-0-10 assembly jar in %s. " %
+             kafka_assembly_dir) + "You need to build Spark with "
+            "'build/sbt assembly/package streaming-kafka-0-10-assembly/assembly' or "
+            "'build/mvn package' before running this test.")
+    elif len(jars) > 1:
+        raise Exception(("Found multiple Spark Streaming Kafka-0-10 assembly JARs: %s; please "
+                         "remove all but one") % (", ".join(jars)))
+    else:
+        return jars[0]
+
+
+if __name__ == "__main__":
+    from pyspark.streaming.kafka010_tests import *
+    kafka010_assembly_jar = search_kafka010_assembly_jar()
+    os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars %s pyspark-shell" % kafka010_assembly_jar
+
+    sys.stderr.write("Running tests: %s \n" % (str(Kafka010StreamTests)))
+    failed = False
+    tests = unittest.TestLoader().loadTestsFromTestCase(Kafka010StreamTests)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=3).run(tests)
+        if not result.wasSuccessful():
+            failed = True
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(tests)
+        if not result.wasSuccessful():
+            failed = True
+    sys.exit(failed)

--- a/python/pyspark/streaming/kafka010_tests.py
+++ b/python/pyspark/streaming/kafka010_tests.py
@@ -245,6 +245,7 @@ class Kafka010StreamTests(PySparkStreamingTestCase):
 
         self.assertEqual(offsetRanges, [OffsetRange(topic, 0, long(0), long(6))])
 
+    @unittest.skipIf(sys.version >= "3", "long type not support")
     def test_kafka_direct_stream_commit_offsets(self):
         """Test the Python direct kafka stream commit offsets"""
         topic = self._randomTopic()

--- a/python/pyspark/streaming/kafka010_tests.py
+++ b/python/pyspark/streaming/kafka010_tests.py
@@ -260,6 +260,7 @@ class Kafka010StreamTests(PySparkStreamingTestCase):
                                                Subscribe([topic], kafkaParams))
 
         offsetRanges = []
+
         def commitOffsets(rdd):
             stream.commitAsync(rdd.offsetRanges())
             for o in rdd.offsetRanges():

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1010,8 +1010,8 @@ class KafkaStreamTests(PySparkStreamingTestCase):
         cls._kafkaTestUtils.setup()
 
     @classmethod
-    def tearDown(cls):
-        super(KafkaStreamTests, cls).tearDown()
+    def tearDownClass(cls):
+        super(KafkaStreamTests, cls).tearDownClass()
 
         if cls._kafkaTestUtils is not None:
             cls._kafkaTestUtils.teardown()

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1003,17 +1003,19 @@ class KafkaStreamTests(PySparkStreamingTestCase):
     timeout = 20  # seconds
     duration = 1
 
-    def setUp(self):
-        super(KafkaStreamTests, self).setUp()
-        self._kafkaTestUtils = self.ssc._jvm.org.apache.spark.streaming.kafka.KafkaTestUtils()
-        self._kafkaTestUtils.setup()
+    @classmethod
+    def setUpClass(cls):
+        super(KafkaStreamTests, cls).setUpClass()
+        cls._kafkaTestUtils = cls.sc._jvm.org.apache.spark.streaming.kafka.KafkaTestUtils()
+        cls._kafkaTestUtils.setup()
 
-    def tearDown(self):
-        super(KafkaStreamTests, self).tearDown()
+    @classmethod
+    def tearDown(cls):
+        super(KafkaStreamTests, cls).tearDown()
 
-        if self._kafkaTestUtils is not None:
-            self._kafkaTestUtils.teardown()
-            self._kafkaTestUtils = None
+        if cls._kafkaTestUtils is not None:
+            cls._kafkaTestUtils.teardown()
+            cls._kafkaTestUtils = None
 
     def _randomTopic(self):
         return "topic-%d" % random.randint(0, 10000)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the support of Python API for Spark Streaming Kafka 0.10 connector.
1. Provides equal functionality for Python API.
2. Adds unit test to test different location strategies and consumer strategies for python API.
3. Adds a example `kafka010_direct_wordcount.py`.
## How was this patch tested?

Adds the unit tests to cover different APIs. Also did integrated tests in real cluster.

CC @tdas @koeninger  please help to review, thanks a lot.
