### PR TITLE
[SPARK-16709][CORE] Kill the running task if stage failed

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenc
 import scala.collection.JavaConverters._
 import scala.collection.Map
 import scala.collection.generic.Growable
-import scala.collection.mutable.{HashSet, HashMap}
+import scala.collection.mutable.{HashMap, HashSet}
 import scala.language.implicitConversions
 import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenc
 import scala.collection.JavaConverters._
 import scala.collection.Map
 import scala.collection.generic.Growable
-import scala.collection.mutable.{HashMap, HashSet}
+import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
 import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
@@ -1562,14 +1562,6 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
         logWarning("Killing executors is only supported in coarse-grained mode")
         false
     }
-  }
-
-  def killTasks(tasks: HashSet[Long], taskInfo: HashMap[Long, TaskInfo]): Boolean = {
-    tasks.foreach { task =>
-      val executorId = taskInfo(task).executorId
-      schedulerBackend.killTask(task, executorId, true)
-    }
-    true
   }
 
   /** The version of Spark on which this application is running. */

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenc
 import scala.collection.JavaConverters._
 import scala.collection.Map
 import scala.collection.generic.Growable
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{HashSet, HashMap}
 import scala.language.implicitConversions
 import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
@@ -1562,6 +1562,14 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
         logWarning("Killing executors is only supported in coarse-grained mode")
         false
     }
+  }
+
+  def killTasks(tasks: HashSet[Long], taskInfo: HashMap[Long, TaskInfo]): Boolean = {
+    tasks.foreach { task =>
+      val executorId = taskInfo(task).executorId
+      schedulerBackend.killTask(task, executorId, true)
+    }
+    true
   }
 
   /** The version of Spark on which this application is running. */

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -801,8 +801,16 @@ private[spark] class TaskSetManager(
 
     // kill running task if stage failed
     if(reason.isInstanceOf[FetchFailed]) {
-      sched.sc.killTasks(runningTasksSet, taskInfos)
+      killTasks(runningTasksSet, taskInfos)
     }
+  }
+
+  def killTasks(tasks: HashSet[Long], taskInfo: HashMap[Long, TaskInfo]): Boolean = {
+    tasks.foreach { task =>
+      val executorId = taskInfo(task).executorId
+      sched.sc.schedulerBackend.killTask(task, executorId, true)
+    }
+    true
   }
 
   def abort(message: String, exception: Option[Throwable] = None): Unit = sched.synchronized {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -800,17 +800,16 @@ private[spark] class TaskSetManager(
     maybeFinishTaskSet()
 
     // kill running task if stage failed
-    if(reason.isInstanceOf[FetchFailed]) {
+    if (reason.isInstanceOf[FetchFailed]) {
       killTasks(runningTasksSet, taskInfos)
     }
   }
 
-  def killTasks(tasks: HashSet[Long], taskInfo: HashMap[Long, TaskInfo]): Boolean = {
+  def killTasks(tasks: HashSet[Long], taskInfo: HashMap[Long, TaskInfo]): Unit = {
     tasks.foreach { task =>
       val executorId = taskInfo(task).executorId
       sched.sc.schedulerBackend.killTask(task, executorId, true)
     }
-    true
   }
 
   def abort(message: String, exception: Option[Throwable] = None): Unit = sched.synchronized {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -798,6 +798,11 @@ private[spark] class TaskSetManager(
       }
     }
     maybeFinishTaskSet()
+
+    // kill running task if stage failed
+    if(reason.isInstanceOf[FetchFailed]) {
+      sched.sc.killTasks(runningTasksSet, taskInfos)
+    }
   }
 
   def abort(message: String, exception: Option[Throwable] = None): Unit = sched.synchronized {


### PR DESCRIPTION
## What changes were proposed in this pull request?

At SPARK-16709,  when a stage failed, but the running task is still running, the retry stage will rerun the running task, it could cause TaskCommitDeniedException and task retry forever.

Here is the log:

```
16/07/28 05:22:15 INFO scheduler.TaskSetManager: Starting task 1.0 in stage 1.0 (TID 175, 10.215.146.81, partition 1,PROCESS_LOCAL, 1930 bytes)
16/07/28 05:28:35 INFO scheduler.TaskSetManager: Starting task 1.0 in stage 1.1 (TID 207, 10.196.147.232, partition 1,PROCESS_LOCAL, 1930 bytes)
16/07/28 05:28:48 INFO scheduler.TaskSetManager: Finished task 1.0 in stage 1.0 (TID 175) in 393261 ms on 10.215.146.81 (3/50)
16/07/28 05:34:11 WARN scheduler.TaskSetManager: Lost task 1.0 in stage 1.1 (TID 207, 10.196.147.232): TaskCommitDenied (Driver denied task commit) for job: 1, partition: 1, attemptNumber: 207
16/07/28 05:34:40 INFO scheduler.TaskSetManager: Starting task 1.1 in stage 1.1 (TID 227, 10.196.129.22, partition 1,PROCESS_LOCAL, 1930 bytes)
16/07/28 05:40:08 WARN scheduler.TaskSetManager: Lost task 1.1 in stage 1.1 (TID 227, 10.196.129.22): TaskCommitDenied (Driver denied task commit) for job: 1, partition: 1, attemptNumber: 227
16/07/28 05:42:28 INFO scheduler.TaskSetManager: Starting task 1.2 in stage 1.1 (TID 250, 10.215.146.82, partition 1,PROCESS_LOCAL, 1930 bytes)
...
```

1 task 1.0 in stage1.0 start
2 stage1.0 failed, start stage1.1.
3 task 1.0 in stage1.1 start
4 task 1.0 in stage1.0 finished.
5 task 1.0 in stage1.1 failed with TaskCommitDenied Exception, then retry forever.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
