### PR TITLE
Make logDir easily copy/paste-able

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -194,7 +194,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     // Validate the log directory.
     val path = new Path(logDir)
     if (!fs.exists(path)) {
-      var msg = s"Log directory specified does not exist: $logDir."
+      var msg = s"Log directory specified does not exist: $logDir"
       if (logDir == DEFAULT_LOG_DIR) {
         msg += " Did you configure the correct one through spark.history.fs.logDirectory?"
       }


### PR DESCRIPTION
In many terminals double-clicking and dragging also includes the trailing period.  Simply remove this to make the value more easily copy/pasteable.

Example value:
`hdfs://mybox-123.net.example.com:8020/spark-events.`
