### PR TITLE
[Spark-16791] [SQL] cast struct with timestamp field fails

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -416,7 +416,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
   }
 
   private[this] def cast(from: DataType, to: DataType): Any => Any = to match {
-    case dt if dt ==  from => identity[Any]
+    case dt if dt == from => identity[Any]
     case StringType => castToString(from)
     case BinaryType => castToBinary(from)
     case DateType => castToDate(from)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -416,7 +416,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
   }
 
   private[this] def cast(from: DataType, to: DataType): Any => Any = to match {
-    case dt if dt == child.dataType => identity[Any]
+    case dt if dt ==  from => identity[Any]
     case StringType => castToString(from)
     case BinaryType => castToBinary(from)
     case DateType => castToDate(from)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -727,6 +727,19 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("cast struct with a timestamp field") {
+    val origSchema = StructType(
+      Seq(StructField( "tsField", TimestampType, false ))
+    )
+    val trgSchema = StructType(
+      // nine out of ten times I'm casting a struct, it's to normalize its fields nullability
+      Seq(StructField( "tsField", TimestampType, true ))
+    )
+    val inp = Literal.create(InternalRow(0L), origSchema)
+    val expected = InternalRow(0L)
+    checkEvaluation( Cast(inp, trgSchema), expected)
+  }
+
   test("complex casting") {
     val complex = Literal.create(
       Row(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -728,9 +728,9 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("cast struct with a timestamp field") {
-    val originalSchema = new StructType().add( "tsField", TimestampType, nullable = false )
+    val originalSchema = new StructType().add("tsField", TimestampType, nullable = false)
     // nine out of ten times I'm casting a struct, it's to normalize its fields nullability
-    val targetSchema = new StructType().add( "tsField", TimestampType, nullable = true )
+    val targetSchema = new StructType().add("tsField", TimestampType, nullable = true)
 
     val inp = Literal.create(InternalRow(0L), originalSchema)
     val expected = InternalRow(0L)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -728,16 +728,16 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("cast struct with a timestamp field") {
-    val origSchema = StructType(
-      Seq(StructField( "tsField", TimestampType, false ))
+    val originalSchema = StructType(
+      Seq(StructField( "tsField", TimestampType, nullable = false ))
     )
-    val trgSchema = StructType(
+    val targetSchema = StructType(
       // nine out of ten times I'm casting a struct, it's to normalize its fields nullability
-      Seq(StructField( "tsField", TimestampType, true ))
+      Seq(StructField( "tsField", TimestampType, nullable = true ))
     )
-    val inp = Literal.create(InternalRow(0L), origSchema)
+    val inp = Literal.create(InternalRow(0L), originalSchema)
     val expected = InternalRow(0L)
-    checkEvaluation( Cast(inp, trgSchema), expected)
+    checkEvaluation(cast(inp, targetSchema), expected )
   }
 
   test("complex casting") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -728,13 +728,10 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("cast struct with a timestamp field") {
-    val originalSchema = StructType(
-      Seq(StructField( "tsField", TimestampType, nullable = false ))
-    )
-    val targetSchema = StructType(
-      // nine out of ten times I'm casting a struct, it's to normalize its fields nullability
-      Seq(StructField( "tsField", TimestampType, nullable = true ))
-    )
+    val originalSchema = new StructType().add( "tsField", TimestampType, nullable = false )
+    // nine out of ten times I'm casting a struct, it's to normalize its fields nullability
+    val targetSchema = new StructType().add( "tsField", TimestampType, nullable = true )
+
     val inp = Literal.create(InternalRow(0L), originalSchema)
     val expected = InternalRow(0L)
     checkEvaluation(cast(inp, targetSchema), expected )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -734,7 +734,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     val inp = Literal.create(InternalRow(0L), originalSchema)
     val expected = InternalRow(0L)
-    checkEvaluation(cast(inp, targetSchema), expected )
+    checkEvaluation(cast(inp, targetSchema), expected)
   }
 
   test("complex casting") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

a failing test case + fix to SPARK-16791 (https://issues.apache.org/jira/browse/SPARK-16791)
## How was this patch tested?

added a failing test case to CastSuit, then fixed the Cast code and rerun the entire CastSuit
