### PR TITLE
[SPARK-16810] Refactor registerSinks with multiple constructos

### DIFF
--- a/core/src/test/resources/test_metrics_system.properties
+++ b/core/src/test/resources/test_metrics_system.properties
@@ -20,3 +20,7 @@
 test.sink.console.class = org.apache.spark.metrics.sink.ConsoleSink
 test.sink.console.period = 20
 test.sink.console.unit = minutes
+
+sinkWithSparkConf.sink.testSink.class = org.apache.spark.metrics.sink.TestSinks.TestSinkWithSparkConfInConstructor
+sinkWithoutSparkConf.sink.testSink.class = org.apache.spark.metrics.sink.TestSinks.TestSinkWithoutSparkConfInConstructor
+sinkWithInvalidConstructor.sink.testSink.class = org.apache.spark.metrics.sink.TestSinks.TestSinkWithInvalidConstructor

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -268,4 +268,30 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     assert(metricName === source.sourceName)
   }
 
+  test("MetricsSystem with different types of constructors") {
+    val instanceName1 = "sinkWithSparkConf"
+    val metricsSystem1 = MetricsSystem.createMetricsSystem(instanceName1, conf, securityMgr)
+    metricsSystem1.start()
+    val sinks = PrivateMethod[ArrayBuffer[Source]]('sinks)
+
+    assert(metricsSystem1.invokePrivate(sinks()).length === 1)
+
+    val instanceName2 = "sinkWithoutSparkConf"
+    val metricsSystem2 = MetricsSystem.createMetricsSystem(instanceName1, conf, securityMgr)
+    metricsSystem2.start()
+
+    assert(metricsSystem1.invokePrivate(sinks()).length === 1)
+
+    val instanceName3 = "sinkWithInvalidConstructor"
+    val metricsSystem3 = MetricsSystem.createMetricsSystem(instanceName1, conf, securityMgr)
+    try {
+      metricsSystem2.start()
+      fail("Expected exception for invalid sink constructor with empty arguments.")
+    }
+    catch {
+      case e: Exception => /** Passs */
+    }
+    assert(metricsSystem3.invokePrivate(sinks()).length === 0)
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.master.MasterSource
 import org.apache.spark.internal.config._
+import org.apache.spark.metrics.sink.Sink
 import org.apache.spark.metrics.source.{Source, StaticSources}
 
 class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateMethodTester{
@@ -42,7 +43,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     val metricsSystem = MetricsSystem.createMetricsSystem("default", conf, securityMgr)
     metricsSystem.start()
     val sources = PrivateMethod[ArrayBuffer[Source]]('sources)
-    val sinks = PrivateMethod[ArrayBuffer[Source]]('sinks)
+    val sinks = PrivateMethod[ArrayBuffer[Sink]]('sinks)
 
     assert(metricsSystem.invokePrivate(sources()).length === StaticSources.allSources.length)
     assert(metricsSystem.invokePrivate(sinks()).length === 0)
@@ -53,7 +54,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     val metricsSystem = MetricsSystem.createMetricsSystem("test", conf, securityMgr)
     metricsSystem.start()
     val sources = PrivateMethod[ArrayBuffer[Source]]('sources)
-    val sinks = PrivateMethod[ArrayBuffer[Source]]('sinks)
+    val sinks = PrivateMethod[ArrayBuffer[Sink]]('sinks)
 
     assert(metricsSystem.invokePrivate(sources()).length === StaticSources.allSources.length)
     assert(metricsSystem.invokePrivate(sinks()).length === 1)
@@ -272,7 +273,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     val instanceName1 = "sinkWithSparkConf"
     val metricsSystem1 = MetricsSystem.createMetricsSystem(instanceName1, conf, securityMgr)
     metricsSystem1.start()
-    val sinks = PrivateMethod[ArrayBuffer[Source]]('sinks)
+    val sinks = PrivateMethod[ArrayBuffer[Sink]]('sinks)
 
     assert(metricsSystem1.invokePrivate(sinks()).length === 1)
 

--- a/core/src/test/scala/org/apache/spark/metrics/sink/TestSinks.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/sink/TestSinks.scala
@@ -25,8 +25,8 @@ import org.apache.spark.{SecurityManager, SparkConf}
 
 object TestSinks {
   class TestSinkWithoutSparkConfInConstructor(val property: Properties,
-                                           val registry: MetricRegistry,
-                                           val securityMgr: SecurityManager) extends Sink {
+                                              val registry: MetricRegistry,
+                                              val securityMgr: SecurityManager) extends Sink {
     override def start(): Unit = { /** Do nothing */ }
 
     override def stop(): Unit = { /** Do nothing */ }

--- a/core/src/test/scala/org/apache/spark/metrics/sink/TestSinks.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/sink/TestSinks.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.metrics.sink
+
+import java.util.Properties
+
+import com.codahale.metrics.MetricRegistry
+
+import org.apache.spark.{SecurityManager, SparkConf}
+
+object TestSinks {
+  class TestSinkWithoutSparkConfInConstructor(val property: Properties,
+                                           val registry: MetricRegistry,
+                                           val securityMgr: SecurityManager) extends Sink {
+    override def start(): Unit = { /** Do nothing */ }
+
+    override def stop(): Unit = { /** Do nothing */ }
+
+    override def report(): Unit = { /** Do nothing */ }
+  }
+
+  class TestSinkWithSparkConfInConstructor(val property: Properties,
+                                           val registry: MetricRegistry,
+                                           val securityMgr: SecurityManager,
+                                           val sparkConf: SparkConf) extends Sink {
+    override def start(): Unit = { /** Do nothing */ }
+
+    override def stop(): Unit = { /** Do nothing */ }
+
+    override def report(): Unit = { /** Do nothing */ }
+  }
+
+  class TestSinkWithInvalidConstructor() extends Sink {
+    override def start(): Unit = { /** Do nothing */ }
+
+    override def stop(): Unit = { /** Do nothing */ }
+
+    override def report(): Unit = { /** Do nothing */ }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

For some metrics, it may require some **app detailed information** from `SparkConf`. So for those sinks, we need to pass `SparkConf` via sink constructor. Refactored registerSink class reflection part to allow multiple types of sink constructor to be initialized.
## How was this patch tested?

Using existing tests.
