### PR TITLE
[SPARK-17500][PySpark]Make DiskBytesSpilled metric in PySpark shuffle right

### DIFF
--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -322,15 +322,16 @@ class ExternalMerger(Merger):
             self.pdata.extend([{} for i in range(self.partitions)])
 
         else:
-            diskBytesSpilled = 0
             for i in range(self.partitions):
                 p = os.path.join(path, str(i))
+                beforeWriteSize = os.path.getsize(p)
                 with open(p, "wb") as f:
                     # dump items in batch
                     self.serializer.dump_stream(iter(self.pdata[i].items()), f)
                 self.pdata[i].clear()
-                diskBytesSpilled += os.path.getsize(p)
-            DiskBytesSpilled = diskBytesSpilled
+                afterWriteSize = os.path.getsize(p)
+                DiskBytesSpilled += (afterWriteSize - beforeWriteSize)
+
 
         self.spills += 1
         gc.collect()  # release the memory as much as possible
@@ -748,9 +749,9 @@ class ExternalGroupBy(ExternalMerger):
             self.pdata.extend([{} for i in range(self.partitions)])
 
         else:
-            diskBytesSpilled = 0
             for i in range(self.partitions):
                 p = os.path.join(path, str(i))
+                beforeWriteSize = os.path.getsize(p)
                 with open(p, "wb") as f:
                     # dump items in batch
                     if self._sorted:
@@ -760,8 +761,8 @@ class ExternalGroupBy(ExternalMerger):
                     else:
                         self.serializer.dump_stream(self.pdata[i].items(), f)
                 self.pdata[i].clear()
-                diskBytesSpilled += os.path.getsize(p)
-            DiskBytesSpilled = diskBytesSpilled
+                afterWriteSize = os.path.getsize(p)
+                DiskBytesSpilled += (afterWriteSize - beforeWriteSize)
 
         self.spills += 1
         gc.collect()  # release the memory as much as possible

--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -322,13 +322,15 @@ class ExternalMerger(Merger):
             self.pdata.extend([{} for i in range(self.partitions)])
 
         else:
+            diskBytesSpilled = 0
             for i in range(self.partitions):
                 p = os.path.join(path, str(i))
                 with open(p, "wb") as f:
                     # dump items in batch
                     self.serializer.dump_stream(iter(self.pdata[i].items()), f)
                 self.pdata[i].clear()
-                DiskBytesSpilled += os.path.getsize(p)
+                diskBytesSpilled += os.path.getsize(p)
+            DiskBytesSpilled = diskBytesSpilled
 
         self.spills += 1
         gc.collect()  # release the memory as much as possible
@@ -746,6 +748,7 @@ class ExternalGroupBy(ExternalMerger):
             self.pdata.extend([{} for i in range(self.partitions)])
 
         else:
+            diskBytesSpilled = 0
             for i in range(self.partitions):
                 p = os.path.join(path, str(i))
                 with open(p, "wb") as f:
@@ -757,7 +760,8 @@ class ExternalGroupBy(ExternalMerger):
                     else:
                         self.serializer.dump_stream(self.pdata[i].items(), f)
                 self.pdata[i].clear()
-                DiskBytesSpilled += os.path.getsize(p)
+                diskBytesSpilled += os.path.getsize(p)
+            DiskBytesSpilled = diskBytesSpilled
 
         self.spills += 1
         gc.collect()  # release the memory as much as possible


### PR DESCRIPTION
## What changes were proposed in this pull request?

The origin way increases the DiskBytesSpilled metric with the file size during each spill in ExternalMerger && ExternalGroupBy, but we only need the last size.
## How was this patch tested?

No extra tests, because this just update the metrics
