### PR TITLE
[SPARK-17266] [TEST] Add empty strings to the regressionTests of PrefixComparatorsSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/collection/unsafe/sort/PrefixComparatorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/unsafe/sort/PrefixComparatorsSuite.scala
@@ -50,7 +50,8 @@ class PrefixComparatorsSuite extends SparkFunSuite with PropertyChecks {
       ("s1", "s2"),
       ("abc", "世界"),
       ("你好", "世界"),
-      ("你好123", "你好122")
+      ("你好123", "你好122"),
+      ("", "")
     )
     // scalastyle:on
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a regression test to PrefixComparatorsSuite's "String prefix comparator" because this test failed on jenkins once (https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.4/1620/testReport/junit/org.apache.spark.util.collection.unsafe.sort/PrefixComparatorsSuite/String_prefix_comparator/).

I could not reproduce it locally. But, let's this test case in the regressionTests.
