### PR TITLE
[SPARK-16578][SparkR] Enable SparkR to connect to a remote machine running RBackend

### DIFF
--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -163,7 +163,7 @@ sparkR.sparkContext <- function(
     backendPort <- existingPort
   } else {
 
-    if (!nzchar(master) || is_master_local(master)) {
+    if (is_master_local(master) || is_yarn_client(master)) {
       path <- tempfile(pattern = "backend_port")
       submitOps <- getClientModeSparkSubmitOpts(
         Sys.getenv("SPARKR_SUBMIT_ARGS", "sparkr-shell"),

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -233,7 +233,7 @@ sparkR.sparkContext <- function(
     connectBackend(host, backendPort)
   },
   error = function(err) {
-    stop(paste0("Failed to connect JVM\n", existingPort))
+    stop("Failed to connect JVM\n")
   })
 
   if (nchar(sparkHome) != 0) {

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -201,7 +201,7 @@ sparkR.sparkContext <- function(
         assign(".libPath", rLibPath, envir = .sparkREnv)
         .libPaths(c(rLibPath, .libPaths()))
       }
-      host = "localhost"
+      host <- "localhost"
     } else {
       backendPort <- if (!is.null(sparkEnvirMap[["backend.port"]])) {
         sparkEnvirMap[["backend.port"]]

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -206,12 +206,12 @@ sparkR.sparkContext <- function(
       backendPort <- if (!is.null(sparkEnvirMap[["backend.port"]])) {
         sparkEnvirMap[["backend.port"]]
       } else {
-        "8000"
+        "9212"
       }
       monitorPort <- if (!is.null(sparkEnvirMap[["monitor.port"]])) {
         sparkEnvirMap[["monitor.port"]]
       } else {
-        "8001"
+        "9213"
       }
       host <- getRemoteMasterInfo(master)$host
       port <- getRemoteMasterInfo(master)$port

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -718,7 +718,7 @@ getRemoteMasterInfo <- function(master) {
       }
     }
   } else {
-    port = NULL
+    port <- NULL
   }
   list(host = host, port = port)
 }

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -696,4 +696,29 @@ is_master_local <- function(master) {
 
 is_sparkR_shell <- function() {
   grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
+
+getRemoteMasterInfo <- function(master) {
+  hostPort <- sub("spark://", "", master)
+  host <- sub(":.*", "", hostPort)
+  port <- sub(".*:", "", hostPort)
+
+  if (nzchar(port)) {
+    if (is.na(as.numeric(port))) {
+      msg <- sprintf("Invalid backend port number %s parsed from master. Ignored.",
+                    port)
+      message(msg)
+      port <- NULL
+    } else {
+      numPort <- as.numeric(port)
+      if (numPort < 0 || numPort > 65535) {
+        msg <- sprintf("Backend port number %s out of range. Ignored.",
+                       port)
+        message(msg)
+        port <- NULL
+      }
+    }
+  } else {
+    port = NULL
+  }
+  list(host = host, port = port)
 }

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -691,7 +691,11 @@ getSparkContext <- function() {
 }
 
 is_master_local <- function(master) {
-  grepl("^local(\\[([0-9]+|\\*)\\])?$", master, perl = TRUE)
+  !nzchar(master) || grepl("^local(\\[([0-9]+|\\*)\\])?$", master, perl = TRUE)
+}
+
+is_yarn_client <- function(master) {
+  master %in% c("yarn-client")
 }
 
 is_sparkR_shell <- function() {

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -700,6 +700,7 @@ is_yarn_client <- function(master) {
 
 is_sparkR_shell <- function() {
   grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
+}
 
 getRemoteMasterInfo <- function(master) {
   hostPort <- sub("spark://", "", master)

--- a/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
@@ -68,7 +68,7 @@ private[spark] class RBackend {
     })
 
     // accept any IPv4 address
-    val backendPort = conf.getInt("spark.r.backendPort", 8000)
+    val backendPort = conf.getInt("spark.r.backendPort", 9212)
     channelFuture = bootstrap.bind(new InetSocketAddress("0.0.0.0", backendPort))
     channelFuture.syncUninterruptibly()
     channelFuture.channel().localAddress().asInstanceOf[InetSocketAddress].getPort()
@@ -108,10 +108,10 @@ private[spark] object RBackend extends Logging {
 
     val sparkRBackend = new RBackend()
     try {
-      // bind to port configured by spark.r.backendPort, with default 8000
+      // bind to port configured by spark.r.backendPort, with default 9212
       val boundPort = sparkRBackend.init()
       val conf = new SparkConf()
-      val listenPort = conf.getInt("spark.r.monitorPort", 8001)
+      val listenPort = conf.getInt("spark.r.monitorPort", 9213)
       val serverSocket = new ServerSocket(listenPort, 1)
 
       // tell the R process via temporary file


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR tries to enable SparkR to connect to a remote machine that runs the RBackend. 
- Default port numbers are used, backend 9212 and monitor 9213, if not set otherwise. They can be set by `spark.r.backendPort` and `spark.r.monitorPort` on the RBackend side and by `backend.port` and `monitor.port` in `sparkConfig` on the client side.
## How was this patch tested?

R unit test. Manual test: connect to local standalone cluster and to AWS EC2 instance.

Start RBackend: run `bin/spark-submit --master [master url] --class org.apache.spark.api.r.RBackend  core/target/scala-2.11/spark-core_2.11-2.1.0-SNAPSHOT.jar /tmp/backendFile`

From R: import SparkR. Run `sparkR.session(master = [master url])`.
