### PR TITLE
[SPARK-17026][MLlib][Tests] remove identical values substraction

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
@@ -71,9 +71,6 @@ class MulticlassMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(math.abs(metrics.accuracy -
       (2.0 + 3.0 + 1.0) / ((2 + 3 + 1) + (1 + 1 + 1))) < delta)
-    assert(math.abs(metrics.accuracy - metrics.precision) < delta)
-    assert(math.abs(metrics.accuracy - metrics.recall) < delta)
-    assert(math.abs(metrics.accuracy - metrics.fMeasure) < delta)
     assert(math.abs(metrics.accuracy - metrics.weightedRecall) < delta)
     assert(math.abs(metrics.weightedFalsePositiveRate -
       ((4.0 / 9) * fpRate0 + (4.0 / 9) * fpRate1 + (1.0 / 9) * fpRate2)) < delta)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-17026
## What changes were proposed in this pull request?

I'm not sure if this is a valid patch, just submitting for the record.

Got warning when building project:

```
[warn] /home/jenkins/workspace/SparkPullRequestBuilder/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala:74: value precision in class MulticlassMetrics is deprecated: Use accuracy.
[warn]    assert(math.abs(metrics.accuracy - metrics.precision) < delta)
[warn]                                                ^
[warn] /home/jenkins/workspace/SparkPullRequestBuilder/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala:75: value recall in class MulticlassMetrics is deprecated: Use accuracy.
[warn]    assert(math.abs(metrics.accuracy - metrics.recall) < delta)
[warn]                                                ^
[warn] /home/jenkins/workspace/SparkPullRequestBuilder/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala:76: value fMeasure in class MulticlassMetrics is deprecated: Use accuracy.
[warn]    assert(math.abs(metrics.accuracy - metrics.fMeasure) < delta)
[warn]                                                ^
```

And `precision` and `recall` and `fMeasure` are all referencing to `accuracy`. So in this PR I just removed these 3 assert.

```
    assert(math.abs(metrics.accuracy - metrics.precision) < delta)
    assert(math.abs(metrics.accuracy - metrics.recall) < delta)
    assert(math.abs(metrics.accuracy - metrics.fMeasure) < delta)
```

```
  /**
   * Returns precision
   */
  @Since("1.1.0")
  @deprecated("Use accuracy.", "2.0.0")
  lazy val precision: Double = accuracy


  /**
   * Returns recall
   * (equals to precision for multiclass classifier
   * because sum of all false positives is equal to sum
   * of all false negatives)
   */
  @Since("1.1.0")
  @deprecated("Use accuracy.", "2.0.0")
  lazy val recall: Double = accuracy


  /**
   * Returns f-measure
   * (equals to precision and recall because precision equals recall)
   */
  @Since("1.1.0")
  @deprecated("Use accuracy.", "2.0.0")
  lazy val fMeasure: Double = accuracy
```
## How was this patch tested?

Tested manually on local laptop
