### PR TITLE
[SPARK-16778][SQL][TRIVIAL] Fix deprecation warning with SQLContext

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -28,7 +28,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   test("propagate from spark conf") {
     // We create a new context here to avoid order dependence with other tests that might call
     // clear().
-    val newContext = new SQLContext(sparkContext)
+    val newContext = new SQLContext(SparkSession.builder().sparkContext(sc).getOrCreate())
     assert(newContext.getConf("spark.sql.testkey", "false") === "true")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -28,7 +28,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   test("propagate from spark conf") {
     // We create a new context here to avoid order dependence with other tests that might call
     // clear().
-    val newContext = new SQLContext(SparkSession.builder().sparkContext(sc).getOrCreate())
+    val newContext = new SQLContext(SparkSession.builder().sparkContext(sparkContext).getOrCreate())
     assert(newContext.getConf("spark.sql.testkey", "false") === "true")
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change to non-deprecated constructor for SQLContext.
## How was this patch tested?

Existing tests
