### PR TITLE
[SPARK-17053][SQL] Support `hive.exec.drop.ignorenonexistent`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -189,7 +189,8 @@ case class DropTableCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     if (!catalog.tableExists(tableName)) {
-      if (!ifExists) {
+      if (!ifExists &&
+          sparkSession.conf.get("hive.exec.drop.ignorenonexistent", "false").equals("false")) {
         val objectName = if (isView) "View" else "Table"
         throw new AnalysisException(s"$objectName to drop '$tableName' does not exist")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -126,6 +126,18 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("SPARK-17053: Support `hive.exec.drop.ignorenonexistent`") {
+    withSQLConf("hive.exec.drop.ignorenonexistent" -> "false") {
+      val m = intercept[AnalysisException] {
+        sql("drop table non_exist_table")
+      }.getMessage
+      assert(m.contains("Table to drop '`non_exist_table`' does not exist"))
+    }
+    withSQLConf("hive.exec.drop.ignorenonexistent" -> "true") {
+      sql("drop table non_exist_table")
+    }
+  }
+
   test("self join with aliases") {
     Seq(1, 2, 3).map(i => (i, i.toString)).toDF("int", "str").createOrReplaceTempView("df")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `hive.exec.drop.ignorenonexistent` is set `true`, `DROP` statement is assumed to have `IF EXISTS` clause.

**Reported Error Scenario**

``` scala
scala> sql("set hive.exec.drop.ignorenonexistent=true")
res1: org.apache.spark.sql.DataFrame = [key: string, value: string]

scala> sql("drop table a")
org.apache.spark.sql.AnalysisException: Table to drop '`a`' does not exist;
```

Refer https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL .
## How was this patch tested?

Pass the Jenkins test including a new test case.
