### PR TITLE
[SPARK-16883][SparkR]:SQL decimal type is not properly cast to number when collecting SparkDataFrame

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -401,7 +401,7 @@ setMethod("coltypes",
                   if (is.null(specialtype)) {
                     stop(paste("Unsupported data type: ", x))
                   }
-                  type <- specialtype
+                  type <- PRIMITIVE_TYPES[[specialtype]]
                 }
               }
               type

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -359,24 +359,6 @@ setMethod("colnames<-",
             dataFrame(sdf)
           })
 
-specialtypeshandle <- function(type) {
-  if (!is.null(PRIMITIVE_TYPES[[type]])) {
-    type
-  } else {
-      firstChar <- substr(type, 1, 1)
-      returntype <- NULL
-      switch (firstChar,
-              d = {
-                  m <- regexec("^decimal(.+)", type)
-                  matchedStrings <- regmatches(type, m)
-                  if (length(matchedStrings[[1]]) >= 2) {
-                    returntype <- "double"
-                  }
-              })
-      returntype
-  }
-}
-
 #' coltypes
 #'
 #' Get column types of a SparkDataFrame

--- a/R/pkg/R/types.R
+++ b/R/pkg/R/types.R
@@ -67,3 +67,24 @@ rToSQLTypes <- as.environment(list(
   "double" = "double",
   "character" = "string",
   "logical" = "boolean"))
+
+# Helper function of coverting decimal type. When backend returns column type in the
+# format of decimal(,) (e.g., decimal(10, 0)), this function coverts the column type
+# as double type.
+specialtypeshandle <- function(type) {
+  if (!is.null(PRIMITIVE_TYPES[[type]])) {
+    type
+  } else {
+    firstChar <- substr(type, 1, 1)
+    returntype <- NULL
+    switch (firstChar,
+    d = {
+      m <- regexec("^decimal(.+)", type)
+      matchedStrings <- regmatches(type, m)
+      if (length(matchedStrings[[1]]) >= 2) {
+        returntype <- "double"
+      }
+    })
+    returntype
+  }
+}

