### PR TITLE
[SPARK-17387][PYSPARK] Creating SparkContext() from python without spark-submit ignores user conf

### DIFF
--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -111,7 +111,6 @@ class SparkConf(object):
                 # JVM is not created, so store data in self._conf first
                 self._jconf = None
                 self._conf = {}
-                self.loadDefaults = loadDefaults
 
     def set(self, key, value):
         """Set a configuration property."""

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -126,7 +126,6 @@ class SparkConf(object):
         if self._jconf is not None:
             self._jconf.set(key, unicode(value))
         else:
-            # Don't use unicode for self._conf, otherwise we will get exception when launching jvm.
             self._conf[key] = unicode(value)
         return self
 

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -106,21 +106,16 @@ class SparkConf(object):
             if _jvm:
                 # JVM is created, so create self._jconf directly through JVM
                 self._jconf = _jvm.SparkConf(loadDefaults)
+                self._conf = None
             else:
                 # JVM is not created, so store data in self._conf first
                 self._jconf = None
                 self._conf = {}
                 self.loadDefaults = loadDefaults
 
-    def _set_jvm(self, _jvm):
-        # JVM is created so we switch from self._conf to self._jconf
-        # Because self._conf has already been pass to JVM so self._jconf will be created properly.
-        self._jconf = _jvm.SparkConf(self.loadDefaults)
-        self._conf.clear()
-
     def set(self, key, value):
         """Set a configuration property."""
-        # Try to set self._jconf first if JVM is created, set self._conf is JVM is not created yet.
+        # Try to set self._jconf first if JVM is created, set self._conf if JVM is not created yet.
         if self._jconf:
             self._jconf.set(key, unicode(value))
         else:

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -22,9 +22,9 @@
 >>> conf.setMaster("local").setAppName("My app")
 <pyspark.conf.SparkConf object at ...>
 >>> conf.get("spark.master")
-u'local'
+'local'
 >>> conf.get("spark.app.name")
-u'My app'
+'My app'
 >>> sc = SparkContext(conf=conf)
 >>> sc.master
 u'local'
@@ -101,13 +101,31 @@ class SparkConf(object):
             self._jconf = _jconf
         else:
             from pyspark.context import SparkContext
-            SparkContext._ensure_initialized()
             _jvm = _jvm or SparkContext._jvm
-            self._jconf = _jvm.SparkConf(loadDefaults)
+
+            if _jvm:
+                # JVM is created, so create self._jconf directly through JVM
+                self._jconf = _jvm.SparkConf(loadDefaults)
+            else:
+                # JVM is not created, so store data in self._conf first
+                self._jconf = None
+                self._conf = {}
+                self.loadDefaults = loadDefaults
+
+    def _set_jvm(self, _jvm):
+        # JVM is created so we switch from self._conf to self._jconf
+        # Because self._conf has already been pass to JVM so self._jconf will be created properly.
+        self._jconf = _jvm.SparkConf(self.loadDefaults)
+        self._conf.clear()
 
     def set(self, key, value):
         """Set a configuration property."""
-        self._jconf.set(key, unicode(value))
+        # Try to set self._jconf first if JVM is created, set self._conf is JVM is not created yet.
+        if self._jconf:
+            self._jconf.set(key, unicode(value))
+        else:
+            # Don't use unicode for self._conf, otherwise we will get exception when launching jvm.
+            self._conf[key] = value
         return self
 
     def setIfMissing(self, key, value):
@@ -118,17 +136,17 @@ class SparkConf(object):
 
     def setMaster(self, value):
         """Set master URL to connect to."""
-        self._jconf.setMaster(value)
+        self.set("spark.master", value)
         return self
 
     def setAppName(self, value):
         """Set application name."""
-        self._jconf.setAppName(value)
+        self.set("spark.app.name", value)
         return self
 
     def setSparkHome(self, value):
         """Set path where Spark is installed on worker nodes."""
-        self._jconf.setSparkHome(value)
+        self.set("spark.home", value)
         return self
 
     def setExecutorEnv(self, key=None, value=None, pairs=None):
@@ -136,10 +154,10 @@ class SparkConf(object):
         if (key is not None and pairs is not None) or (key is None and pairs is None):
             raise Exception("Either pass one key-value pair or a list of pairs")
         elif key is not None:
-            self._jconf.setExecutorEnv(key, value)
+            self.set("spark.executorEnv." + key, value)
         elif pairs is not None:
             for (k, v) in pairs:
-                self._jconf.setExecutorEnv(k, v)
+                self.set("spark.executorEnv." + k, v)
         return self
 
     def setAll(self, pairs):
