### PR TITLE
[SPARK-17464][SparkR][ML] SparkR spark.als argument reg should be 0.1 by default.

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -1241,7 +1241,7 @@ setMethod("predict", signature(object = "GaussianMixtureModel"),
 #' @note spark.als since 2.1.0
 setMethod("spark.als", signature(data = "SparkDataFrame"),
           function(data, ratingCol = "rating", userCol = "user", itemCol = "item",
-                   rank = 10, reg = 1.0, maxIter = 10, nonnegative = FALSE,
+                   rank = 10, reg = 0.1, maxIter = 10, nonnegative = FALSE,
                    implicitPrefs = FALSE, alpha = 1.0, numUserBlocks = 10, numItemBlocks = 10,
                    checkpointInterval = 10, seed = 0) {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

SparkR `spark.als` arguments `reg` should be 0.1 by default, which need to be consistent with ML.
## How was this patch tested?

Existing tests.
