### PR TITLE
[SPARK-16796] [Web UI] Visible passwords on Spark environment page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -25,11 +25,9 @@ import org.apache.spark.ui.{UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
-  val passwordProperties: Set[String] = Set("spark.ssl.keyPassword",
-    "spark.ssl.keyStorePassword", "spark.ssl.trustStorePassword")
 
-  def removePass(kv: (String, String)): (String, String) = {
-    if (passwordProperties.contains(kv._1)) {
+  private def removePass(kv: (String, String)): (String, String) = {
+    if (kv._1.toLowerCase.contains("password")) {
       return (kv._1, "******")
     }
     kv

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -25,12 +25,20 @@ import org.apache.spark.ui.{UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
+  val passwordProperties: Seq[String] = Seq("spark.ssl.keyPassword",
+    "spark.ssl.keyStorePassword", "spark.ssl.trustStorePassword")
 
+  def removePass(kv: (String, String)): (String, String) = {
+    if (passwordProperties.contains(kv._1)) {
+      return (kv._1, "******")
+    }
+    kv
+  }
   def render(request: HttpServletRequest): Seq[Node] = {
     val runtimeInformationTable = UIUtils.listingTable(
       propertyHeader, jvmRow, listener.jvmInformation, fixedWidth = true)
     val sparkPropertiesTable = UIUtils.listingTable(
-      propertyHeader, propertyRow, listener.sparkProperties, fixedWidth = true)
+      propertyHeader, propertyRow, listener.sparkProperties.map(removePass), fixedWidth = true)
     val systemPropertiesTable = UIUtils.listingTable(
       propertyHeader, propertyRow, listener.systemProperties, fixedWidth = true)
     val classpathEntriesTable = UIUtils.listingTable(

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -27,11 +27,9 @@ private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") 
   private val listener = parent.listener
 
   private def removePass(kv: (String, String)): (String, String) = {
-    if (kv._1.toLowerCase.contains("password")) {
-      return (kv._1, "******")
-    }
-    kv
+    if (kv._1.toLowerCase.contains("password")) (kv._1, "******") else kv
   }
+
   def render(request: HttpServletRequest): Seq[Node] = {
     val runtimeInformationTable = UIUtils.listingTable(
       propertyHeader, jvmRow, listener.jvmInformation, fixedWidth = true)

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -25,7 +25,7 @@ import org.apache.spark.ui.{UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
-  val passwordProperties: Seq[String] = Seq("spark.ssl.keyPassword",
+  val passwordProperties: Set[String] = Set("spark.ssl.keyPassword",
     "spark.ssl.keyStorePassword", "spark.ssl.trustStorePassword")
 
   def removePass(kv: (String, String)): (String, String) = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mask spark.ssl.keyPassword, spark.ssl.keyStorePassword, spark.ssl.trustStorePassword in Web UI environment page.
(Changes their values to ****\* in env. page)
## How was this patch tested?

I've built spark, run spark shell and checked that this values have been masked with *****.

Also run tests:
./dev/run-tests

[info] ScalaTest
[info] Run completed in 1 hour, 9 minutes, 5 seconds.
[info] Total number of tests run: 2166
[info] Suites: completed 65, aborted 0
[info] Tests: succeeded 2166, failed 0, canceled 0, ignored 590, pending 0
[info] All tests passed.

![mask](https://cloud.githubusercontent.com/assets/15244468/17262154/7641e132-55e2-11e6-8a6c-30ead77c7372.png)
