### PR TITLE
[SPARK-17059][SQL] Allow FileFormat to specify partition pruning strategy

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -199,6 +199,11 @@ case class FileSourceScanExec(
         relation.location.paths.head,
         originalPartitions)
     }
+    val totalFilesRaw = originalPartitions.map(_.files.size).sum
+    val totalFilesFiltered = filteredPartitions.map(_.files.size).sum
+    logInfo(s"Filtered down total number of partitions to ${filteredPartitions.size}"
+      + s" from ${originalPartitions.size}, "
+      + s"total number of files to ${totalFilesFiltered} from ${totalFilesRaw}")
 
     val readFile: (PartitionedFile) => Iterator[InternalRow] =
       relation.fileFormat.buildReaderWithPartitionValues(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -220,7 +220,7 @@ trait FileFormat {
   }
 
   /**
-   * Allow FileFormat's to have a pluggable way to utilize pushed filters to eliminate partitions
+   * Allow FileFormats to have a pluggable way to utilize pushed filters to eliminate partitions
    * before execution. By default no pruning is performed and the original partitioning is
    * preserved.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -220,6 +220,21 @@ trait FileFormat {
   }
 
   /**
+   * Allow FileFormat's to have a pluggable way to utilize pushed filters to eliminate partitions
+   * before execution. By default no pruning is performed and the original partitioning is
+   * preserved.
+   */
+  def filterPartitions(
+      filters: Seq[Filter],
+      schema: StructType,
+      conf: Configuration,
+      allFiles: Seq[FileStatus],
+      root: Path,
+      partitions: Seq[Partition]): Seq[Partition] = {
+    partitions
+  }
+
+  /**
    * Returns whether a file with `path` could be splitted or not.
    */
   def isSplitable(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -60,7 +60,7 @@ class ParquetFileFormat
   with Logging
   with Serializable {
 
-  // Attempt to cache parquet metadata for this instance of
+  // Attempt to cache parquet metadata
   @transient @volatile private var cachedMetadata: ParquetMetadata = _
 
   override def shortName(): String = "parquet"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -27,12 +27,14 @@ import scala.util.{Failure, Try}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce._
-import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat, FileSplit}
+import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.parquet.{Log => ApacheParquetLog}
-import org.apache.parquet.filter2.compat.FilterCompat
+import org.apache.parquet.filter2.compat.{FilterCompat, RowGroupFilter}
 import org.apache.parquet.filter2.predicate.FilterApi
+import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop._
+import org.apache.parquet.hadoop.metadata.ParquetMetadata
 import org.apache.parquet.hadoop.util.ContextUtil
 import org.apache.parquet.schema.MessageType
 import org.slf4j.bridge.SLF4JBridgeHandler
@@ -423,6 +425,54 @@ class ParquetFileFormat
       sqlContext.sessionState.newHadoopConf(),
       options)
   }
+
+  override def filterPartitions(
+      filters: Seq[Filter],
+      schema: StructType,
+      conf: Configuration,
+      allFiles: Seq[FileStatus],
+      root: Path,
+      partitions: Seq[Partition]): Seq[Partition] = {
+    // Read the "_metadata" file if available, contains all block headers. On S3 better to grab
+    // all of the footers in a batch rather than having to read every single file just to get its
+    // footer.
+    allFiles.find(_.getPath.getName == ParquetFileWriter.PARQUET_METADATA_FILE).map { stat =>
+      val metadata = ParquetFileReader.readFooter(conf, stat, ParquetMetadataConverter.NO_FILTER)
+      partitions.map { part =>
+        filterByMetadata(
+          filters,
+          schema,
+          conf,
+          root,
+          metadata,
+          part)
+      }.filterNot(_.files.isEmpty)
+    }.getOrElse(partitions)
+  }
+
+  private def filterByMetadata(
+      filters: Seq[Filter],
+      schema: StructType,
+      conf: Configuration,
+      root: Path,
+      metadata: ParquetMetadata,
+      partition: Partition): Partition = {
+    val blockMetadatas = metadata.getBlocks.asScala
+    val parquetSchema = metadata.getFileMetaData.getSchema
+    val conjunctiveFilter = filters
+      .flatMap(ParquetFilters.createFilter(schema, _))
+      .reduceOption(FilterApi.and)
+    conjunctiveFilter.map { conjunction =>
+      val filteredBlocks = RowGroupFilter.filterRowGroups(
+        FilterCompat.get(conjunction), blockMetadatas.asJava, parquetSchema).asScala.map { bmd =>
+        new Path(root, bmd.getPath).toString
+      }
+      Partition(partition.values, partition.files.filter { f =>
+        filteredBlocks.contains(f.getPath.toString)
+      })
+    }.getOrElse(partition)
+  }
+
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -704,7 +704,7 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
     }
   }
 
-  test("SPARK-17059: Allow Allow FileFormat to specify partition pruning strategy") {
+  test("SPARK-17059: Allow FileFormat to specify partition pruning strategy") {
     withSQLConf(ParquetOutputFormat.ENABLE_JOB_SUMMARY -> "true") {
       withTempPath { path =>
         Seq(1, 2, 3).toDF("x").write.parquet(path.getCanonicalPath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -703,6 +703,16 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
       }
     }
   }
+
+  test("SPARK-17059: Allow Allow FileFormat to specify partition pruning strategy") {
+    withSQLConf(ParquetOutputFormat.ENABLE_JOB_SUMMARY -> "true") {
+      withTempPath { path =>
+        Seq(1, 2, 3).toDF("x").write.parquet(path.getCanonicalPath)
+        val df = spark.read.parquet(path.getCanonicalPath).where("x = 0")
+        assert(df.rdd.partitions.length == 0)
+      }
+    }
+  }
 }
 
 object TestingUDT {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Different FileFormat implementations may be able to make intelligent decisions about files that will need to be processed as part of a FileSourceScanExec based on the `pushedFilters` available. This PR implements a way to do that pluggably, with an implementation for Parquet that allows applying the summary metadata to prevent task creation.

This has a few performance benefits:
1. Reading of files is generally slow, especially for S3. In the current Parquet implementation the summary metadata is not used and so the footers are read directly. This can be very slow for large Parquet datasets, as even as of Hadoop 2.7 S3 reads will read the entire file by default (random reads are configurable only starting on 2.7 onwards, and is disabled by default)
2. Partitions that are found to contain no files can then be pruned out or coalesced depending on the FileFormat's implementation, allowing for fewer tasks being created.
## How was this patch tested?

Existing tests and Spark Shell, plus unit test for the Parquet implementation.
