### PR TITLE
[SPARK-16972][CORE] Move DriverEndpoint out of CoarseGrainedSchedulerBackend

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -48,7 +48,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // Total number of executors that are currently registered
   protected val totalRegisteredExecutors = new AtomicInteger(0)
   protected val conf = scheduler.sc.conf
-  private val maxRpcMessageSize = RpcUtils.maxMessageSizeBytes(conf)
   // Submit tasks only after (registered resources / total expected resources)
   // is equal to at least this value, that is double between 0 and 1.
   private val _minRegisteredRatio =
@@ -59,24 +58,18 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     conf.getTimeAsMs("spark.scheduler.maxRegisteredResourcesWaitingTime", "30s")
   private val createTime = System.currentTimeMillis()
 
-  // Accessing `executorDataMap` in `DriverEndpoint.receive/receiveAndReply` doesn't need any
-  // protection. But accessing `executorDataMap` out of `DriverEndpoint.receive/receiveAndReply`
-  // must be protected by `CoarseGrainedSchedulerBackend.this`. Besides, `executorDataMap` should
-  // only be modified in `DriverEndpoint.receive/receiveAndReply` with protection by
-  // `CoarseGrainedSchedulerBackend.this`.
-  private val executorDataMap = new HashMap[String, ExecutorData]
-
   // Number of executors requested from the cluster manager that have not registered yet
   @GuardedBy("CoarseGrainedSchedulerBackend.this")
   private var numPendingExecutors = 0
-
-  private val listenerBus = scheduler.sc.listenerBus
 
   // Executors we have requested the cluster manager to kill that have not died yet; maps
   // the executor ID to whether it was explicitly killed by the driver (and thus shouldn't
   // be considered an app-related failure).
   @GuardedBy("CoarseGrainedSchedulerBackend.this")
   private val executorsPendingToRemove = new HashMap[String, Boolean]
+
+  // Executors that have been lost, but for which we don't yet know the real exit reason.
+  protected val executorsPendingLossReason = new HashSet[String]
 
   // A map to store hostname with its possible task number running on it
   @GuardedBy("CoarseGrainedSchedulerBackend.this")
@@ -89,249 +82,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // The num of current max ExecutorId used to re-register appMaster
   @volatile protected var currentExecutorIdCounter = 0
 
