### PR TITLE
[SPARK-16735][SQL] `map` should create a decimal key or value from decimals with different precisions and scales

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -995,6 +995,15 @@ The following options can be used to configure the version of Hive that is used 
       </p>
     </td>
   </tr>
+  <tr>
+    <td><code>spark.sql.broadcastTimeout</code></td>
+    <td><code>300</code></td>
+    <td>
+      <p>
+	Timeout in seconds for the broadcast wait time in broadcast joins
+      </p>
+    </td>
+  </tr>	
 </table>
 
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue
+import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, UnresolvedExtractValue}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -132,6 +132,16 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(CreateArray(longWithNull), longSeq :+ null, EmptyRow)
     checkEvaluation(CreateArray(strWithNull), strSeq :+ null, EmptyRow)
     checkEvaluation(CreateArray(Literal.create(null, IntegerType) :: Nil), null :: Nil)
+  }
+
+  test("SPARK-16715: CreateMap with Decimals") {
+    val map1 = CreateMap(Seq(Literal(Decimal(0.02)), Literal(Decimal(0.001)),
+      Literal(Decimal(0.001)), Literal(Decimal(0.03))))
+
+    assert(map1.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+
+    checkEvaluation(map1, Seq(Decimal(0.020), Decimal(0.001),
+      Literal(Decimal(0.001)), Literal(Decimal(0.030))))
   }
 
   test("CreateMap") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -143,7 +143,7 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     scala.collection.immutable.ListMap(keys.zip(values): _*)
   }
 
-  test("SPARK-16715: CreateMap with Decimals") {
+  test("SPARK-16735: CreateMap with Decimals") {
     val keys = Seq(0.02, 0.004)
     val values = Seq(0.001, 0.5)
     val keys1 = Seq(0.020, 0.004)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Spark 2.0, we will parse float literals as decimals. However, it introduces a side-effect, which is described below.

Before
spark-sql> select map(0.1,0.01, 0.2,0.033);
    Error in query: cannot resolve 'map(CAST(0.1 AS DECIMAL(1,1)), CAST(0.01 AS DECIMAL(2,2)), CAST(0.2 AS DECIMAL(1,1)), CAST(0.033 AS DECIMAL(3,3)))' due to data type mismatch: The given values of function map should all be the same type, but they are [decimal(2,2), decimal(3,3)]; line 1 pos 7

After

spark-sql> select map(0.1,0.01, 0.2,0.033);
    {0.1:0.010,0.2:0.033}
    Time taken: 2.448 seconds, Fetched 1 row(s)
## How was this patch tested?

Pass the run-tests with a new test case.