@@ -149,35 +167,53 @@ class SparkConf(object):
         :param pairs: list of key-value pairs to set
         """
         for (k, v) in pairs:
-            self._jconf.set(k, v)
+            self.set(k, v)
         return self
 
     def get(self, key, defaultValue=None):
         """Get the configured value for some key, or return a default otherwise."""
         if defaultValue is None:   # Py4J doesn't call the right get() if we pass None
-            if not self._jconf.contains(key):
-                return None
-            return self._jconf.get(key)
+            if self._jconf:
+                if not self._jconf.contains(key):
+                    return None
+                return self._jconf.get(key)
+            else:
+                if not key in self._conf:
+                    return None
+                return self._conf[key]
         else:
-            return self._jconf.get(key, defaultValue)
+            if self._jconf:
+                return self._jconf.get(key, defaultValue)
+            else:
+                return self._conf.get(key, defaultValue)
 
     def getAll(self):
         """Get all values as a list of key-value pairs."""
         pairs = []
-        for elem in self._jconf.getAll():
-            pairs.append((elem._1(), elem._2()))
+        if self._jconf:
+            for elem in self._jconf.getAll():
+                pairs.append((elem._1(), elem._2()))
+        else:
+            for k,v in self._conf.items():
+                pairs.append((k, v))
         return pairs
 
     def contains(self, key):
         """Does this configuration contain a given key?"""
-        return self._jconf.contains(key)
+        if self._jconf:
+            return self._jconf.contains(key)
+        else:
+            return key in self._conf
 
     def toDebugString(self):
         """
         Returns a printable version of the configuration, as a list of
         key=value pairs, one per line.
         """
-        return self._jconf.toDebugString()
+        if self._jconf:
+            return self._jconf.toDebugString()
+        else:
+            return '\n'.join('%s=%s' % (k,v) for k,v in self._conf.items())
 
 
 def _test():

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -196,7 +196,6 @@ class SparkConf(object):
         else:
             return self._conf.items()
 
-
     def contains(self, key):
         """Does this configuration contain a given key?"""
         if self._jconf is not None:

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -178,7 +178,7 @@ class SparkConf(object):
                     return None
                 return self._jconf.get(key)
             else:
-                if not key in self._conf:
+                if key not in self._conf:
                     return None
                 return self._conf[key]
         else:
@@ -194,7 +194,7 @@ class SparkConf(object):
             for elem in self._jconf.getAll():
                 pairs.append((elem._1(), elem._2()))
         else:
-            for k,v in self._conf.items():
+            for k, v in self._conf.items():
                 pairs.append((k, v))
         return pairs
 
@@ -213,7 +213,7 @@ class SparkConf(object):
         if self._jconf:
             return self._jconf.toDebugString()
         else:
-            return '\n'.join('%s=%s' % (k,v) for k,v in self._conf.items())
+            return '\n'.join('%s=%s' % (k, v) for k, v in self._conf.items())
 
 
 def _test():

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -121,11 +121,7 @@ class SparkContext(object):
     def _do_init(self, master, appName, sparkHome, pyFiles, environment, batchSize, serializer,
                  conf, jsc, profiler_cls):
         self.environment = environment or {}
-        if conf and not conf._jconf:
-            self._conf = conf
-            self._conf._set_jvm(self._jvm)
-        else:
-            self._conf = SparkConf(_jvm=self._jvm)
+        self._conf = SparkConf(_jvm=self._jvm)
 
         self._batchSize = batchSize  # -1 represents an unlimited batch size
         self._unbatched_serializer = serializer

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -122,7 +122,7 @@ class SparkContext(object):
                  conf, jsc, profiler_cls):
         self.environment = environment or {}
         # java gateway must have been launched at this point.
-        if conf is not None and conf._jconf:
+        if conf is not None and conf._jconf is not None:
             # conf has been initialized in JVM properly, so use conf directly. This represent the
             # scenario that JVM has been launched before SparkConf is created (e.g. SparkContext is
             # created and then stopped, and we create a new SparkConf and new SparkContext again)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -125,7 +125,7 @@ class SparkContext(object):
         if conf is not None and conf._jconf:
             # conf has been initialized in JVM properly, so use conf directly. This represent the
             # scenario that JVM has been launched before SparkConf is created (e.g. SparkContext is
-            # created and then stopped, and we create a new SparkConf and new SparkContext again
+            # created and then stopped, and we create a new SparkConf and new SparkContext again)
             self._conf = conf
         else:
             self._conf = SparkConf(_jvm=SparkContext._jvm)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -109,7 +109,7 @@ class SparkContext(object):
         ValueError:...
         """
         self._callsite = first_spark_call() or CallSite(None, None, None)
-        SparkContext._ensure_initialized(self, gateway=gateway, conf = conf)
+        SparkContext._ensure_initialized(self, gateway=gateway, conf=conf)
         try:
             self._do_init(master, appName, sparkHome, pyFiles, environment, batchSize, serializer,
                           conf, jsc, profiler_cls)
@@ -237,7 +237,7 @@ class SparkContext(object):
         return self._jvm.JavaSparkContext(jconf)
 
     @classmethod