-  class DriverEndpoint(override val rpcEnv: RpcEnv, sparkProperties: Seq[(String, String)])
-    extends ThreadSafeRpcEndpoint with Logging {
-
-    // Executors that have been lost, but for which we don't yet know the real exit reason.
-    protected val executorsPendingLossReason = new HashSet[String]
-
-    // If this DriverEndpoint is changed to support multiple threads,
-    // then this may need to be changed so that we don't share the serializer
-    // instance across threads
-    private val ser = SparkEnv.get.closureSerializer.newInstance()
-
-    protected val addressToExecutorId = new HashMap[RpcAddress, String]
-
-    private val reviveThread =
-      ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-revive-thread")
-
-    override def onStart() {
-      // Periodically revive offers to allow delay scheduling to work
-      val reviveIntervalMs = conf.getTimeAsMs("spark.scheduler.revive.interval", "1s")
-
-      reviveThread.scheduleAtFixedRate(new Runnable {
-        override def run(): Unit = Utils.tryLogNonFatalError {
-          Option(self).foreach(_.send(ReviveOffers))
-        }
-      }, 0, reviveIntervalMs, TimeUnit.MILLISECONDS)
-    }
-
-    override def receive: PartialFunction[Any, Unit] = {
-      case StatusUpdate(executorId, taskId, state, data) =>
-        scheduler.statusUpdate(taskId, state, data.value)
-        if (TaskState.isFinished(state)) {
-          executorDataMap.get(executorId) match {
-            case Some(executorInfo) =>
-              executorInfo.freeCores += scheduler.CPUS_PER_TASK
-              makeOffers(executorId)
-            case None =>
-              // Ignoring the update since we don't know about the executor.
-              logWarning(s"Ignored task status update ($taskId state $state) " +
-                s"from unknown executor with ID $executorId")
-          }
-        }
-
-      case ReviveOffers =>
-        makeOffers()
-
-      case KillTask(taskId, executorId, interruptThread) =>
-        executorDataMap.get(executorId) match {
-          case Some(executorInfo) =>
-            executorInfo.executorEndpoint.send(KillTask(taskId, executorId, interruptThread))
-          case None =>
-            // Ignoring the task kill since the executor is not registered.
-            logWarning(s"Attempted to kill task $taskId for unknown executor $executorId.")
-        }
-    }
-
-    override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
-
-      case RegisterExecutor(executorId, executorRef, hostname, cores, logUrls) =>
-        if (executorDataMap.contains(executorId)) {
-          executorRef.send(RegisterExecutorFailed("Duplicate executor ID: " + executorId))
-          context.reply(true)
-        } else {
-          // If the executor's rpc env is not listening for incoming connections, `hostPort`
-          // will be null, and the client connection should be used to contact the executor.
-          val executorAddress = if (executorRef.address != null) {
-              executorRef.address
-            } else {
-              context.senderAddress
-            }
-          logInfo(s"Registered executor $executorRef ($executorAddress) with ID $executorId")
-          addressToExecutorId(executorAddress) = executorId
-          totalCoreCount.addAndGet(cores)
-          totalRegisteredExecutors.addAndGet(1)
-          val data = new ExecutorData(executorRef, executorRef.address, hostname,
-            cores, cores, logUrls)
-          // This must be synchronized because variables mutated
-          // in this block are read when requesting executors
-          CoarseGrainedSchedulerBackend.this.synchronized {
-            executorDataMap.put(executorId, data)
-            if (currentExecutorIdCounter < executorId.toInt) {
-              currentExecutorIdCounter = executorId.toInt
-            }
-            if (numPendingExecutors > 0) {
-              numPendingExecutors -= 1
-              logDebug(s"Decremented number of pending executors ($numPendingExecutors left)")
-            }
-          }
-          executorRef.send(RegisteredExecutor)
-          // Note: some tests expect the reply to come after we put the executor in the map
-          context.reply(true)
-          listenerBus.post(
-            SparkListenerExecutorAdded(System.currentTimeMillis(), executorId, data))
-          makeOffers()
-        }
-
-      case StopDriver =>
-        context.reply(true)
-        stop()
-
-      case StopExecutors =>
-        logInfo("Asking each executor to shut down")
-        for ((_, executorData) <- executorDataMap) {
-          executorData.executorEndpoint.send(StopExecutor)
-        }
-        context.reply(true)
-
-      case RemoveExecutor(executorId, reason) =>
-        // We will remove the executor's state and cannot restore it. However, the connection
-        // between the driver and the executor may be still alive so that the executor won't exit
-        // automatically, so try to tell the executor to stop itself. See SPARK-13519.
-        executorDataMap.get(executorId).foreach(_.executorEndpoint.send(StopExecutor))
-        removeExecutor(executorId, reason)
-        context.reply(true)
-
-      case RetrieveSparkProps =>
-        context.reply(sparkProperties)
-    }
-
-    // Make fake resource offers on all executors
-    private def makeOffers() {
-      // Filter out executors under killing
-      val activeExecutors = executorDataMap.filterKeys(executorIsAlive)
-      val workOffers = activeExecutors.map { case (id, executorData) =>
-        new WorkerOffer(id, executorData.executorHost, executorData.freeCores)
-      }.toSeq
-      launchTasks(scheduler.resourceOffers(workOffers))
-    }
-
-    override def onDisconnected(remoteAddress: RpcAddress): Unit = {
-      addressToExecutorId
-        .get(remoteAddress)
-        .foreach(removeExecutor(_, SlaveLost("Remote RPC client disassociated. Likely due to " +
-          "containers exceeding thresholds, or network issues. Check driver logs for WARN " +
-          "messages.")))
-    }
-
-    // Make fake resource offers on just one executor
-    private def makeOffers(executorId: String) {
-      // Filter out executors under killing
-      if (executorIsAlive(executorId)) {
-        val executorData = executorDataMap(executorId)
-        val workOffers = Seq(
-          new WorkerOffer(executorId, executorData.executorHost, executorData.freeCores))
-        launchTasks(scheduler.resourceOffers(workOffers))
-      }
-    }
-
-    private def executorIsAlive(executorId: String): Boolean = synchronized {
-      !executorsPendingToRemove.contains(executorId) &&
-        !executorsPendingLossReason.contains(executorId)
-    }
-
-    // Launch tasks returned by a set of resource offers
-    private def launchTasks(tasks: Seq[Seq[TaskDescription]]) {
-      for (task <- tasks.flatten) {
-        val serializedTask = ser.serialize(task)
-        if (serializedTask.limit >= maxRpcMessageSize) {
-          scheduler.taskIdToTaskSetManager.get(task.taskId).foreach { taskSetMgr =>
-            try {
-              var msg = "Serialized task %s:%d was %d bytes, which exceeds max allowed: " +
-                "spark.rpc.message.maxSize (%d bytes). Consider increasing " +
-                "spark.rpc.message.maxSize or using broadcast variables for large values."
-              msg = msg.format(task.taskId, task.index, serializedTask.limit, maxRpcMessageSize)
-              taskSetMgr.abort(msg)
-            } catch {
-              case e: Exception => logError("Exception in error callback", e)
-            }
-          }
-        }
-        else {
-          val executorData = executorDataMap(task.executorId)
-          executorData.freeCores -= scheduler.CPUS_PER_TASK
-
-          logInfo(s"Launching task ${task.taskId} on executor id: ${task.executorId} hostname: " +
-            s"${executorData.executorHost}.")
-
-          executorData.executorEndpoint.send(LaunchTask(new SerializableBuffer(serializedTask)))
-        }
-      }
-    }
-
-    // Remove a disconnected slave from the cluster
-    private def removeExecutor(executorId: String, reason: ExecutorLossReason): Unit = {
-      executorDataMap.get(executorId) match {
-        case Some(executorInfo) =>
-          // This must be synchronized because variables mutated
-          // in this block are read when requesting executors
-          val killed = CoarseGrainedSchedulerBackend.this.synchronized {
-            addressToExecutorId -= executorInfo.executorAddress
-            executorDataMap -= executorId
-            executorsPendingLossReason -= executorId
-            executorsPendingToRemove.remove(executorId).getOrElse(false)
-          }
-          totalCoreCount.addAndGet(-executorInfo.totalCores)
-          totalRegisteredExecutors.addAndGet(-1)
-          scheduler.executorLost(executorId, if (killed) ExecutorKilled else reason)
-          listenerBus.post(
-            SparkListenerExecutorRemoved(System.currentTimeMillis(), executorId, reason.toString))
-        case None =>
-          // SPARK-15262: If an executor is still alive even after the scheduler has removed
-          // its metadata, we may receive a heartbeat from that executor and tell its block
-          // manager to reregister itself. If that happens, the block manager master will know
-          // about the executor, but the scheduler will not. Therefore, we should remove the
-          // executor from the block manager when we hit this case.
-          scheduler.sc.env.blockManager.master.removeExecutorAsync(executorId)
-          logInfo(s"Asked to remove non-existent executor $executorId")
-      }
-    }
-
-    /**
-     * Stop making resource offers for the given executor. The executor is marked as lost with
-     * the loss reason still pending.
-     *
-     * @return Whether executor should be disabled
-     */
-    protected def disableExecutor(executorId: String): Boolean = {
-      val shouldDisable = CoarseGrainedSchedulerBackend.this.synchronized {
-        if (executorIsAlive(executorId)) {
-          executorsPendingLossReason += executorId
-          true
-        } else {
-          // Returns true for explicitly killed executors, we also need to get pending loss reasons;
-          // For others return false.
-          executorsPendingToRemove.contains(executorId)
-        }
-      }
-
-      if (shouldDisable) {
-        logInfo(s"Disabling executor $executorId.")
-        scheduler.executorLost(executorId, LossReasonPending)
-      }
-
-      shouldDisable
-    }
-
-    override def onStop() {
-      reviveThread.shutdownNow()
-    }
-  }
-
   var driverEndpoint: RpcEndpointRef = null
 
   protected def minRegisteredRatio: Double = _minRegisteredRatio
