### PR TITLE
[SPARK-17378] [HOTFIX] Upgrade snappy-java to 1.1.2.6 -- fix Hadoop 1 deps

### DIFF
--- a/dev/deps/spark-deps-hadoop-1
+++ b/dev/deps/spark-deps-hadoop-1
@@ -143,7 +143,7 @@ servlet-api-2.5.jar
 slf4j-api-1.7.10.jar
 slf4j-log4j12-1.7.10.jar
 snappy-0.2.jar
-snappy-java-1.1.2.1.jar
+snappy-java-1.1.2.6.jar
 spire-macros_2.10-0.7.4.jar
 spire_2.10-0.7.4.jar
 stax-api-1.0.1.jar


### PR DESCRIPTION
## What changes were proposed in this pull request?

Also update Hadoop 1 deps file to reflect Snappy 1.1.2.6
## How was this patch tested?

N/A
