### PR TITLE
[SPARK-11374][SQL] Support `skip.header.line.count` option for Hive Table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -115,7 +115,8 @@ class HadoopTableReader(
     val inputPathStr = applyFilterIfNeeded(tablePath, filterOpt)
     val skipHeaderLineCount =
       tableDesc.getProperties.getProperty("skip.header.line.count", "0").toInt
-    val isTextInputFormatTable = hiveTable.getInputFormatClass == classOf[TextInputFormat]
+    val isTextInputFormatTable =
+      classOf[TextInputFormat].isAssignableFrom(hiveTable.getInputFormatClass)
 
     // logDebug("Table input: %s".format(tablePath))
     val ifc = hiveTable.getInputFormatClass

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -113,10 +113,10 @@ class HadoopTableReader(
 
     val tablePath = hiveTable.getPath
     val inputPathStr = applyFilterIfNeeded(tablePath, filterOpt)
-    val skipHeaderLineCount = Integer.parseInt(
-      tableDesc.getProperties.getProperty("skip.header.line.count", "0"))
+    val skipHeaderLineCount =
+      tableDesc.getProperties.getProperty("skip.header.line.count", "0").toInt
     val isTextInputFormatTable =
-      hiveTable.getInputFormatClass().getName().equals("org.apache.hadoop.mapred.TextInputFormat")
+      hiveTable.getInputFormatClass().getName() == "org.apache.hadoop.mapred.TextInputFormat"
 
     // logDebug("Table input: %s".format(tablePath))
     val ifc = hiveTable.getInputFormatClass
@@ -133,8 +133,10 @@ class HadoopTableReader(
       if (skipHeaderLineCount > 0 && isTextInputFormatTable) {
         val partition = hadoopRDD.partitions(index).asInstanceOf[HadoopPartition]
         if (partition.inputSplit.t.asInstanceOf[FileSplit].getStart() == 0) {
-          for (i <- 0 until skipHeaderLineCount) {
-            if (iter.hasNext) iter.next()
+          var i = 0
+          while (i < skipHeaderLineCount && iter.hasNext) {
+            i += 1
+            iter.next()
           }
         }
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -31,12 +31,12 @@ import org.apache.hadoop.hive.serde2.Deserializer
 import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorConverters, StructObjectInspector}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.io.Writable
-import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf}
+import org.apache.hadoop.mapred.{FileInputFormat, FileSplit, InputFormat, JobConf}
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, RDD, UnionRDD}
+import org.apache.spark.rdd.{EmptyRDD, HadoopPartition, HadoopRDD, RDD, UnionRDD}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -113,6 +113,8 @@ class HadoopTableReader(
 
     val tablePath = hiveTable.getPath
     val inputPathStr = applyFilterIfNeeded(tablePath, filterOpt)
+    val skipHeaderLineCount = Integer.parseInt(
+      tableDesc.getProperties.getProperty("skip.header.line.count", "0"))
 
     // logDebug("Table input: %s".format(tablePath))
     val ifc = hiveTable.getInputFormatClass
@@ -122,10 +124,18 @@ class HadoopTableReader(
     val attrsWithIndex = attributes.zipWithIndex
     val mutableRow = new SpecificInternalRow(attributes.map(_.dataType))
 
-    val deserializedHadoopRDD = hadoopRDD.mapPartitions { iter =>
+    val deserializedHadoopRDD = hadoopRDD.mapPartitionsWithIndex { (index, iter) =>
       val hconf = broadcastedHadoopConf.value.value
       val deserializer = deserializerClass.newInstance()
       deserializer.initialize(hconf, tableDesc.getProperties)
+      if (skipHeaderLineCount > 0) {
+        val partition = hadoopRDD.partitions(index).asInstanceOf[HadoopPartition]
+        if (partition.inputSplit.t.asInstanceOf[FileSplit].getStart() == 0) {
+          for (i <- 0 until skipHeaderLineCount) {
+            if (iter.hasNext) iter.next()
+          }
+        }
+      }
       HadoopTableReader.fillObject(iter, deserializer, attrsWithIndex, mutableRow, deserializer)
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2011,8 +2011,8 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
-  test("SPARK-11374 Support skip.header.line.count option in Hive external table") {
-    withTable("skip_table_0", "skip_table_1", "skip_table_2", "skip_table_3") {
+  test("SPARK-11374 Support skip.header.line.count option in Hive table") {
+    withTable("skip_table_0", "skip_table_1", "skip_table_2", "skip_table_3", "skip_table_4") {
       withTempDir { dir =>
         dir.delete()
         val path = dir.getCanonicalPath
@@ -2043,19 +2043,21 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
     // Since the default value of fs.local.block.size is 32MB (32 * 1024 * 1024),
     // the following creates a file with three input splits.
-    withTempDir { dir =>
-      dir.delete()
-      val path = dir.getCanonicalPath
-      spark.range(0, 3 * 1024 * 1024).map(x => "c" * 32).repartition(1).write.csv(path)
-      sql(
-        s"""
-           |CREATE EXTERNAL TABLE skip_table_3 (id INT, b VARCHAR(10))
-           |ROW FORMAT DELIMITED
-           |FIELDS TERMINATED BY ','
-           |STORED AS TEXTFILE LOCATION '$path'
-           |TBLPROPERTIES('skip.header.line.count'='1')
-        """.stripMargin)
-      checkAnswer(sql(s"SELECT count(*) FROM skip_table_3"), Row(3 * 1024 * 1024 - 1) :: Nil)
+    withTable("skip_table_5") {
+      withTempDir { dir =>
+        dir.delete()
+        val path = dir.getCanonicalPath
+        spark.range(0, 3 * 1024 * 1024).map(x => "c" * 32).repartition(1).write.csv(path)
+        sql(
+          s"""
+            |CREATE EXTERNAL TABLE skip_table_5 (id INT, b VARCHAR(10))
+            |ROW FORMAT DELIMITED
+            |FIELDS TERMINATED BY ','
+            |STORED AS TEXTFILE LOCATION '$path'
+            |TBLPROPERTIES('skip.header.line.count'='1')
+          """.stripMargin)
+        checkAnswer(sql(s"SELECT count(*) FROM skip_table_5"), Row(3 * 1024 * 1024 - 1) :: Nil)
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds `skip.header.line.count` option support for Hive tables (external and managed).

- `CREATE EXTERNAL TABLE` or `CREATE TABLE ... LOCATION` uses external files as a data source for the tables. External files like CSV frequently contains one or more header lines as their own metadata. So, **skip.header.line.count** table property is used in order to exclude those metadata lines from data lines.
- Managed tables also have the same situations to handle files loaded by `LOAD DATA` SQL commands. 

[SPARK-11374](https://issues.apache.org/jira/browse/SPARK-11374) is a long lasting issue since 1.5.1, and all current Spark versions have the same situation.

The following is an example for SPARK-11374.

**CSV Data**

``` bash
$ cat /data/test.csv 
c1,c2
1,a
2,b
```

**Scala**

``` scala
scala> spark.read.option("header","true").csv("/data").show
+---+---+
| c1| c2|
+---+---+
|  1|  a|
|  2|  b|
+---+---+
```

**SQL (External Table)**

``` scala
scala> sql("CREATE TABLE t1 (id INT, value VARCHAR(10)) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE LOCATION '/data' TBLPROPERTIES('skip.header.line.count'='1')")
scala> sql("SELECT * FROM t1").show
+---+-----+
| id|value|
+---+-----+
|  1|    a|
|  2|    b|
+---+-----+
```

**SQL (Managed Table)**

```scala
scala> sql("CREATE TABLE t2 (id INT, value VARCHAR(10)) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' TBLPROPERTIES('skip.header.line.count'='1')")
scala> sql("LOAD DATA LOCAL INPATH '/data/test.csv' OVERWRITE INTO TABLE t2")
scala> sql("SELECT * FROM t2").show
+---+-----+
| id|value|
+---+-----+
|  1|    a|
|  2|    b|
+---+-----+
```

## How was this patch tested?

Pass the Jenkins test with a new test case.
