### PR TITLE
[SPARK-16837] [SQL] TimeWindow incorrectly drops slideDuration in constructors

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -45,12 +45,12 @@ case class TimeWindow(
       slideDuration: Expression,
       startTime: Expression) = {
     this(timeColumn, TimeWindow.parseExpression(windowDuration),
-      TimeWindow.parseExpression(windowDuration), TimeWindow.parseExpression(startTime))
+      TimeWindow.parseExpression(slideDuration), TimeWindow.parseExpression(startTime))
   }
 
   def this(timeColumn: Expression, windowDuration: Expression, slideDuration: Expression) = {
     this(timeColumn, TimeWindow.parseExpression(windowDuration),
-      TimeWindow.parseExpression(windowDuration), 0)
+      TimeWindow.parseExpression(slideDuration), 0)
   }
 
   def this(timeColumn: Expression, windowDuration: Expression) = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeWindowSuite.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.scalatest.PrivateMethodTester
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.types.LongType
-import org.apache.spark.unsafe.types.CalendarInterval
 
 class TimeWindowSuite extends SparkFunSuite with ExpressionEvalHelper with PrivateMethodTester {
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeWindowSuite.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.scalatest.PrivateMethodTester
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.types.LongType
+import org.apache.spark.unsafe.types.CalendarInterval
 
 class TimeWindowSuite extends SparkFunSuite with ExpressionEvalHelper with PrivateMethodTester {
 
@@ -106,6 +106,18 @@ class TimeWindowSuite extends SparkFunSuite with ExpressionEvalHelper with Priva
   test("parse sql expression for duration in microseconds - invalid expression") {
     intercept[AnalysisException] {
       TimeWindow.invokePrivate(parseExpression(Rand(123)))
+    }
+  }
+
+  test("SPARK-16837: TimeWindow.apply equivalent to TimeWindow constructor") {
+    val slideLength = "1 second"
+    for (windowLength <- Seq("10 second", "1 minute", "2 hours")) {
+      val applyValue = TimeWindow(Literal(10L), windowLength, slideLength, "0 seconds")
+      val constructed = new TimeWindow(Literal(10L),
+        Literal(windowLength),
+        Literal(slideLength),
+        Literal("0 seconds"))
+      assert(applyValue == constructed)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix of incorrect arguments (dropping slideDuration and using windowDuration) in constructors for TimeWindow.

The JIRA this addresses is here: https://issues.apache.org/jira/browse/SPARK-16837
## How was this patch tested?

Added a test to TimeWindowSuite to check that the results of TimeWindow object apply and TimeWindow class constructor are equivalent.
