### PR TITLE
[SPARK-16713][SQL] Check codegen method size ≤ 8K on compile

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeFormatter.scala
@@ -81,7 +81,7 @@ object CodeFormatter {
 
       lastLine = line
     }
-    new CodeAndComment(code.result().trim(), map)
+    new CodeAndComment(code.result().trim(), map, codeAndComment.funcSizeHints)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import com.google.common.cache.{CacheBuilder, CacheLoader}
+import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.{ByteArrayClassLoader, ClassBodyEvaluator, SimpleCompiler}
 import org.codehaus.janino.util.ClassFile
 import scala.language.existentials
@@ -71,6 +72,35 @@ case class SubExprEliminationState(isNull: String, value: String)
  *               the state to use.
  */
 case class SubExprCodes(codes: Seq[String], states: Map[Expression, SubExprEliminationState])
+
+
+object CodegenContext {
+
+  /**
+   * Ideally, we would wish codegen methods to be less than 8KB for bytecode size. Beyond 8K JIT
+   * won't compile and can cause performance degradation.
+   *
+   * This defines what behavior is expected when the methods exceed 8KB for bytecode size.
+   */
+  sealed trait FunctionSizeHint
+
+  /** No-op when the method exceeds 8K size. */
+  case object NO_OP extends FunctionSizeHint
+
+  /** Log a warning when the method exceeds 8K size. */
+  case object WARN_IF_EXCEEDS_JIT_LIMIT extends FunctionSizeHint
+
+  /**
+   * Throw a compilation exception when the method exceeds 8K size.
+   * Fail fast so that we can catch it asap; this is useful in testing corner/edge cases.
+   */
+  case object ERROR_IF_EXCEEDS_JIT_LIMIT extends FunctionSizeHint
+
+  /**
+   * See http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/tip/src/share/vm/runtime/globals.hpp
+   */
+  private[codegen] val JIT_HUGE_METHOD_LIMIT = 8000
+}
 
 /**
  * A context for codegen, tracking a list of objects that could be passed into generated Java
@@ -168,11 +198,18 @@ class CodegenContext {
   /**
    * Holding all the functions those will be added into generated class.
    */
-  val addedFunctions: mutable.Map[String, String] =
-    mutable.Map.empty[String, String]
+  val addedFunctions: mutable.Map[String, (String, CodegenContext.FunctionSizeHint)] =
+    mutable.Map.empty[String, (String, CodegenContext.FunctionSizeHint)]
 
