### PR TITLE
[SPARK-17205] Literal.sql should handle Infinity and NaN

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -251,8 +251,21 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression with 
     case (v: Short, ShortType) => v + "S"
     case (v: Long, LongType) => v + "L"
     // Float type doesn't have a suffix
-    case (v: Float, FloatType) => s"CAST($v AS ${FloatType.sql})"
-    case (v: Double, DoubleType) => v + "D"
+    case (v: Float, FloatType) =>
+      val castedValue = v match {
+        case _ if v.isNaN => "'NaN'"
+        case Float.PositiveInfinity => "'Infinity'"
+        case Float.NegativeInfinity => "'-Infinity'"
+        case _ => v
+      }
+      s"CAST($castedValue AS ${FloatType.sql})"
+    case (v: Double, DoubleType) =>
+      v match {
+        case _ if v.isNaN => s"CAST('NaN' AS ${DoubleType.sql})"
+        case Double.PositiveInfinity => s"CAST('Infinity' AS ${DoubleType.sql})"
+        case Double.NegativeInfinity => s"CAST('-Infinity' AS ${DoubleType.sql})"
+        case _ => v + "D"
+      }
     case (v: Decimal, t: DecimalType) => s"CAST($v AS ${t.sql})"
     case (v: Int, DateType) => s"DATE '${DateTimeUtils.toJavaDate(v)}'"
     case (v: Long, TimestampType) => s"TIMESTAMP('${DateTimeUtils.toJavaTimestamp(v)}')"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/ExpressionSQLBuilderSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/catalyst/ExpressionSQLBuilderSuite.scala
@@ -32,7 +32,13 @@ class ExpressionSQLBuilderSuite extends SQLBuilderTest {
     checkSQL(Literal(4: Int), "4")
     checkSQL(Literal(8: Long), "8L")
     checkSQL(Literal(1.5F), "CAST(1.5 AS FLOAT)")
+    checkSQL(Literal(Float.PositiveInfinity), "CAST('Infinity' AS FLOAT)")
+    checkSQL(Literal(Float.NegativeInfinity), "CAST('-Infinity' AS FLOAT)")
+    checkSQL(Literal(Float.NaN), "CAST('NaN' AS FLOAT)")
     checkSQL(Literal(2.5D), "2.5D")
+    checkSQL(Literal(Double.PositiveInfinity), "CAST('Infinity' AS DOUBLE)")
+    checkSQL(Literal(Double.NegativeInfinity), "CAST('-Infinity' AS DOUBLE)")
+    checkSQL(Literal(Double.NaN), "CAST('NaN' AS DOUBLE)")
     checkSQL(
       Literal(Timestamp.valueOf("2016-01-01 00:00:00")), "TIMESTAMP('2016-01-01 00:00:00.0')")
     // TODO tests for decimals


### PR DESCRIPTION
This patch updates `Literal.sql` to properly generate SQL for `NaN` and `Infinity` float and double literals: these special values need to be handled differently from regular values, since simply appending a suffix to the value's `toString()` representation will not work for these values.
