### PR TITLE
Add rand(numRows: Int, numCols: Int) functions

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -497,6 +497,20 @@ object DenseMatrix {
   }
 
   /**
+    * Generate a `DenseMatrix` consisting of `i.i.d.` uniform random numbers.
+    * 
+    * @param numRows number of rows of the matrix
+    * @param numCols number of columns of the matrix
+    * @return DenseMatrix` with size `numRows` x `numCols` and values in U(0, 1)
+    */
+  @Since("2.0.0")
+  def rand(numRows: Int, numCols: Int): DenseMatrix = {
+    require(numRows.toLong * numCols <= Int.MaxValue,
+      s"$numRows x $numCols dense matrix is too large to allocate")
+    new DenseMatrix(numRows, numCols, Array.fill(numRows * numCols)((new Random).nextDouble()))
+  }
+  
+  /**
    * Generate a `DenseMatrix` consisting of `i.i.d.` gaussian random numbers.
    * @param numRows number of rows of the matrix
    * @param numCols number of columns of the matrix

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -507,7 +507,8 @@ object DenseMatrix {
   def rand(numRows: Int, numCols: Int): DenseMatrix = {
     require(numRows.toLong * numCols <= Int.MaxValue,
       s"$numRows x $numCols dense matrix is too large to allocate")
-    new DenseMatrix(numRows, numCols, Array.fill(numRows * numCols)((new Random).nextDouble()))
+    val rng=new Random()
+    new DenseMatrix(numRows, numCols, Array.fill(numRows * numCols)(rng.nextDouble()))
   }
   
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

add rand(numRows: Int, numCols: Int) functions to DenseMatrix object,like breeze.linalg.DenseMatrix.rand()