--- a/R/pkg/R/types.R
+++ b/R/pkg/R/types.R
@@ -75,15 +75,11 @@ rToSQLTypes <- as.environment(list(
 # @param A type returned from the JVM backend.
 # @return A type is the key of the PRIMITIVE_TYPES.
 specialtypeshandle <- function(type) {
-  firstChar <- substr(type, 1, 1)
   returntype <- NULL
-  switch (firstChar,
-  d = {
-    m <- regexec("^decimal(.+)$", type)
-    matchedStrings <- regmatches(type, m)
-    if (length(matchedStrings[[1]]) >= 2) {
-      returntype <- "double"
-    }
-  })
+  m <- regexec("^decimal(.+)$", type)
+  matchedStrings <- regmatches(type, m)
+  if (length(matchedStrings[[1]]) >= 2) {
+    returntype <- "double"
+  }
   returntype
 }

--- a/R/pkg/R/types.R
+++ b/R/pkg/R/types.R
@@ -70,7 +70,10 @@ rToSQLTypes <- as.environment(list(
 
 # Helper function of coverting decimal type. When backend returns column type in the
 # format of decimal(,) (e.g., decimal(10, 0)), this function coverts the column type
-# as double type.
+# as double type. This function converts backend returned types that are not the key
+# of PRIMITIVE_TYPES, but should be treated as PRIMITIVE_TYPES.
+# @param A type returned from the JVM backend.
+# @return A type is the key of the PRIMITIVE_TYPES.
 specialtypeshandle <- function(type) {
   if (!is.null(PRIMITIVE_TYPES[[type]])) {
     type

--- a/R/pkg/R/types.R
+++ b/R/pkg/R/types.R
@@ -75,19 +75,15 @@ rToSQLTypes <- as.environment(list(
 # @param A type returned from the JVM backend.
 # @return A type is the key of the PRIMITIVE_TYPES.
 specialtypeshandle <- function(type) {
-  if (!is.null(PRIMITIVE_TYPES[[type]])) {
-    type
-  } else {
-    firstChar <- substr(type, 1, 1)
-    returntype <- NULL
-    switch (firstChar,
-    d = {
-      m <- regexec("^decimal(.+)", type)
-      matchedStrings <- regmatches(type, m)
-      if (length(matchedStrings[[1]]) >= 2) {
-        returntype <- "double"
-      }
-    })
-    returntype
-  }
+  firstChar <- substr(type, 1, 1)
+  returntype <- NULL
+  switch (firstChar,
+  d = {
+    m <- regexec("^decimal(.+)$", type)
+    matchedStrings <- regmatches(type, m)
+    if (length(matchedStrings[[1]]) >= 2) {
+      returntype <- "double"
+    }
+  })
+  returntype
 }

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -668,6 +668,15 @@ test_that("collect() returns a data.frame", {
   df <- createDataFrame(list(list(1, 2)), schema = c("name", "name"))
   ldf <- collect(df)
   expect_equal(names(ldf), c("name", "name"))
+  createOrReplaceTempView(df, "dfView")
+  sqlCast <- collect(sql("select cast('2' as decimal) as x from dfView limit 1"))
+  out <- capture.output(sqlCast)
+  expect_true(is.data.frame(sqlCast))
+  expect_equal(names(sqlCast)[1], "x")
+  expect_equal(nrow(sqlCast), 1)
+  expect_equal(ncol(sqlCast), 1)
+  expect_equal(out[1], "  x")
+  expect_equal(out[2], "1 2")
 })
 
 test_that("limit() returns DataFrame with the correct number of rows", {
@@ -2089,6 +2098,9 @@ test_that("Method coltypes() to get and set R's data types of a DataFrame", {
   # Test primitive types
   DF <- createDataFrame(data, schema)
   expect_equal(coltypes(DF), c("integer", "logical", "POSIXct"))
+  createOrReplaceTempView(DF, "DFView")
+  sqlCast <- sql("select cast('2' as decimal) as x from DFView limit 1")
+  expect_equal(coltypes(sqlCast), "double")
 
   # Test complex types
   x <- createDataFrame(list(list(as.environment(
@@ -2120,6 +2132,13 @@ test_that("Method str()", {
   colnames(iris2) <- c("Sepal_Length", "Sepal_Width", "Petal_Length", "Petal_Width", "Species")
   iris2$col <- TRUE
   irisDF2 <- createDataFrame(iris2)
+  createOrReplaceTempView(irisDF2, "irisView")
+
+  sqlCast <- sql("select cast('2' as decimal) as x from irisView limit 1")
+  castStr <- capture.output(str(sqlCast))
+  expect_equal(length(castStr), 2)
+  expect_equal(castStr[1], "'SparkDataFrame': 1 variables:")
+  expect_equal(castStr[2], " $ x: dou 2")
 
   out <- capture.output(str(irisDF2))
   expect_equal(length(out), 7)


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

registerTempTable(createDataFrame(iris), "iris")
str(collect(sql("select cast('1' as double) as x, cast('2' as decimal) as y  from iris limit 5")))

'data.frame':   5 obs. of  2 variables:
 $ x: num  1 1 1 1 1
 $ y:List of 5
  ..$ : num 2
  ..$ : num 2
  ..$ : num 2
  ..$ : num 2
  ..$ : num 2

The problem is that spark returns `decimal(10, 0)` col type, instead of `decimal`. Thus, `decimal(10, 0)` is not handled correctly. It should be handled as "double".

As discussed in JIRA thread, we can have two potential fixes:
1). Scala side fix to add a new case when writing the object back; However, I can't use spark.sql.types._ in Spark core due to dependency issues. I don't find a way of doing type case match;

2). SparkR side fix: Add a helper function to check special type like `"decimal(10, 0)"` and replace it with `double`, which is PRIMITIVE type. This special helper is generic for adding new types handling in the future. 

I open this PR to discuss pros and cons of both approaches. If we want to do Scala side fix, we need to find a way to match the case of DecimalType and StructType in Spark Core.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Manual test:

> str(collect(sql("select cast('1' as double) as x, cast('2' as decimal) as y  from iris limit 5")))
> 'data.frame':   5 obs. of  2 variables:
>  $ x: num  1 1 1 1 1
>  $ y: num  2 2 2 2 2
> R Unit tests
