### PR TITLE
[SPARK-17032][SQL] Add test cases for methods in ParserUtils.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -31,11 +31,7 @@ import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 object ParserUtils {
   /** Get the command which created the token. */
   def command(ctx: ParserRuleContext): String = {
-    command(ctx.getStart.getInputStream)
-  }
-
-  /** Get the command which created the token. */
-  def command(stream: CharStream): String = {
+    val stream = ctx.getStart.getInputStream
     stream.getText(Interval.of(0, stream.size()))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -70,11 +70,8 @@ object ParserUtils {
 
   /** Get the origin (line and position) of the token. */
   def position(token: Token): Origin = {
-    if (token != null) {
-      Origin(Option(token.getLine), Option(token.getCharPositionInLine))
-    } else {
-      Origin(None, None)
-    }
+    val opt = Option(token)
+    Origin(opt.map(_.getLine), opt.map(_.getCharPositionInLine))
   }
 
   /** Validate the condition. If it doesn't throw a parse exception. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -70,7 +70,11 @@ object ParserUtils {
 
   /** Get the origin (line and position) of the token. */
   def position(token: Token): Origin = {
-    Origin(Option(token.getLine), Option(token.getCharPositionInLine))
+    if (token != null) {
+      Origin(Option(token.getLine), Option(token.getCharPositionInLine))
+    } else {
+      Origin(None, None)
+    }
   }
 
   /** Validate the condition. If it doesn't throw a parse exception. */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -42,6 +42,16 @@ class ParserUtilsSuite extends SparkFunSuite {
     parser.statement().asInstanceOf[ShowDatabasesContext]
   }
 
+  val createDbContext = buildContext(
+    """
+      |CREATE DATABASE IF NOT EXISTS database_name
+      |COMMENT 'database_comment' LOCATION '/home/user/db'
+      |WITH DBPROPERTIES ('a'='a', 'b'='b', 'c'='c')
+    """.stripMargin
+  ) { parser =>
+    parser.statement().asInstanceOf[CreateDatabaseContext]
+  }
+
   private def buildContext[T](command: String)(toResult: SqlBaseParser => T): T = {
     val lexer = new SqlBaseLexer(new ANTLRNoCaseStringStream(command))
     val tokenStream = new CommonTokenStream(lexer)
@@ -116,6 +126,9 @@ class ParserUtilsSuite extends SparkFunSuite {
 
   test("string") {
     assert(string(showDbsContext.pattern) == "identifier_with_wildcards")
+    assert(string(createDbContext.comment) == "database_comment")
+
+    assert(string(createDbContext.locationSpec.STRING) == "/home/user/db")
   }
 
   test("position") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -163,15 +163,15 @@ class ParserUtilsSuite extends SparkFunSuite {
     assert(position(emptyContext.stop) == Origin(None, None))
   }
 
-  test("assert") {
+  test("validate") {
     val f1 = { ctx: ParserRuleContext =>
       ctx.children != null && !ctx.children.isEmpty
     }
     val message = "ParserRuleContext should not be empty."
-    ParserUtils.assert(f1(showFuncContext), message, showFuncContext)
+    validate(f1(showFuncContext), message, showFuncContext)
 
     val e = intercept[ParseException] {
-      ParserUtils.assert(f1(emptyContext), message, emptyContext)
+      validate(f1(emptyContext), message, emptyContext)
     }.getMessage
     assert(e.contains(message))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -179,10 +179,11 @@ class ParserUtilsSuite extends SparkFunSuite {
   test("withOrigin") {
     val ctx = createDbContext.locationSpec
     val current = CurrentOrigin.get
-    val location = withOrigin(ctx) {
-      string(ctx.STRING)
+    val (location, origin) = withOrigin(ctx) {
+      (string(ctx.STRING), CurrentOrigin.get)
     }
     assert(location == "/home/user/db")
+    assert(origin == Origin(Some(3), Some(27)))
     assert(CurrentOrigin.get == current)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.catalyst.parser
 
-import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.{CommonTokenStream, ParserRuleContext}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
@@ -50,6 +50,10 @@ class ParserUtilsSuite extends SparkFunSuite {
     """.stripMargin
   ) { parser =>
     parser.statement().asInstanceOf[CreateDatabaseContext]
+  }
+
+  val emptyContext = buildContext("") { parser =>
+    parser.statement
   }
 
   private def buildContext[T](command: String)(toResult: SqlBaseParser => T): T = {
@@ -105,6 +109,26 @@ class ParserUtilsSuite extends SparkFunSuite {
     assert(command(showDbsContext) == "show databases like 'identifier_with_wildcards'")
   }
 
+  test("operationNotAllowed") {
+    val errorMessage = "parse.fail.operation.not.allowed.error.message"
+    val e = intercept[ParseException] {
+      operationNotAllowed(errorMessage, showFuncContext)
+    }.getMessage
+    assert(e.contains("Operation not allowed"))
+    assert(e.contains(errorMessage))
+  }
+
+  test("checkDuplicateKeys") {
+    val properties = Seq(("a", "a"), ("b", "b"), ("c", "c"))
+    checkDuplicateKeys[String](properties, createDbContext)
+
+    val properties2 = Seq(("a", "a"), ("b", "b"), ("a", "c"))
+    val e = intercept[ParseException] {
+      checkDuplicateKeys(properties2, createDbContext)
+    }.getMessage
+    assert(e.contains("Found duplicate keys"))
+  }
+
   test("source") {
     assert(source(setConfContext) == "set example.setting.name=setting.value")
     assert(source(showFuncContext) == "show functions foo.bar")
@@ -135,5 +159,27 @@ class ParserUtilsSuite extends SparkFunSuite {
     assert(position(setConfContext.start) == Origin(Some(1), Some(0)))
     assert(position(showFuncContext.stop) == Origin(Some(1), Some(19)))
     assert(position(descFuncContext.describeFuncName.start) == Origin(Some(1), Some(27)))
+    assert(position(emptyContext.stop) == Origin(None, None))
+  }
+
+  test("assert") {
+    val f1 = { ctx: ParserRuleContext =>
+      ctx.children != null && !ctx.children.isEmpty
+    }
+    val message = "ParserRuleContext should not be empty."
+    ParserUtils.assert(f1(showFuncContext), message, showFuncContext)
+
+    val e = intercept[ParseException] {
+      ParserUtils.assert(f1(emptyContext), message, emptyContext)
+    }.getMessage
+    assert(e.contains(message))
+  }
+
+  test("withOrigin") {
+    val ctx = createDbContext.locationSpec
+    val location = withOrigin(ctx) {
+      string(ctx.STRING)
+    }
+    assert(location == "/home/user/db")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -20,7 +20,7 @@ import org.antlr.v4.runtime.{CommonTokenStream, ParserRuleContext}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
-import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 
 class ParserUtilsSuite extends SparkFunSuite {
 
@@ -159,6 +159,7 @@ class ParserUtilsSuite extends SparkFunSuite {
     assert(position(setConfContext.start) == Origin(Some(1), Some(0)))
     assert(position(showFuncContext.stop) == Origin(Some(1), Some(19)))
     assert(position(descFuncContext.describeFuncName.start) == Origin(Some(1), Some(27)))
+    assert(position(createDbContext.locationSpec.start) == Origin(Some(3), Some(27)))
     assert(position(emptyContext.stop) == Origin(None, None))
   }
 
@@ -177,9 +178,11 @@ class ParserUtilsSuite extends SparkFunSuite {
 
   test("withOrigin") {
     val ctx = createDbContext.locationSpec
+    val current = CurrentOrigin.get
     val location = withOrigin(ctx) {
       string(ctx.STRING)
     }
     assert(location == "/home/user/db")
+    assert(CurrentOrigin.get == current)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently methods in `ParserUtils` are tested indirectly, we should add test cases in `ParserUtilsSuite` to verify their integrity directly.
## How was this patch tested?

New test cases in `ParserUtilsSuite`
