### PR TITLE
[SPARK-17210][SPARKR] sparkr.zip is not distributed to executors when running sparkr in RStudio

### DIFF
--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -368,6 +368,30 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
+<<<<<<< 8f0c35a4d0dd458719627be5f524792bf244d70a
+=======
+  if (nzchar(master)) {
+    assign("spark.master", master, envir = sparkConfigMap)
+  }
+
+  # do not download if it is run in the sparkR shell
+  if (!nzchar(master) || is_master_local(master)) {
+    if (!is_sparkR_shell()) {
+      if (is.na(file.info(sparkHome)$isdir)) {
+        msg <- paste0("Spark not found in SPARK_HOME: ",
+                      sparkHome,
+                      " .\nTo search in the cache directory. ",
+                      "Installation will start if not found.")
+        message(msg)
+        packageLocalDir <- install.spark()
+        sparkHome <- packageLocalDir
+      } else {
+        msg <- paste0("Spark package is found in SPARK_HOME: ", sparkHome)
+        message(msg)
+      }
+    }
+  }
+>>>>>>> [SPARK-17210][SPARKR] sparkr.zip is not distributed to executors when run sparkr in RStudio
 
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
     retHome <- sparkCheckInstall(sparkHome, master)
@@ -491,6 +515,10 @@ sparkConfToSubmitOps[["spark.driver.memory"]]           <- "--driver-memory"
 sparkConfToSubmitOps[["spark.driver.extraClassPath"]]   <- "--driver-class-path"
 sparkConfToSubmitOps[["spark.driver.extraJavaOptions"]] <- "--driver-java-options"
 sparkConfToSubmitOps[["spark.driver.extraLibraryPath"]] <- "--driver-library-path"
+sparkConfToSubmitOps[["spark.master"]] <- "--master"
+sparkConfToSubmitOps[["spark.yarn.keytab"]] <- "--keytab"
+sparkConfToSubmitOps[["spark.yarn.principal"]] <- "--principal"
+
 
 # Utility function that returns Spark Submit arguments as a string
 #
@@ -566,3 +594,12 @@ sparkCheckInstall <- function(sparkHome, master) {
     NULL
   }
 }
+
+# Utility function for print enviroment
+printEnvs <- function(env) {
+  envNames <- names(env)
+  for (envName in envNames) {
+    cat(paste0(envName, "=",env[[envName]], "\n"))
+  }
+}
+

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -368,30 +368,6 @@ sparkR.session <- function(
     }
     overrideEnvs(sparkConfigMap, paramMap)
   }
