### PR TITLE
[SPARK-13979][Core] Killed executor is re spawned without AWS key…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -107,6 +107,7 @@ class SparkHadoopUtil extends Logging {
         if (key.startsWith("spark.hadoop.")) {
           hadoopConf.set(key.substring("spark.hadoop.".length), value)
         }
+        // fix added for SPARK-13979
 	// Copy any "fs.swift2d.foo=bar" or "fs.swift.foo=bar" properties into conf 
         else if (key.startsWith("fs.swift")){
           hadoopConf.set(key, value)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -102,8 +102,8 @@ class SparkHadoopUtil extends Logging {
         hadoopConf.set("fs.s3n.awsSecretAccessKey", accessKey)
         hadoopConf.set("fs.s3a.secret.key", accessKey)
       }
-      // Copy any "spark.hadoop.foo=bar" system properties into conf as "foo=bar"
       conf.getAll.foreach { case (key, value) =>
+        // Copy any "spark.hadoop.foo=bar" system properties into conf as "foo=bar"
         if (key.startsWith("spark.hadoop.")) {
           hadoopConf.set(key.substring("spark.hadoop.".length), value)
         }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -107,6 +107,14 @@ class SparkHadoopUtil extends Logging {
         if (key.startsWith("spark.hadoop.")) {
           hadoopConf.set(key.substring("spark.hadoop.".length), value)
         }
+	// Copy any "fs.swift2d.foo=bar" properties into conf as "fs.swift2d.foo=bar"
+        else if (key.startsWith("fs.swift2d")){
+          hadoopConf.set(key, value)
+        }
+        // Copy any "fs.s3x.foo=bar" properties into conf as "fs.s3x.foo=bar"
+        else if (key.startsWith("fs.s3")){
+          hadoopConf.set(key, value)
+        }
       }
       val bufferSize = conf.get("spark.buffer.size", "65536")
       hadoopConf.set("io.file.buffer.size", bufferSize)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -107,11 +107,11 @@ class SparkHadoopUtil extends Logging {
         if (key.startsWith("spark.hadoop.")) {
           hadoopConf.set(key.substring("spark.hadoop.".length), value)
         }
-	// Copy any "fs.swift2d.foo=bar" properties into conf as "fs.swift2d.foo=bar"
-        else if (key.startsWith("fs.swift2d")){
+	// Copy any "fs.swift2d.foo=bar" or "fs.swift.foo=bar" properties into conf 
+        else if (key.startsWith("fs.swift")){
           hadoopConf.set(key, value)
         }
-        // Copy any "fs.s3x.foo=bar" properties into conf as "fs.s3x.foo=bar"
+        // Copy any "fs.s3.foo=bar" or "fs.s3a.foo=bar" or "fs.s3n.foo=bar" properties into conf 
         else if (key.startsWith("fs.s3")){
           hadoopConf.set(key, value)
         }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -108,12 +108,8 @@ class SparkHadoopUtil extends Logging {
           hadoopConf.set(key.substring("spark.hadoop.".length), value)
         }
         // fix added for SPARK-13979
-	// Copy any "fs.swift2d.foo=bar" or "fs.swift.foo=bar" properties into conf 
-        else if (key.startsWith("fs.swift")){
-          hadoopConf.set(key, value)
-        }
-        // Copy any "fs.s3.foo=bar" or "fs.s3a.foo=bar" or "fs.s3n.foo=bar" properties into conf 
-        else if (key.startsWith("fs.s3")){
+	// Copy any "fs.*=bar" properties into conf it will cover almost all filesystem 
+        else if (key.startsWith("fs.")){
           hadoopConf.set(key, value)
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -121,7 +121,9 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
     case PhysicalOperation(projects, filters, l @ LogicalRelation(t: HadoopFsRelation, _)) =>
       // See buildPartitionedTableScan for the reason that we need to create a shard
       // broadcast HadoopConf.
-      val sharedHadoopConf = SparkHadoopUtil.get.conf
+      // fix added for SPARK-13979
+      // val sharedHadoopConf = SparkHadoopUtil.get.conf 
+      val sharedHadoopConf = t.sqlContext.sparkContext.hadoopConfiguration
       val confBroadcast =
         t.sqlContext.sparkContext.broadcast(new SerializableConfiguration(sharedHadoopConf))
       pruneFilterProject(
@@ -156,7 +158,9 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
 
     // Because we are creating one RDD per partition, we need to have a shared HadoopConf.
     // Otherwise, the cost of broadcasting HadoopConf in every RDD will be high.
-    val sharedHadoopConf = SparkHadoopUtil.get.conf
+    // fix added for SPARK-13979
+    // val sharedHadoopConf = SparkHadoopUtil.get.conf
+    val sharedHadoopConf = relation.sqlContext.sparkContext.hadoopConfiguration
     val confBroadcast =
       relation.sqlContext.sparkContext.broadcast(new SerializableConfiguration(sharedHadoopConf))
     val partitionColumnNames = partitionColumns.fieldNames.toSet


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
_Summery we need to make two changes_
1) in DataSourceStratgy.scala. use sqlContext.sparkContext.hadoopConfiguration instead of SparkHadoopUtil.get.conf
2) update  def newConfiguration(conf: SparkConf): Configuration = {..} function to copy only s3 and swift related confs
## How was this patch tested?

This patch was manually tested on local machine in standalone cluster mode.
To simulate the case of executor failure. We manually killed the executor then master started new executor with updated config params.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
no

…s in standalone spark cluster
