### PR TITLE
[Minor] [ML] Correct weights doc of MultilayerPerceptronClassificationModel.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
@@ -288,7 +288,7 @@ object MultilayerPerceptronClassifier
  *
  * @param uid uid
  * @param layers array of layer sizes including input and output layers
- * @param weights vector of initial weights for the model that consists of the weights of layers
+ * @param weights the weights of layers
  * @return prediction model
  */
 @Since("1.5.0")

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1276,7 +1276,7 @@ class MultilayerPerceptronClassificationModel(JavaModel, JavaPredictionModel, Ja
     @since("2.0.0")
     def weights(self):
         """
-        vector of initial weights for the model that consists of the weights of layers.
+        the weights of layers.
         """
         return self._call_java("weights")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`weights` of `MultilayerPerceptronClassificationModel` should be the output weights of layers rather than initial weights, this PR correct it.
## How was this patch tested?

Doc change.
