### PR TITLE
[SPARK-16971][SQL] Strip trailing zeros for decimal's string representation when using show() API in Dataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -256,6 +256,12 @@ class Dataset[T] private[sql](
           case binary: Array[Byte] => binary.map("%02X".format(_)).mkString("[", " ", "]")
           case array: Array[_] => array.mkString("[", ", ", "]")
           case seq: Seq[_] => seq.mkString("[", ", ", "]")
+          case decimal: BigDecimal =>
+            val d = decimal.bigDecimal.stripTrailingZeros
+            if (d.scale() < 0) d.setScale(0).toString else d.toString
+          case jdecimal: java.math.BigDecimal =>
+            val d = jdecimal.stripTrailingZeros
+            if (d.scale() < 0) d.setScale(0).toString else d.toString
           case _ => cell.toString
         }
         if (truncate > 0 && str.length > truncate) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -256,9 +256,6 @@ class Dataset[T] private[sql](
           case binary: Array[Byte] => binary.map("%02X".format(_)).mkString("[", " ", "]")
           case array: Array[_] => array.mkString("[", ", ", "]")
           case seq: Seq[_] => seq.mkString("[", ", ", "]")
-          case decimal: BigDecimal =>
-            val d = decimal.bigDecimal.stripTrailingZeros
-            if (d.scale() < 0) d.setScale(0).toString else d.toString
           case jdecimal: java.math.BigDecimal =>
             val d = jdecimal.stripTrailingZeros
             if (d.scale() < 0) d.setScale(0).toString else d.toString

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -815,6 +815,21 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.showString(10) === expectedAnswer)
   }
 
+  test("showString: decimals") {
+    val df = Seq(
+      (0L, 10.1D),
+      (10L, 0.101D)
+    ).toDF().select('_1.cast(DecimalType(30, 20)), '_2.cast(DecimalType(30, 20)))
+    val expectedAnswer = """+---+-----+
+                           || _1|   _2|
+                           |+---+-----+
+                           ||  0| 10.1|
+                           || 10|0.101|
+                           |+---+-----+
+                           |""".stripMargin
+    assert(df.showString(10) === expectedAnswer)
+  }
+
   test("showString: minimum column width") {
     val df = Seq(
       (1, 1),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `Dataset.show()` prints all the trailing zeros for decimals. For example,

``` scala
spark.range(11).toDF("a").select('a.cast(DecimalType(30, 20))).show()
```

prints below:

``` bash
+--------------------+
|                   a|
+--------------------+
|               0E-20|
|1.000000000000000...|
|2.000000000000000...|
|3.000000000000000...|
|4.000000000000000...|
|5.000000000000000...|
|6.000000000000000...|
|7.000000000000000...|
|8.000000000000000...|
|9.000000000000000...|
|10.00000000000000...|
+--------------------+
```

It might be confusing, in particular, for `0E-20`. Also, I think we can strip the trailing zeros.

This PR fixes this as below:

``` bash
+---+
|  a|
+---+
|  0|
|  1|
|  2|
|  3|
|  4|
|  5|
|  6|
|  7|
|  8|
|  9|
| 10|
+---+
```
## How was this patch tested?

Unit test in `DataFrameSuite`.
