### PR TITLE
[SPARK-17303] Added spark-warehouse to dev/.rat-excludes

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -101,3 +101,4 @@ org.apache.spark.scheduler.ExternalClusterManager
 .*\.sql
 .Rbuildignore
 org.apache.spark.deploy.yarn.security.ServiceCredentialProvider
+spark-warehouse


### PR DESCRIPTION
## What changes were proposed in this pull request?

Excludes the `spark-warehouse` directory from the Apache RAT checks that src/run-tests performs. `spark-warehouse` is created by some of the Spark SQL tests, as well as by `bin/spark-sql`.
## How was this patch tested?

Ran src/run-tests twice. The second time, the script failed because the first iteration
Made the change in this PR.
Ran src/run-tests a third time; RAT checks succeeded.
