### PR TITLE
[SparkR][Minor] Add installation message for remote master mode and improve other messages

### DIFF
--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -72,9 +72,9 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
                           localDir = NULL, overwrite = FALSE) {
   version <- paste0("spark-", packageVersion("SparkR"))
   hadoopVersion <- tolower(hadoopVersion)
-  hadoopVersionName <- hadoop_version_name(hadoopVersion)
+  hadoopVersionName <- hadoopVersionName(hadoopVersion)
   packageName <- paste(version, "bin", hadoopVersionName, sep = "-")
-  localDir <- ifelse(is.null(localDir), spark_cache_path(),
+  localDir <- ifelse(is.null(localDir), sparkCachePath(),
                      normalizePath(localDir, mustWork = FALSE))
 
   if (is.na(file.info(localDir)$isdir)) {
@@ -106,7 +106,7 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
   if (tarExists && !overwrite) {
     message("tar file found.")
   } else {
-    robust_download_tar(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath)
+    robustDownloadTar(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath)
   }
 
   message(sprintf("Installing to %s", localDir))
@@ -120,12 +120,12 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
   invisible(packageLocalDir)
 }
 
-robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
+robustDownloadTar <- function(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
   # step 1: use user-provided url
   if (!is.null(mirrorUrl)) {
     msg <- sprintf("Use user-provided mirror site: %s.", mirrorUrl)
     message(msg)
-    success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
+    success <- directDownloadTar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
     if (success) {
       return()
@@ -138,9 +138,9 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
 
   # step 2: use url suggested from apache website
   message("Looking for preferred site from apache website...")
-  mirrorUrl <- get_preferred_mirror(version, packageName)
+  mirrorUrl <- getPreferredMirror(version, packageName)
   if (!is.null(mirrorUrl)) {
-    success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
+    success <- directDownloadTar(mirrorUrl, version, hadoopVersion,
                                    packageName, packageLocalPath)
     if (success) return()
   } else {
@@ -149,8 +149,8 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
 
   # step 3: use backup option
   message("To use backup site...")
-  mirrorUrl <- default_mirror_url()
-  success <- direct_download_tar(mirrorUrl, version, hadoopVersion,
+  mirrorUrl <- defaultMirrorUrl()
+  success <- directDownloadTar(mirrorUrl, version, hadoopVersion,
                                  packageName, packageLocalPath)
   if (success) {
     return(packageLocalPath)
@@ -163,7 +163,7 @@ robust_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
   }
 }
 
-get_preferred_mirror <- function(version, packageName) {
+getPreferredMirror <- function(version, packageName) {
   jsonUrl <- paste0("http://www.apache.org/dyn/closer.cgi?path=",
                         file.path("spark", version, packageName),
                         ".tgz&as_json=1")
@@ -183,10 +183,10 @@ get_preferred_mirror <- function(version, packageName) {
   mirrorPreferred
 }
 
-direct_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
+directDownloadTar <- function(mirrorUrl, version, hadoopVersion, packageName, packageLocalPath) {
   packageRemotePath <- paste0(
     file.path(mirrorUrl, version, packageName), ".tgz")
-  fmt <- paste("Downloading %s for Hadoop %s from:\n- %s")
+  fmt <- "Downloading %s for Hadoop %s from:\n- %s"
   msg <- sprintf(fmt, version, ifelse(hadoopVersion == "without", "Free build", hadoopVersion),
                  packageRemotePath)
   message(msg)
@@ -200,11 +200,11 @@ direct_download_tar <- function(mirrorUrl, version, hadoopVersion, packageName, 
   !isFail
 }
 
-default_mirror_url <- function() {
+defaultMirrorUrl <- function() {
   "http://www-us.apache.org/dist/spark"
 }
 
-hadoop_version_name <- function(hadoopVersion) {
+hadoopVersionName <- function(hadoopVersion) {
   if (hadoopVersion == "without") {
     "without-hadoop"
   } else if (grepl("^[0-9]+\\.[0-9]+$", hadoopVersion, perl = TRUE)) {
@@ -216,7 +216,7 @@ hadoop_version_name <- function(hadoopVersion) {
 
 # The implementation refers to appdirs package: https://pypi.python.org/pypi/appdirs and
 # adapt to Spark context
-spark_cache_path <- function() {
+sparkCachePath <- function() {
   if (.Platform$OS.type == "windows") {
     winAppPath <- Sys.getenv("LOCALAPPDATA", unset = NA)
     if (is.na(winAppPath)) {
@@ -238,4 +238,22 @@ spark_cache_path <- function() {
     stop(sprintf("Unknown OS: %s", .Platform$OS.type))
   }
   normalizePath(path, mustWork = FALSE)
+}
+
+
+installInstruction <- function(mode) {
+  if (mode == "remote") {
+    paste0("Connecting to a remote Spark master. ",
+           "Please make sure Spark package is also installed in this machine.\n",
+           "- If there is one, set the path in sparkHome parameter or ",
+           "environment variable SPARK_HOME.\n",
+           "- If not, you may run install.spark function to do the job. ",
+           "Please make sure the Spark and the Hadoop versions ",
+           "match the versions on the cluster. ",
+           "SparkR package is compatible with Spark ", packageVersion("SparkR"), ".",
+           "If you need further help, ",
+           "contact the administrators of the cluster.")
+  } else {
+    stop(paste0("No instruction found for ", mode, " mode."))
+  }
 }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -382,7 +382,7 @@ sparkR.session <- function(
           sparkHome <- packageLocalDir
         } else {
           msg <- paste0("Spark not found in SPARK_HOME: ",
-                        sparkHome, "\n", instructionForInstall("remote"))
+                        sparkHome, "\n", installInstruction("remote"))
           stop(msg)
         }
       }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -366,27 +366,28 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
-  # do not download if it is run in the sparkR shell
-  if (!is_sparkR_shell()) {
-    if (!is.na(file.info(sparkHome)$isdir)) {
-      msg <- paste0("Spark package found in SPARK_HOME: ", sparkHome)
-      message(msg)
-    } else {
-      if (!nzchar(master) || is_master_local(master)) {
-        msg <- paste0("Spark not found in SPARK_HOME: ",
-                      sparkHome)
-        message(msg)
-        packageLocalDir <- install.spark()
-        sparkHome <- packageLocalDir
-      } else {
-        msg <- paste0("Spark not found in SPARK_HOME: ",
-                     sparkHome, "\n", instructionForInstall("remote"))
-        stop(msg)
-      }
-    }
-  }
 
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
+    # do not download if it is run in the sparkR shell
+    if (!is_sparkR_shell()) {
+      if (!is.na(file.info(sparkHome)$isdir)) {
+        msg <- paste0("Spark package found in SPARK_HOME: ", sparkHome)
+        message(msg)
+      } else {
+        if (!nzchar(master) || is_master_local(master)) {
+          msg <- paste0("Spark not found in SPARK_HOME: ",
+                        sparkHome)
+          message(msg)
+          packageLocalDir <- install.spark()
+          sparkHome <- packageLocalDir
+        } else {
+          msg <- paste0("Spark not found in SPARK_HOME: ",
+                        sparkHome, "\n", instructionForInstall("remote"))
+          stop(msg)
+        }
+      }
+    }
+
     sparkExecutorEnvMap <- new.env()
     sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorEnvMap,
        sparkJars, sparkPackages)

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -368,7 +368,7 @@ sparkR.session <- function(
   }
 
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
-    retHome <- sparkLocalInstall(sparkHome, master)
+    retHome <- sparkCheckInstall(sparkHome, master)
     if (!is.null(retHome)) sparkHome <- retHome
     sparkExecutorEnvMap <- new.env()
     sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorEnvMap,
@@ -537,22 +537,30 @@ processSparkPackages <- function(packages) {
 #
 # Installation will not be triggered if it's called from sparkR shell
 # or if the master url is not local
-sparkLocalInstall <- function(sparkHome, master) {
+#
+# @param sparkHome directory to find Spark package.
+# @param master the Spark master URL, used to check local or remote mode.
+# @return NULL if no need to update sparkHome, and new sparkHome otherwise.
+sparkCheckInstall <- function(sparkHome, master) {
   if (!isSparkRShell()) {
     if (!is.na(file.info(sparkHome)$isdir)) {
       msg <- paste0("Spark package found in SPARK_HOME: ", sparkHome)
       message(msg)
+      NULL
     } else {
       if (!nzchar(master) || isMasterLocal(master)) {
         msg <- paste0("Spark not found in SPARK_HOME: ",
                       sparkHome)
         message(msg)
         packageLocalDir <- install.spark()
+        packageLocalDir
       } else {
         msg <- paste0("Spark not found in SPARK_HOME: ",
                       sparkHome, "\n", installInstruction("remote"))
         stop(msg)
       }
     }
+  } else {
+    NULL
   }
 }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -367,19 +367,21 @@ sparkR.session <- function(
     overrideEnvs(sparkConfigMap, paramMap)
   }
   # do not download if it is run in the sparkR shell
-  if (!nzchar(master) || is_master_local(master)) {
-    if (!is_sparkR_shell()) {
-      if (is.na(file.info(sparkHome)$isdir)) {
+  if (!is_sparkR_shell()) {
+    if (!is.na(file.info(sparkHome)$isdir)) {
+      msg <- paste0("Spark package found in SPARK_HOME: ", sparkHome)
+      message(msg)
+    } else {
+      if (!nzchar(master) || is_master_local(master)) {
         msg <- paste0("Spark not found in SPARK_HOME: ",
-                      sparkHome,
-                      " .\nTo search in the cache directory. ",
-                      "Installation will start if not found.")
+                      sparkHome)
         message(msg)
         packageLocalDir <- install.spark()
         sparkHome <- packageLocalDir
       } else {
-        msg <- paste0("Spark package is found in SPARK_HOME: ", sparkHome)
-        message(msg)
+        msg <- paste0("Spark not found in SPARK_HOME: ",
+                     sparkHome, "\n", instructionForInstall("remote"))
+        stop(msg)
       }
     }
   }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -368,7 +368,8 @@ sparkR.session <- function(
   }
 
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
-    sparkLocalInstall(sparkHome, master)
+    retHome <- sparkLocalInstall(sparkHome, master)
+    if (!is.null(retHome)) sparkHome <- retHome
     sparkExecutorEnvMap <- new.env()
     sparkR.sparkContext(master, appName, sparkHome, sparkConfigMap, sparkExecutorEnvMap,
        sparkJars, sparkPackages)
@@ -547,7 +548,6 @@ sparkLocalInstall <- function(sparkHome, master) {
                       sparkHome)
         message(msg)
         packageLocalDir <- install.spark()
-        sparkHome <- packageLocalDir
       } else {
         msg <- paste0("Spark not found in SPARK_HOME: ",
                       sparkHome, "\n", installInstruction("remote"))

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -697,3 +697,20 @@ is_master_local <- function(master) {
 is_sparkR_shell <- function() {
   grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
 }
+
+instructionForInstall <- function(mode) {
+  if (mode == "remote") {
+    paste0("Connecting to a remote Spark master. ",
+           "Please make sure Spark package is also installed in this machine.\n",
+           "- If there is one, set the path in sparkHome parameter or ",
+           "environment variable SPARK_HOME.\n",
+           "- If not, you may run install.spark function to do the job. ",
+           "Please make sure the Spark and the Hadoop versions ",
+           "match the versions on the cluster. ",
+           "Currently only Spark 2.0 is supported. ",
+           "If you need further help, ",
+           "contact the administrators of the cluster.")
+  } else {
+    stop(paste0("No instruction found for ", mode, " mode."))
+  }
+}

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -707,7 +707,7 @@ instructionForInstall <- function(mode) {
            "- If not, you may run install.spark function to do the job. ",
            "Please make sure the Spark and the Hadoop versions ",
            "match the versions on the cluster. ",
-           "Currently only Spark 2.0 is supported. ",
+           "SparkR package is compatible with Spark 2.0.0.",
            "If you need further help, ",
            "contact the administrators of the cluster.")
   } else {

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -698,7 +698,7 @@ is_sparkR_shell <- function() {
   grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
 }
 
-instructionForInstall <- function(mode) {
+installInstruction <- function(mode) {
   if (mode == "remote") {
     paste0("Connecting to a remote Spark master. ",
            "Please make sure Spark package is also installed in this machine.\n",

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -697,4 +697,3 @@ isMasterLocal <- function(master) {
 isSparkRShell <- function() {
   grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
 }
-

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -690,27 +690,11 @@ getSparkContext <- function() {
   sc
 }
 
-is_master_local <- function(master) {
+isMasterLocal <- function(master) {
   grepl("^local(\\[([0-9]+|\\*)\\])?$", master, perl = TRUE)
 }
 
-is_sparkR_shell <- function() {
+isSparkRShell <- function() {
   grepl(".*shell\\.R$", Sys.getenv("R_PROFILE_USER"), perl = TRUE)
 }
 
-installInstruction <- function(mode) {
-  if (mode == "remote") {
-    paste0("Connecting to a remote Spark master. ",
-           "Please make sure Spark package is also installed in this machine.\n",
-           "- If there is one, set the path in sparkHome parameter or ",
-           "environment variable SPARK_HOME.\n",
-           "- If not, you may run install.spark function to do the job. ",
-           "Please make sure the Spark and the Hadoop versions ",
-           "match the versions on the cluster. ",
-           "SparkR package is compatible with Spark 2.0.0.",
-           "If you need further help, ",
-           "contact the administrators of the cluster.")
-  } else {
-    stop(paste0("No instruction found for ", mode, " mode."))
-  }
-}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR gives informative message to users when they try to connect to a remote master but don't have Spark package in their local machine.  

As a clarification, for now, automatic installation will only happen if they start SparkR in R console (rather than from sparkr-shell) and connect to local master. In the remote master mode, local Spark package is still needed, but we will not trigger the install.spark function because the versions have to match those on the cluster, which involves more user input. Instead, we here try to provide detailed message that may help the users.

Some of the other messages have also been slightly changed.
## How was this patch tested?

Manual test.
