### PR TITLE
[WIP][SPARK-17046][SQL] prevent user using dataframe.select with empty param list

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1004,7 +1004,10 @@ class Dataset[T] private[sql](
    * @since 2.0.0
    */
   @scala.annotation.varargs
-  def select(cols: Column*): DataFrame = withPlan {
+  def select(col: Column, cols: Column*): DataFrame = select((col +: cols): _*)
+
+  @scala.annotation.varargs
+  private[spark] def select(cols: Column*): DataFrame = withPlan {
     Project(cols.map(_.named), logicalPlan)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can see the DataFrame API:
`def select(col: String, cols: String*)`
such definition can prevent user to call `select` in such way: `df.select( )`

but, currently we can still use `df.select( )` and pass compiling, 
because it match the API
`def select(cols: Column*)`

so, my modification is, add an API such as:
`def select(col: Column, cols: Column*)`
and change `def select(cols: Column*)` into `private[spark] def select(cols: Column*)`
so that the public `select` API can only be called with non-empty param list.
## How was this patch tested?

Existing test.
