### PR TITLE
[SPARK-17013][SQL] Parse negative numeric literals

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -625,13 +625,13 @@ quotedIdentifier
     ;
 
 number
-    : DECIMAL_VALUE            #decimalLiteral
-    | SCIENTIFIC_DECIMAL_VALUE #scientificDecimalLiteral
-    | INTEGER_VALUE            #integerLiteral
-    | BIGINT_LITERAL           #bigIntLiteral
-    | SMALLINT_LITERAL         #smallIntLiteral
-    | TINYINT_LITERAL          #tinyIntLiteral
-    | DOUBLE_LITERAL           #doubleLiteral
+    : MINUS? DECIMAL_VALUE            #decimalLiteral
+    | MINUS? SCIENTIFIC_DECIMAL_VALUE #scientificDecimalLiteral
+    | MINUS? INTEGER_VALUE            #integerLiteral
+    | MINUS? BIGINT_LITERAL           #bigIntLiteral
+    | MINUS? SMALLINT_LITERAL         #smallIntLiteral
+    | MINUS? TINYINT_LITERAL          #tinyIntLiteral
+    | MINUS? DOUBLE_LITERAL           #doubleLiteral
     ;
 
 nonReserved

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -58,7 +58,7 @@ case class UnaryMinus(child: Expression) extends UnaryExpression
     }
   }
 
