### PR TITLE
[SPARK-16946][SQL]throw Exception if saveAsTable[apend] has different…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -193,7 +193,13 @@ case class CreateDataSourceTableAsSelectCommand(
               }
               existingSchema = Some(l.schema)
             case s: SimpleCatalogRelation if DDLUtils.isDatasourceTable(s.metadata) =>
-              existingSchema = Some(DDLUtils.getSchemaFromTableProperties(s.metadata))
+            val schemaStruct = DDLUtils.getSchemaFromTableProperties(s.metadata)
+              if (query.schema.size != schemaStruct.size) {
+                throw new AnalysisException(
+                  s"The column number of the existing schema ${schemaStruct} " +
+                    s"doesn't match the column number of the inserted schema ${query.schema}")
+              }
+              existingSchema = Some(schemaStruct)
             case o =>
               throw new AnalysisException(s"Saving data in ${o.toString} is not supported.")
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1662,6 +1662,30 @@ class DDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
     }
   }
 
+  test("saveAsTable[append]: too many columns") {
+    import testImplicits._
+    withTable("saveAsTable_too_many_columns") {
+      Seq((1, 2)).toDF("i", "j").write.saveAsTable("saveAsTable_too_many_columns")
+      val e = intercept[AnalysisException] {
+        Seq((3, 4, 5)).toDF("i", "j", "k")
+          .write.mode("append").saveAsTable("saveAsTable_too_many_columns")
+      }
+      assert(e.getMessage.contains("doesn't match"))
+    }
+  }
+
+  test("saveAsTable[append]: less columns") {
+    import testImplicits._
+    withTable("saveAsTable_less_columns") {
+      Seq((1, 2)).toDF("i", "j").write.saveAsTable("saveAsTable_less_columns")
+      val e = intercept[AnalysisException] {
+        Seq((4)).toDF("j")
+          .write.mode("append").saveAsTable("saveAsTable_less_columns")
+      }
+      assert(e.getMessage.contains("doesn't match"))
+    }
+  }
+
   test("show functions") {
     withUserDefinedFunction("add_one" -> true) {
       val numFunctions = FunctionRegistry.functionSet.size.toLong


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HiveContext, if saveAsTable[append] has different number of columns, Spark will throw Exception.
e.g.

```
    test("saveAsTable[append]: too many columns") {
      withTable("saveAsTable_too_many_columns") {
        Seq((1, 2)).toDF("i", "j").write.saveAsTable("saveAsTable_too_many_columns")
        val e = intercept[AnalysisException] {
          Seq((3, 4, 5)).toDF("i", "j", "k").write.mode("append").saveAsTable("saveAsTable_too_many_columns")
        }
        assert(e.getMessage.contains("doesn't match"))
      }
    }

```

However, in SparkSession or SQLContext, if use the above code example, the extra column in the append data will be removed silently without any warning or Exception. The table becomes

```
i j
3 4
1 2

```

I changed the code to throw Exception  if saveAsTable[apend] has different column numbers
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Add unit tests to test the patch. 
