### PR TITLE
[SPARK-16921][PYSPARK] RDD/DataFrame persist()/cache() should return Python context managers

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -188,6 +188,12 @@ class RDD(object):
         self._id = jrdd.id()
         self.partitioner = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.unpersist()
+
     def _pickled(self):
         return self._reserialize(AutoBatchedSerializer(PickleSerializer()))
 
@@ -221,6 +227,21 @@ class RDD(object):
     def cache(self):
         """
         Persist this RDD with the default storage level (C{MEMORY_ONLY}).
+
+        :py:meth:`cache` can be used in a 'with' statement. The RDD will be automatically
+        unpersisted once the 'with' block is exited. Note however that any actions on the RDD
+        that require the RDD to be cached, should be invoked inside the 'with' block; otherwise,
+        caching will have no effect.
+
+        >>> rdd = sc.parallelize(["b", "a", "c"])
+        >>> with rdd.cache() as cached:
+        ...     print(cached.getStorageLevel())
+        ...     print(cached.count())
+        ...
+        Memory Serialized 1x Replicated
+        3
+        >>> print(rdd.getStorageLevel())
+        Serialized 1x Replicated
         """
         self.is_cached = True
         self.persist(StorageLevel.MEMORY_ONLY)
@@ -233,9 +254,22 @@ class RDD(object):
         a new storage level if the RDD does not have a storage level set yet.
         If no storage level is specified defaults to (C{MEMORY_ONLY}).
 
+        :py:meth:`persist` can be used in a 'with' statement. The RDD will be automatically
+        unpersisted once the 'with' block is exited. Note however that any actions on the RDD
+        that require the RDD to be cached, should be invoked inside the 'with' block; otherwise,
+        caching will have no effect.
+
         >>> rdd = sc.parallelize(["b", "a", "c"])
-        >>> rdd.persist().is_cached
+        >>> with rdd.persist() as persisted:
+        ...     print(persisted.getStorageLevel())
+        ...     print(persisted.is_cached)
+        ...     print(persisted.count())
+        ...
+        Memory Serialized 1x Replicated
         True
+        3
+        >>> print(rdd.getStorageLevel())
+        Serialized 1x Replicated
         """
         self.is_cached = True
         javaStorageLevel = self.ctx._getJavaStorageLevel(storageLevel)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -75,6 +75,12 @@ class DataFrame(object):
         self._schema = None  # initialized lazily
         self._lazy_rdd = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.unpersist()
+
     @property
     @since(1.3)
     def rdd(self):
@@ -390,6 +396,16 @@ class DataFrame(object):
     @since(1.3)
     def cache(self):
         """ Persists with the default storage level (C{MEMORY_ONLY}).
+
+        :py:meth:`cache` can be used in a 'with' statement. The DataFrame will be automatically
+        unpersisted once the 'with' block is exited. Note however that any actions on the DataFrame
+        that require the DataFrame to be cached, should be invoked inside the 'with' block;
+        otherwise, caching will have no effect.
+
+        >>> with df.cache() as cached:
+        ...     print(cached.count())
+        ...
+        2
         """
         self.is_cached = True
         self._jdf.cache()
@@ -401,6 +417,16 @@ class DataFrame(object):
         after the first time it is computed. This can only be used to assign
         a new storage level if the RDD does not have a storage level set yet.
         If no storage level is specified defaults to (C{MEMORY_ONLY}).
+
+        :py:meth:`persist` can be used in a 'with' statement. The DataFrame will be automatically
+        unpersisted once the 'with' block is exited. Note however that any actions on the DataFrame
+        that require the DataFrame to be cached, should be invoked inside the 'with' block;
+        otherwise, caching will have no effect.
+
+        >>> with df.persist() as persisted:
+        ...     print(persisted.count())
+        ...
+        2
         """
         self.is_cached = True
         javaStorageLevel = self._sc._getJavaStorageLevel(storageLevel)


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-16921

Context managers are a natural way to capture closely related setup and teardown code in Python. It can be useful to apply this pattern to persisting/unpersisting RDDs and DataFrames.

This PR makes RDDs and DataFrames implement the context manager `__enter__` and `__exit__`  functions, allowing code such as:

``` python
with labeled_data.persist():
    model = pipeline.fit(labeled_data)
```
## How was this patch tested?

New doc tests.
