### PR TITLE
[SPARK-7877][MESOS] Allow configuration of framework timeout

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -418,6 +418,15 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.mesos.failoverTimeout</code></td>
+  <td><code>Integer.MAX</code> for cluster scheduler, <code>0.0</code> for Spark jobs</td>
+  <td>
+    The Mesos framework failover timeout in seconds. This acts as a threshold for Mesos masters.
+    Exceeding the timeout, when the Spark driver looses the connection to the Mesos master without reconnecting,
+    will cause the Mesos master to remove the associated executors.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.constraints</code></td>
   <td>(none)</td>
   <td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -313,7 +313,7 @@ private[spark] class MesosClusterScheduler(
       conf,
       Some(frameworkUrl),
       Some(true),
-      Some(Integer.MAX_VALUE),
+      conf.getOption("spark.mesos.failoverTimeout").map(_.toDouble).orElse(Some(Integer.MAX_VALUE)),
       fwId)
 
     startScheduler(driver)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -165,7 +165,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       sc.conf,
       sc.conf.getOption("spark.mesos.driver.webui.url").orElse(sc.ui.map(_.webUrl)),
       None,
-      None,
+      sc.conf.getOption("spark.mesos.failoverTimeout").map(_.toDouble),
       sc.conf.getOption("spark.mesos.driver.frameworkId")
     )
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -82,7 +82,7 @@ private[spark] class MesosFineGrainedSchedulerBackend(
       sc.conf,
       sc.conf.getOption("spark.mesos.driver.webui.url").orElse(sc.ui.map(_.webUrl)),
       Option.empty,
-      Option.empty,
+      sc.conf.getOption("spark.mesos.failoverTimeout").map(_.toDouble),
       sc.conf.getOption("spark.mesos.driver.frameworkId")
     )
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -56,7 +56,8 @@ trait MesosSchedulerUtils extends Logging {
    * @param conf Spark configuration
    * @param webuiUrl The WebUI url to link from Mesos UI
    * @param checkpoint Option to checkpoint tasks for failover
-   * @param failoverTimeout Duration Mesos master expect scheduler to reconnect on disconnect
+   * @param failoverTimeout Duration Mesos master expect scheduler to reconnect on disconnect in
+   *                        seconds
    * @param frameworkId The id of the new framework
    */
   protected def createSchedulerDriver(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This commit introduces a setting for configuring the Mesos framework failover timeout (`spark.mesos.failoverTimeout`). The default timeout is 10 seconds.

Before, the timeout was set to 0 (which causes all tasks to be killed by mesos) or Integer.MAX which kindof leaves them hanging forever, depending on how the driver was launched.
## How was this patch tested?

unit test
