### PR TITLE
[SPARK-16803] [SQL] SaveAsTable does not work when source DataFrame is built on a Hive Table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -693,6 +693,10 @@ object DDLUtils {
     table.provider.isDefined && table.provider.get != HIVE_PROVIDER
   }
 
+  def isHiveSerdeTable(table: CatalogTable): Boolean = {
+    table.provider.isDefined && table.provider.get == HIVE_PROVIDER
+  }
+
   /**
    * Throws a standard error for actions that require partitionProvider = hive.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -138,8 +138,8 @@ case class AnalyzeCreateTable(sparkSession: SparkSession) extends Rule[LogicalPl
   }
 
   private def isHiveSerdeTable(tableIdent: TableIdentifier): Boolean = {
-    sparkSession.sessionState.catalog.getTableMetadataOption(tableIdent)
-      .exists(_.provider == Option("hive"))
+    val tableMeta = sparkSession.sessionState.catalog.getTableMetadataOption(tableIdent)
+    tableMeta.isDefined && DDLUtils.isHiveSerdeTable(tableMeta.get)
   }
 
   private def checkPartitionColumns(schema: StructType, tableDesc: CatalogTable): CatalogTable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In Spark 2.0, `SaveAsTable` does not work when source DataFrame is built on a Hive Table, but Spark 1.6 works.

**Spark 1.6**

``` Scala
scala> sql("create table sample.sample stored as SEQUENCEFILE as select 1 as key, 'abc' as value")
res2: org.apache.spark.sql.DataFrame = []

scala> val df = sql("select key, value as value from sample.sample")
df: org.apache.spark.sql.DataFrame = [key: int, value: string]

scala> df.write.mode("append").saveAsTable("sample.sample")

scala> sql("select * from sample.sample").show()
+---+-----+
|key|value|
+---+-----+
|  1|  abc|
|  1|  abc|
+---+-----+
```

**Spark 2.0**

``` Scala
scala> df.write.mode("append").saveAsTable("sample.sample")
org.apache.spark.sql.AnalysisException: Saving data in MetastoreRelation sample, sample
 is not supported.;
```

This PR is to provide a support with by-name resolution. In 1.6, it is by-position resolution. The previous behavior is wrong. We need to adjust the order.
### How was this patch tested?

Test cases are added
