### PR TITLE
[SPARK-17391] [TEST] [2.0] Fix Two Test Failures After Backport

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
@@ -77,7 +77,7 @@ class HiveExplainSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       "src")
   }
 
-  test("SPARK-6212: The EXPLAIN output of CTAS only shows the analyzed plan") {
+  test("SPARK-17230: The EXPLAIN output of CTAS only shows the analyzed plan") {
     withTempView("jt") {
       val rdd = sparkContext.parallelize((1 to 10).map(i => s"""{"a":$i, "b":"str$i"}"""))
       spark.read.json(rdd).createOrReplaceTempView("jt")
@@ -98,8 +98,8 @@ class HiveExplainSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       }
 
       val physicalIndex = outputs.indexOf("== Physical Plan ==")
-      assert(!outputs.substring(physicalIndex).contains("Subquery"),
-        "Physical Plan should not contain Subquery since it's eliminated by optimizer")
+      assert(outputs.substring(physicalIndex).contains("SubqueryAlias"),
+        "Physical Plan should contain SubqueryAlias since the query should not be optimized")
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
@@ -232,12 +232,12 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
       val catalog = spark.sessionState.catalog
       val viewMeta = catalog.getTableMetadata(TableIdentifier("test_view"))
-      assert(viewMeta.properties("comment") == "test")
+      assert(viewMeta.comment == Some("test"))
       assert(viewMeta.properties("key") == "a")
 
       sql("ALTER VIEW test_view AS SELECT 3 AS i, 4 AS j")
       val updatedViewMeta = catalog.getTableMetadata(TableIdentifier("test_view"))
-      assert(updatedViewMeta.properties("comment") == "test")
+      assert(updatedViewMeta.comment == Some("test"))
       assert(updatedViewMeta.properties("key") == "a")
       assert(updatedViewMeta.createTime == viewMeta.createTime)
       // The view should be updated.


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the latest branch 2.0, we have two test case failure due to backport.
- test("ALTER VIEW AS should keep the previous table properties, comment, create_time, etc.")
- test("SPARK-6212: The EXPLAIN output of CTAS only shows the analyzed plan")
### How was this patch tested?

N/A
