### PR TITLE
[SPARK-16991][SQL] Fix `EliminateOuterJoin` optimizer to check all outer columns except join columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1334,11 +1334,7 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     val rightConditions = splitConjunctiveConditions
       .filter(_.references.subsetOf(join.right.outputSet))
 
-    val joinAttributeSet = if (join.condition.isDefined) {
-      join.condition.get.references
-    } else {
-      AttributeSet.empty
-    }
+    val joinAttributeSet = join.condition.map(_.references).getOrElse(AttributeSet.empty)
     val leftOuterAttributeSet = join.left.outputSet -- joinAttributeSet
     val rightOuterAttributeSet = join.right.outputSet -- joinAttributeSet
     val leftHasNonNullPredicate = leftConditions.exists(canFilterOutNull) ||

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2602,6 +2602,14 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       Row(s"$expected") :: Nil)
   }
 
+  test("SPARK-16991: Full outer join followed by inner join produces wrong results") {
+    val a = Seq((1, 2), (2, 3)).toDF("a", "b")
+    val b = Seq((2, 5), (3, 4)).toDF("a", "c")
+    val c = Seq((3, 1)).toDF("a", "d")
+    val ab = a.join(b, Seq("a"), "fullouter")
+    checkAnswer(ab.join(c, "a"), Row(3, null, 4, 1) :: Nil)
+  }
+
   test("SPARK-15752 optimize metadata only query for datasource table") {
     withSQLConf(SQLConf.OPTIMIZER_METADATA_ONLY.key -> "true") {
       withTable("srcpart_15752") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, full outer join followed by inner join produces wrong results like the following. The root cause is that `EliminateOuterJoin` considers all columns including join columns together.

**Reported Error Scenario**

``` scala
scala> val a = Seq((1, 2), (2, 3)).toDF("a", "b")
scala> val b = Seq((2, 5), (3, 4)).toDF("a", "c")
scala> val c = Seq((3, 1)).toDF("a", "d")
scala> val ab = a.join(b, Seq("a"), "fullouter")
scala> ab.join(c, "a").show
+---+---+---+---+
|  a|  b|  c|  d|
+---+---+---+---+
+---+---+---+---+
```

**After**

``` scala
scala> ab.join(c, "a").show
+---+----+---+---+
|  a|   b|  c|  d|
+---+----+---+---+
|  3|null|  4|  1|
+---+----+---+---+
```
## How was this patch tested?

Pass the Jenkins tests with new testcase.
