### PR TITLE
[SPARK-17447] Performance improvement in Partitioner.defaultPartitioner without sortBy

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -56,7 +56,6 @@ object Partitioner {
    */
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
     val rdds = Seq(rdd) ++ others
-
     val filteredRdds = rdds.filter( _.partitioner.exists(_.numPartitions > 0 ))
     if(filteredRdds.nonEmpty) {
       return filteredRdds.maxBy( _.partitions.length).partitioner.get

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -55,14 +55,16 @@ object Partitioner {
    * We use two method parameters (rdd, others) to enforce callers passing at least 1 RDD.
    */
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
-    val bySize = (Seq(rdd) ++ others).sortBy(_.partitions.length).reverse
-    for (r <- bySize if r.partitioner.isDefined && r.partitioner.get.numPartitions > 0) {
-      return r.partitioner.get
+    val rdds = Seq(rdd) ++ others
+
+    val filteredRdds = rdds.filter( _.partitioner.exists(_.numPartitions > 0 ))
+    if(filteredRdds.nonEmpty) {
+      return filteredRdds.maxBy( _.partitions.length).partitioner.get
     }
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)
     } else {
-      new HashPartitioner(bySize.head.partitions.length)
+      new HashPartitioner(rdds.map(_.partitions.length).max)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -55,15 +55,16 @@ object Partitioner {
    * We use two method parameters (rdd, others) to enforce callers passing at least 1 RDD.
    */
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
-    val rdds = Seq(rdd) ++ others
-    val filteredRdds = rdds.filter( _.partitioner.exists(_.numPartitions > 0 ))
-    if(filteredRdds.nonEmpty) {
-      return filteredRdds.maxBy( _.partitions.length).partitioner.get
-    }
-    if (rdd.context.conf.contains("spark.default.parallelism")) {
-      new HashPartitioner(rdd.context.defaultParallelism)
+    val rdds = (Seq(rdd) ++ others)
+    val hashPartitioner = rdds.filter(_.partitioner.exists(_.numPartitions > 0))
+    if (hashPartitioner.nonEmpty) {
+      hashPartitioner.maxBy(_.partitions.length).partitioner.get
     } else {
-      new HashPartitioner(rdds.map(_.partitions.length).max)
+      if (rdd.context.conf.contains("spark.default.parallelism")) {
+        new HashPartitioner(rdd.context.defaultParallelism)
+      } else {
+        new HashPartitioner(rdds.map(_.partitions.length).max)
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -56,9 +56,9 @@ object Partitioner {
    */
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
     val rdds = (Seq(rdd) ++ others)
-    val hashPartitioner = rdds.filter(_.partitioner.exists(_.numPartitions > 0))
-    if (hashPartitioner.nonEmpty) {
-      hashPartitioner.maxBy(_.partitions.length).partitioner.get
+    val hasPartitioner = rdds.filter(_.partitioner.exists(_.numPartitions > 0))
+    if (hasPartitioner.nonEmpty) {
+      hasPartitioner.maxBy(_.partitions.length).partitioner.get
     } else {
       if (rdd.context.conf.contains("spark.default.parallelism")) {
         new HashPartitioner(rdd.context.defaultParallelism)


### PR DESCRIPTION
## What changes were proposed in this pull request?

if there are many rdds in some situations,the sort will loss he performance servely,actually we needn't sort the rdds , we can just scan the rdds one time to gain the same goal.
## How was this patch tested?

manual tests
