### PR TITLE
[SPARK-15083] [Web UI] History Server can OOM due to unlimited TaskUIData

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -114,4 +114,9 @@ package object config {
   private[spark] val PYSPARK_PYTHON = ConfigBuilder("spark.pyspark.python")
     .stringConf
     .createOptional
+
+  // To limit memory usage, we only track information for a fixed number of tasks
+  private[spark] val UI_RETAINED_TASKS = ConfigBuilder("spark.ui.retainedTasks")
+    .intConf
+    .createWithDefault(100000)
 }

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -141,7 +141,7 @@ private[spark] object SparkUI {
   val DEFAULT_POOL_NAME = "default"
   val DEFAULT_RETAINED_STAGES = 1000
   val DEFAULT_RETAINED_JOBS = 1000
-  val DEFAULT_RETAINED_TASKS = 10000
+  val DEFAULT_RETAINED_TASKS = 100000
 
   def getUIPort(conf: SparkConf): Int = {
     conf.getInt("spark.ui.port", SparkUI.DEFAULT_PORT)

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -141,7 +141,6 @@ private[spark] object SparkUI {
   val DEFAULT_POOL_NAME = "default"
   val DEFAULT_RETAINED_STAGES = 1000
   val DEFAULT_RETAINED_JOBS = 1000
-  val DEFAULT_RETAINED_TASKS = 100000
 
   def getUIPort(conf: SparkConf): Int = {
     conf.getInt("spark.ui.port", SparkUI.DEFAULT_PORT)

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -141,6 +141,7 @@ private[spark] object SparkUI {
   val DEFAULT_POOL_NAME = "default"
   val DEFAULT_RETAINED_STAGES = 1000
   val DEFAULT_RETAINED_JOBS = 1000
+  val DEFAULT_RETAINED_TASKS = 10000
 
   def getUIPort(conf: SparkConf): Int = {
     conf.getInt("spark.ui.port", SparkUI.DEFAULT_PORT)

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -93,6 +93,8 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
 
   val retainedStages = conf.getInt("spark.ui.retainedStages", SparkUI.DEFAULT_RETAINED_STAGES)
   val retainedJobs = conf.getInt("spark.ui.retainedJobs", SparkUI.DEFAULT_RETAINED_JOBS)
+  val retainedTasks = conf.getInt("spark.ui.retainedTasks", SparkUI.DEFAULT_RETAINED_TASKS)
+  val trimTasks = conf.getBoolean("spark.ui.trimTasks", false)
 
   // We can test for memory leaks by ensuring that collections that track non-active jobs and
   // stages do not grow without bound and that collections for active jobs/stages eventually become
@@ -135,6 +137,17 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       // Since jobGroupToJobIds is map of sets, check that we don't leak keys with empty values:
       "jobGroupToJobIds keySet" -> jobGroupToJobIds.keys.size
     )
+  }
+
+  /** If Tasks is too large, remove and garbage collect old tasks */
+  private def trimTasksIfNecessary(taskData: HashMap[Long, TaskUIData]) = synchronized {
+    if (taskData.size > retainedTasks) {
+      val toRemove = (taskData.size - retainedTasks)
+      val oldIds = taskData.map(_._2.taskInfo.taskId).toList.sorted.take(toRemove)
+      for (id <- oldIds) {
+        taskData.remove(id)
+      }
+    }
   }
 
   /** If stages is too large, remove and garbage collect old stages */
@@ -404,6 +417,9 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       taskData.updateTaskInfo(info)
       taskData.updateTaskMetrics(taskMetrics)
       taskData.errorMessage = errorMessage
+      if (trimTasks) {
+        trimTasksIfNecessary(stageData.taskData)
+      }
 
       for (
         activeJobsDependentOnStage <- stageIdToActiveJobIds.get(taskEnd.stageId);

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -133,7 +133,14 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
 
       val stageData = stageDataOption.get
       val tasks = stageData.taskData.values.toSeq.sortBy(_.taskInfo.launchTime)
-      val numCompleted = tasks.count(_.taskInfo.finished)
+      val numCompleted = stageData.numCompleteTasks
+      val totalTasks = stageData.numActiveTasks +
+        stageData.numCompleteTasks + stageData.numFailedTasks
+      val totalTasksNumStr = if (totalTasks == tasks.size) {
+        s"$totalTasks"
+      } else {
+        s"$totalTasks, only showing ${tasks.size}"
+      }
 
       val allAccumulables = progressListener.stageIdToData((stageId, stageAttemptId)).accumulables
       val externalAccumulables = allAccumulables.values.filter { acc => !acc.internal }
@@ -591,7 +598,8 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
         <div>{summaryTable.getOrElse("No tasks have reported metrics yet.")}</div> ++
         aggMetrics ++
         maybeAccumulableTable ++
-        <h4 id="tasks-section">Tasks</h4> ++ taskTableHTML ++ jsForScrollingDownToTaskTable
+        <h4 id="tasks-section">Tasks ({totalTasksNumStr})</h4> ++
+          taskTableHTML ++ jsForScrollingDownToTaskTable
       UIUtils.headerSparkPage(stageHeader, content, parent, showVisualization = true)
     }
   }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -139,7 +139,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
       val totalTasksNumStr = if (totalTasks == tasks.size) {
         s"$totalTasks"
       } else {
-        s"$totalTasks, only showing ${tasks.size}"
+        s"$totalTasks, showing ${tasks.size}"
       }
 
       val allAccumulables = progressListener.stageIdToData((stageId, stageAttemptId)).accumulables

--- a/core/src/main/scala/org/apache/spark/ui/jobs/UIData.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/UIData.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ui.jobs
 
 import scala.collection.mutable
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{HashMap, LinkedHashMap}
 
 import org.apache.spark.JobExecutionStatus
 import org.apache.spark.executor.{ShuffleReadMetrics, ShuffleWriteMetrics, TaskMetrics}
@@ -97,7 +97,7 @@ private[spark] object UIData {
     var description: Option[String] = None
 
     var accumulables = new HashMap[Long, AccumulableInfo]
-    var taskData = new HashMap[Long, TaskUIData]
+    var taskData = new LinkedHashMap[Long, TaskUIData]
     var executorSummary = new HashMap[String, ExecutorSummary]
 
     def hasInput: Boolean = inputBytes > 0

--- a/core/src/test/resources/HistoryServerExpectations/stage_task_list_w__sortBy_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/stage_task_list_w__sortBy_expectation.json
@@ -39,6 +39,46 @@
     }
   }
 }, {
+  "taskId" : 1,
+  "index" : 1,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:06.502GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 31,
+    "executorRunTime" : 350,
+    "resultSize" : 2010,
+    "jvmGcTime" : 7,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 60488,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 3934399,
+      "recordsWritten" : 10
+    }
+  }
+}, {
   "taskId" : 5,
   "index" : 5,
   "attempt" : 0,
@@ -79,10 +119,50 @@
     }
   }
 }, {
-  "taskId" : 1,
-  "index" : 1,
+  "taskId" : 0,
+  "index" : 0,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.502GMT",
+  "launchTime" : "2015-05-06T13:03:06.494GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 32,
+    "executorRunTime" : 349,
+    "resultSize" : 2010,
+    "jvmGcTime" : 7,
+    "resultSerializationTime" : 1,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 49294,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 3842811,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 3,
+  "index" : 3,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:06.504GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
@@ -90,10 +170,10 @@
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
     "executorDeserializeTime" : 31,
-    "executorRunTime" : 350,
+    "executorRunTime" : 349,
     "resultSize" : 2010,
     "jvmGcTime" : 7,
-    "resultSerializationTime" : 0,
+    "resultSerializationTime" : 2,
     "memoryBytesSpilled" : 0,
     "diskBytesSpilled" : 0,
     "inputMetrics" : {
@@ -114,7 +194,7 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 3934399,
+      "writeTime" : 1311694,
       "recordsWritten" : 10
     }
   }
