### PR TITLE
[SPARK-17356][SQL] Fix out of memory issue when generating JSON for TreeNode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -604,7 +604,6 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     }.toList
   }
 
-  // TODO: Fix toJSON so that we can more safely handle Map and Seq with loop.
   private def parseToJson(obj: Any): JValue = obj match {
     case b: Boolean => JBool(b)
     case b: Byte => JInt(b.toInt)

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -274,8 +274,9 @@ abstract class QueryTest extends PlanTest {
     val normalized1 = logicalPlan.transformAllExpressions {
       case udf: ScalaUDF => udf.copy(function = null)
       case gen: UserDefinedGenerator => gen.copy(function = null)
-      // SPARK-17356: In usage of mllib, Metadata may store a huge vector of data, transforming
-      // it to JSON may trigger OutOfMemoryError.
+      // After SPARK-17356: the JSON representation no longer has the Metadata. We need to remove
+      // the Metadata from the normalized plan so that we can compare this plan with the
+      // JSON-deserialzed plan.
       case a @ Alias(child, name) if a.explicitMetadata.isDefined =>
         Alias(child, name)(a.exprId, a.qualifier, Some(Metadata.empty), a.isGenerated)
       case a: AttributeReference if a.metadata != Metadata.empty =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

class `org.apache.spark.sql.types.Metadata` is widely used in mllib to store some ml attributes. `Metadata` is commonly stored in `Alias` expression. 

```
case class Alias(child: Expression, name: String)(
    val exprId: ExprId = NamedExpression.newExprId,
    val qualifier: Option[String] = None,
    val explicitMetadata: Option[Metadata] = None,
    override val isGenerated: java.lang.Boolean = false)
```

The `Metadata` can take a big memory footprint since the number of attributes is big ( in scale of million). When `toJSON` is called on `Alias` expression, the `Metadata` will also be converted to a big JSON string. 
If a plan contains many such kind of `Alias` expressions, it may trigger out of memory error when `toJSON` is called, since converting all `Metadata` references to JSON will take huge memory.

With this PR, we will skip scanning Metadata when doing JSON conversion. For a reproducer of the OOM, and analysis, please look at jira https://issues.apache.org/jira/browse/SPARK-17356. 
## How was this patch tested?

Existing tests.
