### PR TITLE
[SPARK-16757] Set up Spark caller context to HDFS and YARN

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1015,7 +1015,7 @@ class DAGScheduler(
             val locs = taskIdToLocations(id)
             val part = stage.rdd.partitions(id)
             new ShuffleMapTask(stage.id, stage.latestInfo.attemptId,
-              taskBinary, part, locs, stage.latestInfo.taskMetrics, properties)
+              taskBinary, part, locs, stage.latestInfo.taskMetrics, properties, Option(jobId))
           }
 
         case stage: ResultStage =>
@@ -1024,7 +1024,7 @@ class DAGScheduler(
             val part = stage.rdd.partitions(p)
             val locs = taskIdToLocations(id)
             new ResultTask(stage.id, stage.latestInfo.attemptId,
-              taskBinary, part, locs, id, properties, stage.latestInfo.taskMetrics)
+              taskBinary, part, locs, id, properties, stage.latestInfo.taskMetrics, Option(jobId))
           }
       }
     } catch {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1015,7 +1015,8 @@ class DAGScheduler(
             val locs = taskIdToLocations(id)
             val part = stage.rdd.partitions(id)
             new ShuffleMapTask(stage.id, stage.latestInfo.attemptId,
-              taskBinary, part, locs, stage.latestInfo.taskMetrics, properties, Option(jobId))
+              taskBinary, part, locs, stage.latestInfo.taskMetrics, properties, Option(jobId),
+              Option(sc.applicationId), sc.applicationAttemptId)
           }
 
         case stage: ResultStage =>
