### PR TITLE
[SPARK-17340][YARN] cleanup .sparkStaging when app is killed by yarn

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -222,7 +222,9 @@ private[spark] class ApplicationMaster(
 
         if (!unregistered) {
           // we only want to unregister if we don't want the RM to retry
-          if (finalStatus == FinalApplicationStatus.SUCCEEDED || isLastAttempt) {
+          if (finalStatus == FinalApplicationStatus.SUCCEEDED ||
+            exitCode == ApplicationMaster.EXIT_EARLY ||
+            exitCode == ApplicationMaster.EXIT_EXCEPTION_USER_CLASS || isLastAttempt) {
             unregister(finalStatus, finalMsg)
             cleanupStagingDir(fs)
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cleanup .sparkStaging directory whenever spark application has exitCode 15/16
`EXIT_EXCEPTION_USER_CLASS = 15`
`EXIT_EARLY = 16`

It happens when you kill spark-submit in terminal and do
`$ yarn application -kill <app id>`
## How was this patch tested?

Existing tests. (./dev/run-tests)
Also manually verified that application does cleanup when it is killed in such way.
