### PR TITLE
[SPARK-17319] [SQL] Move addJar from HiveSessionState to SharedState

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -184,4 +184,9 @@ abstract class ExternalCatalog {
 
   def listFunctions(db: String, pattern: String): Seq[String]
 
+  // --------------------------------------------------------------------------
+  // Resources
+  // --------------------------------------------------------------------------
+
+  def addJar(path: String): Unit
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -188,5 +188,13 @@ abstract class ExternalCatalog {
   // Resources
   // --------------------------------------------------------------------------
 
+  /**
+   * Add a JAR resource to the underlying external catalog for DDL (e.g. CREATE TABLE) and DML
+   * (e.g., LOAD TABLE) operations.
+   *
+   * For example, when users create a Hive serde table, they can specify a custom
+   * Serializer-Deserializer (SerDe) class. When Hive metastore is unable to access the custom SerDe
+   * JAR (e.g., not on the Hive classpath), the JAR file must be added at runtime using this API.
+   */
   def addJar(path: String): Unit
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -509,4 +509,10 @@ class InMemoryCatalog(
     StringUtils.filterPattern(catalog(db).functions.keysIterator.toSeq, pattern)
   }
 
+  // --------------------------------------------------------------------------
+  // Resources
+  // --------------------------------------------------------------------------
+
+  override def addJar(path: String): Unit = { /* no-op */ }
+
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -513,6 +513,8 @@ class InMemoryCatalog(
   // Resources
   // --------------------------------------------------------------------------
 
-  override def addJar(path: String): Unit = { /* no-op */ }
+  override def addJar(path: String): Unit = {
+    throw new UnsupportedOperationException("addJar is not supported")
+  }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/resources.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/resources.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 /**
- * Adds a jar to the current session so it can be used (for UDFs or serdes).
+ * Adds a cross-session jar so it can be used (for UDFs or serdes). The jar is accessible to
+ * all the sessions.
  */
 case class AddJarCommand(path: String) extends RunnableCommand {
   override val output: Seq[Attribute] = {
@@ -43,7 +44,7 @@ case class AddJarCommand(path: String) extends RunnableCommand {
 }
 
 /**
- * Adds a file to the current session so it can be used.
+ * Adds a cross-session file so it can be used.
  */
 case class AddFileCommand(path: String) extends RunnableCommand {
   override def run(sparkSession: SparkSession): Seq[Row] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/resources.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/resources.scala
@@ -37,7 +37,7 @@ case class AddJarCommand(path: String) extends RunnableCommand {
   }
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    sparkSession.sessionState.addJar(path)
+    sparkSession.sharedState.addJar(path)
     Seq(Row(0))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -171,6 +171,7 @@ private[sql] class SessionState(sparkSession: SparkSession) {
   }
 
   def addJar(path: String): Unit = {
+    sparkSession.sharedState.externalCatalog.addJar(path)
     sparkSession.sparkContext.addJar(path)
 
     val uri = new Path(path).toUri

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -40,17 +40,17 @@ private[sql] class SessionState(sparkSession: SparkSession) {
   // Note: These are all lazy vals because they depend on each other (e.g. conf) and we
   // want subclasses to override some of the fields. Otherwise, we would get a lot of NPEs.
 
+  // Since both sharedState and sessionState are lazily initialized in SparkSession,
+  // we need to ensure sharedState are initialized before the sessionState; otherwise,
+  // hive-site.xml might not be loaded when we using it.
+  sparkSession.sharedState
+
   /**
    * SQL-specific key-value configurations.
    */
   lazy val conf: SQLConf = new SQLConf
 
   def newHadoopConf(): Configuration = {
-    // Since both sharedState and sessionState are lazily initialized in SparkSession,
-    // we need to ensure sharedState are initialized before the sessionState; otherwise,
-    // hive-site.xml might not be loaded when we using it.
-    sparkSession.sharedState
-
     val hadoopConf = new Configuration(sparkSession.sparkContext.hadoopConfiguration)
     conf.getAllConfs.foreach { case (k, v) => if (v ne null) hadoopConf.set(k, v) }
     hadoopConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -75,7 +75,10 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
    * Add a global-scoped jar
    */
   def addJar(path: String): Unit = {
-    externalCatalog.addJar(path)
+    if (sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive") {
+      // Hive metastore supports custom serde.
+      externalCatalog.addJar(path)
+    }
     // The added jar is shared by all the sessions, because SparkContext does not support sessions
     sparkContext.addJar(path)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -17,10 +17,13 @@
 
 package org.apache.spark.sql.internal
 
+import java.io.File
+
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.config._
@@ -30,7 +33,6 @@ import org.apache.spark.sql.catalyst.catalog.{ExternalCatalog, InMemoryCatalog}
 import org.apache.spark.sql.execution.CacheManager
 import org.apache.spark.sql.execution.ui.{SQLListener, SQLTab}
 import org.apache.spark.util.{MutableURLClassLoader, Utils}
-
 
 /**
  * A class that holds all state shared across sessions in a given [[SQLContext]].
@@ -68,6 +70,26 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
    */
   val jarClassLoader = new NonClosableMutableURLClassLoader(
     org.apache.spark.util.Utils.getContextOrSparkClassLoader)
+
+  /**
+   * Add a global-scoped jar
+   */
+  def addJar(path: String): Unit = {
+    externalCatalog.addJar(path)
+    // The added jar is shared by all the sessions, because SparkContext does not support sessions
+    sparkContext.addJar(path)
+
+    val uri = new Path(path).toUri
+    val jarURL = if (uri.getScheme == null) {
+      // `path` is a local file path without a URL scheme
+      new File(path).toURI.toURL
+    } else {
+      // `path` is a URL with a scheme
+      uri.toURL
+    }
+    jarClassLoader.addURL(jarURL)
+    Thread.currentThread().setContextClassLoader(jarClassLoader)
+  }
 
   {
     // Set the Hive metastore warehouse path to the one we use

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -593,6 +593,14 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.listFunctions(db, pattern)
   }
 
+  // --------------------------------------------------------------------------
+  // Resources
+  // --------------------------------------------------------------------------
+
+  override def addJar(path: String): Unit = withClient {
+    client.addJar(path)
+  }
+
 }
 
 object HiveExternalCatalog {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionState.scala
@@ -100,11 +100,6 @@ private[hive] class HiveSessionState(sparkSession: SparkSession)
   //  Helper methods, partially leftover from pre-2.0 days
   // ------------------------------------------------------
 
-  override def addJar(path: String): Unit = {
-    metadataHive.addJar(path)
-    super.addJar(path)
-  }
-
   /**
    * When true, enables an experimental feature where metastore tables that use the parquet SerDe
    * are automatically converted to use the Spark SQL parquet table scan, instead of the Hive


### PR DESCRIPTION
### What changes were proposed in this pull request?

The added jar is shared by all the sessions, because SparkContext does not support sessions. Thus, it makes more sense to move `addJar` from `HiveSessionState` to `HiveSharedState`

This is another step to remove Hive client usage in `HiveSessionState`.

Different sessions are sharing the same class loader (IsolatedClientLoader), and thus, `metadataHive.addJar(path)` basically loads the JARs for all the sessions. Thus, no impact is made if we move `addJar` from `HiveSessionState` to `HiveExternalCatalog`.
### How was this patch tested?

The existing test cases.
