### PR TITLE
[SPARK-17241][SparkR][MLlib] SparkR spark.glm should have configurable regularization parameter

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -138,11 +138,11 @@ predict_internal <- function(object, newData) {
 #'               This can be a character string naming a family function, a family function or
 #'               the result of a call to a family function. Refer R family at
 #'               \url{https://stat.ethz.ch/R-manual/R-devel/library/stats/html/family.html}.
+#' @param tol positive convergence tolerance of iterations.
+#' @param maxIter integer giving the maximal number of IRLS iterations.
 #' @param weightCol the weight column name. If this is not set or \code{NULL}, we treat all instance
 #'                  weights as 1.0.
-#' @param tol positive convergence tolerance of iterations.
 #' @param regParam regularization parameter for L2 regularization.
-#' @param maxIter integer giving the maximal number of IRLS iterations.
 #' @param ... additional arguments passed to the method.
 #' @aliases spark.glm,SparkDataFrame,formula-method
 #' @return \code{spark.glm} returns a fitted generalized linear model

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -172,8 +172,8 @@ predict_internal <- function(object, newData) {
 #' @note spark.glm since 2.0.0
 #' @seealso \link{glm}, \link{read.ml}
 setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
-          function(data, formula, family = gaussian, tol = 1e-6, regParam = 0.0, maxIter = 25,
-                   weightCol = NULL) {
+          function(data, formula, family = gaussian, tol = 1e-6, maxIter = 25, weightCol = NULL,
+                   regParam = 0.0) {
             if (is.character(family)) {
               family <- get(family, mode = "function", envir = parent.frame())
             }
@@ -192,7 +192,7 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 
             jobj <- callJStatic("org.apache.spark.ml.r.GeneralizedLinearRegressionWrapper",
                                 "fit", formula, data@sdf, family$family, family$link,
-                                tol, regParam, as.integer(maxIter), as.character(weightCol))
+                                tol, as.integer(maxIter), as.character(weightCol), regParam)
             new("GeneralizedLinearRegressionModel", jobj = jobj)
           })
 

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -141,6 +141,7 @@ predict_internal <- function(object, newData) {
 #' @param weightCol the weight column name. If this is not set or \code{NULL}, we treat all instance
 #'                  weights as 1.0.
 #' @param tol positive convergence tolerance of iterations.
+#' @param regParam regularization parameter for L2 regularization.
 #' @param maxIter integer giving the maximal number of IRLS iterations.
 #' @param ... additional arguments passed to the method.
 #' @aliases spark.glm,SparkDataFrame,formula-method
@@ -171,7 +172,8 @@ predict_internal <- function(object, newData) {
 #' @note spark.glm since 2.0.0
 #' @seealso \link{glm}, \link{read.ml}
 setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
-          function(data, formula, family = gaussian, tol = 1e-6, maxIter = 25, weightCol = NULL) {
+          function(data, formula, family = gaussian, tol = 1e-6, regParam = 0.0, maxIter = 25,
+                   weightCol = NULL) {
             if (is.character(family)) {
               family <- get(family, mode = "function", envir = parent.frame())
             }
@@ -190,7 +192,7 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 
             jobj <- callJStatic("org.apache.spark.ml.r.GeneralizedLinearRegressionWrapper",
                                 "fit", formula, data@sdf, family$family, family$link,
-                                tol, as.integer(maxIter), as.character(weightCol))
+                                tol, regParam, as.integer(maxIter), as.character(weightCol))
             new("GeneralizedLinearRegressionModel", jobj = jobj)
           })
 

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -99,10 +99,6 @@ test_that("spark.glm summary", {
   expect_match(out[2], "Deviance Residuals:")
   expect_true(any(grepl("AIC: 59.22", out)))
 
-  # Test spark.glm works with regularization parameter
-  regStats <- summary(spark.glm(training, Sepal_Width ~ Sepal_Length + Species, regParam = 0.3))
-  expect_equal(regStats$aic, 136.7, tolerance = 1e-3)
-
   # binomial family
   df <- suppressWarnings(createDataFrame(iris))
   training <- df[df$Species %in% c("versicolor", "virginica"), ]
@@ -152,6 +148,12 @@ test_that("spark.glm summary", {
   baseModel <- stats::glm(Sepal.Width ~ Sepal.Length + Species, data = iris)
   baseSummary <- summary(baseModel)
   expect_true(abs(baseSummary$deviance - 12.19313) < 1e-4)
+
+  # Test spark.glm works with regularization parameter
+  data <- as.data.frame(cbind(a1, a2, b))
+  df <- suppressWarnings(createDataFrame(data))
+  regStats <- summary(spark.glm(df, b ~ a1 + a2, regParam = 1.0))
+  expect_equal(regStats$aic, 13.32836, tolerance = 1e-4) # 13.32836 is from summary() result
 })
 
 test_that("spark.glm save/load", {

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -99,6 +99,10 @@ test_that("spark.glm summary", {
   expect_match(out[2], "Deviance Residuals:")
   expect_true(any(grepl("AIC: 59.22", out)))
 
+  # Test spark.glm works with regularization parameter
+  regStats <- summary(spark.glm(training, Sepal_Width ~ Sepal_Length + Species, regParam = 0.3))
+  expect_equal(regStats$aic, 136.7, tolerance = 1e-3)
+
   # binomial family
   df <- suppressWarnings(createDataFrame(iris))
   training <- df[df$Species %in% c("versicolor", "virginica"), ]

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -68,6 +68,7 @@ private[r] object GeneralizedLinearRegressionWrapper
       family: String,
       link: String,
       tol: Double,
+      regParam: Double,
       maxIter: Int,
       weightCol: String): GeneralizedLinearRegressionWrapper = {
     val rFormula = new RFormula()
@@ -84,6 +85,7 @@ private[r] object GeneralizedLinearRegressionWrapper
       .setLink(link)
       .setFitIntercept(rFormula.hasIntercept)
       .setTol(tol)
+      .setRegParam(regParam)
       .setMaxIter(maxIter)
       .setWeightCol(weightCol)
     val pipeline = new Pipeline()

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -68,9 +68,9 @@ private[r] object GeneralizedLinearRegressionWrapper
       family: String,
       link: String,
       tol: Double,
-      regParam: Double,
       maxIter: Int,
-      weightCol: String): GeneralizedLinearRegressionWrapper = {
+      weightCol: String,
+      regParam: Double): GeneralizedLinearRegressionWrapper = {
     val rFormula = new RFormula()
       .setFormula(formula)
     val rFormulaModel = rFormula.fit(data)
@@ -85,9 +85,9 @@ private[r] object GeneralizedLinearRegressionWrapper
       .setLink(link)
       .setFitIntercept(rFormula.hasIntercept)
       .setTol(tol)
-      .setRegParam(regParam)
       .setMaxIter(maxIter)
       .setWeightCol(weightCol)
+      .setRegParam(regParam)
     val pipeline = new Pipeline()
       .setStages(Array(rFormulaModel, glr))
       .fit(data)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-17241
## What changes were proposed in this pull request?

Spark has configurable L2 regularization parameter for generalized linear regression. It is very important to have them in SparkR so that users can run ridge regression.
## How was this patch tested?

Test manually on local laptop.
