### PR TITLE
[SPARK-16870][docs]Summary:add "spark.sql.broadcastTimeout" into docs/sql-programming-gu…

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -790,15 +790,6 @@ Configuration of Parquet can be done using the `setConf` method on `SparkSession
     </p>
   </td>
 </tr>
-<tr>
-  <td><code>spark.sql.broadcastTimeout</code></td>
-  <td>300</td>
-  <td>
-    <p>
-      Timeout in seconds for the broadcast wait time in broadcast joins
-    </p>
-  </td>
-</tr>
 </table>
 
 ## JSON Datasets
@@ -1194,6 +1185,15 @@ that these options will be deprecated in future release as more optimizations ar
       time. This is used when putting multiple files into a partition. It is better to over estimated,
       then the partitions with small files will be faster than partitions with bigger files (which is
       scheduled first).
+    </td>
+  </tr>
+  <tr>
+    <td><code>spark.sql.broadcastTimeout</code></td>
+    <td>300</td>
+    <td>
+    <p>
+      Timeout in seconds for the broadcast wait time in broadcast joins
+    </p>
     </td>
   </tr>
   <tr>

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -790,6 +790,15 @@ Configuration of Parquet can be done using the `setConf` method on `SparkSession
     </p>
   </td>
 </tr>
+<tr>
+  <td><code>spark.sql.broadcastTimeout</code></td>
+  <td>300</td>
+  <td>
+    <p>
+      Timeout in seconds for the broadcast wait time in broadcast joins
+    </p>
+  </td>
+</tr>
 </table>
 
 ## JSON Datasets


### PR DESCRIPTION
## What changes were proposed in this pull request?

default value for spark.sql.broadcastTimeout is 300s. and this property do not show in any docs of spark. so add "spark.sql.broadcastTimeout" into docs/sql-programming-guide.md to help people to how to fix this timeout error when it happenned
## How was this patch tested?

not need

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

…ide.md

JIRA_ID:SPARK-16870
Description:default value for spark.sql.broadcastTimeout is 300s. and this property do not show in any docs of spark. so add "spark.sql.broadcastTimeout" into docs/sql-programming-guide.md to help people to how to fix this timeout error when it happenned
Test:done
