### PR TITLE
[SPARK-16715][Tests]Fix a potential ExprId conflict for SubexpressionEliminationSuite."Semantic equals and hash"

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -21,8 +21,12 @@ import org.apache.spark.sql.types.IntegerType
 
 class SubexpressionEliminationSuite extends SparkFunSuite {
   test("Semantic equals and hash") {
-    val id = ExprId(1)
     val a: AttributeReference = AttributeReference("name", IntegerType)()
+    val id = {
+      // Make sure we use a "ExprId" different from "a.exprId"
+      val _id = ExprId(1)
+      if (a.exprId == _id) ExprId(2) else _id
+    }
     val b1 = a.withName("name2").withExprId(id)
     val b2 = a.withExprId(id)
     val b3 = a.withQualifier(Some("qualifierName"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

SubexpressionEliminationSuite."Semantic equals and hash" assumes the default AttributeReference's exprId wont' be "ExprId(1)". However, that depends on when this test runs. It may happen to use "ExprId(1)".

This PR detects the conflict and makes sure we create a different ExprId when the conflict happens.
## How was this patch tested?

Jenkins unit tests.
