### PR TITLE
[WIP][MINOR][TYPO]Fix several trivival typos

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -355,7 +355,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Valid log levels include: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
    */
   def setLogLevel(logLevel: String) {
-    // let's allow lowcase or mixed case too
+    // let's allow lowercase or mixed case too
     val upperCased = logLevel.toUpperCase(Locale.ENGLISH)
     require(SparkContext.VALID_LOG_LEVELS.contains(upperCased),
       s"Supplied level $logLevel did not match one of:" +

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -82,7 +82,7 @@ private[spark] object Utils extends Logging {
 
   /**
    * The performance overhead of creating and logging strings for wide schemas can be large. To
-   * limit the impact, we bound the number of fields to include by default. This can be overriden
+   * limit the impact, we bound the number of fields to include by default. This can be overridden
    * by setting the 'spark.debug.maxToStringFields' conf in SparkEnv.
    */
   val DEFAULT_MAX_TO_STRING_FIELDS = 25


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Fixed one typo `"overriden"` as `"overridden"`, also make sure no other same typo. 
- Fixed one typo `"lowcase"` as `"lowercase"`, also make sure no other same typo. 
## How was this patch tested?

Since the change is very tiny, so I just make sure compilation is successful. 
I am new to the spark community,  please feel free to let me do other necessary steps. 

Thanks in advance!

---

Updated: Found another typo `lowcase` later and fixed then in the same patch
