### PR TITLE
[SPARK-17255] [Core] Spark queries inside Futures occasionally fail due to missing class definitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1212,7 +1212,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       minPartitions: Int = defaultMinPartitions): RDD[T] = withScope {
     assertNotStopped()
     sequenceFile(path, classOf[NullWritable], classOf[BytesWritable], minPartitions)
-      .flatMap(x => Utils.deserialize[Array[T]](x._2.getBytes, Utils.getContextOrSparkClassLoader))
+      .flatMap(x => Utils.deserialize[Array[T]](x._2.getBytes, Utils.getSparkClassLoader))
   }
 
   protected[spark] def checkpointFile[T: ClassTag](path: String): RDD[T] = withScope {
@@ -2543,7 +2543,7 @@ object SparkContext extends Logging {
   }
 
   private def getClusterManager(url: String): Option[ExternalClusterManager] = {
-    val loader = Utils.getContextOrSparkClassLoader
+    val loader = Utils.getSparkClassLoader
     val serviceLoaders =
     ServiceLoader.load(classOf[ExternalClusterManager], loader).asScala.filter(_.canCreate(url))
     if (serviceLoaders.size > 1) {

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -427,7 +427,7 @@ private[spark] class Executor(
       currentJars(url.getPath().split("/").last) = now
     }
 
-    val currentLoader = Utils.getContextOrSparkClassLoader
+    val currentLoader = Utils.getSparkClassLoader
 
     // For each of the jars in the jarSet, add them to the class loader.
     // We assume each of the files has already been fetched.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -122,7 +122,7 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
     try {
       getTaskResultExecutor.execute(new Runnable {
         override def run(): Unit = Utils.logUncaughtExceptions {
-          val loader = Utils.getContextOrSparkClassLoader
+          val loader = Utils.getSparkClassLoader
           try {
             if (serializedData != null && serializedData.limit() > 0) {
               reason = serializer.get().deserialize[TaskEndReason](

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -169,7 +169,7 @@ private[spark] object SparkUI {
       None, conf, listenerBus, securityManager, appName, basePath, startTime = startTime)
 
     val listenerFactories = ServiceLoader.load(classOf[SparkHistoryListenerFactory],
-      Utils.getContextOrSparkClassLoader).asScala
+      Utils.getSparkClassLoader).asScala
     listenerFactories.foreach { listenerFactory =>
       val listeners = listenerFactory.createListeners(conf, sparkUI)
       listeners.foreach(listenerBus.addListener)

--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -429,7 +429,7 @@ private class InnerClosureFinder(output: Set[Class[_]]) extends ClassVisitor(ASM
           output += Class.forName(
               owner.replace('/', '.'),
               false,
-              Thread.currentThread.getContextClassLoader)
+              getClass.getClassLoader)
           // scalastyle:on classforname
         }
       }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -215,14 +215,14 @@ private[spark] object Utils extends Logging {
   /** Determines whether the provided class is loadable in the current thread. */
   def classIsLoadable(clazz: String): Boolean = {
     // scalastyle:off classforname
-    Try { Class.forName(clazz, false, getContextOrSparkClassLoader) }.isSuccess
+    Try { Class.forName(clazz, false, getSparkClassLoader) }.isSuccess
     // scalastyle:on classforname
   }
 
   // scalastyle:off classforname
   /** Preferred alternative to Class.forName(className) */
   def classForName(className: String): Class[_] = {
-    Class.forName(className, true, getContextOrSparkClassLoader)
+    Class.forName(className, true, getSparkClassLoader)
     // scalastyle:on classforname
   }
 

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -185,7 +185,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     val original = Thread.currentThread().getContextClassLoader
     val className = "FileSuiteObjectFileTest"
     val jar = TestUtils.createJarWithClasses(Seq(className))
-    val loader = new java.net.URLClassLoader(Array(jar), Utils.getContextOrSparkClassLoader)
+    val loader = new java.net.URLClassLoader(Array(jar), Utils.getSparkClassLoader)
     Thread.currentThread().setContextClassLoader(loader)
     try {
       sc = new SparkContext("local", "test")

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerDistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerDistributedSuite.scala
@@ -36,7 +36,7 @@ class KryoSerializerDistributedSuite extends SparkFunSuite with LocalSparkContex
 
     sc = new SparkContext("local-cluster[2,1,1024]", "test", conf)
     val original = Thread.currentThread.getContextClassLoader
-    val loader = new java.net.URLClassLoader(Array(jar), Utils.getContextOrSparkClassLoader)
+    val loader = new java.net.URLClassLoader(Array(jar), Utils.getSparkClassLoader)
     SparkEnv.get.serializer.setDefaultClassLoader(loader)
 
     val cachedRDD = sc.parallelize((0 until 10).map((_, new MyCustomClass)), 3).cache()

--- a/core/src/test/scala/org/apache/spark/util/MutableURLClassLoaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/MutableURLClassLoaderSuite.scala
@@ -114,7 +114,7 @@ class MutableURLClassLoaderSuite extends SparkFunSuite with Matchers {
 
     val className = "ClassForDriverTest"
     val jar = TestUtils.createJarWithClasses(Seq(className))
-    val contextLoader = new URLClassLoader(Array(jar), Utils.getContextOrSparkClassLoader)
+    val contextLoader = new MutableURLClassLoader(Array(jar), Utils.getSparkClassLoader)
     Thread.currentThread().setContextClassLoader(contextLoader)
 
     val sc = new SparkContext("local", "driverLoaderTest")

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -140,7 +140,7 @@ class SparkILoop(
   private def history = in.history
 
   /** The context class loader at the time this object was created */
-  protected val originalClassLoader = Utils.getContextOrSparkClassLoader
+  protected val originalClassLoader = Utils.getSparkClassLoader
 
   // classpath entries added via :cp
   private var addedClasspath: String = ""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -43,7 +43,7 @@ object ScalaReflection extends ScalaReflection {
   // class loader of the current thread.
   // SPARK-13640: Synchronize this because universe.runtimeMirror is not thread-safe in Scala 2.10.
   override def mirror: universe.Mirror = ScalaReflectionLock.synchronized {
-    universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
+    universe.runtimeMirror(getClass.getClassLoader)
   }
 
   import universe._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -108,7 +108,7 @@ object ExpressionEncoder {
         StructField(s"_${i + 1}", dataType, nullable)
     })
 
-    val cls = Utils.getContextOrSparkClassLoader.loadClass(s"scala.Tuple${encoders.size}")
+    val cls = Utils.getSparkClassLoader.loadClass(s"scala.Tuple${encoders.size}")
 
     val serializer = encoders.zipWithIndex.map { case (enc, index) =>
       val originalInputObject = enc.serializer.head.collect { case b: BoundReference => b }.head

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -854,7 +854,7 @@ object CodeGenerator extends Logging {
     // find other possible classes (see org.codehaus.janinoClassLoaderIClassLoader's
     // findIClass method). Please also see https://issues.apache.org/jira/browse/SPARK-15622 and
     // https://issues.apache.org/jira/browse/SPARK-11636.
-    val parentClassLoader = new ParentClassLoader(Utils.getContextOrSparkClassLoader)
+    val parentClassLoader = new ParentClassLoader(Utils.getSparkClassLoader)
     evaluator.setParentClassLoader(parentClassLoader)
     // Cannot be under package codegen, or fail with java.lang.InstantiationException
     evaluator.setClassName("org.apache.spark.sql.catalyst.expressions.GeneratedClass")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -313,7 +313,7 @@ class ScalaReflectionSuite extends SparkFunSuite {
       case (name, exec) =>
         test(s"SPARK-13640: thread safety of ${name}") {
           (0 until 100).foreach { _ =>
-            val loader = new URLClassLoader(Array.empty, Utils.getContextOrSparkClassLoader)
+            val loader = new URLClassLoader(Array.empty, Utils.getSparkClassLoader)
             (0 until 10).par.foreach { _ =>
               val cl = Thread.currentThread.getContextClassLoader
               try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -121,7 +121,7 @@ case class DataSource(
   private def lookupDataSource(provider0: String): Class[_] = {
     val provider = backwardCompatibilityMap.getOrElse(provider0, provider0)
     val provider2 = s"$provider.DefaultSource"
-    val loader = Utils.getContextOrSparkClassLoader
+    val loader = Utils.getSparkClassLoader
     val serviceLoader = ServiceLoader.load(classOf[DataSourceRegister], loader)
 
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/DriverRegistry.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/DriverRegistry.scala
@@ -35,7 +35,7 @@ object DriverRegistry extends Logging {
   private val wrapperMap: mutable.Map[String, DriverWrapper] = mutable.Map.empty
 
   def register(className: String): Unit = {
-    val cls = Utils.getContextOrSparkClassLoader.loadClass(className)
+    val cls = Utils.getSparkClassLoader.loadClass(className)
     if (cls.getClassLoader == null) {
       logTrace(s"$className has been loaded with bootstrap ClassLoader, wrapper is not required")
     } else if (wrapperMap.get(className).isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -48,7 +48,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   val listener: SQLListener = createListenerAndUI(sparkContext)
 
   {
-    val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
+    val configFile = Utils.getSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
       sparkContext.hadoopConfiguration.addResource(configFile)
     }
@@ -67,7 +67,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
    * A classloader used to load all user-added jar.
    */
   val jarClassLoader = new NonClosableMutableURLClassLoader(
-    org.apache.spark.util.Utils.getContextOrSparkClassLoader)
+    org.apache.spark.util.Utils.getSparkClassLoader)
 
   {
     // Set the Hive metastore warehouse path to the one we use

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -208,7 +208,7 @@ private[hive] object HiveShim {
 
         // deserialize the function object via Hive Utilities
         instance = deserializePlan[AnyRef](new java.io.ByteArrayInputStream(functionInBytes),
-          Utils.getContextOrSparkClassLoader.loadClass(functionClassName))
+          Utils.getSparkClassLoader.loadClass(functionClassName))
       }
     }
 
@@ -216,7 +216,7 @@ private[hive] object HiveShim {
       if (instance != null) {
         instance.asInstanceOf[UDFType]
       } else {
-        val func = Utils.getContextOrSparkClassLoader
+        val func = Utils.getSparkClassLoader
           .loadClass(functionClassName).newInstance.asInstanceOf[UDFType]
         if (!func.isInstanceOf[UDF]) {
           // We cache the function if it's no the Simple UDF,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -246,7 +246,7 @@ private[spark] object HiveUtils extends Logging {
       hadoopConf = hadoopConf,
       config = newTemporaryConfiguration(useInMemoryDerby = true),
       isolationOn = false,
-      baseClassLoader = Utils.getContextOrSparkClassLoader)
+      baseClassLoader = Utils.getSparkClassLoader)
     loader.createClient().asInstanceOf[HiveClientImpl]
   }
 
@@ -293,7 +293,7 @@ private[spark] object HiveUtils extends Logging {
         case other => allJars(other.getParent)
       }
 
-      val classLoader = Utils.getContextOrSparkClassLoader
+      val classLoader = Utils.getSparkClassLoader
       val jars = allJars(classLoader)
       if (jars.length == 0) {
         throw new IllegalArgumentException(

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -596,9 +596,9 @@ private[spark] class ApplicationMaster(
     }
     val userClassLoader =
       if (Client.isUserClassPathFirst(sparkConf, isDriver = true)) {
-        new ChildFirstURLClassLoader(urls, Utils.getContextOrSparkClassLoader)
+        new ChildFirstURLClassLoader(urls, Utils.getSparkClassLoader)
       } else {
-        new MutableURLClassLoader(urls, Utils.getContextOrSparkClassLoader)
+        new MutableURLClassLoader(urls, Utils.getSparkClassLoader)
       }
 
     var userArgs = args.userArgs

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -683,7 +683,7 @@ private[spark] class Client(
     // If user specify this file using --files then executors will use the one
     // from --files instead.
     for { prop <- Seq("log4j.properties", "metrics.properties")
-          url <- Option(Utils.getContextOrSparkClassLoader.getResource(prop))
+          url <- Option(Utils.getSparkClassLoader.getResource(prop))
           if url.getProtocol == "file" } {
       hadoopConfFiles(prop) = new File(url.getPath)
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/ConfigurableCredentialManager.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/ConfigurableCredentialManager.scala
@@ -47,7 +47,7 @@ private[yarn] final class ConfigurableCredentialManager(
   // Maintain all the registered credential providers
   private val credentialProviders = {
     val providers = ServiceLoader.load(classOf[ServiceCredentialProvider],
-      Utils.getContextOrSparkClassLoader).asScala
+      Utils.getSparkClassLoader).asScala
 
     // Filter out credentials in which spark.yarn.security.credentials.{service}.enabled is false.
     providers.filter { p =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/HiveCredentialProvider.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/HiveCredentialProvider.scala
@@ -39,7 +39,7 @@ private[security] class HiveCredentialProvider extends ServiceCredentialProvider
 
   private def hiveConf(hadoopConf: Configuration): Configuration = {
     try {
-      val mirror = universe.runtimeMirror(Utils.getContextOrSparkClassLoader)
+      val mirror = universe.runtimeMirror(Utils.getSparkClassLoader)
       // the hive configuration class is a subclass of Hadoop Configuration, so can be cast down
       // to a Configuration and used without reflection
       val hiveConfClass = mirror.classLoader.loadClass("org.apache.hadoop.hive.conf.HiveConf")
@@ -76,7 +76,7 @@ private[security] class HiveCredentialProvider extends ServiceCredentialProvider
     logDebug(s"Getting Hive delegation token for ${currentUser.getUserName()} against " +
       s"$principal at $metastoreUri")
 
-    val mirror = universe.runtimeMirror(Utils.getContextOrSparkClassLoader)
+    val mirror = universe.runtimeMirror(Utils.getSparkClassLoader)
     val hiveClass = mirror.classLoader.loadClass("org.apache.hadoop.hive.ql.metadata.Hive")
     val hiveConfClass = mirror.classLoader.loadClass("org.apache.hadoop.hive.conf.HiveConf")
     val closeCurrent = hiveClass.getMethod("closeCurrent")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use 
- getClass.getClassLoader instead of Thread.getCurrentThread.getContextClassLoader 
- Utils.getSparkClassLoader instead of Utils.getContextOrSparkClassLoader

to avoid situations where a thread from a thread pool does not have Spark jars in its class loader.

When Spark queries are run inside Futures using **scala.concurrent.ExecutionContext.Implicits.global** the threads offered by ForkJoinPool are occasionally not ones that have loaded Spark and despite class path definitions they might be missing Spark jars in their class loaders.

In our application we return Spark queries inside Futures. The query would sometimes fail as a result of packages missing from the thread's context class loader. There is no single point of failure. Changing the query does not help. If the jars are missing from the thread's class loader the first attempt to call ClassLoader.loadClass would crash the driver.
## How was this patch tested?

Tests were run (./dev/run-tests) and the Spark driver in our application is now stable. Previously the Spark driver would crash often due to missing jars in class loader. All queries are returned wrapped inside futures.
