### PR TITLE
[SPARK-16825] [SQL] Replace hive.default.fileformat by spark.sql.default.fileformat

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -956,7 +956,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
     // Storage format
     val defaultStorage: CatalogStorageFormat = {
-      val defaultStorageType = conf.getConfString("hive.default.fileformat", "textfile")
+      val defaultStorageType = conf.defaultFileFormat.toLowerCase
       val defaultHiveSerde = HiveSerDe.sourceToSerDe(defaultStorageType, conf)
       CatalogStorageFormat(
         locationUri = None,

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -295,17 +295,13 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
-  // This is used to set the default data source
+  // This is used to set the default format for data source tables and Hive tables.
   val DEFAULT_DATA_SOURCE_NAME = SQLConfigBuilder("spark.sql.sources.default")
-    .doc("The default data source to use in input/output.")
+    .doc("The default format for data source tables to use in input/output and Hive tables in " +
+      "CREATE TABLE statement. If not specified, the default format for data source tables is " +
+      "parquet; the default format for hive tables is textfile")
     .stringConf
-    .createWithDefault("parquet")
-
-  val DEFAULT_FILE_FORMAT = SQLConfigBuilder("spark.sql.default.fileformat")
-    .doc("The default file format for CREATE TABLE statement. Options are TextFile, Parquet, " +
-      "SequenceFile, RCfile, ORC, and Avro.")
-    .stringConf
-    .createWithDefault("textfile")
+    .createOptional
 
   val CONVERT_CTAS = SQLConfigBuilder("spark.sql.hive.convertCTAS")
     .internal()
@@ -649,9 +645,13 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
 
   def broadcastTimeout: Int = getConf(BROADCAST_TIMEOUT)
 
-  def defaultDataSourceName: String = getConf(DEFAULT_DATA_SOURCE_NAME)
+  def defaultDataSourceName: String = {
+    getConf(DEFAULT_DATA_SOURCE_NAME).getOrElse("parquet")
+  }
 
-  def defaultFileFormat: String = getConf(DEFAULT_FILE_FORMAT)
+  def defaultFileFormat: String = {
+    getConf(DEFAULT_DATA_SOURCE_NAME).getOrElse("textfile")
+  }
 
   def convertCTAS: Boolean = getConf(CONVERT_CTAS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -301,6 +301,12 @@ object SQLConf {
     .stringConf
     .createWithDefault("parquet")
 
+  val DEFAULT_FILE_FORMAT = SQLConfigBuilder("spark.sql.default.fileformat")
+    .doc("The  Default file format for CREATE TABLE statement. Options are TextFile, Parquet, " +
+      "SequenceFile, RCfile, ORC, and Avro.")
+    .stringConf
+    .createWithDefault("textfile")
+
   val CONVERT_CTAS = SQLConfigBuilder("spark.sql.hive.convertCTAS")
     .internal()
     .doc("When true, a table created by a Hive CTAS statement (no USING clause) " +
@@ -644,6 +650,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def broadcastTimeout: Int = getConf(BROADCAST_TIMEOUT)
 
   def defaultDataSourceName: String = getConf(DEFAULT_DATA_SOURCE_NAME)
+
+  def defaultFileFormat: String = getConf(DEFAULT_FILE_FORMAT)
 
   def convertCTAS: Boolean = getConf(CONVERT_CTAS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -302,7 +302,7 @@ object SQLConf {
     .createWithDefault("parquet")
 
   val DEFAULT_FILE_FORMAT = SQLConfigBuilder("spark.sql.default.fileformat")
-    .doc("The  Default file format for CREATE TABLE statement. Options are TextFile, Parquet, " +
+    .doc("The default file format for CREATE TABLE statement. Options are TextFile, Parquet, " +
       "SequenceFile, RCfile, ORC, and Avro.")
     .stringConf
     .createWithDefault("textfile")

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -98,8 +98,8 @@ private[sql] trait SQLTestUtils
     (keys, values).zipped.foreach(spark.conf.set)
     try f finally {
       keys.zip(currentValues).foreach {
-        case (key, Some(value)) => spark.conf.set(key, value)
-        case (key, None) => spark.conf.unset(key)
+        case (key, Some(value)) if value != "<undefined>" => spark.conf.set(key, value)
+        case (key, _) => spark.conf.unset(key)
       }
     }
   }

--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveWindowFunctionQuerySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveWindowFunctionQuerySuite.scala
@@ -89,15 +89,6 @@ class HiveWindowFunctionQuerySuite extends HiveComparisonTest with BeforeAndAfte
       s"""
         |LOAD DATA LOCAL INPATH '$testData2' overwrite into table over1k
       """.stripMargin)
-
-    // The following settings are used for generating golden files with Hive.
-    // We have to use kryo to correctly let Hive serialize plans with window functions.
-    // This is used to generate golden files.
-    sql("set hive.plan.serialization.format=kryo")
-    // Explicitly set fs to local fs.
-    sql(s"set fs.default.name=file://$testTempDir/")
-    // Ask Hive to run jobs in-process as a single map and reduce task.
-    sql("set mapred.job.tracker=local")
   }
 
   override def afterAll() {
@@ -758,15 +749,6 @@ class HiveWindowFunctionQueryFileSuite
     TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
     // Add Locale setting
     Locale.setDefault(Locale.US)
-
-    // The following settings are used for generating golden files with Hive.
-    // We have to use kryo to correctly let Hive serialize plans with window functions.
-    // This is used to generate golden files.
-    // sql("set hive.plan.serialization.format=kryo")
-    // Explicitly set fs to local fs.
-    // sql(s"set fs.default.name=file://$testTempDir/")
-    // Ask Hive to run jobs in-process as a single map and reduce task.
-    // sql("set mapred.job.tracker=local")
   }
 
   override def afterAll() {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -159,7 +159,7 @@ class HiveDDLSuite
     val tabName = "tab1"
     withTable(tabName) {
       // the format name should be case incensitive
-      withSQLConf(SQLConf.DEFAULT_FILE_FORMAT.key -> "pArQuEt") {
+      withSQLConf(SQLConf.DEFAULT_DATA_SOURCE_NAME.key -> "pArQuEt") {
         sql(s"CREATE TABLE $tabName(c1 int)")
         val tableMetadata = catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
         val storage = tableMetadata.storage
@@ -176,7 +176,7 @@ class HiveDDLSuite
     val tabName = "tab1"
     withTable(tabName) {
       // the format name should be case insensitive
-      withSQLConf(SQLConf.DEFAULT_FILE_FORMAT.key -> "nonExistent") {
+      withSQLConf(SQLConf.DEFAULT_DATA_SOURCE_NAME.key -> "nonExistent") {
         sql(s"CREATE TABLE $tabName(c1 int)")
         val tableMetadata = catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
         val storage = tableMetadata.storage
@@ -191,7 +191,7 @@ class HiveDDLSuite
     val catalog = spark.sessionState.catalog
     val tabName = "tab1"
     withTable(tabName) {
-      withSQLConf(SQLConf.DEFAULT_FILE_FORMAT.key -> "parquet") {
+      withSQLConf(SQLConf.DEFAULT_DATA_SOURCE_NAME.key -> "parquet") {
         sql(s"CREATE TABLE $tabName(c1 int)")
         val tableMetadata = catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
         val storage = tableMetadata.storage

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -175,7 +175,7 @@ class HiveDDLSuite
     val catalog = spark.sessionState.catalog
     val tabName = "tab1"
     withTable(tabName) {
-      // the format name should be case incensitive
+      // the format name should be case insensitive
       withSQLConf(SQLConf.DEFAULT_FILE_FORMAT.key -> "nonExistent") {
         sql(s"CREATE TABLE $tabName(c1 int)")
         val tableMetadata = catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, we are using `hive.default.fileformat` for specifying the default file format in CREATE TABLE statement. Multiple issues exist:
- This parameter value is not from `hive-site.xml`. Thus, even if users change the hive.default.fileformat in `hive-site.xml`, Spark will ignore it. To change the parameter values, users have to use Spark interface, (e.g., by a SET command or API). 
- This parameter is not documented. 
- This parameter value will not be sent to Hive metastore. It is being used by Spark internals when processing CREATE TABLE statement. 
- This parameter is case sensitive. 

Since this is being used by Spark only, it does not make sense to use a parameter starting from `hive`. we might follow the other Hive-related parameters and introduce a new Spark parameter here. It should be public. Thus, this PR is to replace `hive.default.fileformat` by `spark.sql.default.fileformat`. It also makes it case insensitive.
## How was this patch tested?

Added test cases
