### PR TITLE
[MINOR][SparkR] R API documentation for "coltypes" is confusing

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -223,7 +223,7 @@ setMethod("showDF",
 #' sparkR.session()
 #' path <- "path/to/file.json"
 #' df <- read.json(path)
-#' df
+#' show(df)
 #'}
 #' @note show(SparkDataFrame) since 1.4.0
 setMethod("show", "SparkDataFrame",

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -358,7 +358,7 @@ setMethod("colnames<-",
 #'
 #' Get column types of a SparkDataFrame
 #'
-#' @param x A SparkDataFrame
+#' @param x A SparkDataFrame whose column types to be get
 #' @return value A character vector with the column types of the given SparkDataFrame
 #' @rdname coltypes
 #' @aliases coltypes,SparkDataFrame-method
@@ -411,7 +411,7 @@ setMethod("coltypes",
 #'
 #' Set the column types of a SparkDataFrame.
 #'
-#' @param x A SparkDataFrame
+#' @param y A SparkDataFrame whose column types to be set
 #' @param value A character vector with the target column types for the given
 #'    SparkDataFrame. Column types can be one of integer, numeric/double, character, logical, or NA
 #'    to keep that column as-is.
@@ -429,9 +429,9 @@ setMethod("coltypes",
 #'}
 #' @note coltypes<- since 1.6.0
 setMethod("coltypes<-",
-          signature(x = "SparkDataFrame", value = "character"),
-          function(x, value) {
-            cols <- columns(x)
+          signature(y = "SparkDataFrame", value = "character"),
+          function(y, value) {
+            cols <- columns(y)
             ncols <- length(cols)
             if (length(value) == 0) {
               stop("Cannot set types of an empty SparkDataFrame with no Column")
@@ -440,7 +440,7 @@ setMethod("coltypes<-",
               stop("Length of type vector should match the number of columns for SparkDataFrame")
             }
             newCols <- lapply(seq_len(ncols), function(i) {
-              col <- getColumn(x, cols[i])
+              col <- getColumn(y, cols[i])
               if (!is.na(value[i])) {
                 stype <- rToSQLTypes[[value[i]]]
                 if (is.null(stype)) {
@@ -451,7 +451,7 @@ setMethod("coltypes<-",
                 col
               }
             })
-            nx <- select(x, newCols)
+            nx <- select(y, newCols)
             dataFrame(nx@sdf)
           })
 

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -358,7 +358,7 @@ setMethod("colnames<-",
 #'
 #' Get column types of a SparkDataFrame
 #'
-#' @param x A SparkDataFrame whose column types to be get
+#' @param x A SparkDataFrame
 #' @return value A character vector with the column types of the given SparkDataFrame
 #' @rdname coltypes
 #' @aliases coltypes,SparkDataFrame-method
@@ -411,7 +411,6 @@ setMethod("coltypes",
 #'
 #' Set the column types of a SparkDataFrame.
 #'
-#' @param y A SparkDataFrame whose column types to be set
 #' @param value A character vector with the target column types for the given
 #'    SparkDataFrame. Column types can be one of integer, numeric/double, character, logical, or NA
 #'    to keep that column as-is.
@@ -429,9 +428,9 @@ setMethod("coltypes",
 #'}
 #' @note coltypes<- since 1.6.0
 setMethod("coltypes<-",
-          signature(y = "SparkDataFrame", value = "character"),
-          function(y, value) {
-            cols <- columns(y)
+          signature(x = "SparkDataFrame", value = "character"),
+          function(x, value) {
+            cols <- columns(x)
             ncols <- length(cols)
             if (length(value) == 0) {
               stop("Cannot set types of an empty SparkDataFrame with no Column")
@@ -440,7 +439,7 @@ setMethod("coltypes<-",
               stop("Length of type vector should match the number of columns for SparkDataFrame")
             }
             newCols <- lapply(seq_len(ncols), function(i) {
-              col <- getColumn(y, cols[i])
+              col <- getColumn(x, cols[i])
               if (!is.na(value[i])) {
                 stype <- rToSQLTypes[[value[i]]]
                 if (is.null(stype)) {
@@ -451,7 +450,7 @@ setMethod("coltypes<-",
                 col
               }
             })
-            nx <- select(y, newCols)
+            nx <- select(x, newCols)
             dataFrame(nx@sdf)
           })
 

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -368,7 +368,7 @@ setMethod("colnames<-",
 #' @examples
 #'\dontrun{
 #' irisDF <- createDataFrame(iris)
-#' coltypes(irisDF)
+#' coltypes(irisDF) # get column types
 #'}
 #' @note coltypes since 1.6.0
 setMethod("coltypes",
@@ -424,8 +424,8 @@ setMethod("coltypes",
 #' sparkR.session()
 #' path <- "path/to/file.json"
 #' df <- read.json(path)
-#' coltypes(df) <- c("character", "integer")
-#' coltypes(df) <- c(NA, "numeric")
+#' coltypes(df) <- c("character", "integer") # set column types
+#' coltypes(df) <- c(NA, "numeric") # set column types
 #'}
 #' @note coltypes<- since 1.6.0
 setMethod("coltypes<-",

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -428,7 +428,7 @@ setGeneric("coltypes", function(x) { standardGeneric("coltypes") })
 
 #' @rdname coltypes
 #' @export
-setGeneric("coltypes<-", function(x, value) { standardGeneric("coltypes<-") })
+setGeneric("coltypes<-", function(y, value) { standardGeneric("coltypes<-") })
 
 #' @rdname columns
 #' @export

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -428,7 +428,7 @@ setGeneric("coltypes", function(x) { standardGeneric("coltypes") })
 
 #' @rdname coltypes
 #' @export
-setGeneric("coltypes<-", function(y, value) { standardGeneric("coltypes<-") })
+setGeneric("coltypes<-", function(x, value) { standardGeneric("coltypes<-") })
 
 #' @rdname columns
 #' @export


### PR DESCRIPTION
## What changes were proposed in this pull request?

R API documentation for "coltypes" is confusing, found when working on another ticket.

Current version http://spark.apache.org/docs/2.0.0/api/R/coltypes.html, where parameters have 2 "x" which is a duplicate, and also the example is not very clear

![current](https://cloud.githubusercontent.com/assets/3925641/17386808/effb98ce-59a2-11e6-9657-d477d258a80c.png)

![screen shot 2016-08-03 at 5 56 00 pm](https://cloud.githubusercontent.com/assets/3925641/17386884/91831096-59a3-11e6-84af-39890b3d45d8.png)
## How was this patch tested?

Tested manually on local machine. And the screenshots are like below:

![screen shot 2016-08-07 at 11 29 20 pm](https://cloud.githubusercontent.com/assets/3925641/17471144/df36633c-5cf6-11e6-8238-4e32ead0e529.png)

![screen shot 2016-08-03 at 5 56 22 pm](https://cloud.githubusercontent.com/assets/3925641/17386896/9d36cb26-59a3-11e6-9619-6dae29f7ab17.png)
