### PR TITLE
[SQL][DOC] Fix a default name for parquet compression

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -749,7 +749,7 @@ Configuration of Parquet can be done using the `setConf` method on `SparkSession
 </tr>
 <tr>
   <td><code>spark.sql.parquet.compression.codec</code></td>
-  <td>gzip</td>
+  <td>snappy</td>
   <td>
     Sets the compression codec use when writing Parquet files. Acceptable values include:
     uncompressed, snappy, gzip, lzo.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is to fix a wrong description for parquet default compression.