+
+  private val liveExecutors = new HashSet[String]
 
   override def start() {
     val properties = new ArrayBuffer[(String, String)]
@@ -351,7 +106,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   }
 
   protected def createDriverEndpoint(properties: Seq[(String, String)]): DriverEndpoint = {
-    new DriverEndpoint(rpcEnv, properties)
+    new DriverEndpoint(this, scheduler, rpcEnv, properties)
   }
 
   def stopExecutors() {
@@ -388,7 +143,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Remove all the lingering executors that should be removed but not yet. The reason might be
     // because (1) disconnected event is not yet received; (2) executors die silently.
-    executorDataMap.toMap.foreach { case (eid, _) =>
+    liveExecutors.foreach { case eid =>
       driverEndpoint.askWithRetry[Boolean](
         RemoveExecutor(eid, SlaveLost("Stale executor after cluster manager re-registered.")))
     }
@@ -435,10 +190,77 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   /**
    * Return the number of executors currently registered with this backend.
    */
-  private def numExistingExecutors: Int = executorDataMap.size
+  private def numExistingExecutors: Int = liveExecutors.size
 
   override def getExecutorIds(): Seq[String] = {
-    executorDataMap.keySet.toSeq
+    liveExecutors.toSeq
+  }
+
+  /**
+   * Handle the event of an executor registered.
+   * This must be synchronized because variables mutated
+   * in this block are read when requesting executors
+   * @param executorId the executor id
+   * @param cores the executor core num
+   */
+  def handleExecutorRegistered(executorId: String, cores: Int): Unit = synchronized {
+    liveExecutors += executorId
+    totalCoreCount.addAndGet(cores)
+    totalRegisteredExecutors.addAndGet(1)
+    if (currentExecutorIdCounter < executorId.toInt) {
+      currentExecutorIdCounter = executorId.toInt
+    }
+    if (numPendingExecutors > 0) {
+      numPendingExecutors -= 1
+      logDebug(s"Decremented number of pending executors ($numPendingExecutors left)")
+    }
+  }
+
+  /**
+   * Handle the event of disabling an executor.
+   * This must be synchronized because variables mutated
+   * in this block are read when requesting executors
+   * @param executorId the executor id
+   * @return true if executor should be disabled
+   */
+  def  handleDisableExecutor(executorId: String): Boolean = synchronized {
+    if (executorIsAlive(executorId)) {
+      executorsPendingLossReason += executorId
+      true
+    } else {
+      // Returns true for explicitly killed executors, we also need to get pending loss reasons;
+      // For others return false.
+      executorsPendingToRemove.contains(executorId)
+    }
+  }
+
+  /**
+   * Handle the event of removing an executor.
+   * This must be synchronized because variables mutated
+   * in this block are read when requesting executors
+   * @param executorId the executor id
+   * @param cores the executor core num
+   * @return true if the executor killed by driver
+   */
+  def handleRemoveExecutor(executorId: String, cores: Int): Boolean = synchronized {
+    liveExecutors -= executorId
+    totalCoreCount.addAndGet(cores)
+    totalRegisteredExecutors.addAndGet(-1)
+    executorsPendingLossReason -= executorId
+    executorsPendingToRemove.remove(executorId).getOrElse(false)
+  }
+
+  def getLostReason(execId: String): String = {
+    if (executorsPendingToRemove.contains(execId)) {
+      "Killed By Driver, e.g.heartbeat or idle expired"
+    } else {
+      "remote Rpc client disassociated"
+    }
+  }
+
+  def executorIsAlive(executorId: String): Boolean = synchronized {
+    !executorsPendingToRemove.contains(executorId) &&
+      !executorsPendingLossReason.contains(executorId)
   }
 
   /**
@@ -534,7 +356,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       replace: Boolean,
       force: Boolean): Boolean = synchronized {
     logInfo(s"Requesting to kill executor(s) ${executorIds.mkString(", ")}")
-    val (knownExecutors, unknownExecutors) = executorIds.partition(executorDataMap.contains)
+    val (knownExecutors, unknownExecutors) = executorIds.partition(liveExecutors.contains)
     unknownExecutors.foreach { id =>
       logWarning(s"Executor to kill $id does not exist!")
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -17,19 +17,17 @@
 
 package org.apache.spark.scheduler.cluster
 
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 
-import org.apache.spark.{ExecutorAllocationClient, SparkEnv, SparkException, TaskState}
+import org.apache.spark.{ExecutorAllocationClient, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc._
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend.ENDPOINT_NAME
-import org.apache.spark.util.{RpcUtils, SerializableBuffer, ThreadUtils, Utils}
 
 /**
  * A scheduler backend that waits for coarse-grained executors to connect.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/DriverEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/DriverEndpoint.scala
@@ -19,15 +19,16 @@ package org.apache.spark.scheduler.cluster
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.scheduler._
-import org.apache.spark.{TaskState, SparkEnv}
+import scala.collection.mutable.HashMap
+
+import org.apache.spark.{SparkEnv, TaskState}
 import org.apache.spark.internal.Logging
-import org.apache.spark.rpc.{RpcCallContext, RpcAddress, ThreadSafeRpcEndpoint, RpcEnv}
+import org.apache.spark.rpc.{RpcCallContext, RpcAddress, RpcEnv, ThreadSafeRpcEndpoint}
+import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
-import org.apache.spark.util.{RpcUtils, SerializableBuffer, Utils, ThreadUtils}
+import org.apache.spark.util.{RpcUtils, SerializableBuffer, ThreadUtils, Utils}
 
-import scala.collection.mutable.{HashMap, HashSet}
-
+private[spark]
 class DriverEndpoint(backend: CoarseGrainedSchedulerBackend,
                      scheduler: TaskSchedulerImpl,
                      override val rpcEnv: RpcEnv, sparkProperties: Seq[(String, String)])

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/DriverEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/DriverEndpoint.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.scheduler._
+import org.apache.spark.{TaskState, SparkEnv}
+import org.apache.spark.internal.Logging
+import org.apache.spark.rpc.{RpcCallContext, RpcAddress, ThreadSafeRpcEndpoint, RpcEnv}
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
+import org.apache.spark.util.{RpcUtils, SerializableBuffer, Utils, ThreadUtils}
+
+import scala.collection.mutable.{HashMap, HashSet}
+
+class DriverEndpoint(backend: CoarseGrainedSchedulerBackend,
+                     scheduler: TaskSchedulerImpl,
+                     override val rpcEnv: RpcEnv, sparkProperties: Seq[(String, String)])
+  extends ThreadSafeRpcEndpoint with Logging {
+
+  protected val conf = scheduler.sc.conf
+  private val maxRpcMessageSize = RpcUtils.maxMessageSizeBytes(conf)
+  // If this DriverEndpoint is changed to support multiple threads,
+  // then this may need to be changed so that we don't share the serializer
+  // instance across threads
+  private val ser = SparkEnv.get.closureSerializer.newInstance()
+
+  protected val addressToExecutorId = new HashMap[RpcAddress, String]
+
+  private val reviveThread =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-revive-thread")
+
+  private val executorDataMap = new HashMap[String, ExecutorData]
+
+  private val listenerBus = scheduler.sc.listenerBus
+
+  override def onStart() {
+    // Periodically revive offers to allow delay scheduling to work
+    val reviveIntervalMs = conf.getTimeAsMs("spark.scheduler.revive.interval", "1s")
+
+    reviveThread.scheduleAtFixedRate(new Runnable {
+      override def run(): Unit = Utils.tryLogNonFatalError {
+        Option(self).foreach(_.send(ReviveOffers))
+      }
+    }, 0, reviveIntervalMs, TimeUnit.MILLISECONDS)
+  }
+
+  override def receive: PartialFunction[Any, Unit] = {
+    case StatusUpdate(executorId, taskId, state, data) =>
+      scheduler.statusUpdate(taskId, state, data.value)
+      if (TaskState.isFinished(state)) {
+        executorDataMap.get(executorId) match {
+          case Some(executorInfo) =>
+            executorInfo.freeCores += scheduler.CPUS_PER_TASK
+            makeOffers(executorId)
+          case None =>
+            // Ignoring the update since we don't know about the executor.
+            logWarning(s"Ignored task status update ($taskId state $state) " +
+              s"from unknown executor with ID $executorId")
+        }
+      }
+
+    case ReviveOffers =>
+      makeOffers()
+
+    case KillTask(taskId, executorId, interruptThread) =>
+      executorDataMap.get(executorId) match {
+        case Some(executorInfo) =>
+          executorInfo.executorEndpoint.send(KillTask(taskId, executorId, interruptThread))
+        case None =>
+          // Ignoring the task kill since the executor is not registered.
+          logWarning(s"Attempted to kill task $taskId for unknown executor $executorId.")
+      }
+  }
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+
+    case RegisterExecutor(executorId, executorRef, hostname, cores, logUrls) =>
+      if (executorDataMap.contains(executorId)) {
+        executorRef.send(RegisterExecutorFailed("Duplicate executor ID: " + executorId))
+        context.reply(true)
+      } else {
+        // If the executor's rpc env is not listening for incoming connections, `hostPort`
+        // will be null, and the client connection should be used to contact the executor.
+        val executorAddress = if (executorRef.address != null) {
+          executorRef.address
+        } else {
+          context.senderAddress
+        }
+        logInfo(s"Registered executor $executorRef ($executorAddress) with ID $executorId")
+        addressToExecutorId(executorAddress) = executorId
+
+        val data = new ExecutorData(executorRef, executorRef.address, hostname,
+          cores, cores, logUrls)
+        executorDataMap.put(executorId, data)
+        backend.handleExecutorRegistered(executorId, cores)
+        executorRef.send(RegisteredExecutor)
+        // Note: some tests expect the reply to come after we put the executor in the map
+        context.reply(true)
+        listenerBus.post(
+          SparkListenerExecutorAdded(System.currentTimeMillis(), executorId, data))
+        makeOffers()
+      }
+
+    case StopDriver =>
+      context.reply(true)
+      stop()
+
+    case StopExecutors =>
+      logInfo("Asking each executor to shut down")
+      for ((_, executorData) <- executorDataMap) {
+        executorData.executorEndpoint.send(StopExecutor)
+      }
+      context.reply(true)
+
+    case RemoveExecutor(executorId, reason) =>
+      // We will remove the executor's state and cannot restore it. However, the connection
+      // between the driver and the executor may be still alive so that the executor won't exit
+      // automatically, so try to tell the executor to stop itself. See SPARK-13519.
+      executorDataMap.get(executorId).foreach(_.executorEndpoint.send(StopExecutor))
+      removeExecutor(executorId, reason)
+      context.reply(true)
+
+    case RetrieveSparkProps =>
+      context.reply(sparkProperties)
+  }
+
+  // Make fake resource offers on all executors
+  private def makeOffers() {
+    // Filter out executors under killing
+    val activeExecutors = executorDataMap.filterKeys(backend.executorIsAlive)
+    val workOffers = activeExecutors.map { case (id, executorData) =>
+      new WorkerOffer(id, executorData.executorHost, executorData.freeCores)
+    }.toSeq
+    launchTasks(scheduler.resourceOffers(workOffers))
+  }
+
+  override def onDisconnected(remoteAddress: RpcAddress): Unit = {
+    addressToExecutorId
+      .get(remoteAddress)
+      .foreach(removeExecutor(_, SlaveLost("Remote RPC client disassociated. Likely due to " +
+      "containers exceeding thresholds, or network issues. Check driver logs for WARN " +
+      "messages.")))
+  }
+
+  // Make fake resource offers on just one executor
+  private def makeOffers(executorId: String) {
+    // Filter out executors under killing
+    if (backend.executorIsAlive(executorId)) {
+      val executorData = executorDataMap(executorId)
+      val workOffers = Seq(
+        new WorkerOffer(executorId, executorData.executorHost, executorData.freeCores))
+      launchTasks(scheduler.resourceOffers(workOffers))
+    }
+  }
+
+  // Launch tasks returned by a set of resource offers
+  private def launchTasks(tasks: Seq[Seq[TaskDescription]]) {
+    for (task <- tasks.flatten) {
+      val serializedTask = ser.serialize(task)
+      if (serializedTask.limit >= maxRpcMessageSize) {
+        scheduler.taskIdToTaskSetManager.get(task.taskId).foreach { taskSetMgr =>
+          try {
+            var msg = "Serialized task %s:%d was %d bytes, which exceeds max allowed: " +
+              "spark.rpc.message.maxSize (%d bytes). Consider increasing " +
+              "spark.rpc.message.maxSize or using broadcast variables for large values."
+            msg = msg.format(task.taskId, task.index, serializedTask.limit, maxRpcMessageSize)
+            taskSetMgr.abort(msg)
+          } catch {
+            case e: Exception => logError("Exception in error callback", e)
+          }
+        }
+      }
+      else {
+        val executorData = executorDataMap(task.executorId)
+        executorData.freeCores -= scheduler.CPUS_PER_TASK
+
+        logInfo(s"Launching task ${task.taskId} on executor id: ${task.executorId} hostname: " +
+          s"${executorData.executorHost}.")
+
+        executorData.executorEndpoint.send(LaunchTask(new SerializableBuffer(serializedTask)))
+      }
+    }
+  }
+
+  // Remove a disconnected slave from the cluster
+  private def removeExecutor(executorId: String, reason: ExecutorLossReason): Unit = {
+    executorDataMap.get(executorId) match {
+      case Some(executorInfo) =>
+
+        val killed = backend.handleRemoveExecutor(executorId, executorInfo.totalCores)
+        addressToExecutorId -= executorInfo.executorAddress
+        executorDataMap -= executorId
+        scheduler.executorLost(executorId, if (killed) ExecutorKilled else reason)
+        listenerBus.post(
+          SparkListenerExecutorRemoved(System.currentTimeMillis(), executorId, reason.toString))
+      case None =>
+        // SPARK-15262: If an executor is still alive even after the scheduler has removed
+        // its metadata, we may receive a heartbeat from that executor and tell its block
+        // manager to reregister itself. If that happens, the block manager master will know
+        // about the executor, but the scheduler will not. Therefore, we should remove the
+        // executor from the block manager when we hit this case.
+        scheduler.sc.env.blockManager.master.removeExecutorAsync(executorId)
+        logInfo(s"Asked to remove non-existent executor $executorId")
+    }
+  }
+
+  /**
+   * Stop making resource offers for the given executor. The executor is marked as lost with
+   * the loss reason still pending.
+   *
+   * @return Whether executor should be disabled
+   */
+  protected def disableExecutor(executorId: String): Boolean = {
+    val shouldDisable = backend.handleDisableExecutor(executorId)
+    if (shouldDisable) {
+      logInfo(s"Disabling executor $executorId.")
+      scheduler.executorLost(executorId, LossReasonPending)
+    }
+
+    shouldDisable
+  }
+
+  override def onStop() {
+    reviveThread.shutdownNow()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/DriverEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/DriverEndpoint.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.HashMap
 
 import org.apache.spark.{SparkEnv, TaskState}
 import org.apache.spark.internal.Logging
-import org.apache.spark.rpc.{RpcCallContext, RpcAddress, RpcEnv, ThreadSafeRpcEndpoint}
+import org.apache.spark.rpc.{RpcAddress, RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.util.{RpcUtils, SerializableBuffer, ThreadUtils, Utils}

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -163,7 +163,7 @@ private[spark] abstract class YarnSchedulerBackend(
   }
 
   override def createDriverEndpoint(properties: Seq[(String, String)]): DriverEndpoint = {
-    new YarnDriverEndpoint(rpcEnv, properties)
+    new YarnDriverEndpoint(this, scheduler, rpcEnv, properties)
   }
 
   /**
@@ -181,8 +181,10 @@ private[spark] abstract class YarnSchedulerBackend(
    * This endpoint communicates with the executors and queries the AM for an executor's exit
    * status when the executor is disconnected.
    */
-  private class YarnDriverEndpoint(rpcEnv: RpcEnv, sparkProperties: Seq[(String, String)])
-      extends DriverEndpoint(rpcEnv, sparkProperties) {
+  private class YarnDriverEndpoint(backend: CoarseGrainedSchedulerBackend,
+                                   scheduler: TaskSchedulerImpl,
+                                   rpcEnv: RpcEnv, sparkProperties: Seq[(String, String)])
+      extends DriverEndpoint(backend, scheduler, rpcEnv, sparkProperties) {
 
     /**
      * When onDisconnected is received at the driver endpoint, the superclass DriverEndpoint


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move DriverEndpoint out of CoarseGrainedSchedulerBackend and make the two classes clean.
## How was this patch tested?

Pass the unit tests in local.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
