### PR TITLE
[SPARK-16939][SQL] Fix build error by using `Tuple1` explicitly in StringFunctionsSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -95,7 +95,7 @@ class StringFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("non-matching optional group") {
-    val df = Seq("aaaac").toDF("s")
+    val df = Seq(Tuple1("aaaac")).toDF("s")
     checkAnswer(
       df.select(regexp_extract($"s", "(a+)(b)?(c)", 2)),
       Row("")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to fix a build error on branch 1.6 at https://github.com/apache/spark/commit/8d8725208771a8815a60160a5a30dc6ea87a7e6a, but I think we had better have this consistently in master branch, too. It's because there exist other ongoing PR (https://github.com/apache/spark/pull/14525) about this.

https://amplab.cs.berkeley.edu/jenkins/job/spark-branch-1.6-compile-maven-with-yarn-2.3/286/console

``` scala
[error] /home/jenkins/workspace/spark-branch-1.6-compile-maven-with-yarn-2.3/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala:82: value toDF is not a member of Seq[String]
[error]     val df = Seq("aaaac").toDF("s")
[error]                           ^
```
## How was this patch tested?

After passing Jenkins, run compilation test on branch 1.6.

```
build/mvn -DskipTests -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver install
```
