### PR TITLE
[SPARK-17321][YARN] YARN shuffle service should use good disk from yarn.nodemanager.local-dirs

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -283,6 +283,6 @@ public class YarnShuffleService extends AuxiliaryService {
       }
     }
 
-    return null;
+    return _recoveryPath;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use good disk from yarn.nodemanager.local-dirs if first one was broken.
## How was this patch tested?

Manual tests similar code in branch 1.6.2 on one of the node which have first disk broken.
