### PR TITLE
[SPARK-17170] [SQL] InMemoryTableScanExec driver-side partition pruning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -69,7 +69,7 @@ class CacheManager extends Logging {
 
   /** Clears all cached tables. */
   def clearCache(): Unit = writeLock {
-    cachedData.foreach(_.cachedRepresentation.cachedColumnBuffers.unpersist())
+    cachedData.foreach(_.cachedRepresentation.unpersist())
     cachedData.clear()
   }
 
@@ -113,7 +113,7 @@ class CacheManager extends Logging {
     val dataIndex = cachedData.indexWhere(cd => planToCache.sameResult(cd.plan))
     val found = dataIndex >= 0
     if (found) {
-      cachedData(dataIndex).cachedRepresentation.cachedColumnBuffers.unpersist(blocking)
+      cachedData(dataIndex).cachedRepresentation.unpersist(blocking)
       cachedData.remove(dataIndex)
     }
     found
@@ -167,7 +167,7 @@ class CacheManager extends Logging {
       case data if data.plan.find(lookupAndRefresh(_, fs, qualifiedPath)).isDefined =>
         val dataIndex = cachedData.indexWhere(cd => data.plan.sameResult(cd.plan))
         if (dataIndex >= 0) {
-          data.cachedRepresentation.cachedColumnBuffers.unpersist(blocking = true)
+          data.cachedRepresentation.unpersist(blocking = true)
           cachedData.remove(dataIndex)
         }
         sparkSession.sharedState.cacheManager.cacheQuery(Dataset.ofRows(sparkSession, data.plan))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -100,9 +100,14 @@ case class InMemoryRelation(
     buildBuffers()
   }
 
-  def recache(): Unit = {
-    _cachedColumnBuffers.unpersist()
+  def unpersist(blocking: Boolean = true): Unit = {
+    batchStats.reset()
+    _cachedColumnBuffers.unpersist(blocking)
     _cachedColumnBuffers = null
+  }
+
+  def recache(): Unit = {
+    unpersist(true)
     buildBuffers()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.commons.lang3.StringUtils
 
+import org.apache.spark.TaskContext
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -63,6 +64,7 @@ case class InMemoryRelation(
     @transient child: SparkPlan,
     tableName: Option[String])(
     @transient var _cachedColumnBuffers: RDD[CachedBatch] = null,
+    // Accumulator tracking (partitionId, batchStats) for each CachedBatch
     val batchStats: CollectionAccumulator[(Int, InternalRow)] =
       child.sqlContext.sparkContext.collectionAccumulator[(Int, InternalRow)])
   extends logical.LeafNode with MultiInstanceRelation {
@@ -106,7 +108,7 @@ case class InMemoryRelation(
 
   private def buildBuffers(): Unit = {
     val output = child.output
-    val cached = child.execute().mapPartitionsWithIndex { (i, rowIterator) =>
+    val cached = child.execute().mapPartitionsInternal { rowIterator =>
       new Iterator[CachedBatch] {
         def next(): CachedBatch = {
           val columnBuilders = output.map { attribute =>
@@ -142,7 +144,7 @@ case class InMemoryRelation(
           val stats = InternalRow.fromSeq(columnBuilders.map(_.columnStats.collectedStatistics)
             .flatMap(_.values))
 
-          batchStats.add((i, stats))
+          batchStats.add((TaskContext.get().partitionId(), stats))
           CachedBatch(rowCount, columnBuilders.map { builder =>
             JavaUtils.bufferToArray(builder.build())
           }, stats)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.sql.execution.columnar
 
+import scala.collection.JavaConverters._
+
+import org.apache.spark.rdd.EmptyRDD
+import org.apache.spark.rdd.PartitionPruningRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -125,12 +129,37 @@ case class InMemoryTableScanExec(
     val schema = relation.partitionStatistics.schema
     val schemaIndex = schema.zipWithIndex
     val relOutput: AttributeSeq = relation.output
-    val buffers = relation.cachedColumnBuffers
+    val partitionFilter = newPredicate(
+      partitionFilters.reduceOption(And).getOrElse(Literal(true)),
+      schema)
+
+    val buffers = if (inMemoryPartitionPruningEnabled && !relation.batchStats.value.isEmpty) {
+      val validPartitions = relation.batchStats.value.asScala
+        .filter(batchStat => partitionFilter(batchStat._2))
+        .map(_._1)
+        .distinct
+      if (validPartitions.isEmpty) {
+        new EmptyRDD[CachedBatch](sparkContext)
+      } else {
+        new PartitionPruningRDD[CachedBatch](relation.cachedColumnBuffers,
+          index => {
+            if (validPartitions.contains(index)) {
+              true
+            } else {
+              logInfo(s"Skipping partition $index because all cached batches will be pruned")
+              false
+            }
+          })
+      }
+    } else {
+      relation.cachedColumnBuffers
+    }
 
     buffers.mapPartitionsInternal { cachedBatchIterator =>
-      val partitionFilter = newPredicate(
-        partitionFilters.reduceOption(And).getOrElse(Literal(true)),
-        schema)
+      if (enableAccumulators) {
+        // Mark any partition as a read partition
+        readPartitions.add(1)
+      }
 
       // Find the ordinals and data types of the requested columns.
       val (requestedColumnIndices, requestedColumnDataTypes) =
@@ -142,13 +171,16 @@ case class InMemoryTableScanExec(
       val cachedBatchesToScan =
         if (inMemoryPartitionPruningEnabled) {
           cachedBatchIterator.filter { cachedBatch =>
+            val partitionFilter = newPredicate(
+              partitionFilters.reduceOption(And).getOrElse(Literal(true)),
+              schema)
             if (!partitionFilter(cachedBatch.stats)) {
               def statsString: String = schemaIndex.map {
                 case (a, i) =>
                   val value = cachedBatch.stats.get(i, a.dataType)
                   s"${a.name}: $value"
               }.mkString(", ")
-              logInfo(s"Skipping partition based on stats $statsString")
+              logInfo(s"Skipping batch based on stats $statsString")
               false
             } else {
               true
@@ -173,9 +205,6 @@ case class InMemoryTableScanExec(
       }.toArray
       val columnarIterator = GenerateColumnAccessor.generate(columnTypes)
       columnarIterator.initialize(withMetrics, columnTypes, requestedColumnIndices.toArray)
-      if (enableAccumulators && columnarIterator.hasNext) {
-        readPartitions.add(1)
-      }
       columnarIterator
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -139,9 +139,9 @@ case class InMemoryTableScanExec(
         .map(_._1)
         .distinct
       if (validPartitions.isEmpty) {
-        new EmptyRDD[CachedBatch](sparkContext)
+        sparkContext.emptyRDD[CachedBatch]
       } else {
-        new PartitionPruningRDD[CachedBatch](relation.cachedColumnBuffers,
+        PartitionPruningRDD.create[CachedBatch](relation.cachedColumnBuffers,
           index => {
             if (validPartitions.contains(index)) {
               true

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
@@ -71,6 +71,10 @@ class PartitionBatchPruningSuite
     }, 5).toDF()
     pruningStringData.createOrReplaceTempView("pruningStringData")
     spark.catalog.cacheTable("pruningStringData")
+
+    // Trigger the cache of the tables to enable eager partition pruning.
+    pruningData.count()
+    pruningStringData.count()
   }
 
   override protected def afterEach(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

After caching data, we have statistics that enable us to eagerly prune entire partitions before launching a query. This modifies the InMemoryTableScanExec to prune partitions before launching the tasks.
## How was this patch tested?

Existing test suite with slight modification to scan over the data once as setup.
