### PR TITLE
Fix PySpark DataFrameWriter JDBC method docstring because a dictiona…

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -716,9 +716,9 @@ class DataFrameWriter(OptionUtils):
             * ``overwrite``: Overwrite existing data.
             * ``ignore``: Silently ignore this operation if data already exists.
             * ``error`` (default case): Throw an exception if data already exists.
-        :param properties: JDBC database connection arguments, a list of
-                           arbitrary string tag/value. Normally at least a
-                           "user" and "password" property should be included.
+        :param properties: a dictionary of JDBC database connection arguments. Normally at  
+                           least properties "user" and "password" with their corresponding values.  
+                           For example { 'user' : 'SYSTEM', 'password' : 'mypassword' }
         """
         if properties is None:
             properties = dict()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Python DocString of the method jdbc of PySpark DataFrameWriter is modified to specify that a dictionary is used instead of a list.
## How was this patch tested?

No testing is needed only the docstring was modified.
