### PR TITLE
[SPARK-17028][Repl]Backport SI-9734 for Scala 2.10

### DIFF
--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkImports.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkImports.scala
@@ -208,7 +208,7 @@ private[repl] trait SparkImports {
             val valName = "$VAL" + newValId()
 
             if(!code.toString.endsWith(".`" + imv + "`;\n")) { // Which means already imported
-                code.append("val " + valName + " = " + objName + ".INSTANCE;\n")
+                code.append(s"val $valName: ${objName}.INSTANCE.type = ${objName}.INSTANCE;\n")
                 code.append("import " + valName + req.accessPath + ".`" + imv + "`;\n")
             }
             // code.append("val " + valName + " = " + objName + ".INSTANCE;\n")

--- a/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -363,4 +363,15 @@ class ReplSuite extends SparkFunSuite {
     assertDoesNotContain("Exception", output)
     assertContains("ret: Array[(Int, Iterable[Foo])] = Array((1,", output)
   }
+
+  test("SI-9734 class defined with paste mode mismatches") {
+    val output = runInterpreter("local",
+      """
+        |case class Data(i: Int); val d = Data(1)
+        |val d2: Data = d
+      """.stripMargin)
+    assertDoesNotContain("error:", output)
+    assertDoesNotContain("Exception", output)
+    assertContains("d2: Data = Data(1)", output)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport [SI-9734](https://github.com/scala/scala/pull/5084) to Spark Scala 2.10 shell.
## How was this patch tested?

The added unit test.
