### PR TITLE
[Trivial][ML] Remove unnecessary `new` before case class construction

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
@@ -159,7 +159,7 @@ object MaxAbsScalerModel extends MLReadable[MaxAbsScalerModel] {
 
     override protected def saveImpl(path: String): Unit = {
       DefaultParamsWriter.saveMetadata(instance, path, sc)
-      val data = new Data(instance.maxAbs)
+      val data = Data(instance.maxAbs)
       val dataPath = new Path(path, "data").toString
       sparkSession.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -223,7 +223,7 @@ object MinMaxScalerModel extends MLReadable[MinMaxScalerModel] {
 
     override protected def saveImpl(path: String): Unit = {
       DefaultParamsWriter.saveMetadata(instance, path, sc)
-      val data = new Data(instance.originalMin, instance.originalMax)
+      val data = Data(instance.originalMin, instance.originalMax)
       val dataPath = new Path(path, "data").toString
       sparkSession.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Delete unnecessary `new` before case class' apply function.
Run `find mllib/src/main/scala/org/apache/spark/ml -name "*scala" | xargs -i bash -c 'grep -i "new Data(" {} && echo {}'` to make sure that only `MaxAbsScaler` and `MinMaxScaler` need modification.
## How was this patch tested?

unit test