@@ -195,86 +275,6 @@
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
       "writeTime" : 2579051,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 3,
-  "index" : 3,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.504GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 31,
-    "executorRunTime" : 349,
-    "resultSize" : 2010,
-    "jvmGcTime" : 7,
-    "resultSerializationTime" : 2,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 60488,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 1311694,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 0,
-  "index" : 0,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.494GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 32,
-    "executorRunTime" : 349,
-    "resultSize" : 2010,
-    "jvmGcTime" : 7,
-    "resultSerializationTime" : 1,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 49294,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 3842811,
       "recordsWritten" : 10
     }
   }
@@ -479,6 +479,46 @@
     }
   }
 }, {
+  "taskId" : 9,
+  "index" : 9,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:06.915GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 9,
+    "executorRunTime" : 84,
+    "resultSize" : 2010,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 60489,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 101664,
+      "recordsWritten" : 10
+    }
+  }
+}, {
   "taskId" : 16,
   "index" : 16,
   "attempt" : 0,
@@ -559,25 +599,25 @@
     }
   }
 }, {
-  "taskId" : 9,
-  "index" : 9,
+  "taskId" : 14,
+  "index" : 14,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.915GMT",
+  "launchTime" : "2015-05-06T13:03:06.925GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
   "speculative" : false,
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
-    "executorDeserializeTime" : 9,
-    "executorRunTime" : 84,
+    "executorDeserializeTime" : 6,
+    "executorRunTime" : 83,
     "resultSize" : 2010,
     "jvmGcTime" : 0,
     "resultSerializationTime" : 0,
     "memoryBytesSpilled" : 0,
     "diskBytesSpilled" : 0,
     "inputMetrics" : {
-      "bytesRead" : 60489,
+      "bytesRead" : 70564,
       "recordsRead" : 10000
     },
     "outputMetrics" : {
@@ -594,7 +634,7 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 101664,
+      "writeTime" : 95646,
       "recordsWritten" : 10
     }
   }
