### PR TITLE
[SPARK-17247][SQL]: when calcualting size of a relation from hdfs, th…

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -73,6 +73,7 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton with SQLTestUtils
   test("MetastoreRelations fallback to HDFS for size estimation") {
     val enableFallBackToHdfsForStats = spark.sessionState.conf.fallBackToHdfsForStatsEnabled
     val autoBroadCastThreshold = spark.sessionState.conf.autoBroadcastJoinThreshold
+    val defaultSize = spark.sessionState.conf.defaultSizeInBytes
     try {
       withTempDir { tempDir =>
 
@@ -114,7 +115,7 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton with SQLTestUtils
         spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, file1.length() - 1)
         relation = spark.sessionState.catalog.lookupRelation(TableIdentifier("csv_table"))
           .asInstanceOf[MetastoreRelation]
-        assert(relation.statistics.sizeInBytes === BigInt(file1.length()))
+        assert(relation.statistics.sizeInBytes === BigInt(defaultSize))
       }
     } finally {
       spark.conf.set(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key, enableFallBackToHdfsForStats)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -72,6 +72,7 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton with SQLTestUtils
 
   test("MetastoreRelations fallback to HDFS for size estimation") {
     val enableFallBackToHdfsForStats = spark.sessionState.conf.fallBackToHdfsForStatsEnabled
+    val autoBroadCastThreshold = spark.sessionState.conf.autoBroadcastJoinThreshold
     try {
       withTempDir { tempDir =>
 
@@ -99,7 +100,7 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton with SQLTestUtils
 
         spark.conf.set(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key, true)
 
-        val relation = spark.sessionState.catalog.lookupRelation(TableIdentifier("csv_table"))
+        var relation = spark.sessionState.catalog.lookupRelation(TableIdentifier("csv_table"))
           .asInstanceOf[MetastoreRelation]
 
         val properties = relation.hiveQlTable.getParameters
@@ -108,9 +109,16 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton with SQLTestUtils
 
         val sizeInBytes = relation.statistics.sizeInBytes
         assert(sizeInBytes === BigInt(file1.length() + file2.length()))
+
+        // Ensure fall back to hdfs stops calculating size once size is > threshold.
+        spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, file1.length() - 1)
+        relation = spark.sessionState.catalog.lookupRelation(TableIdentifier("csv_table"))
+          .asInstanceOf[MetastoreRelation]
+        assert(relation.statistics.sizeInBytes === BigInt(file1.length()))
       }
     } finally {
       spark.conf.set(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key, enableFallBackToHdfsForStats)
+      spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, autoBroadCastThreshold)
       sql("DROP TABLE csv_table ")
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

when calcualting size of a relation from hdfs, the size calculation should be aborted once size is established to be > broadcast threshold. This will be really helpful when the config is enabled and one of the tables in query is partitioned and fairly large.
## How was this patch tested?

Unit test modified.
