### PR TITLE
[SPARK-16610][SQL] Add `orc.compress` as an alias for `compression` option.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -67,9 +67,9 @@ private[sql] class OrcFileFormat
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
-    val configuration = job.getConfiguration
+    val orcOptions = new OrcOptions(options)
 
-    val orcOptions = new OrcOptions(options, configuration)
+    val configuration = job.getConfiguration
 
     configuration.set(OrcRelation.ORC_COMPRESSION, orcOptions.compressionCodec)
     configuration match {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -67,7 +67,6 @@ private[sql] class OrcFileFormat
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
-
     val configuration = job.getConfiguration
 
     val orcOptions = new OrcOptions(options, configuration)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -67,9 +67,10 @@ private[sql] class OrcFileFormat
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
-    val orcOptions = new OrcOptions(options)
 
     val configuration = job.getConfiguration
+
+    val orcOptions = new OrcOptions(options, configuration)
 
     configuration.set(OrcRelation.ORC_COMPRESSION, orcOptions.compressionCodec)
     configuration match {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
@@ -17,27 +17,39 @@
 
 package org.apache.spark.sql.hive.orc
 
+import org.apache.hadoop.conf.Configuration
+
 /**
  * Options for the ORC data source.
  */
 private[orc] class OrcOptions(
-    @transient private val parameters: Map[String, String])
+    @transient private val parameters: Map[String, String],
+    @transient private val conf: Configuration)
   extends Serializable {
 
   import OrcOptions._
 
   /**
-   * Compression codec to use. By default snappy compression.
+   * Compression codec to use. By default use the value specified in Hadoop configuration.
    * Acceptable values are defined in [[shortOrcCompressionCodecNames]].
    */
   val compressionCodec: String = {
-    val codecName = parameters.getOrElse("compression", "snappy").toLowerCase
-    if (!shortOrcCompressionCodecNames.contains(codecName)) {
-      val availableCodecs = shortOrcCompressionCodecNames.keys.map(_.toLowerCase)
-      throw new IllegalArgumentException(s"Codec [$codecName] " +
-        s"is not available. Available codecs are ${availableCodecs.mkString(", ")}.")
+    val default = conf.get(OrcRelation.ORC_COMPRESSION, "NONE")
+
+    // Because the ORC configuration value in `default` is not guaranteed to be the same
+    // with keys in `shortOrcCompressionCodecNames` in Spark, this value should not be
+    // used as the key for `shortOrcCompressionCodecNames` but just a return value.
+    parameters.get("compression") match {
+      case None => default
+      case Some(name) =>
+        val lowerCaseName = name.toLowerCase
+        if (!shortOrcCompressionCodecNames.contains(lowerCaseName)) {
+          val availableCodecs = shortOrcCompressionCodecNames.keys.map(_.toLowerCase)
+          throw new IllegalArgumentException(s"Codec [$lowerCaseName] " +
+            s"is not available. Available codecs are ${availableCodecs.mkString(", ")}.")
+        }
+        shortOrcCompressionCodecNames(lowerCaseName)
     }
-    shortOrcCompressionCodecNames(codecName)
   }
 }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
@@ -31,6 +31,7 @@ private[orc] class OrcOptions(
 
   /**
    * Compression codec to use. By default use the value specified in Hadoop configuration.
+   * If `orc.compress` is unset, then we use snappy.
    * Acceptable values are defined in [[shortOrcCompressionCodecNames]].
    */
   val compressionCodec: String = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
@@ -30,8 +30,14 @@ private[orc] class OrcOptions(@transient private val parameters: Map[String, Str
    * Acceptable values are defined in [[shortOrcCompressionCodecNames]].
    */
   val compressionCodec: String = {
-    val codecName = parameters.getOrElse(
-      "compression", parameters.getOrElse("orc.compress", "snappy")).toLowerCase
+    // `orc.compress` is a ORC configuration. So, here we respect this as an option but
+    // `compression` has higher precedence than `orc.compress`. It means if both are set,
+    // we will use `compression`.
+    val orcCompressionConf = parameters.get(OrcRelation.ORC_COMPRESSION)
+    val codecName = parameters
+      .get("compression")
+      .orElse(orcCompressionConf)
+      .getOrElse("snappy").toLowerCase
     if (!shortOrcCompressionCodecNames.contains(codecName)) {
       val availableCodecs = shortOrcCompressionCodecNames.keys.map(_.toLowerCase)
       throw new IllegalArgumentException(s"Codec [$codecName] " +

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
@@ -17,40 +17,27 @@
 
 package org.apache.spark.sql.hive.orc
 
-import org.apache.hadoop.conf.Configuration
-
 /**
  * Options for the ORC data source.
  */
-private[orc] class OrcOptions(
-    @transient private val parameters: Map[String, String],
-    @transient private val conf: Configuration)
+private[orc] class OrcOptions(@transient private val parameters: Map[String, String])
   extends Serializable {
 
   import OrcOptions._
 
   /**
-   * Compression codec to use. By default use the value specified in Hadoop configuration.
-   * If `orc.compress` is unset, then we use snappy.
+   * Compression codec to use. By default snappy compression.
    * Acceptable values are defined in [[shortOrcCompressionCodecNames]].
    */
   val compressionCodec: String = {
-    val default = conf.get(OrcRelation.ORC_COMPRESSION, "SNAPPY")
-
-    // Because the ORC configuration value in `default` is not guaranteed to be the same
-    // with keys in `shortOrcCompressionCodecNames` in Spark, this value should not be
-    // used as the key for `shortOrcCompressionCodecNames` but just a return value.
-    parameters.get("compression") match {
-      case None => default
-      case Some(name) =>
-        val lowerCaseName = name.toLowerCase
-        if (!shortOrcCompressionCodecNames.contains(lowerCaseName)) {
-          val availableCodecs = shortOrcCompressionCodecNames.keys.map(_.toLowerCase)
-          throw new IllegalArgumentException(s"Codec [$lowerCaseName] " +
-            s"is not available. Available codecs are ${availableCodecs.mkString(", ")}.")
-        }
-        shortOrcCompressionCodecNames(lowerCaseName)
+    val codecName = parameters.getOrElse(
+      "compression", parameters.getOrElse("orc.compress", "snappy")).toLowerCase
+    if (!shortOrcCompressionCodecNames.contains(codecName)) {
+      val availableCodecs = shortOrcCompressionCodecNames.keys.map(_.toLowerCase)
+      throw new IllegalArgumentException(s"Codec [$codecName] " +
+        s"is not available. Available codecs are ${availableCodecs.mkString(", ")}.")
     }
+    shortOrcCompressionCodecNames(codecName)
   }
 }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
@@ -34,7 +34,7 @@ private[orc] class OrcOptions(
    * Acceptable values are defined in [[shortOrcCompressionCodecNames]].
    */
   val compressionCodec: String = {
-    val default = conf.get(OrcRelation.ORC_COMPRESSION, "NONE")
+    val default = conf.get(OrcRelation.ORC_COMPRESSION, "SNAPPY")
 
     // Because the ORC configuration value in `default` is not guaranteed to be the same
     // with keys in `shortOrcCompressionCodecNames` in Spark, this value should not be

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
@@ -161,7 +161,7 @@ class OrcQuerySuite extends QueryTest with BeforeAndAfterAll with OrcTest {
     }
   }
 
-  test("SPARK-16610: Respect orc.compress configuration when compression is unset") {
+  test("SPARK-16610: Respect orc.compress option when compression is unset") {
     // Respect `orc.compress`.
     withTempPath { file =>
       spark.range(0, 10).write

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcQuerySuite.scala
@@ -161,6 +161,29 @@ class OrcQuerySuite extends QueryTest with BeforeAndAfterAll with OrcTest {
     }
   }
 
+  test("SPARK-16610: Respect orc.compress configuration when compression is unset") {
+    // Respect `orc.compress`.
+    withTempPath { file =>
+      spark.range(0, 10).write
+        .option("orc.compress", "ZLIB")
+        .orc(file.getCanonicalPath)
+      val expectedCompressionKind =
+        OrcFileOperator.getFileReader(file.getCanonicalPath).get.getCompression
+      assert("ZLIB" === expectedCompressionKind.name())
+    }
+
+    // `compression` overrides `orc.compress`.
+    withTempPath { file =>
+      spark.range(0, 10).write
+        .option("compression", "ZLIB")
+        .option("orc.compress", "SNAPPY")
+        .orc(file.getCanonicalPath)
+      val expectedCompressionKind =
+        OrcFileOperator.getFileReader(file.getCanonicalPath).get.getCompression
+      assert("ZLIB" === expectedCompressionKind.name())
+    }
+  }
+
   // Hive supports zlib, snappy and none for Hive 1.2.1.
   test("Compression options for writing to an ORC file (SNAPPY, ZLIB and NONE)") {
     withTempPath { file =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

For ORC source, Spark SQL has a writer option `compression`, which is used to set the codec and its value will be also set to `orc.compress` (the orc conf used for codec). However, if a user only set `orc.compress` in the writer option, we should not use the default value of `compression` (snappy) as the codec. Instead, we should respect the value of `orc.compress`.

This PR makes ORC data source not ignoring `orc.compress` when `comperssion` is unset.

So, here is the behaviour,
1. Check `compression` and use this if it is set.
2. If `compression` is not set, check `orc.compress` and use it.
3. If `compression` and `orc.compress` are not set, then use the default snappy.
## How was this patch tested?

Unit test in `OrcQuerySuite`.
