### PR TITLE
[SPARK-17071][SQL] Add an option to support for reading schemas in Parquet within driver-side without another Spark job

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -265,6 +265,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val PARQUET_READ_SCHEMA_LOCAL_THRESHOLD =
+    buildConf("spark.sql.parquet.readSchemaLocalThreshold")
+      .doc("Configures the maximum number of files to allow reading schema in driver-side. " +
+        "If the number of files exceeds this value, then schemas will be read then in parallel " +
+        "via another Spark distributed job.")
+      .intConf
+      .createWithDefault(32)
+
   val ORC_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.orc.filterPushdown")
     .doc("When true, enable filter pushdown for ORC files.")
     .booleanConf
@@ -847,6 +855,8 @@ class SQLConf extends Serializable with Logging {
   def parquetCacheMetadata: Boolean = getConf(PARQUET_CACHE_METADATA)
 
   def parquetVectorizedReaderEnabled: Boolean = getConf(PARQUET_VECTORIZED_READER_ENABLED)
+
+  def parquetReadSchemaLocalThreshold: Int = getConf(PARQUET_READ_SCHEMA_LOCAL_THRESHOLD)
 
   def columnBatchSize: Int = getConf(COLUMN_BATCH_SIZE)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It seems Spark executes another job to figure out schema always ([ParquetFileFormat#L739-L778](https://github.com/apache/spark/blob/abff92bfdc7d4c9d2308794f0350561fe0ceb4dd/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala#L739-L778)).

However, it seems it's a bit of overhead to touch only a small number of files.

This PR make Parquet data source touch a small number of files to infer schema within driver-side without launching another Spark job with an new option, `spark.sql.parquet.readSchemaLocalThreshold`.

I ran a benchmark with the code below:

``` scala
test("Benchmark for Parquet reader") {
  withTempPath { path =>
    Seq((1, 2D, 3L, "4")).toDF("a", "b", "c", "d")
      .write.format("parquet").save(path.getAbsolutePath)

    val benchmark = new Benchmark("Parquet - read schema", 1)
    benchmark.addCase("Parquet - read schema", 10) { _ =>
      spark.read.format("parquet").load(path.getCanonicalPath).schema
    }
    benchmark.run()
  }
}
```

with the results as below:
- **Before**
  
  ```
  Parquet - read schema:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
  ------------------------------------------------------------------------------------------------
  Parquet - read schema                           47 /   49          0.0    46728419.0       1.0X
  ```
- **After**
  
  ```
  Parquet - read schema:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
  ------------------------------------------------------------------------------------------------
  Parquet - read schema                            2 /    3          0.0     1811673.0       1.0X
  ```

It seems it became ~25X faster (although It is a small bit in total job run-time).

As a reference, it seems ORC is doing this within driver-side [OrcFileOperator.scala#L74-L83](https://github.com/apache/spark/blob/a95252823e09939b654dd425db38dadc4100bc87/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala#L74-L83).
## How was this patch tested?

Existing tests should cover this