@@ -635,46 +675,6 @@
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
       "writeTime" : 97716,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 14,
-  "index" : 14,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.925GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 6,
-    "executorRunTime" : 83,
-    "resultSize" : 2010,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 95646,
       "recordsWritten" : 10
     }
   }

--- a/core/src/test/resources/HistoryServerExpectations/stage_task_list_w__sortBy_short_names___runtime_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/stage_task_list_w__sortBy_short_names___runtime_expectation.json
@@ -39,6 +39,46 @@
     }
   }
 }, {
+  "taskId" : 1,
+  "index" : 1,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:06.502GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 31,
+    "executorRunTime" : 350,
+    "resultSize" : 2010,
+    "jvmGcTime" : 7,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 60488,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 3934399,
+      "recordsWritten" : 10
+    }
+  }
+}, {
   "taskId" : 5,
   "index" : 5,
   "attempt" : 0,
@@ -79,10 +119,50 @@
     }
   }
 }, {
-  "taskId" : 1,
-  "index" : 1,
+  "taskId" : 0,
+  "index" : 0,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.502GMT",
+  "launchTime" : "2015-05-06T13:03:06.494GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 32,
+    "executorRunTime" : 349,
+    "resultSize" : 2010,
+    "jvmGcTime" : 7,
+    "resultSerializationTime" : 1,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 49294,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 3842811,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 3,
+  "index" : 3,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:06.504GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
@@ -90,10 +170,10 @@
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
     "executorDeserializeTime" : 31,
-    "executorRunTime" : 350,
+    "executorRunTime" : 349,
     "resultSize" : 2010,
     "jvmGcTime" : 7,
-    "resultSerializationTime" : 0,
+    "resultSerializationTime" : 2,
     "memoryBytesSpilled" : 0,
     "diskBytesSpilled" : 0,
     "inputMetrics" : {
@@ -114,7 +194,7 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 3934399,
+      "writeTime" : 1311694,
       "recordsWritten" : 10
     }
   }
@@ -195,86 +275,6 @@
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
       "writeTime" : 2579051,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 3,
-  "index" : 3,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.504GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 31,
-    "executorRunTime" : 349,
-    "resultSize" : 2010,
-    "jvmGcTime" : 7,
-    "resultSerializationTime" : 2,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 60488,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 1311694,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 0,
-  "index" : 0,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.494GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 32,
-    "executorRunTime" : 349,
-    "resultSize" : 2010,
-    "jvmGcTime" : 7,
-    "resultSerializationTime" : 1,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 49294,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 3842811,
       "recordsWritten" : 10
     }
   }
