### PR TITLE
[SPARK-16767][SQL] Add existsRecursively to UserDefinedType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -93,6 +93,10 @@ abstract class UserDefinedType[UserType >: Null] extends DataType with Serializa
   }
 
   override def catalogString: String = sqlType.simpleString
+
+  override private[spark] def existsRecursively(f: (DataType) => Boolean): Boolean = {
+    f(this) || f(sqlType)
+  }
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -19,6 +19,15 @@ package org.apache.spark.sql.types
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 
+private[types] class TestClass
+
+private[types] class TestUDT extends UserDefinedType[TestClass] {
+  override def sqlType: DataType = DoubleType
+  override def serialize(feature: TestClass): Double = 0.0
+  override def deserialize(datum: Any): TestClass = new TestClass
+  override def userClass: java.lang.Class[TestClass] = classOf[TestClass]
+}
+
 class DataTypeSuite extends SparkFunSuite {
 
   test("construct an ArrayType") {
@@ -196,10 +205,13 @@ class DataTypeSuite extends SparkFunSuite {
   test("existsRecursively") {
     val struct = StructType(
       StructField("a", LongType) ::
-      StructField("b", FloatType) :: Nil)
+      StructField("b", FloatType) ::
+      StructField("c", new TestUDT) :: Nil)
     assert(struct.existsRecursively(_.isInstanceOf[LongType]))
     assert(struct.existsRecursively(_.isInstanceOf[StructType]))
     assert(!struct.existsRecursively(_.isInstanceOf[IntegerType]))
+    assert(struct.existsRecursively(_.isInstanceOf[UserDefinedType[_]]))
+    assert(struct.existsRecursively(_.isInstanceOf[DoubleType]))
 
     val mapType = MapType(struct, StringType)
     assert(mapType.existsRecursively(_.isInstanceOf[LongType]))


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DataType` has a method `existsRecursively` used to check recursively if a data type contains certain type. `UserDefinedType`'s `existsRecursively` is the default one which just check itself. However, `UserDefinedType` has a `sqlType` attribute that should be checked too.
## How was this patch tested?

Jenkins tests.
