### PR TITLE
[SPARK-16796][Web UI] Mask spark.authenticate.secret on Spark environ…

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -25,9 +25,13 @@ import org.apache.spark.ui.{UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
+  // Spark Properties (lowercase). Their values will be changed to ***** in WebUI
+  private val propertiesToMask = Set("spark.authenticate.secret")
 
   private def removePass(kv: (String, String)): (String, String) = {
-    if (kv._1.toLowerCase.contains("password")) (kv._1, "******") else kv
+    if (kv._1.toLowerCase.contains("password") || propertiesToMask.contains(kv._1.toLowerCase)) {
+      (kv._1, "******")
+    } else kv
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -25,11 +25,9 @@ import org.apache.spark.ui.{UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
-  // Spark Properties (lowercase). Their values will be changed to ***** in WebUI
-  private val propertiesToMask = Set("spark.authenticate.secret")
 
   private def removePass(kv: (String, String)): (String, String) = {
-    if (kv._1.toLowerCase.contains("password") || propertiesToMask.contains(kv._1.toLowerCase)) {
+    if (kv._1.toLowerCase.contains("password") || kv._1.toLowerCase.contains("secret")) {
       (kv._1, "******")
     } else kv
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mask `spark.authenticate.secret` on Spark environment page (Web UI).
This is addition to https://github.com/apache/spark/pull/14409
## How was this patch tested?

`./dev/run-tests`
[info] ScalaTest
[info] Run completed in 1 hour, 8 minutes, 38 seconds.
[info] Total number of tests run: 2166
[info] Suites: completed 65, aborted 0
[info] Tests: succeeded 2166, failed 0, canceled 0, ignored 590, pending 0
[info] All tests passed.
