### PR TITLE
[SPARK-16673] [Web UI] New Executor Page removed conditional for Logs and Thread Dump columns

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -15,6 +15,16 @@
  * limitations under the License.
  */
 
+var threadDumpEnabled = false;
+
+function setThreadDumpEnabled(val) {
+    threadDumpEnabled = val;
+}
+
+function getThreadDumpEnabled() {
+    return threadDumpEnabled;
+}
+
 function formatStatus(status, type) {
     if (type !== 'display') return status;
     if (status) {
@@ -116,6 +126,12 @@ function formatLogsCells(execLogs, type) {
     return result;
 }
 
+function logsExist(execs) {
+    return execs.some(function(exec) {
+        return !($.isEmptyObject(exec["executorLogs"]));
+    });
+}
+
 // Determine Color Opacity from 0.5-1
 // activeTasks range from 0 to maxTasks
 function activeTasksAlpha(activeTasks, maxTasks) {
@@ -143,18 +159,16 @@ function totalDurationAlpha(totalGCTime, totalDuration) {
         (Math.min(totalGCTime / totalDuration + 0.5, 1)) : 1;
 }
 
+// When GCTimePercent is edited change ToolTips.TASK_TIME to match
+var GCTimePercent = 0.1;
+
 function totalDurationStyle(totalGCTime, totalDuration) {
     // Red if GC time over GCTimePercent of total time
-    // When GCTimePercent is edited change ToolTips.TASK_TIME to match
-    var GCTimePercent = 0.1;
     return (totalGCTime > GCTimePercent * totalDuration) ?
         ("hsla(0, 100%, 50%, " + totalDurationAlpha(totalGCTime, totalDuration) + ")") : "";
 }
 
 function totalDurationColor(totalGCTime, totalDuration) {
-    // Red if GC time over GCTimePercent of total time
-    // When GCTimePercent is edited change ToolTips.TASK_TIME to match
-    var GCTimePercent = 0.1;
     return (totalGCTime > GCTimePercent * totalDuration) ? "white" : "black";
 }
 
@@ -392,8 +406,18 @@ $(document).ready(function () {
                         {data: 'executorLogs', render: formatLogsCells},
                         {
                             data: 'id', render: function (data, type) {
-                            return type === 'display' ? ("<a href='threadDump/?executorId=" + data + "'>Thread Dump</a>" ) : data;
+                                return type === 'display' ? ("<a href='threadDump/?executorId=" + data + "'>Thread Dump</a>" ) : data;
+                            }
                         }
+                    ],
+                    "columnDefs": [
+                        {
+                            "targets": [ 15 ],
+                            "visible": logsExist(response)
+                        },
+                        {
+                            "targets": [ 16 ],
+                            "visible": getThreadDumpEnabled()
                         }
                     ],
                     "order": [[0, "asc"]]
@@ -458,7 +482,7 @@ $(document).ready(function () {
                     "paging": false,
                     "searching": false,
                     "info": false
-    
+
                 };
     
                 $(sumSelector).DataTable(sumConf);

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -50,16 +50,15 @@ private[ui] class ExecutorsPage(
     threadDumpEnabled: Boolean)
   extends WebUIPage("") {
   private val listener = parent.listener
-  // When GCTimePercent is edited change ToolTips.TASK_TIME to match
-  private val GCTimePercent = 0.1
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val content =
       <div>
         {
-        <div id="active-executors"></div> ++
+          <div id="active-executors"></div> ++
           <script src={UIUtils.prependBaseUri("/static/utils.js")}></script> ++
-          <script src={UIUtils.prependBaseUri("/static/executorspage.js")}></script>
+          <script src={UIUtils.prependBaseUri("/static/executorspage.js")}></script> ++
+          <script>setThreadDumpEnabled({threadDumpEnabled})</script>
         }
       </div>;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When #13670 switched `ExecutorsPage` to use JQuery DataTables it incidentally removed the conditional for the Logs and Thread Dump columns. I reimplemented the conditional display of the Logs and Thread dump columns as it was before the switch.
## How was this patch tested?

Manually tested and dev/run-tests

![both](https://cloud.githubusercontent.com/assets/13952758/17186879/da8dd1a8-53eb-11e6-8b0c-d0ff0156a9a7.png)
![dump](https://cloud.githubusercontent.com/assets/13952758/17186881/dab08a04-53eb-11e6-8b1c-50ffd0bf2ae8.png)
![logs](https://cloud.githubusercontent.com/assets/13952758/17186880/dab04d00-53eb-11e6-8754-68dd64d6d9f4.png)
