### PR TITLE
[SPARK-16751] [HOTFIX] Also update hadoop-1 deps file to reflect derby 10.12.1.1 security fix

### DIFF
--- a/dev/deps/spark-deps-hadoop-1
+++ b/dev/deps/spark-deps-hadoop-1
@@ -53,7 +53,7 @@ curator-recipes-2.4.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar
-derby-10.10.1.1.jar
+derby-10.12.1.1.jar
 eigenbase-properties-1.1.5.jar
 geronimo-annotation_1.0_spec-1.1.1.jar
 geronimo-jaspic_1.0_spec-1.0.jar


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://github.com/apache/spark/pull/14379 ; I failed to note in back-porting to 1.6 that an additional Hadoop 1 deps file would need to be updated. This makes that change.
## How was this patch tested?

Jenkins tests.
