### PR TITLE
[SPARK-17189][SQL][MINOR] Prefers InternalRow over UnsafeRow if UnsafeRow specific interface is not used in AggregationIterator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -127,7 +127,7 @@ class TungstenAggregationIterator(
   }
 
   // Creates a function used to generate output rows.
-  override protected def generateResultProjection(): (UnsafeRow, MutableRow) => UnsafeRow = {
+  override protected def generateResultProjection(): (InternalRow, MutableRow) => UnsafeRow = {
     val modes = aggregateExpressions.map(_.mode).distinct
     if (modes.nonEmpty && !modes.contains(Final) && !modes.contains(Complete)) {
       // Fast path for partial aggregation, UnsafeRowJoiner is usually faster than projection
@@ -137,8 +137,10 @@ class TungstenAggregationIterator(
       val bufferSchema = StructType.fromAttributes(bufferAttributes)
       val unsafeRowJoiner = GenerateUnsafeRowJoiner.create(groupingKeySchema, bufferSchema)
 
-      (currentGroupingKey: UnsafeRow, currentBuffer: MutableRow) => {
-        unsafeRowJoiner.join(currentGroupingKey, currentBuffer.asInstanceOf[UnsafeRow])
+      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
+        unsafeRowJoiner.join(
+          currentGroupingKey.asInstanceOf[UnsafeRow],
+          currentBuffer.asInstanceOf[UnsafeRow])
       }
     } else {
       super.generateResultProjection()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor change to use InternalRow instead of UnsafeRow in method declaration of `AggregationIterator.generateResultProjection(...)`, as UnsafeRow specific methods are not used.
### Before change:

```
protected def generateResultProjection(): (UnsafeRow, MutableRow) => UnsafeRow
```
### After change

```
protected def generateResultProjection(): (InternalRow, MutableRow) => UnsafeRow
```
## How was this patch tested?

Existing test.
