### PR TITLE
[SPARK-17141] [ML] MinMaxScaler should remain NaN value.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -186,8 +186,10 @@ class MinMaxScalerModel private[ml] (
       val size = values.length
       var i = 0
       while (i < size) {
-        val raw = if (originalRange(i) != 0) (values(i) - minArray(i)) / originalRange(i) else 0.5
-        values(i) = raw * scale + $(min)
+        if (!values(i).isNaN) {
+          val raw = if (originalRange(i) != 0) (values(i) - minArray(i)) / originalRange(i) else 0.5
+          values(i) = raw * scale + $(min)
+        }
         i += 1
       }
       Vectors.dense(values)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the existing code, `MinMaxScaler` handle `NaN` value indeterminately. 
- If a column has identity value, that is `max == min`, `MinMaxScalerModel` transformation will output `0.5` for all rows even the original value is `NaN`.
- Otherwise, it will remain `NaN` after transformation.

I think we should unify the behavior by remaining `NaN` value at any condition, since we don't know how to transform a `NaN` value. In Python sklearn, it will throw exception when there is `NaN` in the dataset.
## How was this patch tested?

Unit tests.
