### PR TITLE
improve the  LabelPropagation of graphx lib, and reduce "label shake"and "discontinuity of communities"

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
@@ -58,7 +58,7 @@ object LabelPropagation {
       }.toMap
     }
     def vertexProgram(vid: VertexId, attr: Long, message: Map[VertexId, Long]): VertexId = {
-      if (message.isEmpty) attr else message.maxBy(_._2)._1
+      (Map(attr -> 1L) ++ message).maxBy(e=>(e._2,e._1))._1
     }
     val initialMessage = Map[VertexId, Long]()
     Pregel(lpaGraph, initialMessage, maxIterations = maxSteps)(


### PR DESCRIPTION
I test the result, which  is more reasonable
Because the LabelPropagation often suffers "labe shock"， and the result of communities are often non-adjacent.
 I think the label of node  is  userful between adjacent supersteps, and the adjacent supersteps are relevant.
