### PR TITLE
[Minor] Remove unnecessary check in MLSerDe

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/python/MLSerDe.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/python/MLSerDe.scala
@@ -57,7 +57,7 @@ private[spark] object MLSerDe extends SerDeBase with Serializable {
 
     def construct(args: Array[Object]): Object = {
       if (args.length != 1) {
-        throw new PickleException("should be 1")
+        throw new PickleException("length of args should be 1")
       }
       val bytes = getBytes(args(0))
       val bb = ByteBuffer.wrap(bytes, 0, bytes.length)
@@ -94,7 +94,7 @@ private[spark] object MLSerDe extends SerDeBase with Serializable {
 
     def construct(args: Array[Object]): Object = {
       if (args.length != 4) {
-        throw new PickleException("should be 4")
+        throw new PickleException("length of args should be 4")
       }
       val bytes = getBytes(args(2))
       val n = bytes.length / 8
@@ -142,7 +142,7 @@ private[spark] object MLSerDe extends SerDeBase with Serializable {
 
     def construct(args: Array[Object]): Object = {
       if (args.length != 6) {
-        throw new PickleException("should be 6")
+        throw new PickleException("length of args should be 6")
       }
       val order = ByteOrder.nativeOrder()
       val colPtrsBytes = getBytes(args(2))
@@ -186,7 +186,7 @@ private[spark] object MLSerDe extends SerDeBase with Serializable {
 
     def construct(args: Array[Object]): Object = {
       if (args.length != 3) {
-        throw new PickleException("should be 3")
+        throw new PickleException("length of args should be 3")
       }
       val size = args(0).asInstanceOf[Int]
       val indiceBytes = getBytes(args(1))

--- a/mllib/src/main/scala/org/apache/spark/ml/python/MLSerDe.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/python/MLSerDe.scala
@@ -56,7 +56,6 @@ private[spark] object MLSerDe extends SerDeBase with Serializable {
     }
 
     def construct(args: Array[Object]): Object = {
-      require(args.length == 1)
       if (args.length != 1) {
         throw new PickleException("should be 1")
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1, remove unnecessary `require()`, because it will make following check useless.
2, update the error msg.
## How was this patch tested?

no test
