### PR TITLE
[SPARK-17426][SQL] Refactor `TreeNode.toJSON` to avoid OOM when converting unknown fields to JSON

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -597,10 +597,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       // this child in all children.
       case (name, value: TreeNode[_]) if containsChild(value) =>
         name -> JInt(children.indexOf(value))
-      // Check the value (Seq[BaseType]) element type first before converting it to a Set.
-      // Otherwise, it may take a lot of memory to convert a super big Seq to Set.
-      case (name, value: Seq[BaseType]) if value.length > 1 &&
-        value.head.isInstanceOf[TreeNode[_]] && value.toSet.subsetOf(containsChild) =>
+      case (name, value: Seq[BaseType]) if value.forall(containsChild) =>
         name -> JArray(
           value.map(v => JInt(children.indexOf(v.asInstanceOf[TreeNode[_]]))).toList
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -30,7 +30,7 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.{EmptyRDD, RDD}
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, FunctionResource}
+import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogTableType, FunctionResource}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.ScalaReflection._
 import org.apache.spark.sql.catalyst.ScalaReflectionLock
@@ -671,6 +671,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case partition: Partitioning => true
     case resource: FunctionResource => true
     case broadcast: BroadcastMode => true
+    case table: CatalogTableType => true
+    case storage: CatalogStorageFormat => true
     case _ => false
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -627,7 +627,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case n: TreeNode[_] => n.jsonValue
     case o: Option[_] => o.map(parseToJson)
     // Recursive scan Seq[TreeNode]
-    case t: Seq[_] if t.length > 0 && t.head.isInstanceOf[TreeNode[_]] =>
+    case t: Seq[_] if t.forall(_.isInstanceOf[TreeNode[_]]) =>
       JArray(t.map(parseToJson).toList)
     // if it's a scala object, we can simply keep the full class path.
     // TODO: currently if the class name ends with "$", we think it's a scala object, there is

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -636,13 +636,14 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case t: Seq[_] if t.forall(_.isInstanceOf[TreeNode[_]]) ||
       t.forall(_.isInstanceOf[Partitioning]) || t.forall(_.isInstanceOf[DataType]) =>
       JArray(t.map(parseToJson).toList)
+    case t: Seq[_] if t.length > 0 && t.head.isInstanceOf[String] =>
+      JString(Utils.truncatedString(t, "[", ", ", "]"))
+    case t: Seq[_] => JNull
+    case m: Map[_, _] => JNull
     // if it's a scala object, we can simply keep the full class path.
     // TODO: currently if the class name ends with "$", we think it's a scala object, there is
     // probably a better way to check it.
     case obj if obj.getClass.getName.endsWith("$") => "object" -> obj.getClass.getName
