### PR TITLE
Add zeros(size: Int) function

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -728,6 +728,20 @@ object DenseVector {
   def fromML(v: newlinalg.DenseVector): DenseVector = {
     new DenseVector(v.values)
   }
+  
+  
+  /**
+    * Generate a `DenseVector` consisting of zeros.
+    *
+    * @param size size of the DenseVector
+    * @return  a `DenseVector` consisting of zeros and Double type.
+    */
+  @Since("2.0.0")
+  def zeros(size: Int): DenseVector = {
+    val bdv=BDV.zeros[Double](size)
+    return new DenseVector(bdv.toArray)
+  }
+
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Generate a `DenseVector` consisting of zeros.
It can replace breeze.linalg.DenseVector#zeros[Double]
