### PR TITLE
[SPARK-17276][Core][Test] Stop env params output on Jenkins job page

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -214,7 +214,13 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   def testCommandAvailable(command: String): Boolean = {
-    val attempt = Try(Process(command).run().exitValue())
+    val attempt = Try(Process(command).run(
+      new ProcessLogger {
+        override def out(s: => String): Unit = ()
+        override def buffer[T](f: => T): T = f
+        override def err(s: => String): Unit = ()
+      }
+    ).exitValue())
     attempt.isSuccess && attempt.get == 0
   }
 

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -214,13 +214,7 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   def testCommandAvailable(command: String): Boolean = {
-    val attempt = Try(Process(command).run(
-      new ProcessLogger {
-        override def out(s: => String): Unit = ()
-        override def buffer[T](f: => T): T = f
-        override def err(s: => String): Unit = ()
-      }
-    ).exitValue())
+    val attempt = Try(Process(command).run(ProcessLogger(_ => ())).exitValue())
     attempt.isSuccess && attempt.get == 0
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1788,13 +1788,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   def testCommandAvailable(command: String): Boolean = {
-    val attempt = Try(Process(command).run(
-      new ProcessLogger {
-        override def out(s: => String): Unit = ()
-        override def buffer[T](f: => T): T = f
-        override def err(s: => String): Unit = ()
-      }
-    ).exitValue())
+    val attempt = Try(Process(command).run(ProcessLogger(_ => ())).exitValue())
     attempt.isSuccess && attempt.get == 0
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive.execution
 
 import java.sql.{Date, Timestamp}
 
-import scala.sys.process.Process
+import scala.sys.process.{Process, ProcessLogger}
 import scala.util.Try
 
 import org.apache.hadoop.fs.Path
@@ -1788,7 +1788,13 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   def testCommandAvailable(command: String): Boolean = {
-    val attempt = Try(Process(command).run().exitValue())
+    val attempt = Try(Process(command).run(
+      new ProcessLogger {
+        override def out(s: => String): Unit = ()
+        override def buffer[T](f: => T): T = f
+        override def err(s: => String): Unit = ()
+      }
+    ).exitValue())
     attempt.isSuccess && attempt.get == 0
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-17276
## What changes were proposed in this pull request?

When trying to find error msg in a failed Jenkins build job, I'm annoyed by the huge env output.
The env parameter output should be muted.

![screen shot 2016-08-26 at 10 52 07 pm](https://cloud.githubusercontent.com/assets/3925641/18025581/b8d567ba-6be2-11e6-9eeb-6aec223f1730.png)
## How was this patch tested?

Tested manually on local laptop.
