### PR TITLE
[SPARK-17209][YARN] Add the ability to manually update credentials for Spark running on YARN

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -138,7 +138,7 @@ class SparkHadoopUtil extends Logging {
   }
 
   /**
-   * Update credentials manually. This will trigger AM will renew the credentials immediately,
+   * Update credentials manually. This will trigger AM to renew the credentials immediately,
    * also executors and driver (in client mode) will update the credentials accordingly.
    *
    * Note this will only be worked under YARN cluster manager.

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -24,6 +24,7 @@ import java.text.DateFormat
 import java.util.{Arrays, Comparator, Date, Locale}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 import com.google.common.primitives.Longs
@@ -143,7 +144,10 @@ class SparkHadoopUtil extends Logging {
    *
    * Note this will only be worked under YARN cluster manager.
    */
-  def updateCredentials(sc: SparkContext): Unit = { }
+  def updateCredentials(sc: SparkContext): Future[Boolean] = {
+    throw new UnsupportedOperationException("updateCredentials can only be used under YARN " +
+      "cluster manager")
+  }
 
   /**
    * Returns a function that can be called to find Hadoop FileSystem bytes read. If

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -138,10 +138,10 @@ class SparkHadoopUtil extends Logging {
   }
 
   /**
-   * Update credentials manually. When this method is invoked AM will renew the credentials,
-   * executors and driver (in client mode) will update the credentials accordingly.
+   * Update credentials manually. This will trigger AM will renew the credentials immediately,
+   * also executors and driver (in client mode) will update the credentials accordingly.
    *
-   * Note this will only be worked in YARN cluster manager.
+   * Note this will only be worked under YARN cluster manager.
    */
   def updateCredentials(sc: SparkContext): Unit = { }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -35,7 +35,7 @@ import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkContext, SparkException}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
@@ -136,6 +136,14 @@ class SparkHadoopUtil extends Logging {
   def loginUserFromKeytab(principalName: String, keytabFilename: String) {
     UserGroupInformation.loginUserFromKeytab(principalName, keytabFilename)
   }
+
+  /**
+   * Update credentials manually. When this method is invoked AM will renew the credentials,
+   * executors and driver (in client mode) will update the credentials accordingly.
+   *
+   * Note this will only be worked in YARN cluster manager.
+   */
+  def updateCredentials(sc: SparkContext): Unit = { }
 
   /**
    * Returns a function that can be called to find Hadoop FileSystem bytes read. If
@@ -320,6 +328,11 @@ class SparkHadoopUtil extends Logging {
    * Stop the thread that does the credential updates.
    */
   private[spark] def stopCredentialUpdater() {}
+
+  /**
+   * Manually trigger the credential updater to update the credentials immediately.
+   */
+  private[spark] def triggerCredentialUpdater() {}
 
   /**
    * Return a fresh Hadoop configuration, bypassing the HDFS cache mechanism.

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -123,6 +123,9 @@ private[spark] class CoarseGrainedExecutorBackend(
           executor.stop()
         }
       }.start()
+
+    case UpdateCredentials =>
+      SparkHadoopUtil.get.triggerCredentialUpdater()
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -123,9 +123,12 @@ private[spark] class CoarseGrainedExecutorBackend(
           executor.stop()
         }
       }.start()
+  }
 
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
     case UpdateCredentials =>
       SparkHadoopUtil.get.triggerCredentialUpdater()
+      context.reply(true)
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -106,4 +106,7 @@ private[spark] object CoarseGrainedClusterMessages {
   // Used internally by executors to shut themselves down.
   case object Shutdown extends CoarseGrainedClusterMessage
 
+  // Used to update credentials for Spark on YARN, exchanged between driver and AM, driver and
+  // executors.
+  case object UpdateCredentials extends CoarseGrainedClusterMessage
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -24,6 +24,8 @@ import javax.annotation.concurrent.GuardedBy
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
+import scala.util.control.NonFatal
 
 import org.apache.spark.{ExecutorAllocationClient, SparkEnv, SparkException, TaskState}
 import org.apache.spark.internal.Logging
@@ -67,7 +69,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // must be protected by `CoarseGrainedSchedulerBackend.this`. Besides, `executorDataMap` should
   // only be modified in `DriverEndpoint.receive/receiveAndReply` with protection by
   // `CoarseGrainedSchedulerBackend.this`.
-  protected val executorDataMap = new HashMap[String, ExecutorData]
+  private val executorDataMap = new HashMap[String, ExecutorData]
 
   // Number of executors requested from the cluster manager that have not registered yet
   @GuardedBy("CoarseGrainedSchedulerBackend.this")
@@ -208,6 +210,19 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
       case RetrieveSparkProps =>
         context.reply(sparkProperties)
+
+      case UpdateCredentials =>
+        val futures = executorDataMap.map { case (_, executorData) =>
+          executorData.executorEndpoint.ask[Boolean](UpdateCredentials)
+        }
+
+        implicit val executorContext = ThreadUtils.sameThread
+        Future.sequence(futures)
+          .map { booleans => booleans.reduce(_ && _) }
+          .andThen {
+            case Success(b) => context.reply(b)
+            case Failure(NonFatal(e)) => context.sendFailure(e)
+          }
     }
 
     // Make fake resource offers on all executors

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -67,7 +67,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // must be protected by `CoarseGrainedSchedulerBackend.this`. Besides, `executorDataMap` should
   // only be modified in `DriverEndpoint.receive/receiveAndReply` with protection by
   // `CoarseGrainedSchedulerBackend.this`.
-  private val executorDataMap = new HashMap[String, ExecutorData]
+  protected val executorDataMap = new HashMap[String, ExecutorData]
 
   // Number of executors requested from the cluster manager that have not registered yet
   @GuardedBy("CoarseGrainedSchedulerBackend.this")

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -721,6 +721,16 @@ private[spark] class ApplicationMaster(
           case None =>
             logWarning("Container allocator is not ready to find executor loss reasons yet.")
         }
+
+      case UpdateCredentials =>
+        logInfo("Driver request to update credentials")
+        Option(credentialRenewer) match {
+          case Some(r) =>
+            r.renewCredentials()
+            context.reply(true)
+          case None =>
+            context.reply(false)
+        }
     }
 
     override def onDisconnected(remoteAddress: RpcAddress): Unit = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -23,6 +23,7 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 import scala.collection.mutable.{HashMap, ListBuffer}
+import scala.concurrent.Future
 import scala.util.Try
 
 import org.apache.hadoop.conf.Configuration
@@ -90,7 +91,7 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
     if (credentials != null) credentials.getSecretKey(new Text(key)) else null
   }
 
-  override def updateCredentials(sc: SparkContext): Unit = {
+  override def updateCredentials(sc: SparkContext): Future[Boolean] = {
     val sparkConf = sc.conf
     require(sparkConf.get(PRINCIPAL).isDefined && sparkConf.get(KEYTAB).isDefined,
       s"${PRINCIPAL.key} and ${KEYTAB.key} should be set to update credentials")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR propose to add a new API in `SparkHadoopUtil` to trigger manual credential updating in the run-time.

This is mainly used in long running spark applications which needs to access different secured system in the run-time. For example, when Zeppelin / Spark Shell needs to access different secured HBase cluster or Hive metastore service in the run-time, it requires tokens from new services and updates to executors immediately. Previously either we need to relaunch the application to get new tokens, or we need to wait until the old tokens to expire to get new ones. 

With this new API, user could manually trigger credential updating in the run-time when required. Credentials will be renewed in AM and updated in executor and driver side.
## How was this patch tested?

Manually verified in the secured cluster.