-    def _ensure_initialized(cls, instance=None, gateway=None, conf = None):
+    def _ensure_initialized(cls, instance=None, gateway=None, conf=None):
         """
         Checks whether a SparkContext is initialized or not.
         Throws error if a SparkContext is already running.

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -121,7 +121,14 @@ class SparkContext(object):
     def _do_init(self, master, appName, sparkHome, pyFiles, environment, batchSize, serializer,
                  conf, jsc, profiler_cls):
         self.environment = environment or {}
-        self._conf = SparkConf(_jvm=self._jvm)
+        # java gateway must have been launched at this point.
+        if conf is not None and conf._jconf:
+            # conf has been initialized in JVM properly, so use conf directly. This represent the
+            # scenario that JVM has been launched before SparkConf is created (e.g. SparkContext is
+            # created and then stopped, and we create a new SparkConf and new SparkContext again
+            self._conf = conf
+        else:
+            self._conf = SparkConf(_jvm=SparkContext._jvm)
 
         self._batchSize = batchSize  # -1 represents an unlimited batch size
         self._unbatched_serializer = serializer

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -33,6 +33,11 @@ from pyspark.serializers import read_int
 
 
 def launch_gateway(conf=None):
+    """
+    launch jvm gateway
+    :param conf: spark configuration passed to spark-submit
+    :return:
+    """
     if "PYSPARK_GATEWAY_PORT" in os.environ:
         gateway_port = int(os.environ["PYSPARK_GATEWAY_PORT"])
     else:

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -42,8 +42,9 @@ def launch_gateway(conf=None):
         on_windows = platform.system() == "Windows"
         script = "./bin/spark-submit.cmd" if on_windows else "./bin/spark-submit"
         command = [os.path.join(SPARK_HOME, script)]
-        for k,v in conf.getAll():
-            command += ['--conf', '%s=%s' % (k, v)]
+        if conf:
+            for k, v in conf.getAll():
+                command += ['--conf', '%s=%s' % (k, v)]
         submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
         if os.environ.get("SPARK_TESTING"):
             submit_args = ' '.join([

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -41,17 +41,17 @@ def launch_gateway(conf=None):
         # proper classpath and settings from spark-env.sh
         on_windows = platform.system() == "Windows"
         script = "./bin/spark-submit.cmd" if on_windows else "./bin/spark-submit"
+        command = [os.path.join(SPARK_HOME, script)]
+        for k,v in conf.getAll():
+            command += ['--conf', '%s=%s' % (k, v)]
         submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
-        if conf and conf.getAll():
-            submit_args = ' '.join(['--conf %s="%s"' % (k, v) for k, v in conf.getAll()]) \
-                + ' ' + submit_args
         if os.environ.get("SPARK_TESTING"):
             submit_args = ' '.join([
                 "--conf spark.ui.enabled=false",
                 submit_args
             ])
+        command = command + shlex.split(submit_args)
 
-        command = [os.path.join(SPARK_HOME, script)] + shlex.split(submit_args)
         # Start a socket that will be used by PythonGatewayServer to communicate its port to us
         callback_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         callback_socket.bind(('127.0.0.1', 0))

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -32,7 +32,7 @@ from py4j.java_gateway import java_import, JavaGateway, GatewayClient
 from pyspark.serializers import read_int
 
 
-def launch_gateway(conf = None):
+def launch_gateway(conf=None):
     if "PYSPARK_GATEWAY_PORT" in os.environ:
         gateway_port = int(os.environ["PYSPARK_GATEWAY_PORT"])
     else:
@@ -43,7 +43,7 @@ def launch_gateway(conf = None):
         script = "./bin/spark-submit.cmd" if on_windows else "./bin/spark-submit"
         submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
         if conf and conf.getAll():
-            submit_args = ' '.join([ '--conf %s="%s"' % (k, v) for k, v in conf.getAll()]) \
+            submit_args = ' '.join(['--conf %s="%s"' % (k, v) for k, v in conf.getAll()]) \
                 + ' ' + submit_args
         if os.environ.get("SPARK_TESTING"):
             submit_args = ' '.join([


### PR DESCRIPTION
## What changes were proposed in this pull request?

The root cause that we would ignore SparkConf when launching JVM is that SparkConf require JVM to be created first.  https://github.com/apache/spark/blob/master/python/pyspark/conf.py#L106
In this PR, I would defer the launching of JVM until SparkContext is created so that we can pass SparkConf to JVM correctly. 
## How was this patch tested?

Use the example code in the description of SPARK-17387,

```
$ SPARK_HOME=$PWD PYTHONPATH=python:python/lib/py4j-0.10.3-src.zip python
Python 2.7.12 (default, Jul  1 2016, 15:12:24) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyspark import SparkContext
>>> from pyspark import SparkConf
>>> conf = SparkConf().set("spark.driver.memory", "4g")
>>> sc = SparkContext(conf=conf)
```

And verify the spark.driver.memory is correctly picked up.

```
...op/ -Xmx4g org.apache.spark.deploy.SparkSubmit --conf spark.driver.memory=4g pyspark-shell
```
