### PR TITLE
[MINOR][SPARKR] Verbose build comment in WINDOWS.md rather than promoting default build without Hive

### DIFF
--- a/R/WINDOWS.md
+++ b/R/WINDOWS.md
@@ -20,7 +20,7 @@ directory in Maven in `PATH`.
     mvn -DskipTests -Psparkr package
     ```
 
-    `build/mvn` is a shell script so `mvn` should be used directly on Windows.
+    `.\build\mvn` is a shell script so `mvn` should be used directly on Windows.
 
 ##  Unit tests
 

--- a/R/WINDOWS.md
+++ b/R/WINDOWS.md
@@ -4,13 +4,21 @@ To build SparkR on Windows, the following steps are required
 
 1. Install R (>= 3.1) and [Rtools](http://cran.r-project.org/bin/windows/Rtools/). Make sure to
 include Rtools and R in `PATH`.
+
 2. Install
 [JDK7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) and set
 `JAVA_HOME` in the system environment variables.
+
 3. Download and install [Maven](http://maven.apache.org/download.html). Also include the `bin`
 directory in Maven in `PATH`.
+
 4. Set `MAVEN_OPTS` as described in [Building Spark](http://spark.apache.org/docs/latest/building-spark.html).
-5. Open a command shell (`cmd`) in the Spark directory and run `mvn -DskipTests -Psparkr package`
+
+5. Open a command shell (`cmd`) in the Spark directory and build Spark with [Maven](http://spark.apache.org/docs/latest/building-spark.html#building-with-buildmvn) and include the `-Psparkr` profile to build the R package. For example to use the default Hadoop versions you can run
+
+    ```bash
+    build/mvn -DskipTests -Psparkr package
+    ```
 
 ##  Unit tests
 

--- a/R/WINDOWS.md
+++ b/R/WINDOWS.md
@@ -17,8 +17,10 @@ directory in Maven in `PATH`.
 5. Open a command shell (`cmd`) in the Spark directory and build Spark with [Maven](http://spark.apache.org/docs/latest/building-spark.html#building-with-buildmvn) and include the `-Psparkr` profile to build the R package. For example to use the default Hadoop versions you can run
 
     ```bash
-    build/mvn -DskipTests -Psparkr package
+    mvn -DskipTests -Psparkr package
     ```
+
+    `build/mvn` is a shell script so `mvn` should be used directly on Windows.
 
 ##  Unit tests
 

--- a/R/WINDOWS.md
+++ b/R/WINDOWS.md
@@ -17,10 +17,10 @@ directory in Maven in `PATH`.
 5. Open a command shell (`cmd`) in the Spark directory and build Spark with [Maven](http://spark.apache.org/docs/latest/building-spark.html#building-with-buildmvn) and include the `-Psparkr` profile to build the R package. For example to use the default Hadoop versions you can run
 
     ```bash
-    mvn -DskipTests -Psparkr package
+    mvn.cmd -DskipTests -Psparkr package
     ```
 
-    `.\build\mvn` is a shell script so `mvn` should be used directly on Windows.
+    `.\build\mvn` is a shell script so `mvn.cmd` should be used directly on Windows.
 
 ##  Unit tests
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes `WINDOWS.md` to imply referring other profiles in http://spark.apache.org/docs/latest/building-spark.html#building-with-buildmvn rather than directly pointing to run `mvn -DskipTests -Psparkr package` without Hive supports.
## How was this patch tested?

Manually, 

<img width="626" alt="2016-08-31 6 01 08" src="https://cloud.githubusercontent.com/assets/6477701/18122549/f6297b2c-6fa4-11e6-9b5e-fd4347355d87.png">
