### PR TITLE
[SPARK-17013][SQL] handle corner case for negative integral literal

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -627,6 +627,7 @@ quotedIdentifier
 number
     : DECIMAL_VALUE            #decimalLiteral
     | SCIENTIFIC_DECIMAL_VALUE #scientificDecimalLiteral
+    | MINUS INTEGER_VALUE      #negativeIntegerLiteral
     | INTEGER_VALUE            #integerLiteral
     | BIGINT_LITERAL           #bigIntLiteral
     | SMALLINT_LITERAL         #smallIntLiteral

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1256,16 +1256,30 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
   }
 
   /**
+   * Create a negative integral literal expression. The code selects the most narrow integral type
+   * possible, either a BigDecimal, a Long or an Integer is returned.
+   */
+  override def visitNegativeIntegerLiteral(
+      ctx: NegativeIntegerLiteralContext): Literal = withOrigin(ctx) {
+    createIntegralLiteral(ctx.getText)
+  }
+
+  /**
    * Create an integral literal expression. The code selects the most narrow integral type
    * possible, either a BigDecimal, a Long or an Integer is returned.
    */
   override def visitIntegerLiteral(ctx: IntegerLiteralContext): Literal = withOrigin(ctx) {
-    BigDecimal(ctx.getText) match {
-      case v if v.isValidInt =>
-        Literal(v.intValue())
-      case v if v.isValidLong =>
-        Literal(v.longValue())
-      case v => Literal(v.underlying())
+    createIntegralLiteral(ctx.getText)
+  }
+
+  private def createIntegralLiteral(s: String): Literal = {
+    val bigDecimal = BigDecimal(s)
+    if (bigDecimal.isValidInt) {
+      Literal(bigDecimal.intValue())
+    } else if (bigDecimal.isValidLong) {
+      Literal(bigDecimal.longValue())
+    } else {
+      Literal(bigDecimal.underlying())
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/results/number-format.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/number-format.sql.out
@@ -5,7 +5,7 @@
 -- !query 0
 select 1, -1
 -- !query 0 schema
-struct<1:int,(-1):int>
+struct<1:int,-1:int>
 -- !query 0 output
 1	-1
 
@@ -13,7 +13,7 @@ struct<1:int,(-1):int>
 -- !query 1
 select 2147483648, -2147483649
 -- !query 1 schema
-struct<2147483648:bigint,(-2147483649):bigint>
+struct<2147483648:bigint,-2147483649:bigint>
 -- !query 1 output
 2147483648	-2147483649
 
@@ -21,7 +21,7 @@ struct<2147483648:bigint,(-2147483649):bigint>
 -- !query 2
 select 9223372036854775807, -9223372036854775808
 -- !query 2 schema
-struct<9223372036854775807:bigint,(-9223372036854775808):decimal(19,0)>
+struct<9223372036854775807:bigint,-9223372036854775808:bigint>
 -- !query 2 output
 9223372036854775807	-9223372036854775808
 
@@ -29,7 +29,7 @@ struct<9223372036854775807:bigint,(-9223372036854775808):decimal(19,0)>
 -- !query 3
 select 9223372036854775808, -9223372036854775809
 -- !query 3 schema
-struct<9223372036854775808:decimal(19,0),(-9223372036854775809):decimal(19,0)>
+struct<9223372036854775808:decimal(19,0),-9223372036854775809:decimal(19,0)>
 -- !query 3 output
 9223372036854775808	-9223372036854775809
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark 2.0 parses negative numeric literals as the unary minus of positive literals. This introduces problems for the edge cases such as -9223372036854775809 being parsed as decimal instead of bigint.

This PR fixes it by make negative integral a direct literal in parser.
## How was this patch tested?

number-format.sql
