### PR TITLE
[SPARK-15869][Streaming]Fix a potential NPE in StreamingJobProgressListener.getBatchUIData

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -259,7 +259,7 @@ private[streaming] class StreamingJobProgressListener(ssc: StreamingContext)
       // We use an Iterable rather than explicitly converting to a seq so that updates
       // will propagate
       val outputOpIdToSparkJobIds: Iterable[OutputOpIdAndSparkJobId] =
-        Option(batchTimeToOutputOpIdSparkJobIdPair.get(batchTime).asScala)
+        Option(batchTimeToOutputOpIdSparkJobIdPair.get(batchTime)).map(_.asScala)
           .getOrElse(Seq.empty)
       _batchUIData.outputOpIdSparkJobIdPairs = outputOpIdToSparkJobIds
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moved `asScala` to a `map` to avoid NPE.
## How was this patch tested?

Existing unit tests.
