### PR TITLE
[SPARK-17295][SQL] Create TestHiveSessionState use reflect logic based on the setting of CATALOG_IMPLEMENTATION

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -94,7 +94,7 @@ package object config {
   private[spark] val CATALOG_IMPLEMENTATION = ConfigBuilder("spark.sql.catalogImplementation")
     .internal()
     .stringConf
-    .checkValues(Set("hive", "in-memory"))
+    .checkValues(Set("hive", "test-hive", "in-memory"))
     .createWithDefault("in-memory")
 
   private[spark] val LISTENER_BUS_EVENT_QUEUE_SIZE =

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -911,10 +911,13 @@ object SparkSession {
   private val defaultSession = new AtomicReference[SparkSession]
 
   private val HIVE_SESSION_STATE_CLASS_NAME = "org.apache.spark.sql.hive.HiveSessionState"
+  private val TEST_HIVE_SESSION_STATE_CLASS_NAME =
+    "org.apache.spark.sql.hive.test.TestHiveSessionState"
 
   private def sessionStateClassName(conf: SparkConf): String = {
     conf.get(CATALOG_IMPLEMENTATION) match {
       case "hive" => HIVE_SESSION_STATE_CLASS_NAME
+      case "test-hive" => TEST_HIVE_SESSION_STATE_CLASS_NAME
       case "in-memory" => classOf[SessionState].getCanonicalName
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -115,6 +115,7 @@ object SharedState {
   private def externalCatalogClassName(conf: SparkConf): String = {
     conf.get(CATALOG_IMPLEMENTATION) match {
       case "hive" => HIVE_EXTERNAL_CATALOG_CLASS_NAME
+      case "test-hive" => HIVE_EXTERNAL_CATALOG_CLASS_NAME
       case "in-memory" => classOf[InMemoryCatalog].getCanonicalName
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -52,6 +52,11 @@ private[spark] object HiveUtils extends Logging {
     sc
   }
 
+  def withTestHiveExternalCatalog(sc: SparkContext): SparkContext = {
+    sc.conf.set(CATALOG_IMPLEMENTATION.key, "test-hive")
+    sc
+  }
+
   /** The version of hive used internally by Spark SQL. */
   val hiveExecutionVersion: String = "1.2.1"
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
@@ -47,6 +47,7 @@ class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEac
 
   override def afterAll(): Unit = {
     try {
+      HiveUtils.withTestHiveExternalCatalog(sc)
       sc = null
       hc = null
     } finally {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable, Cat
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.CaseInsensitiveMap
-import org.apache.spark.sql.hive.HiveExternalCatalog
+import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveSessionState}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
@@ -500,7 +500,7 @@ class HiveDDLSuite
   }
 
   test("desc table for data source table using Hive Metastore") {
-    assume(spark.sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive")
+    assume(spark.sessionState.isInstanceOf[HiveSessionState])
     val tabName = "tab1"
     withTable(tabName) {
       sql(s"CREATE TABLE $tabName(a int comment 'test') USING parquet ")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we create a new `TestHiveSessionState` in `TestHive`, but in `SparkSession` we create `SessionState`/`HiveSessionState` use reflect logic based on the setting of CATALOG_IMPLEMENTATION, we should make the both consist, then we can test the reflect logic of `SparkSession` in `TestHive`.

To achieve this, we add "test-hive" to the value set of CATALOG_IMPLEMENTATION, and updated relative references.
## How was this patch tested?

existing tests.
