### PR TITLE
[SPARK-17279][SQL] better error message for exceptions during ScalaUDF execution

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -510,18 +510,18 @@ class ALSSuite
       (1, 1L, 1d, 0, 0L, 0d, 5.0)
     ).toDF("user", "user_big", "user_small", "item", "item_big", "item_small", "rating")
     withClue("fit should fail when ids exceed integer range. ") {
-      assert(intercept[IllegalArgumentException] {
+      assert(intercept[SparkException] {
         als.fit(df.select(df("user_big").as("user"), df("item"), df("rating")))
-      }.getMessage.contains("was out of Integer range"))
-      assert(intercept[IllegalArgumentException] {
+      }.getCause.getMessage.contains("was out of Integer range"))
+      assert(intercept[SparkException] {
         als.fit(df.select(df("user_small").as("user"), df("item"), df("rating")))
-      }.getMessage.contains("was out of Integer range"))
-      assert(intercept[IllegalArgumentException] {
+      }.getCause.getMessage.contains("was out of Integer range"))
+      assert(intercept[SparkException] {
         als.fit(df.select(df("item_big").as("item"), df("user"), df("rating")))
-      }.getMessage.contains("was out of Integer range"))
-      assert(intercept[IllegalArgumentException] {
+      }.getCause.getMessage.contains("was out of Integer range"))
+      assert(intercept[SparkException] {
         als.fit(df.select(df("item_small").as("item"), df("user"), df("rating")))
-      }.getMessage.contains("was out of Integer range"))
+      }.getCause.getMessage.contains("was out of Integer range"))
     }
     withClue("transform should fail when ids exceed integer range. ") {
       val model = als.fit(df)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -1039,7 +1039,9 @@ case class ScalaUDF(
          try {
            $resultTerm = (${ctx.boxedType(dataType)})$catalystConverterTerm.apply($getFuncResult);
          } catch (NullPointerException e) {
-           throw new RuntimeException($scalaUDF.npeErrorMessage(), e);
+           NullPointerException npe = new NullPointerException($scalaUDF.npeErrorMessage());
+           npe.setStackTrace(e.getStackTrace());
+           throw npe;
          }
        """.stripMargin
 
@@ -1065,7 +1067,9 @@ case class ScalaUDF(
       f(input)
     } catch {
       case e: NullPointerException =>
-        throw new RuntimeException(npeErrorMessage, e)
+        val npe = new NullPointerException(npeErrorMessage)
+        npe.setStackTrace(e.getStackTrace)
+        throw npe
     }
 
     converter(result)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -1058,7 +1058,7 @@ case class ScalaUDF(
 
   private[this] val converter = CatalystTypeConverters.createToCatalystConverter(dataType)
 
-  val udfErrorMessage = {
+  lazy val udfErrorMessage = {
     val funcCls = function.getClass.getSimpleName
     val inputTypes = children.map(_.dataType.simpleString).mkString(", ")
     s"Failed to execute user defined function($funcCls: ($inputTypes) => ${dataType.simpleString})"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -37,12 +37,12 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
       Literal.create(null, StringType) :: Nil)
 
     val e1 = intercept[SparkException](udf.eval())
-    assert(e1.getMessage.contains("Exception happens when execute user code in Scala UDF"))
+    assert(e1.getMessage.contains("Failed to execute user defined function"))
 
     val e2 = intercept[SparkException] {
       checkEvalutionWithUnsafeProjection(udf, null)
     }
-    assert(e2.getMessage.contains("Exception happens when execute user code in Scala UDF"))
+    assert(e2.getMessage.contains("Failed to execute user defined function"))
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -36,10 +36,10 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
       StringType,
       Literal.create(null, StringType) :: Nil)
 
-    val e1 = intercept[RuntimeException](udf.eval())
+    val e1 = intercept[NullPointerException](udf.eval())
     assert(e1.getMessage.contains("Given UDF throws NPE during execution"))
 
-    val e2 = intercept[RuntimeException] {
+    val e2 = intercept[NullPointerException] {
       checkEvalutionWithUnsafeProjection(udf, null)
     }
     assert(e2.getMessage.contains("Given UDF throws NPE during execution"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.{IntegerType, StringType}
+
+class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
+
+  test("basic") {
+    val intUdf = ScalaUDF((i: Int) => i + 1, IntegerType, Literal(1) :: Nil)
+    checkEvaluation(intUdf, 2)
+
+    val stringUdf = ScalaUDF((s: String) => s + "x", StringType, Literal("a") :: Nil)
+    checkEvaluation(stringUdf, "ax")
+  }
+
+  test("better error message for NPE") {
+    val udf = ScalaUDF(
+      (s: String) => s.toLowerCase,
+      StringType,
+      Literal.create(null, StringType) :: Nil)
+
+    val e1 = intercept[RuntimeException](udf.eval())
+    assert(e1.getMessage.contains("Given UDF throws NPE during execution"))
+
+    val e2 = intercept[RuntimeException] {
+      checkEvalutionWithUnsafeProjection(udf, null)
+    }
+    assert(e2.getMessage.contains("Given UDF throws NPE during execution"))
+  }
+
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -36,13 +36,13 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
       StringType,
       Literal.create(null, StringType) :: Nil)
 
-    val e1 = intercept[NullPointerException](udf.eval())
-    assert(e1.getMessage.contains("Given UDF throws NPE during execution"))
+    val e1 = intercept[SparkException](udf.eval())
+    assert(e1.getMessage.contains("Exception happens when execute user code in Scala UDF"))
 
-    val e2 = intercept[NullPointerException] {
+    val e2 = intercept[SparkException] {
       checkEvalutionWithUnsafeProjection(udf, null)
     }
-    assert(e2.getMessage.contains("Given UDF throws NPE during execution"))
+    assert(e2.getMessage.contains("Exception happens when execute user code in Scala UDF"))
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `ScalaUDF` throws exceptions during executing user code, sometimes it's hard for users to figure out what's wrong, especially when they use Spark shell. An example

```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 12 in stage 325.0 failed 4 times, most recent failure: Lost task 12.3 in stage 325.0 (TID 35622, 10.0.207.202): java.lang.NullPointerException
    at line8414e872fb8b42aba390efc153d1611a12.$read$$iwC$$iwC$$iwC$$iwC$$anonfun$2.apply(<console>:40)
    at line8414e872fb8b42aba390efc153d1611a12.$read$$iwC$$iwC$$iwC$$iwC$$anonfun$2.apply(<console>:40)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.processNext(Unknown Source)
...
```

We should catch these exceptions and rethrow them with better error message, to say that the exception is happened in scala udf.

This PR also does some clean up for `ScalaUDF` and add a unit test suite for it.
## How was this patch tested?

the new test suite
