### PR TITLE
[SPARK-17402][SQL] separate the management of temp views and metastore tables/views in SessionCatalog

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
@@ -30,8 +30,8 @@ class DatabaseAlreadyExistsException(db: String)
 class TableAlreadyExistsException(db: String, table: String)
   extends AnalysisException(s"Table or view '$table' already exists in database '$db'")
 
-class TempTableAlreadyExistsException(table: String)
-  extends AnalysisException(s"Temporary table '$table' already exists")
+class TempViewAlreadyExistsException(name: String)
+  extends AnalysisException(s"Temporary view '$name' already exists")
 
 class PartitionAlreadyExistsException(db: String, table: String, spec: TablePartitionSpec)
   extends AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -439,16 +439,7 @@ class Analyzer(
   object ResolveRelations extends Rule[LogicalPlan] {
     private def lookupTableFromCatalog(u: UnresolvedRelation): LogicalPlan = {
       try {
-        if (u.tableIdentifier.database.isDefined) {
-          catalog.lookupRelation(u.tableIdentifier, u.alias)
-        } else {
-          val maybeTempView = catalog.lookupTempView(u.tableIdentifier.table, u.alias)
-          if (maybeTempView.isDefined) {
-            maybeTempView.get
-          } else {
-            catalog.lookupRelation(u.tableIdentifier, u.alias)
-          }
-        }
+        catalog.lookupTempViewOrRelation(u.tableIdentifier, u.alias)
       } catch {
         case _: NoSuchTableException =>
           u.failAnalysis(s"Table or view not found: ${u.tableName}")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -272,6 +272,22 @@ class SessionCatalog(
   }
 
   /**
+   * Return a [[LogicalPlan]] that represents the given table/view in metastore.
+   *
+   * If the relation is a view, the relation will be wrapped in a [[SubqueryAlias]] which will
+   * track the name of the view.
+   */
+  def lookupRelation(name: TableIdentifier, alias: Option[String] = None): LogicalPlan = {
+    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
+    val table = formatTableName(name.table)
+    val tableMeta = externalCatalog.getTable(db, table)
+    val view = Option(tableMeta.tableType).collect {
+      case CatalogTableType.VIEW => TableIdentifier(table, Some(db))
+    }
+    SubqueryAlias(alias.getOrElse(table), SimpleCatalogRelation(db, tableMeta), view)
+  }
+
+  /**
    * Return whether a table/view with the specified name exists in metastore.
    */
   def tableExists(name: TableIdentifier): Boolean = {
@@ -371,6 +387,16 @@ class SessionCatalog(
   }
 
   /**
+   * Return a [[LogicalPlan]] that represents the given temporary view.
+   */
+  def lookupTempView(name: String, alias: Option[String] = None): Option[LogicalPlan] = {
+    val viewName = formatTableName(name)
+    tempViews.get(viewName).map { viewDef =>
+      SubqueryAlias(alias.getOrElse(viewName), viewDef, Some(TableIdentifier(viewName)))
+    }
+  }
+
+  /**
    * Rename a temporary view, and returns true if it succeeds, false otherwise.
    */
   def renameTempView(oldName: String, newName: String): Boolean = {
@@ -400,43 +426,6 @@ class SessionCatalog(
   // -------------------------------------------------------------------------
   // | Methods that interact with temporary views and metastore tables/views |
   // -------------------------------------------------------------------------
-
-  /**
-   * Return a [[LogicalPlan]] that represents the given table/view.
-   *
-   * If a database is specified in `name`, this will return the table/view from that database.
-   * If no database is specified, this will first attempt to return a temporary view with
-   * the same name, then, if that does not exist, return the table/view from the current database.
-   *
-   * If the relation is a view, the relation will be wrapped in a [[SubqueryAlias]] which will
-   * track the name of the view.
-   */
-  def lookupRelation(name: TableIdentifier, alias: Option[String] = None): LogicalPlan = {
-    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
-    val table = formatTableName(name.table)
-
-    if (name.database.isDefined) {
-      lookupMetastoreRelation(db, table, alias)
-    } else {
-      val maybeTempView = tempViews.get(table)
-      if (maybeTempView.isDefined) {
-        SubqueryAlias(alias.getOrElse(table), maybeTempView.get, Some(name))
-      } else {
-        lookupMetastoreRelation(db, table, alias)
-      }
-    }
-  }
-
-  protected def lookupMetastoreRelation(
-      db: String,
-      table: String,
-      alias: Option[String]): LogicalPlan = {
-    val metadata = externalCatalog.getTable(db, table)
-    val view = Option(metadata.tableType).collect {
-      case CatalogTableType.VIEW => TableIdentifier(table, Some(db))
-    }
-    SubqueryAlias(alias.getOrElse(table), SimpleCatalogRelation(db, metadata), view)
-  }
 
   /**
    * List all tables/views in the specified database, including temporary views.
@@ -474,11 +463,6 @@ class SessionCatalog(
    * For testing only.
    */
   def clearTempViews(): Unit = tempViews.clear()
-
-  /**
-   * Return a temporary view exactly as it was stored.
-   */
-  def getTempView(name: String): Option[LogicalPlan] = tempViews.get(formatTableName(name))
 
   // ----------------------------------------------------------------------------
   // Partitions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TempViewManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TempViewManager.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.catalyst.util.StringUtils
 
 /**
  * A thread-safe manager for a list of temp views, providing atomic operations to manage temp views.
+ * Note that, the temp view name is always case-sensitive here, callers are responsible to format
+ * the view name w.r.t. case-sensitivity config.
  */
 class TempViewManager {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TempViewManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TempViewManager.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import javax.annotation.concurrent.GuardedBy
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.TempViewAlreadyExistsException
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.StringUtils
+
+
+/**
+ * A thread-safe manager for a list of temp views, providing atomic operations to manage temp views.
+ */
+class TempViewManager {
+
+  /** List of temporary views, mapping from view name to logical plan. */
+  @GuardedBy("this")
+  private val tempViews = new mutable.HashMap[String, LogicalPlan]
+
+  def get(name: String): Option[LogicalPlan] = synchronized {
+    tempViews.get(name)
+  }
+
+  def create(
+      name: String,
+      viewDefinition: LogicalPlan,
+      overrideIfExists: Boolean): Unit = synchronized {
+    if (!overrideIfExists && tempViews.contains(name)) {
+      throw new TempViewAlreadyExistsException(name)
+    }
+    tempViews.put(name, viewDefinition)
+  }
+
+  def update(
+      name: String,
+      viewDefinition: LogicalPlan): Boolean = synchronized {
+    // Only update it when the view with the given name exits.
+    if (tempViews.contains(name)) {
+      tempViews.put(name, viewDefinition)
+      true
+    } else {
+      false
+    }
+  }
+
+  def remove(name: String): Boolean = synchronized {
+    tempViews.remove(name).isDefined
+  }
+
+  def rename(oldName: String, newName: String): Boolean = synchronized {
+    if (tempViews.contains(oldName)) {
+      if (tempViews.contains(newName)) {
+        throw new AnalysisException(
+          s"rename temporary view from '$oldName' to '$newName': destination view already exists")
+      }
+
+      val viewDefinition = tempViews(oldName)
+      tempViews.remove(oldName)
+      tempViews.put(newName, viewDefinition)
+      true
+    } else {
+      false
+    }
+  }
+
+  def listNames(pattern: String): Seq[String] = synchronized {
+    StringUtils.filterPattern(tempViews.keys.toSeq, pattern)
+  }
+
+  def clear(): Unit = synchronized {
+    tempViews.clear()
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -201,16 +201,16 @@ class SessionCatalogSuite extends SparkFunSuite {
     val tempTable2 = Range(1, 20, 2, 10)
     catalog.createTempView("tbl1", tempTable1, overrideIfExists = false)
     catalog.createTempView("tbl2", tempTable2, overrideIfExists = false)
-    assert(catalog.getTempView("tbl1") == Option(tempTable1))
-    assert(catalog.getTempView("tbl2") == Option(tempTable2))
-    assert(catalog.getTempView("tbl3").isEmpty)
+    assert(catalog.lookupTempView("tbl1") == Option(tempTable1))
+    assert(catalog.lookupTempView("tbl2") == Option(tempTable2))
+    assert(catalog.lookupTempView("tbl3").isEmpty)
     // Temporary table already exists
     intercept[TempViewAlreadyExistsException] {
       catalog.createTempView("tbl1", tempTable1, overrideIfExists = false)
     }
     // Temporary table already exists but we override it
     catalog.createTempView("tbl1", tempTable2, overrideIfExists = true)
-    assert(catalog.getTempView("tbl1") == Option(tempTable2))
+    assert(catalog.lookupTempView("tbl1") == Option(tempTable2))
   }
 
   test("drop table") {
@@ -251,10 +251,10 @@ class SessionCatalogSuite extends SparkFunSuite {
     val tempTable = Range(1, 10, 2, 10)
     sessionCatalog.createTempView("tbl1", tempTable, overrideIfExists = false)
     sessionCatalog.setCurrentDatabase("db2")
-    assert(sessionCatalog.getTempView("tbl1") == Some(tempTable))
+    assert(sessionCatalog.lookupTempView("tbl1") == Some(tempTable))
     assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
     sessionCatalog.dropTempView("tbl1")
-    assert(sessionCatalog.getTempView("tbl1").isEmpty)
+    assert(sessionCatalog.lookupTempView("tbl1").isEmpty)
     assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
   }
 
@@ -292,11 +292,11 @@ class SessionCatalogSuite extends SparkFunSuite {
     val tempTable = Range(1, 10, 2, 10)
     sessionCatalog.createTempView("tbl1", tempTable, overrideIfExists = false)
     sessionCatalog.setCurrentDatabase("db2")
-    assert(sessionCatalog.getTempView("tbl1") == Option(tempTable))
+    assert(sessionCatalog.lookupTempView("tbl1") == Option(tempTable))
     assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
     sessionCatalog.renameTempView("tbl1", "tbl3")
-    assert(sessionCatalog.getTempView("tbl1").isEmpty)
-    assert(sessionCatalog.getTempView("tbl3") == Option(tempTable))
+    assert(sessionCatalog.lookupTempView("tbl1").isEmpty)
+    assert(sessionCatalog.lookupTempView("tbl3") == Option(tempTable))
     assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -358,7 +358,7 @@ class SessionCatalogSuite extends SparkFunSuite {
     }
   }
 
-  test("lookup table relation") {
+  test("lookupTempViewOrRelation") {
     val externalCatalog = newBasicCatalog()
     val sessionCatalog = new SessionCatalog(externalCatalog)
     val tempTable1 = Range(1, 10, 1, 10)
@@ -366,14 +366,14 @@ class SessionCatalogSuite extends SparkFunSuite {
     sessionCatalog.createTempView("tbl1", tempTable1, overrideIfExists = false)
     sessionCatalog.setCurrentDatabase("db2")
     // If we explicitly specify the database, we'll look up the relation in that database
-    assert(sessionCatalog.lookupRelation(TableIdentifier("tbl1", Some("db2")))
+    assert(sessionCatalog.lookupTempViewOrRelation(TableIdentifier("tbl1", Some("db2")))
       == SubqueryAlias("tbl1", SimpleCatalogRelation("db2", metastoreTable1), None))
     // Otherwise, we'll first look up a temporary table with the same name
-    assert(sessionCatalog.lookupRelation(TableIdentifier("tbl1"))
+    assert(sessionCatalog.lookupTempViewOrRelation(TableIdentifier("tbl1"))
       == SubqueryAlias("tbl1", tempTable1, Some(TableIdentifier("tbl1"))))
     // Then, if that does not exist, look up the relation in the current database
     sessionCatalog.dropTempView("tbl1")
-    assert(sessionCatalog.lookupRelation(TableIdentifier("tbl1"))
+    assert(sessionCatalog.lookupTempViewOrRelation(TableIdentifier("tbl1"))
       == SubqueryAlias("tbl1", SimpleCatalogRelation("db2", metastoreTable1), None))
   }
 
@@ -395,7 +395,7 @@ class SessionCatalogSuite extends SparkFunSuite {
     val catalog = new SessionCatalog(newBasicCatalog())
     val tmpView = Range(1, 10, 2, 10)
     catalog.createTempView("vw1", tmpView, overrideIfExists = false)
-    val plan = catalog.lookupRelation(TableIdentifier("vw1"), Option("range"))
+    val plan = catalog.lookupTempViewOrRelation(TableIdentifier("vw1"), Option("range"))
     assert(plan == SubqueryAlias("range", tmpView, Option(TableIdentifier("vw1"))))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -463,9 +463,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * @since 1.4.0
    */
   def table(tableName: String): DataFrame = {
-    Dataset.ofRows(sparkSession,
-      sparkSession.sessionState.catalog.lookupRelation(
-        sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)))
+    sparkSession.table(tableName)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -556,20 +556,7 @@ class SparkSession private(
   }
 
   private[sql] def table(tableIdent: TableIdentifier): DataFrame = {
-    val plan = {
-      if (tableIdent.database.isDefined) {
-        sessionState.catalog.lookupRelation(tableIdent)
-      } else {
-        val maybeTempView = sessionState.catalog.lookupTempView(tableIdent.table)
-        if (maybeTempView.isDefined) {
-          maybeTempView.get
-        } else {
-          sessionState.catalog.lookupRelation(tableIdent)
-        }
-      }
-    }
-
-    Dataset.ofRows(self, plan)
+    Dataset.ofRows(self, sessionState.catalog.lookupTempViewOrRelation(tableIdent))
   }
 
   /* ----------------- *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -49,7 +49,7 @@ case class CreateTempViewUsing(
 
   if (tableIdent.database.isDefined) {
     throw new AnalysisException(
-      s"Temporary table '$tableIdent' should not have specified a database")
+      s"Temporary view '$tableIdent' should not have specified a database")
   }
 
   def run(sparkSession: SparkSession): Seq[Row] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -139,7 +139,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    */
   @throws[AnalysisException]("table does not exist")
   override def listColumns(tableName: String): Dataset[Column] = {
-    val maybeTempView = sessionCatalog.getTempView(tableName)
+    val maybeTempView = sessionCatalog.lookupTempView(tableName)
     if (maybeTempView.isDefined) {
       val columns = maybeTempView.get.schema.map { c =>
         new Column(
@@ -368,7 +368,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
     // If this table is cached as an InMemoryRelation, drop the original
     // cached version and make the new version cached lazily.
-    val logicalPlan = sparkSession.sessionState.catalog.lookupRelation(tableIdent)
+    val logicalPlan = sparkSession.table(tableIdent).queryExecution.logical
     // Use lookupCachedData directly since RefreshTable also takes databaseName.
     val isCached = sparkSession.sharedState.cacheManager.lookupCachedData(logicalPlan).nonEmpty
     if (isCached) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLContextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLContextSuite.scala
@@ -94,8 +94,7 @@ class SQLContextSuite extends SparkFunSuite with SharedSparkContext {
       sqlContext.sql("SHOW tables").filter("tableName = 'listtablessuitetable'").collect().toSeq ==
       Row("listtablessuitetable", true) :: Nil)
 
-    sqlContext.sessionState.catalog.dropTable(
-      TableIdentifier("listtablessuitetable"), ignoreIfNotExists = true, purge = false)
+    sqlContext.sessionState.catalog.dropTempView("listtablessuitetable")
     assert(sqlContext.tables().filter("tableName = 'listtablessuitetable'").count() === 0)
   }
 
@@ -111,8 +110,7 @@ class SQLContextSuite extends SparkFunSuite with SharedSparkContext {
       sqlContext.sql("show TABLES in default").filter("tableName = 'listtablessuitetable'")
         .collect().toSeq == Row("listtablessuitetable", true) :: Nil)
 
-    sqlContext.sessionState.catalog.dropTable(
-      TableIdentifier("listtablessuitetable"), ignoreIfNotExists = true, purge = false)
+    sqlContext.sessionState.catalog.dropTempView("listtablessuitetable")
     assert(sqlContext.tables().filter("tableName = 'listtablessuitetable'").count() === 0)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2661,4 +2661,15 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         data.selectExpr("`part.col1`", "`col.1`"))
     }
   }
+
+  test("CREATE TABLE USING if a same-name temp view exists") {
+    withTable("same_name") {
+      withTempView("same_name") {
+        spark.range(10).createTempView("same_name")
+        sql("CREATE TABLE same_name(i int) USING json")
+        checkAnswer(spark.table("same_name"), spark.range(10).toDF())
+        assert(spark.table("default.same_name").collect().isEmpty)
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -458,12 +458,15 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
   }
 
   test("save as table if a same-name temp view exists") {
-    withTable("same_name") {
-      withTempView("same_name") {
-        spark.range(10).createTempView("same_name")
-        spark.range(20).write.saveAsTable("same_name")
-        checkAnswer(spark.table("same_name"), spark.range(10).toDF())
-        checkAnswer(spark.table("default.same_name"), spark.range(20).toDF())
+    import SaveMode._
+    for (mode <- Seq(Append, ErrorIfExists, Overwrite, Ignore)) {
+      withTable("same_name") {
+        withTempView("same_name") {
+          spark.range(10).createTempView("same_name")
+          spark.range(20).write.mode(mode).saveAsTable("same_name")
+          checkAnswer(spark.table("same_name"), spark.range(10).toDF())
+          checkAnswer(spark.table("default.same_name"), spark.range(20).toDF())
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -457,6 +457,17 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
     checkAnswer(df2, df)
   }
 
+  test("save as table if a same-name temp view exists") {
+    withTable("same_name") {
+      withTempView("same_name") {
+        spark.range(10).createTempView("same_name")
+        spark.range(20).write.saveAsTable("same_name")
+        checkAnswer(spark.table("same_name"), spark.range(10).toDF())
+        checkAnswer(spark.table("default.same_name"), spark.range(20).toDF())
+      }
+    }
+  }
+
   private def testRead(
       df: => DataFrame,
       expectedResult: Seq[String],

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -53,19 +53,11 @@ private[sql] class HiveSessionCatalog(
     conf,
     hadoopConf) {
 
-  override def lookupRelation(name: TableIdentifier, alias: Option[String]): LogicalPlan = {
-    val table = formatTableName(name.table)
-    if (name.database.isDefined || !tempTables.contains(table)) {
-      val database = name.database.map(formatDatabaseName)
-      val newName = name.copy(database = database, table = table)
-      metastoreCatalog.lookupRelation(newName, alias)
-    } else {
-      val relation = tempTables(table)
-      val tableWithQualifiers = SubqueryAlias(table, relation, None)
-      // If an alias was specified by the lookup, wrap the plan in a subquery so that
-      // attributes are properly qualified with this alias.
-      alias.map(a => SubqueryAlias(a, tableWithQualifiers, None)).getOrElse(tableWithQualifiers)
-    }
+  override protected def lookupMetastoreRelation(
+      db: String,
+      table: String,
+      alias: Option[String]): LogicalPlan = {
+    metastoreCatalog.lookupRelation(TableIdentifier(table, Some(db)), alias)
   }
 
   // ----------------------------------------------------------------

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -53,10 +53,9 @@ private[sql] class HiveSessionCatalog(
     conf,
     hadoopConf) {
 
-  override protected def lookupMetastoreRelation(
-      db: String,
-      table: String,
-      alias: Option[String]): LogicalPlan = {
+  override def lookupRelation(name: TableIdentifier, alias: Option[String] = None): LogicalPlan = {
+    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
+    val table = formatTableName(name.table)
     metastoreCatalog.lookupRelation(TableIdentifier(table, Some(db)), alias)
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -424,7 +424,7 @@ private[hive] class TestHiveSparkSession(
 
       sharedState.cacheManager.clearCache()
       loadedTables.clear()
-      sessionState.catalog.clearTempTables()
+      sessionState.catalog.clearTempViews()
       sessionState.catalog.invalidateCache()
 
       sessionState.metadataHive.reset()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -675,7 +675,7 @@ class HiveDDLSuite
           identifier = TableIdentifier(sourceViewName),
           tableType = CatalogTableType.VIEW,
           storage = CatalogStorageFormat.empty,
-          schema = spark.sessionState.catalog.getTempView(sourceViewName).get.schema)
+          schema = spark.sessionState.catalog.lookupTempView(sourceViewName).get.schema)
         val targetTable = spark.sessionState.catalog.getTableMetadata(
           TableIdentifier(targetTabName, Some("default")))
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.internal.config._
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.CaseInsensitiveMap
@@ -671,8 +671,11 @@ class HiveDDLSuite
           .createTempView(sourceViewName)
         sql(s"CREATE TABLE $targetTabName LIKE $sourceViewName")
 
-        val sourceTable = spark.sessionState.catalog.getTableMetadata(
-          TableIdentifier(sourceViewName, None))
+        val sourceTable = CatalogTable(
+          identifier = TableIdentifier(sourceViewName),
+          tableType = CatalogTableType.VIEW,
+          storage = CatalogStorageFormat.empty,
+          schema = spark.sessionState.catalog.getTempView(sourceViewName).get.schema)
         val targetTable = spark.sessionState.catalog.getTableMetadata(
           TableIdentifier(targetTabName, Some("default")))
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
@@ -62,15 +62,15 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       var e = intercept[AnalysisException] {
         sql("CREATE OR REPLACE VIEW tab1 AS SELECT * FROM jt")
       }.getMessage
-      assert(e.contains("`default`.`tab1` is not a view"))
+      assert(e.contains("`tab1` is not a view"))
       e = intercept[AnalysisException] {
         sql("CREATE VIEW tab1 AS SELECT * FROM jt")
       }.getMessage
-      assert(e.contains("`default`.`tab1` is not a view"))
+      assert(e.contains("`tab1` is not a view"))
       e = intercept[AnalysisException] {
         sql("ALTER VIEW tab1 AS SELECT * FROM jt")
       }.getMessage
-      assert(e.contains("`default`.`tab1` is not a view"))
+      assert(e.contains("`tab1` is not a view"))
     }
   }
 
@@ -95,12 +95,12 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       e = intercept[AnalysisException] {
         sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE $viewName""")
       }.getMessage
-      assert(e.contains(s"Target table in LOAD DATA cannot be temporary: `$viewName`"))
+      assert(e.contains(s"Target table in LOAD DATA does not exist: `$viewName`"))
 
       e = intercept[AnalysisException] {
         sql(s"TRUNCATE TABLE $viewName")
       }.getMessage
-      assert(e.contains(s"Operation not allowed: TRUNCATE TABLE on temporary tables: `$viewName`"))
+      assert(e.contains(s"Table `$viewName` in TRUNCATE TABLE does not exist"))
     }
   }
 
@@ -195,7 +195,7 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         sql("CREATE TEMPORARY VIEW testView AS SELECT id FROM jt")
       }
 
-      assert(e.message.contains("Temporary table") && e.message.contains("already exists"))
+      assert(e.message.contains("Temporary view") && e.message.contains("already exists"))
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLViewSuite.scala
@@ -83,7 +83,7 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("error handling: insert/load/truncate table commands against a temp view") {
-    val viewName = "testView"
+    val viewName = "test_view"
     withTempView(viewName) {
       sql(s"CREATE TEMPORARY VIEW $viewName AS SELECT id FROM jt")
       var e = intercept[AnalysisException] {
@@ -95,12 +95,12 @@ class SQLViewSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       e = intercept[AnalysisException] {
         sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE $viewName""")
       }.getMessage
-      assert(e.contains(s"Target table in LOAD DATA does not exist: `$viewName`"))
+      assert(e.contains(s"Table or view '$viewName' not found in database 'default'"))
 
       e = intercept[AnalysisException] {
         sql(s"TRUNCATE TABLE $viewName")
       }.getMessage
-      assert(e.contains(s"Table `$viewName` in TRUNCATE TABLE does not exist"))
+      assert(e.contains(s"Table or view '$viewName' not found in database 'default'"))
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
@@ -337,9 +337,8 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
   }
 
   test("saveAsTable()/load() - non-partitioned table - ErrorIfExists") {
-    Seq.empty[(Int, String)].toDF().createOrReplaceTempView("t")
-
-    withTempView("t") {
+    withTable("t") {
+      Seq.empty[(Int, String)].toDF().write.mode(SaveMode.Overwrite).saveAsTable("t")
       intercept[AnalysisException] {
         testDF.write.format(dataSourceName).mode(SaveMode.ErrorIfExists).saveAsTable("t")
       }
@@ -347,9 +346,8 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
   }
 
   test("saveAsTable()/load() - non-partitioned table - Ignore") {
-    Seq.empty[(Int, String)].toDF().createOrReplaceTempView("t")
-
-    withTempView("t") {
+    withTable("t") {
+      Seq.empty[(Int, String)].toDF().write.mode(SaveMode.Overwrite).saveAsTable("t")
       testDF.write.format(dataSourceName).mode(SaveMode.Ignore).saveAsTable("t")
       assert(spark.table("t").collect().isEmpty)
     }
@@ -459,9 +457,9 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
   }
 
   test("saveAsTable()/load() - partitioned table - ErrorIfExists") {
-    Seq.empty[(Int, String)].toDF().createOrReplaceTempView("t")
+    withTable("t") {
+      Seq.empty[(Int, String)].toDF().write.mode(SaveMode.Overwrite).saveAsTable("t")
 
-    withTempView("t") {
       intercept[AnalysisException] {
         partitionedTestDF.write
           .format(dataSourceName)
@@ -474,9 +472,9 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
   }
 
   test("saveAsTable()/load() - partitioned table - Ignore") {
-    Seq.empty[(Int, String)].toDF().createOrReplaceTempView("t")
+    withTable("t") {
+      Seq.empty[(Int, String)].toDF().write.mode(SaveMode.Overwrite).saveAsTable("t")
 
-    withTempView("t") {
       partitionedTestDF.write
         .format(dataSourceName)
         .mode(SaveMode.Ignore)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `SessionCatalog`, we have several operations(`getTableMetadata`, `tableExists`, `renameTable`, `dropTable`, `loopupRelation`) that handle both temp views and metastore tables/views. They can save some lines of code for some commands that need to deal with both temp views and metastore tables/views, but also introduce bugs for other commands, because the operation names say nothing about temp views and are very likely to be misused:
- `DataFrameWriter.saveAsTable`/`CREATE TABLE USING` will fail if a same-name temp view exits
- `DataFrameWriter.saveAsTable` with overwrite mode will mistakenly drop a same-name temp view.
- `Catalog.dropTempView` may drop metastore table mistakenly
- `ALTER TABLE RECOVER PARTITIONS`/`LOAD DATA`/`TRUNCATE TABLE`/`SHOW CREATE TABLE` should report "table not found" instead of "temp view is not supported", if a same-name temp view exists, because these commands don't need to deal with temp views.

In some commands we support temp views mistakenly without mentioning it in document: `ShowTablePropertiesCommand`, `ShowColumnsCommand`, `Catalog.listColumns`.
This PR remove the temp view support in `ShowTablePropertiesCommand`, as temp view doesn't have properties. And explicitly document that `ShowColumnsCommand` and `Catalog.listColumns` support temp view.

Mixing the handling of temp views and metastore tables/views also makes it harder to implement thread-safe operations. e.g. `AlterViewAsCommand` checks `isTemporaryTable` first then `createTempView`, which is not atomic. Most temp view related operations in `SessionCatalog` hold a lock on the `SessionCatalog` object, which is unnecessary.

This PR separates the management of temp views and metastore tables/views in `SessionCatalog`, any commands that need to deal with temp views should explicitly call temp view related operations in `SessionCatalog`, to fix existing bugs and prevent future bug like this.
## How was this patch tested?

existing tests and 3 new tests.
