### PR TITLE
[SPARK-16714][SQL] Refactor type widening for consistency

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala
@@ -67,6 +67,7 @@ object DecimalPrecision extends Rule[LogicalPlan] {
   def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     widerDecimalType(d1.precision, d1.scale, d2.precision, d2.scale)
   }
+
   // max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)
   def widerDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
     val scale = max(s1, s2)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -49,7 +49,7 @@ object TypeCoercion {
       InConversion ::
       WidenSetOperationTypes ::
       PromoteStrings ::
-      DecimalPrecision ::
+      DecimalPrecision ::  // DecimalPrecision must happen before ImplicitTypeCasts.
       BooleanEquality ::
       StringToIntegralCasts ::
       FunctionArgumentConversion ::
@@ -440,7 +440,7 @@ object TypeCoercion {
 
       case a @ CreateArray(children) if !haveSameType(children) =>
         val types = children.map(_.dataType)
-        findTightestCommonTypeAndPromoteToString(types) match {
+        findWiderCommonType(types) match {
           case Some(finalDataType) => CreateArray(children.map(Cast(_, finalDataType)))
           case None => a
         }
@@ -451,7 +451,7 @@ object TypeCoercion {
           m.keys
         } else {
           val types = m.keys.map(_.dataType)
-          findTightestCommonTypeAndPromoteToString(types) match {
+          findWiderCommonType(types) match {
             case Some(finalDataType) => m.keys.map(Cast(_, finalDataType))
             case None => m.keys
           }
@@ -461,7 +461,7 @@ object TypeCoercion {
           m.values
         } else {
           val types = m.values.map(_.dataType)
-          findTightestCommonTypeAndPromoteToString(types) match {
+          findWiderCommonType(types) match {
             case Some(finalDataType) => m.values.map(Cast(_, finalDataType))
             case None => m.values
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -496,14 +496,14 @@ object TypeCoercion {
 
       case g @ Greatest(children) if !haveSameType(children) =>
         val types = children.map(_.dataType)
-        findTightestCommonType(types) match {
+        findWiderCommonType(types) match {
           case Some(finalDataType) => Greatest(children.map(Cast(_, finalDataType)))
           case None => g
         }
 
       case l @ Least(children) if !haveSameType(children) =>
         val types = children.map(_.dataType)
-        findTightestCommonType(types) match {
+        findWiderCommonType(types) match {
           case Some(finalDataType) => Least(children.map(Cast(_, finalDataType)))
           case None => l
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -137,7 +137,7 @@ object TypeCoercion {
    * i.e. the main difference with [[findTightestCommonTypeOfTwo]] is that here we allow some
    * loss of precision when widening decimal and double.
    */
-  private def findWiderTypeForTwo(t1: DataType, t2: DataType): Option[DataType] = (t1, t2) match {
+  def findWiderTypeForTwo(t1: DataType, t2: DataType): Option[DataType] = (t1, t2) match {
     case (t1: DecimalType, t2: DecimalType) =>
       Some(DecimalPrecision.widerDecimalType(t1, t2))
     case (t: IntegralType, d: DecimalType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -103,7 +103,7 @@ object TypeCoercion {
    * Case 2 type widening (see the classdoc comment above for TypeCoercion).
    *
    * i.e. the main difference with [[findTightestCommonTypeOfTwo]] is that here we allow some
-   * loss of precision when widening decimal and double.
+   * loss of precision when widening decimal and double, and also widen all the way to string type.
    */
   def findWiderTypeForTwo(t1: DataType, t2: DataType): Option[DataType] = (t1, t2) match {
     case (t1: DecimalType, t2: DecimalType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -96,7 +96,7 @@ case class IfNull(left: Expression, right: Expression) extends RuntimeReplaceabl
 
   override def replaceForTypeCoercion(): Expression = {
     if (left.dataType != right.dataType) {
-      TypeCoercion.findTightestCommonTypeOfTwo(left.dataType, right.dataType).map { dtype =>
+      TypeCoercion.findWiderTypeForTwo(left.dataType, right.dataType).map { dtype =>
         copy(left = Cast(left, dtype), right = Cast(right, dtype))
       }.getOrElse(this)
     } else {
@@ -116,7 +116,7 @@ case class NullIf(left: Expression, right: Expression) extends RuntimeReplaceabl
 
   override def replaceForTypeCoercion(): Expression = {
     if (left.dataType != right.dataType) {
-      TypeCoercion.findTightestCommonTypeOfTwo(left.dataType, right.dataType).map { dtype =>
+      TypeCoercion.findWiderTypeForTwo(left.dataType, right.dataType).map { dtype =>
         copy(left = Cast(left, dtype), right = Cast(right, dtype))
       }.getOrElse(this)
     } else {
@@ -134,7 +134,7 @@ case class Nvl(left: Expression, right: Expression) extends RuntimeReplaceable {
 
   override def replaceForTypeCoercion(): Expression = {
     if (left.dataType != right.dataType) {
-      TypeCoercion.findTightestCommonTypeToString(left.dataType, right.dataType).map { dtype =>
+      TypeCoercion.findWiderTypeForTwo(left.dataType, right.dataType).map { dtype =>
         copy(left = Cast(left, dtype), right = Cast(right, dtype))
       }.getOrElse(this)
     } else {
@@ -154,7 +154,7 @@ case class Nvl2(expr1: Expression, expr2: Expression, expr3: Expression)
 
   override def replaceForTypeCoercion(): Expression = {
     if (expr2.dataType != expr3.dataType) {
-      TypeCoercion.findTightestCommonTypeOfTwo(expr2.dataType, expr3.dataType).map { dtype =>
+      TypeCoercion.findWiderTypeForTwo(expr2.dataType, expr3.dataType).map { dtype =>
         copy(expr2 = Cast(expr2, dtype), expr3 = Cast(expr3, dtype))
       }.getOrElse(this)
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -215,8 +215,6 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
   test("check types for Greatest/Least") {
     for (operator <- Seq[(Seq[Expression] => Expression)](Greatest, Least)) {
       assertError(operator(Seq('booleanField)), "requires at least 2 arguments")
-      assertError(operator(Seq('intField, 'stringField)), "should all have the same type")
-      assertError(operator(Seq('intField, 'decimalField)), "should all have the same type")
       assertError(operator(Seq('mapField, 'mapField)), "does not support ordering")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLTypeCoercionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLTypeCoercionSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.math.BigDecimal
+
+import org.apache.spark.sql.test.SharedSQLContext
+
+/**
+ * End-to-end tests for type coercion.
+ */
+class SQLTypeCoercionSuite extends QueryTest with SharedSQLContext {
+
+  test("SPARK-16714 decimal in map and struct") {
+    val v1 = new BigDecimal(1).divide(new BigDecimal(1000))
+    val v2 = new BigDecimal(1).divide(new BigDecimal(10)).setScale(3)
+
+    checkAnswer(
+      sql("select map(0.001, 0.001, 0.1, 0.1)"),
+      Row(Map(v1 -> v1, v2 -> v2))
+    )
+
+    checkAnswer(
+      sql("select array(0.001, 0.1)"),
+      Row(Seq(v1, v2))
+    )
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLTypeCoercionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLTypeCoercionSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.test.SharedSQLContext
  */
 class SQLTypeCoercionSuite extends QueryTest with SharedSQLContext {
 
-  test("SPARK-16714 decimal in map and struct") {
+  test("SPARK-16714 decimal widening") {
     val v1 = new BigDecimal(1).divide(new BigDecimal(1000))
     val v2 = new BigDecimal(1).divide(new BigDecimal(10)).setScale(3)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLTypeCoercionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLTypeCoercionSuite.scala
@@ -39,6 +39,20 @@ class SQLTypeCoercionSuite extends QueryTest with SharedSQLContext {
       sql("select array(0.001, 0.1)"),
       Row(Seq(v1, v2))
     )
+
+    checkAnswer(
+      sql("select greatest(0.001, 0.1), least(0.001, 0.1)"),
+      Row(v2, v1)
+    )
+
+    checkAnswer(
+      sql(
+        """
+          |select ifnull(0.001, 0.1), nullif(0.001, 0.1), nvl2(0.001, 0.001, 0.1), nvl(0.001, 0.1),
+          |       if(true, 0.001, 0.1)
+        """.stripMargin),
+      Row(v1, v1, v1, v1, v1)
+    )
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch refactors type widening and makes the usage of them in expressions more consistent.

Before this patch, we have the following 6 functions for type widening (and their usage):

```
findTightestCommonTypeOfTwo (binary version)
- BinaryOperator
- IfNull
- NullIf
- Nvl2
- JSON schema inference

findTightestCommonTypeToString (binary version)
- Nvl

findTightestCommonTypeAndPromoteToString (n-ary version)
- CreateArray
- CreateMap

findTightestCommonType (n-ary version)
- Greatest
- Least

findWiderTypeForTwo (binary version)
- IfCoercion

findWiderCommonType (n-ary version)
- WidenSetOperationTypes
- InConversion
- Coalesce
- CaseWhenCoercion
```

After this patch, we have only 3 functions for type widening (and their usage):

```
findTightestCommonTypeOfTwo (binary version)
- BinaryOperator
- JSON schema inference

findWiderTypeForTwo (binary version)
- IfCoercion
- Nvl
- IfNull
- NullIf
- Nvl2

findWiderCommonType (n-ary version)
- WidenSetOperationTypes
- InConversion
- Coalesce
- CaseWhenCoercion
- Greatest
- Least
- CreateArray
- CreateMap
```

As a result, this patch changes the type coercion rule for the aforementioned functions so they can accept decimals of different precision/scale. This is not a regression from Spark 1.x, but it is a much bigger problem in Spark 2.0 because floating point literals are parsed as decimals. Queries below would fail in Spark 2.0:

```
scala> sql("select array(0.001, 0.02)")
org.apache.spark.sql.AnalysisException: cannot resolve `array(CAST(0.001 AS DECIMAL(3,3)), CAST(0.02 AS DECIMAL(2,2)))` due to data type mismatch: input to function array should all be the same type, but it's [decimal(3,3), decimal(2,2)]; line 1 pos 7
```
## How was this patch tested?

Created a new end-to-end test suite SQLTypeCoercionSuite. In the future we can move all other type checking tests here. I first tried adding a test in SQLQuerySuite but the suite was clearly already too large.
