### PR TITLE
[SPARK-4119][SQL] Remove unused HIVE_DEV_HOME related variable

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -171,9 +171,6 @@ private[hive] class TestHiveSparkSession(
   /** The location of the compiled hive distribution */
   lazy val hiveHome = envVarToFile("HIVE_HOME")
 
-  /** The location of the hive source code. */
-  lazy val hiveDevHome = envVarToFile("HIVE_DEV_HOME")
-
   /**
    * Returns the value of specified environmental variable as a [[java.io.File]] after checking
    * to ensure it exists


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to the [Spark SQL Internals](https://cwiki.apache.org/confluence/display/SPARK/Spark+SQL+Internals) wiki, Spark uses `HIVE_HOME` or `HADOOP_HOME` instead `HIVE_DEV_HOME` during generating golden answer files since Hive 0.13.1 (June 2014). Also, Spark uses Hive 1.2 since Spark 1.5.0 (Sep. 2015). This PR removes HIVE_DEV_HOME-related variable.
## How was this patch tested?

This is about test suites.
