### PR TITLE
[SPARKR][MINOR] Add Xiangrui and Felix to maintainers

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -5,6 +5,8 @@ Version: 2.0.0
 Date: 2016-07-07
 Author: The Apache Software Foundation
 Maintainer: Shivaram Venkataraman <shivaram@cs.berkeley.edu>
+            Xiangrui Meng <meng@databricks.com>
+            Felix Cheung <felixcheung_m@hotmail.com>
 Depends:
     R (>= 3.0),
     methods


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds Xiangrui Meng and Felix Cheung to the maintainers field in the package description.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
