### PR TITLE
[SPARK-17271] [SQL] Remove redundant `semanticEquals()` from `SortOrder`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -61,9 +61,6 @@ case class SortOrder(child: Expression, direction: SortDirection)
   override def sql: String = child.sql + " " + direction.sql
 
   def isAscending: Boolean = direction == Ascending
-
-  def semanticEquals(other: SortOrder): Boolean =
-    (direction == other.direction) && child.semanticEquals(other.child)
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removing `semanticEquals()` from `SortOrder` because it can use the `semanticEquals()` provided by its parent class (`Expression`). This was as per suggestion by @cloud-fan at https://github.com/apache/spark/pull/14841/files/7192418b3a26a14642fc04fc92bf496a954ffa5d#r77106801
## How was this patch tested?

Ran the test added in https://github.com/apache/spark/pull/14841
