### PR TITLE
[SPARK-16818] Exchange reuse incorrectly reuses scans over different sets of partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -202,7 +202,9 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
           partitions
       }
 
+      // These metadata values make scan plans uniquely identifiable for equality checking.
       val meta = Map(
+        "PartitionFilters" -> partitionKeyFilters.mkString("[", ", ", "]"),
         "Format" -> files.fileFormat.toString,
         "ReadSchema" -> prunedDataSchema.simpleString,
         PUSHED_FILTERS -> pushedDownFilters.mkString("[", ", ", "]"),


### PR DESCRIPTION
https://github.com/apache/spark/pull/14425 rebased for branch-2.0
