### PR TITLE
[SPARK-17387][PYSPARK] Allow passing of args to gateway to configure JVM

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -56,6 +56,8 @@ def launch_gateway():
                 "--conf spark.ui.enabled=false",
                 submit_args
             ])
+        if len(sys.argv) > 1 and os.environ.get("PYSPARK_PASS_ARGS_TO_GATEWAY", True):
+            submit_args = ' '.join(sys.argv[1:] + [submit_args])
         command = [os.path.join(SPARK_HOME, script)] + shlex.split(submit_args)
 
         # Start a socket that will be used by PythonGatewayServer to communicate its port to us


### PR DESCRIPTION
## What changes were proposed in this pull request?

When not using spark-submit, user configuration for the JVM is ignored when creating the SparkContext.  This is because the JVM is started before the SparkConf object is initialized.  This change allows user to specify --conf args on the command line that will be used when launching the java gateway to configure the JVM.
## How was this patch tested?

Started a plain Python shell with this command and verified the JVM was configured with the correct amount of memory. 

```
SPARK_HOME=$PWD PYTHONPATH=python:python/lib/py4j-0.10.3-src.zip python - --conf spark.driver.memory=4g
```

Note, the additional '-' is needed for the cmd line args to not be processed when invoking the interpreter.
