### PR TITLE
[SPARK-17125][SPARKR] Allow to specify spark config using non-string type in SparkR

### DIFF
--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -630,7 +630,7 @@ convertNamedListToEnv <- function(namedList) {
 
   env <- new.env()
   for (name in names) {
-    env[[name]] <- namedList[[name]]
+    env[[name]] <- as.character(namedList[[name]])
   }
   env
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow to set spark configuration using non-string type in sparkR
## How was this patch tested?

Tested manually using the following command

```
sparkR.session(master="yarn-client", sparkConfig = list(spark.executor.instances=1))
```