-  def addNewFunction(funcName: String, funcCode: String): Unit = {
-    addedFunctions += ((funcName, funcCode))
+  def addNewFunction(
+      funcName: String,
+      funcCode: String,
+      sizeHint: CodegenContext.FunctionSizeHint = CodegenContext.NO_OP): Unit = {
+    addedFunctions += ((funcName, (funcCode, sizeHint)))
+  }
+
+  def getFuncToSizeHintMap: mutable.Map[String, CodegenContext.FunctionSizeHint] = {
+    addedFunctions.map { case (funcName, (funcCode, sizeHint)) => (funcName, sizeHint) }
   }
 
   /**
@@ -197,7 +234,7 @@ class CodegenContext {
   val subexprFunctions = mutable.ArrayBuffer.empty[String]
 
   def declareAddedFunctions(): String = {
-    addedFunctions.map { case (funcName, funcCode) => funcCode }.mkString("\n")
+    addedFunctions.map { case (funcName, (funcCode, sizeHint)) => funcCode }.mkString("\n")
   }
 
   final val JAVA_BOOLEAN = "boolean"
@@ -779,7 +816,10 @@ abstract class GeneratedClass {
 /**
  * A wrapper for the source code to be compiled by [[CodeGenerator]].
  */
-class CodeAndComment(val body: String, val comment: collection.Map[String, String])
+class CodeAndComment(
+    val body: String,
+    val comment: collection.Map[String, String],
+    val funcSizeHints: collection.Map[String, CodegenContext.FunctionSizeHint] = Map())
   extends Serializable {
   override def equals(that: Any): Boolean = that match {
     case t: CodeAndComment if t.body == body => true
@@ -881,7 +921,7 @@ object CodeGenerator extends Logging {
 
     try {
       evaluator.cook("generated.java", code.body)
-      recordCompilationStats(evaluator)
+      recordCompilationStats(evaluator, code.funcSizeHints)
     } catch {
       case e: Exception =>
         val msg = s"failed to compile: $e\n$formatted"
@@ -894,7 +934,9 @@ object CodeGenerator extends Logging {
   /**
    * Records the generated class and method bytecode sizes by inspecting janino private fields.
    */
-  private def recordCompilationStats(evaluator: ClassBodyEvaluator): Unit = {
+  private def recordCompilationStats(
+      evaluator: ClassBodyEvaluator,
+      functionSizeHints: collection.Map[String, CodegenContext.FunctionSizeHint]): Unit = {
     // First retrieve the generated classes.
     val classes = {
       val resultField = classOf[SimpleCompiler].getDeclaredField("result")
@@ -915,8 +957,21 @@ object CodeGenerator extends Logging {
       cf.methodInfos.asScala.foreach { method =>
         method.getAttributes().foreach { a =>
           if (a.getClass.getName == codeAttr.getName) {
-            CodegenMetrics.METRIC_GENERATED_METHOD_BYTECODE_SIZE.update(
-              codeAttrField.get(a).asInstanceOf[Array[Byte]].length)
+            val funcSize = codeAttrField.get(a).asInstanceOf[Array[Byte]].length
+            CodegenMetrics.METRIC_GENERATED_METHOD_BYTECODE_SIZE.update(funcSize)
+            if (funcSize > CodegenContext.JIT_HUGE_METHOD_LIMIT) {
+              lazy val ce = new CompileException(
+                s"Method ${cf.getThisClassName}.${method.getName} should not exceed 8K size " +
+                  s"limit -- observed size is $funcSize.", null)
+              functionSizeHints.getOrElse(method.getName, CodegenContext.NO_OP) match {
+                case CodegenContext.NO_OP => // do nothing
+                case CodegenContext.WARN_IF_EXCEEDS_JIT_LIMIT =>
+                  logWarning("You hit a code-gen compilation issue. Please report this warning " +
+                             "to Spark dev mailing list.", ce)
+                case CodegenContext.ERROR_IF_EXCEEDS_JIT_LIMIT =>
+                  throw ce
+              }
+            }
           }
         }
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -58,8 +58,51 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     GenerateOrdering.generate(Add(Literal(123), Literal(1)).asc :: Nil)
     assert(CodegenMetrics.METRIC_COMPILATION_TIME.getCount() == startCount1 + 1)
     assert(CodegenMetrics.METRIC_SOURCE_CODE_SIZE.getCount() == startCount2 + 1)
-    assert(CodegenMetrics.METRIC_GENERATED_CLASS_BYTECODE_SIZE.getCount() > startCount1)
-    assert(CodegenMetrics.METRIC_GENERATED_METHOD_BYTECODE_SIZE.getCount() > startCount1)
+    assert(CodegenMetrics.METRIC_GENERATED_CLASS_BYTECODE_SIZE.getCount() > startCount3)
+    assert(CodegenMetrics.METRIC_GENERATED_METHOD_BYTECODE_SIZE.getCount() > startCount4)
+  }
+
+  test("compilation should respect func size hints") {
+    def genCode(loc: Int) =
+      s"""
+        public Object generate(Object[] references) { return null; }
+        public static void inc() {
+          int i = 0;
+          ${(1 to loc).map(_ => "i ++; ").mkString}
+        }
+      """
+
+    val emptyComments = Map[String, String]()
+    val funcSizeHints = Map("inc" -> CodegenContext.ERROR_IF_EXCEEDS_JIT_LIMIT)
+
+    // compilation should pass against default empty funcSizeHints
+    val code1 = new CodeAndComment(genCode(20000), emptyComments)
+    CodeGenerator.compile(code1)
+
+    // compilation should pass because 1000 loc would be compiled to ~3K bytes
+    val code2 = new CodeAndComment(genCode(1000), emptyComments, funcSizeHints)
+    CodeGenerator.compile(code2)
+
+    // compilation should fail because 10000 loc would be compiled to ~30K bytes
+    val code3 = new CodeAndComment(genCode(10000), emptyComments, funcSizeHints)
+    val e1 = intercept[Exception] { CodeGenerator.compile(code3) }
+    Seq("failed to compile", "Method org.apache.spark.sql.catalyst.expressions.GeneratedClass.inc",
+      "should not exceed 8K size limit", "observed size is 30003").foreach { msg =>
+      assert(e1.getMessage.contains(msg))
+    }
+
+    // test CodegenContext.addNewFunction() and CodegenContext.getFuncToSizeHintMap()
+    // compilation should fail because 15000 loc would be compiled to ~45K bytes
+    val ctx = new CodegenContext()
+    ctx.addNewFunction("inc", genCode(15000), CodegenContext.ERROR_IF_EXCEEDS_JIT_LIMIT)
+    val e2 = intercept[Exception] {
+      CodeGenerator.compile(
+        new CodeAndComment(ctx.declareAddedFunctions(), emptyComments, ctx.getFuncToSizeHintMap))
+    }
+    Seq("failed to compile", "Method org.apache.spark.sql.catalyst.expressions.GeneratedClass.inc",
+      "should not exceed 8K size limit", "observed size is 45003").foreach { msg =>
+      assert(e2.getMessage.contains(msg))
+    }
   }
 
   test("SPARK-8443: split wide projections into blocks due to JVM code size limit") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -63,7 +63,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("compilation should respect func size hints") {
-    def genCode(loc: Int) =
+    def genCode(loc: Int): String =
       s"""
         public Object generate(Object[] references) { return null; }
         public static void inc() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ideally, we would wish codegen methods to be less than 8KB for bytecode size. Beyond 8K JIT won't compile and can cause performance degradation.

Instead of understanding the generated source code and automatically breaking large methods into smaller ones (which is also a little hard to do), it'd be better we discover large methods asap and then manually improve the source code.

This patch adds support for checking codegen method size on compile. We can specify for each method what is the expected behavior when it exceeds 8KB for bytecode size:

``` scala
 /** No-op when the method exceeds 8K size. */
 case object NO_OP extends FunctionSizeHint

 /** Log a warning when the method exceeds 8K size. */
 case object WARN_IF_EXCEEDS_JIT_LIMIT extends FunctionSizeHint

 /**
  * Throw a compilation exception when the method exceeds 8K size.
  * Fail fast so that we can catch it asap; this is useful in testing corner/edge cases.
  */
 case object ERROR_IF_EXCEEDS_JIT_LIMIT extends FunctionSizeHint
```

This way we can test against some extreme case such as a 10000-columns-wide table, to see if the generated code is small enough to get a chance to be JITed at runtime.
## Sample Usage

``` scala

val codeBody =
    s"""
      public static void inc() {
        int i = 0;
        i++;
        i++;
        ... // up to 15000 i++ s here, making this inc() method exceed 8K size
      }
    """

// == prior to this patch ===================
ctx = new CodegenContext()
ctx.addNewFunction("inc", codeBody)
CodeGenerator.compile(
  new CodeAndComment(ctx.declareAddedFunctions(), emptyComments))

// == after this patch ======================
// Exception: failed to compile. Method org.apache.spark.sql.catalyst.expressions.GeneratedClass.inc
// should not exceed 8K size limit -- observed size is 45003
ctx = new CodegenContext()
ctx.addNewFunction("inc", codeBody, CodegenContext.ERROR_IF_EXCEEDS_JIT_LIMIT)
CodeGenerator.compile(
  new CodeAndComment(ctx.declareAddedFunctions(), emptyComments, ctx.getFuncToSizeHintMap))
```
## How was this patch tested?

new unit test
