### PR TITLE
[SPARK-16805][SQL] Log timezone when query result does not match

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -401,6 +401,9 @@ object QueryTest {
     sameRows(expectedAnswer, sparkAnswer, isSorted).map { results =>
         s"""
         |Results do not match for query:
+        |Timezone: ${TimeZone.getDefault}
+        |Timezone Env: ${sys.env("TZ")}
+        |
         |${df.queryExecution}
         |== Results ==
         |$results


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is useful to log the timezone when query result does not match, especially on build machines that have different timezone from AMPLab Jenkins.
## How was this patch tested?

This is a test-only change.
