### PR TITLE
[SPARK-17031][SQL] Add `Scanner` operator to wrap the optimized plan directly in planner

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -480,6 +480,8 @@ class Analyzer(
           r
         case i @ InsertIntoTable(r: MultiInstanceRelation, _, _, _, _) =>
           r
+        case s @ Scanner(_, _, SubqueryAlias(_, r: MultiInstanceRelation)) =>
+          r
       }.toSet
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -480,7 +480,7 @@ class Analyzer(
           r
         case i @ InsertIntoTable(r: MultiInstanceRelation, _, _, _, _) =>
           r
-        case s @ Scanner(_, _, SubqueryAlias(_, r: MultiInstanceRelation)) =>
+        case s @ Scanner(_, _, SubqueryAlias(_, r: MultiInstanceRelation, _)) =>
           r
       }.toSet
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2100,6 +2100,11 @@ object CleanupAliases extends Rule[LogicalPlan] {
         projectList.map(trimNonTopLevelAliases(_).asInstanceOf[NamedExpression])
       Project(cleanedProjectList, child)
 
+    case Scanner(projectList, filters, child) =>
+      val cleanedProjectList =
+        projectList.map(trimNonTopLevelAliases(_).asInstanceOf[NamedExpression])
+      Scanner(cleanedProjectList, filters, child)
+
     case Aggregate(grouping, aggs, child) =>
       val cleanedAggs = aggs.map(trimNonTopLevelAliases(_).asInstanceOf[NamedExpression])
       Aggregate(grouping.map(trimAliases), cleanedAggs, child)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Scanner, SubqueryAlias}
 import org.apache.spark.sql.catalyst.util.StringUtils
 
 object SessionCatalog {
@@ -417,9 +417,9 @@ class SessionCatalog(
         val view = Option(metadata.tableType).collect {
           case CatalogTableType.VIEW => name
         }
-        SubqueryAlias(relationAlias, SimpleCatalogRelation(db, metadata), view)
+        SubqueryAlias(relationAlias, Scanner(SimpleCatalogRelation(db, metadata)), view)
       } else {
-        SubqueryAlias(relationAlias, tempTables(table), Option(name))
+        SubqueryAlias(relationAlias, Scanner(tempTables(table)), Option(name))
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -298,6 +298,10 @@ package object dsl {
 
       def filter[T : Encoder](func: T => Boolean): LogicalPlan = TypedFilter(func, logicalPlan)
 
+      def scanner(): LogicalPlan = Scanner(logicalPlan)
+
+      def scanner(condition: Expression): LogicalPlan = Scanner(condition, logicalPlan)
+
       def serialize[T : Encoder]: LogicalPlan = CatalystSerde.serialize[T](logicalPlan)
 
       def deserialize[T : Encoder]: LogicalPlan = CatalystSerde.deserialize[T](logicalPlan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -558,6 +558,15 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan] with PredicateHelpe
         filter
       }
 
+    case scanner @ Scanner(projectList, filters, child) =>
+      val newFilters = scanner.constraints --
+        (child.constraints ++ filters)
+      if (newFilters.nonEmpty) {
+        Scanner(projectList, newFilters.toSeq ++ filters, child)
+      } else {
+        scanner
+      }
+
     case join @ Join(left, right, joinType, conditionOpt) =>
       // Only consider constraints that can be pushed down completely to either the left or the
       // right child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -426,7 +426,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
       val required = child.references ++ p.references
       if ((child.inputSet -- required).nonEmpty) {
         val newChildren = child.children.map { c =>
-          c transformUp {
+          c match {
             case r: MultiInstanceRelation => r
             case _ => prunedChild(c, required)
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1107,6 +1107,9 @@ object InsertRelationScanner extends Rule[LogicalPlan] with PredicateHelper {
     case Filter(condition, child: Scanner) if condition.deterministic =>
       val newFilters = splitConjunctivePredicates(condition) ++ child.filters
       child.copy(filters = newFilters)
+    case Scanner(fields, filters, child: Scanner) =>
+      val newFilters = filters ++ child.filters
+      child.copy(projectList = fields, filters = newFilters)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -115,6 +115,17 @@ case class Filter(condition: Expression, child: LogicalPlan)
   }
 }
 
+/** Factory for constructing new `Scanner` nodes. */
+object Scanner extends PredicateHelper {
+  def apply(child: LogicalPlan): Scanner = {
+    Scanner(child.output, Nil, child)
+  }
+
+  def apply(condition: Expression, child: LogicalPlan): Scanner = {
+    Scanner(child.output, splitConjunctivePredicates(condition), child)
+  }
+}
+
 case class Scanner(projectList: Seq[NamedExpression], filters: Seq[Expression], child: LogicalPlan)
   extends UnaryNode {
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -144,7 +144,6 @@ case class Scanner(projectList: Seq[NamedExpression], filters: Seq[Expression], 
 
   override def validConstraints: Set[Expression] =
     child.constraints
-      .union(getAliasedConstraints(projectList))
       .union(filters.filterNot(SubqueryExpression.hasCorrelatedSubquery).toSet)
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
@@ -39,7 +39,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using inner join") {
     val naturalPlan = r1.join(r2, NaturalJoin(Inner), None)
     val usingPlan = r1.join(r2, UsingJoin(Inner, Seq(UnresolvedAttribute("a"))), None)
-    val expected = r1.join(r2, Inner, Some(EqualTo(a, a))).select(a, b, c)
+    val expected = r1.scanner().join(r2.scanner(), Inner, Some(EqualTo(a, a))).select(a, b, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -47,7 +47,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using left join") {
     val naturalPlan = r1.join(r2, NaturalJoin(LeftOuter), None)
     val usingPlan = r1.join(r2, UsingJoin(LeftOuter, Seq(UnresolvedAttribute("a"))), None)
-    val expected = r1.join(r2, LeftOuter, Some(EqualTo(a, a))).select(a, b, c)
+    val expected = r1.scanner().join(r2.scanner(), LeftOuter, Some(EqualTo(a, a))).select(a, b, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -55,7 +55,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using right join") {
     val naturalPlan = r1.join(r2, NaturalJoin(RightOuter), None)
     val usingPlan = r1.join(r2, UsingJoin(RightOuter, Seq(UnresolvedAttribute("a"))), None)
-    val expected = r1.join(r2, RightOuter, Some(EqualTo(a, a))).select(a, b, c)
+    val expected = r1.scanner().join(r2.scanner(), RightOuter, Some(EqualTo(a, a))).select(a, b, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -63,7 +63,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using full outer join") {
     val naturalPlan = r1.join(r2, NaturalJoin(FullOuter), None)
     val usingPlan = r1.join(r2, UsingJoin(FullOuter, Seq(UnresolvedAttribute("a"))), None)
-    val expected = r1.join(r2, FullOuter, Some(EqualTo(a, a))).select(
+    val expected = r1.scanner().join(r2.scanner(), FullOuter, Some(EqualTo(a, a))).select(
       Alias(Coalesce(Seq(a, a)), "a")(), b, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
@@ -72,8 +72,8 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using inner join with no nullability") {
     val naturalPlan = r3.join(r4, NaturalJoin(Inner), None)
     val usingPlan = r3.join(r4, UsingJoin(Inner, Seq(UnresolvedAttribute("b"))), None)
-    val expected = r3.join(r4, Inner, Some(EqualTo(bNotNull, bNotNull))).select(
-      bNotNull, aNotNull, cNotNull)
+    val expected = r3.scanner().join(r4.scanner(), Inner, Some(EqualTo(bNotNull, bNotNull)))
+      .select(bNotNull, aNotNull, cNotNull)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -81,8 +81,8 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using left join with no nullability") {
     val naturalPlan = r3.join(r4, NaturalJoin(LeftOuter), None)
     val usingPlan = r3.join(r4, UsingJoin(LeftOuter, Seq(UnresolvedAttribute("b"))), None)
-    val expected = r3.join(r4, LeftOuter, Some(EqualTo(bNotNull, bNotNull))).select(
-      bNotNull, aNotNull, c)
+    val expected = r3.scanner().join(r4.scanner(), LeftOuter, Some(EqualTo(bNotNull, bNotNull)))
+      .select(bNotNull, aNotNull, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -90,8 +90,8 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using right join with no nullability") {
     val naturalPlan = r3.join(r4, NaturalJoin(RightOuter), None)
     val usingPlan = r3.join(r4, UsingJoin(RightOuter, Seq(UnresolvedAttribute("b"))), None)
-    val expected = r3.join(r4, RightOuter, Some(EqualTo(bNotNull, bNotNull))).select(
-      bNotNull, a, cNotNull)
+    val expected = r3.scanner().join(r4.scanner(), RightOuter, Some(EqualTo(bNotNull, bNotNull)))
+      .select(bNotNull, a, cNotNull)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -99,8 +99,8 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   test("natural/using full outer join with no nullability") {
     val naturalPlan = r3.join(r4, NaturalJoin(FullOuter), None)
     val usingPlan = r3.join(r4, UsingJoin(FullOuter, Seq(UnresolvedAttribute("b"))), None)
-    val expected = r3.join(r4, FullOuter, Some(EqualTo(bNotNull, bNotNull))).select(
-      Alias(Coalesce(Seq(b, b)), "b")(), a, c)
+    val expected = r3.scanner().join(r4.scanner(), FullOuter, Some(EqualTo(bNotNull, bNotNull)))
+      .select(Alias(Coalesce(Seq(b, b)), "b")(), a, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }
@@ -115,7 +115,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   }
 
   test("using join with a case sensitive analyzer") {
-    val expected = r1.join(r2, Inner, Some(EqualTo(a, a))).select(a, b, c)
+    val expected = r1.scanner().join(r2.scanner(), Inner, Some(EqualTo(a, a))).select(a, b, c)
 
     {
       val usingPlan = r1.join(r2, UsingJoin(Inner, Seq(UnresolvedAttribute("a"))), None)
@@ -131,7 +131,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   }
 
   test("using join with a case insensitive analyzer") {
-    val expected = r1.join(r2, Inner, Some(EqualTo(a, a))).select(a, b, c)
+    val expected = r1.scanner().join(r2.scanner(), Inner, Some(EqualTo(a, a))).select(a, b, c)
 
     {
       val usingPlan = r1.join(r2, UsingJoin(Inner, Seq(UnresolvedAttribute("a"))), None)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -134,14 +134,16 @@ class ColumnPruningSuite extends PlanTest {
   test("Column pruning on Filter") {
     val input = LocalRelation('a.int, 'b.string, 'c.double)
     val plan1 = Filter('a > 1, input).analyze
-    comparePlans(Optimize.execute(plan1), plan1)
+    val expected1 = Scanner('a > 1, input).analyze
+    comparePlans(Optimize.execute(plan1), expected1)
     val query = Project('a :: Nil, Filter('c > Literal(0.0), input)).analyze
-    comparePlans(Optimize.execute(query), query)
+    val expectedQuery = Project('a :: Nil, Scanner('c > Literal(0.0), input)).analyze
+    comparePlans(Optimize.execute(query), expectedQuery)
     val plan2 = Filter('b > 1, Project(Seq('a, 'b), input)).analyze
-    val expected2 = Project(Seq('a, 'b), Filter('b > 1, input)).analyze
+    val expected2 = Project(Seq('a, 'b), Scanner('b > 1, input)).analyze
     comparePlans(Optimize.execute(plan2), expected2)
     val plan3 = Project(Seq('a), Filter('b > 1, Project(Seq('a, 'b), input))).analyze
-    val expected3 = Project(Seq('a), Filter('b > 1, input)).analyze
+    val expected3 = Project(Seq('a), Scanner('b > 1, input)).analyze
     comparePlans(Optimize.execute(plan3), expected3)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSubqueryAliasesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSubqueryAliasesSuite.scala
@@ -47,7 +47,7 @@ class EliminateSubqueryAliasesSuite extends PlanTest with PredicateHelper {
   test("eliminate top level subquery") {
     val input = LocalRelation('a.int, 'b.int)
     val query = SubqueryAlias("a", input, None)
-    comparePlans(afterOptimization(query), input)
+    comparePlans(afterOptimization(query), Scanner(input))
   }
 
   test("eliminate mid-tree subquery") {
@@ -55,7 +55,7 @@ class EliminateSubqueryAliasesSuite extends PlanTest with PredicateHelper {
     val query = Filter(TrueLiteral, SubqueryAlias("a", input, None))
     comparePlans(
       afterOptimization(query),
-      Filter(TrueLiteral, LocalRelation('a.int, 'b.int)))
+      Filter(TrueLiteral, Scanner(LocalRelation('a.int, 'b.int))))
   }
 
   test("eliminate multiple subqueries") {
@@ -64,6 +64,6 @@ class EliminateSubqueryAliasesSuite extends PlanTest with PredicateHelper {
       SubqueryAlias("c", SubqueryAlias("b", SubqueryAlias("a", input, None), None), None))
     comparePlans(
       afterOptimization(query),
-      Filter(TrueLiteral, LocalRelation('a.int, 'b.int)))
+      Filter(TrueLiteral, Scanner(LocalRelation('a.int, 'b.int))))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -71,7 +71,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .where('a === 1)
+        .scanner('a === 1)
         .select('a)
         .analyze
 
@@ -87,7 +87,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .where('a === 1 && 'b === 1 && 'c === 1)
+        .scanner('a === 1 && 'b === 1 && 'c === 1)
         .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -103,7 +103,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .where('a === 1 && 'b === 1)
+        .scanner('a === 1 && 'b === 1)
         .select('a, 'b)
         .analyze
 
@@ -127,7 +127,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .where('a + 'b === 1)
+        .scanner('a + 'b === 1)
         .select('a + 'b as 'e)
         .analyze
 
@@ -165,7 +165,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .where('a === 1 && 'a === 2)
+        .scanner('a === 1 && 'a === 2)
         .select('a).analyze
 
     comparePlans(optimized, correctAnswer)
@@ -182,8 +182,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 1)
-    val right = testRelation.where('b === 2)
+    val left = testRelation.scanner('b === 1)
+    val right = testRelation.scanner('b === 2)
     val correctAnswer =
       left.join(right).analyze
 
@@ -200,7 +200,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 1)
+    val left = testRelation.scanner('b === 1)
     val right = testRelation
     val correctAnswer =
       left.join(right).analyze
@@ -219,7 +219,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('a === 1)
+    val left = testRelation.scanner('a === 1)
     val right = testRelation1
     val correctAnswer =
       left.join(right, condition = Some("d".attr === "b".attr || "d".attr === "c".attr)).analyze
@@ -237,8 +237,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 1)
-    val right = testRelation.where('b === 2)
+    val left = testRelation.scanner('b === 1)
+    val right = testRelation.scanner('b === 2)
     val correctAnswer =
       left.join(right).analyze
 
@@ -254,8 +254,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b >= 1)
-    val right = testRelation1.where('d >= 2)
+    val left = testRelation.scanner('b >= 1)
+    val right = testRelation1.scanner('d >= 2)
     val correctAnswer =
       left.join(right, LeftSemi, Option("a".attr === "d".attr)).analyze
 
@@ -272,7 +272,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 1)
+    val left = testRelation.scanner('b === 1)
     val correctAnswer =
       left.join(y, LeftOuter).where("y.b".attr === 2).analyze
 
@@ -289,7 +289,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val right = testRelation.where('b === 2).subquery('d)
+    val right = testRelation.scanner('b === 2).subquery('d)
     val correctAnswer =
       x.join(right, RightOuter).where("x.b".attr === 1).analyze
 
@@ -306,7 +306,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 2).subquery('d)
+    val left = testRelation.scanner('b === 2).subquery('d)
     val correctAnswer =
       left.join(y, LeftOuter, Some("d.b".attr === 1)).where("y.b".attr === 2).analyze
 
@@ -323,7 +323,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val right = testRelation.where('b === 2).subquery('d)
+    val right = testRelation.scanner('b === 2).subquery('d)
     val correctAnswer =
       x.join(right, RightOuter, Some("d.b".attr === 1)).where("x.b".attr === 2).analyze
 
@@ -340,8 +340,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 2).subquery('l)
-    val right = testRelation.where('b === 1).subquery('r)
+    val left = testRelation.scanner('b === 2).subquery('l)
+    val right = testRelation.scanner('b === 1).subquery('r)
     val correctAnswer =
       left.join(right, LeftOuter).where("r.b".attr === 2).analyze
 
@@ -358,7 +358,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val right = testRelation.where('b === 2).subquery('r)
+    val right = testRelation.scanner('b === 2).subquery('r)
     val correctAnswer =
       x.join(right, RightOuter, Some("r.b".attr === 1)).where("x.b".attr === 2).analyze
 
@@ -375,8 +375,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 2).subquery('l)
-    val right = testRelation.where('b === 1).subquery('r)
+    val left = testRelation.scanner('b === 2).subquery('l)
+    val right = testRelation.scanner('b === 1).subquery('r)
     val correctAnswer =
       left.join(right, LeftOuter).where("r.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
 
@@ -394,7 +394,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val left = testRelation.subquery('l)
-    val right = testRelation.where('b === 2).subquery('r)
+    val right = testRelation.scanner('b === 2).subquery('r)
     val correctAnswer =
       left.join(right, RightOuter, Some("r.b".attr === 1)).
         where("l.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
@@ -412,8 +412,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b === 2).subquery('l)
-    val right = testRelation.where('b === 1).subquery('r)
+    val left = testRelation.scanner('b === 2).subquery('l)
+    val right = testRelation.scanner('b === 1).subquery('r)
     val correctAnswer =
       left.join(right, LeftOuter, Some("l.a".attr===3)).
         where("r.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
@@ -431,8 +431,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('a === 3).subquery('l)
-    val right = testRelation.where('b === 2).subquery('r)
+    val left = testRelation.scanner('a === 3).subquery('l)
+    val right = testRelation.scanner('b === 2).subquery('r)
     val correctAnswer =
       left.join(right, RightOuter, Some("r.b".attr === 1)).
         where("l.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
@@ -462,8 +462,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('a === 1).subquery('x)
-    val right = testRelation.where('a === 1).subquery('y)
+    val left = testRelation.scanner('a === 1).subquery('x)
+    val right = testRelation.scanner('a === 1).subquery('y)
     val correctAnswer =
       left.join(right, condition = Some("x.b".attr === "y.b".attr))
         .analyze
@@ -481,7 +481,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('a === 1).subquery('x)
+    val left = testRelation.scanner('a === 1).subquery('x)
     val right = testRelation.subquery('y)
     val correctAnswer =
       left.join(right, condition = Some("x.b".attr === "y.b".attr))
@@ -502,8 +502,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val lleft = testRelation.where('a >= 3).subquery('z)
-    val left = testRelation.where('a === 1).subquery('x)
+    val lleft = testRelation.scanner('a >= 3).subquery('z)
+    val left = testRelation.scanner('a === 1).subquery('x)
     val right = testRelation.subquery('y)
     val correctAnswer =
       lleft.join(
@@ -525,7 +525,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = {
       testRelationWithArrayType
-        .where(('b >= 5) && ('a > 6))
+        .scanner(('b >= 5) && ('a > 6))
         .generate(Explode('c_arr), true, false, Some("arr")).analyze
     }
 
@@ -541,7 +541,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = {
       testRelationWithArrayType
-        .where('b >= 5)
+        .scanner('b >= 5)
         .generate(Explode('c_arr), true, false, Some("arr"))
         .where('a + Rand(10).as("rnd") > 6 && 'c > 6)
         .analyze
@@ -560,7 +560,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val referenceResult = {
       testRelationWithArrayType
-        .where('b >= 5)
+        .scanner('b >= 5)
         .generate(generator, true, false, Some("arr"))
         .where('c > 6).analyze
     }
@@ -599,7 +599,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-                        .where('a === 2)
+                        .scanner('a === 2)
                         .groupBy('a)('a, count('b) as 'c)
                         .analyze
     comparePlans(optimized, correctAnswer)
@@ -625,7 +625,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-                        .where('a === 3)
+                        .scanner('a === 3)
                         .select('a, 'b)
                         .groupBy('a)('a, count('b) as 'c)
                         .where('c === 2L)
@@ -643,7 +643,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-      .where('a + 1 < 3)
+      .scanner('a + 1 < 3)
       .select('a, 'b)
       .groupBy('a)(('a + 1) as 'aa, count('b) as 'c)
       .where('c === 2L || 'aa > 4)
@@ -661,7 +661,7 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-      .where("s" === "s")
+      .scanner("s" === "s")
       .select('a, 'b)
       .groupBy('a)('a, count('b) as 'c, "s" as 'd)
       .where('c === 2L)
@@ -693,7 +693,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
-    val correctAnswer = BroadcastHint(testRelation.where('a === 2L))
+    val correctAnswer = BroadcastHint(testRelation.scanner('a === 2L))
       .where('b + Rand(10).as("rnd") === 3)
       .analyze
 
@@ -709,8 +709,8 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = Union(Seq(
-      testRelation.where('a === 2L),
-      testRelation2.where('d === 2L)))
+      testRelation.scanner('a === 2L),
+      testRelation2.scanner('d === 2L)))
       .where('b + Rand(10).as("rnd") === 3 && 'c > 5L)
       .analyze
 
@@ -742,7 +742,7 @@ class FilterPushdownSuite extends PlanTest {
       .where(Exists(z.where("x.a".attr === "z.a".attr)))
       .analyze
     val answer = x
-      .where(Exists(z.where("x.a".attr === "z.a".attr)))
+      .scanner(Exists(z.where("x.a".attr === "z.a".attr)))
       .join(y, Inner, Option("x.a".attr === "y.a".attr))
       .analyze
     val optimized = Optimize.execute(Optimize.execute(query))
@@ -761,7 +761,7 @@ class FilterPushdownSuite extends PlanTest {
       .where(Exists(z.where("w.a".attr === "z.a".attr)))
       .analyze
     val answer = w
-      .where(Exists(z.where("w.a".attr === "z.a".attr)))
+      .scanner(Exists(z.where("w.a".attr === "z.a".attr)))
       .join(x, Inner, Option("w.a".attr === "x.a".attr))
       .join(y, LeftOuter, Option("x.a".attr === "y.a".attr))
       .analyze
@@ -774,7 +774,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val originalQuery = testRelation.select('a, 'b, 'c, winExpr.as('window)).where('a > 1)
     val correctAnswer = testRelation
-      .where('a > 1).select('a, 'b, 'c)
+      .scanner('a > 1).select('a, 'b, 'c)
       .window(winExpr.as('window) :: Nil, 'a :: Nil, 'b.asc :: Nil)
       .select('a, 'b, 'c, 'window).analyze
 
@@ -787,7 +787,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val originalQuery = testRelation.select('a, 'b, 'c, winExpr.as('window)).where('a * 3 > 15)
     val correctAnswer = testRelation
-      .where('a * 3 > 15).select('a, 'b, 'c)
+      .scanner('a * 3 > 15).select('a, 'b, 'c)
       .window(winExpr.as('window) :: Nil, 'a.attr :: 'b.attr :: Nil, 'b.asc :: Nil)
       .select('a, 'b, 'c, 'window).analyze
 
@@ -802,7 +802,7 @@ class FilterPushdownSuite extends PlanTest {
       .select('a, 'b, 'c, winExpr1.as('window1), winExpr2.as('window2)).where('a > 1)
 
     val correctAnswer = testRelation
-      .where('a > 1).select('a, 'b, 'c)
+      .scanner('a > 1).select('a, 'b, 'c)
       .window(winExpr1.as('window1) :: winExpr2.as('window2) :: Nil,
         'a.attr :: 'b.attr :: Nil, 'b.asc :: Nil)
       .select('a, 'b, 'c, 'window1, 'window2).analyze
@@ -820,13 +820,13 @@ class FilterPushdownSuite extends PlanTest {
       .select('a, 'b, 'c, winExpr1.as('window1), winExpr2.as('window2)).where('a > 1)
 
     val correctAnswer1 = testRelation
-      .where('a > 1).select('a, 'b, 'c)
+      .scanner('a > 1).select('a, 'b, 'c)
       .window(winExpr1.as('window1) :: Nil, 'a.attr :: 'b.attr :: Nil, 'b.asc :: Nil)
       .window(winExpr2.as('window2) :: Nil, 'a.attr :: 'b.attr :: Nil, 'a.asc :: Nil)
       .select('a, 'b, 'c, 'window1, 'window2).analyze
 
     val correctAnswer2 = testRelation
-      .where('a > 1).select('a, 'b, 'c)
+      .scanner('a > 1).select('a, 'b, 'c)
       .window(winExpr2.as('window2) :: Nil, 'a.attr :: 'b.attr :: Nil, 'a.asc :: Nil)
       .window(winExpr1.as('window1) :: Nil, 'a.attr :: 'b.attr :: Nil, 'b.asc :: Nil)
       .select('a, 'b, 'c, 'window1, 'window2).analyze
@@ -880,7 +880,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val originalQuery = testRelation.select('a, 'b, 'c, winExpr.as('window)).where('a + 'b > 1)
     val correctAnswer = testRelation
-      .where('a + 'b > 1).select('a, 'b, 'c)
+      .scanner('a + 'b > 1).select('a, 'b, 'c)
       .window(winExpr.as('window) :: Nil, 'a.attr :: 'b.attr :: Nil, 'b.asc :: Nil)
       .select('a, 'b, 'c, 'window).analyze
 
@@ -905,7 +905,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val originalQuery = testRelation.select('a, 'b, 'c, winExpr.as('window)).where('a + 'b > 1)
     val correctAnswer = testRelation
-      .where('a + 'b > 1).select('a, 'b, 'c, ('a + 'b).as("_w0"))
+      .scanner('a + 'b > 1).select('a, 'b, 'c, ('a + 'b).as("_w0"))
       .window(winExprAnalyzed.as('window) :: Nil, '_w0 :: Nil, 'b.asc :: Nil)
       .select('a, 'b, 'c, 'window).analyze
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveAliasOnlyProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveAliasOnlyProjectSuite.scala
@@ -35,7 +35,7 @@ class RemoveAliasOnlyProjectSuite extends PlanTest with PredicateHelper {
     val relation = LocalRelation('a.int, 'b.int)
     val query = relation.select('a as 'a, 'b as 'b).analyze
     val optimized = Optimize.execute(query)
-    comparePlans(optimized, relation)
+    comparePlans(optimized, Scanner(relation))
   }
 
   test("all expressions in project list are aliased child output but with different order") {
@@ -49,7 +49,7 @@ class RemoveAliasOnlyProjectSuite extends PlanTest with PredicateHelper {
     val relation = LocalRelation('a.int, 'b.int)
     val query = relation.select('a as 'a, 'b).analyze
     val optimized = Optimize.execute(query)
-    comparePlans(optimized, relation)
+    comparePlans(optimized, Scanner(relation))
   }
 
   test("some expressions in project list are aliased child output but with different order") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
@@ -67,7 +67,7 @@ class ReplaceOperatorSuite extends PlanTest {
     val query = Distinct(input)
     val optimized = Optimize.execute(query.analyze)
 
-    val correctAnswer = Aggregate(input.output, input.output, input)
+    val correctAnswer = Aggregate(input.output, input.output, input).analyze
 
     comparePlans(optimized, correctAnswer)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/SQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/SQLBuilder.scala
@@ -126,9 +126,6 @@ class SQLBuilder private (
     case p: Project =>
       projectToSQL(p, isDistinct = false)
 
-    case s: Scanner =>
-      scannerToSQL(s)
-
     case a @ Aggregate(_, _, e @ Expand(_, _, p: Project)) if isGroupingSet(a, e, p) =>
       groupingSetToSQL(a, e, p)
 
@@ -175,12 +172,8 @@ class SQLBuilder private (
         toSQL(p.right),
         p.condition.map(" ON " + _.sql).getOrElse(""))
 
-    case SQLTable(database, table, _, sample) =>
-      val qualifiedName = s"${quoteIdentifier(database)}.${quoteIdentifier(table)}"
-      sample.map { case (lowerBound, upperBound) =>
-        val fraction = math.min(100, math.max(0, (upperBound - lowerBound) * 100))
-        qualifiedName + " TABLESAMPLE(" + fraction + " PERCENT)"
-      }.getOrElse(qualifiedName)
+    case t: SQLTable =>
+      tableToSQL(t)
 
     case relation: CatalogRelation =>
       val m = relation.catalogTable
@@ -239,22 +232,28 @@ class SQLBuilder private (
     )
   }
 
-  private def scannerToSQL(scanner: Scanner): String = {
-    if (scanner.filters.nonEmpty) {
+  private def tableToSQL(table: SQLTable): String = {
+    val qualifiedName = s"${quoteIdentifier(table.database)}.${quoteIdentifier(table.table)}"
+    val withSample = table.sample.map { case (lowerBound, upperBound) =>
+      val fraction = math.min(100, math.max(0, (upperBound - lowerBound) * 100))
+      qualifiedName + " TABLESAMPLE(" + fraction + " PERCENT)"
+    }.getOrElse(qualifiedName)
+
+    if (table.filters.nonEmpty) {
       build(
         "SELECT",
-        scanner.projectList.map(_.sql).mkString(", "),
-        if (scanner.child == OneRowRelation) "" else "FROM",
-        toSQL(scanner.child),
+        table.projectList.map(_.sql).mkString(", "),
+        "FROM",
+        withSample,
         "WHERE",
-        scanner.filters.reduce(And).sql
+        table.filters.reduce(And).sql
       )
     } else {
       build(
         "SELECT",
-        scanner.projectList.map(_.sql).mkString(","),
-        if (scanner.child == OneRowRelation) "" else "FROM",
-        toSQL(scanner.child)
+        table.projectList.map(_.sql).mkString(", "),
+        "FROM",
+        withSample
       )
     }
   }
@@ -469,28 +468,17 @@ class SQLBuilder private (
 
     object RemoveSubqueriesAboveSQLTable extends Rule[LogicalPlan] {
       override def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
-        case SubqueryAlias(_, t @ ExtractSQLTable(_), _) => t
+        case SubqueryAlias(_, t: Scanner) => t
+        case SubqueryAlias(_, r: LogicalRelation) => r
       }
     }
 
     object ResolveSQLTable extends Rule[LogicalPlan] {
       override def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
-        case Sample(lowerBound, upperBound, _, _, s @ Scanner(_, _, ExtractSQLTable(table))) =>
-          addSubquery(s.copy(child = aliasColumns(table.withSample(lowerBound, upperBound))))
-        case s @ Scanner(_, _, ExtractSQLTable(table)) =>
-          addSubquery(s.copy(child = aliasColumns(table)))
-      }
-
-      /**
-       * Aliases the table columns to the generated attribute names, as we use exprId to generate
-       * unique name for each attribute when normalize attributes, and we can't reference table
-       * columns with their real names.
-       */
-      private def aliasColumns(table: SQLTable): LogicalPlan = {
-        val aliasedOutput = table.output.map { attr =>
-          Alias(attr, normalizedName(attr))(exprId = attr.exprId)
-        }
-        addSubquery(Project(aliasedOutput, table))
+        case Sample(lowerBound, upperBound, _, _, ExtractSQLTable(table)) =>
+          addSubquery(table.withSample(lowerBound, upperBound))
+        case s @ ExtractSQLTable(table) =>
+          addSubquery(table)
       }
     }
 
@@ -605,26 +593,47 @@ class SQLBuilder private (
   case class SQLTable(
       database: String,
       table: String,
-      output: Seq[Attribute],
+      projectList: Seq[NamedExpression],
+      filters: Seq[Expression],
       sample: Option[(Double, Double)] = None) extends LeafNode {
+    override def output: Seq[Attribute] = projectList.map(_.toAttribute)
+
     def withSample(lowerBound: Double, upperBound: Double): SQLTable =
       this.copy(sample = Some(lowerBound -> upperBound))
   }
 
   object ExtractSQLTable {
     def unapply(plan: LogicalPlan): Option[SQLTable] = plan match {
-      case l @ LogicalRelation(_, _, Some(catalogTable))
-          if catalogTable.identifier.database.isDefined =>
+      case s @ Scanner(projectList, filters, l @ LogicalRelation(_, _, Some(catalogTable)))
+        if catalogTable.identifier.database.isDefined =>
         Some(SQLTable(
           catalogTable.identifier.database.get,
           catalogTable.identifier.table,
-          l.output.map(_.withQualifier(None))))
+          l.output.map(_.withQualifier(None)),
+          filters))
 
-      case relation: CatalogRelation =>
+      case s @ Scanner(projectList, filters, relation: CatalogRelation) =>
         val m = relation.catalogTable
-        Some(SQLTable(m.database, m.identifier.table, relation.output.map(_.withQualifier(None))))
+        val aliasedOutput = aliasColumns(projectList, relation.output.map(_.withQualifier(None)))
+        Some(SQLTable(m.database, m.identifier.table, aliasedOutput, filters))
 
       case _ => None
+    }
+
+    private def aliasColumns(
+        projectList: Seq[NamedExpression],
+        output: Seq[Attribute]): Seq[NamedExpression] = {
+      val aliasedOutput = output.map { attr =>
+        Alias(attr, normalizedName(attr))(exprId = attr.exprId)
+      }
+
+      val aliasMap = AttributeMap(aliasedOutput.collect {
+        case a: Alias => (a.toAttribute, a)
+      })
+
+      projectList.map(_.transformUp {
+        case a: Attribute => aliasMap.getOrElse(a, a)
+      }.asInstanceOf[NamedExpression])
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/SQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/SQLBuilder.scala
@@ -468,8 +468,8 @@ class SQLBuilder private (
 
     object RemoveSubqueriesAboveSQLTable extends Rule[LogicalPlan] {
       override def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
-        case SubqueryAlias(_, t: Scanner) => t
-        case SubqueryAlias(_, r: LogicalRelation) => r
+        case SubqueryAlias(_, t: Scanner, _) => t
+        case SubqueryAlias(_, r: LogicalRelation, _) => r
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.{Scanner, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Scanner}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
@@ -140,7 +140,7 @@ class CacheManager extends Logging {
     }
   }
 
-  def generateCachePlan(cachedData: CachedData, output: Seq[Attribute]) = {
+  private def generateCachePlan(cachedData: CachedData, output: Seq[Attribute]): LogicalPlan = {
     val cachedRelation = cachedData.cachedRepresentation.withOutput(output)
     Scanner(output, Nil, cachedRelation)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -22,7 +22,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{Scanner, LogicalPlan}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
@@ -134,9 +135,14 @@ class CacheManager extends Logging {
     plan transformDown {
       case currentFragment =>
         lookupCachedData(currentFragment)
-          .map(_.cachedRepresentation.withOutput(currentFragment.output))
+          .map(generateCachePlan(_, currentFragment.output))
           .getOrElse(currentFragment)
     }
+  }
+
+  def generateCachePlan(cachedData: CachedData, output: Seq[Attribute]) = {
+    val cachedRelation = cachedData.cachedRepresentation.withOutput(output)
+    Scanner(output, Nil, cachedRelation)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
@@ -136,6 +136,11 @@ case class OptimizeMetadataOnlyQuery(
         val partAttrs = getPartitionAttrs(relation.catalogTable.partitionColumnNames, relation)
         Some(AttributeSet(partAttrs), relation)
 
+      case s @ Scanner(projectList, filters, child) =>
+        unapply(child).flatMap { case (partAttrs, relation) =>
+          if (s.references.subsetOf(partAttrs)) Some(s.outputSet, relation) else None
+        }
+
       case p @ Project(projectList, child) if projectList.forall(_.deterministic) =>
         unapply(child).flatMap { case (partAttrs, relation) =>
           if (p.references.subsetOf(partAttrs)) Some(p.outputSet, relation) else None

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -412,8 +412,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case BroadcastHint(child) => planLater(child) :: Nil
       case Scanner(projectList, filters, child) =>
         if (filters != Nil) {
-          val condition = filters.reduceLeft(expressions.And)
+          val condition = filters.reduceLeft(And)
           planLater(Project(projectList, Filter(condition, child))) :: Nil
+        } else if (projectList.equals(child.output)) {
+          planLater(child) :: Nil
         } else {
           planLater(Project(projectList, child)) :: Nil
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{execution, SaveMode, Strategy}
 import org.apache.spark.sql.catalyst.{expressions, InternalRow}
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -21,8 +21,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Scanner}
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.SparkPlan
 
@@ -51,7 +51,7 @@ import org.apache.spark.sql.execution.SparkPlan
  */
 object FileSourceStrategy extends Strategy with Logging {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-    case PhysicalOperation(projects, filters,
+    case Scanner(projects, filters,
       l @ LogicalRelation(fsRelation: HadoopFsRelation, _, table)) =>
       // Filters on this relation fall into four categories based on where we can use them to avoid
       // reading unneeded data:

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.plans.logical.Scanner
-
 import scala.collection.mutable.HashSet
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -26,6 +24,7 @@ import scala.language.postfixOps
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.CleanerListener
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.execution.RDDScanExec
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.exchange.ShuffleExchange

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
+
 import scala.collection.mutable.HashSet
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -146,14 +148,14 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
 
     assertCached(spark.table("testData"))
     assert(spark.table("testData").queryExecution.withCachedData match {
-      case _: InMemoryRelation => true
+      case Scanner(_, _, _: InMemoryRelation) => true
       case _ => false
     })
 
     spark.catalog.uncacheTable("testData")
     assert(!spark.catalog.isCached("testData"))
     assert(spark.table("testData").queryExecution.withCachedData match {
-      case _: InMemoryRelation => false
+      case Scanner(_, _, _: InMemoryRelation) => false
       case _ => true
     })
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.plans.logical.{Scanner, LocalRelation}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Scanner}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.plans.logical.{Scanner, LocalRelation}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 
@@ -42,14 +42,14 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSQLContext {
 
   private def assertMetadataOnlyQuery(df: DataFrame): Unit = {
     val localRelations = df.queryExecution.optimizedPlan.collect {
-      case l @ LocalRelation(_, _) => l
+      case l @ Scanner(_, _, LocalRelation(_, _)) => l
     }
     assert(localRelations.size == 1)
   }
 
   private def assertNotMetadataOnlyQuery(df: DataFrame): Unit = {
     val localRelations = df.queryExecution.optimizedPlan.collect {
-      case l @ LocalRelation(_, _) => l
+      case l @ Scanner(_, _, LocalRelation(_, _)) => l
     }
     assert(localRelations.size == 0)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.{execution, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.Inner
-import org.apache.spark.sql.catalyst.plans.logical.{Scanner, LogicalPlan, Repartition}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Repartition, Scanner}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReusedExchangeExec, ReuseExchange, ShuffleExchange}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -159,7 +159,7 @@ class PlannerSuite extends SharedSQLContext {
 
       withTempView("testPushed") {
         val exp = sql("select * from testPushed where key = 15").queryExecution.sparkPlan
-        assert(exp.toString.contains("PushedFilters: [IsNotNull(key), EqualTo(key,15)]"))
+        assert(exp.toString.contains("PushedFilters: [EqualTo(key,15), IsNotNull(key)]"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.{execution, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.Inner
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Repartition}
+import org.apache.spark.sql.catalyst.plans.logical.{Scanner, LogicalPlan, Repartition}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReusedExchangeExec, ReuseExchange, ShuffleExchange}
@@ -193,8 +193,9 @@ class PlannerSuite extends SharedSQLContext {
 
   test("CollectLimit can appear in the middle of a plan when caching is used") {
     val query = testData.select('key, 'value).limit(2).cache()
-    val planned = query.queryExecution.optimizedPlan.asInstanceOf[InMemoryRelation]
-    assert(planned.child.isInstanceOf[CollectLimitExec])
+    val planned = query.queryExecution.optimizedPlan.asInstanceOf[Scanner]
+    val relation = planned.child.asInstanceOf[InMemoryRelation]
+    assert(relation.child.isInstanceOf[CollectLimitExec])
   }
 
   test("PartitioningCollection") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -23,13 +23,13 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, Path, RawLocalFileSystem}
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.sql.catalyst.plans.logical.Scanner
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet, PredicateHelper}
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.catalyst.util
 import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.functions._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -509,7 +509,9 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
       val bucketed = df.queryExecution.analyzed transform {
         case s @ Scanner(_, _, l @ LogicalRelation(r: HadoopFsRelation, _, _)) =>
           val newRelation = l.copy(relation =
-            r.copy(bucketSpec = Some(BucketSpec(numBuckets = buckets, "c1" :: Nil, Nil)))(r.sparkSession))
+            r.copy(
+              bucketSpec = Some(BucketSpec(numBuckets = buckets, "c1" :: Nil, Nil)))(
+                r.sparkSession))
           Scanner(newRelation.output, s.filters, newRelation)
       }
       Dataset.ofRows(spark, bucketed)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, Path, RawLocalFileSystem}
 import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql._
@@ -506,10 +507,10 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
 
     if (buckets > 0) {
       val bucketed = df.queryExecution.analyzed transform {
-        case l @ LogicalRelation(r: HadoopFsRelation, _, _) =>
-          l.copy(relation =
-            r.copy(bucketSpec =
-              Some(BucketSpec(numBuckets = buckets, "c1" :: Nil, Nil)))(r.sparkSession))
+        case s @ Scanner(_, _, l @ LogicalRelation(r: HadoopFsRelation, _, _)) =>
+          val newRelation = l.copy(relation =
+            r.copy(bucketSpec = Some(BucketSpec(numBuckets = buckets, "c1" :: Nil, Nil)))(r.sparkSession))
+          Scanner(newRelation.output, s.filters, newRelation)
       }
       Dataset.ofRows(spark, bucketed)
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -26,7 +26,7 @@ import org.apache.parquet.filter2.predicate.Operators.{Column => _, _}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -64,7 +64,7 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
 
         var maybeRelation: Option[HadoopFsRelation] = None
         val maybeAnalyzedPredicate = query.queryExecution.optimizedPlan.collect {
-          case PhysicalOperation(_, filters, LogicalRelation(relation: HadoopFsRelation, _, _)) =>
+          case Scanner(_, filters, LogicalRelation(relation: HadoopFsRelation, _, _)) =>
             maybeRelation = Some(relation)
             filters
         }.flatten.reduceLeftOption(_ && _)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.catalog.{FunctionResourceLoader, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, ExpressionInfo}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Scanner, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
 import org.apache.spark.sql.internal.SQLConf
@@ -61,7 +61,7 @@ private[sql] class HiveSessionCatalog(
       metastoreCatalog.lookupRelation(newName, alias)
     } else {
       val relation = tempTables(table)
-      val tableWithQualifiers = SubqueryAlias(table, relation, None)
+      val tableWithQualifiers = SubqueryAlias(table, Scanner(relation), None)
       // If an alias was specified by the lookup, wrap the plan in a subquery so that
       // attributes are properly qualified with this alias.
       alias.map(a => SubqueryAlias(a, tableWithQualifiers, None)).getOrElse(tableWithQualifiers)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -19,9 +19,8 @@ package org.apache.spark.sql.hive
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Scanner}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.datasources.CreateTable
@@ -82,7 +81,7 @@ private[hive] trait HiveStrategies {
    */
   object HiveTableScans extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-      case PhysicalOperation(projectList, predicates, relation: MetastoreRelation) =>
+      case Scanner(projectList, predicates, relation: MetastoreRelation) =>
         // Filter out all predicates that only deal with partition keys, these are given to the
         // hive table scan operator to be used for partition pruning.
         val partitionKeyIds = AttributeSet(relation.partitionKeys)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -21,7 +21,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan, Scanner}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.hive.MetastoreRelation
 
@@ -73,7 +73,7 @@ case class CreateHiveTableAsSelectCommand(
 
       // Get the Metastore Relation
       sparkSession.sessionState.catalog.lookupRelation(tableIdentifier) match {
-        case r: MetastoreRelation => r
+        case Scanner(_, _, r: MetastoreRelation) => r
       }
     }
     // TODO ideally, we should get the output data ready first and then

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.hive.HiveExternalCatalog._
 import org.apache.spark.sql.hive.client.HiveClient
@@ -572,7 +573,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
             Row(3) :: Row(4) :: Nil)
 
           table("test_parquet_ctas").queryExecution.optimizedPlan match {
-            case LogicalRelation(p: HadoopFsRelation, _, _) => // OK
+            case Scanner(_, _, l @ LogicalRelation(fsRelation: HadoopFsRelation, _, _)) => // OK
             case _ =>
               fail(s"test_parquet_ctas should have be converted to ${classOf[HadoopFsRelation]}")
           }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, FunctionRegistry}
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.{HiveUtils, MetastoreRelation}
@@ -902,7 +903,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     try {
       sql("CREATE TABLE explodeTest (key bigInt)")
       table("explodeTest").queryExecution.analyzed match {
-        case metastoreRelation: MetastoreRelation => // OK
+        case scanner @ Scanner(_, _, metastoreRelation: MetastoreRelation) => // OK
         case _ =>
           fail("To correctly test the fix of SPARK-5875, explodeTest should be a MetastoreRelation")
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcFilterSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcFilterSuite.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.ql.io.sarg.{PredicateLeaf, SearchArgument}
 import org.apache.spark.sql.{Column, DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation}
 
 /**
@@ -45,7 +45,7 @@ class OrcFilterSuite extends QueryTest with OrcTest {
 
     var maybeRelation: Option[HadoopFsRelation] = None
     val maybeAnalyzedPredicate = query.queryExecution.optimizedPlan.collect {
-      case PhysicalOperation(_, filters, LogicalRelation(orcRelation: HadoopFsRelation, _, _)) =>
+      case Scanner(_, filters, LogicalRelation(orcRelation: HadoopFsRelation, _, _)) =>
         maybeRelation = Some(orcRelation)
         filters
     }.flatten.reduceLeftOption(_ && _)
@@ -89,7 +89,7 @@ class OrcFilterSuite extends QueryTest with OrcTest {
 
     var maybeRelation: Option[HadoopFsRelation] = None
     val maybeAnalyzedPredicate = query.queryExecution.optimizedPlan.collect {
-      case PhysicalOperation(_, filters, LogicalRelation(orcRelation: HadoopFsRelation, _, _)) =>
+      case Scanner(_, filters, LogicalRelation(orcRelation: HadoopFsRelation, _, _)) =>
         maybeRelation = Some(orcRelation)
         filters
     }.flatten.reduceLeftOption(_ && _)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcFilterSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcFilterSuite.scala
@@ -243,14 +243,14 @@ class OrcFilterSuite extends QueryTest with OrcTest {
       )
       checkFilterPredicate(
         '_1 =!= 1,
-        """leaf-0 = (IS_NULL _1)
-          |leaf-1 = (EQUALS _1 1)
+        """leaf-0 = (EQUALS _1 1)
+          |leaf-1 = (IS_NULL _1)
           |expr = (and (not leaf-0) (not leaf-1))""".stripMargin.trim
       )
       checkFilterPredicate(
         !('_1 < 4),
-        """leaf-0 = (IS_NULL _1)
-          |leaf-1 = (LESS_THAN _1 4)
+        """leaf-0 = (LESS_THAN _1 4)
+          |leaf-1 = (IS_NULL _1)
           |expr = (and (not leaf-0) (not leaf-1))""".stripMargin.trim
       )
       checkFilterPredicate(
@@ -261,10 +261,10 @@ class OrcFilterSuite extends QueryTest with OrcTest {
       )
       checkFilterPredicate(
         '_1 < 2 && '_1 > 3,
-        """leaf-0 = (IS_NULL _1)
-          |leaf-1 = (LESS_THAN _1 2)
-          |leaf-2 = (LESS_THAN_EQUALS _1 3)
-          |expr = (and (not leaf-0) leaf-1 (not leaf-2))""".stripMargin.trim
+        """leaf-0 = (LESS_THAN _1 2)
+          |leaf-1 = (LESS_THAN_EQUALS _1 3)
+          |leaf-2 = (IS_NULL _1)
+          |expr = (and leaf-0 (not leaf-1) (not leaf-2))""".stripMargin.trim
       )
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.Scanner
 import org.apache.spark.sql.execution.DataSourceScanExec
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InsertIntoDataSourceCommand, InsertIntoHadoopFsRelationCommand, LogicalRelation}
@@ -284,7 +285,7 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
       )
 
       table("test_parquet_ctas").queryExecution.optimizedPlan match {
-        case LogicalRelation(_: HadoopFsRelation, _, _) => // OK
+        case Scanner(_, _, l @ LogicalRelation(fsRelation: HadoopFsRelation, _, _)) => // OK
         case _ => fail(
           "test_parquet_ctas should be converted to " +
               s"${classOf[HadoopFsRelation ].getCanonicalName }")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added `Scanner` operator to wrap the optimized plan directly in planner, it holds project lists as well as filter predicates.
Updated relative `Analyzer` and `Optimizer` rules.
## How was this patch tested?

Existing testcases.