@@ -479,6 +479,46 @@
     }
   }
 }, {
+  "taskId" : 9,
+  "index" : 9,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:06.915GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 9,
+    "executorRunTime" : 84,
+    "resultSize" : 2010,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 60489,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 101664,
+      "recordsWritten" : 10
+    }
+  }
+}, {
   "taskId" : 16,
   "index" : 16,
   "attempt" : 0,
@@ -559,25 +599,25 @@
     }
   }
 }, {
-  "taskId" : 9,
-  "index" : 9,
+  "taskId" : 14,
+  "index" : 14,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.915GMT",
+  "launchTime" : "2015-05-06T13:03:06.925GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
   "speculative" : false,
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
-    "executorDeserializeTime" : 9,
-    "executorRunTime" : 84,
+    "executorDeserializeTime" : 6,
+    "executorRunTime" : 83,
     "resultSize" : 2010,
     "jvmGcTime" : 0,
     "resultSerializationTime" : 0,
     "memoryBytesSpilled" : 0,
     "diskBytesSpilled" : 0,
     "inputMetrics" : {
-      "bytesRead" : 60489,
+      "bytesRead" : 70564,
       "recordsRead" : 10000
     },
     "outputMetrics" : {
@@ -594,7 +634,7 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 101664,
+      "writeTime" : 95646,
       "recordsWritten" : 10
     }
   }
@@ -635,46 +675,6 @@
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
       "writeTime" : 97716,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 14,
-  "index" : 14,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:06.925GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 6,
-    "executorRunTime" : 83,
-    "resultSize" : 2010,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 95646,
       "recordsWritten" : 10
     }
   }

--- a/core/src/test/resources/HistoryServerExpectations/stage_task_list_w__sortBy_short_names__runtime_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/stage_task_list_w__sortBy_short_names__runtime_expectation.json
@@ -39,46 +39,6 @@
     }
   }
 }, {
-  "taskId" : 86,
-  "index" : 86,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.374GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 3,
-    "executorRunTime" : 16,
-    "resultSize" : 2065,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 1,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 95848,
-      "recordsWritten" : 10
-    }
-  }
-}, {
   "taskId" : 41,
   "index" : 41,
   "attempt" : 0,
@@ -115,86 +75,6 @@
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
       "writeTime" : 90765,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 68,
-  "index" : 68,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.306GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 2,
-    "executorRunTime" : 16,
-    "resultSize" : 2065,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 101750,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 58,
-  "index" : 58,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.263GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 3,
-    "executorRunTime" : 16,
-    "resultSize" : 2065,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 97521,
       "recordsWritten" : 10
     }
   }
@@ -279,10 +159,10 @@
     }
   }
 }, {
-  "taskId" : 59,
-  "index" : 59,
+  "taskId" : 58,
+  "index" : 58,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.265GMT",
+  "launchTime" : "2015-05-06T13:03:07.263GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
@@ -290,7 +170,7 @@
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
     "executorDeserializeTime" : 3,
-    "executorRunTime" : 17,
+    "executorRunTime" : 16,
     "resultSize" : 2065,
     "jvmGcTime" : 0,
     "resultSerializationTime" : 0,
@@ -314,7 +194,87 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 100753,
+      "writeTime" : 97521,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 68,
+  "index" : 68,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.306GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 2,
+    "executorRunTime" : 16,
+    "resultSize" : 2065,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70564,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 101750,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 86,
+  "index" : 86,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.374GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 3,
+    "executorRunTime" : 16,
+    "resultSize" : 2065,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 1,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70564,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 95848,
       "recordsWritten" : 10
     }
   }
@@ -355,166 +315,6 @@
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
       "writeTime" : 89603,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 87,
