### PR TITLE
[SPARK-16873] [Core] Fix SpillReader NPE when spillFile has no data

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -611,7 +611,9 @@ private[spark] class ExternalSorter[K, V, C](
       val ds = deserializeStream
       deserializeStream = null
       fileStream = null
-      ds.close()
+      if (ds != null) {
+        ds.close()
+      }
       // NOTE: We don't do file.delete() here because that is done in ExternalSorter.stop().
       // This should also be fixed in ExternalAppendOnlyMap.
     }

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -204,13 +204,8 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(false,
       mainClassName(YarnClusterDriverUseSparkHadoopUtilConf.getClass),
-<<<<<<< 7f968867ff61c6b1a007874ee7e3a7421d94d373
       appArgs = Seq("key=value", result.getAbsolutePath()),
       extraConf = Map("spark.hadoop.key" -> "value"))
-=======
-      appArgs = Seq("spark.hadoop.key=value", result.getAbsolutePath()),
-      extraConf = Map(("spark.hadoop.key", "value")))
->>>>>>> add a unit test
     checkResult(finalState, result)
   }
 
@@ -317,15 +312,9 @@ private object YarnClusterDriverUseSparkHadoopUtilConf extends Logging with Matc
       // scalastyle:off println
       System.err.println(
         s"""
-<<<<<<< 7f968867ff61c6b1a007874ee7e3a7421d94d373
         |Invalid command line: ${args.mkString(" ")}
         |
         |Usage: YarnClusterDriverUseSparkHadoopUtilConf [hadoopConfKey=value] [result file]
-=======
-           |Invalid command line: ${args.mkString(" ")}
-           |
-        |Usage: YarnClusterDriverUseSparkHadoopUtilConf [propertyKey=value] [result file]
->>>>>>> add a unit test
         """.stripMargin)
       // scalastyle:on println
       System.exit(1)
@@ -335,19 +324,11 @@ private object YarnClusterDriverUseSparkHadoopUtilConf extends Logging with Matc
       .set("spark.extraListeners", classOf[SaveExecutorInfo].getName)
       .setAppName("yarn test using SparkHadoopUtil's conf"))
 
-<<<<<<< 7f968867ff61c6b1a007874ee7e3a7421d94d373
     val kv = args(0).split("=")
     val status = new File(args(1))
     var result = "failure"
     try {
       SparkHadoopUtil.get.conf.get(kv(0)) should be (kv(1))
-=======
-    val propertyKeyValue = args(0).split("=")
-    val status = new File(args(1))
-    var result = "failure"
-    try {
-      SparkHadoopUtil.get.conf.get(propertyKeyValue(0)) should be (propertyKeyValue(1))
->>>>>>> add a unit test
       result = "success"
     } finally {
       Files.write(result, status, StandardCharsets.UTF_8)

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -204,8 +204,13 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(false,
       mainClassName(YarnClusterDriverUseSparkHadoopUtilConf.getClass),
+<<<<<<< 7f968867ff61c6b1a007874ee7e3a7421d94d373
       appArgs = Seq("key=value", result.getAbsolutePath()),
       extraConf = Map("spark.hadoop.key" -> "value"))
+=======
+      appArgs = Seq("spark.hadoop.key=value", result.getAbsolutePath()),
+      extraConf = Map(("spark.hadoop.key", "value")))
+>>>>>>> add a unit test
     checkResult(finalState, result)
   }
 
@@ -312,9 +317,15 @@ private object YarnClusterDriverUseSparkHadoopUtilConf extends Logging with Matc
       // scalastyle:off println
       System.err.println(
         s"""
+<<<<<<< 7f968867ff61c6b1a007874ee7e3a7421d94d373
         |Invalid command line: ${args.mkString(" ")}
         |
         |Usage: YarnClusterDriverUseSparkHadoopUtilConf [hadoopConfKey=value] [result file]
+=======
+           |Invalid command line: ${args.mkString(" ")}
+           |
+        |Usage: YarnClusterDriverUseSparkHadoopUtilConf [propertyKey=value] [result file]
+>>>>>>> add a unit test
         """.stripMargin)
       // scalastyle:on println
       System.exit(1)
