### PR TITLE
[SPARK-16719][ML] Random Forests should communicate fewer trees on each iteration

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -163,7 +163,7 @@ private[spark] object RandomForest extends Logging {
 
     /*
       Stack of nodes to train: (treeIndex, node)
-      The reason this is FILO is that we train many trees at once, but we want to focus on
+      The reason this is a stack is that we train many trees at once, but we want to focus on
       completing trees, rather than training all simultaneously.  If we are splitting nodes from
       1 tree, then the new nodes to split will be put at the top of this stack, so we will continue
       training the same tree in the next iteration.  This focus allows us to send fewer trees to

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -51,7 +51,7 @@ import org.apache.spark.util.random.{SamplingUtils, XORShiftRandom}
  * findSplits() method during initialization, after which each continuous feature becomes
  * an ordered discretized feature with at most maxBins possible values.
  *
- * The main loop in the algorithm operates on a queue of nodes (nodeQueue).  These nodes
+ * The main loop in the algorithm operates on a queue of nodes (nodeStack).  These nodes
  * lie at the periphery of the tree being trained.  If multiple trees are being trained at once,
  * then this queue contains nodes from all of them.  Each iteration works roughly as follows:
  *   On the master node:
@@ -162,11 +162,10 @@ private[spark] object RandomForest extends Logging {
     }
 
     /*
-      FILO queue of nodes to train: (treeIndex, node)
-      We make this FILO by always inserting nodes by appending (+=) and removing with dropRight.
+      Stack of nodes to train: (treeIndex, node)
       The reason this is FILO is that we train many trees at once, but we want to focus on
       completing trees, rather than training all simultaneously.  If we are splitting nodes from
-      1 tree, then the new nodes to split will be put at the end of this list, so we will continue
+      1 tree, then the new nodes to split will be put at the top of this stack, so we will continue
       training the same tree in the next iteration.  This focus allows us to send fewer trees to
       workers on each iteration; see topNodesForGroup below.
      */

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -170,22 +170,22 @@ private[spark] object RandomForest extends Logging {
       training the same tree in the next iteration.  This focus allows us to send fewer trees to
       workers on each iteration; see topNodesForGroup below.
      */
-    val nodeQueue = new NodeQueue
+    val nodeStack = new NodeStack
 
     val rng = new Random()
     rng.setSeed(seed)
 
     // Allocate and queue root nodes.
     val topNodes = Array.fill[LearningNode](numTrees)(LearningNode.emptyNode(nodeIndex = 1))
-    Range(0, numTrees).foreach(treeIndex => nodeQueue.put(treeIndex, topNodes(treeIndex)))
+    Range(0, numTrees).foreach(treeIndex => nodeStack.put(treeIndex, topNodes(treeIndex)))
 
     timer.stop("init")
 
-    while (nodeQueue.nonEmpty) {
+    while (nodeStack.nonEmpty) {
       // Collect some nodes to split, and choose features for each node (if subsampling).
       // Each group of nodes may come from one or multiple trees, and at multiple levels.
       val (nodesForGroup, treeToNodeToIndexInfo) =
-        RandomForest.selectNodesToSplit(nodeQueue, maxMemoryUsage, metadata, rng)
+        RandomForest.selectNodesToSplit(nodeStack, maxMemoryUsage, metadata, rng)
       // Sanity check (should never occur):
       assert(nodesForGroup.nonEmpty,
         s"RandomForest selected empty nodesForGroup.  Error for unknown reason.")
@@ -197,7 +197,7 @@ private[spark] object RandomForest extends Logging {
       // Choose node splits, and enqueue new nodes as needed.
       timer.start("findBestSplits")
       RandomForest.findBestSplits(baggedInput, metadata, topNodesForGroup, nodesForGroup,
-        treeToNodeToIndexInfo, splits, nodeQueue, timer, nodeIdCache)
+        treeToNodeToIndexInfo, splits, nodeStack, timer, nodeIdCache)
       timer.stop("findBestSplits")
     }
 
@@ -353,7 +353,7 @@ private[spark] object RandomForest extends Logging {
    *                              where nodeIndexInfo stores the index in the group and the
    *                              feature subsets (if using feature subsets).
    * @param splits possible splits for all features, indexed (numFeatures)(numSplits)
-   * @param nodeQueue  Queue of nodes to split, with values (treeIndex, node).
+   * @param nodeStack  Queue of nodes to split, with values (treeIndex, node).
    *                   Updated with new non-leaf nodes which are created.
    * @param nodeIdCache Node Id cache containing an RDD of Array[Int] where
    *                    each value in the array is the data point's node Id
@@ -368,7 +368,7 @@ private[spark] object RandomForest extends Logging {
       nodesForGroup: Map[Int, Array[LearningNode]],
       treeToNodeToIndexInfo: Map[Int, Map[Int, NodeIndexInfo]],
       splits: Array[Array[Split]],
-      nodeQueue: NodeQueue,
+      nodeStack: NodeStack,
       timer: TimeTracker = new TimeTracker,
       nodeIdCache: Option[NodeIdCache] = None): Unit = {
 
@@ -607,10 +607,10 @@ private[spark] object RandomForest extends Logging {
 
           // enqueue left child and right child if they are not leaves
           if (!leftChildIsLeaf) {
-            nodeQueue.put(treeIndex, node.leftChild.get)
+            nodeStack.put(treeIndex, node.leftChild.get)
           }
           if (!rightChildIsLeaf) {
-            nodeQueue.put(treeIndex, node.rightChild.get)
+            nodeStack.put(treeIndex, node.rightChild.get)
           }
 
           logDebug("leftChildIndex = " + node.leftChild.get.id +
@@ -1043,7 +1043,7 @@ private[spark] object RandomForest extends Logging {
    * will be needed; this allows an adaptive number of nodes since different nodes may require
    * different amounts of memory (if featureSubsetStrategy is not "all").
    *
-   * @param nodeQueue  Queue of nodes to split.
+   * @param nodeStack  Queue of nodes to split.
    * @param maxMemoryUsage  Bound on size of aggregate statistics.
    * @return  (nodesForGroup, treeToNodeToIndexInfo).
    *          nodesForGroup holds the nodes to split: treeIndex --> nodes in tree.
@@ -1055,7 +1055,7 @@ private[spark] object RandomForest extends Logging {
    *          The feature indices are None if not subsampling features.
    */
   private[tree] def selectNodesToSplit(
-      nodeQueue: NodeQueue,
+      nodeStack: NodeStack,
       maxMemoryUsage: Long,
       metadata: DecisionTreeMetadata,
       rng: Random): (Map[Int, Array[LearningNode]], Map[Int, Map[Int, NodeIndexInfo]]) = {
@@ -1068,8 +1068,8 @@ private[spark] object RandomForest extends Logging {
     var numNodesInGroup = 0
     // If maxMemoryInMB is set very small, we want to still try to split 1 node,
     // so we allow one iteration if memUsage == 0.
-    while (nodeQueue.nonEmpty && (memUsage < maxMemoryUsage || memUsage == 0)) {
-      val (treeIndex, node) = nodeQueue.peek()
+    while (nodeStack.nonEmpty && (memUsage < maxMemoryUsage || memUsage == 0)) {
+      val (treeIndex, node) = nodeStack.peek()
       // Choose subset of features for node (if subsampling).
       val featureSubset: Option[Array[Int]] = if (metadata.subsamplingFeatures) {
         Some(SamplingUtils.reservoirSampleAndCount(Range(0,
@@ -1080,7 +1080,7 @@ private[spark] object RandomForest extends Logging {
       // Check if enough memory remains to add this node to the group.
       val nodeMemUsage = RandomForest.aggregateSizeForNode(metadata, featureSubset) * 8L
       if (memUsage + nodeMemUsage <= maxMemoryUsage || memUsage == 0) {
-        nodeQueue.pop()
+        nodeStack.pop()
         mutableNodesForGroup.getOrElseUpdate(treeIndex, new mutable.ArrayBuffer[LearningNode]()) +=
           node
         mutableTreeToNodeToIndexInfo
@@ -1126,9 +1126,9 @@ private[spark] object RandomForest extends Logging {
 
   /**
    * Class for queueing nodes to split on each iteration.
-   * This is a FILO queue.
+   * This must be a stack (FILO); see developer note where it is used above.
    */
-  private[impl] class NodeQueue {
+  private[impl] class NodeStack {
     private var q: List[(Int, LearningNode)] =
       List.empty[(Int, LearningNode)]
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1129,18 +1129,18 @@ private[spark] object RandomForest extends Logging {
    * This is a FILO queue.
    */
   private[impl] class NodeQueue {
-    private var q: mutable.MutableList[(Int, LearningNode)] =
-      mutable.MutableList.empty[(Int, LearningNode)]
+    private var q: List[(Int, LearningNode)] =
+      List.empty[(Int, LearningNode)]
 
     /** Put (treeIndex, node) into queue. Constant time. */
     def put(treeIndex: Int, node: LearningNode): Unit = {
-      q += ((treeIndex, node))
+      q = (treeIndex, node) +: q
     }
 
-    /** Remove and return last inserted element.  Linear time (unclear in Scala docs though) */
+    /** Remove and return last inserted element. Constant time. */
     def pop(): (Int, LearningNode) = {
       val (treeIndex: Int, node: LearningNode) = peek()
-      q = q.dropRight(1)
+      q = q.tail
       (treeIndex, node)
     }
 
@@ -1150,7 +1150,7 @@ private[spark] object RandomForest extends Logging {
         throw new NoSuchElementException(
           s"Attempted to get node from tree node queue, but queue is empty.")
       }
-      q.last
+      q.head
     }
 
     def size: Int = q.size

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -548,7 +548,20 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("NodeQueue should be FILO") {
-    // TODO
+    val q = new NodeQueue
+    Range(0, 5).foreach { idx =>
+      val node = LearningNode.emptyNode(idx)
+      q.put(treeIndex = idx, node = node)
+      assert(q.peek()._1 === idx)
+      assert(q.peek()._2.id === node.id)
+    }
+    assert(q.nonEmpty)
+    assert(q.size === 5)
+    Range(0, 5).reverse.foreach { idx =>
+      assert(q.peek()._1 === idx)
+      q.pop()
+    }
+    assert(q.isEmpty)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.ml.classification.DecisionTreeClassificationModel
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.tree._
-import org.apache.spark.ml.tree.impl.RandomForest.NodeQueue
+import org.apache.spark.ml.tree.impl.RandomForest.NodeStack
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.tree.{DecisionTreeSuite => OldDTSuite, EnsembleTestHelper}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo, QuantileStrategy,
@@ -239,12 +239,12 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     val treeToNodeToIndexInfo = Map((0, Map(
       (topNode.id, new RandomForest.NodeIndexInfo(0, None))
     )))
-    val nodeQueue = new NodeQueue
+    val nodeStack = new NodeStack
     RandomForest.findBestSplits(baggedInput, metadata, Map(0 -> topNode),
-      nodesForGroup, treeToNodeToIndexInfo, splits, nodeQueue)
+      nodesForGroup, treeToNodeToIndexInfo, splits, nodeStack)
 
     // don't enqueue leaf nodes into node queue
-    assert(nodeQueue.isEmpty)
+    assert(nodeStack.isEmpty)
 
     // set impurity and predict for topNode
     assert(topNode.stats !== null)
@@ -281,12 +281,12 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     val treeToNodeToIndexInfo = Map((0, Map(
       (topNode.id, new RandomForest.NodeIndexInfo(0, None))
     )))
-    val nodeQueue = new NodeQueue
+    val nodeStack = new NodeStack
     RandomForest.findBestSplits(baggedInput, metadata, Map(0 -> topNode),
-      nodesForGroup, treeToNodeToIndexInfo, splits, nodeQueue)
+      nodesForGroup, treeToNodeToIndexInfo, splits, nodeStack)
 
     // don't enqueue a node into node queue if its impurity is 0.0
-    assert(nodeQueue.isEmpty)
+    assert(nodeStack.isEmpty)
 
     // set impurity and predict for topNode
     assert(topNode.stats !== null)
@@ -393,16 +393,16 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
         val failString = s"Failed on test with:" +
           s"numTrees=$numTrees, featureSubsetStrategy=$featureSubsetStrategy," +
           s" numFeaturesPerNode=$numFeaturesPerNode, seed=$seed"
-        val nodeQueue = new NodeQueue
+        val nodeStack = new NodeStack
         val topNodes: Array[LearningNode] = new Array[LearningNode](numTrees)
         Range(0, numTrees).foreach { treeIndex =>
           topNodes(treeIndex) = LearningNode.emptyNode(nodeIndex = 1)
-          nodeQueue.put(treeIndex, topNodes(treeIndex))
+          nodeStack.put(treeIndex, topNodes(treeIndex))
         }
         val rng = new scala.util.Random(seed = seed)
         val (nodesForGroup: Map[Int, Array[LearningNode]],
         treeToNodeToIndexInfo: Map[Int, Map[Int, RandomForest.NodeIndexInfo]]) =
-          RandomForest.selectNodesToSplit(nodeQueue, maxMemoryUsage, metadata, rng)
+          RandomForest.selectNodesToSplit(nodeStack, maxMemoryUsage, metadata, rng)
 
         assert(nodesForGroup.size === numTrees, failString)
         assert(nodesForGroup.values.forall(_.length == 1), failString) // 1 node per tree
@@ -547,8 +547,8 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(mapToVec(map.toMap) ~== mapToVec(expected) relTol 0.01)
   }
 
-  test("NodeQueue should be FILO") {
-    val q = new NodeQueue
+  test("NodeStack should be FILO") {
+    val q = new NodeStack
     Range(0, 5).foreach { idx =>
       val node = LearningNode.emptyNode(idx)
       q.put(treeIndex = idx, node = node)


### PR DESCRIPTION
## What changes were proposed in this pull request?

RandomForest currently sends the entire forest to each worker on each iteration. This is because (a) the node queue is FIFO and (b) the closure references the entire array of trees (topNodes). (a) causes RFs to handle splits in many trees, especially early on in learning. (b) sends all trees explicitly.

This PR:
(a) Change the RF node queue to be FILO (a stack), so that RFs tend to focus on 1 or a few trees before focusing on others.
(b) Change topNodes to pass only the trees required on that iteration.
## How was this patch tested?

Unit tests:
- Existing tests for correctness of tree learning
- Manually modifying code and running tests to verify that a small number of trees are communicated on each iteration
  - This last item is hard to test via unit tests given the current APIs.
