### PR TITLE
[SPARK-16994][SQL] PushDownPredicate should not ignore limits.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1212,6 +1212,9 @@ object PushDownPredicate extends Rule[LogicalPlan] with PredicateHelper {
     case filter @ Filter(_, _: Filter) => filter
     // should not push predicates through sample, or will generate different results.
     case filter @ Filter(_, _: Sample) => filter
+    // should not push predicates through limit, or will generate different results.
+    case filter @ Filter(_, _: GlobalLimit) => filter
+    case filter @ Filter(_, _: LocalLimit) => filter
 
     case filter @ Filter(condition, u: UnaryNode) if u.expressions.forall(_.deterministic) =>
       pushDownPredicate(filter, u.child) { predicate =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -150,6 +150,17 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, originalQuery)
   }
 
+  test("SPARK-16994: filter should not be pushed down into local limit") {
+    val originalQuery = testRelation
+      .limit(1)
+      .where('a % 2 == 0)
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    comparePlans(optimized, originalQuery)
+  }
+
   test("filters: combines filters") {
     val originalQuery = testRelation
       .select('a)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1730,6 +1730,11 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("SPARK-16994: filter should not be pushed down into local limit") {
+    checkAnswer(spark.createDataset(1 to 100).limit(10).filter($"value" % 10 === 0).toDF(),
+      Row(10) :: Nil)
+  }
+
   test("Struct Star Expansion") {
     val structDf = testData2.select("a", "b").as("record")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1730,11 +1730,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("SPARK-16994: filter should not be pushed down into local limit") {
-    checkAnswer(spark.createDataset(1 to 100).limit(10).filter($"value" % 10 === 0).toDF(),
-      Row(10) :: Nil)
-  }
-
   test("Struct Star Expansion") {
     val structDf = testData2.select("a", "b").as("record")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `filter` and `limit` are illegally permuted because `PushDownPredicate` optimizer pushes `filters` through `limit`. This PR fixes that.

**Reported Error Scenario**

``` scala
scala> spark.createDataset(1 to 100).limit(10).filter($"value" % 10 === 0).explain
== Physical Plan ==
CollectLimit 10
+- *Filter ((value#875 % 10) = 0)
   +- LocalTableScan [value#875]

scala> spark.createDataset(1 to 100).limit(10).filter($"value" % 10 === 0).collect
res23: Array[Int] = Array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
```

**After**

``` scala
scala> spark.createDataset(1 to 100).limit(10).filter($"value" % 10 === 0).explain
== Physical Plan ==
*Filter ((value#1 % 10) = 0)
+- *GlobalLimit 10
   +- Exchange SinglePartition
      +- *LocalLimit 10
         +- LocalTableScan [value#1]

scala> spark.createDataset(1 to 100).limit(10).filter($"value" % 10 === 0).collect
res1: Array[Int] = Array(10)
```
## How was this patch tested?

Pass the Jenkins with a new test case.
