### PR TITLE
[SPARK-17357][SQL] Fix current predicate pushdown

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -89,6 +89,8 @@ abstract class Optimizer(sessionCatalog: SessionCatalog, conf: CatalystConf)
       CombineFilters,
       CombineLimits,
       CombineUnions,
+      // Push down Filters again after combination
+      PushDownPredicate,
       // Constant folding and strength reduction
       NullPropagation,
       FoldablePropagation,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -34,6 +34,7 @@ class FilterPushdownSuite extends PlanTest {
       Batch("Subqueries", Once,
         EliminateSubqueryAliases) ::
       Batch("Filter Pushdown", FixedPoint(10),
+        PushDownPredicate,
         CombineFilters,
         PushDownPredicate,
         BooleanSimplification,
@@ -167,6 +168,27 @@ class FilterPushdownSuite extends PlanTest {
       testRelation
         .where('a === 1 && 'a === 2)
         .select('a).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("push down filters that are combined") {
+    // The following predicate ('a === 2 || 'a === 3) && ('c > 10 || 'a === 2)
+    // will be simplified as ('a == 2) || ('c > 10 && 'a == 3).
+    // ('a === 2 || 'a === 3) can be pushed down. But the simplified one can't.
+    val originalQuery = testRelation
+      .select('a, 'b, ('c + 1) as 'cc)
+      .groupBy('a)('a, count('cc) as 'c)
+      .where('c > 10) // this predicate can't be pushed down.
+      .where(('a === 2 || 'a === 3) && ('c > 10 || 'a === 2))
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer =
+      testRelation
+        .where('a === 2 || 'a === 3)
+        .select('a, 'b, ('c + 1) as 'cc)
+        .groupBy('a)('a, count('cc) as 'c)
+        .where('c > 10).analyze
 
     comparePlans(optimized, correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -192,7 +192,9 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("disjunctive predicates which are able to pushdown should be pushed down after converted") {
+  // TODO: currently predicate pushdown doesn't convert predicates to pushdown-able form.
+  // We should do it to push down more predicates.
+  ignore("predicates which are able to pushdown should be pushed down after converted") {
     // (('a === 2) || ('c > 10 || 'a === 3)) can't be pushdown due to the disjunctive form.
     // However, its conjunctive normal form can be pushdown.
     val originalQuery = testRelation


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently some predicates, which should be pushdown, will not be correctly pushdown in `Optimizer`.
### Predicates simplified to the form that can't be push down before they are pushed down

In `Optimizer`, `Filter` operator will go through the rules `PushDownPredicate`, `CombineFilters` and `BooleanSimplification`.

Under this rule order, it is possibly that some predicates that should be able to push down, can't be pushed down through operators.

Because `Filter` will not pushdown through another `Filter` node and will wait for combination in the rule `CombineFilters` later. After the `Filter`s are combined, `BooleanSimplification` will simplify conditions in the combined `Filter` and make some predicates, which are able to push down, become unable to push down.

This is this change wants to fix.
### Predicates are in the form unable to push down at the beginning

We may need to come out an approach to maintain multiple forms of predicates which at least can benefit pushdown and expression simplification. This will leave to later PRs. Need more discussion.
### Change in this patch

After `Filter`s are combined in `CombineFilters`, this change triggers `PushDownPredicates` immediately to push down the combined predicates. So the combined predicates will not be simplified by `BooleanSimplification` before pushing down.
## How was this patch tested?

Jenkins tests.