-  "index" : 87,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.374GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 12,
-    "executorRunTime" : 17,
-    "resultSize" : 2065,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 102159,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 99,
-  "index" : 99,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.426GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 2,
-    "executorRunTime" : 17,
-    "resultSize" : 2065,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70565,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 133964,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 63,
-  "index" : 63,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.276GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 20,
-    "executorRunTime" : 17,
-    "resultSize" : 2065,
-    "jvmGcTime" : 5,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 102779,
-      "recordsWritten" : 10
-    }
-  }
-}, {
-  "taskId" : 90,
-  "index" : 90,
-  "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.385GMT",
-  "executorId" : "driver",
-  "host" : "localhost",
-  "taskLocality" : "PROCESS_LOCAL",
-  "speculative" : false,
-  "accumulatorUpdates" : [ ],
-  "taskMetrics" : {
-    "executorDeserializeTime" : 2,
-    "executorRunTime" : 17,
-    "resultSize" : 2065,
-    "jvmGcTime" : 0,
-    "resultSerializationTime" : 0,
-    "memoryBytesSpilled" : 0,
-    "diskBytesSpilled" : 0,
-    "inputMetrics" : {
-      "bytesRead" : 70564,
-      "recordsRead" : 10000
-    },
-    "outputMetrics" : {
-      "bytesWritten" : 0,
-      "recordsWritten" : 0
-    },
-    "shuffleReadMetrics" : {
-      "remoteBlocksFetched" : 0,
-      "localBlocksFetched" : 0,
-      "fetchWaitTime" : 0,
-      "remoteBytesRead" : 0,
-      "localBytesRead" : 0,
-      "recordsRead" : 0
-    },
-    "shuffleWriteMetrics" : {
-      "bytesWritten" : 1710,
-      "writeTime" : 98472,
       "recordsWritten" : 10
     }
   }
@@ -639,18 +439,18 @@
     }
   }
 }, {
-  "taskId" : 50,
-  "index" : 50,
+  "taskId" : 59,
+  "index" : 59,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.240GMT",
+  "launchTime" : "2015-05-06T13:03:07.265GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
   "speculative" : false,
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
-    "executorDeserializeTime" : 4,
-    "executorRunTime" : 18,
+    "executorDeserializeTime" : 3,
+    "executorRunTime" : 17,
     "resultSize" : 2065,
     "jvmGcTime" : 0,
     "resultSerializationTime" : 0,
@@ -674,23 +474,63 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 90836,
+      "writeTime" : 100753,
       "recordsWritten" : 10
     }
   }
 }, {
-  "taskId" : 53,
-  "index" : 53,
+  "taskId" : 63,
+  "index" : 63,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.244GMT",
+  "launchTime" : "2015-05-06T13:03:07.276GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
   "speculative" : false,
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
-    "executorDeserializeTime" : 6,
-    "executorRunTime" : 18,
+    "executorDeserializeTime" : 20,
+    "executorRunTime" : 17,
+    "resultSize" : 2065,
+    "jvmGcTime" : 5,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70564,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 102779,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 87,
+  "index" : 87,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.374GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 12,
+    "executorRunTime" : 17,
     "resultSize" : 2065,
     "jvmGcTime" : 0,
     "resultSerializationTime" : 0,
@@ -714,7 +554,87 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 92835,
+      "writeTime" : 102159,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 90,
+  "index" : 90,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.385GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 2,
+    "executorRunTime" : 17,
+    "resultSize" : 2065,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70564,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 98472,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 99,
+  "index" : 99,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.426GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 2,
+    "executorRunTime" : 17,
+    "resultSize" : 2065,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70565,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 133964,
       "recordsWritten" : 10
     }
   }