@@ -324,11 +335,19 @@ private object YarnClusterDriverUseSparkHadoopUtilConf extends Logging with Matc
       .set("spark.extraListeners", classOf[SaveExecutorInfo].getName)
       .setAppName("yarn test using SparkHadoopUtil's conf"))
 
+<<<<<<< 7f968867ff61c6b1a007874ee7e3a7421d94d373
     val kv = args(0).split("=")
     val status = new File(args(1))
     var result = "failure"
     try {
       SparkHadoopUtil.get.conf.get(kv(0)) should be (kv(1))
+=======
+    val propertyKeyValue = args(0).split("=")
+    val status = new File(args(1))
+    var result = "failure"
+    try {
+      SparkHadoopUtil.get.conf.get(propertyKeyValue(0)) should be (propertyKeyValue(1))
+>>>>>>> add a unit test
       result = "success"
     } finally {
       Files.write(result, status, StandardCharsets.UTF_8)


### PR DESCRIPTION
## What changes were proposed in this pull request?

SpillReader NPE when spillFile has no data. See follow logs:

16/07/31 20:54:04 INFO collection.ExternalSorter: spill memory to file:/data4/yarnenv/local/usercache/tesla/appcache/application_1465785263942_56138/blockmgr-db5f46c3-d7a4-4f93-8b77-565e469696fb/09/temp_shuffle_ec3ece08-4569-4197-893a-4a5dfcbbf9fa, fileSize:0.0 B
16/07/31 20:54:04 WARN memory.TaskMemoryManager: leak 164.3 MB memory from org.apache.spark.util.collection.ExternalSorter@3db4b52d
16/07/31 20:54:04 ERROR executor.Executor: Managed memory leak detected; size = 190458101 bytes, TID = 2358516/07/31 20:54:04 ERROR executor.Executor: Exception in task 1013.0 in stage 18.0 (TID 23585)
java.lang.NullPointerException
    at org.apache.spark.util.collection.ExternalSorter$SpillReader.cleanup(ExternalSorter.scala:624)
    at org.apache.spark.util.collection.ExternalSorter$SpillReader.nextBatchStream(ExternalSorter.scala:539)
    at org.apache.spark.util.collection.ExternalSorter$SpillReader.<init>(ExternalSorter.scala:507)
    at org.apache.spark.util.collection.ExternalSorter$SpillableIterator.spill(ExternalSorter.scala:816)
    at org.apache.spark.util.collection.ExternalSorter.forceSpill(ExternalSorter.scala:251)
    at org.apache.spark.util.collection.Spillable.spill(Spillable.scala:109)
    at org.apache.spark.memory.TaskMemoryManager.acquireExecutionMemory(TaskMemoryManager.java:154)
    at org.apache.spark.memory.TaskMemoryManager.allocatePage(TaskMemoryManager.java:249)
    at org.apache.spark.memory.MemoryConsumer.allocatePage(MemoryConsumer.java:112)
    at org.apache.spark.shuffle.sort.ShuffleExternalSorter.acquireNewPageIfNecessary(ShuffleExternalSorter.java:346)
    at org.apache.spark.shuffle.sort.ShuffleExternalSorter.insertRecord(ShuffleExternalSorter.java:367)
    at org.apache.spark.shuffle.sort.UnsafeShuffleWriter.insertRecordIntoSorter(UnsafeShuffleWriter.java:237)
    at org.apache.spark.shuffle.sort.UnsafeShuffleWriter.write(UnsafeShuffleWriter.java:164)
    at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:73)
    at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:41)
    at org.apache.spark.scheduler.Task.run(Task.scala:89)
    at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:227)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:744)
16/07/31 20:54:30 INFO executor.Executor: Executor is trying to kill task 1090.1 in stage 18.0 (TID 23793)
16/07/31 20:54:30 INFO executor.CoarseGrainedExecutorBackend: Driver commanded a shutdown
## How was this patch tested?

Manual test.
