### PR TITLE
[CORE] Added new high-order function to RDD: cartesianFilter(other)(f)

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
@@ -232,6 +232,17 @@ trait JavaRDDLike[T, This <: JavaRDDLike[T, This]] extends Serializable {
     JavaPairRDD.fromRDD(rdd.cartesian(other.rdd)(other.classTag))(classTag, other.classTag)
 
   /**
+   * Return the Cartesian product of this RDD and another one, that is, the RDD of all pairs of
+   * elements (a, b) where a is in `this` and b is in `other`, where pair satisfies predicate `f`.
+   */
+  def cartesianFilter[U](
+      other: JavaRDDLike[U, _],
+      f: JFunction[(T, U), java.lang.Boolean]): JavaPairRDD[T, U] =
+    JavaPairRDD.fromRDD(
+      rdd.cartesianFilter(other.rdd)((x, y) => f.call((x, y)).booleanValue())
+        (other.classTag))(classTag, other.classTag)
+
+  /**
    * Return an RDD of grouped elements. Each group consists of a key and a sequence of elements
    * mapping to that key.
    */

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -653,6 +653,14 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
+   * Return the Cartesian product of this RDD and another one, that is, the RDD of all pairs of
+   * elements (a, b) where a is in `this` and b is in `other`, where pair satisfies predicate `f`.
+   */
+  def cartesianFilter[U: ClassTag](other: RDD[U])(f: (T, U) => Boolean): RDD[(T, U)] = withScope {
+    new CartesianFilterRDD(sc, this, other, f)
+  }
+
+  /**
    * Return an RDD of grouped items. Each group consists of a key and a sequence of elements
    * mapping to that key. The ordering of elements within each group is not guaranteed, and
    * may even differ each time the resulting RDD is evaluated.

--- a/core/src/test/java/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/org/apache/spark/JavaAPISuite.java
@@ -711,6 +711,20 @@ public class JavaAPISuite implements Serializable {
   }
 
   @Test
+  public void cartesianFilter() {
+    JavaRDD<Integer> doubleRDD = sc.parallelize(Arrays.asList(1, 2, 3, 5, 8));
+    JavaRDD<String> stringRDD = sc.parallelize(Arrays.asList("Hello", "World"));
+    JavaPairRDD<String, Integer> cartesian =
+        stringRDD.cartesianFilter(doubleRDD, new Function<Tuple2<String, Integer>, Boolean>() {
+          @Override
+          public Boolean call(Tuple2<String, Integer> v1) throws Exception {
+            return v1._2 > 1;
+          }
+        });
+    assertEquals(new Tuple2<>("Hello", 2), cartesian.first());
+  }
+
+  @Test
   public void javaDoubleRDD() {
     JavaDoubleRDD rdd = sc.parallelizeDoubles(Arrays.asList(1.0, 1.0, 2.0, 3.0, 5.0, 8.0));
     JavaDoubleRDD distinct = rdd.distinct();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new high-order function to RDD to make cartesian filter pairs in one step. Scala and Java API only.
## How was this patch tested?

This patch include a test in JavaAPISuite
