### PR TITLE
[SPARK-16832] [ML] [WIP] CrossValidator and TrainValidationSplit are not random without seed

### DIFF
--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -549,15 +549,15 @@ test_that("spark.gaussianMixture", {
   df <- createDataFrame(data, c("x1", "x2"))
   model <- spark.gaussianMixture(df, ~ x1 + x2, k = 2)
   stats <- summary(model)
-  rLambda <- c(0.4666667, 0.5333333)
-  rMu <- c(0.11731091, -0.06192351, 10.363673, 9.897081)
-  rSigma <- c(0.62049934, 0.06880802, 0.06880802, 1.27431874,
-              0.2961543, 0.160783, 0.1607830, 1.008878)
+  rLambda <- c(0.5333333, 0.4666667)
+  rMu <- c(10.363673, 9.897081, 0.11731091, -0.06192351)
+  rSigma <- c(0.2961543, 0.160783, 0.1607830, 1.008878,
+              0.62049934, 0.06880802, 0.06880802, 1.27431874)
   expect_equal(stats$lambda, rLambda, tolerance = 1e-3)
   expect_equal(unlist(stats$mu), rMu, tolerance = 1e-3)
   expect_equal(unlist(stats$sigma), rSigma, tolerance = 1e-3)
   p <- collect(select(predict(model, df), "prediction"))
-  expect_equal(p$prediction, c(0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1))
+  expect_equal(p$prediction, c(1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0))
 
   # Test model save/load
   modelPath <- tempfile(pattern = "spark-gaussianMixture", fileext = ".tmp")

--- a/docs/mllib-clustering.md
+++ b/docs/mllib-clustering.md
@@ -379,7 +379,7 @@ The implementation in MLlib has the following parameters:
 * *k*: the desired number of leaf clusters (default: 4). The actual number could be smaller if there are no divisible leaf clusters.
 * *maxIterations*: the max number of k-means iterations to split clusters (default: 20)
 * *minDivisibleClusterSize*: the minimum number of points (if >= 1.0) or the minimum proportion of points (if < 1.0) of a divisible cluster (default: 1)
-* *seed*: a random seed (default: hash value of the class name)
+* *seed*: a random seed
 
 **Examples**
 

--- a/mllib/src/main/scala/org/apache/spark/ml/ann/Layer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/ann/Layer.scala
@@ -684,7 +684,7 @@ private[ml] class FeedForwardTrainer(
     val inputSize: Int,
     val outputSize: Int) extends Serializable {
 
-  private var _seed = this.getClass.getName.hashCode.toLong
+  private var _seed = new Random().nextLong()
   private var _weights: Vector = null
   private var _stackSize = 128
   private var dataStacker = new DataStacker(_stackSize, inputSize, outputSize)

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
@@ -67,7 +67,7 @@ private[shared] object SharedParamsCodeGen {
         isValid = "ParamValidators.inArray(Array(\"skip\", \"error\"))"),
       ParamDesc[Boolean]("standardization", "whether to standardize the training features" +
         " before fitting the model", Some("true")),
-      ParamDesc[Long]("seed", "random seed", Some("this.getClass.getName.hashCode.toLong")),
+      ParamDesc[Long]("seed", "random seed", Some("new java.util.Random().nextLong()")),
       ParamDesc[Double]("elasticNetParam", "the ElasticNet mixing parameter, in range [0, 1]." +
         " For alpha = 0, the penalty is an L2 penalty. For alpha = 1, it is an L1 penalty",
         isValid = "ParamValidators.inRange(0, 1)"),

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -297,7 +297,7 @@ private[ml] trait HasStandardization extends Params {
 }
 
 /**
- * Trait for shared param seed (default: this.getClass.getName.hashCode.toLong).
+ * Trait for shared param seed (default: new java.util.Random().nextLong()).
  */
 private[ml] trait HasSeed extends Params {
 
@@ -307,7 +307,7 @@ private[ml] trait HasSeed extends Params {
    */
   final val seed: LongParam = new LongParam(this, "seed", "random seed")
 
-  setDefault(seed, this.getClass.getName.hashCode.toLong)
+  setDefault(seed, new java.util.Random().nextLong())
 
   /** @group getParam */
   final def getSeed: Long = $(seed)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -126,13 +126,15 @@ private[python] class PythonMLLibAPI extends Serializable {
       k: Int,
       maxIterations: Int,
       minDivisibleClusterSize: Double,
-      seed: Long): BisectingKMeansModel = {
-    new BisectingKMeans()
+      seed: java.lang.Long): BisectingKMeansModel = {
+    val algo = new BisectingKMeans()
       .setK(k)
       .setMaxIterations(maxIterations)
       .setMinDivisibleClusterSize(minDivisibleClusterSize)
-      .setSeed(seed)
-      .run(data)
+
+    if (seed != null) algo.setSeed(seed)
+
+    algo.run(data)
   }
 
   /**
@@ -678,7 +680,7 @@ private[python] class PythonMLLibAPI extends Serializable {
       learningRate: Double,
       numPartitions: Int,
       numIterations: Int,
-      seed: Long,
+      seed: java.lang.Long,
       minCount: Int,
       windowSize: Int): Word2VecModelWrapper = {
     val word2vec = new Word2Vec()
@@ -686,9 +688,11 @@ private[python] class PythonMLLibAPI extends Serializable {
       .setLearningRate(learningRate)
       .setNumPartitions(numPartitions)
       .setNumIterations(numIterations)
-      .setSeed(seed)
       .setMinCount(minCount)
       .setWindowSize(windowSize)
+
+    if (seed != null) word2vec.setSeed(seed)
+
     try {
       val model = word2vec.fit(dataJRDD.rdd.persist(StorageLevel.MEMORY_AND_DISK_SER))
       new Word2VecModelWrapper(model)
@@ -751,7 +755,7 @@ private[python] class PythonMLLibAPI extends Serializable {
       impurityStr: String,
       maxDepth: Int,
       maxBins: Int,
-      seed: Int): RandomForestModel = {
+      seed: java.lang.Long): RandomForestModel = {
 
     val algo = Algo.fromString(algoStr)
     val impurity = Impurities.fromString(impurityStr)
@@ -763,11 +767,13 @@ private[python] class PythonMLLibAPI extends Serializable {
       maxBins = maxBins,
       categoricalFeaturesInfo = categoricalFeaturesInfo.asScala.toMap)
     val cached = data.rdd.persist(StorageLevel.MEMORY_AND_DISK)
+    // Only done because methods below want an int, not an optional Long
+    val intSeed = getSeedOrDefault(seed).toInt
     try {
       if (algo == Algo.Classification) {
-        RandomForest.trainClassifier(cached, strategy, numTrees, featureSubsetStrategy, seed)
+        RandomForest.trainClassifier(cached, strategy, numTrees, featureSubsetStrategy, intSeed)
       } else {
-        RandomForest.trainRegressor(cached, strategy, numTrees, featureSubsetStrategy, seed)
+        RandomForest.trainRegressor(cached, strategy, numTrees, featureSubsetStrategy, intSeed)
       }
     } finally {
       cached.unpersist(blocking = false)

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeans.scala
@@ -45,7 +45,7 @@ import org.apache.spark.storage.StorageLevel
  * @param maxIterations the max number of k-means iterations to split clusters (default: 20)
  * @param minDivisibleClusterSize the minimum number of points (if >= 1.0) or the minimum proportion
  *                                of points (if < 1.0) of a divisible cluster (default: 1)
- * @param seed a random seed (default: hash value of the class name)
+ * @param seed a random seed
  *
  * @see [[http://glaros.dtc.umn.edu/gkhome/fetch/papers/docclusterKDDTMW00.pdf
  *     Steinbach, Karypis, and Kumar, A comparison of document clustering techniques,
@@ -119,7 +119,7 @@ class BisectingKMeans private (
   def getMinDivisibleClusterSize: Double = minDivisibleClusterSize
 
   /**
-   * Sets the random seed (default: hash value of the class name).
+   * Sets the random seed.
    */
   @Since("1.6.0")
   def setSeed(seed: Long): this.type = {

--- a/python/pyspark/ml/param/shared.py
+++ b/python/pyspark/ml/param/shared.py
@@ -311,7 +311,7 @@ class HasSeed(Params):
 
     def __init__(self):
         super(HasSeed, self).__init__()
-        self._setDefault(seed=hash(type(self).__name__))
+        self._setDefault(seed=None)
 
     def setSeed(self, value):
         """

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -375,8 +375,6 @@ class ParamTests(PySparkTestCase):
         self.assertEqual(noSeedSpecd.getSeed(), origSeed)
         # Check that a specified seed is honored
         self.assertEqual(withSeedSpecd.getSeed(), 42)
-        # Check that a different class has a different seed
-        self.assertNotEqual(other.getSeed(), noSeedSpecd.getSeed())
 
     def test_param_property_error(self):
         param_store = HasThrowableProperty()

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -140,7 +140,7 @@ class BisectingKMeans(object):
 
     @classmethod
     @since('2.0.0')
-    def train(self, rdd, k=4, maxIterations=20, minDivisibleClusterSize=1.0, seed=-1888008604):
+    def train(self, rdd, k=4, maxIterations=20, minDivisibleClusterSize=1.0, seed=None):
         """
         Runs the bisecting k-means algorithm return the model.
 

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -676,7 +676,7 @@ class Word2Vec(object):
             raise TypeError("data should be an RDD of list of string")
         jmodel = callMLlibFunc("trainWord2VecModel", data, int(self.vectorSize),
                                float(self.learningRate), int(self.numPartitions),
-                               int(self.numIterations), int(self.seed),
+                               int(self.numIterations), self.seed,
                                int(self.minCount), int(self.windowSize))
         return Word2VecModel(jmodel)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default random seed for ML classes should be random not fixed to class `hashCode`
## How was this patch tested?

Existing Jenkins tests
