### PR TITLE
[SPARK-16586][core] Handle JVM errors printed to stdout.

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -80,6 +80,15 @@ done < <(build_command "$@")
 COUNT=${#CMD[@]}
 LAST=$((COUNT - 1))
 LAUNCHER_EXIT_CODE=${CMD[$LAST]}
+
+# Certain JVM failures result in error being printed to stdout (instead of stderr), which causes
+# the code that parses the output of the launcher to get confused. In those cases, we check if
+# the exit code is an integer, and if it's not, handle it as a special error case.
+if ! [[ $LAUNCHER_EXIT_CODE =~ ^[0-9]+$ ]]; then
+  echo "${CMD[@]}" | head -n-1 1>&2
+  exit 1
+fi
+
 if [ $LAUNCHER_EXIT_CODE != 0 ]; then
   exit $LAUNCHER_EXIT_CODE
 fi

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -81,9 +81,9 @@ COUNT=${#CMD[@]}
 LAST=$((COUNT - 1))
 LAUNCHER_EXIT_CODE=${CMD[$LAST]}
 
-# Certain JVM failures result in error being printed to stdout (instead of stderr), which causes
-# the code that parses the output of the launcher to get confused. In those cases, we check if
-# the exit code is an integer, and if it's not, handle it as a special error case.
+# Certain JVM failures result in errors being printed to stdout (instead of stderr), which causes
+# the code that parses the output of the launcher to get confused. In those cases, check if the
+# exit code is an integer, and if it's not, handle it as a special error case.
 if ! [[ $LAUNCHER_EXIT_CODE =~ ^[0-9]+$ ]]; then
   echo "${CMD[@]}" | head -n-1 1>&2
   exit 1


### PR DESCRIPTION
Some very rare JVM errors are printed to stdout, and that confuses
the code in spark-class. So add a check so that those cases are
detected and the proper error message is shown to the user.

Tested by running spark-submit after setting "ulimit -v 32000".

Closes #14231
