### PR TITLE
Make offsetRanges variable volatile

### DIFF
--- a/docs/streaming-kafka-integration.md
+++ b/docs/streaming-kafka-integration.md
@@ -139,7 +139,7 @@ Next, we discuss how to use this approach in your streaming application.
 	<div class="codetabs">
 	<div data-lang="scala" markdown="1">
 		// Hold a reference to the current offset ranges, so it can be used downstream
-		var offsetRanges = Array[OffsetRange]()
+		@volatile var offsetRanges: Array[OffsetRange] = _
 		
 		directKafkaStream.transform { rdd =>
 		  offsetRanges = rdd.asInstanceOf[HasOffsetRanges].offsetRanges


### PR DESCRIPTION
the foreach and transform closures can be executed on different driver threads.  The java example uses an atomic reference, but the scala example doesn't have anything.
## What changes were proposed in this pull request?

documentation update
## How was this patch tested?

ran locally
