### PR TITLE
[SPARK-17016][SQL] Improve group-by/order-by ordinal error reporting

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -538,39 +538,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql("SELECT 1, 2, sum(b) FROM testData2"))
   }
 
-  test("Group By Ordinal - negative cases") {
-    intercept[UnresolvedException[Aggregate]] {
-      sql("SELECT a, b FROM testData2 GROUP BY -1")
-    }
-
-    intercept[UnresolvedException[Aggregate]] {
-      sql("SELECT a, b FROM testData2 GROUP BY 3")
-    }
-
-    var e = intercept[UnresolvedException[Aggregate]](
-      sql("SELECT SUM(a) FROM testData2 GROUP BY 1"))
-    assert(e.getMessage contains
-      "Invalid call to Group by position: the '1'th column in the select contains " +
-        "an aggregate function")
-
-    e = intercept[UnresolvedException[Aggregate]](
-      sql("SELECT SUM(a) + 1 FROM testData2 GROUP BY 1"))
-    assert(e.getMessage contains
-      "Invalid call to Group by position: the '1'th column in the select contains " +
-        "an aggregate function")
-
-    var ae = intercept[AnalysisException](
-      sql("SELECT a, rand(0), sum(b) FROM testData2 GROUP BY a, 2"))
-    assert(ae.getMessage contains
-      "nondeterministic expression rand(0) should not appear in grouping expression")
-
-    ae = intercept[AnalysisException](
-      sql("SELECT * FROM testData2 GROUP BY a, b, 1"))
-    assert(ae.getMessage contains
-      "Group by position: star is not allowed to use in the select list " +
-        "when using ordinals in group by")
-  }
-
   test("Group By Ordinal: spark.sql.groupByOrdinal=false") {
     withSQLConf(SQLConf.GROUP_BY_ORDINAL.key -> "false") {
       // If spark.sql.groupByOrdinal=false, ignore the position number.
@@ -2465,18 +2432,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       sql("SELECT * FROM testData2 ORDER BY 1 ASC, b ASC"),
       Seq(Row(1, 1), Row(1, 2), Row(2, 1), Row(2, 2), Row(3, 1), Row(3, 2)))
-  }
-
-  test("order by ordinal number - negative cases") {
-    intercept[UnresolvedException[SortOrder]] {
-      sql("SELECT * FROM testData2 ORDER BY 0")
-    }
-    intercept[UnresolvedException[SortOrder]] {
-      sql("SELECT * FROM testData2 ORDER BY -1 DESC, b ASC")
-    }
-    intercept[UnresolvedException[SortOrder]] {
-      sql("SELECT * FROM testData2 ORDER BY 3 DESC, b ASC")
-    }
   }
 
   test("order by ordinal number with conf spark.sql.orderByOrdinal=false") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch improves error handling for group-by/order-by ordinals:
1. Report error position in more places.
2. Throw AnalysisException instead of UnresolvedException, which is an internal exception not meant for end-users.
3. Made error messages more consistent.

Error messages look like the following:

```
org.apache.spark.sql.AnalysisException
GROUP BY position 3 is an aggregate function, and aggregate functions are not allowed in GROUP BY; line 1 pos 39
```

```
Star (*) is not allowed in select list when GROUP BY ordinal position is used;
```

```
org.apache.spark.sql.AnalysisException
ORDER BY position 3 is not in select list (valid range is [1, 2]); line 1 pos 28
```
## How was this patch tested?

This is tested in SPARK-17015 but I'm submitting this part in isolation so it is easier to back port into branch-2.0. I will submit a separate pull request for SPARK-17015.
