### PR TITLE
[SPARK-16803] [SQL] SaveAsTable does not work when source DataFrame is built on a Hive Table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -236,6 +236,11 @@ case class CreateDataSourceTableAsSelectCommand(
               existingSchema = Some(l.schema)
             case s: SimpleCatalogRelation if DDLUtils.isDatasourceTable(s.metadata) =>
               existingSchema = Some(DDLUtils.getSchemaFromTableProperties(s.metadata))
+            // When the source table is a Hive table, the `saveAsTable` API of DataFrameWriter
+            // does not work. Instead, use the `insertInto` API.
+            case o if o.getClass.getName == "org.apache.spark.sql.hive.MetastoreRelation" =>
+              throw new AnalysisException("saveAsTable() for Hive tables is not supported yet. " +
+                "Please use insertInto() as an alternative.")
             case o =>
               throw new AnalysisException(s"Saving data in ${o.toString} is not supported.")
           }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1510,20 +1510,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
-  test("insertInto when the source DataFrame is ") {
-    val tableName = "tab1"
-    withTable(tableName) {
-      (1 to 2).map { i => (i, i) }.toDF("key", "value").write.insertInto(tableName)
-      val df = sql(s"select key, value as value from $tableName")
-
-      df.write.mode("append").saveAsTable(tableName)
-      checkAnswer(
-        sql(s"SELECT key, value FROM $tableName"),
-        Row(1, 1) :: Row(1, 1) :: Nil
-      )
-    }
-  }
-
   test("SPARK-11590: use native json_tuple in lateral view") {
     checkAnswer(sql(
       """


### PR DESCRIPTION
### What changes were proposed in this pull request?

In Spark 2.0, `SaveAsTable` does not work when source DataFrame is built on a Hive Table, but Spark 1.6 works.

**Spark 1.6**

``` Scala
scala> sql("create table sample.sample stored as SEQUENCEFILE as select 1 as key, 'abc' as value")
res2: org.apache.spark.sql.DataFrame = []

scala> val df = sql("select key, value as value from sample.sample")
df: org.apache.spark.sql.DataFrame = [key: int, value: string]

scala> df.write.mode("append").saveAsTable("sample.sample")

scala> sql("select * from sample.sample").show()
+---+-----+
|key|value|
+---+-----+
|  1|  abc|
|  1|  abc|
+---+-----+
```

**Spark 2.0**

``` Scala
scala> df.write.mode("append").saveAsTable("sample.sample")
org.apache.spark.sql.AnalysisException: Saving data in MetastoreRelation sample, sample
 is not supported.;
```

So far, we do not plan to support it in Spark 2.0. Spark 1.6 works because it internally uses `insertInto`. But, if we change it back it will break the semantic of `saveAsTable` (this method uses by-name resolution instead of using by-position resolution used by `insertInto`).

Instead, users should use `insertInto` API. This PR corrects the error messages. Users can understand how to bypass it before we support it in a separate PR.
### How was this patch tested?

Test cases are added
