### PR TITLE
[minor] Update AccumulatorV2 doc to not mention "+=".

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -131,7 +131,7 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
   def reset(): Unit
 
   /**
-   * Takes the inputs and accumulates. e.g. it can be a simple `+=` for counter accumulator.
+   * Takes the inputs and accumulates.
    */
   def add(v: IN): Unit
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As reported by Bryan Cutler on the mailing list, AccumulatorV2 does not have a += method, yet the documentation still references it. 
## How was this patch tested?

N/A
