### PR TITLE
[SPARK-16887] Add SPARK_DIST_CLASSPATH to LAUNCH_CLASSPATH

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -47,7 +47,7 @@ if [ ! -d "$SPARK_JARS_DIR" ] && [ -z "$SPARK_TESTING$SPARK_SQL_TESTING" ]; then
   echo "You need to build Spark with the target \"package\" before running this program." 1>&2
   exit 1
 else
-  LAUNCH_CLASSPATH="$SPARK_JARS_DIR/*"
+  LAUNCH_CLASSPATH="$SPARK_JARS_DIR/*:$SPARK_DIST_CLASSPATH"
 fi
 
 # Add the launcher build dir to the classpath if requested.

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -41,7 +41,7 @@ if not exist "%SPARK_JARS_DIR%"\ (
   exit /b 1
 )
 
-set LAUNCH_CLASSPATH=%SPARK_JARS_DIR%\*
+set LAUNCH_CLASSPATH="%SPARK_JARS_DIR%\*;%SPARK_DIST_CLASSPATH%"
 
 rem Add the launcher build dir to the classpath if requested.
 if not "x%SPARK_PREPEND_CLASSES%"=="x" (


### PR DESCRIPTION
## What changes were proposed in this pull request?

To deploy Spark, it can be pretty convenient to put all jars (spark jars, hadoop jars, and other libs' jars) that we want to include in the classpath of Spark in the same dir, which may not be spark's assembly dir. So, I am proposing to also add SPARK_DIST_CLASSPATH to the LAUNCH_CLASSPATH.
