### PR TITLE
[Doc] add config option spark.ui.enabled into document

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,6 +568,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.ui.enabled</code></td>
+  <td>true</td>
+  <td>
+    Whether to run web ui service inside spark application.
+  </td>
+</tr>
+<tr>
   <td><code>spark.ui.killEnabled</code></td>
   <td>true</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -571,7 +571,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.ui.enabled</code></td>
   <td>true</td>
   <td>
-    Whether to run web ui service inside spark application.
+    Whether to run the web UI for the Spark application.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The configuration doc lost the config option `spark.ui.enabled` (default value is `true`)
I think this option is important because many cases we would like to turn it off.
so I add it.
## How was this patch tested?

N/A
