### PR TITLE
[SPARK-17455][MLlib] Improve PAVA implementation in IsotonicRegression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -343,27 +343,30 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
     }
 
     var i = 0
-    val len = input.length
-    while (i < len) {
-      var j = i
+    val n = input.length - 1
+    var notFinished = true
 
-      // Find monotonicity violating sequence, if any.
-      while (j < len - 1 && input(j)._1 > input(j + 1)._1) {
-        j = j + 1
-      }
+    while (notFinished) {
+      i = 0
+      notFinished = false
 
-      // If monotonicity was not violated, move to next data point.
-      if (i == j) {
-        i = i + 1
-      } else {
-        // Otherwise pool the violating sequence
-        // and check if pooling caused monotonicity violation in previously processed points.
-        while (i >= 0 && input(i)._1 > input(i + 1)._1) {
-          pool(input, i, j)
-          i = i - 1
+      // Iterate through the data, fix any monotonicity violations we find
+      // We may need to do this multiple times, as pooling can introduce violations
+      // at locations that were previously fine.
+      while (i < n) {
+        var j = i
+
+        // Find next monotonicity violating sequence, if any.
+        while (j < n && input(j)._1 >= input(j + 1)._1) {
+          j = j + 1
         }
 
-        i = j
+        // Pool the violating sequence with the data point preceding it
+        if (input(i)._1 != input(j)._1) {
+          pool(input, i, j)
+          notFinished = true
+        }
+        i = j + 1
       }
     }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -28,7 +28,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
-import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
 import org.apache.spark.api.java.{JavaDoubleRDD, JavaRDD}
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
@@ -344,10 +344,9 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
     // Keep track of the sum of weights and sum of weight * y for each block. weights(start)
     // gives the values for the block. Entries that are not at the start of a block
     // are meaningless.
-    val weights: Array[(Double, Double)] = input.map {
-      case (_, _, weight) if weight == 0d =>
-        throw new SparkException("Input contains zero weight")
-      case (y, _, weight) => (weight, weight * y)
+    val weights: Array[(Double, Double)] = input.map { case (y, _, weight) =>
+      require(weight != 0.0)
+      (weight, weight * y)
     }
 
     // a few convenience functions to make the code more readable

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -345,8 +345,9 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
     // gives the values for the block. Entries that are not at the start of a block
     // are meaningless.
     val weights: Array[(Double, Double)] = input.map {
-      case (y, _, weight) => if (weight == 0d) throw new SparkException("Input contains zero weight")
-                             else (weight, weight * y)
+      case (_, _, weight) if weight == 0d =>
+        throw new SparkException("Input contains zero weight")
+      case (y, _, weight) => (weight, weight * y)
     }
 
     // a few convenience functions to make the code more readable

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -28,7 +28,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.annotation.Since
 import org.apache.spark.api.java.{JavaDoubleRDD, JavaRDD}
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
@@ -345,7 +345,8 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
     // gives the values for the block. Entries that are not at the start of a block
     // are meaningless.
     val weights: Array[(Double, Double)] = input.map {
-      case (y, _, weight) => (weight, weight * y)
+      case (y, _, weight) => if (weight == 0d) throw new SparkException("Input contains zero weight")
+                             else (weight, weight * y)
     }
 
     // a few convenience functions to make the code more readable

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -313,9 +313,9 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
 
   /**
    * Performs a pool adjacent violators algorithm (PAV).
-   * Uses approach with single processing of data where violators
-   * in previously processed data created by pooling are fixed immediately.
-   * Uses optimization of discovering monotonicity violating sequences (blocks).
+   * Iterate through data multiple times, fixing any monotonicity violations
+   * we find. Uses optimization of discovering monotonicity violating sequences (blocks).
+   * Typical complexity is linear, with quadratic worst-case.
    *
    * @param input Input data of tuples (label, feature, weight).
    * @return Result tuples (label, feature, weight) where labels were updated
@@ -338,7 +338,7 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
       var i = start
       while (i <= end) {
         input(i) = (weightedSum / weight, input(i)._2, input(i)._3)
-        i = i + 1
+        i += 1
       }
     }
 
@@ -357,11 +357,11 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
         var j = i
 
         // Find next monotonicity violating sequence, if any.
-        while (j < n && input(j)._1 >= input(j + 1)._1) {
-          j = j + 1
+        while (j < n && input(j)._1 > input(j + 1)._1) {
+          j += 1
         }
 
-        // Pool the violating sequence with the data point preceding it
+        // Pool the violating sequence
         if (input(i)._1 != input(j)._1) {
           pool(input, i, j)
           notFinished = true

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -327,7 +327,8 @@ class IsotonicRegression private (private var isotonic: Boolean)
    * functions subject to simple chain constraints." SIAM Journal on Optimization 10.3 (2000):
    * 658-672.
    *
-   * @param input Input data of tuples (label, feature, weight).
+   * @param input Input data of tuples (label, feature, weight). Weights must
+                  be non-negative.
    * @return Result tuples (label, feature, weight) where labels were updated
    *         to form a monotone sequence as per isotonic regression definition.
    */

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -236,9 +236,8 @@ object IsotonicRegressionModel extends Loader[IsotonicRegressionModel] {
  * Only univariate (single feature) algorithm supported.
  *
  * Sequential PAV implementation based on:
- * Tibshirani, Ryan J., Holger Hoefling, and Robert Tibshirani.
- *   "Nearly-isotonic regression." Technometrics 53.1 (2011): 54-61.
- *   Available from <a href="http://www.stat.cmu.edu/~ryantibs/papers/neariso.pdf">here</a>
+ * Grotzinger, S. J., and C. Witzgall.
+ *   "Projections onto order simplexes." Applied mathematics and Optimization 12.1 (1984): 247-270.
  *
  * Sequential PAV parallelization based on:
  * Kearsley, Anthony J., Richard A. Tapia, and Michael W. Trosset.
@@ -312,18 +311,19 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
   }
 
   /**
-   * Performs a pool adjacent violators algorithm (PAV). Implements the algorithm originally described
-   * in [1], using the formulation from [2, 3]. Uses an array to keep track of start and end indices of
-   * blocks.
+   * Performs a pool adjacent violators algorithm (PAV). Implements the algorithm originally
+   * described in [1], using the formulation from [2, 3]. Uses an array to keep track of start
+   * and end indices of blocks.
    *
-   * [1] Grotzinger, S. J., and C. Witzgall. "Projections onto order simplexes." Applied mathematics and
-   * Optimization 12.1 (1984): 247-270.
-   * 
-   * [2] Best, Michael J., and Nilotpal Chakravarti. "Active set algorithms for isotonic regression; a
-   * unifying framework." Mathematical Programming 47.1-3 (1990): 425-439.
-   * 
-   * [3] Best, Michael J., Nilotpal Chakravarti, and Vasant A. Ubhaya. "Minimizing separable convex functions
-   * subject to simple chain constraints." SIAM Journal on Optimization 10.3 (2000): 658-672.
+   * [1] Grotzinger, S. J., and C. Witzgall. "Projections onto order simplexes." Applied
+   * mathematics and Optimization 12.1 (1984): 247-270.
+   *
+   * [2] Best, Michael J., and Nilotpal Chakravarti. "Active set algorithms for isotonic
+   * regression; a unifying framework." Mathematical Programming 47.1-3 (1990): 425-439.
+   *
+   * [3] Best, Michael J., Nilotpal Chakravarti, and Vasant A. Ubhaya. "Minimizing separable convex
+   * functions subject to simple chain constraints." SIAM Journal on Optimization 10.3 (2000):
+   * 658-672.
    *
    * @param input Input data of tuples (label, feature, weight).
    * @return Result tuples (label, feature, weight) where labels were updated
@@ -391,8 +391,9 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
       if (input(blockEnd(i))._2 > input(i)._2) {
         output += ((average(i), input(i)._2, weights(i)._1 / 2))
         output += ((average(i), input(blockEnd(i))._2, weights(i)._1 / 2))
-      } else
+      } else {
         output += ((average(i), input(i)._2, weights(i)._1))
+      }
       i = nextBlock(i)
     }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -163,17 +163,16 @@ class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
   }
 
   test("weighted isotonic regression with negative weights") {
-    val model = runIsotonicRegression(Seq(1, 2, 3, 2, 1), Seq(-1, 1, -3, 1, -5), true)
-
-    assert(model.boundaries === Array(0.0, 1.0, 4.0))
-    assert(model.predictions === Array(1.0, 10.0/6, 10.0/6))
+    val ex = intercept[SparkException] {
+      runIsotonicRegression(Seq(1, 2, 3, 2, 1), Seq(-1, 1, -3, 1, -5), true)
+    }
+    assert(ex.getCause.isInstanceOf[IllegalArgumentException])
   }
 
   test("weighted isotonic regression with zero weights") {
-    val ex = intercept[SparkException] {
-      runIsotonicRegression(Seq[Double](1, 2, 3, 2, 1), Seq[Double](0, 0, 0, 1, 0), true)
-    }
-    assert(ex.getCause.isInstanceOf[IllegalArgumentException])
+    val model = runIsotonicRegression(Seq(1, 2, 3, 2, 1, 0), Seq(0, 0, 0, 1, 1, 0), true)
+    assert(model.boundaries === Array(3, 4))
+    assert(model.predictions === Array(1.5, 1.5))
   }
 
   test("SPARK-16426 isotonic regression with duplicate features that produce NaNs") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.regression
 
 import org.scalatest.Matchers
 
-import org.apache.spark.{SparkFunSuite, SparkException}
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.util.Utils

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -169,13 +169,6 @@ class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
     assert(model.predictions === Array(1.0, 10.0/6, 10.0/6))
   }
 
-  test("weighted isotonic regression with zero weights") {
-    val model = runIsotonicRegression(Seq[Double](1, 2, 3, 2, 1), Seq[Double](0, 0, 0, 1, 0), true)
-
-    assert(model.boundaries === Array(0.0, 1.0, 4.0))
-    assert(model.predictions === Array(1, 2, 2))
-  }
-
   test("SPARK-16426 isotonic regression with duplicate features that produce NaNs") {
     val trainRDD = sc.parallelize(Seq[(Double, Double, Double)]((2, 1, 1), (1, 1, 1), (0, 2, 1),
                                                                 (1, 2, 1), (0.5, 3, 1), (0, 3, 1)),

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -169,6 +169,13 @@ class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
     assert(model.predictions === Array(1.0, 10.0/6, 10.0/6))
   }
 
+  test("weighted isotonic regression with zero weights") {
+    val model = runIsotonicRegression(Seq[Double](1, 2, 3, 2, 1), Seq[Double](0, 0, 0, 1, 0), true)
+
+    assert(model.boundaries === Array(0.0, 1.0, 4.0))
+    assert(model.predictions === Array(1, 2, 2))
+  }
+
   test("SPARK-16426 isotonic regression with duplicate features that produce NaNs") {
     val trainRDD = sc.parallelize(Seq[(Double, Double, Double)]((2, 1, 1), (1, 1, 1), (0, 2, 1),
                                                                 (1, 2, 1), (0.5, 3, 1), (0, 3, 1)),

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -170,9 +170,10 @@ class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
   }
 
   test("weighted isotonic regression with zero weights") {
-    intercept[SparkException] {
+    val ex = intercept[SparkException] {
       runIsotonicRegression(Seq[Double](1, 2, 3, 2, 1), Seq[Double](0, 0, 0, 1, 0), true)
     }
+    assert(ex.getCause.isInstanceOf[IllegalArgumentException])
   }
 
   test("SPARK-16426 isotonic regression with duplicate features that produce NaNs") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.regression
 
 import org.scalatest.Matchers
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkException}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.util.Utils
@@ -170,10 +170,9 @@ class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
   }
 
   test("weighted isotonic regression with zero weights") {
-    val model = runIsotonicRegression(Seq[Double](1, 2, 3, 2, 1), Seq[Double](0, 0, 0, 1, 0), true)
-
-    assert(model.boundaries === Array(0.0, 1.0, 4.0))
-    assert(model.predictions === Array(1, 2, 2))
+    intercept[SparkException] {
+      runIsotonicRegression(Seq[Double](1, 2, 3, 2, 1), Seq[Double](0, 0, 0, 1, 0), true)
+    }
   }
 
   test("SPARK-16426 isotonic regression with duplicate features that produce NaNs") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

New implementation of the Pool Adjacent Violators Algorithm (PAVA) in mllib.IsotonicRegression, which used under the hood by ml.regression.IsotonicRegression. The previous implementation could have factorial complexity in the worst case. This implementation, which closely follows those in scikit-learn and the R `iso` package, runs in quadratic time in the worst case.
## How was this patch tested?

Existing unit tests in both `mllib` and `ml` passed before and after this patch. Scaling properties were tested by running the `poolAdjacentViolators` method in [scala-benchmarking-template](https://github.com/sirthias/scala-benchmarking-template) with the input generated by

``` scala
val x = (1 to length).toArray.map(_.toDouble)
val y = x.reverse.zipWithIndex.map{ case (yi, i) => if (i % 2 == 1) yi - 1.5 else yi}
val w = Array.fill(length)(1d)

val input: Array[(Double, Double, Double)] = (y zip x zip w) map{ case ((y, x), w) => (y, x, w)}
```

Before this patch:

| Input Length | Time (us) |
| --: | --: |
| 100 | 1.35 |
| 200 | 3.14 |
| 400 | 116.10 |
| 800 | 2134225.90 |

After this patch:

| Input Length | Time (us) |
| --: | --: |
| 100 | 1.25 |
| 200 | 2.53 |
| 400 | 5.86 |
| 800 | 10.55 |

Benchmarking was also performed with randomly-generated y values, with similar results.
