### PR TITLE
[Minor] [SparkR] spark.glm weightCol should in the signature.

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -140,7 +140,7 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 
             jobj <- callJStatic("org.apache.spark.ml.r.GeneralizedLinearRegressionWrapper",
                                 "fit", formula, data@sdf, family$family, family$link,
-                                tol, as.integer(maxIter), weightCol)
+                                tol, as.integer(maxIter), as.character(weightCol))
             return(new("GeneralizedLinearRegressionModel", jobj = jobj))
           })
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the issue that `spark.glm` `weightCol` should in the signature.
## How was this patch tested?

Existing tests.
