### PR TITLE
[SPARK-16786] [Python] [WIP] LDA topic distributions API Call for python

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.mllib.api.python
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConverters._
 
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.SparkContext
@@ -37,11 +37,11 @@ private[python] class LDAModelWrapper(model: LDAModel) {
 
   def describeTopics(maxTermsPerTopic: Int): Array[Byte] = {
     val topics = model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
-      val jTerms = JavaConverters.seqAsJavaListConverter(terms).asJava
-      val jTermWeights = JavaConverters.seqAsJavaListConverter(termWeights).asJava
+      val jTerms = seqAsJavaListConverter(terms).asJava
+      val jTermWeights = seqAsJavaListConverter(termWeights).asJava
       Array[Any](jTerms, jTermWeights)
     }
-    SerDe.dumps(JavaConverters.seqAsJavaListConverter(topics).asJava)
+    SerDe.dumps(seqAsJavaListConverter(topics).asJava)
   }
 
   def topicDistributions(
@@ -62,6 +62,6 @@ private[python] class LDAModelWrapper(model: LDAModel) {
     }.asInstanceOf[ RDD[(Any, Any)] ])
 
   }
-  
+
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -176,7 +176,7 @@ abstract class LDAModel private[clustering] extends Saveable {
    *          The returned RDD may be zipped with the given RDD, where each returned vector
    *          is a multinomial distribution over topics.
    */
-  // def topicDistributions(documents: RDD[(Long, Vector)]): RDD[(Long, Vector)]
+  def topicDistributions(documents: RDD[(Long, Vector)]): RDD[(Long, Vector)]
 
 }
 
@@ -341,7 +341,7 @@ class LocalLDAModel private[spark] (
    */
   @Since("1.3.0")
   // TODO: declare in LDAModel and override once implemented in DistributedLDAModel
-  def topicDistributions(documents: RDD[(Long, Vector)]): RDD[(Long, Vector)] = {
+  override def topicDistributions(documents: RDD[(Long, Vector)]): RDD[(Long, Vector)] = {
     // Double transpose because dirichletExpectation normalizes by row and we need to normalize
     // by topic (columns of lambda)
     val expElogbeta = exp(LDAUtils.dirichletExpectation(topicsMatrix.asBreeze.toDenseMatrix.t).t)
@@ -775,6 +775,10 @@ class DistributedLDAModel private[clustering] (
   @Since("1.4.1")
   def javaTopicDistributions: JavaPairRDD[java.lang.Long, Vector] = {
     JavaPairRDD.fromRDD(topicDistributions.asInstanceOf[RDD[(java.lang.Long, Vector)]])
+  }
+
+  override def topicDistributions(documents: RDD[(Long, Vector)]: RDD[(Long, Vector)] = {
+    throw new NotImplementedError("Convert to LocalLDAModel or use online optimizer.")
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -777,7 +777,7 @@ class DistributedLDAModel private[clustering] (
     JavaPairRDD.fromRDD(topicDistributions.asInstanceOf[RDD[(java.lang.Long, Vector)]])
   }
 
-  override def topicDistributions(documents: RDD[(Long, Vector)]: RDD[(Long, Vector)] = {
+  override def topicDistributions(documents: RDD[(Long, Vector)]): RDD[(Long, Vector)] = {
     throw new NotImplementedError("Convert to LocalLDAModel or use online optimizer.")
   }
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -979,7 +979,7 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
         :param documents:
           RDD of document id and features.
         :return:
-          RDD where each row is a tuple of document id and array of 
+          RDD where each row is a tuple of document id and array of
           estimated topic distribution for k topics.
         """
         if not isinstance(documents, RDD):

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -972,6 +972,20 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
             topics = self.call("describeTopics", maxTermsPerTopic)
         return topics
 
+    def topicDistributions(self, documents):
+        """
+        Compute the estimated topic distribution for each document.
+        This is often called 'theta' in the literature.
+        :param documents:
+          RDD of document id and features.
+        :return:
+          RDD where each row is a tuple of document id and array of 
+          estimated topic distribution for k topics.
+        """
+        if not isinstance(documents, RDD):
+            raise TypeError("documents should be rdd, got type %s" % type(documents))
+        return self.call("topicDistributions", documents)
+
     @classmethod
     @since('1.5.0')
     def load(cls, sc, path):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implemented python call to topicDistributions for pyspark.clustering.mllib.LDAModel
## How was this patch tested?

Ran ./dev/run-tests, all passing
Manually verified.
Used function parameter types, return types etc. from existing API calls so all behaviour is consistent with existing behaviour.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