@@ -1024,7 +1025,8 @@ class DAGScheduler(
             val part = stage.rdd.partitions(p)
             val locs = taskIdToLocations(id)
             new ResultTask(stage.id, stage.latestInfo.attemptId,
-              taskBinary, part, locs, id, properties, stage.latestInfo.taskMetrics, Option(jobId))
+              taskBinary, part, locs, id, properties, stage.latestInfo.taskMetrics,
+              Option(jobId), Option(sc.applicationId), sc.applicationAttemptId)
           }
       }
     } catch {

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -42,6 +42,8 @@ import org.apache.spark.rdd.RDD
  *                 input RDD's partitions).
  * @param localProperties copy of thread-local properties set by the user on the driver side.
  * @param metrics a [[TaskMetrics]] that is created at driver side and sent to executor side.
+ *
+ * The parameters below are optional:
  * @param jobId id of the job this task belongs to
  * @param appId id of the app this task belongs to
  * @param appAttemptId attempt id of the app this task belongs to

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -42,7 +42,10 @@ import org.apache.spark.rdd.RDD
  *                 input RDD's partitions).
  * @param localProperties copy of thread-local properties set by the user on the driver side.
  * @param metrics a [[TaskMetrics]] that is created at driver side and sent to executor side.
- */
+ * @param jobId id of the job this task belongs to
+ * @param appId id of the app this task belongs to
+ * @param appAttemptId attempt id of the app this task belongs to
+  */
 private[spark] class ResultTask[T, U](
     stageId: Int,
     stageAttemptId: Int,

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -51,8 +51,9 @@ private[spark] class ResultTask[T, U](
     locs: Seq[TaskLocation],
     val outputId: Int,
     localProperties: Properties,
-    metrics: TaskMetrics)
-  extends Task[U](stageId, stageAttemptId, partition.index, metrics, localProperties)
+    metrics: TaskMetrics,
+    jobId: Option[Int] = None)
+  extends Task[U](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId)
   with Serializable {
 
   @transient private[this] val preferredLocs: Seq[TaskLocation] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -52,8 +52,11 @@ private[spark] class ResultTask[T, U](
     val outputId: Int,
     localProperties: Properties,
     metrics: TaskMetrics,
-    jobId: Option[Int] = None)
-  extends Task[U](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId)
+    jobId: Option[Int] = None,
+    appId: Option[String] = None,
+    appAttemptId: Option[String] = None)
+  extends Task[U](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId,
+    appId, appAttemptId)
   with Serializable {
 
   @transient private[this] val preferredLocs: Seq[TaskLocation] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -43,6 +43,8 @@ import org.apache.spark.shuffle.ShuffleWriter
  * @param locs preferred task execution locations for locality scheduling
  * @param metrics a [[TaskMetrics]] that is created at driver side and sent to executor side.
  * @param localProperties copy of thread-local properties set by the user on the driver side.
+ *
+ * The parameters below are optional:
  * @param jobId id of the job this task belongs to
  * @param appId id of the app this task belongs to
  * @param appAttemptId attempt id of the app this task belongs to

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -51,8 +51,9 @@ private[spark] class ShuffleMapTask(
     partition: Partition,
     @transient private var locs: Seq[TaskLocation],
     metrics: TaskMetrics,
-    localProperties: Properties)
-  extends Task[MapStatus](stageId, stageAttemptId, partition.index, metrics, localProperties)
+    localProperties: Properties,
+    jobId: Option[Int] = None)
+  extends Task[MapStatus](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId)
   with Logging {
 
   /** A constructor used only in test suites. This does not require passing in an RDD. */

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -43,6 +43,9 @@ import org.apache.spark.shuffle.ShuffleWriter
  * @param locs preferred task execution locations for locality scheduling
  * @param metrics a [[TaskMetrics]] that is created at driver side and sent to executor side.
  * @param localProperties copy of thread-local properties set by the user on the driver side.
+ * @param jobId id of the job this task belongs to
+ * @param appId id of the app this task belongs to
+ * @param appAttemptId attempt id of the app this task belongs to
  */
 private[spark] class ShuffleMapTask(
     stageId: Int,

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -52,8 +52,11 @@ private[spark] class ShuffleMapTask(
     @transient private var locs: Seq[TaskLocation],
     metrics: TaskMetrics,
     localProperties: Properties,
-    jobId: Option[Int] = None)
-  extends Task[MapStatus](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId)
+    jobId: Option[Int] = None,
+    appId: Option[String] = None,
+    appAttemptId: Option[String] = None)
+  extends Task[MapStatus](stageId, stageAttemptId, partition.index, metrics, localProperties, jobId,
+    appId, appAttemptId)
   with Logging {
 
   /** A constructor used only in test suites. This does not require passing in an RDD. */

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -29,7 +29,7 @@ import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.{MemoryMode, TaskMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.serializer.SerializerInstance
-import org.apache.spark.util.{AccumulatorV2, ByteBufferInputStream, ByteBufferOutputStream, Utils}
+import org.apache.spark.util._
 
 /**
  * A unit of execution. We have two kinds of Task's in Spark:
@@ -47,6 +47,9 @@ import org.apache.spark.util.{AccumulatorV2, ByteBufferInputStream, ByteBufferOu
  * @param partitionId index of the number in the RDD
  * @param metrics a [[TaskMetrics]] that is created at driver side and sent to executor side.
  * @param localProperties copy of thread-local properties set by the user on the driver side.
+ * @param jobId id of the job this task belongs to
+ * @param appId id of the app this task belongs to
+ * @param appAttemptId attempt id of the app this task belongs to
  */
 private[spark] abstract class Task[T](
     val stageId: Int,
@@ -83,15 +86,13 @@ private[spark] abstract class Task[T](
     TaskContext.setTaskContext(context)
     taskThread = Thread.currentThread()
 
-    val callerContext =
-      s"Spark_AppId_${appId.getOrElse("")}_AppAttemptId_${appAttemptId.getOrElse("None")}" +
-        s"_JobId_${jobId.getOrElse("0")}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
-        s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber}"
-    Utils.setCallerContext(callerContext)
-
     if (_killed) {
       kill(interruptThread = false)
     }
+
+    new CallerContext(None, appId, appAttemptId, jobId, Option(stageId), Option(stageAttemptId),
+      Option(taskAttemptId), Option(attemptNumber)).set()
+
     try {
       runTask(context)
     } catch {

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -47,6 +47,8 @@ import org.apache.spark.util._
  * @param partitionId index of the number in the RDD
  * @param metrics a [[TaskMetrics]] that is created at driver side and sent to executor side.
  * @param localProperties copy of thread-local properties set by the user on the driver side.
+ *
+ * The parameters below are optional:
  * @param jobId id of the job this task belongs to
  * @param appId id of the app this task belongs to
  * @param appAttemptId attempt id of the app this task belongs to
@@ -90,8 +92,8 @@ private[spark] abstract class Task[T](
       kill(interruptThread = false)
     }
 
-    new CallerContext(None, appId, appAttemptId, jobId, Option(stageId), Option(stageAttemptId),
-      Option(taskAttemptId), Option(attemptNumber)).set()
+    new CallerContext("TASK", appId, appAttemptId, jobId, Option(stageId), Option(stageAttemptId),
+      Option(taskAttemptId), Option(attemptNumber)).setCurrentContext()
 
     try {
       runTask(context)

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -82,7 +82,7 @@ private[spark] abstract class Task[T](
     taskThread = Thread.currentThread()
 
     val callerContext =
-      s"JobId_${jobId.get}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
+      s"JobId_${jobId.getOrElse("0")}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
         s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber} on Spark"
     Utils.setCallerContext(callerContext)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -82,8 +82,8 @@ private[spark] abstract class Task[T](
     taskThread = Thread.currentThread()
 
     val callerContext =
-      s"JobId_${jobId.getOrElse("0")}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
-        s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber} on Spark"
+      s"Spark_JobId_${jobId.getOrElse("0")}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
+        s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber}"
     Utils.setCallerContext(callerContext)
 
     if (_killed) {

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -54,7 +54,8 @@ private[spark] abstract class Task[T](
     val partitionId: Int,
     // The default value is only used in tests.
     val metrics: TaskMetrics = TaskMetrics.registered,
-    @transient var localProperties: Properties = new Properties) extends Serializable {
+    @transient var localProperties: Properties = new Properties,
+    val jobId: Option[Int] = None) extends Serializable {
 
   /**
    * Called by [[org.apache.spark.executor.Executor]] to run this task.
@@ -79,6 +80,12 @@ private[spark] abstract class Task[T](
       metrics)
     TaskContext.setTaskContext(context)
     taskThread = Thread.currentThread()
+
+    val callerContext =
+      s"JobId_${jobId.get}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
+        s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber} on Spark"
+    Utils.setCallerContext(callerContext)
+
     if (_killed) {
       kill(interruptThread = false)
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -55,7 +55,9 @@ private[spark] abstract class Task[T](
     // The default value is only used in tests.
     val metrics: TaskMetrics = TaskMetrics.registered,
     @transient var localProperties: Properties = new Properties,
-    val jobId: Option[Int] = None) extends Serializable {
+    val jobId: Option[Int] = None,
+    val appId: Option[String] = None,
+    val appAttemptId: Option[String] = None) extends Serializable {
 
   /**
    * Called by [[org.apache.spark.executor.Executor]] to run this task.
@@ -82,7 +84,8 @@ private[spark] abstract class Task[T](
     taskThread = Thread.currentThread()
 
     val callerContext =
-      s"Spark_JobId_${jobId.getOrElse("0")}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
+      s"Spark_AppId_${appId.getOrElse("")}_AppAttemptId_${appAttemptId.getOrElse("None")}" +
+        s"_JobId_${jobId.getOrElse("0")}_StageID_${stageId}_stageAttemptId_${stageAttemptId}" +
         s"_taskID_${taskAttemptId}_attemptNumber_${attemptNumber}"
     Utils.setCallerContext(callerContext)
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2439,7 +2439,6 @@ private[spark] object Utils extends Logging {
  * @param stageAttemptId attempt id of the stage this task belongs to
  * @param taskId task id
  * @param taskAttemptNumber task attempt id
- * @since 2.0.1
  */
 private[spark] class CallerContext(
    from: String,
@@ -2451,17 +2450,17 @@ private[spark] class CallerContext(
    taskId: Option[Long] = None,
    taskAttemptNumber: Option[Int] = None) extends Logging {
 
-   val AppId = if (appId.isDefined) s"_${appId.get}" else ""
-   val AppAttemptId = if (appAttemptId.isDefined) s"_${appAttemptId.get}" else ""
-   val JobId = if (jobId.isDefined) s"_JId_${jobId.get}" else ""
-   val StageId = if (stageId.isDefined) s"_SId_${stageId.get}" else ""
-   val StageAttemptId = if (stageAttemptId.isDefined) s"_${stageAttemptId.get}" else ""
-   val TaskId = if (taskId.isDefined) s"_TId_${taskId.get}" else ""
-   val TaskAttemptNumber =
+   val appIdStr = if (appId.isDefined) s"_${appId.get}" else ""
+   val appAttemptIdStr = if (appAttemptId.isDefined) s"_${appAttemptId.get}" else ""
+   val jobIdStr = if (jobId.isDefined) s"_JId_${jobId.get}" else ""
+   val stageIdStr = if (stageId.isDefined) s"_SId_${stageId.get}" else ""
+   val stageAttemptIdStr = if (stageAttemptId.isDefined) s"_${stageAttemptId.get}" else ""
+   val taskIdStr = if (taskId.isDefined) s"_TId_${taskId.get}" else ""
+   val taskAttemptNumberStr =
      if (taskAttemptNumber.isDefined) s"_${taskAttemptNumber.get}" else ""
 
-   val context = "SPARK_" + from + AppId + AppAttemptId +
-     JobId + StageId + StageAttemptId + TaskId + TaskAttemptNumber
+   val context = "SPARK_" + from + appIdStr + appAttemptIdStr +
+     jobIdStr + stageIdStr + stageAttemptIdStr + taskIdStr + taskAttemptNumberStr
 
   /**
    * Set up the caller context [[context]] by invoking Hadoop CallerContext API of

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2419,16 +2419,19 @@ private[spark] object Utils extends Logging {
     }
   }
 
-  def setCallerContext(context: String): Unit = {
+  def setCallerContext(context: String): Boolean = {
+    var succeed = false
     try {
       val Builder = Utils.classForName("org.apache.hadoop.ipc.CallerContext$Builder")
       val builderInst = Builder.getConstructor(classOf[String]).newInstance(context)
       val ret = Builder.getMethod("build").invoke(builderInst)
       val callerContext = Utils.classForName("org.apache.hadoop.ipc.CallerContext")
       callerContext.getMethod("setCurrent", callerContext).invoke(null, ret)
+      succeed = true
     } catch {
-      case NonFatal(e) => logDebug(s"${e.getMessage}")
+      case NonFatal(e) => logDebug(s"$e", e)
     }
+    succeed
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2429,13 +2429,13 @@ private[spark] object Utils extends Logging {
  * creating (e.g. overloading NN). As HDFS mentioned in HDFS-9184, for a given HDFS operation, it's
  * very helpful to track which upper level job issues it.
  *
- * @param from who sets up the caller context (TASK, CLIENT, APPLICATION_MASTER)
+ * @param from who sets up the caller context (TASK, CLIENT, APPMASTER)
  *
  * The parameters below are optional:
- * @param appID id of the app this task belongs to
- * @param appAttemptID attempt id of the app this task belongs to
- * @param jobID id of the job this task belongs to
- * @param stageID id of the stage this task belongs to
+ * @param appId id of the app this task belongs to
+ * @param appAttemptId attempt id of the app this task belongs to
+ * @param jobId id of the job this task belongs to
+ * @param stageId id of the stage this task belongs to
  * @param stageAttemptId attempt id of the stage this task belongs to
  * @param taskId task id
  * @param taskAttemptNumber task attempt id
@@ -2451,14 +2451,14 @@ private[spark] class CallerContext(
    taskId: Option[Long] = None,
    taskAttemptNumber: Option[Int] = None) extends Logging {
 
-   val AppId = if (appId.isDefined) s"_AppId_${appId.get}" else ""
-   val AppAttemptId = if (appAttemptId.isDefined) s"_AttemptId_${appAttemptId.get}" else ""
-   val JobId = if (jobId.isDefined) s"_JobId_${jobId.get}" else ""
-   val StageId = if (stageId.isDefined) s"_StageId_${stageId.get}" else ""
-   val StageAttemptId = if (stageAttemptId.isDefined) s"_AttemptId_${stageAttemptId.get}" else ""
-   val TaskId = if (taskId.isDefined) s"_TaskId_${taskId.get}" else ""
+   val AppId = if (appId.isDefined) s"_${appId.get}" else ""
+   val AppAttemptId = if (appAttemptId.isDefined) s"_${appAttemptId.get}" else ""
+   val JobId = if (jobId.isDefined) s"_JId_${jobId.get}" else ""
+   val StageId = if (stageId.isDefined) s"_SId_${stageId.get}" else ""
+   val StageAttemptId = if (stageAttemptId.isDefined) s"_${stageAttemptId.get}" else ""
+   val TaskId = if (taskId.isDefined) s"_TId_${taskId.get}" else ""
    val TaskAttemptNumber =
-     if (taskAttemptNumber.isDefined) s"_AttemptNum_${taskAttemptNumber.get}" else ""
+     if (taskAttemptNumber.isDefined) s"_${taskAttemptNumber.get}" else ""
 
    val context = "SPARK_" + from + AppId + AppAttemptId +
      JobId + StageId + StageAttemptId + TaskId + TaskAttemptNumber

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2418,6 +2418,18 @@ private[spark] object Utils extends Logging {
       sparkJars.map(_.split(",")).map(_.filter(_.nonEmpty)).toSeq.flatten
     }
   }
+
+  def setCallerContext(context: String): Unit = {
+    try {
+      val Builder = Utils.classForName("org.apache.hadoop.ipc.CallerContext$Builder")
+      val builderInst = Builder.getConstructor(classOf[String]).newInstance(context)
+      val ret = Builder.getMethod("build").invoke(builderInst)
+      val callerContext = Utils.classForName("org.apache.hadoop.ipc.CallerContext")
+      callerContext.getMethod("setCurrent", callerContext).invoke(null, ret)
+    } catch {
+      case NonFatal(e) => logDebug(s"${e.getMessage}")
+    }
+  }
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -787,6 +787,14 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
         .set("spark.executor.instances", "1")) === 3)
   }
 
+  test("setCallerContext") {
+    try {
+      Utils.classForName("org.apache.hadoop.ipc.CallerContext")
+      assert(Utils.setCallerContext("sparkCallerContext"))
+    } catch {
+      case e: ClassNotFoundException => assert(!Utils.setCallerContext("sparkCallerContext"))
+    }
+  }
 
   test("encodeFileNameToURIRawPath") {
     assert(Utils.encodeFileNameToURIRawPath("abc") === "abc")

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -787,12 +787,16 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
         .set("spark.executor.instances", "1")) === 3)
   }
 
-  test("setCallerContext") {
+  test("Set Spark CallerContext") {
+    val appName = "myTestApp"
     try {
-      Utils.classForName("org.apache.hadoop.ipc.CallerContext")
-      assert(Utils.setCallerContext("sparkCallerContext"))
+      val callerContext = Utils.classForName("org.apache.hadoop.ipc.CallerContext")
+      assert(new CallerContext(Option(s"$appName")).set())
+      assert(s"SPARK_AppName_$appName" ===
+        callerContext.getMethod("getCurrent").invoke(null).toString)
     } catch {
-      case e: ClassNotFoundException => assert(!Utils.setCallerContext("sparkCallerContext"))
+      case e: ClassNotFoundException =>
+        assert(!new CallerContext(Option(s"$appName")).set())
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -788,15 +788,15 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
   }
 
   test("Set Spark CallerContext") {
-    val appName = "myTestApp"
+    val context = "test"
     try {
       val callerContext = Utils.classForName("org.apache.hadoop.ipc.CallerContext")
-      assert(new CallerContext(Option(s"$appName")).set())
-      assert(s"SPARK_AppName_$appName" ===
+      assert(new CallerContext(context).setCurrentContext())
+      assert(s"SPARK_$context" ===
         callerContext.getMethod("getCurrent").invoke(null).toString)
     } catch {
       case e: ClassNotFoundException =>
-        assert(!new CallerContext(Option(s"$appName")).set())
+        assert(!new CallerContext(context).setCurrentContext())
     }
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -202,7 +202,7 @@ private[spark] class ApplicationMaster(
         attemptID = Option(appAttemptId.getAttemptId.toString)
       }
 
-      new CallerContext("APPLICATION_MASTER",
+      new CallerContext("APPMASTER",
         Option(appAttemptId.getApplicationId.toString), attemptID).setCurrentContext()
 
       logInfo("ApplicationAttemptId: " + appAttemptId)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -202,8 +202,8 @@ private[spark] class ApplicationMaster(
         attemptID = Option(appAttemptId.getAttemptId.toString)
       }
 
-      new CallerContext(Option(System.getProperty("spark.app.name")),
-        Option(appAttemptId.getApplicationId.toString), attemptID).set()
+      new CallerContext("APPLICATION_MASTER",
+        Option(appAttemptId.getApplicationId.toString), attemptID).setCurrentContext()
 
       logInfo("ApplicationAttemptId: " + appAttemptId)
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -184,8 +184,7 @@ private[spark] class ApplicationMaster(
     try {
       val appAttemptId = client.getAttemptId()
 
-      var context = s"Spark_AppName_${System.getProperty("spark.app.name")}" +
-        s"_AppId_${appAttemptId.getApplicationId}"
+      var attemptID: Option[String] = None
 
       if (isClusterMode) {
         // Set the web ui port to be ephemeral for yarn so we don't conflict with
@@ -200,10 +199,11 @@ private[spark] class ApplicationMaster(
         // configuration will be checked in SparkContext to avoid misuse of yarn cluster mode.
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
 
-        context = context + s"_AttemptId_${appAttemptId.getAttemptId}"
+        attemptID = Option(appAttemptId.getAttemptId.toString)
       }
-      // Set Spark caller context to HDFS
-      Utils.setCallerContext(context)
+
+      new CallerContext(Option(System.getProperty("spark.app.name")),
+        Option(appAttemptId.getApplicationId.toString), attemptID).set()
 
       logInfo("ApplicationAttemptId: " + appAttemptId)
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -198,6 +198,9 @@ private[spark] class ApplicationMaster(
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
       }
 
+      val context = s"${System.getProperty("spark.app.name")} running on Spark"
+      Utils.setCallerContext(context)
+
       logInfo("ApplicationAttemptId: " + appAttemptId)
 
       val fs = FileSystem.get(yarnConf)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -184,6 +184,9 @@ private[spark] class ApplicationMaster(
     try {
       val appAttemptId = client.getAttemptId()
 
+      var context = s"Spark_AppName_${System.getProperty("spark.app.name")}" +
+        s"_AppId_${appAttemptId.getApplicationId}"
+
       if (isClusterMode) {
         // Set the web ui port to be ephemeral for yarn so we don't conflict with
         // other spark processes running on the same box
@@ -196,9 +199,10 @@ private[spark] class ApplicationMaster(
         // Set this internal configuration if it is running on cluster mode, this
         // configuration will be checked in SparkContext to avoid misuse of yarn cluster mode.
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
-      }
 
-      val context = s"Spark_${System.getProperty("spark.app.name")}"
+        context = context + s"_AttemptId_${appAttemptId.getAttemptId}"
+      }
+      // Set Spark caller context to HDFS
       Utils.setCallerContext(context)
 
       logInfo("ApplicationAttemptId: " + appAttemptId)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -198,7 +198,7 @@ private[spark] class ApplicationMaster(
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
       }
 
-      val context = s"${System.getProperty("spark.app.name")} running on Spark"
+      val context = s"Spark_${System.getProperty("spark.app.name")}"
       Utils.setCallerContext(context)
 
       logInfo("ApplicationAttemptId: " + appAttemptId)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -54,7 +54,7 @@ import org.apache.spark.deploy.yarn.security.ConfigurableCredentialManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle, YarnCommandBuilderUtils}
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{CallerContext, Utils}
 
 private[spark] class Client(
     val args: ClientArguments,
@@ -161,8 +161,7 @@ private[spark] class Client(
       reportLauncherState(SparkAppHandle.State.SUBMITTED)
       launcherBackend.setAppId(appId.toString)
 
-      val context: String = s"Spark_AppName_${sparkConf.get("spark.app.name", "")}_AppId_$appId"
-      Utils.setCallerContext(context)
+      new CallerContext(Option(sparkConf.get("spark.app.name", "")), Option(appId.toString)).set()
 
       // Verify whether the cluster has enough resources for our AM
       verifyClusterResources(newAppResponse)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -161,7 +161,7 @@ private[spark] class Client(
       reportLauncherState(SparkAppHandle.State.SUBMITTED)
       launcherBackend.setAppId(appId.toString)
 
-      new CallerContext(Option(sparkConf.get("spark.app.name", "")), Option(appId.toString)).set()
+      new CallerContext("CLIENT", Option(appId.toString)).setCurrentContext()
 
       // Verify whether the cluster has enough resources for our AM
       verifyClusterResources(newAppResponse)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -65,7 +65,8 @@ private[spark] class Client(
   import Client._
   import YarnSparkHadoopUtil._
 
-  val context: String = s"${sparkConf.get("spark.app.name")} running on Spark"
+
+  val context: String = s"${sparkConf.get("spark.app.name", "")} running on Spark"
   Utils.setCallerContext(context)
 
   def this(clientArgs: ClientArguments, spConf: SparkConf) =

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -65,6 +65,9 @@ private[spark] class Client(
   import Client._
   import YarnSparkHadoopUtil._
 
+  val context: String = s"${sparkConf.get("spark.app.name")} running on Spark"
+  Utils.setCallerContext(context)
+
   def this(clientArgs: ClientArguments, spConf: SparkConf) =
     this(clientArgs, SparkHadoopUtil.get.newConfiguration(spConf), spConf)
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -66,7 +66,7 @@ private[spark] class Client(
   import YarnSparkHadoopUtil._
 
 
-  val context: String = s"${sparkConf.get("spark.app.name", "")} running on Spark"
+  val context: String = s"Spark_${sparkConf.get("spark.app.name", "")}"
   Utils.setCallerContext(context)
 
   def this(clientArgs: ClientArguments, spConf: SparkConf) =

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -65,10 +65,6 @@ private[spark] class Client(
   import Client._
   import YarnSparkHadoopUtil._
 
-
-  val context: String = s"Spark_${sparkConf.get("spark.app.name", "")}"
-  Utils.setCallerContext(context)
-
   def this(clientArgs: ClientArguments, spConf: SparkConf) =
     this(clientArgs, SparkHadoopUtil.get.newConfiguration(spConf), spConf)
 
@@ -164,6 +160,9 @@ private[spark] class Client(
       appId = newAppResponse.getApplicationId()
       reportLauncherState(SparkAppHandle.State.SUBMITTED)
       launcherBackend.setAppId(appId.toString)
+
+      val context: String = s"Spark_AppName_${sparkConf.get("spark.app.name", "")}_AppId_$appId"
+      Utils.setCallerContext(context)
 
       // Verify whether the cluster has enough resources for our AM
       verifyClusterResources(newAppResponse)


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Pass `jobId` to Task.
2. Invoke Hadoop APIs. 
   - A new function `setCallerContext` is added in `Utils`. `setCallerContext` function invokes APIs of   `org.apache.hadoop.ipc.CallerContext` to set up spark caller contexts, which will be written into `hdfs-audit.log` and Yarn RM audit log.
   - For HDFS: Spark sets up its caller context by invoking`org.apache.hadoop.ipc.CallerContext` in `Task` and Yarn `Client` and `ApplicationMaster`.
   - For Yarn: Spark sets up its caller context by invoking `org.apache.hadoop.ipc.CallerContext` in Yarn `Client`.
## How was this patch tested?

Manual Tests against some Spark applications in Yarn client mode and Yarn cluster mode. Need to check if spark caller contexts are written into HDFS hdfs-audit.log and Yarn RM audit log successfully.

For example, run SparkKmeans in Yarn client mode: 

```
./bin/spark-submit --verbose --executor-cores 3 --num-executors 1 --master yarn --deploy-mode client --class org.apache.spark.examples.SparkKMeans examples/target/original-spark-examples_2.11-2.1.0-SNAPSHOT.jar hdfs://localhost:9000/lr_big.txt 2 5
```

**Before**:
There will be no Spark caller context in records of `hdfs-audit.log` and Yarn RM audit log.

**After**:
Spark caller contexts will be written in records of `hdfs-audit.log` and Yarn RM audit log.

These are records in `hdfs-audit.log`:

```
2016-09-20 11:54:24,116 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_CLIENT_AppId_application_1474394339641_0005
2016-09-20 11:54:28,164 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0005_JobId_0_StageId_0_AttemptId_0_TaskId_2_AttemptNum_0
2016-09-20 11:54:28,164 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0005_JobId_0_StageId_0_AttemptId_0_TaskId_1_AttemptNum_0
2016-09-20 11:54:28,164 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0005_JobId_0_StageId_0_AttemptId_0_TaskId_0_AttemptNum_0
```

```
2016-09-20 11:59:33,868 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=mkdirs  src=/private/tmp/hadoop-wyang/nm-local-dir/usercache/wyang/appcache/application_1474394339641_0006/container_1474394339641_0006_01_000001/spark-warehouse   dst=null    perm=wyang:supergroup:rwxr-xr-x proto=rpc   callerContext=SPARK_APPLICATION_MASTER_AppId_application_1474394339641_0006_AttemptId_1
2016-09-20 11:59:37,214 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0006_AttemptId_1_JobId_0_StageId_0_AttemptId_0_TaskId_1_AttemptNum_0
2016-09-20 11:59:37,215 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0006_AttemptId_1_JobId_0_StageId_0_AttemptId_0_TaskId_2_AttemptNum_0
2016-09-20 11:59:37,215 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0006_AttemptId_1_JobId_0_StageId_0_AttemptId_0_TaskId_0_AttemptNum_0
2016-09-20 11:59:42,391 INFO FSNamesystem.audit: allowed=true   ugi=wyang (auth:SIMPLE) ip=/127.0.0.1   cmd=open    src=/lr_big.txt dst=null    perm=null   proto=rpc   callerContext=SPARK_TASK_AppId_application_1474394339641_0006_AttemptId_1_JobId_0_StageId_0_AttemptId_0_TaskId_3_AttemptNum_0
```

This is a record in Yarn RM log:

```
2016-09-20 11:59:24,050 INFO org.apache.hadoop.yarn.server.resourcemanager.RMAuditLogger: USER=wyang    IP=127.0.0.1    OPERATION=Submit Application Request    TARGET=ClientRMService  RESULT=SUCCESS  APPID=application_1474394339641_0006    CALLERCONTEXT=SPARK_CLIENT_AppId_application_1474394339641_0006
```
