### PR TITLE
[SPARK-16499][ML][MLLib] optimize ann algorithm where using ApplyInPlace function 

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/ann/LossFunction.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/ann/LossFunction.scala
@@ -55,7 +55,8 @@ private[ann] class SigmoidLayerWithSquaredError extends Layer {
 private[ann] class SigmoidLayerModelWithSquaredError
   extends FunctionalLayerModel(new FunctionalLayer(new SigmoidFunction)) with LossFunction {
   override def loss(output: BDM[Double], target: BDM[Double], delta: BDM[Double]): Double = {
-    ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)
+    delta := output
+    delta -= target
     val error = Bsum(delta :* delta) / 2 / output.cols
     ApplyInPlace(delta, output, delta, (x: Double, o: Double) => x * (o - o * o))
     error
@@ -118,7 +119,8 @@ private[ann] class SoftmaxLayerModelWithCrossEntropyLoss extends LayerModel with
   }
 
   override def loss(output: BDM[Double], target: BDM[Double], delta: BDM[Double]): Double = {
-    ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)
+    delta := output
+    delta -= target
     -Bsum( target :* brzlog(output)) / output.cols
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

replace
`ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)`
with
`
delta := output;
delta -= target;
`
it is a little like what is done in https://github.com/apache/spark/pull/14156
in that PR the `ApplyInPlace` cannot be optimized because the function may be anything.
but here we know that it is only matrix substraction so we can directly using breeze matrix operator
to get better performance than using `ApplyInPlace`.
## How was this patch tested?

Existing test.