@@ -759,20 +679,20 @@
     }
   }
 }, {
-  "taskId" : 80,
-  "index" : 80,
+  "taskId" : 47,
+  "index" : 47,
   "attempt" : 0,
-  "launchTime" : "2015-05-06T13:03:07.341GMT",
+  "launchTime" : "2015-05-06T13:03:07.212GMT",
   "executorId" : "driver",
   "host" : "localhost",
   "taskLocality" : "PROCESS_LOCAL",
   "speculative" : false,
   "accumulatorUpdates" : [ ],
   "taskMetrics" : {
-    "executorDeserializeTime" : 13,
+    "executorDeserializeTime" : 2,
     "executorRunTime" : 18,
     "resultSize" : 2065,
-    "jvmGcTime" : 5,
+    "jvmGcTime" : 0,
     "resultSerializationTime" : 0,
     "memoryBytesSpilled" : 0,
     "diskBytesSpilled" : 0,
@@ -794,7 +714,87 @@
     },
     "shuffleWriteMetrics" : {
       "bytesWritten" : 1710,
-      "writeTime" : 98069,
+      "writeTime" : 103015,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 50,
+  "index" : 50,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.240GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 4,
+    "executorRunTime" : 18,
+    "resultSize" : 2065,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70564,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 90836,
+      "recordsWritten" : 10
+    }
+  }
+}, {
+  "taskId" : 52,
+  "index" : 52,
+  "attempt" : 0,
+  "launchTime" : "2015-05-06T13:03:07.243GMT",
+  "executorId" : "driver",
+  "host" : "localhost",
+  "taskLocality" : "PROCESS_LOCAL",
+  "speculative" : false,
+  "accumulatorUpdates" : [ ],
+  "taskMetrics" : {
+    "executorDeserializeTime" : 5,
+    "executorRunTime" : 18,
+    "resultSize" : 2065,
+    "jvmGcTime" : 0,
+    "resultSerializationTime" : 0,
+    "memoryBytesSpilled" : 0,
+    "diskBytesSpilled" : 0,
+    "inputMetrics" : {
+      "bytesRead" : 70564,
+      "recordsRead" : 10000
+    },
+    "outputMetrics" : {
+      "bytesWritten" : 0,
+      "recordsWritten" : 0
+    },
+    "shuffleReadMetrics" : {
+      "remoteBlocksFetched" : 0,
+      "localBlocksFetched" : 0,
+      "fetchWaitTime" : 0,
+      "remoteBytesRead" : 0,
+      "localBytesRead" : 0,
+      "recordsRead" : 0
+    },
+    "shuffleWriteMetrics" : {
+      "bytesWritten" : 1710,
+      "writeTime" : 89664,
       "recordsWritten" : 10
     }
   }

--- a/core/src/test/scala/org/apache/spark/status/api/v1/AllStagesResourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/api/v1/AllStagesResourceSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.status.api.v1
 
 import java.util.Date
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.LinkedHashMap
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.scheduler.{StageInfo, TaskInfo, TaskLocality}
@@ -28,7 +28,7 @@ import org.apache.spark.ui.jobs.UIData.{StageUIData, TaskUIData}
 class AllStagesResourceSuite extends SparkFunSuite {
 
   def getFirstTaskLaunchTime(taskLaunchTimes: Seq[Long]): Option[Date] = {
-    val tasks = new HashMap[Long, TaskUIData]
+    val tasks = new LinkedHashMap[Long, TaskUIData]
     taskLaunchTimes.zipWithIndex.foreach { case (time, idx) =>
       tasks(idx.toLong) = TaskUIData(
         new TaskInfo(idx, idx, 1, time, "", "", TaskLocality.ANY, false), None)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -627,6 +627,21 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.ui.retainedTasks</code></td>
+  <td>10000</td>
+  <td>
+    How many tasks the Spark UI and status APIs remember before garbage
+    collecting, if <code>spark.ui.trimTasks</code> is true.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.ui.trimTasks</code></td>
+  <td>false</td>
+  <td>
+    Whether the Spark UI and status APIs will garbage collect tasks.
+  </td>
+</tr>
+<tr>
   <td><code>spark.worker.ui.retainedExecutors</code></td>
   <td>1000</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -628,17 +628,10 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.ui.retainedTasks</code></td>
-  <td>10000</td>
+  <td>100000</td>
   <td>
     How many tasks the Spark UI and status APIs remember before garbage
-    collecting, if <code>spark.ui.trimTasks</code> is true.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.ui.trimTasks</code></td>
-  <td>false</td>
-  <td>
-    Whether the Spark UI and status APIs will garbage collect tasks.
+    collecting.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Based on #12990 by @tankkyo

Since the History Server currently loads all application's data it can OOM if too many applications have a significant task count. `spark.ui.trimTasks` (default: false) can be set to true to trim tasks by `spark.ui.retainedTasks` (default: 10000) 

(This is a "quick fix" to help those running into the problem until a update of how the history server loads app data can be done)
## How was this patch tested?

Manual testing and dev/run-tests

![spark-15083](https://cloud.githubusercontent.com/assets/13952758/17713694/fe82d246-63b0-11e6-9697-b87ea75ff4ef.png)