-<<<<<<< 8f0c35a4d0dd458719627be5f524792bf244d70a
-=======
-  if (nzchar(master)) {
-    sparkConfigMap[["spark.master"]] <- master
-  }
-
-  # do not download if it is run in the sparkR shell
-  if (!nzchar(master) || is_master_local(master)) {
-    if (!is_sparkR_shell()) {
-      if (is.na(file.info(sparkHome)$isdir)) {
-        msg <- paste0("Spark not found in SPARK_HOME: ",
-                      sparkHome,
-                      " .\nTo search in the cache directory. ",
-                      "Installation will start if not found.")
-        message(msg)
-        packageLocalDir <- install.spark()
-        sparkHome <- packageLocalDir
-      } else {
-        msg <- paste0("Spark package is found in SPARK_HOME: ", sparkHome)
-        message(msg)
-      }
-    }
-  }
->>>>>>> [SPARK-17210][SPARKR] sparkr.zip is not distributed to executors when run sparkr in RStudio
 
   if (!exists(".sparkRjsc", envir = .sparkREnv)) {
     retHome <- sparkCheckInstall(sparkHome, master)

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -599,7 +599,6 @@ sparkCheckInstall <- function(sparkHome, master) {
 printEnvs <- function(env) {
   envNames <- names(env)
   for (envName in envNames) {
-    cat(paste0(envName, "=",env[[envName]], "\n"))
+    cat(paste0(envName, "=", env[[envName]], "\n"))
   }
 }
-

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -371,7 +371,7 @@ sparkR.session <- function(
 <<<<<<< 8f0c35a4d0dd458719627be5f524792bf244d70a
 =======
   if (nzchar(master)) {
-    assign("spark.master", master, envir = sparkConfigMap)
+    sparkConfigMap[["spark.master"]] <- master
   }
 
   # do not download if it is run in the sparkR shell
@@ -592,13 +592,5 @@ sparkCheckInstall <- function(sparkHome, master) {
     }
   } else {
     NULL
-  }
-}
-
-# Utility function for print enviroment
-printEnvs <- function(env) {
-  envNames <- names(env)
-  for (envName in envNames) {
-    cat(paste0(envName, "=", env[[envName]], "\n"))
   }
 }

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -63,6 +63,21 @@ The following Spark driver properties can be set in `sparkConfig` with `sparkR.s
 <table class="table">
   <tr><th>Property Name</th><th>Property group</th><th><code>spark-submit</code> equivalent</th></tr>
   <tr>
+    <td><code>spark.master</code></td>
+    <td>Application Properties</td>
+    <td><code>--master</code></td>
+  </tr>
+  <tr>
+    <td><code>spark.yarn.keytab</code></td>
+    <td>Application Properties</td>
+    <td><code>--keytab</code></td>
+  </tr>
+  <tr>
+    <td><code>spark.yarn.principal</code></td>
+    <td>Application Properties</td>
+    <td><code>--principal</code></td>
+  </tr>
+  <tr>
     <td><code>spark.driver.memory</code></td>
     <td>Application Properties</td>
     <td><code>--driver-memory</code></td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark will add sparkr.zip to archive only when it is yarn mode (SparkSubmit.scala).

```
    if (args.isR && clusterManager == YARN) {
      val sparkRPackagePath = RUtils.localSparkRPackagePath
      if (sparkRPackagePath.isEmpty) {
        printErrorAndExit("SPARK_HOME does not exist for R application in YARN mode.")
      }
      val sparkRPackageFile = new File(sparkRPackagePath.get, SPARKR_PACKAGE_ARCHIVE)
      if (!sparkRPackageFile.exists()) {
        printErrorAndExit(s"$SPARKR_PACKAGE_ARCHIVE does not exist for R application in YARN mode.")
      }
      val sparkRPackageURI = Utils.resolveURI(sparkRPackageFile.getAbsolutePath).toString

      // Distribute the SparkR package.
      // Assigns a symbol link name "sparkr" to the shipped package.
      args.archives = mergeFileLists(args.archives, sparkRPackageURI + "#sparkr")

      // Distribute the R package archive containing all the built R packages.
      if (!RUtils.rPackages.isEmpty) {
        val rPackageFile =
          RPackageUtils.zipRLibraries(new File(RUtils.rPackages.get), R_PACKAGE_ARCHIVE)
        if (!rPackageFile.exists()) {
          printErrorAndExit("Failed to zip all the built R packages.")
        }

        val rPackageURI = Utils.resolveURI(rPackageFile.getAbsolutePath).toString
        // Assigns a symbol link name "rpkg" to the shipped package.
        args.archives = mergeFileLists(args.archives, rPackageURI + "#rpkg")
      }
    }
```

So it is necessary to pass spark.master from R process to JVM. Otherwise sparkr.zip won't be distributed to executor.  Besides that I also pass spark.yarn.keytab/spark.yarn.principal to spark side, because JVM process need them to access secured cluster. 
## How was this patch tested?

Verify it manually in R Studio using the following code.

```
Sys.setenv(SPARK_HOME="/Users/jzhang/github/spark")
.libPaths(c(file.path(Sys.getenv(), "R", "lib"), .libPaths()))
library(SparkR)
sparkR.session(master="yarn-client", sparkConfig = list(spark.executor.instances="1"))
df <- as.DataFrame(mtcars)
head(df)

```

… 
