### PR TITLE
[SPARK-17287] [PYSPARK] Add recursive kwarg to Python SparkContext.addFile

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -670,6 +670,19 @@ class JavaSparkContext(val sc: SparkContext)
   }
 
   /**
+   * Add a file to be downloaded with this Spark job on every node.
+   * The `path` passed can be either a local file, a file in HDFS (or other Hadoop-supported
+   * filesystems), or an HTTP, HTTPS or FTP URI.  To access the file in Spark jobs,
+   * use `SparkFiles.get(fileName)` to find its download location.
+   *
+   * A directory can be given if the recursive option is set to true. Currently directories are only
+   * supported for Hadoop-supported filesystems.
+   */
+  def addFile(path: String, recursive: Boolean) {
+    sc.addFile(path, recursive)
+  }
+
+  /**
    * Adds a JAR dependency for all tasks to be executed on this SparkContext in the future.
    * The `path` passed can be either a local file, a file in HDFS (or other Hadoop-supported
    * filesystems), or an HTTP, HTTPS or FTP URI.

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -762,12 +762,15 @@ class SparkContext(object):
         SparkContext._next_accum_id += 1
         return Accumulator(SparkContext._next_accum_id - 1, value, accum_param)
 
-    def addFile(self, path):
+    def addFile(self, path, recursive=False):
         """
         Add a file to be downloaded with this Spark job on every node.
         The C{path} passed can be either a local file, a file in HDFS
         (or other Hadoop-supported filesystems), or an HTTP, HTTPS or
         FTP URI.
+
+        A directory can be given if the recursive option is set to true.
+        Currently directories are onlysupported for Hadoop-supported filesystems.
 
         To access the file in Spark jobs, use
         L{SparkFiles.get(fileName)<pyspark.files.SparkFiles.get>} with the
@@ -785,7 +788,7 @@ class SparkContext(object):
         >>> sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
         [100, 200, 300, 400]
         """
-        self._jsc.sc().addFile(path)
+        self._jsc.sc().addFile(path, recursive)
 
     def clearFiles(self):
         """

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -416,6 +416,14 @@ class AddFileTests(PySparkTestCase):
         with open(download_path) as test_file:
             self.assertEqual("Hello World!\n", test_file.readline())
 
+    def test_add_folder_locally(self):
+        path = os.path.join(SPARK_HOME, "python/test_support/test_folder/")
+        self.sc.addFile(path, recursive=True)
+        download_path = SparkFiles.get("test_folder/test_folder2/hello.txt")
+        self.assertNotEqual(path, download_path)
+        with open(download_path) as test_file:
+            self.assertEqual("Hello World!\n", test_file.readline())
+
     def test_add_py_file_locally(self):
         # To ensure that we're actually testing addPyFile's effects, check that
         # this fails due to `userlibrary` not being on the Python path:

--- a/python/test_support/test_folder/test_folder2/hello.txt
+++ b/python/test_support/test_folder/test_folder2/hello.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the ability to add entire directories using the PySpark interface `SparkContext.addFile(dir, recursive=True)`
## How was this patch tested?

I've added a test file in a nested folders in `python/test_support`. I use `addFile` to distribute this folder, and then read the file back using the directory structure.
