### PR TITLE
[SQL][MINOR] Adds parentheses to quote the child expression in GetStructField toString method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -113,7 +113,7 @@ case class GetStructField(child: Expression, ordinal: Int, name: Option[String] 
 
   override def toString: String = {
     val fieldName = if (resolved) childSchema(ordinal).name else s"_$ordinal"
-    s"$child.${name.getOrElse(fieldName)}"
+    s"($child).${name.getOrElse(fieldName)}"
   }
 
   override def sql: String =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds parentheses to quote the child expression in `GetStructField.toString`.
## How was this patch tested?

N/A
