### PR TITLE
[SPARK-16986][WEB UI] Make 'Started' time, 'Completed' time and 'Last…

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -31,9 +31,20 @@ function makeIdNumeric(id) {
   return resl;
 }
 
+function padLeft(val) {
+  if(val < 10) return "0" + val;
+  else return val;
+}
+
 function formatDate(date) {
-  if (date <= 0) return "-";
-  else return date.split(".")[0].replace("T", " ");
+  if (date <= 0) {
+     return "-";
+  } else {
+     var localDate = new Date(date.split(".")[0].replace("T", " ") + " UTC");
+     return localDate.getFullYear() + "-" + padLeft(localDate.getMonth() + 1) + "-"
+            + padLeft(localDate.getDate()) + " " + padLeft(localDate.getHours()) + ":"
+            + padLeft(localDate.getMinutes()) + ":" + padLeft(localDate.getSeconds());
+  }
 }
 
 function getParameterByName(name, searchString) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to remove time inconsistency between webpages. In historypage.js, format 'Started' time, 'Completed' time and 'Last Updated' time to user local time.
## How was this patch tested?

Test manually. For example:
(1) Before this PR:
    The screenshot below is the application list in the history server webpage:

![1](https://cloud.githubusercontent.com/assets/8546874/17545378/8d2e96c6-5e91-11e6-8637-8cc3dcb2a9e8.png)

   When clicking the application_1470694797714_0010, we can see its job list:

![2](https://cloud.githubusercontent.com/assets/8546874/17545407/b288d918-5e91-11e6-9ed7-7ee46c6a4ed9.png)

  When clicking the job 1 (Job Id “1”), we can see the detailed information of job 1:

![3](https://cloud.githubusercontent.com/assets/8546874/17545442/d993e6b0-5e91-11e6-9558-ef005080cd35.png)

Compare the times in the three screenshots above, we could see the times in the first screenshot are not consistent with the times in the second screenshot and the third screenshot.

(2) After this PR:
After making the times showing in the history server page (historypage.js) to user local time, the first screenshot will change to:

![4](https://cloud.githubusercontent.com/assets/8546874/17545524/648a14e2-5e92-11e6-9c15-5ef2c901f2fc.png)

Then the times in different pages will be consistent.

… Updated' time in history server UI to the user local time
