### PR TITLE
[SPARK-16997][SQL] Allow loading of JSON float values as TimestampType

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JacksonParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JacksonParser.scala
@@ -208,6 +208,9 @@ class JacksonParser(
 
         case VALUE_NUMBER_INT =>
           parser.getLongValue * 1000000L
+
+        case VALUE_NUMBER_FLOAT =>
+          math.round(parser.getDoubleValue * 1000000L)
       }
 
     case DateType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -92,6 +92,8 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         enforceCorrectType(intNumber, TimestampType))
     checkTypePromotion(DateTimeUtils.fromJavaTimestamp(new Timestamp(intNumber.toLong * 1000L)),
         enforceCorrectType(intNumber.toLong, TimestampType))
+    checkTypePromotion(DateTimeUtils.fromJavaTimestamp(new Timestamp(123L + intNumber * 1000L)),
+      enforceCorrectType(0.123 + intNumber, TimestampType))
     val strTime = "2014-09-30 12:34:56"
     checkTypePromotion(DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(strTime)),
         enforceCorrectType(strTime, TimestampType))
@@ -1646,6 +1648,20 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
       checkAnswer(
         sql("select ts from jsonTable"),
         Row(java.sql.Timestamp.valueOf("2016-01-02 03:04:05"))
+      )
+    }
+  }
+
+  test("Casting float as timestamp") {
+    withTempView("jsonTable") {
+      val schema = (new StructType).add("ts", TimestampType)
+      val jsonDF = spark.read.schema(schema).json(timestampAsFloat)
+
+      jsonDF.createOrReplaceTempView("jsonTable")
+
+      checkAnswer(
+        sql("select ts from jsonTable"),
+        Row(java.sql.Timestamp.valueOf("2016-01-02 03:04:05.123456"))
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/TestJsonData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/TestJsonData.scala
@@ -209,6 +209,10 @@ private[json] trait TestJsonData {
     spark.sparkContext.parallelize(
       """{"ts":1451732645}""" :: Nil)
 
+  def timestampAsFloat: RDD[String] =
+    spark.sparkContext.parallelize(
+      """{"ts":1451732645.123456}""" :: Nil)
+
   def arrayAndStructRecords: RDD[String] =
     spark.sparkContext.parallelize(
       """{"a": {"b": 1}}""" ::


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-16997
## What changes were proposed in this pull request?

This allows loading JSON like `{"ts": 1470840303.636409}` directly to a `TimestampType` field, without going through `DoubleType` and then casting it to `TimestampType`.

The goal is to make something like this work:

```
scala> val json = sc.parallelize(Seq("""{"ts": 1470852490.807188}"""))
json: org.apache.spark.rdd.RDD[String] = ParallelCollectionRDD[22] at parallelize at <console>:27

scala> spark.read.schema(StructType(Seq(StructField("ts", TimestampType)))).json(json).show(false)
+--------------------------+
|ts                        |
+--------------------------+
|2016-08-10 20:08:10.807188|
+--------------------------+

```
## How was this patch tested?

Ran the relevant unit tests.
