### PR TITLE
[SPARK-17437] Add uiWebUrl to JavaSparkContext and pyspark.SparkContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -678,14 +678,6 @@ class JavaSparkContext(val sc: SparkContext)
     sc.addJar(path)
   }
 
-
-  /**
-   * Returns the URL to the SparkUI instance running for this SparkContext. This may or may
-   * not be the same one set by the configuration, since Spark will attempt to listen on
-   * successive ports if the configured one is not available.
-   */
-  def uiWebUrl(): Optional[String] = JavaUtils.optionToOptional(sc.uiWebUrl)
-
   /**
    * Returns the Hadoop configuration used for the Hadoop code (e.g. file systems) we reuse.
    *

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -678,6 +678,14 @@ class JavaSparkContext(val sc: SparkContext)
     sc.addJar(path)
   }
 
+
+  /**
+   * Returns the URL to the SparkUI instance running for this SparkContext. This may or may
+   * not be the same one set by the configuration, since Spark will attempt to listen on
+   * successive ports if the configured one is not available.
+   */
+  def uiWebUrl(): Optional[String] = JavaUtils.optionToOptional(sc.uiWebUrl)
+
   /**
    * Returns the Hadoop configuration used for the Hadoop code (e.g. file systems) we reuse.
    *

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -333,6 +333,11 @@ class SparkContext(object):
         return self._jsc.sc().applicationId()
 
     @property
+    def uiWebUrl(self):
+        """Return the URL of the SparkUI instance started by this SparkContext"""
+        return self._jsc.uiWebUrl().orNull()
+
+    @property
     def startTime(self):
         """Return the epoch time when the Spark Context was started."""
         return self._jsc.startTime()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -335,7 +335,7 @@ class SparkContext(object):
     @property
     def uiWebUrl(self):
         """Return the URL of the SparkUI instance started by this SparkContext"""
-        return self._jsc.uiWebUrl().orNull()
+        return self._jsc.sc().uiWebUrl().get()
 
     @property
     def startTime(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Scala version of `SparkContext` has a handy field called `uiWebUrl` that tells you which URL the SparkUI spawned by that instance lives at. This is often very useful because the value for `spark.ui.port` in the config is only a suggestion; if that port number is taken by another Spark instance on the same machine, Spark will just keep incrementing the port until it finds a free one. So, on a machine with a lot of running PySpark instances, you often have to start trying all of them one-by-one until you find your application name.

Scala users have a way around this with `uiWebUrl` but Java and Python users do not. This pull request fixes this in the most straightforward way possible, simply propagating this field through the `JavaSparkContext` and into pyspark through the Java gateway.

Please let me know if any additional documentation/testing is needed.
## How was this patch tested?

Existing tests were run to make sure there were no regressions, and a binary distribution was created and tested manually for the correct value of `sc.uiWebPort` in a variety of circumstances.
