### PR TITLE
[SPARK-17438][WebUI]	Show Application.executorLimit in the application page

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -24,7 +24,7 @@ import scala.xml.Node
 import org.apache.spark.deploy.DeployMessages.{MasterStateResponse, RequestMasterState}
 import org.apache.spark.deploy.ExecutorState
 import org.apache.spark.deploy.master.ExecutorDesc
-import org.apache.spark.ui.{UIUtils, WebUIPage}
+import org.apache.spark.ui.{ToolTips, UIUtils, WebUIPage}
 import org.apache.spark.util.Utils
 
 private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") {
@@ -68,6 +68,16 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
                   app.desc.maxCores.get, app.coresGranted, app.coresLeft)
               }
             }
+            </li>
+            <li>
+              <span data-toggle="tooltip" title={ToolTips.APPLICATION_EXECUTOR_LIMIT}
+                    data-placement="right">
+                <strong>Executor Limit: </strong>
+                {
+                  if (app.executorLimit == Int.MaxValue) "Unlimited" else app.executorLimit
+                }
+                ({app.executors.size} granted)
+              </span>
             </li>
             <li>
               <strong>Executor Memory:</strong>

--- a/core/src/main/scala/org/apache/spark/ui/ToolTips.scala
+++ b/core/src/main/scala/org/apache/spark/ui/ToolTips.scala
@@ -90,4 +90,10 @@ private[spark] object ToolTips {
 
   val TASK_TIME =
   "Shaded red when garbage collection (GC) time is over 10% of task time"
+
+  val APPLICATION_EXECUTOR_LIMIT =
+    """The number of executors this application can have at any given time. This is set only when
+       dynamic allocation is enabled. Master assigns executors to an application only when the
+       number of its executors is less than this limit.
+    """
 }

--- a/core/src/main/scala/org/apache/spark/ui/ToolTips.scala
+++ b/core/src/main/scala/org/apache/spark/ui/ToolTips.scala
@@ -92,8 +92,8 @@ private[spark] object ToolTips {
   "Shaded red when garbage collection (GC) time is over 10% of task time"
 
   val APPLICATION_EXECUTOR_LIMIT =
-    """The number of executors this application can have at any given time. This is set only when
-       dynamic allocation is enabled. Master assigns executors to an application only when the
-       number of its executors is less than this limit.
+    """Maximum number of executors that this application will use. This limit is finite only when
+       dynamic allocation is enabled. The number of granted executors may exceed the limit
+       ephemerally when executors are being killed.
     """
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds `Application.executorLimit` to the applicatino page
## How was this patch tested?

Checked the UI manually.

Screenshots:
1. Dynamic allocation is disabled

<img width="484" alt="screen shot 2016-09-07 at 4 21 49 pm" src="https://cloud.githubusercontent.com/assets/1000778/18332029/210056ea-7518-11e6-9f52-76d96046c1c0.png">
1. Dynamic allocation is enabled.

<img width="466" alt="screen shot 2016-09-07 at 4 25 30 pm" src="https://cloud.githubusercontent.com/assets/1000778/18332034/2c07700a-7518-11e6-8fce-aebe25014902.png">
