### PR TITLE
[SPARK-16995][SQL] TreeNodeException when flat mapping RelationalGroupedDataset created from DataFrame containing a column created with lit/expr

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -730,9 +730,15 @@ object FoldablePropagation extends Rule[LogicalPlan] {
 
         // Operators that operate on objects should only have expressions from encoders, which
         // should never have foldable expressions.
-        case o: ObjectConsumer => o
-        case o: ObjectProducer => o
-        case a: AppendColumns => a
+        case o: ObjectConsumer =>
+          stop = true
+          o
+        case o: ObjectProducer =>
+          stop = true
+          o
+        case a: AppendColumns =>
+          stop = true
+          a
 
         case p: LogicalPlan if !stop => p.transformExpressions {
           case a: AttributeReference if foldableMap.contains(a) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -728,8 +728,8 @@ object FoldablePropagation extends Rule[LogicalPlan] {
           stop = true
           j
 
-        // Operators that operate on objects should only have expressions from encoders, which
-        // should never have foldable expressions.
+        // These 3 operators take attributes as constructor parameters, and these attributes
+        // can't be replaced by alias.
         case m: MapGroups =>
           stop = true
           m

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -727,6 +727,13 @@ object FoldablePropagation extends Rule[LogicalPlan] {
         case j @ Join(_, _, LeftOuter | RightOuter | FullOuter, _) =>
           stop = true
           j
+
+        // Operators that operate on objects should only have expressions from encoders, which
+        // should never have foldable expressions.
+        case o: ObjectConsumer => o
+        case o: ObjectProducer => o
+        case a: AppendColumns => a
+
         case p: LogicalPlan if !stop => p.transformExpressions {
           case a: AttributeReference if foldableMap.contains(a) =>
             foldableMap(a)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -730,15 +730,15 @@ object FoldablePropagation extends Rule[LogicalPlan] {
 
         // Operators that operate on objects should only have expressions from encoders, which
         // should never have foldable expressions.
-        case o: ObjectConsumer =>
+        case m: MapGroups =>
           stop = true
-          o
-        case o: ObjectProducer =>
+          m
+        case f: FlatMapGroupsInR =>
           stop = true
-          o
-        case a: AppendColumns =>
+          f
+        case c: CoGroup =>
           stop = true
-          a
+          c
 
         case p: LogicalPlan if !stop => p.transformExpressions {
           case a: AttributeReference if foldableMap.contains(a) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -884,14 +884,12 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
     import df.sparkSession.implicits._
 
-    assertResult(Seq()) {
+    checkDataset(
       df.withColumn("b", lit(0)).as[ClassData]
-        .groupByKey(_.a).flatMapGroups { case (x, iter) => List[Int]() }.collect().toSeq
-    }
-    assertResult(Seq()) {
+        .groupByKey(_.a).flatMapGroups { case (x, iter) => List[Int]() })
+    checkDataset(
       df.withColumn("b", expr("0")).as[ClassData]
-        .groupByKey(_.a).flatMapGroups { case (x, iter) => List[Int]() }.collect().toSeq
-    }
+        .groupByKey(_.a).flatMapGroups { case (x, iter) => List[Int]() })
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A TreeNodeException is thrown when executing the following minimal example in Spark 2.0. 

```
import spark.implicits._
case class test (x: Int, q: Int)

val d = Seq(1).toDF("x")
d.withColumn("q", lit(0)).as[test].groupByKey(_.x).flatMapGroups{case (x, iter) => List[Int]()}.show
d.withColumn("q", expr("0")).as[test].groupByKey(_.x).flatMapGroups{case (x, iter) => List[Int]()}.show
```

The problem is at `FoldablePropagation`. The rule will do `transformExpressions` on `LogicalPlan`. The query above contains a `MapGroups` which has a parameter `dataAttributes:Seq[Attribute]`. One attributes in `dataAttributes` will be transformed to an `Alias(literal(0), _)` in `FoldablePropagation`. `Alias` is not an `Attribute` and causes the error.

We can't easily detect such type inconsistency during transforming expressions. A direct approach to this problem is to skip doing `FoldablePropagation` on object operators as they should not contain such expressions.
## How was this patch tested?

Jenkins tests.
