### PR TITLE
Bugs/mvn3.3.3

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -72,7 +72,7 @@ install_mvn() {
   local MVN_VERSION="3.3.3"
 
   install_app \
-    "https://www.apache.org/dyn/closer.lua?action=download&filename=/maven/maven-3/${MVN_VERSION}/binaries" \
+    "https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries"
     "apache-maven-${MVN_VERSION}-bin.tar.gz" \
     "apache-maven-${MVN_VERSION}/bin/mvn"
 

--- a/build/mvn
+++ b/build/mvn
@@ -72,7 +72,7 @@ install_mvn() {
   local MVN_VERSION="3.3.3"
 
   install_app \
-    "https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries"
+    "https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries" \
     "apache-maven-${MVN_VERSION}-bin.tar.gz" \
     "apache-maven-${MVN_VERSION}/bin/mvn"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing the URI for Maven 3.3.3, version is no longer available on previous endpoint
## How was this patch tested?

Successfully built spark using make_distribution after the patch was applied
