### PR TITLE
[SPARK-17055] [MLLIB] add groupKFold to CrossValidator

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
@@ -57,6 +57,17 @@ private[ml] trait ValidatorParams extends HasSeed with Params {
   def getEstimatorParamMaps: Array[ParamMap] = $(estimatorParamMaps)
 
   /**
+    * param for groupKFold column name
+    * default: empty
+    * @group param
+    */
+  val groupKFoldCol: Param[String] = new Param[String](this, "groupKFoldCol",
+    "groupKFold column name")
+
+  /** @group getParam */
+  def getGroupCol: String = $(groupKFoldCol)
+
+  /**
    * param for the evaluator used to select hyper-parameters that maximize the validated metric
    *
    * @group param


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch improves the CrossValidator by adding a new training/validation split method -groupKFold, which splits data based on data group labels and makes sure that the same group is not in both testing and training sets. 
This is necessary, for example when data is gathered from different subjects, i.e., learning person specific features. This method can create subject independent folds, so that we can train and test the model on different subjects. It will improve the generic ability of the model and avoid over-fitting for these use
cases.
## How was this patch tested?

Unit test added to MLUtilsSuite.