-  override def sql: String = s"(-${child.sql})"
+  override def sql: String = s"(- ${child.sql})"
 }
 
 @ExpressionDescription(
@@ -76,7 +76,7 @@ case class UnaryPositive(child: Expression)
 
   protected override def nullSafeEval(input: Any): Any = input
 
-  override def sql: String = s"(+${child.sql})"
+  override def sql: String = s"(+ ${child.sql})"
 }
 
 /**

--- a/sql/core/src/test/resources/sql-tests/results/arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/arithmetic.sql.out
@@ -37,7 +37,7 @@ struct<6.8:double>
 -- !query 4
 select -key, +key from testdata where key = 2
 -- !query 4 schema
-struct<(-key):int,key:int>
+struct<(- key):int,key:int>
 -- !query 4 output
 -2	2
 
@@ -45,7 +45,7 @@ struct<(-key):int,key:int>
 -- !query 5
 select -(key + 1), - key + 1, +(key + 5) from testdata where key = 1
 -- !query 5 schema
-struct<(-(key + 1)):int,((-key) + 1):int,(key + 5):int>
+struct<(- (key + 1)):int,((- key) + 1):int,(key + 5):int>
 -- !query 5 output
 -2	0	6
 
@@ -53,7 +53,7 @@ struct<(-(key + 1)):int,((-key) + 1):int,(key + 5):int>
 -- !query 6
 select -max(key), +max(key) from testdata
 -- !query 6 schema
-struct<(-max(key)):int,max(key):int>
+struct<(- max(key)):int,max(key):int>
 -- !query 6 output
 -100	100
 
@@ -61,7 +61,7 @@ struct<(-max(key)):int,max(key):int>
 -- !query 7
 select - (-10)
 -- !query 7 schema
-struct<(--10):int>
+struct<(- -10):int>
 -- !query 7 output
 10
 
@@ -69,7 +69,7 @@ struct<(--10):int>
 -- !query 8
 select + (-key) from testdata where key = 32
 -- !query 8 schema
-struct<(-key):int>
+struct<(- key):int>
 -- !query 8 output
 -32
 
@@ -77,7 +77,7 @@ struct<(-key):int>
 -- !query 9
 select - (+max(key)) from testdata
 -- !query 9 schema
-struct<(-max(key)):int>
+struct<(- max(key)):int>
 -- !query 9 output
 -100
 
@@ -85,7 +85,7 @@ struct<(-max(key)):int>
 -- !query 10
 select - - 3
 -- !query 10 schema
-struct<(--3):int>
+struct<(- -3):int>
 -- !query 10 output
 3
 
@@ -93,7 +93,7 @@ struct<(--3):int>
 -- !query 11
 select - + 20
 -- !query 11 schema
-struct<(-20):int>
+struct<(- 20):int>
 -- !query 11 output
 -20
 
@@ -109,7 +109,7 @@ struct<100:int>
 -- !query 13
 select - - max(key) from testdata
 -- !query 13 schema
-struct<(-(-max(key))):int>
+struct<(- (- max(key))):int>
 -- !query 13 output
 100
 
@@ -117,7 +117,7 @@ struct<(-(-max(key))):int>
 -- !query 14
 select + - key from testdata where key = 33
 -- !query 14 schema
-struct<(-key):int>
+struct<(- key):int>
 -- !query 14 output
 -33
 

--- a/sql/core/src/test/resources/sql-tests/results/arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/arithmetic.sql.out
@@ -5,7 +5,7 @@
 -- !query 0
 select -100
 -- !query 0 schema
-struct<(-100):int>
+struct<-100:int>
 -- !query 0 output
 -100
 
@@ -21,7 +21,7 @@ struct<230:int>
 -- !query 2
 select -5.2
 -- !query 2 schema
-struct<(-5.2):decimal(2,1)>
+struct<-5.2:decimal(2,1)>
 -- !query 2 output
 -5.2
 
@@ -61,7 +61,7 @@ struct<(-max(key)):int,max(key):int>
 -- !query 7
 select - (-10)
 -- !query 7 schema
-struct<(-(-10)):int>
+struct<(--10):int>
 -- !query 7 output
 10
 
@@ -85,7 +85,7 @@ struct<(-max(key)):int>
 -- !query 10
 select - - 3
 -- !query 10 schema
-struct<(-(-3)):int>
+struct<(--3):int>
 -- !query 10 output
 3
 
@@ -173,6 +173,6 @@ struct<(5 % 3):int>
 -- !query 21
 select pmod(-7, 3)
 -- !query 21 schema
-struct<pmod((-7), 3):int>
+struct<pmod(-7, 3):int>
 -- !query 21 output
 2

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -29,15 +29,9 @@ struct<1:tinyint>
 -- !query 3
 select 127Y, -128Y
 -- !query 3 schema
-struct<>
+struct<127:tinyint,-128:tinyint>
 -- !query 3 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-Value out of range. Value:"128" Radix:10(line 1, pos 14)
-
-== SQL ==
-select 127Y, -128Y
---------------^^^
+127	-128
 
 
 -- !query 4
@@ -65,15 +59,9 @@ struct<1:smallint>
 -- !query 6
 select 32767S, -32768S
 -- !query 6 schema
-struct<>
+struct<32767:smallint,-32768:smallint>
 -- !query 6 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-Value out of range. Value:"32768" Radix:10(line 1, pos 16)
-
-== SQL ==
-select 32767S, -32768S
-----------------^^^
+32767	-32768
 
 
 -- !query 7
@@ -101,15 +89,9 @@ struct<1:bigint,2147483648:bigint>
 -- !query 9
 select 9223372036854775807L, -9223372036854775808L
 -- !query 9 schema
-struct<>
+struct<9223372036854775807:bigint,-9223372036854775808:bigint>
 -- !query 9 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-For input string: "9223372036854775808"(line 1, pos 30)
-
-== SQL ==
-select 9223372036854775807L, -9223372036854775808L
-------------------------------^^^
+9223372036854775807	-9223372036854775808
 
 
 -- !query 10
@@ -129,7 +111,7 @@ select 9223372036854775808L
 -- !query 11
 select 1, -1
 -- !query 11 schema
-struct<1:int,(-1):int>
+struct<1:int,-1:int>
 -- !query 11 output
 1	-1
 
@@ -137,7 +119,7 @@ struct<1:int,(-1):int>
 -- !query 12
 select 2147483647, -2147483648
 -- !query 12 schema
-struct<2147483647:int,(-2147483648):bigint>
+struct<2147483647:int,-2147483648:int>
 -- !query 12 output
 2147483647	-2147483648
 
@@ -145,7 +127,7 @@ struct<2147483647:int,(-2147483648):bigint>
 -- !query 13
 select 9223372036854775807, -9223372036854775808
 -- !query 13 schema
-struct<9223372036854775807:bigint,(-9223372036854775808):decimal(19,0)>
+struct<9223372036854775807:bigint,-9223372036854775808:bigint>
 -- !query 13 output
 9223372036854775807	-9223372036854775808
 
@@ -153,7 +135,7 @@ struct<9223372036854775807:bigint,(-9223372036854775808):decimal(19,0)>
 -- !query 14
 select 9223372036854775808, -9223372036854775809
 -- !query 14 schema
-struct<9223372036854775808:decimal(19,0),(-9223372036854775809):decimal(19,0)>
+struct<9223372036854775808:decimal(19,0),-9223372036854775809:decimal(19,0)>
 -- !query 14 output
 9223372036854775808	-9223372036854775809
 
@@ -193,7 +175,7 @@ struct<1.0:double,1.2:double,1.0E10:double,150000.0:double,0.1:double,0.1:double
 -- !query 18
 select -1D, -1.2D, -1e10, -1.5e5, -.10D, -0.10D, -.1e5
 -- !query 18 schema
-struct<(-1.0):double,(-1.2):double,(-1.0E10):double,(-150000.0):double,(-0.1):double,(-0.1):double,(-10000.0):double>
+struct<-1.0:double,-1.2:double,-1.0E10:double,-150000.0:double,-0.1:double,-0.1:double,-10000.0:double>
 -- !query 18 output
 -1.0	-1.2	-1.0E10	-150000.0	-0.1	-0.1	-10000.0
 
@@ -215,7 +197,7 @@ select .e3
 -- !query 20
 select 1E309, -1E309
 -- !query 20 schema
-struct<Infinity:double,(-Infinity):double>
+struct<Infinity:double,-Infinity:double>
 -- !query 20 output
 Infinity	-Infinity
 
@@ -223,7 +205,7 @@ Infinity	-Infinity
 -- !query 21
 select 0.3, -0.8, .5, -.18, 0.1111, .1111
 -- !query 21 schema
-struct<0.3:decimal(1,1),(-0.8):decimal(1,1),0.5:decimal(1,1),(-0.18):decimal(2,2),0.1111:decimal(4,4),0.1111:decimal(4,4)>
+struct<0.3:decimal(1,1),-0.8:decimal(1,1),0.5:decimal(1,1),-0.18:decimal(2,2),0.1111:decimal(4,4),0.1111:decimal(4,4)>
 -- !query 21 output
 0.3	-0.8	0.5	-0.18	0.1111	0.1111
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/ExpressionSQLBuilderSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/ExpressionSQLBuilderSuite.scala
@@ -75,8 +75,8 @@ class ExpressionSQLBuilderSuite extends SQLBuilderTest {
     checkSQL('a.int / 'b.int, "(`a` / `b`)")
     checkSQL('a.int % 'b.int, "(`a` % `b`)")
 
-    checkSQL(-'a.int, "(-`a`)")
-    checkSQL(-('a.int + 'b.int), "(-(`a` + `b`))")
+    checkSQL(-'a.int, "(- `a`)")
+    checkSQL(-('a.int + 'b.int), "(- (`a` + `b`))")
   }
 
   test("window specification") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch updates the SQL parser to parse negative numeric literals as numeric literals, instead of unary minus of positive literals.

This allows the parser to parse the minimal value for each data type, e.g. "-32768S".
## How was this patch tested?

Updated test cases.
