### PR TITLE
[SPARK-17166] [SQL] Store Table Properties in CTAS that is Converted to Data Source Tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1044,10 +1044,13 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         if (conf.convertCTAS && !hasStorageProperties) {
           // At here, both rowStorage.serdeProperties and fileStorage.serdeProperties
           // are empty Maps.
+          // For data source tables, table properties is only used to store schema and
+          // system-generated metadata. All user-specified properties/options will be stored
+          // in serde properties.
           val optionsWithPath = if (location.isDefined) {
-            Map("path" -> location.get)
+            properties ++ Map("path" -> location.get)
           } else {
-            Map.empty[String, String]
+            properties
           }
 
           val newTableDesc = tableDesc.copy(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -653,6 +653,20 @@ class HiveDDLSuite
     }
   }
 
+  test("CTAS - converted to Data Source Table but lost table properties") {
+    withSQLConf(SQLConf.CONVERT_CTAS.key -> "true") {
+      withTable("t") {
+        sql("CREATE TABLE t TBLPROPERTIES('prop1' = 'c', 'prop2' = 'd') AS SELECT 1 as a, 1 as b")
+        val tableDesc = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))
+        assert(tableDesc.properties.get("prop1").isEmpty)
+        assert(tableDesc.properties.get("prop2").isEmpty)
+        assert(tableDesc.storage.properties.get("prop1") == Option("c"))
+        assert(tableDesc.storage.properties.get("prop2") == Option("d"))
+        checkAnswer(spark.table("t"), Row(1, 1) :: Nil)
+      }
+    }
+  }
+
   test("desc table for data source table - partitioned bucketed table") {
     withTable("t1") {
       spark


### PR DESCRIPTION
## What changes were proposed in this pull request?

CTAS lost table properties after conversion to data source tables. For example, 

``` SQL
CREATE TABLE t TBLPROPERTIES('prop1' = 'c', 'prop2' = 'd') AS SELECT 1 as a, 1 as b
```

The output of `DESC FORMATTED t` does not have the related properties. 

```
|Table Parameters:           |                                                                                                              |       |
|  rawDataSize               |-1                                                                                                            |       |
|  numFiles                  |1                                                                                                             |       |
|  transient_lastDdlTime     |1471670983                                                                                                    |       |
|  totalSize                 |496                                                                                                           |       |
|  spark.sql.sources.provider|parquet                                                                                                       |       |
|  EXTERNAL                  |FALSE                                                                                                         |       |
|  COLUMN_STATS_ACCURATE     |false                                                                                                         |       |
|  numRows                   |-1                                                                                                            |       |
|                            |                                                                                                              |       |
|# Storage Information       |                                                                                                              |       |
|SerDe Library:              |org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe                                                   |       |
|InputFormat:                |org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat                                                 |       |
|OutputFormat:               |org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat                                                |       |
|Compressed:                 |No                                                                                                            |       |
|Storage Desc Parameters:    |                                                                                                              |       |
|  serialization.format      |1                                                                                                             |       |
|  path                      |file:/private/var/folders/4b/sgmfldk15js406vk7lw5llzw0000gn/T/warehouse-f3aa2927-6464-4a35-a715-1300dde6c614/t|       |
```

After the fix, the properties specified by users are stored as serde properties, since the table properties are used for storing table schemas and system generated properties. 

```
|Table Parameters:           |                                                                                                              |       |
|  rawDataSize               |-1                                                                                                            |       |
|  numFiles                  |1                                                                                                             |       |
|  transient_lastDdlTime     |1471672182                                                                                                    |       |
|  totalSize                 |496                                                                                                           |       |
|  spark.sql.sources.provider|parquet                                                                                                       |       |
|  EXTERNAL                  |FALSE                                                                                                         |       |
|  COLUMN_STATS_ACCURATE     |false                                                                                                         |       |
|  numRows                   |-1                                                                                                            |       |
|                            |                                                                                                              |       |
|# Storage Information       |                                                                                                              |       |
|SerDe Library:              |org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe                                                   |       |
|InputFormat:                |org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat                                                 |       |
|OutputFormat:               |org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat                                                |       |
|Compressed:                 |No                                                                                                            |       |
|Storage Desc Parameters:    |                                                                                                              |       |
|  prop2                     |d                                                                                                             |       |
|  prop1                     |c                                                                                                             |       |
|  serialization.format      |1                                                                                                             |       |
|  path                      |file:/private/var/folders/4b/sgmfldk15js406vk7lw5llzw0000gn/T/warehouse-78c38cea-02c9-40aa-9b20-9803686069ae/t|       |
+----------------------------+--------------------------------------------------------------------------------------------------------------+-------+
```
## How was this patch tested?

Added a test case.
