### PR TITLE
[SPARK-16804][SQL] Correlated subqueries containing non-deterministic operations return incorrect results

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1021,6 +1021,16 @@ class Analyzer(
         case e: Expand =>
           failOnOuterReferenceInSubTree(e, "an EXPAND")
           e
+        case l @ LocalLimit(_, child) =>
+          failOnOuterReferenceInSubTree(l, "LIMIT")
+          l
+        // Since LIMIT <n> is represented as GlobalLimit(<n>, (LocalLimit (<n>, child))
+        // and we are walking bottom up, we will fail on LocalLimit before
+        // reaching GlobalLimit.
+        // The code below is just a safety net.
+        case g @ GlobalLimit(_, child) =>
+          failOnOuterReferenceInSubTree(g, "LIMIT")
+          g
         case p =>
           failOnOuterReference(p)
           p

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1021,16 +1021,19 @@ class Analyzer(
         case e: Expand =>
           failOnOuterReferenceInSubTree(e, "an EXPAND")
           e
-        case l @ LocalLimit(_, child) =>
+        case l @ LocalLimit(_, _) =>
           failOnOuterReferenceInSubTree(l, "a LIMIT")
           l
         // Since LIMIT <n> is represented as GlobalLimit(<n>, (LocalLimit (<n>, child))
         // and we are walking bottom up, we will fail on LocalLimit before
         // reaching GlobalLimit.
         // The code below is just a safety net.
-        case g @ GlobalLimit(_, child) =>
+        case g @ GlobalLimit(_, _) =>
           failOnOuterReferenceInSubTree(g, "a LIMIT")
           g
+        case s @ Sample(_, _, _, _, _) =>
+          failOnOuterReferenceInSubTree(s, "a TABLESAMPLE")
+          s
         case p =>
           failOnOuterReference(p)
           p

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1021,17 +1021,17 @@ class Analyzer(
         case e: Expand =>
           failOnOuterReferenceInSubTree(e, "an EXPAND")
           e
-        case l @ LocalLimit(_, _) =>
+        case l : LocalLimit =>
           failOnOuterReferenceInSubTree(l, "a LIMIT")
           l
         // Since LIMIT <n> is represented as GlobalLimit(<n>, (LocalLimit (<n>, child))
         // and we are walking bottom up, we will fail on LocalLimit before
         // reaching GlobalLimit.
         // The code below is just a safety net.
-        case g @ GlobalLimit(_, _) =>
+        case g : GlobalLimit =>
           failOnOuterReferenceInSubTree(g, "a LIMIT")
           g
-        case s @ Sample(_, _, _, _, _) =>
+        case s : Sample =>
           failOnOuterReferenceInSubTree(s, "a TABLESAMPLE")
           s
         case p =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1022,14 +1022,14 @@ class Analyzer(
           failOnOuterReferenceInSubTree(e, "an EXPAND")
           e
         case l @ LocalLimit(_, child) =>
-          failOnOuterReferenceInSubTree(l, "LIMIT")
+          failOnOuterReferenceInSubTree(l, "a LIMIT")
           l
         // Since LIMIT <n> is represented as GlobalLimit(<n>, (LocalLimit (<n>, child))
         // and we are walking bottom up, we will fail on LocalLimit before
         // reaching GlobalLimit.
         // The code below is just a safety net.
         case g @ GlobalLimit(_, child) =>
-          failOnOuterReferenceInSubTree(g, "LIMIT")
+          failOnOuterReferenceInSubTree(g, "a LIMIT")
           g
         case p =>
           failOnOuterReference(p)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -541,5 +541,13 @@ class AnalysisErrorSuite extends AnalysisTest {
       ),
       LocalRelation(a))
     assertAnalysisError(plan4, "Accessing outer query column is not allowed in a LIMIT" :: Nil)
+
+    val plan5 = Filter(
+      Exists(
+        Sample(0.0, 0.5, false, 1L,
+          Filter(EqualTo(OuterReference(a), b), LocalRelation(b)))().select('b)
+      ),
+      LocalRelation(a))
+    assertAnalysisError(plan5, "Accessing outer query column is not allowed in a TABLESAMPLE" :: Nil)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -540,6 +540,6 @@ class AnalysisErrorSuite extends AnalysisTest {
           Filter(EqualTo(OuterReference(a), b), LocalRelation(b)))
       ),
       LocalRelation(a))
-    assertAnalysisError(plan4, "Accessing outer query column is not allowed in LIMIT" :: Nil)
+    assertAnalysisError(plan4, "Accessing outer query column is not allowed in a LIMIT" :: Nil)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -548,6 +548,7 @@ class AnalysisErrorSuite extends AnalysisTest {
           Filter(EqualTo(OuterReference(a), b), LocalRelation(b)))().select('b)
       ),
       LocalRelation(a))
-    assertAnalysisError(plan5, "Accessing outer query column is not allowed in a TABLESAMPLE" :: Nil)
+    assertAnalysisError(plan5, 
+                        "Accessing outer query column is not allowed in a TABLESAMPLE" :: Nil)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -533,5 +533,13 @@ class AnalysisErrorSuite extends AnalysisTest {
       Exists(Union(LocalRelation(b), Filter(EqualTo(OuterReference(a), c), LocalRelation(c)))),
       LocalRelation(a))
     assertAnalysisError(plan3, "Accessing outer query column is not allowed in" :: Nil)
+
+    val plan4 = Filter(
+      Exists(
+        Limit(1,
+          Filter(EqualTo(OuterReference(a), b), LocalRelation(b)))
+      ),
+      LocalRelation(a))
+    assertAnalysisError(plan4, "Accessing outer query column is not allowed in LIMIT" :: Nil)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -548,7 +548,7 @@ class AnalysisErrorSuite extends AnalysisTest {
           Filter(EqualTo(OuterReference(a), b), LocalRelation(b)))().select('b)
       ),
       LocalRelation(a))
-    assertAnalysisError(plan5, 
+    assertAnalysisError(plan5,
                         "Accessing outer query column is not allowed in a TABLESAMPLE" :: Nil)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the incorrect results in the rule ResolveSubquery in Catalyst's Analysis phase by returning an error message when the LIMIT is found in the path from the parent table to the correlated predicate in the subquery.
## How was this patch tested?

./dev/run-tests
a new unit test on the problematic pattern.
