### PR TITLE
[SPARK-17178][SPARKR][SPARKSUBMIT] Allow to set sparkr shell command through --conf

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1752,6 +1752,15 @@ showDF(properties, numRows = 200, truncate = FALSE)
     Executable for executing R scripts in client modes for driver. Ignored in cluster modes.
   </td>
 </tr>
+<tr>
+  <td><code>spark.r.shell.command</code></td>
+  <td>R</td>
+  <td>
+    Executable for executing R shell in both client mode and cluster mode. For now sparkr shell only supports
+    client mode, but this property will be propagated to remote driver in cluster mode and can be used by driver if user want to implement
+    sparkr shell in cluster mode.
+  </td>
+</tr>
 </table>
 
 #### Deploy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1756,7 +1756,8 @@ showDF(properties, numRows = 200, truncate = FALSE)
   <td><code>spark.r.shell.command</code></td>
   <td>R</td>
   <td>
-    Executable for executing R shell.
+    Executable for executing sparkR shell in client modes for driver. Ignored in cluster modes. It is the same as environment variable <code>SPARKR_DRIVER_R</code>, but take precedence over it.
+    <code>spark.r.shell.command</code> is used for interactive mode of sparkR (sparkR shell) while <code>spark.r.driver.command</code> is used for the batch mode (running sparkR script).
   </td>
 </tr>
 </table>
@@ -1825,7 +1826,8 @@ The following variables can be set in `spark-env.sh`:
   </tr>
   <tr>
     <td><code>SPARKR_DRIVER_R</code></td>
-    <td>R binary executable to use for SparkR shell (default is <code>R</code>).</td>
+    <td>R binary executable to use for SparkR shell (default is <code>R</code>).
+    Property <code>spark.r.shell.command</code> take precedence if it is set</td>
   </tr>
   <tr>
     <td><code>SPARK_LOCAL_IP</code></td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1757,7 +1757,7 @@ showDF(properties, numRows = 200, truncate = FALSE)
   <td>R</td>
   <td>
     Executable for executing sparkR shell in client modes for driver. Ignored in cluster modes. It is the same as environment variable <code>SPARKR_DRIVER_R</code>, but take precedence over it.
-    <code>spark.r.shell.command</code> is used for interactive mode of sparkR (sparkR shell) while <code>spark.r.driver.command</code> is used for the batch mode (running sparkR script).
+    <code>spark.r.shell.command</code> is used for sparkR shell while <code>spark.r.driver.command</code> is used for running R script.
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1756,9 +1756,7 @@ showDF(properties, numRows = 200, truncate = FALSE)
   <td><code>spark.r.shell.command</code></td>
   <td>R</td>
   <td>
-    Executable for executing R shell in both client mode and cluster mode. For now sparkr shell only supports
-    client mode, but this property will be propagated to remote driver in cluster mode and can be used by driver if user want to implement
-    sparkr shell in cluster mode.
+    Executable for executing R shell.
   </td>
 </tr>
 </table>

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -68,6 +68,8 @@ public class SparkLauncher {
 
   static final String PYSPARK_PYTHON = "spark.pyspark.python";
 
+  static final String SPARKR_R_SHELL = "spark.r.shell.command";
+
   /** Logger name to use when launching a child process. */
   public static final String CHILD_PROCESS_LOGGER_NAME = "spark.launcher.childProcLoggerName";
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -336,8 +336,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
             join(File.separator, sparkHome, "R", "lib", "SparkR", "profile", "shell.R"));
 
     List<String> args = new ArrayList<>();
-    args.add(firstNonEmpty(firstNonEmpty(conf.get(SparkLauncher.SPARKR_R_SHELL),
-      System.getenv("SPARKR_DRIVER_R"), "R")));
+    args.add(firstNonEmpty(conf.get(SparkLauncher.SPARKR_R_SHELL),
+      System.getenv("SPARKR_DRIVER_R"), "R"));
     return args;
   }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -336,7 +336,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
             join(File.separator, sparkHome, "R", "lib", "SparkR", "profile", "shell.R"));
 
     List<String> args = new ArrayList<>();
-    args.add(firstNonEmpty(System.getenv("SPARKR_DRIVER_R"), "R"));
+    args.add(firstNonEmpty(firstNonEmpty(conf.get(SparkLauncher.SPARKR_R_SHELL),
+      System.getenv("SPARKR_DRIVER_R"), "R")));
     return args;
   }
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -173,6 +173,24 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   }
 
   @Test
+  public void testSparkRShell() throws Exception {
+    List<String> sparkSubmitArgs = Arrays.asList(
+      SparkSubmitCommandBuilder.SPARKR_SHELL,
+      "--master=foo",
+      "--deploy-mode=bar",
+      "--conf", "spark.r.shell.command=/usr/bin/R");
+
+    Map<String, String> env = new HashMap<>();
+    List<String> cmd = buildCommand(sparkSubmitArgs, env);
+    assertEquals("/usr/bin/R", cmd.get(cmd.size() - 1));
+    assertEquals(
+      String.format(
+        "\"%s\" \"foo\" \"%s\" \"bar\" \"--conf\" \"spark.r.shell.command=/usr/bin/R\" \"%s\"",
+        parser.MASTER, parser.DEPLOY_MODE, SparkSubmitCommandBuilder.SPARKR_SHELL_RESOURCE),
+      env.get("SPARKR_SUBMIT_ARGS"));
+  }
+
+  @Test
   public void testExamplesRunner() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
       SparkSubmitCommandBuilder.RUN_EXAMPLE,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow user to set sparkr shell command through --conf spark.r.shell.command
## How was this patch tested?

Unit test is added and also verify it manually through 

```
bin/sparkr --master yarn-client --conf spark.r.shell.command=/usr/local/bin/R
```
