### PR TITLE
[SPARK-15815] Keeping tell yarn the target executors in DA mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -364,13 +364,6 @@ private[spark] class ExecutorAllocationManager(
 
     val delta = numExecutorsTarget - oldNumExecutorsTarget
 
-    // If our target has not changed, do not send a message
-    // to the cluster manager and reset our exponential growth
-    if (delta == 0) {
-      numExecutorsToAdd = 1
-      return 0
-    }
-
     val addRequestAcknowledged = testing ||
       client.requestTotalExecutors(numExecutorsTarget, localityAwareTasks, hostToLocalTaskCount)
     if (addRequestAcknowledged) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current spark DA mode, if we enabled blacklist, it will have a chance to hang the Spark job.

example:
executor: A, taskset(task1), blacklistTime > 60s
1. task1 allocated in exec-A, and failed, so exec-A is blacklist for task1
2. exec-A idled out before can't get any task to run. Because exec-A idled out, `yarnAllocator` decrease the `YarnAllocator.targetExecutorNumber` to 0. 
In the meantime, DA always calculate `DA.targetExecutor` = 1. and so the `DA.oldTargetNumExecutors` also be 1, then the `DA.delta` = 0, and result `DA` will not tell the `YarnAllocator` the actual needed targetNumber.  
3. So, because current delta=0, will skip `DA.targetExecutor -> YarnAllocator.targetExecutor`, then `DA.targetExecutor` = 1 while `YarnAllocator.targetExecutor` = 0,  it will never get a executor to run task, it hangs.

This patch adopts the easiest way just remove `delta = 0` logic, the shortage is will always communicate with YarnAllocator.
## How was this patch tested?

manual test
