### PR TITLE
[SPARK-16812] Open up SparkILoop.getAddedJars

### DIFF
--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -1059,7 +1059,8 @@ class SparkILoop(
   @deprecated("Use `process` instead", "2.9.0")
   private def main(settings: Settings): Unit = process(settings)
 
-  private[repl] def getAddedJars(): Array[String] = {
+  @DeveloperApi
+  def getAddedJars(): Array[String] = {
     val conf = new SparkConf().setMaster(getMaster())
     val envJars = sys.env.get("ADD_JARS")
     if (envJars.isDefined) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch makes SparkILoop.getAddedJars a public developer API. It is a useful function to get the list of jars added.
## How was this patch tested?

N/A - this is a simple visibility change.
