### PR TITLE
[SPARK-17421] [DOCS] Documenting the current treatment of MAVEN_OPTS.

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -38,7 +38,7 @@ You can fix these problems by setting the `MAVEN_OPTS` variable as discussed bef
 
 **Note:**
 
-* If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options for Java 7 to the `MAVEN_OPTS` environment variable.
+* If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options to the `MAVEN_OPTS` environment variable.
 * The `test` phase of the Spark build will automatically add these options to `MAVEN_OPTS`, even when not using `build/mvn`.
 * You may see warnings like "ignoring option MaxPermSize=1g; support was removed in 8.0" when building or running tests with Java 8 and `build/mvn`. These warnings are harmless.
     

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -16,11 +16,11 @@ Building Spark using Maven requires Maven 3.3.9 or newer and Java 7+.
 
 ### Setting up Maven's Memory Usage
 
-You'll need to configure Maven to use more memory than usual by setting `MAVEN_OPTS`. We recommend the following settings:
+If you are compiling with Java 7, you'll need to configure Maven to use more memory than usual by setting `MAVEN_OPTS`:
 
     export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
 
-If you don't run this, you may see errors like the following:
+If you don't add these parameters to `MAVEN_OPTS`, you may see errors like the following:
 
     [INFO] Compiling 203 Scala sources and 9 Java sources to /Users/me/Development/spark/core/target/scala-{{site.SCALA_BINARY_VERSION}}/classes...
     [ERROR] PermGen space -> [Help 1]
@@ -28,12 +28,15 @@ If you don't run this, you may see errors like the following:
     [INFO] Compiling 203 Scala sources and 9 Java sources to /Users/me/Development/spark/core/target/scala-{{site.SCALA_BINARY_VERSION}}/classes...
     [ERROR] Java heap space -> [Help 1]
 
-You can fix this by setting the `MAVEN_OPTS` variable as discussed before.
+You can fix these problems by setting the `MAVEN_OPTS` variable as discussed before.
 
 **Note:**
 
-* For Java 8 and above this step is not required.
-* If using `build/mvn` with no `MAVEN_OPTS` set, the script will automate this for you.
+* This step is not needed for Java 8.
+* If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options to the `MAVEN_OPTS` environment variable.
+* The `test` phase of the Spark build will automatically add these options to `MAVEN_OPTS`, even when not using `build/mvn`.
+* You may see warnings like "ignoring option MaxPermSize=1g; support was removed in 8.0" when building or running tests with Java 8. These warnings are harmless.
+    
 
 ### build/mvn
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -20,6 +20,10 @@ If you are compiling with Java 7, you'll need to configure Maven to use more mem
 
     export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
 
+When compiling with Java 8, a similar but smaller set of memory parameters is necessary:
+
+    export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
+
 If you don't add these parameters to `MAVEN_OPTS`, you may see errors like the following:
 
     [INFO] Compiling 203 Scala sources and 9 Java sources to /Users/me/Development/spark/core/target/scala-{{site.SCALA_BINARY_VERSION}}/classes...
@@ -33,7 +37,7 @@ You can fix these problems by setting the `MAVEN_OPTS` variable as discussed bef
 **Note:**
 
 * This step is not needed for Java 8.
-* If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options to the `MAVEN_OPTS` environment variable.
+* If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options for Java 7 to the `MAVEN_OPTS` environment variable.
 * The `test` phase of the Spark build will automatically add these options to `MAVEN_OPTS`, even when not using `build/mvn`.
 * You may see warnings like "ignoring option MaxPermSize=1g; support was removed in 8.0" when building or running tests with Java 8. These warnings are harmless.
     

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -24,7 +24,7 @@ When compiling with Java 8, a similar but smaller set of memory parameters is ne
 
     export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
 
-If you don't add these parameters to `MAVEN_OPTS`, you may see errors like the following:
+If you don't add these parameters to `MAVEN_OPTS`, you may see errors and warnings like the following:
 
     [INFO] Compiling 203 Scala sources and 9 Java sources to /Users/me/Development/spark/core/target/scala-{{site.SCALA_BINARY_VERSION}}/classes...
     [ERROR] PermGen space -> [Help 1]
@@ -32,11 +32,14 @@ If you don't add these parameters to `MAVEN_OPTS`, you may see errors like the f
     [INFO] Compiling 203 Scala sources and 9 Java sources to /Users/me/Development/spark/core/target/scala-{{site.SCALA_BINARY_VERSION}}/classes...
     [ERROR] Java heap space -> [Help 1]
 
+    [INFO] Compiling 233 Scala sources and 41 Java sources to /Users/me/Development/spark/sql/core/target/scala-{site.SCALA_BINARY_VERSION}/classes...
+    OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
+    OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
+
 You can fix these problems by setting the `MAVEN_OPTS` variable as discussed before.
 
 **Note:**
 
-* This step is not needed for Java 8.
 * If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options for Java 7 to the `MAVEN_OPTS` environment variable.
 * The `test` phase of the Spark build will automatically add these options to `MAVEN_OPTS`, even when not using `build/mvn`.
 * You may see warnings like "ignoring option MaxPermSize=1g; support was removed in 8.0" when building or running tests with Java 8. These warnings are harmless.

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -16,13 +16,11 @@ Building Spark using Maven requires Maven 3.3.9 or newer and Java 7+.
 
 ### Setting up Maven's Memory Usage
 
-If you are compiling with Java 7, you'll need to configure Maven to use more memory than usual by setting `MAVEN_OPTS`:
-
-    export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
-
-When compiling with Java 8, a similar but smaller set of memory parameters is necessary:
+You'll need to configure Maven to use more memory than usual by setting `MAVEN_OPTS`:
 
     export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
+
+When compiling with Java 7, you will need to add the additional option "-XX:MaxPermSize=512M" to MAVEN_OPTS.
 
 If you don't add these parameters to `MAVEN_OPTS`, you may see errors and warnings like the following:
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -42,7 +42,7 @@ You can fix these problems by setting the `MAVEN_OPTS` variable as discussed bef
 
 * If using `build/mvn` with no `MAVEN_OPTS` set, the script will automatically add the above options for Java 7 to the `MAVEN_OPTS` environment variable.
 * The `test` phase of the Spark build will automatically add these options to `MAVEN_OPTS`, even when not using `build/mvn`.
-* You may see warnings like "ignoring option MaxPermSize=1g; support was removed in 8.0" when building or running tests with Java 8. These warnings are harmless.
+* You may see warnings like "ignoring option MaxPermSize=1g; support was removed in 8.0" when building or running tests with Java 8 and `build/mvn`. These warnings are harmless.
     
 
 ### build/mvn


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified the documentation to clarify that `build/mvn` and `pom.xml` always add Java 7-specific parameters to `MAVEN_OPTS`, and that developers can safely ignore warnings about `-XX:MaxPermSize` that may result from compiling or running tests with Java 8.
## How was this patch tested?

Rebuilt HTML documentation, made sure that building-spark.html displays correctly in a browser.
