### PR TITLE
[SPARK-17029] make toJSON not go through rdd form but operate on dataset always

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2828,7 +2828,7 @@ class Dataset[T] private[sql](
           json
         }
       }
-    } (sparkSession.implicits.newStringEncoder)
+    } (Encoders.STRING)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2804,8 +2804,7 @@ class Dataset[T] private[sql](
    * @since 2.0.0
    */
   def toJSON: Dataset[String] = {
-    val rowSchema = schema
-    import sparkSession.implicits.newStringEncoder
+    val rowSchema = this.schema
     val sessionLocalTimeZone = sparkSession.sessionState.conf.sessionLocalTimeZone
     mapPartitions { iter =>
       val writer = new CharArrayWriter()
@@ -2829,7 +2828,7 @@ class Dataset[T] private[sql](
           json
         }
       }
-    }
+    } (sparkSession.implicits.newStringEncoder)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2816,7 +2816,7 @@ class Dataset[T] private[sql](
       new Iterator[String] {
         override def hasNext: Boolean = iter.hasNext
         override def next(): String = {
-          gen.write(boundEnc.toRow(iter.next()))
+          gen.write(exprEnc.toRow(iter.next()))
           gen.flush()
 
           val json = writer.toString

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -130,6 +130,16 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def equals(other: Any): Boolean = other.isInstanceOf[JsonFileFormat]
 }
 
+/**
+ * Implementation of OutputWriter for Json file format. Uses [[JacksonGenerator]]
+ * to do json conversion.
+ *
+ * @param path output location for the job
+ * @param options json generator options
+ * @param bucketId bucket for this partition
+ * @param dataSchema JacksonGenerator factory
+ * @param context hadoop task context
+ */
 private[json] class JsonOutputWriter(
     path: String,
     options: JSONOptions,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -130,16 +130,6 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def equals(other: Any): Boolean = other.isInstanceOf[JsonFileFormat]
 }
 
-/**
- * Implementation of OutputWriter for Json file format. Uses [[JacksonGenerator]]
- * to do json conversion.
- *
- * @param path output location for the job
- * @param options json generator options
- * @param bucketId bucket for this partition
- * @param dataSchema JacksonGenerator factory
- * @param context hadoop task context
- */
 private[json] class JsonOutputWriter(
     path: String,
     options: JSONOptions,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -29,7 +29,7 @@ import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{functions => F, _}
-import org.apache.spark.sql.catalyst.json.{CreateJacksonParser, JSONOptions, JacksonParser}
+import org.apache.spark.sql.catalyst.json.{CreateJacksonParser, JacksonParser, JSONOptions}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.ExternalRDD
 import org.apache.spark.sql.execution.datasources.DataSource

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1333,9 +1333,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
       case _ => false
     }
 
-    if (containsRDD.isDefined) {
-      fail("Expected logical plan of toJSON to not contain an RDD")
-    }
+    assert(containsRDD.isEmpty, "Expected logical plan of toJSON to not contain an RDD")
   }
 
   test("JSONRelation equality test") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -29,8 +29,9 @@ import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{functions => F, _}
-import org.apache.spark.sql.catalyst.json.{CreateJacksonParser, JacksonParser, JSONOptions}
+import org.apache.spark.sql.catalyst.json.{CreateJacksonParser, JSONOptions, JacksonParser}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.execution.ExternalRDD
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.json.JsonInferSchema.compatibleType
 import org.apache.spark.sql.internal.SQLConf
@@ -1324,6 +1325,17 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         "from complexTable"),
       Row(5, null)
     )
+  }
+
+  test("Dataset toJSON doesn't construct rdd") {
+    val containsRDD = spark.emptyDataFrame.toJSON.queryExecution.logical.find {
+      case ExternalRDD(_, _) => true
+      case _ => false
+    }
+
+    if (containsRDD.isDefined) {
+      fail("Expected logical plan of toJSON to not contain an RDD")
+    }
   }
 
   test("JSONRelation equality test") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Don't convert toRdd when doing toJSON
## How was this patch tested?

Existing unit tests
