### PR TITLE
[SPARK-17105][CORE] App name will be random UUID while creating spark context if it will …

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -79,6 +79,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   // The call site where this SparkContext was constructed.
   private val creationSite: CallSite = Utils.getCallSite()
 
+  private val randomAppName = UUID.randomUUID().toString
+
   // If true, log warnings instead of throwing exceptions when multiple SparkContexts are active
   private val allowMultipleContexts: Boolean =
     config.getBoolean("spark.driver.allowMultipleContexts", false)
@@ -371,7 +373,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       throw new SparkException("A master URL must be set in your configuration")
     }
     if (!_conf.contains("spark.app.name")) {
-      throw new SparkException("An application name must be set in your configuration")
+      _conf.setAppName(randomAppName)
     }
 
     // System property spark.yarn.app.id must be set if user code ran by AM on a YARN cluster


### PR DESCRIPTION
## What changes were proposed in this pull request?

App name will be random UUID while creating spark context if it will not set as configuration as same as spark session.
## How was this patch tested?

run all test cases
