### PR TITLE
[SPARK-17050][ML][MLLib] Improve kmean rdd.aggregate to rdd.treeAggregate

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -414,7 +414,7 @@ class KMeans private (
           }
         }.persist(StorageLevel.MEMORY_AND_DISK)
       val sumCosts = costs
-        .aggregate(new Array[Double](runs))(
+        .treeAggregate(new Array[Double](runs))(
           seqOp = (s, v) => {
             // s += v
             var r = 0


### PR DESCRIPTION
## What changes were proposed in this pull request?

The kmean use `aggregate` to compute points cost. As the data RDD is huge so it is better to use `treeAggregate`.
## How was this patch tested?

Existing test.
