### PR TITLE
[SPARK-17216][UI] fix event timeline bars length

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
@@ -83,6 +83,10 @@ rect.getting-result-time-proportion {
   stroke: #75B0A6;
 }
 
+.vis-item .vis-item-content {
+    width: 100%
+}
+
 .vis.timeline {
   line-height: 14px;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make event timeline bar expand to full length of the bar (which is total time)

This issue occurs only on chrome, firefox looks fine. Haven't tested other browsers.
## How was this patch tested?

Inspection in browsers

Before 
![screen shot 2016-08-24 at 3 38 24 pm](https://cloud.githubusercontent.com/assets/512084/17935104/0d6cda74-6a12-11e6-9c66-e00cfa855606.png)

After
![screen shot 2016-08-24 at 3 36 39 pm](https://cloud.githubusercontent.com/assets/512084/17935114/15740ea4-6a12-11e6-83a1-7c06eef6abb8.png)
