### PR TITLE
[SPARK-16999] [SQL] Convert Keyword `path` of Data Source Tables to Lower Case

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -90,7 +90,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * @since 1.4.0
    */
   def option(key: String, value: String): DataFrameWriter[T] = {
-    this.extraOptions += (key -> value)
+    val normalizedKey = if (key.toLowerCase == "path") "path" else key
+    this.extraOptions += (normalizedKey -> value)
     this
   }
 
@@ -121,7 +122,9 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * @since 1.4.0
    */
   def options(options: scala.collection.Map[String, String]): DataFrameWriter[T] = {
-    this.extraOptions ++= options
+    val normalizedOptions =
+      options.map(kv => if (kv._1.toLowerCase == "path") kv.copy(_1 = "path") else kv)
+    this.extraOptions ++= normalizedOptions
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -317,7 +317,11 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     if (external) {
       operationNotAllowed("CREATE EXTERNAL TABLE ... USING", ctx)
     }
-    val options = Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty)
+    val options =
+      Option(ctx.tablePropertyList)
+        .map(visitPropertyKeyValues)
+        .map(normalizePath)
+        .getOrElse(Map.empty)
     val provider = ctx.tableProvider.qualifiedName.getText
     val schema = Option(ctx.colTypeList()).map(createStructType)
     val partitionColumnNames =
@@ -442,6 +446,13 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     // Check for duplicate property names.
     checkDuplicateKeys(properties, ctx)
     properties.toMap
+  }
+
+  /**
+   * Converts the storage property `PATH` to lowercase letters, if existed
+   */
+  private def normalizePath (properties: Map[String, String]): Map[String, String] = {
+    properties.map(kv => if (kv._1.toLowerCase == "path") kv.copy(_1 = "path") else kv)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -70,7 +70,7 @@ case class CreateDataSourceTableCommand(
 
     var isExternal = true
     val optionsWithPath =
-      if (!new CaseInsensitiveMap(options).contains("path") && managedIfNoPath) {
+      if (!options.contains("path") && managedIfNoPath) {
         isExternal = false
         options + ("path" -> sessionState.catalog.defaultTablePath(tableIdent))
       } else {
@@ -142,7 +142,7 @@ case class CreateDataSourceTableAsSelectCommand(
     var createMetastoreTable = false
     var isExternal = true
     val optionsWithPath =
-      if (!new CaseInsensitiveMap(options).contains("path")) {
+      if (!options.contains("path")) {
         isExternal = false
         options + ("path" -> sessionState.catalog.defaultTablePath(tableIdent))
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -887,7 +887,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
       case (key, value) =>
         // If it's a managed table, omit PATH option. Spark SQL always creates external table
         // when the table creation DDL contains the PATH option.
-        key.toLowerCase == "path" && metadata.tableType == MANAGED
+        key == "path" && metadata.tableType == MANAGED
     }.map {
       case (key, value) => s"${quoteIdentifier(key)} '${escapeSingleQuotedString(value)}'"
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -261,12 +261,14 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
     if (source == "hive") {
       throw new AnalysisException("Cannot create hive serde table with createExternalTable API.")
     }
+    val normalizedOptions =
+      options.map(kv => if (kv._1.toLowerCase == "path") kv.copy(_1 = "path") else kv)
 
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     val tableDesc = CatalogTable(
       identifier = tableIdent,
       tableType = CatalogTableType.EXTERNAL,
-      storage = CatalogStorageFormat.empty.copy(properties = options),
+      storage = CatalogStorageFormat.empty.copy(properties = normalizedOptions),
       schema = schema,
       provider = Some(source)
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -170,11 +170,13 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
         .option("opt1", "1")
         .options(Map("opt2" -> "2"))
         .options(map)
+        .option("PaTh", "/test")
         .load()
 
     assert(LastOptions.parameters("opt1") == "1")
     assert(LastOptions.parameters("opt2") == "2")
     assert(LastOptions.parameters("opt3") == "3")
+    assert(LastOptions.parameters("path") == "/test")
 
     LastOptions.clear()
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1170,8 +1170,8 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         checkAnswer(table("t"), Seq(Row(1, 2, 3), Row(2, 3, 4)))
         val catalogTable = sharedState.externalCatalog.getTable("default", "t")
         // there should not be a lowercase key 'path' now
-        assert(catalogTable.storage.properties.get("path").isEmpty)
-        assert(catalogTable.storage.properties.get("PATH").isDefined)
+        assert(catalogTable.storage.properties.get("path").isDefined)
+        assert(catalogTable.storage.properties.get("PATH").isEmpty)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -551,6 +551,24 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
     sql("DROP TABLE IF EXISTS createdJsonTable")
   }
 
+  test("case insensitive option - path") {
+    val tableName = "createdJsonTable"
+    withTable(tableName) {
+      withTempPath { tempPath =>
+        val path = tempPath.getCanonicalPath
+        val df = spark.range(10).toDF()
+        df.write.format("json").save(path)
+        sparkSession.catalog.createExternalTable(
+          tableName,
+          "org.apache.spark.sql.json",
+          Map("PATH" -> path))
+        checkAnswer(
+          table("createdJsonTable"),
+          df)
+      }
+    }
+  }
+
   test("scan a parquet table created through a CTAS statement") {
     withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "true") {
       withTempView("jt") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`path` points to the location of data source tables. The parameters' keywords are case insensitive. However, we do not always follow the rules. Below is the summary of the case sensitivity support:

**Case sensitive**
- AlterTableSetLocationCommand
- AlterTableRenameCommand
- TruncateTableCommand
- newHadoopConfWithOptions in SessionState

**Case insensitive**
- ShowCreateTableCommand
- CreateDataSourceTableCommand
- CreateDataSourceTableAsSelectCommand
- getBatch in FileStreamSource
- write in DataSource
- inferFileFormatSchema in DataSource
- sourceSchema in DataSource
- createSource in DataSource
- createSink in DataSource
- resolveRelation in DataSource

It is not maintainable to consider the case sensitivity of `path` in all the current and future implementation. This PR is to convert the user specified keyword name to lower case for `path` and clean the related code. 
### How was this patch tested?

Added the related tests.