-    case t: Seq[_] if t.length > 0 && t.head.isInstanceOf[String] =>
-      JString(Utils.truncatedString(t, "[", ", ", "]"))
-    case t: Seq[_] => JNull
     case p: Product if shouldConvertToJson(p) =>
       try {
         val fieldNames = getConstructorParameterNames(p.getClass)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -310,8 +310,8 @@ class TreeNodeSuite extends SparkFunSuite {
     compareJSON(JsonTestTreeNode(None).toJSON,
       s"""[
          |  {
-         |    "class":"${classOf[JsonTestTreeNode].getName}",
-         |    "num-children":0
+         |    "class": "${classOf[JsonTestTreeNode].getName}",
+         |    "num-children": 0
          |  }
          |]
        """.stripMargin)
@@ -319,17 +319,17 @@ class TreeNodeSuite extends SparkFunSuite {
     val uuid = UUID.randomUUID()
     assertJSON(uuid, "\"" + uuid.toString + "\"")
 
-    // Converts some Spark Sql types to JSON
+    // Converts Spark Sql DataType to JSON
     assertJSON(IntegerType, "\"integer\"")
     assertJSON(Metadata.empty, Metadata.empty.json)
     assertJSON(
       StorageLevel.NONE,
       """{
-        |  "useDisk":false,
-        |  "useMemory":false,
-        |  "useOffHeap":false,
-        |  "deserialized":false,
-        |  "replication":1
+        |  "useDisk": false,
+        |  "useMemory": false,
+        |  "useOffHeap": false,
+        |  "deserialized": false,
+        |  "replication": 1
         |}
       """.stripMargin)
 
@@ -338,10 +338,10 @@ class TreeNodeSuite extends SparkFunSuite {
       Literal(333),
       """[
         |  {
-        |    "class":"org.apache.spark.sql.catalyst.expressions.Literal",
-        |    "num-children":0,
-        |    "value":"333",
-        |    "dataType":"integer"
+        |    "class": "org.apache.spark.sql.catalyst.expressions.Literal",
+        |    "num-children": 0,
+        |    "value": "333",
+        |    "dataType": "integer"
         |  }
         |]
       """.stripMargin)
@@ -352,17 +352,17 @@ class TreeNodeSuite extends SparkFunSuite {
     // Converts Seq[DataType] to JSON
     assertJSON(Seq(IntegerType, DoubleType, FloatType), """["integer","double","float"]""")
 
-    // Converts Seq[Partitioning]
+    // Converts Seq[Partitioning] to JSON
     assertJSON(
       Seq(SinglePartition, RoundRobinPartitioning(numPartitions = 3)),
       """
         |[
         |  {
-        |    "object":"org.apache.spark.sql.catalyst.plans.physical.SinglePartition$"
+        |    "object": "org.apache.spark.sql.catalyst.plans.physical.SinglePartition$"
         |  },
         |  {
-        |    "product-class":"org.apache.spark.sql.catalyst.plans.physical.RoundRobinPartitioning",
-        |    "numPartitions":3
+        |    "product-class": "org.apache.spark.sql.catalyst.plans.physical.RoundRobinPartitioning",
+        |    "numPartitions": 3
         |  }
         |]
       """.stripMargin)
@@ -370,16 +370,20 @@ class TreeNodeSuite extends SparkFunSuite {
     // Converts case object to JSON
     assertJSON(
       DummyObject,
-      "{\"object\":\"org.apache.spark.sql.catalyst.trees.DummyObject$\"}")
+      """
+        |{
+        |  "object": "org.apache.spark.sql.catalyst.trees.DummyObject$"
+        |}
+      """.stripMargin)
 
     // Converts ExprId to JSON
     assertJSON(
       ExprId(0, uuid),
       s"""
          |{
-         |  "product-class":"org.apache.spark.sql.catalyst.expressions.ExprId",
-         |  "id":0,
-         |  "jvmId":"${uuid.toString}"
+         |  "product-class": "org.apache.spark.sql.catalyst.expressions.ExprId",
+         |  "id": 0,
+         |  "jvmId": "${uuid.toString}"
          |}
        """.stripMargin)
 
@@ -388,11 +392,11 @@ class TreeNodeSuite extends SparkFunSuite {
       StructField("field", IntegerType),
       """
         |{
-        |  "product-class":"org.apache.spark.sql.types.StructField",
-        |  "name":"field",
-        |  "dataType":"integer",
-        |  "nullable":true,
-        |  "metadata":{}
+        |  "product-class": "org.apache.spark.sql.types.StructField",
+        |  "name": "field",
+        |  "dataType": "integer",
+        |  "nullable": true,
+        |  "metadata": {}
         |}
       """.stripMargin)
 
@@ -400,7 +404,10 @@ class TreeNodeSuite extends SparkFunSuite {
     assertJSON(
       TableIdentifier("table"),
       """
-        |{"product-class":"org.apache.spark.sql.catalyst.TableIdentifier","table":"table"}
+        |{
+        |  "product-class": "org.apache.spark.sql.catalyst.TableIdentifier",
+        |  "table": "table"
+        |}
       """.stripMargin)
 
     // Converts JoinType to JSON
@@ -408,8 +415,10 @@ class TreeNodeSuite extends SparkFunSuite {
       NaturalJoin(LeftOuter),
       """
         |{
-        |  "product-class":"org.apache.spark.sql.catalyst.plans.NaturalJoin",
-        |  "tpe":{"object":"org.apache.spark.sql.catalyst.plans.LeftOuter$"}
+        |  "product-class": "org.apache.spark.sql.catalyst.plans.NaturalJoin",
+        |  "tpe":{
+        |    "object": "org.apache.spark.sql.catalyst.plans.LeftOuter$"
+        |  }
         |}
       """.stripMargin)
 
@@ -417,7 +426,10 @@ class TreeNodeSuite extends SparkFunSuite {
     assertJSON(
       FunctionIdentifier("function", None),
       """
-        |{"product-class":"org.apache.spark.sql.catalyst.FunctionIdentifier","funcName":"function"}
+        |{
+        |  "product-class": "org.apache.spark.sql.catalyst.FunctionIdentifier",
+        |  "funcName": "function"
+        |}
       """.stripMargin)
 
     // Converts BucketSpec to JSON
@@ -425,10 +437,10 @@ class TreeNodeSuite extends SparkFunSuite {
       BucketSpec(1, Seq("bucket"), Seq("sort")),
       s"""
          |{
-         |  "product-class":"org.apache.spark.sql.catalyst.catalog.BucketSpec",
-         |  "numBuckets":1,
-         |  "bucketColumnNames":"[bucket]",
-         |  "sortColumnNames":"[sort]"
+         |  "product-class": "org.apache.spark.sql.catalyst.catalog.BucketSpec",
+         |  "numBuckets": 1,
+         |  "bucketColumnNames": "[bucket]",
+         |  "sortColumnNames": "[sort]"
          |}
        """.stripMargin)
 
@@ -436,7 +448,10 @@ class TreeNodeSuite extends SparkFunSuite {
     assertJSON(
       ValueFollowing(3),
       s"""
-         |{"product-class":"org.apache.spark.sql.catalyst.expressions.ValueFollowing","value":3}
+         |{
+         |  "product-class": "org.apache.spark.sql.catalyst.expressions.ValueFollowing",
+         |  "value": 3
+         |}
        """.stripMargin)
 
     // Converts WindowFrame to JSON
@@ -444,15 +459,15 @@ class TreeNodeSuite extends SparkFunSuite {
       SpecifiedWindowFrame(RowFrame, UnboundedFollowing, CurrentRow),
       """
         |{
-        |  "product-class":"org.apache.spark.sql.catalyst.expressions.SpecifiedWindowFrame",
+        |  "product-class": "org.apache.spark.sql.catalyst.expressions.SpecifiedWindowFrame",
         |  "frameType": {
-        |    "object":"org.apache.spark.sql.catalyst.expressions.RowFrame$"
+        |    "object": "org.apache.spark.sql.catalyst.expressions.RowFrame$"
         |  },
         |  "frameStart": {
-        |    "object":"org.apache.spark.sql.catalyst.expressions.UnboundedFollowing$"
+        |    "object": "org.apache.spark.sql.catalyst.expressions.UnboundedFollowing$"
         |  },
-        |  "frameEnd":{
-        |    "object":"org.apache.spark.sql.catalyst.expressions.CurrentRow$"
+        |  "frameEnd": {
+        |    "object": "org.apache.spark.sql.catalyst.expressions.CurrentRow$"
         |  }
         |}
        """.stripMargin)
@@ -462,8 +477,8 @@ class TreeNodeSuite extends SparkFunSuite {
       RoundRobinPartitioning(numPartitions = 3),
       """
         |{
-        |  "product-class":"org.apache.spark.sql.catalyst.plans.physical.RoundRobinPartitioning",
-        |  "numPartitions":3
+        |  "product-class": "org.apache.spark.sql.catalyst.plans.physical.RoundRobinPartitioning",
+        |  "numPartitions": 3
         |}
       """.stripMargin)
 
@@ -472,31 +487,21 @@ class TreeNodeSuite extends SparkFunSuite {
       FunctionResource(JarResource, "file:///"),
       """
         |{
-        |  "product-class":"org.apache.spark.sql.catalyst.catalog.FunctionResource",
-        |  "resourceType":{
-        |    "object":"org.apache.spark.sql.catalyst.catalog.JarResource$"
+        |  "product-class": "org.apache.spark.sql.catalyst.catalog.FunctionResource",
+        |  "resourceType": {
+        |    "object": "org.apache.spark.sql.catalyst.catalog.JarResource$"
         |  },
-        |  "uri":"file:///"
+        |  "uri": "file:///"
         |}
       """.stripMargin)
 
     // Converts BroadcastMode to JSON
     assertJSON(
       IdentityBroadcastMode,
-      """
-        |{"object":"org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode$"}
-      """.stripMargin)
+      """{"object": "org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode$"}""")
 
     // Converts CatalogTable to JSON
     val struct = StructType(StructField("a", IntegerType, true) :: Nil)
-
-    System.out.print(
-      JsonTestTreeNode(CatalogTable(
-        TableIdentifier("table"),
-        CatalogTableType.MANAGED,
-        CatalogStorageFormat.empty,
-        StructType(StructField("a", IntegerType, true) :: Nil))).toJSON)
-
     assertJSON(
       CatalogTable(
         TableIdentifier("table"),
@@ -506,30 +511,28 @@ class TreeNodeSuite extends SparkFunSuite {
         createTime = 0L),
       """
         |{
-        |  "product-class":"org.apache.spark.sql.catalyst.catalog.CatalogTable",
-        |  "identifier":{
-        |    "product-class":"org.apache.spark.sql.catalyst.TableIdentifier",
-        |    "table":"table"
+        |  "product-class": "org.apache.spark.sql.catalyst.catalog.CatalogTable",
+        |  "identifier": {
+        |    "product-class": "org.apache.spark.sql.catalyst.TableIdentifier",
+        |    "table": "table"
         |  },
-        |  "tableType":null,
-        |  "storage":null,
-        |  "schema":{
-        |    "type":"struct",
-        |    "fields":[{
-        |      "name":"a",
-        |      "type":"integer",
-        |      "nullable":true,
-        |      "metadata":{}
+        |  "tableType": null,
+        |  "storage": null,
+        |  "schema": {
+        |    "type": "struct",
+        |    "fields": [{
+        |      "name": "a",
+        |      "type": "integer",
+        |      "nullable": true,
+        |      "metadata": {}
         |    }]
         |  },
-        |  "partitionColumnNames":[],
-        |  "owner":"",
-        |  "createTime":0,
-        |  "lastAccessTime":-1,
-        |  "properties":{
-        |    "object":"scala.collection.immutable.Map$EmptyMap$"
-        |  },
-        |  "unsupportedFeatures":[]
+        |  "partitionColumnNames": [],
+        |  "owner": "",
+        |  "createTime": 0,
+        |  "lastAccessTime": -1,
+        |  "properties": null,
+        |  "unsupportedFeatures": []
         |}
       """.stripMargin)
 
@@ -544,18 +547,18 @@ class TreeNodeSuite extends SparkFunSuite {
         |[
         |  [
         |    {
-        |      "class":"org.apache.spark.sql.catalyst.expressions.Literal",
-        |      "num-children":0,
-        |      "value":"1",
-        |      "dataType":"integer"
+        |      "class": "org.apache.spark.sql.catalyst.expressions.Literal",
+        |      "num-children": 0,
+        |      "value": "1",
+        |      "dataType": "integer"
         |    }
         |  ],
         |  [
         |    {
-        |      "class":"org.apache.spark.sql.catalyst.expressions.Literal",
-        |      "num-children":0,
-        |      "value":"2",
-        |      "dataType":"integer"
+        |      "class": "org.apache.spark.sql.catalyst.expressions.Literal",
+        |      "num-children": 0,
+        |      "value": "2",
+        |      "dataType": "integer"
         |    }
         |  ]
         |]
@@ -576,19 +579,19 @@ class TreeNodeSuite extends SparkFunSuite {
       """
         |[
         |  {
-        |    "class":"org.apache.spark.sql.catalyst.plans.logical.Union",
-        |    "num-children":2,
-        |    "children":[0, 1]
+        |    "class": "org.apache.spark.sql.catalyst.plans.logical.Union",
+        |    "num-children": 2,
+        |    "children": [0, 1]
         |  },
         |  {
-        |    "class":"org.apache.spark.sql.catalyst.trees.JsonTestTreeNode",
-        |    "num-children":0,
-        |    "arg":"0"
+        |    "class": "org.apache.spark.sql.catalyst.trees.JsonTestTreeNode",
+        |    "num-children": 0,
+        |    "arg": "0"
         |  },
         |  {
-        |    "class":"org.apache.spark.sql.catalyst.trees.JsonTestTreeNode",
-        |    "num-children":0,
-        |    "arg":"1"
+        |    "class": "org.apache.spark.sql.catalyst.trees.JsonTestTreeNode",
+        |    "num-children": 0,
+        |    "arg": "1"
         |  }
         |]
       """.stripMargin

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -120,7 +120,6 @@ abstract class QueryTest extends PlanTest {
           throw ae
         }
     }
-    checkJsonFormat(analyzedDS)
     assertEmptyMissingInput(analyzedDS)
 
     try ds.collect() catch {
@@ -167,8 +166,6 @@ abstract class QueryTest extends PlanTest {
           throw ae
         }
     }
-
-    checkJsonFormat(analyzedDF)
 
     assertEmptyMissingInput(analyzedDF)
 
@@ -226,139 +223,6 @@ abstract class QueryTest extends PlanTest {
       cachedData.size == numCachedTables,
       s"Expected query to contain $numCachedTables, but it actually had ${cachedData.size}\n" +
         planWithCaching)
-  }
-
-  private def checkJsonFormat(ds: Dataset[_]): Unit = {
-    // Get the analyzed plan and rewrite the PredicateSubqueries in order to make sure that
-    // RDD and Data resolution does not break.
-    val logicalPlan = ds.queryExecution.analyzed
-
-    // bypass some cases that we can't handle currently.
-    logicalPlan.transform {
-      case _: ObjectConsumer => return
-      case _: ObjectProducer => return
-      case _: AppendColumns => return
-      case _: TypedFilter => return
-      case _: LogicalRelation => return
-      case p if p.getClass.getSimpleName == "MetastoreRelation" => return
-      case _: MemoryPlan => return
-      case p: InMemoryRelation =>
-        p.child.transform {
-          case _: ObjectConsumerExec => return
-          case _: ObjectProducerExec => return
-        }
-        p
-    }.transformAllExpressions {
-      case _: ImperativeAggregate => return
-      case _: TypedAggregateExpression => return
-      case Literal(_, _: ObjectType) => return
-      case _: UserDefinedGenerator => return
-    }
-
-    // bypass hive tests before we fix all corner cases in hive module.
-    if (this.getClass.getName.startsWith("org.apache.spark.sql.hive")) return
-
-    val jsonString = try {
-      logicalPlan.toJSON
-    } catch {
-      case NonFatal(e) =>
-        fail(
-          s"""
-             |Failed to parse logical plan to JSON:
-             |${logicalPlan.treeString}
-           """.stripMargin, e)
-    }
-
-    // scala function is not serializable to JSON, use null to replace them so that we can compare
-    // the plans later.
-    val normalized1 = logicalPlan.transformAllExpressions {
-      case udf: ScalaUDF => udf.copy(function = null)
-      case gen: UserDefinedGenerator => gen.copy(function = null)
-      // After SPARK-17356: the JSON representation no longer has the Metadata. We need to remove
-      // the Metadata from the normalized plan so that we can compare this plan with the
-      // JSON-deserialzed plan.
-      case a @ Alias(child, name) if a.explicitMetadata.isDefined =>
-        Alias(child, name)(a.exprId, a.qualifier, Some(Metadata.empty), a.isGenerated)
-      case a: AttributeReference if a.metadata != Metadata.empty =>
-        AttributeReference(a.name, a.dataType, a.nullable, Metadata.empty)(a.exprId, a.qualifier,
-          a.isGenerated)
-    }
-
-    // RDDs/data are not serializable to JSON, so we need to collect LogicalPlans that contains
-    // these non-serializable stuff, and use these original ones to replace the null-placeholders
-    // in the logical plans parsed from JSON.
-    val logicalRDDs = new ArrayDeque[LogicalRDD]()
-    val localRelations = new ArrayDeque[LocalRelation]()
-    val inMemoryRelations = new ArrayDeque[InMemoryRelation]()
-    def collectData: (LogicalPlan => Unit) = {
-      case l: LogicalRDD =>
-        logicalRDDs.offer(l)
-      case l: LocalRelation =>
-        localRelations.offer(l)
-      case i: InMemoryRelation =>
-        inMemoryRelations.offer(i)
-      case p =>
-        p.expressions.foreach {
-          _.foreach {
-            case s: SubqueryExpression =>
-              s.plan.foreach(collectData)
-            case _ =>
-          }
-        }
-    }
-    logicalPlan.foreach(collectData)
-
-
-    val jsonBackPlan = try {
-      TreeNode.fromJSON[LogicalPlan](jsonString, spark.sparkContext)
-    } catch {
-      case NonFatal(e) =>
-        fail(
-          s"""
-             |Failed to rebuild the logical plan from JSON:
-             |${logicalPlan.treeString}
-             |
-             |${logicalPlan.prettyJson}
-           """.stripMargin, e)
-    }
-
-    def renormalize: PartialFunction[LogicalPlan, LogicalPlan] = {
-      case l: LogicalRDD =>
-        val origin = logicalRDDs.pop()
-        LogicalRDD(l.output, origin.rdd)(spark)
-      case l: LocalRelation =>
-        val origin = localRelations.pop()
-        l.copy(data = origin.data)
-      case l: InMemoryRelation =>
-        val origin = inMemoryRelations.pop()
-        InMemoryRelation(
-          l.output,
-          l.useCompression,
-          l.batchSize,
-          l.storageLevel,
-          origin.child,
-          l.tableName)(
-          origin.cachedColumnBuffers,
-          origin.batchStats)
-      case p =>
-        p.transformExpressions {
-          case s: SubqueryExpression =>
-            s.withNewPlan(s.plan.transformDown(renormalize))
-        }
-    }
-    val normalized2 = jsonBackPlan.transformDown(renormalize)
-
-    assert(logicalRDDs.isEmpty)
-    assert(localRelations.isEmpty)
-    assert(inMemoryRelations.isEmpty)
-
-    if (normalized1 != normalized2) {
-      fail(
-        s"""
-           |== FAIL: the logical plan parsed from json does not match the original one ===
-           |${sideBySide(logicalPlan.treeString, normalized2.treeString).mkString("\n")}
-          """.stripMargin)
-    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is a follow up of SPARK-17356. Current implementation of `TreeNode.toJSON` recursively converts all fields of TreeNode to JSON, even if the field is of type `Seq` or type Map. This may trigger out of memory exception in cases like:
1. the Seq or Map can be very big. Converting them to JSON may take huge memory, which may trigger out of memory error.
2. Some user space input may also be propagated to the Plan. The user space input can be of arbitrary type, and may also be self-referencing. Trying to print user space input to JSON may trigger out of memory error or stack overflow error.

For a code example, please check the Jira description of SPARK-17426.

In this PR, we refactor the `TreeNode.toJSON` so that we only convert a field to JSON string if the field is a safe type.
## How was this patch tested?

Unit test.
