### PR TITLE
[SPARK-16966] [SQL] [CORE] App Name is a randomUUID even when "spark.app.name" exists

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -815,11 +815,6 @@ object SparkSession {
 
         // No active nor global default session. Create a new one.
         val sparkContext = userSuppliedContext.getOrElse {
-          // set app name if not given
-          if (!options.contains("spark.app.name")) {
-            options += "spark.app.name" -> java.util.UUID.randomUUID().toString
-          }
-
           val sparkConf = new SparkConf()
           options.foreach { case (k, v) => sparkConf.set(k, v) }
           val sc = SparkContext.getOrCreate(sparkConf)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -29,6 +29,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
   private lazy val sparkContext: SparkContext = {
     initialSession = SparkSession.builder()
       .master("local")
+      .appName("SparkSessionBuilderSuite")
       .config("spark.ui.enabled", value = false)
       .config("some-config", "v2")
       .getOrCreate()
@@ -74,19 +75,19 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
   }
 
   test("create a new session if the default session has been stopped") {
-    val defaultSession = SparkSession.builder().getOrCreate()
+    val defaultSession = SparkSession.builder().appName("test").getOrCreate()
     SparkSession.setDefaultSession(defaultSession)
     defaultSession.stop()
-    val newSession = SparkSession.builder().master("local").getOrCreate()
+    val newSession = SparkSession.builder().appName("test").master("local").getOrCreate()
     assert(newSession != defaultSession)
     newSession.stop()
   }
 
   test("create a new session if the active thread session has been stopped") {
-    val activeSession = SparkSession.builder().master("local").getOrCreate()
+    val activeSession = SparkSession.builder().appName("test").master("local").getOrCreate()
     SparkSession.setActiveSession(activeSession)
     activeSession.stop()
-    val newSession = SparkSession.builder().master("local").getOrCreate()
+    val newSession = SparkSession.builder().appName("test").master("local").getOrCreate()
     assert(newSession != activeSession)
     newSession.stop()
   }
@@ -104,14 +105,14 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
   }
 
   test("SPARK-15887: hive-site.xml should be loaded") {
-    val session = SparkSession.builder().master("local").getOrCreate()
+    val session = SparkSession.builder().appName("test").master("local").getOrCreate()
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
     assert(session.sparkContext.hadoopConfiguration.get("hive.in.test") == "true")
     session.stop()
   }
 
   test("SPARK-15991: Set global Hadoop conf") {
-    val session = SparkSession.builder().master("local").getOrCreate()
+    val session = SparkSession.builder().appName("test").master("local").getOrCreate()
     val mySpecialKey = "my.special.key.15991"
     val mySpecialValue = "msv"
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Don't override spark.app.name in SparkSession when making a new context, as it will override spark.app.name in SparkConf, and will have already been checked anyway by SparkSubmit
## How was this patch tested?

Jenkins tests.
