### PR TITLE
[WIP][Test only][DEMO][SPARK-6235]Address various 2G limits

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/Allocator.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/Allocator.java
@@ -15,28 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.network.server;
+package org.apache.spark.network.buffer;
 
 import java.nio.ByteBuffer;
 
-import org.apache.spark.network.buffer.ChunkedByteBuffer;
-import org.apache.spark.network.client.RpcResponseCallback;
-import org.apache.spark.network.client.TransportClient;
-
-/** An RpcHandler suitable for a client-only TransportContext, which cannot receive RPCs. */
-public class NoOpRpcHandler extends RpcHandler {
-  private final StreamManager streamManager;
-
-  public NoOpRpcHandler() {
-    streamManager = new OneForOneStreamManager();
-  }
-
-  @Override
-  public void receive(TransportClient client, ChunkedByteBuffer message,
-                      RpcResponseCallback callback) {
-    throw new UnsupportedOperationException("Cannot handle messages");
-  }
-
-  @Override
-  public StreamManager getStreamManager() { return streamManager; }
+public interface Allocator {
+  ByteBuffer allocate(int len);
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/ChunkedByteBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/ChunkedByteBuffer.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.buffer;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+
+import sun.nio.ch.DirectBuffer;
+import com.google.common.base.Preconditions;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.network.util.ByteArrayWritableChannel;
+
+public class ChunkedByteBuffer implements Externalizable {
+  private static final Logger logger = LoggerFactory.getLogger(ChunkedByteBuffer.class);
+  private static final int BUF_SIZE = 0x1000; // 4K
+  private static final ByteBuffer[] emptyChunks = new ByteBuffer[0];
+  private ByteBuffer[] chunks = null;
+  private boolean disposed = false;
+
+  // For deserialization only
+  public ChunkedByteBuffer() {
+    this(emptyChunks);
+  }
+
+  /**
+   * Read-only byte buffer which is physically stored as multiple chunks rather than a single
+   * contiguous array.
+   *
+   * @param chunks an array of [[ByteBuffer]]s. Each buffer in this array must have position == 0.
+   *               Ownership of these buffers is transferred to the ChunkedByteBuffer, so if these
+   *               buffers may also be used elsewhere then the caller is responsible for copying
+   *               them as needed.
+   */
+  public ChunkedByteBuffer(ByteBuffer[] chunks) {
+    this.chunks = chunks;
+    Preconditions.checkArgument(chunks != null, "chunks must not be null");
+    for (int i = 0; i < chunks.length; i++) {
+      ByteBuffer bytes = chunks[i];
+      Preconditions.checkArgument(bytes.remaining() > 0, "chunks must be non-empty");
+    }
+  }
+
+  public ChunkedByteBuffer(ByteBuffer chunk) {
+    this.chunks = new ByteBuffer[1];
+    this.chunks[0] = chunk;
+  }
+
+  public void writeExternal(ObjectOutput out) throws IOException {
+    out.writeBoolean(disposed);
+    out.writeInt(chunks.length);
+    byte[] buf = null;
+    for (int i = 0; i < chunks.length; i++) {
+      ByteBuffer buffer = chunks[i].duplicate();
+      out.writeInt(buffer.remaining());
+      if (buffer.hasArray()) {
+        out.write(buffer.array(), buffer.arrayOffset() + buffer.position(),
+            buffer.remaining());
+      } else {
+        if (buf == null) buf = new byte[BUF_SIZE];
+        while (buffer.hasRemaining()) {
+          int r = Math.min(BUF_SIZE, buffer.remaining());
+          buffer.get(buf, 0, r);
+          out.write(buf, 0, r);
+        }
+      }
+    }
+  }
+
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    this.disposed = in.readBoolean();
+    ByteBuffer[] buffers = new ByteBuffer[in.readInt()];
+    for (int i = 0; i < buffers.length; i++) {
+      int length = in.readInt();
+      byte[] buffer = new byte[length];
+      in.readFully(buffer);
+      buffers[i] = ByteBuffer.wrap(buffer);
+    }
+    this.chunks = buffers;
+  }
+
+  /**
+   * This size of this buffer, in bytes.
+   */
+  public long size() {
+    if (chunks == null) return 0L;
+    int i = 0;
+    long sum = 0L;
+    while (i < chunks.length) {
+      sum += chunks[i].remaining();
+      i++;
+    }
+    return sum;
+  }
+
+  /**
+   * Write this buffer to a channel.
+   */
+  public void writeFully(WritableByteChannel channel) throws IOException {
+    for (int i = 0; i < chunks.length; i++) {
+      ByteBuffer bytes = chunks[i].duplicate();
+      while (bytes.remaining() > 0) {
+        channel.write(bytes);
+      }
+    }
+  }
+
+  /**
+   * Wrap this buffer to view it as a Netty ByteBuf.
+   */
+  public ByteBuf toNetty() {
+    return Unpooled.wrappedBuffer(getChunks());
+  }
+
+  /**
+   * Copy this buffer into a new byte array.
+   *
+   * @throws UnsupportedOperationException if this buffer's size exceeds the maximum array size.
+   */
+  public byte[] toArray() throws IOException, UnsupportedOperationException {
+    long len = size();
+    if (len >= Integer.MAX_VALUE) {
+      throw new UnsupportedOperationException(
+          "cannot call toArray because buffer size (" + len +
+              " bytes) exceeds maximum array size");
+    }
+    ByteArrayWritableChannel byteChannel = new ByteArrayWritableChannel((int) len);
+    writeFully(byteChannel);
+    byteChannel.close();
+    return byteChannel.getData();
+  }
+
+  /**
+   * Copy this buffer into a new ByteBuffer.
+   *
+   * @throws UnsupportedOperationException if this buffer's size exceeds the max ByteBuffer size.
+   */
+  public ByteBuffer toByteBuffer() throws IOException, UnsupportedOperationException {
+    if (chunks.length == 1) {
+      return chunks[0].duplicate();
+    } else {
+      return ByteBuffer.wrap(this.toArray());
+    }
+  }
+
+  public ChunkedByteBufferInputStream toInputStream() {
+    return toInputStream(false);
+  }
+
+  /**
+   * Creates an input stream to read data from this ChunkedByteBuffer.
+   *
+   * @param dispose if true, [[dispose()]] will be called at the end of the stream
+   *                in order to close any memory-mapped files which back this buffer.
+   */
+  public ChunkedByteBufferInputStream toInputStream(boolean dispose) {
+    return new ChunkedByteBufferInputStream(this, dispose);
+  }
+
+  /**
+   * Make a copy of this ChunkedByteBuffer, copying all of the backing data into new buffers.
+   * The new buffer will share no resources with the original buffer.
+   *
+   * @param allocator a method for allocating byte buffers
+   */
+  public ChunkedByteBuffer copy(Allocator allocator) {
+    ByteBuffer[] copiedChunks = new ByteBuffer[chunks.length];
+    for (int i = 0; i < chunks.length; i++) {
+      ByteBuffer chunk = chunks[i].duplicate();
+      ByteBuffer newChunk = allocator.allocate(chunk.remaining());
+      newChunk.put(chunk);
+      newChunk.flip();
+      copiedChunks[i] = newChunk;
+    }
+    return new ChunkedByteBuffer(copiedChunks);
+  }
+
+  /**
+   * Get duplicates of the ByteBuffers backing this ChunkedByteBuffer.
+   */
+  public ByteBuffer[] getChunks() {
+    ByteBuffer[] buffs = new ByteBuffer[chunks.length];
+    for (int i = 0; i < chunks.length; i++) {
+      buffs[i] = chunks[i].duplicate();
+    }
+    return buffs;
+  }
+
+
+  /**
+   * Attempt to clean up a ByteBuffer if it is memory-mapped. This uses an *unsafe* Sun API that
+   * might cause errors if one attempts to read from the unmapped buffer, but it's better than
+   * waiting for the GC to find it because that could lead to huge numbers of open files. There's
+   * unfortunately no standard API to do this.
+   */
+  public void dispose() {
+    if (!disposed) {
+      for (int i = 0; i < chunks.length; i++) {
+        dispose(chunks[i]);
+      }
+      disposed = true;
+    }
+  }
+
+  public ChunkedByteBuffer slice(long offset, long length) {
+    long thisSize = size();
+    if (offset < 0 || offset > thisSize - length) {
+      throw new IndexOutOfBoundsException(String.format(
+          "index: %d, length: %d (expected: range(0, %d))", offset, length, thisSize));
+    }
+    if (length == 0) {
+      return wrap(new ByteBuffer[0]);
+    }
+    ArrayList<ByteBuffer> list = new ArrayList<ByteBuffer>();
+    int i = 0;
+    long sum = 0L;
+    while (i < chunks.length && length > 0) {
+      long lastSum = sum + chunks[i].remaining();
+      if (lastSum > offset) {
+        ByteBuffer buffer = chunks[i].duplicate();
+        int localLength = (int) Math.min(length, buffer.remaining());
+        if (localLength < buffer.remaining()) {
+          buffer.limit(buffer.position() + localLength);
+        }
+        length -= localLength;
+        list.add(buffer);
+      }
+      sum = lastSum;
+      i++;
+    }
+    return wrap(list.toArray(new ByteBuffer[list.size()]));
+  }
+
+  public ChunkedByteBuffer duplicate() {
+    return new ChunkedByteBuffer(getChunks());
+  }
+
+  public static void dispose(ByteBuffer buffer) {
+    if (buffer != null && buffer instanceof MappedByteBuffer) {
+      logger.trace("Unmapping" + buffer);
+      if (buffer instanceof DirectBuffer) {
+        DirectBuffer directBuffer = (DirectBuffer) buffer;
+        if (directBuffer.cleaner() != null) directBuffer.cleaner().clean();
+      }
+    }
+  }
+
+  public static ChunkedByteBuffer wrap(ByteBuffer chunk) {
+    return new ChunkedByteBuffer(chunk);
+  }
+
+  public static ChunkedByteBuffer wrap(ByteBuffer[] chunks) {
+    return new ChunkedByteBuffer(chunks);
+  }
+
+  public static ChunkedByteBuffer wrap(byte[] array) {
+    return wrap(array, 0, array.length);
+  }
+
+  public static ChunkedByteBuffer wrap(byte[] array, int offset, int length) {
+    return new ChunkedByteBuffer(ByteBuffer.wrap(array, offset, length));
+  }
+
+  public static ChunkedByteBuffer allocate(int capacity) {
+    return new ChunkedByteBuffer(ByteBuffer.allocate(capacity));
+  }
+
+  public static ChunkedByteBuffer allocate(int capacity, Allocator allocator) {
+    return new ChunkedByteBuffer(allocator.allocate(capacity));
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/ChunkedByteBufferInputStream.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/ChunkedByteBufferInputStream.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.buffer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import com.google.common.primitives.UnsignedBytes;
+
+public class ChunkedByteBufferInputStream extends InputStream {
+
+  private ChunkedByteBuffer chunkedByteBuffer;
+  private boolean dispose;
+  private Iterator<ByteBuffer> chunks;
+  private ByteBuffer currentChunk;
+
+  /**
+   * Reads data from a ChunkedByteBuffer.
+   *
+   * @param dispose if true, [[ChunkedByteBuffer.dispose()]] will be called at the end of the stream
+   *                in order to close any memory-mapped files which back the buffer.
+   */
+  public ChunkedByteBufferInputStream(ChunkedByteBuffer chunkedByteBuffer, boolean dispose) {
+    this.chunkedByteBuffer = chunkedByteBuffer;
+    this.dispose = dispose;
+    this.chunks = Arrays.asList(chunkedByteBuffer.getChunks()).iterator();
+    if (chunks.hasNext()) {
+      currentChunk = chunks.next();
+    } else {
+      currentChunk = null;
+    }
+  }
+
+  public int read() throws IOException {
+    if (currentChunk != null && !currentChunk.hasRemaining() && chunks.hasNext()) {
+      currentChunk = chunks.next();
+    }
+    if (currentChunk != null && currentChunk.hasRemaining()) {
+      return UnsignedBytes.toInt(currentChunk.get());
+    } else {
+      close();
+      return -1;
+    }
+  }
+
+  public int read(byte[] dest, int offset, int length) throws IOException {
+    if (currentChunk != null && !currentChunk.hasRemaining() && chunks.hasNext()) {
+      currentChunk = chunks.next();
+    }
+    if (currentChunk != null && currentChunk.hasRemaining()) {
+      int amountToGet = Math.min(currentChunk.remaining(), length);
+      currentChunk.get(dest, offset, amountToGet);
+      return amountToGet;
+    } else {
+      close();
+      return -1;
+    }
+  }
+
+  public long skip(long bytes) throws IOException {
+    if (currentChunk != null) {
+      int amountToSkip = (int) Math.min(bytes, currentChunk.remaining());
+      currentChunk.position(currentChunk.position() + amountToSkip);
+      if (currentChunk.remaining() == 0) {
+        if (chunks.hasNext()) {
+          currentChunk = chunks.next();
+        } else {
+          close();
+        }
+      }
+      return amountToSkip;
+    } else {
+      return 0L;
+    }
+  }
+
+  public void close() throws IOException {
+    if (chunkedByteBuffer != null && dispose) {
+      chunkedByteBuffer.dispose();
+    }
+    chunkedByteBuffer = null;
+    chunks = null;
+    currentChunk = null;
+  }
+
+  public ChunkedByteBuffer toChunkedByteBuffer() {
+    ArrayList<ByteBuffer> list = new ArrayList<ByteBuffer>();
+    if (currentChunk != null && !currentChunk.hasRemaining() && chunks.hasNext()) {
+      currentChunk = chunks.next();
+    }
+    while (currentChunk != null) {
+      list.add(currentChunk.slice());
+      if (chunks.hasNext()) {
+        currentChunk = chunks.next();
+      } else {
+        currentChunk = null;
+      }
+    }
+    return ChunkedByteBuffer.wrap(list.toArray(new ByteBuffer[list.size()]));
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/ChunkedByteBufferOutputStream.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/ChunkedByteBufferOutputStream.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.network.buffer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+
+import com.google.common.base.Preconditions;
+
+public class ChunkedByteBufferOutputStream extends OutputStream {
+
+  private final int chunkSize;
+  private final Allocator allocator;
+  /**
+   * Next position to write in the last chunk.
+   *
+   * If this equals chunkSize, it means for next write we need to allocate a new chunk.
+   * This can also never be 0.
+   */
+  private int position;
+
+  private ArrayList<ByteBuffer> chunks = new ArrayList<ByteBuffer>();
+  /** Index of the last chunk. Starting with -1 when the chunks array is empty. */
+  private int lastChunkIndex = -1;
+  private boolean toChunkedByteBufferWasCalled = false;
+  private long _size = 0;
+
+  /**
+   * An OutputStream that writes to fixed-size chunks of byte arrays.
+   *
+   * @param chunkSize size of each chunk, in bytes.
+   */
+  public ChunkedByteBufferOutputStream(int chunkSize, Allocator allocator) {
+    this.chunkSize = chunkSize;
+    this.allocator = allocator;
+    this.position = chunkSize;
+  }
+
+  public ChunkedByteBufferOutputStream(int chunkSize) {
+    this(chunkSize, new Allocator() {
+      public ByteBuffer allocate(int len) {
+        return ByteBuffer.allocate(len);
+      }
+    });
+  }
+
+  public long size() {
+    return _size;
+  }
+
+  public void write(int b) throws IOException {
+    allocateNewChunkIfNeeded();
+    chunks.get(lastChunkIndex).put((byte) b);
+    position += 1;
+    _size += 1;
+  }
+
+  public void write(byte[] bytes, int off, int len) throws IOException {
+    int written = 0;
+    while (written < len) {
+      allocateNewChunkIfNeeded();
+      int thisBatch = Math.min(chunkSize - position, len - written);
+      chunks.get(lastChunkIndex).put(bytes, written + off, thisBatch);
+      written += thisBatch;
+      position += thisBatch;
+    }
+    _size += len;
+  }
+
+  private void allocateNewChunkIfNeeded() {
+    Preconditions.checkArgument(!toChunkedByteBufferWasCalled,
+        "cannot write after toChunkedByteBuffer() is called");
+    if (position == chunkSize) {
+      chunks.add(allocator.allocate(chunkSize));
+      lastChunkIndex += 1;
+      position = 0;
+    }
+  }
+
+  public ChunkedByteBuffer toChunkedByteBuffer() {
+    Preconditions.checkArgument(!toChunkedByteBufferWasCalled,
+        "toChunkedByteBuffer() can only be called once");
+    toChunkedByteBufferWasCalled = true;
+    if (lastChunkIndex == -1) {
+      return new ChunkedByteBuffer(new ByteBuffer[0]);
+    } else {
+      // Copy the first n-1 chunks to the output, and then create an array that fits the last chunk.
+      // An alternative would have been returning an array of ByteBuffers, with the last buffer
+      // bounded to only the last chunk's position. However, given our use case in Spark (to put
+      // the chunks in block manager), only limiting the view bound of the buffer would still
+      // require the block manager to store the whole chunk.
+      ByteBuffer[] ret = new ByteBuffer[chunks.size()];
+      for (int i = 0; i < chunks.size() - 1; i++) {
+        ret[i] = chunks.get(i);
+        ret[i].flip();
+      }
+
+      if (position == chunkSize) {
+        ret[lastChunkIndex] = chunks.get(lastChunkIndex);
+        ret[lastChunkIndex].flip();
+      } else {
+        ret[lastChunkIndex] = allocator.allocate(position);
+        chunks.get(lastChunkIndex).flip();
+        ret[lastChunkIndex].put(chunks.get(lastChunkIndex));
+        ret[lastChunkIndex].flip();
+        ChunkedByteBuffer.dispose(chunks.get(lastChunkIndex));
+      }
+      return new ChunkedByteBuffer(ret);
+    }
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/ManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/ManagedBuffer.java
@@ -44,7 +44,7 @@ public abstract class ManagedBuffer {
    * returned ByteBuffer should not affect the content of this buffer.
    */
   // TODO: Deprecate this, usage may require expensive memory mapping or allocation.
-  public abstract ByteBuffer nioByteBuffer() throws IOException;
+  public abstract ChunkedByteBuffer nioByteBuffer() throws IOException;
 
   /**
    * Exposes this buffer's data as an InputStream. The underlying implementation does not

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/NettyManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/NettyManagedBuffer.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.CompositeByteBuf;
 
 /**
  * A {@link ManagedBuffer} backed by a Netty {@link ByteBuf}.
@@ -41,8 +42,15 @@ public class NettyManagedBuffer extends ManagedBuffer {
   }
 
   @Override
-  public ByteBuffer nioByteBuffer() throws IOException {
-    return buf.nioBuffer();
+  public ChunkedByteBuffer nioByteBuffer() throws IOException {
+    if (buf instanceof CompositeByteBuf) {
+      CompositeByteBuf compositeByteBuf = (CompositeByteBuf) buf;
+      ByteBuffer[] buffers = compositeByteBuf.nioBuffers(compositeByteBuf.readerIndex(),
+          compositeByteBuf.readableBytes());
+      return new ChunkedByteBuffer(buffers);
+    } else {
+      return new ChunkedByteBuffer(buf.nioBuffer());
+    }
   }
 
   @Override

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/NioManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/NioManagedBuffer.java
@@ -29,25 +29,29 @@ import io.netty.buffer.Unpooled;
  * A {@link ManagedBuffer} backed by {@link ByteBuffer}.
  */
 public class NioManagedBuffer extends ManagedBuffer {
-  private final ByteBuffer buf;
+  private final ChunkedByteBuffer buf;
+
+  public NioManagedBuffer(ChunkedByteBuffer buf) {
+    this.buf = buf;
+  }
 
   public NioManagedBuffer(ByteBuffer buf) {
-    this.buf = buf;
+    this(new ChunkedByteBuffer(buf));
   }
 
   @Override
   public long size() {
-    return buf.remaining();
+    return buf.size();
   }
 
   @Override
-  public ByteBuffer nioByteBuffer() throws IOException {
-    return buf.duplicate();
+  public ChunkedByteBuffer nioByteBuffer() throws IOException {
+    return new ChunkedByteBuffer(buf.getChunks());
   }
 
   @Override
   public InputStream createInputStream() throws IOException {
-    return new ByteBufInputStream(Unpooled.wrappedBuffer(buf));
+    return buf.toInputStream();
   }
 
   @Override
@@ -62,7 +66,7 @@ public class NioManagedBuffer extends ManagedBuffer {
 
   @Override
   public Object convertToNetty() throws IOException {
-    return Unpooled.wrappedBuffer(buf);
+    return buf.toNetty();
   }
 
   @Override

--- a/common/network-common/src/main/java/org/apache/spark/network/client/ChunkFetchInputStream.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/ChunkFetchInputStream.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.ClosedChannelException;
+import java.util.Iterator;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.primitives.UnsignedBytes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.protocol.StreamChunkId;
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.network.util.TransportFrameDecoder;
+
+public class ChunkFetchInputStream extends InputStream {
+  private final Logger logger = LoggerFactory.getLogger(ChunkFetchInputStream.class);
+
+  private final TransportResponseHandler handler;
+  private final Channel channel;
+  private final StreamChunkId streamId;
+  private final long byteCount;
+  private final ChunkReceivedCallback callback;
+  private final LinkedBlockingQueue<ByteBuf> buffers = new LinkedBlockingQueue<>(1024);
+  public final TransportFrameDecoder.Interceptor interceptor;
+
+  private ByteBuf curChunk;
+  private ByteBuf emptyByteBuf;
+  private boolean isCallbacked = false;
+  private long writerIndex = 0;
+
+
+  private final AtomicReference<Throwable> cause = new AtomicReference<>(null);
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+  public ChunkFetchInputStream(
+      TransportResponseHandler handler,
+      Channel channel,
+      StreamChunkId streamId,
+      long byteCount,
+      ChunkReceivedCallback callback) {
+    this.handler = handler;
+    this.channel = channel;
+    this.streamId = streamId;
+    this.byteCount = byteCount;
+    this.callback = callback;
+    this.interceptor = new StreamInterceptor();
+    this.emptyByteBuf = new EmptyByteBuf(channel.alloc());
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (isClosed.get()) return -1;
+    pullChunk();
+    if (curChunk != null) {
+      byte b = curChunk.readByte();
+      return UnsignedBytes.toInt(b);
+    } else {
+      return -1;
+    }
+  }
+
+  @Override
+  public int read(byte[] dest, int offset, int length) throws IOException {
+    if (isClosed.get()) return -1;
+    pullChunk();
+    if (curChunk != null) {
+      int amountToGet = Math.min(curChunk.readableBytes(), length);
+      curChunk.readBytes(dest, offset, amountToGet);
+      return amountToGet;
+    } else {
+      return -1;
+    }
+  }
+
+  @Override
+  public long skip(long bytes) throws IOException {
+    if (isClosed.get()) return 0L;
+    pullChunk();
+    if (curChunk != null) {
+      int amountToSkip = (int) Math.min(bytes, curChunk.readableBytes());
+      curChunk.skipBytes(amountToSkip);
+      return amountToSkip;
+    } else {
+      return 0L;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!isClosed.get()) {
+      releaseCurChunk();
+      isClosed.set(true);
+      resetChannel();
+      Iterator<ByteBuf> itr = buffers.iterator();
+      while (itr.hasNext()) {
+        itr.next().release();
+      }
+      buffers.clear();
+    }
+  }
+
+  private void pullChunk() throws IOException {
+    if (curChunk != null && !curChunk.isReadable()) releaseCurChunk();
+    if (curChunk == null && cause.get() == null && !isClosed.get()) {
+      try {
+        if (buffers.size() < 32 && !channel.config().isAutoRead()) {
+          // if channel.read() will be not invoked automatically,
+          // the method is called by here
+          channel.config().setAutoRead(true);
+          channel.read();
+        }
+        curChunk = buffers.take();
+        if (curChunk == emptyByteBuf) {
+          assert cause.get() != null;
+        }
+      } catch (Throwable e) {
+        setCause(e);
+      }
+    }
+    if (cause.get() != null) throw new IOException(cause.get());
+  }
+
+  private void setCause(Throwable e) throws IOException {
+    if (cause.get() == null) {
+      try {
+        cause.set(e);
+        close();
+        buffers.put(emptyByteBuf);
+      } catch (Throwable throwable) {
+        // setCause(throwable);
+      }
+    }
+  }
+
+  private void releaseCurChunk() {
+    if (curChunk != null) {
+      curChunk.release();
+      curChunk = null;
+    }
+  }
+
+  private void onSuccess() throws IOException {
+    if (isCallbacked) return;
+    if (cause.get() != null) {
+      callback.onFailure(streamId.chunkIndex, cause.get());
+    } else {
+      InputStream inputStream = new LimitedInputStream(this, byteCount);
+      ManagedBuffer managedBuffer = new InputStreamManagedBuffer(inputStream, byteCount);
+      callback.onSuccess(streamId.chunkIndex, managedBuffer);
+    }
+    isCallbacked = true;
+  }
+
+  private void resetChannel() {
+    if (!channel.config().isAutoRead()) {
+      channel.config().setAutoRead(true);
+      channel.read();
+    }
+  }
+
+  private class StreamInterceptor implements TransportFrameDecoder.Interceptor {
+    @Override
+    public void exceptionCaught(Throwable e) throws Exception {
+      handler.deactivateStream();
+      setCause(e);
+      logger.trace("exceptionCaught", e);
+      onSuccess();
+      resetChannel();
+    }
+
+    @Override
+    public void channelInactive() throws Exception {
+      handler.deactivateStream();
+      setCause(new ClosedChannelException());
+      logger.trace("channelInactive", cause.get());
+      onSuccess();
+      resetChannel();
+    }
+
+    @Override
+    public boolean handle(ByteBuf buf) throws Exception {
+      try {
+        ByteBuf frame = nextBufferForFrame(byteCount - writerIndex, buf);
+        int available = frame.readableBytes();
+        writerIndex += available;
+        mayTrafficSuspension();
+        if (!isClosed.get() && available > 0) {
+          buffers.put(frame);
+          if (writerIndex > byteCount) {
+            setCause(new IllegalStateException(String.format(
+                "Read too many bytes? Expected %d, but read %d.", byteCount, writerIndex)));
+            handler.deactivateStream();
+          } else if (writerIndex == byteCount) {
+            handler.deactivateStream();
+          }
+        } else {
+          frame.release();
+        }
+        logger.trace(streamId + ", writerIndex  " + writerIndex + " byteCount, " + byteCount);
+        onSuccess();
+      } catch (Exception e) {
+        setCause(e);
+        resetChannel();
+      }
+      return writerIndex != byteCount;
+    }
+
+    /**
+     * Takes the first buffer in the internal list, and either adjust it to fit in the frame
+     * (by taking a slice out of it) or remove it from the internal list.
+     */
+    private ByteBuf nextBufferForFrame(long bytesToRead, ByteBuf buf) {
+      int slen = (int) Math.min(buf.readableBytes(), bytesToRead);
+      ByteBuf frame;
+      if (slen == buf.readableBytes()) {
+        frame = buf.retain().readSlice(slen);
+      } else {
+        frame = buf.alloc().buffer(slen);
+        buf.readBytes(frame);
+        frame.retain();
+      }
+      return frame;
+    }
+
+    private void mayTrafficSuspension() {
+      // If there is too much cached chunk, to manually call channel.read().
+      if (channel.config().isAutoRead() && buffers.size() > 512) {
+        channel.config().setAutoRead(false);
+      }
+      if (writerIndex >= byteCount) resetChannel();
+    }
+  }
+
+  private class InputStreamManagedBuffer extends ManagedBuffer {
+    private final InputStream inputStream;
+    private final long byteCount;
+
+    InputStreamManagedBuffer(InputStream inputStream, long byteCount) {
+      this.inputStream = inputStream;
+      this.byteCount = byteCount;
+    }
+
+    public long size() {
+      return byteCount;
+    }
+
+    public ChunkedByteBuffer nioByteBuffer() throws IOException {
+      throw new UnsupportedOperationException("nioByteBuffer");
+    }
+
+    public InputStream createInputStream() throws IOException {
+      return inputStream;
+    }
+
+    public ManagedBuffer retain() {
+      // throw new UnsupportedOperationException("retain");
+      return this;
+    }
+
+    public ManagedBuffer release() {
+      // throw new UnsupportedOperationException("release");
+      return this;
+    }
+
+    public Object convertToNetty() throws IOException {
+      throw new UnsupportedOperationException("convertToNetty");
+    }
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/client/ChunkFetchStreamCallback.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/ChunkFetchStreamCallback.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.client;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
+import org.apache.spark.network.buffer.*;
+import org.apache.spark.network.protocol.StreamChunkId;
+
+public class ChunkFetchStreamCallback implements StreamCallback {
+  private final StreamChunkId streamChunkId;
+  private final ChunkReceivedCallback listener;
+  private final ChunkedByteBufferOutputStream outputStream = new
+      ChunkedByteBufferOutputStream(32 * 1024);
+  private final WritableByteChannel channel = Channels.newChannel(outputStream);
+
+  public ChunkFetchStreamCallback(
+      ChunkReceivedCallback listener,
+      StreamChunkId streamChunkId) {
+    this.listener = listener;
+    this.streamChunkId = streamChunkId;
+  }
+
+  public void onData(String streamId, ByteBuffer buffer) throws IOException {
+    while (buffer.hasRemaining()) {
+      int ret = channel.write(buffer);
+      if (ret == 0) {
+        throw new IOException("Could not fully write buffer to output stream");
+      }
+    }
+
+  }
+
+  public void onComplete(String streamId) throws IOException {
+    channel.close();
+    ManagedBuffer body = new NioManagedBuffer(outputStream.toChunkedByteBuffer());
+    listener.onSuccess(streamChunkId.chunkIndex, body);
+  }
+
+  public void onFailure(String streamId, Throwable cause) throws IOException {
+    channel.close();
+    listener.onFailure(streamChunkId.chunkIndex, cause);
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/client/RpcResponseCallback.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/RpcResponseCallback.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.network.client;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -30,7 +32,7 @@ public interface RpcResponseCallback {
    * After `onSuccess` returns, `response` will be recycled and its content will become invalid.
    * Please copy the content of `response` if you want to use it after `onSuccess` returns.
    */
-  void onSuccess(ByteBuffer response);
+  void onSuccess(ChunkedByteBuffer response);
 
   /** Exception either propagated from server or raised on client side. */
   void onFailure(Throwable e);

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslClientBootstrap.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslClientBootstrap.java
@@ -25,6 +25,7 @@ import javax.security.sasl.SaslException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,10 +76,11 @@ public class SaslClientBootstrap implements TransportClientBootstrap {
         SaslMessage msg = new SaslMessage(appId, payload);
         ByteBuf buf = Unpooled.buffer(msg.encodedLength() + (int) msg.body().size());
         msg.encode(buf);
-        buf.writeBytes(msg.body().nioByteBuffer());
+        buf.writeBytes(msg.body().nioByteBuffer().toArray());
 
-        ByteBuffer response = client.sendRpcSync(buf.nioBuffer(), conf.saslRTTimeoutMs());
-        payload = saslClient.response(JavaUtils.bufferToArray(response));
+        ChunkedByteBuffer response = client.sendRpcSync(ChunkedByteBuffer.wrap(buf.nioBuffer()),
+            conf.saslRTTimeoutMs());
+        payload = saslClient.response(response.toArray());
       }
 
       client.setClientId(appId);

--- a/common/network-common/src/main/java/org/apache/spark/network/server/RpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/RpcHandler.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
 
@@ -46,7 +47,7 @@ public abstract class RpcHandler {
    */
   public abstract void receive(
       TransportClient client,
-      ByteBuffer message,
+      ChunkedByteBuffer message,
       RpcResponseCallback callback);
 
   /**
@@ -57,14 +58,14 @@ public abstract class RpcHandler {
 
   /**
    * Receives an RPC message that does not expect a reply. The default implementation will
-   * call "{@link #receive(TransportClient, ByteBuffer, RpcResponseCallback)}" and log a warning if
+   * call "{@link #receive(TransportClient, ChunkedByteBuffer, RpcResponseCallback)}" and log a warning if
    * any of the callback methods are called.
    *
    * @param client A channel client which enables the handler to make requests back to the sender
    *               of this RPC. This will always be the exact same object for a particular channel.
    * @param message The serialized bytes of the RPC.
    */
-  public void receive(TransportClient client, ByteBuffer message) {
+  public void receive(TransportClient client, ChunkedByteBuffer message) {
     receive(client, message, ONE_WAY_CALLBACK);
   }
 
@@ -86,7 +87,7 @@ public abstract class RpcHandler {
     private final Logger logger = LoggerFactory.getLogger(OneWayRpcCallback.class);
 
     @Override
-    public void onSuccess(ByteBuffer response) {
+    public void onSuccess(ChunkedByteBuffer response) {
       logger.warn("Response provided for one-way RPC.");
     }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
@@ -157,7 +158,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
     try {
       rpcHandler.receive(reverseClient, req.body().nioByteBuffer(), new RpcResponseCallback() {
         @Override
-        public void onSuccess(ByteBuffer response) {
+        public void onSuccess(ChunkedByteBuffer response) {
           respond(new RpcResponse(req.requestId, new NioManagedBuffer(response)));
         }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchIntegrationSuite.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -107,7 +108,7 @@ public class ChunkFetchIntegrationSuite {
       @Override
       public void receive(
           TransportClient client,
-          ByteBuffer message,
+          ChunkedByteBuffer message,
           RpcResponseCallback callback) {
         throw new UnsupportedOperationException();
       }
@@ -230,8 +231,8 @@ public class ChunkFetchIntegrationSuite {
   }
 
   private void assertBuffersEqual(ManagedBuffer buffer0, ManagedBuffer buffer1) throws Exception {
-    ByteBuffer nio0 = buffer0.nioByteBuffer();
-    ByteBuffer nio1 = buffer1.nioByteBuffer();
+    ByteBuffer nio0 = buffer0.nioByteBuffer().toByteBuffer();
+    ByteBuffer nio1 = buffer1.nioByteBuffer().toByteBuffer();
 
     int len = nio0.remaining();
     assertEquals(nio0.remaining(), nio1.remaining());

--- a/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
@@ -37,6 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
@@ -118,7 +119,7 @@ public class StreamSuite {
       @Override
       public void receive(
           TransportClient client,
-          ByteBuffer message,
+          ChunkedByteBuffer message,
           RpcResponseCallback callback) {
         throw new UnsupportedOperationException();
       }

--- a/common/network-common/src/test/java/org/apache/spark/network/TestManagedBuffer.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TestManagedBuffer.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.Unpooled;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NettyManagedBuffer;
 
@@ -54,7 +55,7 @@ public class TestManagedBuffer extends ManagedBuffer {
   }
 
   @Override
-  public ByteBuffer nioByteBuffer() throws IOException {
+  public ChunkedByteBuffer nioByteBuffer() throws IOException {
     return underlying.nioByteBuffer();
   }
 
@@ -89,7 +90,7 @@ public class TestManagedBuffer extends ManagedBuffer {
   public boolean equals(Object other) {
     if (other instanceof ManagedBuffer) {
       try {
-        ByteBuffer nioBuf = ((ManagedBuffer) other).nioByteBuffer();
+        ByteBuffer nioBuf = ((ManagedBuffer) other).nioByteBuffer().toByteBuffer();
         if (nioBuf.remaining() != len) {
           return false;
         } else {

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportResponseHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportResponseHandlerSuite.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 
 import io.netty.channel.Channel;
 import io.netty.channel.local.LocalChannel;
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -103,7 +104,7 @@ public class TransportResponseHandlerSuite {
 
     ByteBuffer resp = ByteBuffer.allocate(10);
     handler.handle(new RpcResponse(12345, new NioManagedBuffer(resp)));
-    verify(callback, times(1)).onSuccess(eq(ByteBuffer.allocate(10)));
+    verify(callback, times(1)).onSuccess(eq(ChunkedByteBuffer.wrap(ByteBuffer.allocate(10))));
     assertEquals(0, handler.numOutstandingRequests());
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
@@ -78,7 +79,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
   }
 
   @Override
-  public void receive(TransportClient client, ByteBuffer message, RpcResponseCallback callback) {
+  public void receive(TransportClient client, ChunkedByteBuffer message, RpcResponseCallback callback) {
     BlockTransferMessage msgObj = BlockTransferMessage.Decoder.fromByteBuffer(message);
     handleMessage(msgObj, client, callback);
   }
@@ -106,7 +107,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
                      msg.blockIds.length,
                      client.getClientId(),
                      NettyUtils.getRemoteAddress(client.getChannel()));
-        callback.onSuccess(new StreamHandle(streamId, msg.blockIds.length).toByteBuffer());
+        callback.onSuccess(new StreamHandle(streamId, msg.blockIds.length).toChunkedByteBuffer());
         metrics.blockTransferRateBytes.mark(totalBlockSize);
       } finally {
         responseDelayContext.stop();
@@ -119,7 +120,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
         RegisterExecutor msg = (RegisterExecutor) msgObj;
         checkAuth(client, msg.appId);
         blockManager.registerExecutor(msg.appId, msg.execId, msg.executorInfo);
-        callback.onSuccess(ByteBuffer.wrap(new byte[0]));
+        callback.onSuccess(ChunkedByteBuffer.wrap(ByteBuffer.wrap(new byte[0])));
       } finally {
         responseDelayContext.stop();
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.TransportContext;
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportClientBootstrap;
 import org.apache.spark.network.client.TransportClientFactory;
@@ -140,7 +141,8 @@ public class ExternalShuffleClient extends ShuffleClient {
     checkInit();
     TransportClient client = clientFactory.createUnmanagedClient(host, port);
     try {
-      ByteBuffer registerMessage = new RegisterExecutor(appId, execId, executorInfo).toByteBuffer();
+      ChunkedByteBuffer registerMessage = new RegisterExecutor(appId, execId, executorInfo).
+          toChunkedByteBuffer();
       client.sendRpcSync(registerMessage, 5000 /* timeoutMs */);
     } finally {
       client.close();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.ChunkReceivedCallback;
 import org.apache.spark.network.client.RpcResponseCallback;
@@ -90,9 +91,9 @@ public class OneForOneBlockFetcher {
       throw new IllegalArgumentException("Zero-sized blockIds array");
     }
 
-    client.sendRpc(openMessage.toByteBuffer(), new RpcResponseCallback() {
+    client.sendRpc(openMessage.toChunkedByteBuffer(), new RpcResponseCallback() {
       @Override
-      public void onSuccess(ByteBuffer response) {
+      public void onSuccess(ChunkedByteBuffer response) {
         try {
           streamHandle = (StreamHandle) BlockTransferMessage.Decoder.fromByteBuffer(response);
           logger.trace("Successfully opened blocks {}, preparing to fetch chunks.", streamHandle);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.Lists;
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -110,8 +111,9 @@ public class SaslIntegrationSuite {
 
     TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
     String msg = "Hello, World!";
-    ByteBuffer resp = client.sendRpcSync(JavaUtils.stringToBytes(msg), TIMEOUT_MS);
-    assertEquals(msg, JavaUtils.bytesToString(resp));
+    ChunkedByteBuffer resp = client.sendRpcSync(ChunkedByteBuffer.wrap(JavaUtils.stringToBytes(msg)),
+        TIMEOUT_MS);
+    assertEquals(msg, JavaUtils.bytesToString(resp.toByteBuffer()));
   }
 
   @Test
@@ -137,9 +139,10 @@ public class SaslIntegrationSuite {
     clientFactory = context.createClientFactory(
       Lists.<TransportClientBootstrap>newArrayList());
 
-    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
+    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(),
+        server.getPort());
     try {
-      client.sendRpcSync(ByteBuffer.allocate(13), TIMEOUT_MS);
+      client.sendRpcSync(ChunkedByteBuffer.wrap(ByteBuffer.allocate(13)), TIMEOUT_MS);
       fail("Should have failed");
     } catch (Exception e) {
       assertTrue(e.getMessage(), e.getMessage().contains("Expected SaslMessage"));
@@ -147,7 +150,8 @@ public class SaslIntegrationSuite {
 
     try {
       // Guessing the right tag byte doesn't magically get you in...
-      client.sendRpcSync(ByteBuffer.wrap(new byte[] { (byte) 0xEA }), TIMEOUT_MS);
+      client.sendRpcSync(ChunkedByteBuffer.wrap(new byte[] { (byte) 0xEA }),
+          TIMEOUT_MS);
       fail("Should have failed");
     } catch (Exception e) {
       assertTrue(e.getMessage(), e.getMessage().contains("java.lang.IndexOutOfBoundsException"));
@@ -223,12 +227,13 @@ public class SaslIntegrationSuite {
         new String[] { System.getProperty("java.io.tmpdir") }, 1,
           "org.apache.spark.shuffle.sort.SortShuffleManager");
       RegisterExecutor regmsg = new RegisterExecutor("app-1", "0", executorInfo);
-      client1.sendRpcSync(regmsg.toByteBuffer(), TIMEOUT_MS);
+      client1.sendRpcSync(ChunkedByteBuffer.wrap(regmsg.toByteBuffer()), TIMEOUT_MS);
 
       // Make a successful request to fetch blocks, which creates a new stream. But do not actually
       // fetch any blocks, to keep the stream open.
       OpenBlocks openMessage = new OpenBlocks("app-1", "0", blockIds);
-      ByteBuffer response = client1.sendRpcSync(openMessage.toByteBuffer(), TIMEOUT_MS);
+      ChunkedByteBuffer response = client1.sendRpcSync(openMessage.toChunkedByteBuffer(),
+          TIMEOUT_MS);
       StreamHandle stream = (StreamHandle) BlockTransferMessage.Decoder.fromByteBuffer(response);
       long streamId = stream.streamId;
 
@@ -274,7 +279,7 @@ public class SaslIntegrationSuite {
   /** RPC handler which simply responds with the message it received. */
   public static class TestRpcHandler extends RpcHandler {
     @Override
-    public void receive(TransportClient client, ByteBuffer message, RpcResponseCallback callback) {
+    public void receive(TransportClient client, ChunkedByteBuffer message, RpcResponseCallback callback) {
       callback.onSuccess(message);
     }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
@@ -36,7 +36,8 @@ public class BlockTransferMessagesSuite {
   }
 
   private void checkSerializeDeserialize(BlockTransferMessage msg) {
-    BlockTransferMessage msg2 = BlockTransferMessage.Decoder.fromByteBuffer(msg.toByteBuffer());
+    BlockTransferMessage msg2 = BlockTransferMessage.Decoder.
+        fromByteBuffer(msg.toChunkedByteBuffer());
     assertEquals(msg, msg2);
     assertEquals(msg.hashCode(), msg2.hashCode());
     assertEquals(msg.toString(), msg2.toString());

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -256,8 +256,8 @@ public class ExternalShuffleIntegrationSuite {
   }
 
   private void assertBuffersEqual(ManagedBuffer buffer0, ManagedBuffer buffer1) throws Exception {
-    ByteBuffer nio0 = buffer0.nioByteBuffer();
-    ByteBuffer nio1 = buffer1.nioByteBuffer();
+    ByteBuffer nio0 = buffer0.nioByteBuffer().toByteBuffer();
+    ByteBuffer nio1 = buffer1.nioByteBuffer().toByteBuffer();
 
     int len = nio0.remaining();
     assertEquals(nio0.remaining(), nio1.remaining());

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NettyManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
@@ -135,13 +136,13 @@ public class OneForOneBlockFetcherSuite {
       @Override
       public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         BlockTransferMessage message = BlockTransferMessage.Decoder.fromByteBuffer(
-          (ByteBuffer) invocationOnMock.getArguments()[0]);
+          (ChunkedByteBuffer) invocationOnMock.getArguments()[0]);
         RpcResponseCallback callback = (RpcResponseCallback) invocationOnMock.getArguments()[1];
-        callback.onSuccess(new StreamHandle(123, blocks.size()).toByteBuffer());
+        callback.onSuccess(new StreamHandle(123, blocks.size()).toChunkedByteBuffer());
         assertEquals(new OpenBlocks("app-id", "exec-id", blockIds), message);
         return null;
       }
-    }).when(client).sendRpc(any(ByteBuffer.class), any(RpcResponseCallback.class));
+    }).when(client).sendRpc(any(ChunkedByteBuffer.class), any(RpcResponseCallback.class));
 
     // Respond to each chunk request with a single buffer from our blocks array.
     final AtomicInteger expectedChunkIndex = new AtomicInteger(0);

--- a/core/src/main/java/org/apache/spark/serializer/DummySerializerInstance.java
+++ b/core/src/main/java/org/apache/spark/serializer/DummySerializerInstance.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import scala.reflect.ClassTag;
 
 import org.apache.spark.annotation.Private;
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import org.apache.spark.unsafe.Platform;
 
 /**
@@ -71,7 +72,7 @@ public final class DummySerializerInstance extends SerializerInstance {
   }
 
   @Override
-  public <T> ByteBuffer serialize(T t, ClassTag<T> ev1) {
+  public <T> ChunkedByteBuffer serialize(T t, ClassTag<T> ev1) {
     throw new UnsupportedOperationException();
   }
 
@@ -81,12 +82,12 @@ public final class DummySerializerInstance extends SerializerInstance {
   }
 
   @Override
-  public <T> T deserialize(ByteBuffer bytes, ClassLoader loader, ClassTag<T> ev1) {
+  public <T> T deserialize(ChunkedByteBuffer bytes, ClassLoader loader, ClassTag<T> ev1) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public <T> T deserialize(ByteBuffer bytes, ClassTag<T> ev1) {
+  public <T> T deserialize(ChunkedByteBuffer bytes, ClassTag<T> ev1) {
     throw new UnsupportedOperationException();
   }
 }

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -27,10 +27,10 @@ import scala.util.Random
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.io.CompressionCodec
+import org.apache.spark.network.buffer.{Allocator, ChunkedByteBuffer, ChunkedByteBufferOutputStream}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.storage.{BlockId, BroadcastBlockId, StorageLevel}
 import org.apache.spark.util.{ByteBufferInputStream, Utils}
-import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStream}
 
 /**
  * A BitTorrent-like implementation of [[org.apache.spark.broadcast.Broadcast]].
@@ -107,7 +107,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
       TorrentBroadcast.blockifyObject(value, blockSize, SparkEnv.get.serializer, compressionCodec)
     blocks.zipWithIndex.foreach { case (block, i) =>
       val pieceId = BroadcastBlockId(id, "piece" + i)
-      val bytes = new ChunkedByteBuffer(block.duplicate())
+      val bytes = ChunkedByteBuffer.wrap(block.duplicate())
       if (!blockManager.putBytes(pieceId, bytes, MEMORY_AND_DISK_SER, tellMaster = true)) {
         throw new SparkException(s"Failed to store $pieceId of $broadcastId in local BlockManager")
       }
@@ -183,7 +183,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
         case None =>
           logInfo("Started reading broadcast variable " + id)
           val startTimeMs = System.currentTimeMillis()
-          val blocks = readBlocks().flatMap(_.getChunks())
+          val blocks = readBlocks()
           logInfo("Reading broadcast variable " + id + " took" + Utils.getUsedTimeMs(startTimeMs))
 
           val obj = TorrentBroadcast.unBlockifyObject[T](
@@ -220,7 +220,6 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
 
 }
 
-
 private object TorrentBroadcast extends Logging {
 
   def blockifyObject[T: ClassTag](
@@ -228,7 +227,9 @@ private object TorrentBroadcast extends Logging {
       blockSize: Int,
       serializer: Serializer,
       compressionCodec: Option[CompressionCodec]): Array[ByteBuffer] = {
-    val cbbos = new ChunkedByteBufferOutputStream(blockSize, ByteBuffer.allocate)
+    val cbbos = new ChunkedByteBufferOutputStream(blockSize, new Allocator {
+      override def allocate(len: Int) = ByteBuffer.allocate(len)
+    })
     val out = compressionCodec.map(c => c.compressedOutputStream(cbbos)).getOrElse(cbbos)
     val ser = serializer.newInstance()
     val serOut = ser.serializeStream(out)
@@ -241,12 +242,11 @@ private object TorrentBroadcast extends Logging {
   }
 
   def unBlockifyObject[T: ClassTag](
-      blocks: Array[ByteBuffer],
+      blocks: Array[ChunkedByteBuffer],
       serializer: Serializer,
       compressionCodec: Option[CompressionCodec]): T = {
     require(blocks.nonEmpty, "Cannot unblockify an empty array of blocks")
-    val is = new SequenceInputStream(
-      blocks.iterator.map(new ByteBufferInputStream(_)).asJavaEnumeration)
+    val is = ChunkedByteBuffer.wrap(blocks.flatMap(_.getChunks)).toInputStream
     val in: InputStream = compressionCodec.map(c => c.compressedInputStream(is)).getOrElse(is)
     val ser = serializer.newInstance()
     val serIn = ser.deserializeStream(in)

--- a/core/src/main/scala/org/apache/spark/deploy/mesos/MesosExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/mesos/MesosExternalShuffleService.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.ExternalShuffleService
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
 import org.apache.spark.network.shuffle.ExternalShuffleBlockHandler
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage
@@ -62,7 +63,7 @@ private[mesos] class MesosExternalShuffleBlockHandler(
             s"registered")
         }
         connectedApps.put(appId, appState)
-        callback.onSuccess(ByteBuffer.allocate(0))
+        callback.onSuccess(ChunkedByteBuffer.wrap(ByteBuffer.allocate(0)))
       case Heartbeat(appId) =>
         val address = client.getSocketAddress
         Option(connectedApps.get(appId)) match {

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -33,12 +33,12 @@ import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.TaskMemoryManager
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rpc.RpcTimeout
 import org.apache.spark.scheduler.{AccumulableInfo, DirectTaskResult, IndirectTaskResult, Task}
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{StorageLevel, TaskResultBlockId}
 import org.apache.spark.util._
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 /**
  * Spark executor, backed by a threadpool to run tasks.
@@ -62,7 +62,7 @@ private[spark] class Executor(
   private val currentFiles: HashMap[String, Long] = new HashMap[String, Long]()
   private val currentJars: HashMap[String, Long] = new HashMap[String, Long]()
 
-  private val EMPTY_BYTE_BUFFER = ByteBuffer.wrap(new Array[Byte](0))
+  private val EMPTY_BYTE_BUFFER = ChunkedByteBuffer.wrap(new Array[Byte](0))
 
   private val conf = env.conf
 
@@ -140,7 +140,7 @@ private[spark] class Executor(
       taskId: Long,
       attemptNumber: Int,
       taskName: String,
-      serializedTask: ByteBuffer): Unit = {
+      serializedTask: ChunkedByteBuffer): Unit = {
     val tr = new TaskRunner(context, taskId = taskId, attemptNumber = attemptNumber, taskName,
       serializedTask)
     runningTasks.put(taskId, tr)
@@ -189,7 +189,7 @@ private[spark] class Executor(
       val taskId: Long,
       val attemptNumber: Int,
       taskName: String,
-      serializedTask: ByteBuffer)
+      serializedTask: ChunkedByteBuffer)
     extends Runnable {
 
     /** Whether this task has been killed. */
@@ -327,20 +327,21 @@ private[spark] class Executor(
         // TODO: do not serialize value twice
         val directResult = new DirectTaskResult(valueBytes, accumUpdates)
         val serializedDirectResult = ser.serialize(directResult)
-        val resultSize = serializedDirectResult.limit
+        val resultSize = serializedDirectResult.size().toInt
 
         // directSend = sending directly back to the driver
-        val serializedResult: ByteBuffer = {
+        val serializedResult: ChunkedByteBuffer = {
           if (maxResultSize > 0 && resultSize > maxResultSize) {
             logWarning(s"Finished $taskName (TID $taskId). Result is larger than maxResultSize " +
               s"(${Utils.bytesToString(resultSize)} > ${Utils.bytesToString(maxResultSize)}), " +
               s"dropping it.")
-            ser.serialize(new IndirectTaskResult[Any](TaskResultBlockId(taskId), resultSize))
+            ser.serialize(new IndirectTaskResult[Any](TaskResultBlockId(taskId),
+              resultSize))
           } else if (resultSize > maxDirectResultSize) {
             val blockId = TaskResultBlockId(taskId)
             env.blockManager.putBytes(
               blockId,
-              new ChunkedByteBuffer(serializedDirectResult.duplicate()),
+              serializedDirectResult,
               StorageLevel.MEMORY_AND_DISK_SER)
             logInfo(
               s"Finished $taskName (TID $taskId). $resultSize bytes result sent via BlockManager)")

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorBackend.scala
@@ -20,11 +20,12 @@ package org.apache.spark.executor
 import java.nio.ByteBuffer
 
 import org.apache.spark.TaskState.TaskState
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 
 /**
  * A pluggable interface used by the Executor to send updates to the cluster scheduler.
  */
 private[spark] trait ExecutorBackend {
-  def statusUpdate(taskId: Long, state: TaskState, data: ByteBuffer): Unit
+  def statusUpdate(taskId: Long, state: TaskState, data: ChunkedByteBuffer): Unit
 }
 

--- a/core/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
 
-import org.apache.mesos.{Executor => MesosExecutor, ExecutorDriver, MesosExecutorDriver}
+import org.apache.mesos.{ExecutorDriver, MesosExecutorDriver, Executor => MesosExecutor}
 import org.apache.mesos.Protos.{TaskStatus => MesosTaskStatus, _}
 import org.apache.mesos.protobuf.ByteString
 
@@ -29,6 +29,7 @@ import org.apache.spark.{SparkConf, SparkEnv, TaskState}
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.scheduler.cluster.mesos.MesosTaskLaunchData
 import org.apache.spark.util.Utils
 
@@ -40,12 +41,12 @@ private[spark] class MesosExecutorBackend
   var executor: Executor = null
   var driver: ExecutorDriver = null
 
-  override def statusUpdate(taskId: Long, state: TaskState, data: ByteBuffer) {
+  override def statusUpdate(taskId: Long, state: TaskState, data: ChunkedByteBuffer) {
     val mesosTaskId = TaskID.newBuilder().setValue(taskId.toString).build()
     driver.sendStatusUpdate(MesosTaskStatus.newBuilder()
       .setTaskId(mesosTaskId)
       .setState(TaskState.toMesos(state))
-      .setData(ByteString.copyFrom(data))
+      .setData(ByteString.copyFrom(data.toByteBuffer))
       .build())
   }
 
@@ -90,7 +91,7 @@ private[spark] class MesosExecutorBackend
     } else {
       SparkHadoopUtil.get.runAsSparkUser { () =>
         executor.launchTask(this, taskId = taskId, attemptNumber = taskData.attemptNumber,
-          taskInfo.getName, taskData.serializedTask)
+          taskInfo.getName, ChunkedByteBuffer.wrap(taskData.serializedTask))
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
 
-import org.apache.mesos.{ExecutorDriver, MesosExecutorDriver, Executor => MesosExecutor}
+import org.apache.mesos.{Executor => MesosExecutor, ExecutorDriver, MesosExecutorDriver}
 import org.apache.mesos.Protos.{TaskStatus => MesosTaskStatus, _}
 import org.apache.mesos.protobuf.ByteString
 

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -42,6 +42,7 @@ import org.apache.spark.annotation.Experimental
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.OutputMetrics
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.partial.{BoundedDouble, PartialResult}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -162,12 +163,10 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   def aggregateByKey[U: ClassTag](zeroValue: U, partitioner: Partitioner)(seqOp: (U, V) => U,
       combOp: (U, U) => U): RDD[(K, U)] = self.withScope {
     // Serialize the zero value to a byte array so that we can get a new clone of it on each key
-    val zeroBuffer = SparkEnv.get.serializer.newInstance().serialize(zeroValue)
-    val zeroArray = new Array[Byte](zeroBuffer.limit)
-    zeroBuffer.get(zeroArray)
+    val zeroArray = SparkEnv.get.serializer.newInstance().serialize(zeroValue).toArray
 
     lazy val cachedSerializer = SparkEnv.get.serializer.newInstance()
-    val createZero = () => cachedSerializer.deserialize[U](ByteBuffer.wrap(zeroArray))
+    val createZero = () => cachedSerializer.deserialize[U](ChunkedByteBuffer.wrap(zeroArray))
 
     // We will clean the combiner closure later in `combineByKey`
     val cleanedSeqOp = self.context.clean(seqOp)
@@ -212,13 +211,11 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       zeroValue: V,
       partitioner: Partitioner)(func: (V, V) => V): RDD[(K, V)] = self.withScope {
     // Serialize the zero value to a byte array so that we can get a new clone of it on each key
-    val zeroBuffer = SparkEnv.get.serializer.newInstance().serialize(zeroValue)
-    val zeroArray = new Array[Byte](zeroBuffer.limit)
-    zeroBuffer.get(zeroArray)
+    val zeroArray = SparkEnv.get.serializer.newInstance().serialize(zeroValue).toArray
 
     // When deserializing, use a lazy val to create just one instance of the serializer per task
     lazy val cachedSerializer = SparkEnv.get.serializer.newInstance()
-    val createZero = () => cachedSerializer.deserialize[V](ByteBuffer.wrap(zeroArray))
+    val createZero = () => cachedSerializer.deserialize[V](ChunkedByteBuffer.wrap(zeroArray))
 
     val cleanedFunc = self.context.clean(func)
     combineByKeyWithClassTag[V]((v: V) => cleanedFunc(createZero(), v),

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -32,6 +32,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.TransportContext
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.network.client._
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.sasl.{SaslClientBootstrap, SaslServerBootstrap}
@@ -249,11 +250,12 @@ private[netty] class NettyRpcEnv(
     promise.future.mapTo[T].recover(timeout.addMessageIfTimeout)(ThreadUtils.sameThread)
   }
 
-  private[netty] def serialize(content: Any): ByteBuffer = {
+  private[netty] def serialize(content: Any): ChunkedByteBuffer = {
     javaSerializerInstance.serialize(content)
   }
 
-  private[netty] def deserialize[T: ClassTag](client: TransportClient, bytes: ByteBuffer): T = {
+  private[netty] def deserialize[T: ClassTag](client: TransportClient,
+    bytes: ChunkedByteBuffer): T = {
     NettyRpcEnv.currentClient.withValue(client) {
       deserialize { () =>
         javaSerializerInstance.deserialize[T](bytes)
@@ -558,7 +560,7 @@ private[netty] class NettyRpcHandler(
 
   override def receive(
       client: TransportClient,
-      message: ByteBuffer,
+      message: ChunkedByteBuffer,
       callback: RpcResponseCallback): Unit = {
     val messageToDispatch = internalReceive(client, message)
     dispatcher.postRemoteMessage(messageToDispatch, callback)
@@ -566,12 +568,13 @@ private[netty] class NettyRpcHandler(
 
   override def receive(
       client: TransportClient,
-      message: ByteBuffer): Unit = {
+      message: ChunkedByteBuffer): Unit = {
     val messageToDispatch = internalReceive(client, message)
     dispatcher.postOneWayMessage(messageToDispatch)
   }
 
-  private def internalReceive(client: TransportClient, message: ByteBuffer): RequestMessage = {
+  private def internalReceive(client: TransportClient,
+    message: ChunkedByteBuffer): RequestMessage = {
     val addr = client.getChannel().remoteAddress().asInstanceOf[InetSocketAddress]
     assert(addr != null)
     val clientAddr = RpcAddress(addr.getHostString, addr.getPort)

--- a/core/src/main/scala/org/apache/spark/rpc/netty/Outbox.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/Outbox.scala
@@ -25,6 +25,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
 import org.apache.spark.rpc.{RpcAddress, RpcEnvStoppedException}
 
@@ -36,7 +37,7 @@ private[netty] sealed trait OutboxMessage {
 
 }
 
-private[netty] case class OneWayOutboxMessage(content: ByteBuffer) extends OutboxMessage
+private[netty] case class OneWayOutboxMessage(content: ChunkedByteBuffer) extends OutboxMessage
   with Logging {
 
   override def sendWith(client: TransportClient): Unit = {
@@ -53,9 +54,9 @@ private[netty] case class OneWayOutboxMessage(content: ByteBuffer) extends Outbo
 }
 
 private[netty] case class RpcOutboxMessage(
-    content: ByteBuffer,
+    content: ChunkedByteBuffer,
     _onFailure: (Throwable) => Unit,
-    _onSuccess: (TransportClient, ByteBuffer) => Unit)
+    _onSuccess: (TransportClient, ChunkedByteBuffer) => Unit)
   extends OutboxMessage with RpcResponseCallback {
 
   private var client: TransportClient = _
@@ -75,7 +76,7 @@ private[netty] case class RpcOutboxMessage(
     _onFailure(e)
   }
 
-  override def onSuccess(response: ByteBuffer): Unit = {
+  override def onSuccess(response: ChunkedByteBuffer): Unit = {
     _onSuccess(client, response)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -987,10 +987,9 @@ class DAGScheduler(
       // For ResultTask, serialize and broadcast (rdd, func).
       val taskBinaryBytes: Array[Byte] = stage match {
         case stage: ShuffleMapStage =>
-          JavaUtils.bufferToArray(
-            closureSerializer.serialize((stage.rdd, stage.shuffleDep): AnyRef))
+          closureSerializer.serialize((stage.rdd, stage.shuffleDep): AnyRef).toArray
         case stage: ResultStage =>
-          JavaUtils.bufferToArray(closureSerializer.serialize((stage.rdd, stage.func): AnyRef))
+          closureSerializer.serialize((stage.rdd, stage.func): AnyRef).toArray
       }
 
       taskBinary = sc.broadcast(taskBinaryBytes)

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -24,6 +24,7 @@ import java.util.Properties
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rdd.RDD
 
 /**
@@ -64,7 +65,7 @@ private[spark] class ResultTask[T, U](
     val deserializeStartTime = System.currentTimeMillis()
     val ser = SparkEnv.get.closureSerializer.newInstance()
     val (rdd, func) = ser.deserialize[(RDD[T], (TaskContext, Iterator[T]) => U)](
-      ByteBuffer.wrap(taskBinary.value), Thread.currentThread.getContextClassLoader)
+      ChunkedByteBuffer.wrap(taskBinary.value), Thread.currentThread.getContextClassLoader)
     _executorDeserializeTime = System.currentTimeMillis() - deserializeStartTime
 
     func(context, rdd.iterator(partition, context))

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -26,6 +26,7 @@ import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.shuffle.ShuffleWriter
 
@@ -69,7 +70,7 @@ private[spark] class ShuffleMapTask(
     val deserializeStartTime = System.currentTimeMillis()
     val ser = SparkEnv.get.closureSerializer.newInstance()
     val (rdd, dep) = ser.deserialize[(RDD[_], ShuffleDependency[_, _, _])](
-      ByteBuffer.wrap(taskBinary.value), Thread.currentThread.getContextClassLoader)
+      ChunkedByteBuffer.wrap(taskBinary.value), Thread.currentThread.getContextClassLoader)
     _executorDeserializeTime = System.currentTimeMillis() - deserializeStartTime
 
     var writer: ShuffleWriter[Any, Any] = null

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import java.nio.ByteBuffer
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.util.SerializableBuffer
 
 /**
@@ -31,13 +32,8 @@ private[spark] class TaskDescription(
     val executorId: String,
     val name: String,
     val index: Int,    // Index within this task's TaskSet
-    _serializedTask: ByteBuffer)
+    val serializedTask: ChunkedByteBuffer)
   extends Serializable {
-
-  // Because ByteBuffers are not serializable, wrap the task in a SerializableBuffer
-  private val buffer = new SerializableBuffer(_serializedTask)
-
-  def serializedTask: ByteBuffer = buffer.value
 
   override def toString: String = "TaskDescription(TID=%d, index=%d)".format(taskId, index)
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResult.scala
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.storage.BlockId
 import org.apache.spark.util.{AccumulatorV2, Utils}
 
@@ -35,28 +36,24 @@ private[spark] case class IndirectTaskResult[T](blockId: BlockId, size: Int)
 
 /** A TaskResult that contains the task's return value and accumulator updates. */
 private[spark] class DirectTaskResult[T](
-    var valueBytes: ByteBuffer,
+    var valueBytes: ChunkedByteBuffer,
     var accumUpdates: Seq[AccumulatorV2[_, _]])
   extends TaskResult[T] with Externalizable {
 
   private var valueObjectDeserialized = false
   private var valueObject: T = _
 
-  def this() = this(null.asInstanceOf[ByteBuffer], null)
+  def this() = this(null.asInstanceOf[ChunkedByteBuffer], null)
 
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
-    out.writeInt(valueBytes.remaining)
-    Utils.writeByteBuffer(valueBytes, out)
+    valueBytes.writeExternal(out)
     out.writeInt(accumUpdates.size)
     accumUpdates.foreach(out.writeObject)
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
-    val blen = in.readInt()
-    val byteVal = new Array[Byte](blen)
-    in.readFully(byteVal)
-    valueBytes = ByteBuffer.wrap(byteVal)
-
+    valueBytes = new ChunkedByteBuffer()
+    valueBytes.readExternal(in)
     val numUpdates = in.readInt
     if (numUpdates == 0) {
       accumUpdates = Seq()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -26,6 +26,7 @@ import scala.util.control.NonFatal
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.util.{LongAccumulator, ThreadUtils, Utils}
 
@@ -51,20 +52,20 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
   def enqueueSuccessfulTask(
       taskSetManager: TaskSetManager,
       tid: Long,
-      serializedData: ByteBuffer): Unit = {
+      serializedData: ChunkedByteBuffer): Unit = {
     getTaskResultExecutor.execute(new Runnable {
       override def run(): Unit = Utils.logUncaughtExceptions {
         try {
           val (result, size) = serializer.get().deserialize[TaskResult[_]](serializedData) match {
             case directResult: DirectTaskResult[_] =>
-              if (!taskSetManager.canFetchMoreResults(serializedData.limit())) {
+              if (!taskSetManager.canFetchMoreResults(serializedData.size())) {
                 return
               }
               // deserialize "value" without holding any lock so that it won't block other threads.
               // We should call it here, so that when it's called again in
               // "TaskSetManager.handleSuccessfulTask", it does not need to deserialize the value.
               directResult.value()
-              (directResult, serializedData.limit())
+              (directResult, serializedData.size())
             case IndirectTaskResult(blockId, size) =>
               if (!taskSetManager.canFetchMoreResults(size)) {
                 // dropped by executor if size is larger than maxResultSize
@@ -83,9 +84,9 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
                 return
               }
               val deserializedResult = serializer.get().deserialize[DirectTaskResult[_]](
-                serializedTaskResult.get.toByteBuffer)
+                serializedTaskResult.get)
               sparkEnv.blockManager.master.removeBlock(blockId)
-              (deserializedResult, size)
+              (deserializedResult, size.toLong)
           }
 
           // Set the task result size in the accumulator updates received from the executors.
@@ -95,7 +96,7 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
             if (a.name == Some(InternalAccumulator.RESULT_SIZE)) {
               val acc = a.asInstanceOf[LongAccumulator]
               assert(acc.sum == 0L, "task result size should not have been set on the executors")
-              acc.setValue(size.toLong)
+              acc.setValue(size)
               acc
             } else {
               a
@@ -117,16 +118,15 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
   }
 
   def enqueueFailedTask(taskSetManager: TaskSetManager, tid: Long, taskState: TaskState,
-    serializedData: ByteBuffer) {
+    serializedData: ChunkedByteBuffer) {
     var reason : TaskEndReason = UnknownReason
     try {
       getTaskResultExecutor.execute(new Runnable {
         override def run(): Unit = Utils.logUncaughtExceptions {
           val loader = Utils.getContextOrSparkClassLoader
           try {
-            if (serializedData != null && serializedData.limit() > 0) {
-              reason = serializer.get().deserialize[TaskEndReason](
-                serializedData, loader)
+            if (serializedData != null && serializedData.size() > 0) {
+              reason = serializer.get().deserialize[TaskEndReason](serializedData, loader)
             }
           } catch {
             case cnd: ClassNotFoundException =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -30,6 +30,7 @@ import scala.util.Random
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
 import org.apache.spark.scheduler.TaskLocality.TaskLocality
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
@@ -340,7 +341,7 @@ private[spark] class TaskSchedulerImpl(
     return tasks
   }
 
-  def statusUpdate(tid: Long, state: TaskState, serializedData: ByteBuffer) {
+  def statusUpdate(tid: Long, state: TaskState, serializedData: ChunkedByteBuffer) {
     var failedExecutor: Option[String] = None
     synchronized {
       try {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -27,11 +27,11 @@ import scala.collection.mutable.HashMap
 import scala.collection.mutable.HashSet
 import scala.math.{max, min}
 import scala.util.control.NonFatal
-
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.TaskState.TaskState
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.util.{AccumulatorV2, Clock, SystemClock, Utils}
 
 /**
@@ -454,7 +454,7 @@ private[spark] class TaskSetManager(
           }
           // Serialize and return the task
           val startTime = clock.getTimeMillis()
-          val serializedTask: ByteBuffer = try {
+          val serializedTask: ChunkedByteBuffer = try {
             Task.serializeWithDependencies(task, sched.sc.addedFiles, sched.sc.addedJars, ser)
           } catch {
             // If the task cannot be serialized, then there's no point to re-attempt the task,
@@ -465,11 +465,11 @@ private[spark] class TaskSetManager(
               abort(s"$msg Exception during serialization: $e")
               throw new TaskNotSerializableException(e)
           }
-          if (serializedTask.limit > TaskSetManager.TASK_SIZE_TO_WARN_KB * 1024 &&
+          if (serializedTask.size() > TaskSetManager.TASK_SIZE_TO_WARN_KB * 1024 &&
               !emittedTaskSizeWarning) {
             emittedTaskSizeWarning = true
             logWarning(s"Stage ${task.stageId} contains a task of very large size " +
-              s"(${serializedTask.limit / 1024} KB). The maximum recommended task size is " +
+              s"(${serializedTask.size() / 1024} KB). The maximum recommended task size is " +
               s"${TaskSetManager.TASK_SIZE_TO_WARN_KB} KB.")
           }
           addRunningTask(taskId)
@@ -479,7 +479,7 @@ private[spark] class TaskSetManager(
           // val timeTaken = clock.getTime() - startTime
           val taskName = s"task ${info.id} in stage ${taskSet.id}"
           logInfo(s"Starting $taskName (TID $taskId, $host, partition ${task.partitionId}," +
-            s" $taskLocality, ${serializedTask.limit} bytes)")
+            s" $taskLocality, ${serializedTask.size()} bytes)")
 
           sched.dagScheduler.taskStarted(task, info)
           return Some(new TaskDescription(taskId = taskId, attemptNumber = attemptNum, execId,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable.HashMap
 import scala.collection.mutable.HashSet
 import scala.math.{max, min}
 import scala.util.control.NonFatal
+
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SchedulingMode._

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -20,6 +20,7 @@ package org.apache.spark.scheduler.cluster
 import java.nio.ByteBuffer
 
 import org.apache.spark.TaskState.TaskState
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.ExecutorLossReason
 import org.apache.spark.util.SerializableBuffer
@@ -33,7 +34,7 @@ private[spark] object CoarseGrainedClusterMessages {
   case object RetrieveLastAllocatedExecutorId extends CoarseGrainedClusterMessage
 
   // Driver to executors
-  case class LaunchTask(data: SerializableBuffer) extends CoarseGrainedClusterMessage
+  case class LaunchTask(data: ChunkedByteBuffer) extends CoarseGrainedClusterMessage
 
   case class KillTask(taskId: Long, executor: String, interruptThread: Boolean)
     extends CoarseGrainedClusterMessage
@@ -55,15 +56,7 @@ private[spark] object CoarseGrainedClusterMessages {
     extends CoarseGrainedClusterMessage
 
   case class StatusUpdate(executorId: String, taskId: Long, state: TaskState,
-    data: SerializableBuffer) extends CoarseGrainedClusterMessage
-
-  object StatusUpdate {
-    /** Alternate factory method that takes a ByteBuffer directly for the data field */
-    def apply(executorId: String, taskId: Long, state: TaskState, data: ByteBuffer)
-      : StatusUpdate = {
-      StatusUpdate(executorId, taskId, state, new SerializableBuffer(data))
-    }
-  }
+    data: ChunkedByteBuffer) extends CoarseGrainedClusterMessage
 
   // Internal messages in driver
   case object ReviveOffers extends CoarseGrainedClusterMessage

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -118,7 +118,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     override def receive: PartialFunction[Any, Unit] = {
       case StatusUpdate(executorId, taskId, state, data) =>
-        scheduler.statusUpdate(taskId, state, data.value)
+        scheduler.statusUpdate(taskId, state, data)
         if (TaskState.isFinished(state)) {
           executorDataMap.get(executorId) match {
             case Some(executorInfo) =>
@@ -245,13 +245,13 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     private def launchTasks(tasks: Seq[Seq[TaskDescription]]) {
       for (task <- tasks.flatten) {
         val serializedTask = ser.serialize(task)
-        if (serializedTask.limit >= maxRpcMessageSize) {
+        if (serializedTask.size() >= maxRpcMessageSize) {
           scheduler.taskIdToTaskSetManager.get(task.taskId).foreach { taskSetMgr =>
             try {
               var msg = "Serialized task %s:%d was %d bytes, which exceeds max allowed: " +
                 "spark.rpc.message.maxSize (%d bytes). Consider increasing " +
                 "spark.rpc.message.maxSize or using broadcast variables for large values."
-              msg = msg.format(task.taskId, task.index, serializedTask.limit, maxRpcMessageSize)
+              msg = msg.format(task.taskId, task.index, serializedTask.size(), maxRpcMessageSize)
               taskSetMgr.abort(msg)
             } catch {
               case e: Exception => logError("Exception in error callback", e)
@@ -265,7 +265,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           logInfo(s"Launching task ${task.taskId} on executor id: ${task.executorId} hostname: " +
             s"${executorData.executorHost}.")
 
-          executorData.executorEndpoint.send(LaunchTask(new SerializableBuffer(serializedTask)))
+          executorData.executorEndpoint.send(LaunchTask(serializedTask))
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -28,6 +28,7 @@ import org.apache.mesos.protobuf.ByteString
 
 import org.apache.spark.{SparkContext, SparkException, TaskState}
 import org.apache.spark.executor.MesosExecutorBackend
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.util.Utils
@@ -358,7 +359,8 @@ private[spark] class MesosFineGrainedSchedulerBackend(
       .setExecutor(executorInfo)
       .setName(task.name)
       .addAllResources(cpuResources.asJava)
-      .setData(MesosTaskLaunchData(task.serializedTask, task.attemptNumber).toByteString)
+      .setData(MesosTaskLaunchData(task.serializedTask.toByteBuffer,
+        task.attemptNumber).toByteString)
       .build()
     (taskInfo, finalResources.asJava)
   }
@@ -377,7 +379,8 @@ private[spark] class MesosFineGrainedSchedulerBackend(
           taskIdToSlaveId.remove(tid)
         }
       }
-      scheduler.statusUpdate(tid, state, status.getData.asReadOnlyByteBuffer)
+      scheduler.statusUpdate(tid, state,
+        ChunkedByteBuffer.wrap(status.getData.asReadOnlyByteBuffer))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -26,13 +26,14 @@ import org.apache.spark.TaskState.TaskState
 import org.apache.spark.executor.{Executor, ExecutorBackend}
 import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 
 private case class ReviveOffers()
 
-private case class StatusUpdate(taskId: Long, state: TaskState, serializedData: ByteBuffer)
+private case class StatusUpdate(taskId: Long, state: TaskState, serializedData: ChunkedByteBuffer)
 
 private case class KillTask(taskId: Long, interruptThread: Boolean)
 
@@ -148,7 +149,7 @@ private[spark] class LocalSchedulerBackend(
     localEndpoint.send(KillTask(taskId, interruptThread))
   }
 
-  override def statusUpdate(taskId: Long, state: TaskState, serializedData: ByteBuffer) {
+  override def statusUpdate(taskId: Long, state: TaskState, serializedData: ChunkedByteBuffer) {
     localEndpoint.send(StatusUpdate(taskId, state, serializedData))
   }
 

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -35,6 +35,7 @@ import org.roaringbitmap.RoaringBitmap
 import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.{ChunkedByteBuffer, ChunkedByteBufferOutputStream}
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}
 import org.apache.spark.storage._
@@ -80,6 +81,8 @@ class KryoSerializer(conf: SparkConf)
   private val avroSchemas = conf.getAvroSchema
 
   def newKryoOutput(): KryoOutput = new KryoOutput(bufferSize, math.max(bufferSize, maxBufferSize))
+
+  def newKryoInput(): KryoInput = new KryoInput(bufferSize)
 
   def newKryo(): Kryo = {
     val instantiator = new EmptyScalaKryoInstantiator
@@ -288,10 +291,12 @@ private[spark] class KryoSerializerInstance(ks: KryoSerializer) extends Serializ
 
   // Make these lazy vals to avoid creating a buffer unless we use them.
   private lazy val output = ks.newKryoOutput()
-  private lazy val input = new KryoInput()
+  private lazy val input = ks.newKryoInput()
 
-  override def serialize[T: ClassTag](t: T): ByteBuffer = {
+  override def serialize[T: ClassTag](t: T): ChunkedByteBuffer = {
     output.clear()
+    val out = new ChunkedByteBufferOutputStream(32 * 1024)
+    output.setOutputStream(out)
     val kryo = borrowKryo()
     try {
       kryo.writeClassAndObject(output, t)
@@ -300,29 +305,37 @@ private[spark] class KryoSerializerInstance(ks: KryoSerializer) extends Serializ
         throw new SparkException(s"Kryo serialization failed: ${e.getMessage}. To avoid this, " +
           "increase spark.kryoserializer.buffer.max value.")
     } finally {
+      output.close()
+      output.setOutputStream(null)
       releaseKryo(kryo)
     }
-    ByteBuffer.wrap(output.toBytes)
+    out.toChunkedByteBuffer
   }
 
-  override def deserialize[T: ClassTag](bytes: ByteBuffer): T = {
+  override def deserialize[T: ClassTag](bytes: ChunkedByteBuffer): T = {
     val kryo = borrowKryo()
     try {
-      input.setBuffer(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.remaining())
+      input.setInputStream(bytes.toInputStream())
+      // input.setBuffer(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.remaining())
       kryo.readClassAndObject(input).asInstanceOf[T]
     } finally {
+      input.close()
+      input.setInputStream(null)
       releaseKryo(kryo)
     }
   }
 
-  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T = {
+  override def deserialize[T: ClassTag](bytes: ChunkedByteBuffer, loader: ClassLoader): T = {
     val kryo = borrowKryo()
     val oldClassLoader = kryo.getClassLoader
     try {
       kryo.setClassLoader(loader)
-      input.setBuffer(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.remaining())
+      input.setInputStream(bytes.toInputStream())
+      // input.setBuffer(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.remaining())
       kryo.readClassAndObject(input).asInstanceOf[T]
     } finally {
+      input.close()
+      input.setInputStream(null)
       kryo.setClassLoader(oldClassLoader)
       releaseKryo(kryo)
     }

--- a/core/src/main/scala/org/apache/spark/serializer/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/Serializer.scala
@@ -25,6 +25,7 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.annotation.{DeveloperApi, Private}
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.util.NextIterator
 
 /**
@@ -110,11 +111,11 @@ abstract class Serializer {
 @DeveloperApi
 @NotThreadSafe
 abstract class SerializerInstance {
-  def serialize[T: ClassTag](t: T): ByteBuffer
+  def serialize[T: ClassTag](t: T): ChunkedByteBuffer
 
-  def deserialize[T: ClassTag](bytes: ByteBuffer): T
+  def deserialize[T: ClassTag](bytes: ChunkedByteBuffer): T
 
-  def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T
+  def deserialize[T: ClassTag](bytes: ChunkedByteBuffer, loader: ClassLoader): T
 
   def serializeStream(s: OutputStream): SerializationStream
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -32,7 +32,7 @@ import org.apache.spark.executor.{DataReadMethod, ShuffleWriteMetrics}
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.{MemoryManager, MemoryMode}
 import org.apache.spark.network._
-import org.apache.spark.network.buffer.{ManagedBuffer, NettyManagedBuffer}
+import org.apache.spark.network.buffer._
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle.ExternalShuffleClient
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo
@@ -42,7 +42,6 @@ import org.apache.spark.shuffle.ShuffleManager
 import org.apache.spark.storage.memory._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util._
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 /* Class for returning a fetched block and associated metrics. */
 private[spark] class BlockResult(
@@ -278,8 +277,10 @@ private[spark] class BlockManager(
     if (blockId.isShuffle) {
       shuffleManager.shuffleBlockResolver.getBlockData(blockId.asInstanceOf[ShuffleBlockId])
     } else {
-      getLocalBytes(blockId) match {
-        case Some(buffer) => new BlockManagerManagedBuffer(blockInfoManager, blockId, buffer)
+      blockInfoManager.lockForReading(blockId).map { info =>
+        doGetLocalData(blockId, info)
+      } match {
+        case Some(managedBuffer) => managedBuffer
         case None => throw new BlockNotFoundException(blockId.toString)
       }
     }
@@ -293,7 +294,9 @@ private[spark] class BlockManager(
       data: ManagedBuffer,
       level: StorageLevel,
       classTag: ClassTag[_]): Boolean = {
-    putBytes(blockId, new ChunkedByteBuffer(data.nioByteBuffer()), level)(classTag)
+    require(data != null, "data is null")
+    doPutData(blockId, data, level, classTag)
+    // putBytes(blockId, data.nioByteBuffer(), level)(classTag)
   }
 
   /**
@@ -437,16 +440,15 @@ private[spark] class BlockManager(
           Some(new BlockResult(ci, DataReadMethod.Memory, info.size))
         } else if (level.useDisk && diskStore.contains(blockId)) {
           val iterToReturn: Iterator[Any] = {
-            val diskBytes = diskStore.getBytes(blockId)
+            val diskBytes = diskStore.getBlockData(blockId)
             if (level.deserialized) {
               val diskValues = serializerManager.dataDeserializeStream(
-                blockId,
-                diskBytes.toInputStream(dispose = true))(info.classTag)
+                blockId, diskBytes.createInputStream())(info.classTag)
               maybeCacheDiskValuesInMemory(info, blockId, level, diskValues)
             } else {
-              val stream = maybeCacheDiskBytesInMemory(info, blockId, level, diskBytes)
-                .map {_.toInputStream(dispose = false)}
-                .getOrElse { diskBytes.toInputStream(dispose = true) }
+              val stream = maybeCacheDiskDataInMemory(info, blockId, level, diskBytes)
+                .map {_.toInputStream(false)}
+                .getOrElse { diskBytes.createInputStream() }
               serializerManager.dataDeserializeStream(blockId, stream)(info.classTag)
             }
           }
@@ -470,10 +472,11 @@ private[spark] class BlockManager(
       // TODO: This should gracefully handle case where local block is not available. Currently
       // downstream code will throw an exception.
       Option(
-        new ChunkedByteBuffer(
-          shuffleBlockResolver.getBlockData(blockId.asInstanceOf[ShuffleBlockId]).nioByteBuffer()))
+        shuffleBlockResolver.getBlockData(blockId.asInstanceOf[ShuffleBlockId]).nioByteBuffer())
     } else {
-      blockInfoManager.lockForReading(blockId).map { info => doGetLocalBytes(blockId, info) }
+      blockInfoManager.lockForReading(blockId).map { info =>
+        doGetLocalData(blockId, info).nioByteBuffer()
+      }
     }
   }
 
@@ -483,7 +486,7 @@ private[spark] class BlockManager(
    * Must be called while holding a read lock on the block.
    * Releases the read lock upon exception; keeps the read lock upon successful return.
    */
-  private def doGetLocalBytes(blockId: BlockId, info: BlockInfo): ChunkedByteBuffer = {
+  private def doGetLocalData(blockId: BlockId, info: BlockInfo): ManagedBuffer = {
     val level = info.level
     logDebug(s"Level for block $blockId is $level")
     // In order, try to read the serialized bytes from memory, then from disk, then fall back to
@@ -495,19 +498,23 @@ private[spark] class BlockManager(
         // handles deserialized blocks, this block may only be cached in memory as objects, not
         // serialized bytes. Because the caller only requested bytes, it doesn't make sense to
         // cache the block's deserialized objects since that caching may not have a payoff.
-        diskStore.getBytes(blockId)
+        diskStore.getBlockData(blockId)
       } else if (level.useMemory && memoryStore.contains(blockId)) {
         // The block was not found on disk, so serialize an in-memory copy:
-        serializerManager.dataSerialize(blockId, memoryStore.getValues(blockId).get)
+        val buffer = serializerManager.dataSerialize(blockId, memoryStore.getValues(blockId).get)
+        new BlockManagerManagedBuffer(blockInfoManager, blockId, buffer)
       } else {
         handleLocalReadFailure(blockId)
       }
     } else {  // storage level is serialized
       if (level.useMemory && memoryStore.contains(blockId)) {
-        memoryStore.getBytes(blockId).get
+        val buffer = memoryStore.getBytes(blockId).get
+        new BlockManagerManagedBuffer(blockInfoManager, blockId, buffer)
       } else if (level.useDisk && diskStore.contains(blockId)) {
-        val diskBytes = diskStore.getBytes(blockId)
-        maybeCacheDiskBytesInMemory(info, blockId, level, diskBytes).getOrElse(diskBytes)
+        val diskBytes = diskStore.getBlockData(blockId)
+        maybeCacheDiskDataInMemory(info, blockId, level, diskBytes).map { buffer =>
+          new BlockManagerManagedBuffer(blockInfoManager, blockId, buffer)
+        }.getOrElse(diskBytes)
       } else {
         handleLocalReadFailure(blockId)
       }
@@ -522,7 +529,7 @@ private[spark] class BlockManager(
   private def getRemoteValues(blockId: BlockId): Option[BlockResult] = {
     getRemoteBytes(blockId).map { data =>
       val values =
-        serializerManager.dataDeserializeStream(blockId, data.toInputStream(dispose = true))
+        serializerManager.dataDeserializeStream(blockId, data.toInputStream(true))
       new BlockResult(values, DataReadMethod.Network, data.size)
     }
   }
@@ -586,7 +593,7 @@ private[spark] class BlockManager(
       }
 
       if (data != null) {
-        return Some(new ChunkedByteBuffer(data))
+        return Some(data)
       }
       logDebug(s"The value of block $blockId is null")
     }
@@ -738,7 +745,7 @@ private[spark] class BlockManager(
       level: StorageLevel,
       tellMaster: Boolean = true): Boolean = {
     require(bytes != null, "Bytes is null")
-    doPutBytes(blockId, bytes, level, implicitly[ClassTag[T]], tellMaster)
+    doPutData(blockId, new NioManagedBuffer(bytes), level, implicitly[ClassTag[T]], tellMaster)
   }
 
   /**
@@ -752,9 +759,9 @@ private[spark] class BlockManager(
    *                     returns.
    * @return true if the block was already present or if the put succeeded, false otherwise.
    */
-  private def doPutBytes[T](
+  private def doPutData[T](
       blockId: BlockId,
-      bytes: ChunkedByteBuffer,
+      bytes: ManagedBuffer,
       level: StorageLevel,
       classTag: ClassTag[T],
       tellMaster: Boolean = true,
@@ -780,7 +787,7 @@ private[spark] class BlockManager(
         // We will drop it to disk later if the memory store can't hold it.
         val putSucceeded = if (level.deserialized) {
           val values =
-            serializerManager.dataDeserializeStream(blockId, bytes.toInputStream())(classTag)
+            serializerManager.dataDeserializeStream(blockId, bytes.createInputStream())(classTag)
           memoryStore.putIteratorAsValues(blockId, values, classTag) match {
             case Right(_) => true
             case Left(iter) =>
@@ -790,14 +797,22 @@ private[spark] class BlockManager(
               false
           }
         } else {
-          memoryStore.putBytes(blockId, size, level.memoryMode, () => bytes)
+          memoryStore.putBytes(blockId, size, level.memoryMode, () => bytes.nioByteBuffer())
         }
         if (!putSucceeded && level.useDisk) {
           logWarning(s"Persisting block $blockId to disk instead.")
-          diskStore.putBytes(blockId, bytes)
+          diskStore.put(blockId) { fileOutputStream =>
+            val inputStream = bytes.createInputStream()
+            Utils.copyStream(inputStream, fileOutputStream)
+            inputStream.close()
+          }
         }
       } else if (level.useDisk) {
-        diskStore.putBytes(blockId, bytes)
+        diskStore.put(blockId) { fileOutputStream =>
+          val inputStream = bytes.createInputStream()
+          Utils.copyStream(inputStream, fileOutputStream)
+          inputStream.close()
+        }
       }
 
       val putBlockStatus = getCurrentBlockStatus(blockId, info)
@@ -832,7 +847,7 @@ private[spark] class BlockManager(
   }
 
   /**
-   * Helper method used to abstract common code from [[doPutBytes()]] and [[doPutIterator()]].
+   * Helper method used to abstract common code from [[doPutData()]] and [[doPutIterator()]].
    *
    * @param putBody a function which attempts the actual put() and returns None on success
    *                or Some on failure.
@@ -972,11 +987,11 @@ private[spark] class BlockManager(
         logDebug("Put block %s locally took %s".format(blockId, Utils.getUsedTimeMs(startTimeMs)))
         if (level.replication > 1) {
           val remoteStartTime = System.currentTimeMillis
-          val bytesToReplicate = doGetLocalBytes(blockId, info)
+          val bytesToReplicate = doGetLocalData(blockId, info)
           try {
             replicate(blockId, bytesToReplicate, level, classTag)
           } finally {
-            bytesToReplicate.dispose()
+            bytesToReplicate.release()
           }
           logDebug("Put block %s remotely took %s"
             .format(blockId, Utils.getUsedTimeMs(remoteStartTime)))
@@ -996,18 +1011,18 @@ private[spark] class BlockManager(
    *         automatically be disposed and the caller should not continue to use them. Otherwise,
    *         if this returns None then the original disk store bytes will be unaffected.
    */
-  private def maybeCacheDiskBytesInMemory(
-      blockInfo: BlockInfo,
-      blockId: BlockId,
-      level: StorageLevel,
-      diskBytes: ChunkedByteBuffer): Option[ChunkedByteBuffer] = {
+  private def maybeCacheDiskDataInMemory(
+    blockInfo: BlockInfo,
+    blockId: BlockId,
+    level: StorageLevel,
+    diskBytes: ManagedBuffer): Option[ChunkedByteBuffer] = {
     require(!level.deserialized)
     if (level.useMemory) {
       // Synchronize on blockInfo to guard against a race condition where two readers both try to
       // put values read from disk into the MemoryStore.
       blockInfo.synchronized {
         if (memoryStore.contains(blockId)) {
-          diskBytes.dispose()
+          diskBytes.release()
           Some(memoryStore.getBytes(blockId).get)
         } else {
           val allocator = level.memoryMode match {
@@ -1019,10 +1034,14 @@ private[spark] class BlockManager(
             // If the file size is bigger than the free memory, OOM will happen. So if we
             // cannot put it into MemoryStore, copyForMemory should not be created. That's why
             // this action is put into a `() => ChunkedByteBuffer` and created lazily.
-            diskBytes.copy(allocator)
+            val out = new ChunkedByteBufferOutputStream(32 * 1024, new Allocator {
+              override def allocate(len: Int) = allocator(len)
+            })
+            Utils.copyStream(diskBytes.createInputStream(), out, true)
+            out.toChunkedByteBuffer
           })
           if (putSucceeded) {
-            diskBytes.dispose()
+            diskBytes.release()
             Some(memoryStore.getBytes(blockId).get)
           } else {
             None
@@ -1093,7 +1112,7 @@ private[spark] class BlockManager(
    */
   private def replicate(
       blockId: BlockId,
-      data: ChunkedByteBuffer,
+      data: ManagedBuffer,
       level: StorageLevel,
       classTag: ClassTag[_]): Unit = {
     val maxReplicationFailures = conf.getInt("spark.storage.maxReplicationFailures", 1)
@@ -1159,7 +1178,7 @@ private[spark] class BlockManager(
               peer.port,
               peer.executorId,
               blockId,
-              new NettyManagedBuffer(data.toNetty),
+              data,
               tLevel,
               classTag)
             logTrace(s"Replicated $blockId of ${data.size} bytes to $peer in %s ms"

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerManagedBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerManagedBuffer.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.storage
 
-import org.apache.spark.network.buffer.{ManagedBuffer, NettyManagedBuffer}
-import org.apache.spark.util.io.ChunkedByteBuffer
+import org.apache.spark.network.buffer.{ChunkedByteBuffer, ManagedBuffer, NettyManagedBuffer}
 
 /**
  * This [[ManagedBuffer]] wraps a [[ChunkedByteBuffer]] retrieved from the [[BlockManager]]

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -25,8 +25,8 @@ import com.google.common.io.Closeables
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.{ChunkedByteBuffer, FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.util.Utils
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 /**
  * Stores BlockManager blocks on disk.
@@ -83,28 +83,9 @@ private[spark] class DiskStore(conf: SparkConf, diskManager: DiskBlockManager) e
     }
   }
 
-  def getBytes(blockId: BlockId): ChunkedByteBuffer = {
+  def getBlockData(blockId: BlockId): ManagedBuffer = {
     val file = diskManager.getFile(blockId.name)
-    val channel = new RandomAccessFile(file, "r").getChannel
-    Utils.tryWithSafeFinally {
-      // For small files, directly read rather than memory map
-      if (file.length < minMemoryMapBytes) {
-        val buf = ByteBuffer.allocate(file.length.toInt)
-        channel.position(0)
-        while (buf.remaining() != 0) {
-          if (channel.read(buf) == -1) {
-            throw new IOException("Reached EOF before filling buffer\n" +
-              s"offset=0\nfile=${file.getAbsolutePath}\nbuf.remaining=${buf.remaining}")
-          }
-        }
-        buf.flip()
-        new ChunkedByteBuffer(buf)
-      } else {
-        new ChunkedByteBuffer(channel.map(MapMode.READ_ONLY, 0, file.length))
-      }
-    } {
-      channel.close()
-    }
+    new FileSegmentManagedBuffer(minMemoryMapBytes, true, file, 0L, file.length())
   }
 
   def remove(blockId: BlockId): Boolean = {

--- a/core/src/test/java/org/apache/spark/serializer/TestJavaSerializerImpl.java
+++ b/core/src/test/java/org/apache/spark/serializer/TestJavaSerializerImpl.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer;
 import scala.reflect.ClassTag;
 
 
@@ -35,18 +36,19 @@ class TestJavaSerializerImpl extends Serializer {
   }
 
   static class SerializerInstanceImpl extends SerializerInstance {
-      @Override
-      public <T> ByteBuffer serialize(T t, ClassTag<T> evidence$1) {
-        return null;
-      }
 
-      @Override
-    public <T> T deserialize(ByteBuffer bytes, ClassLoader loader, ClassTag<T> evidence$1) {
+    @Override
+    public <T> ChunkedByteBuffer serialize(T t, ClassTag<T> evidence$1) {
       return null;
     }
 
     @Override
-    public <T> T deserialize(ByteBuffer bytes, ClassTag<T> evidence$1) {
+    public <T> T deserialize(ChunkedByteBuffer bytes, ClassLoader loader, ClassTag<T> evidence$1) {
+      return null;
+    }
+
+    @Override
+    public <T> T deserialize(ChunkedByteBuffer bytes, ClassTag<T> evidence$1) {
       return null;
     }
 

--- a/core/src/test/scala/org/apache/spark/DistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DistributedSuite.scala
@@ -21,8 +21,8 @@ import org.scalatest.concurrent.Timeouts._
 import org.scalatest.Matchers
 import org.scalatest.time.{Millis, Span}
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.storage.{RDDBlockId, StorageLevel}
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 class NotSerializableClass
 class NotSerializableExn(val notSer: NotSerializableClass) extends Throwable() {}
@@ -216,7 +216,7 @@ class DistributedSuite extends SparkFunSuite with Matchers with LocalSparkContex
       val bytes = blockTransfer.fetchBlockSync(cmId.host, cmId.port, cmId.executorId,
         blockId.toString)
       val deserialized = serializerManager.dataDeserializeStream[Int](blockId,
-        new ChunkedByteBuffer(bytes.nioByteBuffer()).toInputStream()).toList
+        bytes.nioByteBuffer().toInputStream()).toList
       assert(deserialized === (1 to 100).toList)
     }
   }

--- a/core/src/test/scala/org/apache/spark/broadcast/BroadcastSuite.scala
+++ b/core/src/test/scala/org/apache/spark/broadcast/BroadcastSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.Assertions
 
 import org.apache.spark._
 import org.apache.spark.io.SnappyCompressionCodec
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.storage._
@@ -85,7 +86,9 @@ class BroadcastSuite extends SparkFunSuite with LocalSparkContext {
       val size = 1 + rand.nextInt(1024 * 10)
       val data: Array[Byte] = new Array[Byte](size)
       rand.nextBytes(data)
-      val blocks = blockifyObject(data, blockSize, serializer, compressionCodec)
+      val blocks = blockifyObject(data, blockSize, serializer, compressionCodec).map { block =>
+        ChunkedByteBuffer.wrap(block)
+      }
       val unblockified = unBlockifyObject[Array[Byte]](blocks, serializer, compressionCodec)
       assert(unblockified === data)
     }

--- a/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.memory.MemoryManager
 import org.apache.spark.metrics.MetricsSystem
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.{FakeTask, Task}
 import org.apache.spark.serializer.JavaSerializer
@@ -93,7 +94,7 @@ class ExecutorSuite extends SparkFunSuite {
             // save the returned `taskState` and `testFailedReason` into `executorSuiteHelper`
             val taskState = invocationOnMock.getArguments()(1).asInstanceOf[TaskState]
             executorSuiteHelper.taskState = taskState
-            val taskEndReason = invocationOnMock.getArguments()(2).asInstanceOf[ByteBuffer]
+            val taskEndReason = invocationOnMock.getArguments()(2).asInstanceOf[ChunkedByteBuffer]
             executorSuiteHelper.testFailedReason
               = serializer.newInstance().deserialize(taskEndReason)
             // let the main test thread check `taskState` and `testFailedReason`

--- a/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.io
 import java.nio.ByteBuffer
 
 import com.google.common.io.ByteStreams
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.network.buffer.{Allocator, ChunkedByteBuffer}
 import org.apache.spark.network.util.ByteArrayWritableChannel

--- a/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
@@ -20,10 +20,9 @@ package org.apache.spark.io
 import java.nio.ByteBuffer
 
 import com.google.common.io.ByteStreams
-
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.buffer.{Allocator, ChunkedByteBuffer}
 import org.apache.spark.network.util.ByteArrayWritableChannel
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 class ChunkedByteBufferSuite extends SparkFunSuite {
 
@@ -34,8 +33,8 @@ class ChunkedByteBufferSuite extends SparkFunSuite {
     assert(emptyChunkedByteBuffer.toArray === Array.empty)
     assert(emptyChunkedByteBuffer.toByteBuffer.capacity() === 0)
     assert(emptyChunkedByteBuffer.toNetty.capacity() === 0)
-    emptyChunkedByteBuffer.toInputStream(dispose = false).close()
-    emptyChunkedByteBuffer.toInputStream(dispose = true).close()
+    emptyChunkedByteBuffer.toInputStream(false).close()
+    emptyChunkedByteBuffer.toInputStream(true).close()
   }
 
   test("getChunks() duplicates chunks") {
@@ -46,7 +45,9 @@ class ChunkedByteBufferSuite extends SparkFunSuite {
 
   test("copy() does not affect original buffer's position") {
     val chunkedByteBuffer = new ChunkedByteBuffer(Array(ByteBuffer.allocate(8)))
-    chunkedByteBuffer.copy(ByteBuffer.allocate)
+    chunkedByteBuffer.copy(new Allocator {
+      override def allocate(len: Int): ByteBuffer = ByteBuffer.allocate(len)
+    })
     assert(chunkedByteBuffer.getChunks().head.position() === 0)
   }
 
@@ -80,7 +81,7 @@ class ChunkedByteBufferSuite extends SparkFunSuite {
     val chunkedByteBuffer = new ChunkedByteBuffer(Array(empty, bytes1, bytes2))
     assert(chunkedByteBuffer.size === bytes1.limit() + bytes2.limit())
 
-    val inputStream = chunkedByteBuffer.toInputStream(dispose = false)
+    val inputStream = chunkedByteBuffer.toInputStream(false)
     val bytesFromStream = new Array[Byte](chunkedByteBuffer.size.toInt)
     ByteStreams.readFully(inputStream, bytesFromStream)
     assert(bytesFromStream === bytes1.array() ++ bytes2.array())

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -188,8 +188,8 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     val ser = SparkEnv.get.closureSerializer.newInstance()
     val union = rdd1.union(rdd2)
     // The UnionRDD itself should be large, but each individual partition should be small.
-    assert(ser.serialize(union).limit() > 2000)
-    assert(ser.serialize(union.partitions.head).limit() < 2000)
+    assert(ser.serialize(union).toByteBuffer.limit() > 2000)
+    assert(ser.serialize(union.partitions.head).toByteBuffer.limit() < 2000)
   }
 
   test("aggregate") {

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcHandlerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcHandlerSuite.scala
@@ -25,6 +25,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.network.client.{TransportClient, TransportResponseHandler}
 import org.apache.spark.network.server.StreamManager
 import org.apache.spark.rpc._
@@ -33,7 +34,7 @@ class NettyRpcHandlerSuite extends SparkFunSuite {
 
   val env = mock(classOf[NettyRpcEnv])
   val sm = mock(classOf[StreamManager])
-  when(env.deserialize(any(classOf[TransportClient]), any(classOf[ByteBuffer]))(any()))
+  when(env.deserialize(any(classOf[TransportClient]), any(classOf[ChunkedByteBuffer]))(any()))
     .thenReturn(RequestMessage(RpcAddress("localhost", 12345), null, null))
 
   test("receive") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -60,7 +60,7 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
     }
     val closureSerializer = SparkEnv.get.closureSerializer.newInstance()
     val func = (c: TaskContext, i: Iterator[String]) => i.next()
-    val taskBinary = sc.broadcast(JavaUtils.bufferToArray(closureSerializer.serialize((rdd, func))))
+    val taskBinary = sc.broadcast(closureSerializer.serialize((rdd, func)).toArray)
     val task = new ResultTask[String, String](
       0, 0, taskBinary, rdd.partitions(0), Seq.empty, 0, new Properties, new TaskMetrics)
     intercept[RuntimeException] {
@@ -81,7 +81,7 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
     }
     val closureSerializer = SparkEnv.get.closureSerializer.newInstance()
     val func = (c: TaskContext, i: Iterator[String]) => i.next()
-    val taskBinary = sc.broadcast(JavaUtils.bufferToArray(closureSerializer.serialize((rdd, func))))
+    val taskBinary = sc.broadcast(closureSerializer.serialize((rdd, func)).toArray)
     val task = new ResultTask[String, String](
       0, 0, taskBinary, rdd.partitions(0), Seq.empty, 0, new Properties, new TaskMetrics)
     intercept[RuntimeException] {

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
@@ -36,8 +36,8 @@ import org.scalatest.mock.MockitoSugar
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.executor.MesosExecutorBackend
-import org.apache.spark.scheduler.{LiveListenerBus, SparkListenerExecutorAdded,
-  TaskDescription, TaskSchedulerImpl, WorkerOffer}
+import org.apache.spark.network.buffer.ChunkedByteBuffer
+import org.apache.spark.scheduler.{LiveListenerBus, SparkListenerExecutorAdded, TaskDescription, TaskSchedulerImpl, WorkerOffer}
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 
 class MesosFineGrainedSchedulerBackendSuite
@@ -246,7 +246,8 @@ class MesosFineGrainedSchedulerBackendSuite
       mesosOffers.get(2).getHostname,
       (minCpu - backend.mesosExecutorCores).toInt
     ))
-    val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
+    val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0,
+      ChunkedByteBuffer.wrap(new Array[Byte](0)))
     when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))
     when(taskScheduler.CPUS_PER_TASK).thenReturn(2)
 
@@ -345,7 +346,8 @@ class MesosFineGrainedSchedulerBackendSuite
       2 // Deducting 1 for executor
     ))
 
-    val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
+    val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0,
+      ChunkedByteBuffer.wrap(new Array[Byte](0)))
     when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))
     when(taskScheduler.CPUS_PER_TASK).thenReturn(1)
 

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -188,7 +188,7 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     def check[T: ClassTag](t: T) {
       assert(ser.deserialize[T](ser.serialize(t)) === t)
       // Check that very long ranges don't get written one element at a time
-      assert(ser.serialize(t).limit < 100)
+      assert(ser.serialize(t).toByteBuffer.limit < 100)
     }
     check(1 to 1000000)
     check(1 to 1000000 by 2)

--- a/core/src/test/scala/org/apache/spark/serializer/TestSerializer.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/TestSerializer.scala
@@ -22,6 +22,8 @@ import java.nio.ByteBuffer
 
 import scala.reflect.ClassTag
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer
+
 /**
  * A serializer implementation that always returns two elements in a deserialization stream.
  */
@@ -31,7 +33,8 @@ class TestSerializer extends Serializer {
 
 
 class TestSerializerInstance extends SerializerInstance {
-  override def serialize[T: ClassTag](t: T): ByteBuffer = throw new UnsupportedOperationException
+  override def serialize[T: ClassTag](t: T): ChunkedByteBuffer =
+    throw new UnsupportedOperationException
 
   override def serializeStream(s: OutputStream): SerializationStream =
     throw new UnsupportedOperationException
@@ -39,10 +42,10 @@ class TestSerializerInstance extends SerializerInstance {
   override def deserializeStream(s: InputStream): TestDeserializationStream =
     new TestDeserializationStream
 
-  override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
+  override def deserialize[T: ClassTag](bytes: ChunkedByteBuffer): T =
     throw new UnsupportedOperationException
 
-  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
+  override def deserialize[T: ClassTag](bytes: ChunkedByteBuffer, loader: ClassLoader): T =
     throw new UnsupportedOperationException
 }
 

--- a/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark._
-import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
+import org.apache.spark.network.buffer.{ChunkedByteBuffer, ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.serializer.{JavaSerializer, SerializerManager}
 import org.apache.spark.storage.{BlockManager, BlockManagerId, ShuffleBlockId}
 
@@ -38,7 +38,7 @@ class RecordingManagedBuffer(underlyingBuffer: NioManagedBuffer) extends Managed
   var callsToRelease = 0
 
   override def size(): Long = underlyingBuffer.size()
-  override def nioByteBuffer(): ByteBuffer = underlyingBuffer.nioByteBuffer()
+  override def nioByteBuffer(): ChunkedByteBuffer = underlyingBuffer.nioByteBuffer()
   override def createInputStream(): InputStream = underlyingBuffer.createInputStream()
   override def convertToNetty(): AnyRef = underlyingBuffer.convertToNetty()
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.broadcast.BroadcastManager
 import org.apache.spark.executor.DataReadMethod
 import org.apache.spark.memory.UnifiedMemoryManager
 import org.apache.spark.network.{BlockDataManager, BlockTransferService}
-import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
+import org.apache.spark.network.buffer.{ChunkedByteBuffer, ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.network.netty.NettyBlockTransferService
 import org.apache.spark.network.shuffle.BlockFetchingListener
 import org.apache.spark.rpc.RpcEnv
@@ -46,7 +46,6 @@ import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, SerializerMa
 import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.storage.BlockManagerMessages.BlockManagerHeartbeat
 import org.apache.spark.util._
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterEach
   with PrivateMethodTester with LocalSparkContext with ResetSystemProperties {

--- a/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
@@ -21,7 +21,7 @@ import java.nio.{ByteBuffer, MappedByteBuffer}
 import java.util.Arrays
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.util.io.ChunkedByteBuffer
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 
 class DiskStoreSuite extends SparkFunSuite {
 
@@ -30,19 +30,19 @@ class DiskStoreSuite extends SparkFunSuite {
 
     // Create a non-trivial (not all zeros) byte array
     val bytes = Array.tabulate[Byte](1000)(_.toByte)
-    val byteBuffer = new ChunkedByteBuffer(ByteBuffer.wrap(bytes))
+    val byteBuffer = ChunkedByteBuffer.wrap(bytes)
 
     val blockId = BlockId("rdd_1_2")
     val diskBlockManager = new DiskBlockManager(new SparkConf(), deleteFilesOnStop = true)
 
     val diskStoreMapped = new DiskStore(new SparkConf().set(confKey, "0"), diskBlockManager)
     diskStoreMapped.putBytes(blockId, byteBuffer)
-    val mapped = diskStoreMapped.getBytes(blockId)
+    val mapped = diskStoreMapped.getBlockData(blockId).nioByteBuffer()
     assert(diskStoreMapped.remove(blockId))
 
     val diskStoreNotMapped = new DiskStore(new SparkConf().set(confKey, "1m"), diskBlockManager)
     diskStoreNotMapped.putBytes(blockId, byteBuffer)
-    val notMapped = diskStoreNotMapped.getBytes(blockId)
+    val notMapped = diskStoreNotMapped.getBlockData(blockId).nioByteBuffer
 
     // Not possible to do isInstanceOf due to visibility of HeapByteBuffer
     assert(notMapped.getChunks().forall(_.getClass.getName.endsWith("HeapByteBuffer")),

--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -27,10 +27,10 @@ import org.scalatest._
 
 import org.apache.spark._
 import org.apache.spark.memory.{MemoryMode, StaticMemoryManager}
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.serializer.{KryoSerializer, SerializerManager}
 import org.apache.spark.storage.memory.{BlockEvictionHandler, MemoryStore, PartiallySerializedBlock, PartiallyUnrolledIterator}
 import org.apache.spark.util._
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 class MemoryStoreSuite
   extends SparkFunSuite
@@ -404,7 +404,7 @@ class MemoryStoreSuite
     val blockId = BlockId("rdd_3_10")
     var bytes: ChunkedByteBuffer = null
     memoryStore.putBytes(blockId, 10000, MemoryMode.ON_HEAP, () => {
-      bytes = new ChunkedByteBuffer(ByteBuffer.allocate(10000))
+      bytes = ChunkedByteBuffer.wrap(ByteBuffer.allocate(10000))
       bytes
     })
     assert(memoryStore.getSize(blockId) === 10000)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/UnsafeRowSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/UnsafeRowSerializer.scala
@@ -24,6 +24,7 @@ import scala.reflect.ClassTag
 
 import com.google.common.io.ByteStreams
 
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer, SerializerInstance}
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -176,9 +177,10 @@ private class UnsafeRowSerializerInstance(
   }
 
   // These methods are never called by shuffle code.
-  override def serialize[T: ClassTag](t: T): ByteBuffer = throw new UnsupportedOperationException
-  override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
+  override def serialize[T: ClassTag](t: T): ChunkedByteBuffer =
     throw new UnsupportedOperationException
-  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
+  override def deserialize[T: ClassTag](bytes: ChunkedByteBuffer): T =
+    throw new UnsupportedOperationException
+  override def deserialize[T: ClassTag](bytes: ChunkedByteBuffer, loader: ClassLoader): T =
     throw new UnsupportedOperationException
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.sql.SparkSession
@@ -85,11 +86,11 @@ class HDFSMetadataLog[T: ClassTag](sparkSession: SparkSession, path: String)
   }
 
   protected def serialize(metadata: T): Array[Byte] = {
-    JavaUtils.bufferToArray(serializer.serialize(metadata))
+    serializer.serialize(metadata).toArray
   }
 
   protected def deserialize(bytes: Array[Byte]): T = {
-    serializer.deserialize[T](ByteBuffer.wrap(bytes))
+    serializer.deserialize[T](ChunkedByteBuffer.wrap(bytes))
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -24,11 +24,11 @@ import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 import org.apache.spark._
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.rdd.BlockRDD
 import org.apache.spark.storage.{BlockId, StorageLevel}
 import org.apache.spark.streaming.util._
 import org.apache.spark.util.SerializableConfiguration
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 /**
  * Partition class for [[org.apache.spark.streaming.rdd.WriteAheadLogBackedBlockRDD]].
@@ -158,12 +158,12 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
       logInfo(s"Read partition data of $this from write ahead log, record handle " +
         partition.walRecordHandle)
       if (storeInBlockManager) {
-        blockManager.putBytes(blockId, new ChunkedByteBuffer(dataRead.duplicate()), storageLevel)
+        blockManager.putBytes(blockId, ChunkedByteBuffer.wrap(dataRead.duplicate()), storageLevel)
         logDebug(s"Stored partition data of $this into block manager with level $storageLevel")
         dataRead.rewind()
       }
       serializerManager
-        .dataDeserializeStream(blockId, new ChunkedByteBuffer(dataRead).toInputStream())
+        .dataDeserializeStream(blockId, ChunkedByteBuffer.wrap(dataRead).toInputStream())
         .asInstanceOf[Iterator[T]]
     }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceivedBlockHandler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceivedBlockHandler.scala
@@ -26,12 +26,12 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.storage._
 import org.apache.spark.streaming.receiver.WriteAheadLogBasedBlockHandler._
 import org.apache.spark.streaming.util.{WriteAheadLogRecordHandle, WriteAheadLogUtils}
 import org.apache.spark.util.{Clock, SystemClock, ThreadUtils}
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 /** Trait that represents the metadata related to storage of blocks */
 private[streaming] trait ReceivedBlockStoreResult {
@@ -87,7 +87,7 @@ private[streaming] class BlockManagerBasedBlockHandler(
         putResult
       case ByteBufferBlock(byteBuffer) =>
         blockManager.putBytes(
-          blockId, new ChunkedByteBuffer(byteBuffer.duplicate()), storageLevel, tellMaster = true)
+          blockId, ChunkedByteBuffer.wrap(byteBuffer.duplicate()), storageLevel, tellMaster = true)
       case o =>
         throw new SparkException(
           s"Could not store $blockId to block manager, unexpected block type ${o.getClass.getName}")
@@ -182,7 +182,7 @@ private[streaming] class WriteAheadLogBasedBlockHandler(
         numRecords = countIterator.count
         serializedBlock
       case ByteBufferBlock(byteBuffer) =>
-        new ChunkedByteBuffer(byteBuffer.duplicate())
+        ChunkedByteBuffer.wrap(byteBuffer.duplicate())
       case _ =>
         throw new Exception(s"Could not push $blockId to block manager, unexpected block type")
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark._
 import org.apache.spark.broadcast.BroadcastManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.StaticMemoryManager
+import org.apache.spark.network.buffer.ChunkedByteBuffer
 import org.apache.spark.network.netty.NettyBlockTransferService
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.LiveListenerBus
@@ -41,7 +42,6 @@ import org.apache.spark.storage._
 import org.apache.spark.streaming.receiver._
 import org.apache.spark.streaming.util._
 import org.apache.spark.util.{ManualClock, Utils}
-import org.apache.spark.util.io.ChunkedByteBuffer
 
 class ReceivedBlockHandlerSuite
   extends SparkFunSuite
@@ -163,7 +163,7 @@ class ReceivedBlockHandlerSuite
           val bytes = reader.read(fileSegment)
           reader.close()
           serializerManager.dataDeserializeStream(
-            generateBlockId(), new ChunkedByteBuffer(bytes).toInputStream()).toList
+            generateBlockId(), ChunkedByteBuffer.wrap(bytes).toInputStream()).toList
         }
         loggedData shouldEqual data
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Replace DiskStore method `def getBytes (blockId: BlockId): ChunkedByteBuffer` to `def getBlockData(blockId: BlockId): ManagedBuffer` .
2. ManagedBuffer's nioByteBuffer method return ChunkedByteBuffer.
3. Add class `ChunkFetchInputStream`, used for flow control
4. Move class `ChunkedByteBuffer`, `ChunkedByteBufferInputStream` and `ChunkedByteBufferOutputStream` to `common/network-common/src/main/java/org/apache/spark/network/buffer/`
5. Replace `ByteBuffer` with `ChunkedByteBuffer` :
- FileSegmentManagedBuffer
  add constructor `public FileSegmentManagedBuffer(long memoryMapBytes, boolean lazyFileDescriptor, File file, long offset, long length)`  
- NettyManagedBuffer 
  Support Zero-copy in `nioByteBuffer` method
- NioManagedBuffer  
  add constructor `public NioManagedBuffer(ChunkedByteBuffer buf)`
- RpcResponseCallback
  `void onSuccess(ByteBuffer response)` => `void onSuccess(ChunkedByteBuffer response)`
- TransportClient
  `public long sendRpc(ByteBuffer message, final RpcResponseCallback callback)` => `public long sendRpc(ChunkedByteBuffer message, final RpcResponseCallback callback)`
  `public ByteBuffer sendRpcSync(ByteBuffer message, long timeoutMs)` => `ChunkedByteBuffer sendRpcSync(ChunkedByteBuffer message, long timeoutMs)`  
  `public void send(ByteBuffer message)` => `public void send(ChunkedByteBuffer message)`
- SaslRpcHandler
  `public void receive(TransportClient client, ByteBuffer message, RpcResponseCallback callback)` => `public void receive(TransportClient client, ChunkedByteBuffer message, RpcResponseCallback callback)`
  `public void receive(TransportClient client, ByteBuffer message)` => `public void receive(TransportClient client, ChunkedByteBuffer message)`
- NoOpRpcHandler
  `public void receive(TransportClient client, ByteBuffer message, RpcResponseCallback callback)` => `public void receive(TransportClient client, ChunkedByteBuffer message, RpcResponseCallback callback)`  
- RpcHandler
  `public abstract void receive(TransportClient client,  ByteBuffer message, RpcResponseCallback callback)` =>  `public abstract void receive(TransportClient client,  ChunkedByteBuffer message, RpcResponseCallback callback)`
  `public void receive(TransportClient client, ByteBuffer message)` => `public void receive(TransportClient client, ChunkedByteBuffer message)` 
  `public void onSuccess(ByteBuffer response)` => `public void onSuccess(ChunkedByteBuffer response)`
- org.apache.spark.network.shuffle.protocol.Decoder
  `BlockTransferMessage fromByteBuffer(ByteBuffer msg)` => `public static BlockTransferMessage fromByteBuffer(ChunkedByteBuffer msg)` 
- TorrentBroadcast
  `def unBlockifyObject[T: ClassTag](blocks: Array[ByteBuffer], serializer: Serializer, compressionCodec: Option[CompressionCodec])` =>
  `def unBlockifyObject[T: ClassTag](blocks: Array[ChunkedByteBuffer], serializer: Serializer, compressionCodec: Option[CompressionCodec])`
- Executor
  `def launchTask(context: ExecutorBackend, taskId: Long, attemptNumber: Int, taskName: String, serializedTask: ByteBuffer): Unit` =>
  `def launchTask(context: ExecutorBackend, taskId: Long, attemptNumber: Int, taskName: String, serializedTask: ChunkedByteBuffer): Unit`
- ExecutorBackend
  `def statusUpdate(taskId: Long, state: TaskState, data: ByteBuffer): Unit` => `def statusUpdate(taskId: Long, state: TaskState, data: ChunkedByteBuffer): Unit` 
- OneWayOutboxMessage
  `case class OneWayOutboxMessage(content: ByteBuffer) extends OutboxMessage` => `case class OneWayOutboxMessage(content: ChunkedByteBuffer) extends OutboxMessage`
- org.apache.spark.scheduler.Task  
  `serializeWithDependencies(task: Task[_], currentFiles: mutable.Map[String, Long], currentJars: mutable.Map[String, Long], serializer: SerializerInstance): ByteBuffer` =>
  `serializeWithDependencies(task: Task[_], currentFiles: mutable.Map[String, Long], currentJars: mutable.Map[String, Long], serializer: SerializerInstance): ChunkedByteBuffer`
  `deserializeWithDependencies(serializedTask: ByteBuffer): (HashMap[String, Long], HashMap[String, Long], Properties, ByteBuffer)` =>
  `deserializeWithDependencies(serializedTask: ChunkedByteBuffer): (HashMap[String, Long], HashMap[String, Long], Properties, ChunkedByteBuffer)`
- TaskDescription
  `private[spark] class TaskDescription(val taskId: Long, val attemptNumber: Int, val executorId: String, val name: String, val index: Int, val serializedTask: ChunkedByteBuffer)` => `private[spark] class TaskDescription(val taskId: Long, val attemptNumber: Int, val executorId: String, val name: String, val index: Int, _serializedTask: ByteBuffer)`
- DirectTaskResult
  `private[spark] class DirectTaskResult[T](var valueBytes: ByteBuffer, var accumUpdates: Seq[AccumulatorV2[_, _]]) extends TaskResult[T]`=>
  `private[spark] class DirectTaskResult[T](var valueBytes: ChunkedByteBuffer, var accumUpdates: Seq[AccumulatorV2[_, _]]) extends TaskResult[T]`
- TaskResultGetter
  `def enqueueSuccessfulTask(taskSetManager: TaskSetManager, tid: Long, serializedData: ByteBuffer): Unit` =>`def enqueueSuccessfulTask(taskSetManager: TaskSetManager, tid: Long, serializedData: ChunkedByteBuffer): Unit`
  `def enqueueFailedTask(taskSetManager: TaskSetManager, tid: Long, taskState: TaskState, serializedData: ByteBuffer)` `def enqueueFailedTask(taskSetManager: TaskSetManager, tid: Long, taskState: TaskState, serializedData: ChunkedByteBuffer)`
- TaskSchedulerImpl
  `def statusUpdate(tid: Long, state: TaskState, serializedData: ByteBuffer)` =>  `def statusUpdate(tid: Long, state: TaskState, serializedData: ChunkedByteBuffer)`
- CoarseGrainedClusterMessages.LaunchTask
  `case class LaunchTask(data: SerializableBuffer) extends CoarseGrainedClusterMessage` => `case class LaunchTask(data: ChunkedByteBuffer) extends CoarseGrainedClusterMessage`
- CoarseGrainedClusterMessages.StatusUpdate
  `case class StatusUpdate(executorId: String, taskId: Long, state: TaskState, data: SerializableBuffer) extends CoarseGrainedClusterMessage` => `case class StatusUpdate(executorId: String, taskId: Long, state: TaskState, data: ChunkedByteBuffer) extends CoarseGrainedClusterMessage`
- org.apache.spark.scheduler.local.LocalSchedulerBackend  
  `private case class StatusUpdate(taskId: Long, state: TaskState, serializedData: ByteBuffer)` => `private case class StatusUpdate(taskId: Long, state: TaskState, serializedData: ChunkedByteBuffer)`
- SerializerInstance
  `def serialize[T: ClassTag](t: T): ByteBuffer' =>`def serialize[T: ClassTag](t: T): ChunkedByteBuffer`
  `def deserialize[T: ClassTag](bytes: ByteBuffer): T`=> def deserialize[T: ClassTag](bytes: ChunkedByteBuffer): T
  `def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T`=>`def deserialize[T: ClassTag](bytes: ChunkedByteBuffer, loader: ClassLoader): T`
  `   
