### PR TITLE
[SPARK-16726][SQL] Improve `Union/Intersect/Except` error messages on incompatible types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -266,6 +266,13 @@ trait CheckAnalysis extends PredicateHelper {
                 s"but one table has '${firstError.output.length}' columns and another table has " +
                 s"'${s.children.head.output.length}' columns")
 
+          case Union(c) if c.exists(_.output.map(_.dataType) != c.head.output.map(_.dataType)) =>
+            val firstError = c.find(_.output.map(_.dataType) != c.head.output.map(_.dataType)).get
+            failAnalysis(
+              s"Unions can only be performed on tables with the compatible column types, " +
+                s"but one table has '[${c.head.output.map(_.dataType).mkString(", ")}]' " +
+                s"and another table has '[${firstError.output.map(_.dataType).mkString(", ")}]'")
+
           case GlobalLimit(limitExpr, _) => checkLimitClause(limitExpr)
 
           case LocalLimit(limitExpr, _) => checkLimitClause(limitExpr)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -269,6 +269,7 @@ trait CheckAnalysis extends PredicateHelper {
 
           case _: Union | _: SetOperation if operator.children.length > 1 =>
             def dataTypes(plan: LogicalPlan): Seq[DataType] = plan.output.map(_.dataType)
+            def ordinalTable(i: Int): String = (if (i == 0) "second" else (i + 2) + "th") + " table"
             val ref = dataTypes(operator.children.head)
             operator.children.tail.zipWithIndex.foreach { case (child, ti) =>
               // Check the number of columns
@@ -277,8 +278,7 @@ trait CheckAnalysis extends PredicateHelper {
                   s"""
                     |${operator.nodeName} can only be performed on tables with the same number
                     |of columns, but the first table has ${ref.length} columns and
-                    |the ${if (ti == 0) "second" else (ti + 2) + "th"} table has
-                    |${child.output.length} columns
+                    |the ${ordinalTable(ti)} has ${child.output.length} columns
                   """.stripMargin.replace("\n", " ").trim())
               }
               // Check if the data types match.
@@ -287,8 +287,7 @@ trait CheckAnalysis extends PredicateHelper {
                   failAnalysis(
                     s"""
                       |${operator.nodeName} can only be performed on tables with the compatible
-                      |column types. $dt1 <> $dt2 at ${ci + 1}th column of
-                      |${if (ti == 0) "second" else (ti + 2) + "th"} table
+                      |column types. $dt1 <> $dt2 at ${ci + 1}th column of ${ordinalTable(ti)}
                     """.stripMargin.replace("\n", " ").trim())
                 }
               }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -266,11 +266,6 @@ class AnalysisErrorSuite extends AnalysisTest {
       testRelation.output.length.toString :: Nil)
 
   errorTest(
-    "union with incompatible column types",
-    testRelation.union(nestedRelation),
-    "union" :: "the compatible column types" :: Nil)
-
-  errorTest(
     "intersect with unequal number of columns",
     testRelation.intersect(testRelation2),
     "intersect" :: "number of columns" :: testRelation2.output.length.toString ::
@@ -281,6 +276,21 @@ class AnalysisErrorSuite extends AnalysisTest {
     testRelation.except(testRelation2),
     "except" :: "number of columns" :: testRelation2.output.length.toString ::
       testRelation.output.length.toString :: Nil)
+
+  errorTest(
+    "union with incompatible column types",
+    testRelation.union(nestedRelation),
+    "union" :: "the compatible column types" :: Nil)
+
+  errorTest(
+    "intersect with incompatible column types",
+    testRelation.intersect(nestedRelation),
+    "intersect" :: "the compatible column types" :: Nil)
+
+  errorTest(
+    "except with incompatible column types",
+    testRelation.except(nestedRelation),
+    "except" :: "the compatible column types" :: Nil)
 
   errorTest(
     "SPARK-9955: correct error message for aggregate",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -266,6 +266,11 @@ class AnalysisErrorSuite extends AnalysisTest {
       testRelation.output.length.toString :: Nil)
 
   errorTest(
+    "union with incompatible column types",
+    testRelation.union(nestedRelation),
+    "union" :: "the compatible column types" :: Nil)
+
+  errorTest(
     "intersect with unequal number of columns",
     testRelation.intersect(testRelation2),
     "intersect" :: "number of columns" :: testRelation2.output.length.toString ::


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `UNION` queries on incompatible types show misleading error messages, i.e., `unresolved operator Union`. We had better show a more correct message. This will help users in the situation of [SPARK-16704](https://issues.apache.org/jira/browse/SPARK-16704).

**Before**

``` scala
scala> sql("select 1,2,3 union (select 1,array(2),3)")
org.apache.spark.sql.AnalysisException: unresolved operator 'Union;
scala> sql("select 1,2,3 intersect (select 1,array(2),3)")
org.apache.spark.sql.AnalysisException: unresolved operator 'Intersect;
scala> sql("select 1,2,3 except (select 1,array(2),3)")
org.apache.spark.sql.AnalysisException: unresolved operator 'Except;
```

**After**

``` scala
scala> sql("select 1,2,3 union (select 1,array(2),3)")
org.apache.spark.sql.AnalysisException: Union can only be performed on tables with the compatible column types. ArrayType(IntegerType,false) <> IntegerType at the second column of the second table;
scala> sql("select 1,2,3 intersect (select 1,array(2),3)")
org.apache.spark.sql.AnalysisException: Intersect can only be performed on tables with the compatible column types. ArrayType(IntegerType,false) <> IntegerType at the second column of the second table;
scala> sql("select 1,2,3 except (select array(1),array(2),3)")
org.apache.spark.sql.AnalysisException: Except can only be performed on tables with the compatible column types. ArrayType(IntegerType,false) <> IntegerType at the first column of the second table;
```
## How was this patch tested?

Pass the Jenkins test with a new test case.
