### PR TITLE
[SPARK-17203][SQL] data source options should always be case insensitive

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -316,7 +316,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     if (external) {
       operationNotAllowed("CREATE EXTERNAL TABLE ... USING", ctx)
     }
-    val options = Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty)
+    val options = CaseInsensitiveMap(
+      Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty))
     val provider = ctx.tableProvider.qualifiedName.getText
     val schema = Option(ctx.colTypeList()).map(createStructType)
     val partitionColumnNames =
@@ -377,7 +378,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
       userSpecifiedSchema = Option(ctx.colTypeList()).map(createStructType),
       replace = ctx.REPLACE != null,
       provider = ctx.tableProvider.qualifiedName.getText,
-      options = Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty))
+      options = CaseInsensitiveMap(
+        Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty)))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -65,7 +65,7 @@ case class CreateDataSourceTableCommand(
 
     var isExternal = true
     val optionsWithPath =
-      if (!new CaseInsensitiveMap(options).contains("path") && managedIfNoPath) {
+      if (!options.contains("path") && managedIfNoPath) {
         isExternal = false
         options + ("path" -> sessionState.catalog.defaultTablePath(tableIdent))
       } else {
@@ -140,7 +140,7 @@ case class CreateDataSourceTableAsSelectCommand(
     var createMetastoreTable = false
     var isExternal = true
     val optionsWithPath =
-      if (!new CaseInsensitiveMap(options).contains("path")) {
+      if (!options.contains("path")) {
         isExternal = false
         options + ("path" -> sessionState.catalog.defaultTablePath(tableIdent))
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -186,8 +186,7 @@ case class DataSource(
 
   private def inferFileFormatSchema(format: FileFormat): StructType = {
     userSpecifiedSchema.orElse {
-      val caseInsensitiveOptions = new CaseInsensitiveMap(options)
-      val allPaths = caseInsensitiveOptions.get("path")
+      val allPaths = options.get("path")
       val globbedPaths = allPaths.toSeq.flatMap { path =>
         val hdfsPath = new Path(path)
         val fs = hdfsPath.getFileSystem(sparkSession.sessionState.newHadoopConf())
@@ -197,7 +196,7 @@ case class DataSource(
       val fileCatalog = new ListingFileCatalog(sparkSession, globbedPaths, options, None)
       format.inferSchema(
         sparkSession,
-        caseInsensitiveOptions,
+        options,
         fileCatalog.allFiles())
     }.getOrElse {
       throw new AnalysisException("Unable to infer schema. It must be specified manually.")
@@ -213,8 +212,7 @@ case class DataSource(
         SourceInfo(name, schema)
 
       case format: FileFormat =>
-        val caseInsensitiveOptions = new CaseInsensitiveMap(options)
-        val path = caseInsensitiveOptions.getOrElse("path", {
+        val path = options.getOrElse("path", {
           throw new IllegalArgumentException("'path' is not specified")
         })
 
@@ -255,7 +253,7 @@ case class DataSource(
           sparkSession.sqlContext, metadataPath, userSpecifiedSchema, className, options)
 
       case format: FileFormat =>
-        val path = new CaseInsensitiveMap(options).getOrElse("path", {
+        val path = options.getOrElse("path", {
           throw new IllegalArgumentException("'path' is not specified")
         })
         new FileStreamSource(
@@ -273,8 +271,7 @@ case class DataSource(
         s.createSink(sparkSession.sqlContext, options, partitionColumns, outputMode)
 
       case parquet: parquet.ParquetFileFormat =>
-        val caseInsensitiveOptions = new CaseInsensitiveMap(options)
-        val path = caseInsensitiveOptions.getOrElse("path", {
+        val path = options.getOrElse("path", {
           throw new IllegalArgumentException("'path' is not specified")
         })
         if (outputMode != OutputMode.Append) {
@@ -320,13 +317,12 @@ case class DataSource(
    *                       path of the table does not exist).
    */
   def resolveRelation(checkPathExist: Boolean = true): BaseRelation = {
-    val caseInsensitiveOptions = new CaseInsensitiveMap(options)
     val relation = (providingClass.newInstance(), userSpecifiedSchema) match {
       // TODO: Throw when too much is given.
       case (dataSource: SchemaRelationProvider, Some(schema)) =>
-        dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions, schema)
+        dataSource.createRelation(sparkSession.sqlContext, options, schema)
       case (dataSource: RelationProvider, None) =>
-        dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
+        dataSource.createRelation(sparkSession.sqlContext, options)
       case (_: SchemaRelationProvider, None) =>
         throw new AnalysisException(s"A schema needs to be specified when using $className.")
       case (_: RelationProvider, Some(_)) =>
@@ -335,13 +331,13 @@ case class DataSource(
       // We are reading from the results of a streaming query. Load files from the metadata log
       // instead of listing them using HDFS APIs.
       case (format: FileFormat, _)
-          if hasMetadata(caseInsensitiveOptions.get("path").toSeq ++ paths) =>
-        val basePath = new Path((caseInsensitiveOptions.get("path").toSeq ++ paths).head)
+          if hasMetadata(options.get("path").toSeq ++ paths) =>
+        val basePath = new Path((options.get("path").toSeq ++ paths).head)
         val fileCatalog = new MetadataLogFileCatalog(sparkSession, basePath)
         val dataSchema = userSpecifiedSchema.orElse {
           format.inferSchema(
             sparkSession,
-            caseInsensitiveOptions,
+            options,
             fileCatalog.allFiles())
         }.getOrElse {
           throw new AnalysisException(
@@ -360,7 +356,7 @@ case class DataSource(
 
       // This is a non-streaming file based datasource.
       case (format: FileFormat, _) =>
-        val allPaths = caseInsensitiveOptions.get("path") ++ paths
+        val allPaths = options.get("path") ++ paths
         val globbedPaths = allPaths.flatMap { path =>
           val hdfsPath = new Path(path)
           val fs = hdfsPath.getFileSystem(sparkSession.sessionState.newHadoopConf())
@@ -405,7 +401,7 @@ case class DataSource(
         }.orElse {
           format.inferSchema(
             sparkSession,
-            caseInsensitiveOptions,
+            options,
             fileCatalog.allFiles())
         }.getOrElse {
           throw new AnalysisException(
@@ -420,7 +416,7 @@ case class DataSource(
           dataSchema = dataSchema.asNullable,
           bucketSpec = bucketSpec,
           format,
-          caseInsensitiveOptions)
+          options)
 
       case _ =>
         throw new AnalysisException(
@@ -446,9 +442,8 @@ case class DataSource(
         //  1. Only one output path can be specified on the write path;
         //  2. Output path must be a legal HDFS style file system path;
         //  3. It's OK that the output path doesn't exist yet;
-        val caseInsensitiveOptions = new CaseInsensitiveMap(options)
         val outputPath = {
-          val path = new Path(caseInsensitiveOptions.getOrElse("path", {
+          val path = new Path(options.getOrElse("path", {
             throw new IllegalArgumentException("'path' is not specified")
           }))
           val fs = path.getFileSystem(sparkSession.sessionState.newHadoopConf())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -104,7 +104,7 @@ class FileStreamSource(
     val files = metadataLog.get(Some(startId + 1), Some(endId)).flatMap(_._2)
     logInfo(s"Processing ${files.length} files from ${startId + 1}:$endId")
     logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
-    val newOptions = new CaseInsensitiveMap(options).filterKeys(_ != "path")
+    val newOptions = options.filterKeys(_ != "path")
     val newDataSource =
       DataSource(
         sparkSession,
@@ -133,8 +133,7 @@ class FileStreamSource(
   }
 
   private def getMaxFilesPerBatch(): Option[Int] = {
-    new CaseInsensitiveMap(options)
-      .get("maxFilesPerTrigger")
+    options.get("maxFilesPerTrigger")
       .map { str =>
         Try(str.toInt).toOption.filter(_ > 0).getOrElse {
           throw new IllegalArgumentException(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.CaseInsensitiveMap
 import org.apache.spark.sql.hive.client.HiveClient
 import org.apache.spark.sql.internal.HiveSerDe
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -246,7 +245,7 @@ private[spark] class HiveExternalCatalog(client: HiveClient, hadoopConf: Configu
 
       val qualifiedTableName = tableDefinition.identifier.quotedString
       val maybeSerde = HiveSerDe.sourceToSerDe(tableDefinition.provider.get)
-      val maybePath = new CaseInsensitiveMap(tableDefinition.storage.properties).get("path")
+      val maybePath = tableDefinition.storage.properties.get("path")
       val skipHiveMetadata = tableDefinition.storage.properties
         .getOrElse("skipHiveMetadata", "false").toBoolean
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We don't have a clear definition about When data source options should be case sensitive and when not. Currently `path` is case-insensitive, `numFeatures` in LibSVMFileFormat is case-sensitive, `maxFilesPerTrigger` in FileStreamSource is case-insensitive, etc.

Instead of letting every conf decide whether they should be case-sensitive or not themselves, I think it's better to make it clear that all data source options are case-insensitive.
## How was this patch tested?

existing tests.
