### PR TITLE
[MINOR][SQL] Stripping extra new lines from the generator code

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -133,8 +133,8 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], MutableP
       }
     """
 
-    val code = CodeFormatter.stripOverlappingComments(
-      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+    val code = CodeFormatter.stripOverlappingComments(new CodeAndComment(
+      CodeFormatter.stripExtraNewLines(codeBody), ctx.getPlaceHolderToComments()))
     logDebug(s"code for ${expressions.mkString(",")}:\n${CodeFormatter.format(code)}")
 
     val c = CodeGenerator.compile(code)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -139,8 +139,8 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
         }
       }"""
 
-    val code = CodeFormatter.stripOverlappingComments(
-      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+    val code = CodeFormatter.stripOverlappingComments(new CodeAndComment(
+      CodeFormatter.stripExtraNewLines(codeBody), ctx.getPlaceHolderToComments()))
     logDebug(s"Generated Ordering by ${ordering.mkString(",")}:\n${CodeFormatter.format(code)}")
 
     CodeGenerator.compile(code).generate(ctx.references.toArray).asInstanceOf[BaseOrdering]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -61,8 +61,8 @@ object GeneratePredicate extends CodeGenerator[Expression, (InternalRow) => Bool
         }
       }"""
 
-    val code = CodeFormatter.stripOverlappingComments(
-      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+    val code = CodeFormatter.stripOverlappingComments(new CodeAndComment(
+      CodeFormatter.stripExtraNewLines(codeBody), ctx.getPlaceHolderToComments()))
     logDebug(s"Generated predicate '$predicate':\n${CodeFormatter.format(code)}")
 
     val p = CodeGenerator.compile(code).generate(ctx.references.toArray).asInstanceOf[Predicate]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
@@ -181,8 +181,8 @@ object GenerateSafeProjection extends CodeGenerator[Seq[Expression], Projection]
       }
     """
 
-    val code = CodeFormatter.stripOverlappingComments(
-      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+    val code = CodeFormatter.stripOverlappingComments(new CodeAndComment(
+      CodeFormatter.stripExtraNewLines(codeBody), ctx.getPlaceHolderToComments()))
     logDebug(s"code for ${expressions.mkString(",")}:\n${CodeFormatter.format(code)}")
 
     val c = CodeGenerator.compile(code)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -390,8 +390,8 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       }
       """
 
-    val code = CodeFormatter.stripOverlappingComments(
-      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+    val code = CodeFormatter.stripOverlappingComments(new CodeAndComment(
+      CodeFormatter.stripExtraNewLines(codeBody), ctx.getPlaceHolderToComments()))
     logDebug(s"code for ${expressions.mkString(",")}:\n${CodeFormatter.format(code)}")
 
     val c = CodeGenerator.compile(code)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeRowJoiner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeRowJoiner.scala
@@ -193,7 +193,8 @@ object GenerateUnsafeRowJoiner extends CodeGenerator[(StructType, StructType), U
        |  }
        |}
      """.stripMargin
-    val code = CodeFormatter.stripOverlappingComments(new CodeAndComment(codeBody, Map.empty))
+    val code = CodeFormatter.stripOverlappingComments(
+      new CodeAndComment(CodeFormatter.stripExtraNewLines(codeBody), Map.empty))
     logDebug(s"SpecificUnsafeRowJoiner($schema1, $schema2):\n${CodeFormatter.format(code)}")
 
     val c = CodeGenerator.compile(code)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Here is the simple unit test 

test("Extra new lines in generated code") {
   GeneratePredicate.generate(EqualTo(Literal(1), Literal(1)))
}

Generated code without fix 
/\* 001 _/ public SpecificPredicate generate(Object[] references) {
/_ 002 _/   return new SpecificPredicate(references);
/_ 003 _/ }
/_ 004 _/
/_ 005 _/ class SpecificPredicate extends org.apache.spark.sql.catalyst.expressions.codegen.Predicate {
/_ 006 _/   private final Object[] references;
/_ 007 _/
/_ 008 _/
/_ 009 _/
/_ 010 _/   public SpecificPredicate(Object[] references) {
/_ 011 _/     this.references = references;
/_ 012 _/
/_ 013 _/   }
/_ 014 _/
/_ 015 _/   public boolean eval(InternalRow i) {
/_ 016 _/
/_ 017 _/     boolean isNull = false;
/_ 018 _/
/_ 019 _/
/_ 020 _/     boolean value = false;
/_ 021 _/     value = 1 == 1;
/_ 022 _/     return !false && value;
/_ 023 _/   }
/_ 024 */ }

Generated code with fix 
/\* 001 _/ public SpecificPredicate generate(Object[] references) {
/_ 002 _/   return new SpecificPredicate(references);
/_ 003 _/ }
/_ 004 _/
/_ 005 _/ class SpecificPredicate extends org.apache.spark.sql.catalyst.expressions.codegen.Predicate {
/_ 006 _/   private final Object[] references;
/_ 007 _/
/_ 008 _/   public SpecificPredicate(Object[] references) {
/_ 009 _/     this.references = references;
/_ 010 _/
/_ 011 _/   }
/_ 012 _/
/_ 013 _/   public boolean eval(InternalRow i) {
/_ 014 _/     boolean isNull = false;
/_ 015 _/
/_ 016 _/     boolean value = false;
/_ 017 _/     value = 1 == 1;
/_ 018 _/     return !false && value;
/_ 019 _/   }
/_ 020 */ }
## How was this patch tested?

Manually tested the generated code and it strips the extra new lines.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
