### PR TITLE
[SPARK-17174][SQL] Correct usages and documenations for functions returning date types which truncate time part

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -74,9 +74,11 @@ case class CurrentTimestamp() extends LeafExpression with CodegenFallback {
 /**
  * Adds a number of days to startdate.
  */
+// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(start_date, num_days) - Returns the date that is num_days after start_date.",
+  usage = "_FUNC_(start_date, num_days) - Returns the date that is num_days after start_date. The time part of start_date is ignored.",
   extended = "> SELECT _FUNC_('2016-07-30', 1);\n '2016-07-31'")
+// scalastyle:on line.size.limit
 case class DateAdd(startDate: Expression, days: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 
@@ -103,9 +105,11 @@ case class DateAdd(startDate: Expression, days: Expression)
 /**
  * Subtracts a number of days to startdate.
  */
+// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(start_date, num_days) - Returns the date that is num_days before start_date.",
+  usage = "_FUNC_(start_date, num_days) - Returns the date that is num_days before start_date. The time part of start_date is ignored.",
   extended = "> SELECT _FUNC_('2016-07-30', 1);\n '2016-07-29'")
+// scalastyle:on line.size.limit
 case class DateSub(startDate: Expression, days: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
   override def left: Expression = startDate
@@ -585,9 +589,11 @@ case class FromUnixTime(sec: Expression, format: Expression)
 /**
  * Returns the last day of the month which the date belongs to.
  */
+// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(date) - Returns the last day of the month which the date belongs to.",
+  usage = "_FUNC_(start_date) - Returns the last day of the month which the start_date belongs to. The time part of start_date is ignored.",
   extended = "> SELECT _FUNC_('2009-01-12');\n '2009-01-31'")
+// scalastyle:on line.size.limit
 case class LastDay(startDate: Expression) extends UnaryExpression with ImplicitCastInputTypes {
   override def child: Expression = startDate
 
@@ -616,7 +622,7 @@ case class LastDay(startDate: Expression) extends UnaryExpression with ImplicitC
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(start_date, day_of_week) - Returns the first date which is later than start_date and named as indicated.",
+  usage = "_FUNC_(start_date, day_of_week) - Returns the first date which is later than start_date and named as indicated. The time part of start_date is ignored.",
   extended = "> SELECT _FUNC_('2015-01-14', 'TU');\n '2015-01-20'")
 // scalastyle:on line.size.limit
 case class NextDay(startDate: Expression, dayOfWeek: Expression)
@@ -783,9 +789,11 @@ case class TimeSub(start: Expression, interval: Expression)
 /**
  * Returns the date that is num_months after start_date.
  */
+// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(start_date, num_months) - Returns the date that is num_months after start_date.",
+  usage = "_FUNC_(start_date, num_months) - Returns the date that is num_months after start_date. The time part of start_date is ignored.",
   extended = "> SELECT _FUNC_('2016-08-31', 1);\n '2016-09-30'")
+// scalastyle:on line.size.limit
 case class AddMonths(startDate: Expression, numMonths: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 
@@ -895,9 +903,11 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
 /**
  * Returns the date part of a timestamp or string.
  */
+// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Extracts the date part of the date or datetime expression expr.",
+  usage = "_FUNC_(expr) - Extracts the date part of the date or datetime expression expr. The time part of the date is ignored.",
   extended = "> SELECT _FUNC_('2009-07-30 04:17:52');\n '2009-07-30'")
+// scalastyle:on line.size.limit
 case class ToDate(child: Expression) extends UnaryExpression with ImplicitCastInputTypes {
 
   // Implicit casting of spark will accept string in both date and timestamp format, as
@@ -920,7 +930,7 @@ case class ToDate(child: Expression) extends UnaryExpression with ImplicitCastIn
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(date, fmt) - Returns returns date with the time portion of the day truncated to the unit specified by the format model fmt.",
+  usage = "_FUNC_(date, fmt) - Returns returns date with the time portion of the day truncated to the unit specified by the format model fmt. The time part of the date is ignored.",
   extended = "> SELECT _FUNC_('2009-02-12', 'MM')\n '2009-02-01'\n> SELECT _FUNC_('2015-10-27', 'YEAR');\n '2015-01-01'")
 // scalastyle:on line.size.limit
 case class TruncDate(date: Expression, format: Expression)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the documentation about functions returning `DateType`s to mention the time part will be truncated.

Currently, the functions, `add_months`, `date_add`, `date_sub`, `last_day`, `next_day`, `to_date` and `trunc` can take `TimestampType` or string representation including time part as below:

``` scala
val df = Seq(Tuple1(Timestamp.valueOf("2012-07-16 12:12:12"))).toDF("ts")
df.selectExpr("ts", "add_months(ts, 1)", "date_add(ts, 1)", "date_sub(ts, 1)").show()
df.selectExpr("ts", "last_day(ts)", """next_day(ts, "TU")""", "to_date(ts)", """trunc(ts, "MM")""").show()
```

However, for those functions, the time part is truncated as below:

```
+--------------------+-------------------------------+-----------------------------+-----------------------------+
|                  ts|add_months(CAST(ts AS DATE), 1)|date_add(CAST(ts AS DATE), 1)|date_sub(CAST(ts AS DATE), 1)|
+--------------------+-------------------------------+-----------------------------+-----------------------------+
|2012-07-16 12:12:...|                     2012-08-16|                   2012-07-17|                   2012-07-15|
+--------------------+-------------------------------+-----------------------------+-----------------------------+

+--------------------+--------------------------+------------------------------+-------------------------+---------------------------+
|                  ts|last_day(CAST(ts AS DATE))|next_day(CAST(ts AS DATE), TU)|to_date(CAST(ts AS DATE))|trunc(CAST(ts AS DATE), MM)|
+--------------------+--------------------------+------------------------------+-------------------------+---------------------------+
|2012-07-16 12:12:...|                2012-07-31|                    2012-07-17|               2012-07-16|                 2012-07-01|
+--------------------+--------------------------+------------------------------+-------------------------+---------------------------+
```

In user's perspective, this might be weird and look undocumented behaviour (just like this JIRA was open). As a reference, Hive is mentioning this behaviour, https://github.com/apache/hive/blob/26b5c7b56a4f28ce3eabc0207566cce46b29b558/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFAddMonths.java#L48-L51
## How was this patch tested?

N/A
