### PR TITLE
[SPARK-17478] create event log dir if it does not exist

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -75,6 +75,10 @@ private[spark] class EventLoggingListener(
     CompressionCodec.getShortName(c.getClass.getName)
   }
 
+  if (!fileSystem.exists(new Path(logBaseDir)) && !fileSystem.mkdirs(new Path(logBaseDir))) {
+    throw new IllegalStateException(s"Couldn't create $logBaseDir.")
+  }
+
   // Only defined if the file system scheme is not local
   private var hadoopDataStream: Option[FSDataOutputStream] = None
 

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import java.io.{File, FileOutputStream, InputStream, IOException}
 import java.net.URI
+import java.nio.file.Files
 
 import scala.collection.mutable
 import scala.io.Source
@@ -265,6 +266,24 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
 
 }
 
+class EventLoggingListenerNoCreateSuite extends SparkFunSuite {
+  import EventLoggingListenerSuite._
+
+  private val fileSystem = Utils.getHadoopFileSystem("/",
+    SparkHadoopUtil.get.newConfiguration(new SparkConf()))
+
+  test("Verify log directory creation") {
+    val testDir = Files.createTempDirectory("event-log")
+    val testDirPath = new Path(testDir.toAbsolutePath.toString)
+    testDir.toFile.delete()
+    // Verify logging directory exists
+    val conf = getLoggingConf(testDirPath)
+    new EventLoggingListener("test", None, testDirPath.toUri, conf)
+    assert(fileSystem.exists(testDirPath), "event log directory not created")
+    Utils.deleteRecursively(testDir.toFile)
+  }
+
+}
 
 object EventLoggingListenerSuite {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create spark.eventLog.dir if it does not exist
## How was this patch tested?

Tested with spark shell and added test. Had to create a separate suite since all current tests  created directory before invoking the listener 
