### PR TITLE
[TRIVIAL][SQL] Match the name of OrcRelation companion object to OrcFileFormat

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcOptions.scala
@@ -33,7 +33,7 @@ private[orc] class OrcOptions(@transient private val parameters: Map[String, Str
     // `orc.compress` is a ORC configuration. So, here we respect this as an option but
     // `compression` has higher precedence than `orc.compress`. It means if both are set,
     // we will use `compression`.
-    val orcCompressionConf = parameters.get(OrcRelation.ORC_COMPRESSION)
+    val orcCompressionConf = parameters.get(OrcFileFormat.ORC_COMPRESSION)
     val codecName = parameters
       .get("compression")
       .orElse(orcCompressionConf)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR simply matches the name `OrcRelation` to `OrcFileFormat`.

Just to make sure, `ParquetFileFormat` has the object named `ParquetFileFormat` and the related ones were renamed in https://github.com/apache/spark/commit/361ebc282b2d09dc6dcf21419a53c5c617b1b6bd all together but it seems renaming`OrcFileFormat` was missed.
## How was this patch tested?

N/A
