### PR TITLE
[SPARK-16729][SQL] Throw analysis exception for invalid date casts

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -52,7 +52,8 @@ object Cast {
     case (DateType, TimestampType) => true
     case (_: NumericType, TimestampType) => true
 
-    case (_, DateType) => true
+    case (StringType, DateType) => true
+    case (TimestampType, DateType) => true
 
     case (StringType, CalendarIntervalType) => true
 
@@ -228,18 +229,12 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
       // throw valid precision more than seconds, according to Hive.
       // Timestamp.nanos is in 0 to 999,999,999, no more than a second.
       buildCast[Long](_, t => DateTimeUtils.millisToDays(t / 1000L))
-    // Hive throws this exception as a Semantic Exception
-    // It is never possible to compare result when hive return with exception,
-    // so we can return null
-    // NULL is more reasonable here, since the query itself obeys the grammar.
-    case _ => _ => null
   }
 
   // IntervalConverter
   private[this] def castToInterval(from: DataType): Any => Any = from match {
     case StringType =>
       buildCast[UTF8String](_, s => CalendarInterval.fromString(s.toString))
-    case _ => _ => null
   }
 
   // LongConverter

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -54,9 +54,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     // follow [[org.apache.spark.sql.catalyst.expressions.Cast.canCast]] logic
     // to ensure we test every possible cast situation here
     atomicTypes.zip(atomicTypes).foreach { case (from, to) =>
-      if (Cast.canCast(from, to)) {
-        checkNullCast(from, to)
-      }
+      checkNullCast(from, to)
     }
 
     atomicTypes.foreach(dt => checkNullCast(NullType, dt))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark currently throws exceptions for invalid casts for all other data types except date type. Somehow date type returns null. It should be consistent and throws analysis exception as well.
## How was this patch tested?

Added a unit test case in CastSuite.
