### PR TITLE
[SPARK-17259] [build] Hadoop 2.7 profile to depend on Hadoop 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2511,6 +2511,9 @@
 
     <profile>
       <id>hadoop-2.7</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <hadoop.version>2.7.3</hadoop.version>
         <jets3t.version>0.9.3</jets3t.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2512,7 +2512,7 @@
     <profile>
       <id>hadoop-2.7</id>
       <properties>
-        <hadoop.version>2.7.2</hadoop.version>
+        <hadoop.version>2.7.3</hadoop.version>
         <jets3t.version>0.9.3</jets3t.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <curator.version>2.6.0</curator.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

increment the `hadoop.version` value in the `hadoop-2.7` profile from 2.7.2 to 2.7.3

This switches to the latest release in the 2.7.x line. Bug fixes, continued compatibility with Java 7.
## How was this patch tested?

spark unit tests system tests performed on the version of spark created with this profile enabled
