### PR TITLE
[SPARK-17472] [PYSPARK] Better error message for serialization failures of large objects in Python

### DIFF
--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -81,7 +81,7 @@ class Broadcast(object):
             raise
         except Exception as e:
             msg = "Could not serialize broadcast: " + e.__class__.__name__ + ": " + e.message
-            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]  # noqa
+            raise pickle.PicklingError(msg)
         f.close()
         return f.name
 

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -75,7 +75,13 @@ class Broadcast(object):
             self._path = path
 
     def dump(self, value, f):
-        pickle.dump(value, f, 2)
+        try:
+            pickle.dump(value, f, 2)
+        except pickle.PickleError:
+            raise
+        except Exception as e:
+            msg = "Could not serialize broadcast: " + e.__class__.__name__ + ": " + e.message
+            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]
         f.close()
         return f.name
 

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -81,7 +81,7 @@ class Broadcast(object):
             raise
         except Exception as e:
             msg = "Could not serialize broadcast: " + e.__class__.__name__ + ": " + e.message
-            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]
+            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]  # noqa
         f.close()
         return f.name
 

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -18,6 +18,7 @@
 import os
 import sys
 import gc
+from cloudpickle import print_exec
 from tempfile import NamedTemporaryFile
 
 if sys.version < '3':
@@ -81,6 +82,7 @@ class Broadcast(object):
             raise
         except Exception as e:
             msg = "Could not serialize broadcast: " + e.__class__.__name__ + ": " + e.message
+            print_exec(sys.stderr)
             raise pickle.PicklingError(msg)
         f.close()
         return f.name

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -18,8 +18,9 @@
 import os
 import sys
 import gc
-from cloudpickle import print_exec
 from tempfile import NamedTemporaryFile
+
+from pyspark.cloudpickle import print_exec
 
 if sys.version < '3':
     import cPickle as pickle

--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -109,6 +109,15 @@ class CloudPickler(Pickler):
             if 'recursion' in e.args[0]:
                 msg = """Could not pickle object as excessively deep recursion required."""
                 raise pickle.PicklingError(msg)
+        except pickle.PickleError:
+            raise
+        except Exception as e:
+            if "'i' format requires" in e.message:
+                msg = "Object too large to serialize: " + e.message
+            else:
+                msg = "Could not serialize object: " + e.__class__.__name__ + ": " + e.message
+            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]
+            
 
     def save_memoryview(self, obj):
         """Fallback to save_string"""

--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -116,6 +116,7 @@ class CloudPickler(Pickler):
                 msg = "Object too large to serialize: " + e.message
             else:
                 msg = "Could not serialize object: " + e.__class__.__name__ + ": " + e.message
+            print_exec(sys.stderr)
             raise pickle.PicklingError(msg)
             
 

--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -116,7 +116,7 @@ class CloudPickler(Pickler):
                 msg = "Object too large to serialize: " + e.message
             else:
                 msg = "Could not serialize object: " + e.__class__.__name__ + ": " + e.message
-            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]  # noqa
+            raise pickle.PicklingError(msg)
             
 
     def save_memoryview(self, obj):

--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -116,7 +116,7 @@ class CloudPickler(Pickler):
                 msg = "Object too large to serialize: " + e.message
             else:
                 msg = "Could not serialize object: " + e.__class__.__name__ + ": " + e.message
-            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]
+            raise pickle.PicklingError, pickle.PicklingError(msg), sys.exc_info()[2]  # noqa
             
 
     def save_memoryview(self, obj):


### PR DESCRIPTION
## What changes were proposed in this pull request?

For large objects, pickle does not raise useful error messages. However, we can wrap them to be slightly more user friendly:

Example 1:

```
def run():
  import numpy.random as nr
  b = nr.bytes(8 * 1000000000)
  sc.parallelize(range(1000), 1000).map(lambda x: len(b)).count()

run()
```

Before:

```
error: 'i' format requires -2147483648 <= number <= 2147483647
```

After:

```
pickle.PicklingError: Object too large to serialize: 'i' format requires -2147483648 <= number <= 2147483647
```

Example 2:

```
def run():
  import numpy.random as nr
  b = sc.broadcast(nr.bytes(8 * 1000000000))
  sc.parallelize(range(1000), 1000).map(lambda x: len(b.value)).count()

run()
```

Before:

```
SystemError: error return without exception set
```

After:

```
cPickle.PicklingError: Could not serialize broadcast: SystemError: error return without exception set
```
## How was this patch tested?

Manually tried out these cases

cc @davies 
