### PR TITLE
[SPARK-16761][DOC][ML] Fix doc link in docs/ml-guide.md

### DIFF
--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -33,7 +33,7 @@ The primary Machine Learning API for Spark is now the [DataFrame](sql-programmin
 
 * DataFrames provide a more user-friendly API than RDDs.  The many benefits of DataFrames include Spark Datasources, SQL/DataFrame queries, Tungsten and Catalyst optimizations, and uniform APIs across languages.
 * The DataFrame-based API for MLlib provides a uniform API across ML algorithms and across multiple languages.
-* DataFrames facilitate practical ML Pipelines, particularly feature transformations.  See the [Pipelines guide](ml-pipeline.md) for details.
+* DataFrames facilitate practical ML Pipelines, particularly feature transformations.  See the [Pipelines guide](ml-pipeline.html) for details.
 
 # Dependencies
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the link at http://spark.apache.org/docs/latest/ml-guide.html.
## How was this patch tested?

None
