### PR TITLE
[SPARK-17378] [BUILD] Upgrade snappy-java to 1.1.2.6

### DIFF
--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.io
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.google.common.io.ByteStreams
 
@@ -130,58 +130,4 @@ class CompressionCodecSuite extends SparkFunSuite {
     ByteStreams.readFully(concatenatedBytes, decompressed)
     assert(decompressed.toSeq === (0 to 127))
   }
-
-  // Based on https://github.com/xerial/snappy-java/blob/60cc0c2e1d1a76ae2981d0572a5164fcfdfba5f1/src/test/java/org/xerial/snappy/SnappyInputStreamTest.java
-  test("SPARK 17378: snappy-java should handle magic header when reading stream") {
-    val b = new ByteArrayOutputStream()
-    // Write uncompressed length beginning with -126 (the same with magicheader[0])
-    b.write(-126) // Can't access magic header[0] as it isn't public, so access this way
-    b.write(0x01)
-    // uncompressed data length = 130
-
-    var data = new ByteArrayOutputStream()
-
-    for (i <- 0 until 130) {
-      data.write('A')
-    }
-
-    var dataMoreThan8Len = data.toByteArray()
-
-    // write literal (lower 2-bit of the first tag byte is 00, upper 6-bits represents data size)
-    b.write(60<<2) // 1-byte data length follows
-    b.write(dataMoreThan8Len.length-1) // subsequent data length
-    b.write(dataMoreThan8Len)
-
-    var compressed = b.toByteArray()
-
-    // This should succeed
-    assert(dataMoreThan8Len === org.xerial.snappy.Snappy.uncompress(compressed))
-
-    // Reproduce error in #142
-    val in = new org.xerial.snappy.SnappyInputStream(new ByteArrayInputStream(b.toByteArray()))
-
-    var uncompressed = readFully(in)
-    assert(dataMoreThan8Len === uncompressed) // this fails as uncompressed is empty
-  }
-
-  private def readFully(input: InputStream): Array[Byte] = {
-    try {
-      val out = new ByteArrayOutputStream()
-      var buf = new Array[Byte](4096)
-
-      var readBytes = 0
-      while (readBytes != -1) {
-        readBytes = input.read(buf)
-        if (readBytes != -1) {
-          out.write(buf, 0, readBytes)
-        }
-      }
-      out.flush()
-      return out.toByteArray()
-    }
-    finally {
-     input.close();
-    }
-  }
-
 }

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -152,7 +152,7 @@ shapeless_2.11-2.0.0.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.4.jar
+snappy-java-1.1.2.6.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0.1.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -159,7 +159,7 @@ shapeless_2.11-2.0.0.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.4.jar
+snappy-java-1.1.2.6.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -159,7 +159,7 @@ shapeless_2.11-2.0.0.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.4.jar
+snappy-java-1.1.2.6.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -167,7 +167,7 @@ shapeless_2.11-2.0.0.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.4.jar
+snappy-java-1.1.2.6.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -168,7 +168,7 @@ shapeless_2.11-2.0.0.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.4.jar
+snappy-java-1.1.2.6.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.6.5</fasterxml.jackson.version>
-    <snappy.version>1.1.2.4</snappy.version>
+    <snappy.version>1.1.2.6</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
     <commons-codec.version>1.10</commons-codec.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrades the Snappy version to 1.1.2.6 from 1.1.2.4, release notes: https://github.com/xerial/snappy-java/blob/master/Milestone.md mention "Fix a bug in SnappyInputStream when reading compressed data that happened to have the same first byte with the stream magic header (#142)"
## How was this patch tested?

Existing unit tests using the latest IBM Java 8 on Intel, Power and Z architectures (little and big-endian)
