### PR TITLE
[SPARK-17176][WEB UI]set default task sort column to "Status"

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -104,7 +104,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
       val taskPage = Option(parameterTaskPage).map(_.toInt).getOrElse(1)
       val taskSortColumn = Option(parameterTaskSortColumn).map { sortColumn =>
         UIUtils.decodeURLParameter(sortColumn)
-      }.getOrElse("Index")
+      }.getOrElse("Status")
       val taskSortDesc = Option(parameterTaskSortDesc).map(_.toBoolean).getOrElse(false)
       val taskPageSize = Option(parameterTaskPageSize).map(_.toInt).getOrElse(100)
       val taskPrevPageSize = Option(parameterTaskPrevPageSize).map(_.toInt).getOrElse(taskPageSize)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Task are sorted by "Index" in Stage Page, but user are always concerned about tasks which are failed(see error messages) or still running (maybe it is skewed). When there are too many tasks, it is too slow to sort. So it is better to set the default sort column to ”Status“.
