### PR TITLE
[SPARK-16705] Kafka Direct Stream is not experimental anymore

### DIFF
--- a/docs/streaming-kafka-integration.md
+++ b/docs/streaming-kafka-integration.md
@@ -74,7 +74,7 @@ Next, we discuss how to use this approach in your streaming application.
 	[Maven repository](http://search.maven.org/#search|ga|1|a%3A%22spark-streaming-kafka-0-8-assembly_{{site.SCALA_BINARY_VERSION}}%22%20AND%20v%3A%22{{site.SPARK_VERSION_SHORT}}%22) and add it to `spark-submit` with `--jars`.
 
 ## Approach 2: Direct Approach (No Receivers)
-This new receiver-less "direct" approach has been introduced in Spark 1.3 to ensure stronger end-to-end guarantees. Instead of using receivers to receive data, this approach periodically queries Kafka for the latest offsets in each topic+partition, and accordingly defines the offset ranges to process in each batch. When the jobs to process the data are launched, Kafka's simple consumer API is used to read the defined ranges of offsets from Kafka (similar to read files from a file system). Note that this is an experimental feature introduced in Spark 1.3 for the Scala and Java API, in Spark 1.4 for the Python API.
+This new receiver-less "direct" approach has been introduced in Spark 1.3 to ensure stronger end-to-end guarantees. Instead of using receivers to receive data, this approach periodically queries Kafka for the latest offsets in each topic+partition, and accordingly defines the offset ranges to process in each batch. When the jobs to process the data are launched, Kafka's simple consumer API is used to read the defined ranges of offsets from Kafka (similar to read files from a file system). This feature was introduced in Spark 1.3 for the Scala and Java API, in Spark 1.4 for the Python API. It was, at that time, experimental but is not anymore since Spark 1.5.
 
 This approach has the following advantages over the receiver-based approach (i.e. Approach 1).
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix documentation. Direct Stream for Kafka is not experimental anymore. People should use it and not be afraid that it is not stable or likely to change or to be removed.
## How was this patch tested?

Visual test. It is only documentation.

See https://issues.apache.org/jira/browse/SPARK-16705
