### PR TITLE
[SPARK-16733][SQL] use antlr to parse column name instead of implementing it ourselves

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -36,6 +36,10 @@ singleDataType
     : dataType EOF
     ;
 
+singleColumnName
+    : qualifiedName EOF
+    ;
+
 statement
     : query                                                            #statementDefault
     | USE db=identifier                                                #use

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow, TableIden
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback, ExprCode}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.quoteIdentifier
@@ -77,61 +78,13 @@ object UnresolvedAttribute {
   /**
    * Creates an [[UnresolvedAttribute]], parsing segments separated by dots ('.').
    */
-  def apply(name: String): UnresolvedAttribute = new UnresolvedAttribute(name.split("\\."))
+  def apply(name: String): UnresolvedAttribute = CatalystSqlParser.parseColumnName(name)
 
   /**
    * Creates an [[UnresolvedAttribute]], from a single quoted string (for example using backticks in
    * HiveQL.  Since the string is consider quoted, no processing is done on the name.
    */
   def quoted(name: String): UnresolvedAttribute = new UnresolvedAttribute(Seq(name))
-
-  /**
-   * Creates an [[UnresolvedAttribute]] from a string in an embedded language.  In this case
-   * we treat it as a quoted identifier, except for '.', which must be further quoted using
-   * backticks if it is part of a column name.
-   */
-  def quotedString(name: String): UnresolvedAttribute =
-    new UnresolvedAttribute(parseAttributeName(name))
-
-  /**
-   * Used to split attribute name by dot with backticks rule.
-   * Backticks must appear in pairs, and the quoted string must be a complete name part,
-   * which means `ab..c`e.f is not allowed.
-   * Escape character is not supported now, so we can't use backtick inside name part.
-   */
-  def parseAttributeName(name: String): Seq[String] = {
-    def e = new AnalysisException(s"syntax error in attribute name: $name")
-    val nameParts = scala.collection.mutable.ArrayBuffer.empty[String]
-    val tmp = scala.collection.mutable.ArrayBuffer.empty[Char]
-    var inBacktick = false
-    var i = 0
-    while (i < name.length) {
-      val char = name(i)
-      if (inBacktick) {
-        if (char == '`') {
-          inBacktick = false
-          if (i + 1 < name.length && name(i + 1) != '.') throw e
-        } else {
-          tmp += char
-        }
-      } else {
-        if (char == '`') {
-          if (tmp.nonEmpty) throw e
-          inBacktick = true
-        } else if (char == '.') {
-          if (name(i - 1) == '.' || i == name.length - 1) throw e
-          nameParts += tmp.mkString
-          tmp.clear()
-        } else {
-          tmp += char
-        }
-      }
-      i += 1
-    }
-    if (inBacktick) throw e
-    nameParts += tmp.mkString
-    nameParts.toSeq
-  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -77,6 +77,11 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
     visit(ctx.dataType).asInstanceOf[DataType]
   }
 
+  override def visitSingleColumnName(
+      ctx: SingleColumnNameContext): UnresolvedAttribute = withOrigin(ctx) {
+    UnresolvedAttribute(ctx.qualifiedName().identifier().asScala.map(_.getText))
+  }
+
   /* ********************************************************************************************
    * Plan parsing
    * ******************************************************************************************** */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -23,6 +23,7 @@ import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
@@ -37,6 +38,11 @@ abstract class AbstractSqlParser extends ParserInterface with Logging {
   def parseDataType(sqlText: String): DataType = parse(sqlText) { parser =>
     // TODO add this to the parser interface.
     astBuilder.visitSingleDataType(parser.singleDataType())
+  }
+
+  /** Creates UnresolvedAttribute for a given SQL string */
+  def parseColumnName(sqlText: String): UnresolvedAttribute = parse(sqlText) { parser =>
+    astBuilder.visitSingleColumnName(parser.singleColumnName())
   }
 
   /** Creates Expression for a given SQL string. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -165,7 +165,7 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
   def resolveQuoted(
       name: String,
       resolver: Resolver): Option[NamedExpression] = {
-    resolve(UnresolvedAttribute.parseAttributeName(name), output, resolver)
+    resolve(UnresolvedAttribute(name).nameParts, output, resolver)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -126,9 +126,9 @@ class Column(protected[sql] val expr: Expression) extends Logging {
   def this(name: String) = this(name match {
     case "*" => UnresolvedStar(None)
     case _ if name.endsWith(".*") =>
-      val parts = UnresolvedAttribute.parseAttributeName(name.substring(0, name.length - 2))
+      val parts = UnresolvedAttribute(name.substring(0, name.length - 2)).nameParts
       UnresolvedStar(Some(parts))
-    case _ => UnresolvedAttribute.quotedString(name)
+    case _ => UnresolvedAttribute(name)
   })
 
   override def toString: String = usePrettyExpression(expr).sql


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's weird to write code ourselves to parse column name, while we already have the antlr framework. This PR removes that special code and use antlr to parse column name instead.
## How was this patch tested?

existing tests.
