### PR TITLE
[SPARK-16938][SQL] `drop/dropDuplicate` should handle the columns with qualified names

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1879,7 +1879,7 @@ class Dataset[T] private[sql](
     val resolver = sparkSession.sessionState.analyzer.resolver
     val allColumns = queryExecution.analyzed.output
     val groupCols = colNames.map { colName =>
-      allColumns.find(col => resolver(col.name, colName)).getOrElse(
+      allColumns.find(col => resolver(col.qualifiedName, colName)).getOrElse(
         throw new AnalysisException(
           s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")})"""))
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1827,7 +1827,7 @@ class Dataset[T] private[sql](
     val resolver = sparkSession.sessionState.analyzer.resolver
     val allColumns = queryExecution.analyzed.output
     val remainingCols = allColumns.filter { attribute =>
-      colNames.forall(n => !resolver(attribute.name, n))
+      colNames.forall(n => !(resolver(attribute.name, n) || resolver(attribute.qualifiedName, n)))
     }.map(attribute => Column(attribute))
     if (remainingCols.size == allColumns.size) {
       toDF()
@@ -1879,8 +1879,8 @@ class Dataset[T] private[sql](
     val resolver = sparkSession.sessionState.analyzer.resolver
     val allColumns = queryExecution.analyzed.output
     val groupCols = colNames.map { colName =>
-      allColumns.find(col => resolver(col.qualifiedName, colName)).getOrElse(
-        throw new AnalysisException(
+      allColumns.find(col => resolver(col.qualifiedName, colName) || resolver(col.name, colName))
+        .getOrElse(throw new AnalysisException(
           s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")})"""))
     }
     val groupColExprIds = groupCols.map(_.exprId)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1571,6 +1571,11 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(dfa.drop($"dfa.id"), Row(2) :: Row(3) :: Nil)
     checkAnswer(dfa.drop($"id"), Row(2) :: Row(3) :: Nil)
 
+    checkAnswer(dfa.join(dfb, dfa("id") === dfb("id")).drop("dfa.id"),
+      Row(2, 1, 0) :: Row(2, 1, 1) :: Nil)
+    checkAnswer(dfa.join(dfb, dfa("id") === dfb("id")).drop("dfa.id", "dfb.id"),
+      Row(2, 0) :: Row(2, 1) :: Nil)
+
     checkAnswer(dfb.dropDuplicates(Array("dfb.id")), Row(1, 0) :: Nil)
     checkAnswer(dfb.dropDuplicates(Array("dfb.b")), Row(1, 0) :: Row(1, 1) :: Nil)
     checkAnswer(dfb.dropDuplicates(Array("id")), Row(1, 0) :: Nil)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1562,9 +1562,20 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.distinct(), Row(1) :: Row(2) :: Nil)
   }
 
-  test("SPARK-16938: `dropDuplicate` should not raise exception on qualified column names") {
+  test("SPARK-16938: `drop/dropDuplicate` should handle qualified column names") {
     val dfa = Seq((1, 2), (2, 3)).toDF("id", "a").alias("dfa")
     val dfb = Seq((1, 0), (1, 1)).toDF("id", "b").alias("dfb")
+
+    checkAnswer(dfa.drop("dfa.id"), Row(2) :: Row(3) :: Nil)
+    checkAnswer(dfa.drop("id"), Row(2) :: Row(3) :: Nil)
+    checkAnswer(dfa.drop($"dfa.id"), Row(2) :: Row(3) :: Nil)
+    checkAnswer(dfa.drop($"id"), Row(2) :: Row(3) :: Nil)
+
+    checkAnswer(dfb.dropDuplicates(Array("dfb.id")), Row(1, 0) :: Nil)
+    checkAnswer(dfb.dropDuplicates(Array("dfb.b")), Row(1, 0) :: Row(1, 1) :: Nil)
+    checkAnswer(dfb.dropDuplicates(Array("id")), Row(1, 0) :: Nil)
+    checkAnswer(dfb.dropDuplicates(Array("b")), Row(1, 0) :: Row(1, 1) :: Nil)
+
     checkAnswer(dfa.join(dfb, dfa("id") === dfb("id")).dropDuplicates(Array("dfa.id", "dfb.id")),
       Row(1, 2, 1, 1) :: Nil)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1562,6 +1562,13 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.distinct(), Row(1) :: Row(2) :: Nil)
   }
 
+  test("SPARK-16938: `dropDuplicate` should not raise exception on qualified column names") {
+    val dfa = Seq((1, 2), (2, 3)).toDF("id", "a").alias("dfa")
+    val dfb = Seq((1, 0), (1, 1)).toDF("id", "b").alias("dfb")
+    checkAnswer(dfa.join(dfb, dfa("id") === dfb("id")).dropDuplicates(Array("dfa.id", "dfb.id")),
+      Row(1, 2, 1, 1) :: Nil)
+  }
+
   test("SPARK-16181: outer join with isNull filter") {
     val left = Seq("x").toDF("col")
     val right = Seq("y").toDF("col").withColumn("new", lit(true))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes `dropDuplicate` not to raise exceptions on qualified column names. This bug is recently introduced by [SPARK-15230](https://issues.apache.org/jira/browse/SPARK-15230) with commit https://github.com/apache/spark/commit/925884a612dd88beaddf555c74d90856ab040ec7 . Also, this PR fixes `drop` to handle correctly qualified column names. Currently, it does not remove them correctly if the arguments are string types.

**Reported Scenarios**

``` scala
scala> val dfa = Seq((1, 2), (2, 3)).toDF("id", "a").alias("dfa")
scala> val dfb = Seq((1, 0), (1, 1)).toDF("id", "b").alias("dfb")
scala> dfa.join(dfb, dfa("id") === dfb("id")).dropDuplicates(Array("dfa.id", "dfb.id"))
org.apache.spark.sql.AnalysisException: Cannot resolve column name "dfa.id" among (id, a, id, b);
```

Here is the same result on [Databricks CE / Spark 2.0](https://databricks-prod-cloudfront.cloud.databricks.com/public/4027ec902e239c93eaaa8714f173bcfc/6660119172909095/3193434347349241/5162191866050912/latest.html).
## How was this patch tested?

Pass the Jenkins tests with a newly added test case.
