### PR TITLE
[SPARK-17101][SQL] Provide consistent format identifiers for TextFileFormat and ParquetFileFormat

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -60,7 +60,7 @@ class ParquetFileFormat
 
   override def shortName(): String = "parquet"
 
-  override def toString: String = shortName.toUpperCase
+  override def toString: String = "Parquet"
 
   override def hashCode(): Int = getClass.hashCode()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -60,7 +60,7 @@ class ParquetFileFormat
 
   override def shortName(): String = "parquet"
 
-  override def toString: String = "ParquetFormat"
+  override def toString: String = shortName.toUpperCase
 
   override def hashCode(): Int = getClass.hashCode()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -40,7 +40,7 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
 
   override def shortName(): String = "text"
 
-  override def toString: String = shortName.toUpperCase
+  override def toString: String = "Text"
 
   private def verifySchema(schema: StructType): Unit = {
     if (schema.size != 1) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -40,6 +40,8 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
 
   override def shortName(): String = "text"
 
+  override def toString: String = shortName.toUpperCase
+
   private def verifySchema(schema: StructType): Unit = {
     if (schema.size != 1) {
       throw new AnalysisException(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Define the format identifier that is used in Optimized Logical Plan in `explain` for text and parquet file formats (following CSV and JSON formats).
### Before
- Text

```
== Physical Plan ==
InMemoryTableScan [value#24]
   +- InMemoryRelation [value#24], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
         +- *FileScan text [value#24] Batched: false, Format: org.apache.spark.sql.execution.datasources.text.TextFileFormat@262e2c8c, InputPaths: file:/Users/jacek/dev/oss/spark/people.csv, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<value:string>
```
- Parquet

```
== Physical Plan ==
*FileScan parquet [id#7L] Batched: true, Format: ParquetFormat, InputPaths: file:/tmp/test, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:bigint>
```
### After
- Text

```
== Physical Plan ==
InMemoryTableScan [value#0]
   +- InMemoryRelation [value#0], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
         +- *FileScan text [value#0] Batched: false, Format: Text, InputPaths: file:/Users/jacek/dev/oss/spark/people.csv, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<value:string>
```
- Parquet

```
== Physical Plan ==
*FileScan parquet [id#7L] Batched: true, Format: Parquet, InputPaths: file:/tmp/test, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:bigint>
```
## How was this patch tested?

Local build.
