### PR TITLE
[SPARK-16751] Upgrade derby to 10.12.1.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -46,6 +46,7 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
+derby-10.12.1.1.jar
 eigenbase-properties-1.1.5.jar
 guava-14.0.1.jar
 guice-3.0.jar

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -46,7 +46,6 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
-derby-10.11.1.1.jar
 eigenbase-properties-1.1.5.jar
 guava-14.0.1.jar
 guice-3.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -48,7 +48,6 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
-derby-10.11.1.1.jar
 eigenbase-properties-1.1.5.jar
 guava-14.0.1.jar
 guice-3.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -48,6 +48,7 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
+derby-10.12.1.1.jar
 eigenbase-properties-1.1.5.jar
 guava-14.0.1.jar
 guice-3.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -48,7 +48,6 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
-derby-10.11.1.1.jar
 eigenbase-properties-1.1.5.jar
 guava-14.0.1.jar
 guice-3.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -48,6 +48,7 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
+derby-10.12.1.1.jar
 eigenbase-properties-1.1.5.jar
 guava-14.0.1.jar
 guice-3.0.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -52,6 +52,7 @@ curator-recipes-2.6.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
+derby-10.12.1.1.jar
 eigenbase-properties-1.1.5.jar
 gson-2.2.4.jar
 guava-14.0.1.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -52,7 +52,6 @@ curator-recipes-2.6.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
-derby-10.11.1.1.jar
 eigenbase-properties-1.1.5.jar
 gson-2.2.4.jar
 guava-14.0.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -52,6 +52,7 @@ curator-recipes-2.6.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
+derby-10.12.1.1.jar
 eigenbase-properties-1.1.5.jar
 gson-2.2.4.jar
 guava-14.0.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -52,7 +52,6 @@ curator-recipes-2.6.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
-derby-10.11.1.1.jar
 eigenbase-properties-1.1.5.jar
 gson-2.2.4.jar
 guava-14.0.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <hive.version>1.2.1.spark2</hive.version>
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
-    <derby.version>10.11.1.1</derby.version>
+    <derby.version>10.12.1.1</derby.version>
     <parquet.version>1.8.1</parquet.version>
     <hive.parquet.version>1.6.0</hive.parquet.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
@@ -565,6 +565,7 @@
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
         <version>${derby.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,6 @@
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
         <version>${derby.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Version of derby upgraded based on important security info at VersionEye. Test scope added so we don't include it in our final package anyway. NB: I think this should be backported to all previous releases as it is a security problem https://www.versioneye.com/java/org.apache.derby:derby/10.11.1.1

The CVE number is 2015-1832. I also suggest we add a SECURITY tag for JIRAs
## How was this patch tested?

Existing tests with the change making sure that we see no new failures. I checked derby 10.12.x and not derby 10.11.x is downloaded to our ~/.m2 folder.

I then used dev/make-distribution.sh and checked the dist/jars folder for Spark 2.0: no derby jar is present.

I don't know if this would also remove it from the assembly jar in our 1.x branches.
