### PR TITLE
SPARK-16945: Fix Java Lint errors

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -221,7 +221,8 @@ public class JavaSQLDataSourceExample {
     // an RDD[String] storing one JSON object per string.
     List<String> jsonData = Arrays.asList(
             "{\"name\":\"Yin\",\"address\":{\"city\":\"Columbus\",\"state\":\"Ohio\"}}");
-    JavaRDD<String> anotherPeopleRDD = new JavaSparkContext(spark.sparkContext()).parallelize(jsonData);
+    JavaRDD<String> anotherPeopleRDD =
+            new JavaSparkContext(spark.sparkContext()).parallelize(jsonData);
     Dataset anotherPeople = spark.read().json(anotherPeopleRDD);
     anotherPeople.show();
     // +---------------+----+

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/FixedLengthRowBasedKeyValueBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/FixedLengthRowBasedKeyValueBatch.java
@@ -33,7 +33,7 @@ public final class FixedLengthRowBasedKeyValueBatch extends RowBasedKeyValueBatc
   private final int vlen;
   private final int recordLength;
 
-  private final long getKeyOffsetForFixedLengthRecords(int rowId) {
+  private long getKeyOffsetForFixedLengthRecords(int rowId) {
     return recordStartOffset + rowId * (long) recordLength;
   }
 
@@ -43,7 +43,7 @@ public final class FixedLengthRowBasedKeyValueBatch extends RowBasedKeyValueBatc
    * Returns an UnsafeRow pointing to the value if succeeds, otherwise returns null.
    */
   @Override
-  public final UnsafeRow appendRow(Object kbase, long koff, int klen,
+  public UnsafeRow appendRow(Object kbase, long koff, int klen,
                              Object vbase, long voff, int vlen) {
     // if run out of max supported rows or page size, return null
     if (numRows >= capacity || page == null || page.size() - pageCursor < recordLength) {
@@ -71,7 +71,7 @@ public final class FixedLengthRowBasedKeyValueBatch extends RowBasedKeyValueBatc
    * Returns the key row in this batch at `rowId`. Returned key row is reused across calls.
    */
   @Override
-  public final UnsafeRow getKeyRow(int rowId) {
+  public UnsafeRow getKeyRow(int rowId) {
     assert(rowId >= 0);
     assert(rowId < numRows);
     if (keyRowId != rowId) { // if keyRowId == rowId, desired keyRow is already cached
@@ -90,7 +90,7 @@ public final class FixedLengthRowBasedKeyValueBatch extends RowBasedKeyValueBatc
    * In most times, 1) is skipped because `getKeyRow(id)` is often called before `getValueRow(id)`.
    */
   @Override
-  protected final UnsafeRow getValueFromKey(int rowId) {
+  protected UnsafeRow getValueFromKey(int rowId) {
     if (keyRowId != rowId) {
       getKeyRow(rowId);
     }
@@ -103,7 +103,7 @@ public final class FixedLengthRowBasedKeyValueBatch extends RowBasedKeyValueBatc
    * Returns an iterator to go through all rows
    */
   @Override
-  public final org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> rowIterator() {
+  public org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> rowIterator() {
     return new org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow>() {
       private final UnsafeRow key = new UnsafeRow(keySchema.length());
       private final UnsafeRow value = new UnsafeRow(valueSchema.length());

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatch.java
@@ -123,7 +123,7 @@ public abstract class RowBasedKeyValueBatch extends MemoryConsumer {
     }
   }
 
-  private final boolean acquirePage(long requiredSize) {
+  private boolean acquirePage(long requiredSize) {
     try {
       page = allocatePage(requiredSize);
     } catch (OutOfMemoryError e) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/VariableLengthRowBasedKeyValueBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/VariableLengthRowBasedKeyValueBatch.java
@@ -39,7 +39,7 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
    * Returns an UnsafeRow pointing to the value if succeeds, otherwise returns null.
    */
   @Override
-  public final UnsafeRow appendRow(Object kbase, long koff, int klen,
+  public UnsafeRow appendRow(Object kbase, long koff, int klen,
                              Object vbase, long voff, int vlen) {
     final long recordLength = 8 + klen + vlen + 8;
     // if run out of max supported rows or page size, return null
@@ -94,7 +94,7 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
    * In most times, 1) is skipped because `getKeyRow(id)` is often called before `getValueRow(id)`.
    */
   @Override
-  public final UnsafeRow getValueFromKey(int rowId) {
+  public UnsafeRow getValueFromKey(int rowId) {
     if (keyRowId != rowId) {
       getKeyRow(rowId);
     }
@@ -110,7 +110,7 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
    * Returns an iterator to go through all rows
    */
   @Override
-  public final org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> rowIterator() {
+  public org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> rowIterator() {
     return new org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow>() {
       private final UnsafeRow key = new UnsafeRow(keySchema.length());
       private final UnsafeRow value = new UnsafeRow(valueSchema.length());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to fix the minor Java linter errors as following:
[ERROR] src/main/java/org/apache/spark/sql/catalyst/expressions/VariableLengthRowBasedKeyValueBatch.java:[42,10](modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/apache/spark/sql/catalyst/expressions/VariableLengthRowBasedKeyValueBatch.java:[97,10](modifier) RedundantModifier: Redundant 'final' modifier.
## How was this patch tested?

Manual test.
dev/lint-java
Using `mvn` from path: /usr/local/bin/mvn
Checkstyle checks passed.
