### PR TITLE
[SPARK-17463][Core]Add memory barriers for accumulators

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -280,8 +280,8 @@ private[spark] object AccumulatorContext {
  * @since 2.0.0
  */
 class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
-  private var _sum = 0L
-  private var _count = 0L
+  @volatile private var _sum = 0L
+  @volatile private var _count = 0L
 
   /**
    * Adds v to the accumulator, i.e. increment sum by v and count by 1.
@@ -359,8 +359,8 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
  * @since 2.0.0
  */
 class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
-  private var _sum = 0.0
-  private var _count = 0L
+  @volatile private var _sum = 0.0
+  @volatile private var _count = 0L
 
   override def isZero: Boolean = _sum == 0.0 && _count == 0
 
@@ -469,7 +469,7 @@ class CollectionAccumulator[T] extends AccumulatorV2[T, java.util.List[T]] {
 class LegacyAccumulatorWrapper[R, T](
     initialValue: R,
     param: org.apache.spark.AccumulableParam[R, T]) extends AccumulatorV2[T, R] {
-  private[spark] var _value = initialValue  // Current value on driver
+  @volatile private[spark] var _value = initialValue  // Current value on driver
 
   override def isZero: Boolean = _value == param.zero(initialValue)
 

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.JavaConverters._
 
+import com.google.common.util.concurrent.AtomicDouble
+
 import org.apache.spark.{InternalAccumulator, SparkContext, TaskContext}
 import org.apache.spark.scheduler.AccumulableInfo
 
@@ -280,25 +282,25 @@ private[spark] object AccumulatorContext {
  * @since 2.0.0
  */
 class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
-  @volatile private var _sum = 0L
-  @volatile private var _count = 0L
+  private val _sum = new AtomicLong(0L)
+  private val _count = new AtomicLong(0L)
 
   /**
    * Adds v to the accumulator, i.e. increment sum by v and count by 1.
    * @since 2.0.0
    */
-  override def isZero: Boolean = _sum == 0L && _count == 0
+  override def isZero: Boolean = _sum.get == 0L && _count.get == 0
 
   override def copy(): LongAccumulator = {
     val newAcc = new LongAccumulator
-    newAcc._count = this._count
-    newAcc._sum = this._sum
+    newAcc._count.lazySet(this._count.get)
+    newAcc._sum.lazySet(this._sum.get)
     newAcc
   }
 
   override def reset(): Unit = {
-    _sum = 0L
-    _count = 0L
+    _sum.lazySet(0L)
+    _count.lazySet(0L)
   }
 
   /**
@@ -306,8 +308,8 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
    * @since 2.0.0
    */
   override def add(v: jl.Long): Unit = {
-    _sum += v
-    _count += 1
+    _sum.lazySet(_sum.get + v)
+    _count.lazySet(_count.get + 1)
   }
 
   /**
@@ -315,40 +317,40 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
    * @since 2.0.0
    */
   def add(v: Long): Unit = {
-    _sum += v
-    _count += 1
+    _sum.lazySet(_sum.get + v)
+    _count.lazySet(_count.get + 1)
   }
 
   /**
    * Returns the number of elements added to the accumulator.
    * @since 2.0.0
    */
-  def count: Long = _count
+  def count: Long = _count.get
 
   /**
    * Returns the sum of elements added to the accumulator.
    * @since 2.0.0
    */
-  def sum: Long = _sum
+  def sum: Long = _sum.get
 
   /**
    * Returns the average of elements added to the accumulator.
    * @since 2.0.0
    */
-  def avg: Double = _sum.toDouble / _count
+  def avg: Double = _sum.get.toDouble / _count.get
 
   override def merge(other: AccumulatorV2[jl.Long, jl.Long]): Unit = other match {
     case o: LongAccumulator =>
-      _sum += o.sum
-      _count += o.count
+      _sum.lazySet(_sum.get + o.sum)
+      _count.lazySet(_count.get + o.count)
     case _ =>
       throw new UnsupportedOperationException(
         s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
   }
 
-  private[spark] def setValue(newValue: Long): Unit = _sum = newValue
+  private[spark] def setValue(newValue: Long): Unit = _sum.lazySet(newValue)
 
-  override def value: jl.Long = _sum
+  override def value: jl.Long = _sum.get
 }
 
 
@@ -359,21 +361,21 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
  * @since 2.0.0
  */
 class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
-  @volatile private var _sum = 0.0
-  @volatile private var _count = 0L
+  private val _sum = new AtomicDouble(0.0)
+  private val _count = new AtomicLong(0L)
 
-  override def isZero: Boolean = _sum == 0.0 && _count == 0
+  override def isZero: Boolean = _sum.get == 0.0 && _count.get == 0
 
   override def copy(): DoubleAccumulator = {
     val newAcc = new DoubleAccumulator
-    newAcc._count = this._count
-    newAcc._sum = this._sum
+    newAcc._count.lazySet(this._count.get)
+    newAcc._sum.lazySet(this._sum.get)
     newAcc
   }
 
   override def reset(): Unit = {
-    _sum = 0.0
-    _count = 0L
+    _sum.lazySet(0.0)
+    _count.lazySet(0L)
   }
 
   /**
@@ -381,8 +383,8 @@ class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
    * @since 2.0.0
    */
   override def add(v: jl.Double): Unit = {
-    _sum += v
-    _count += 1
+    _sum.lazySet(_sum.get + v)
+    _count.lazySet(_count.get + 1)
   }
 
   /**
@@ -390,40 +392,40 @@ class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
    * @since 2.0.0
    */
   def add(v: Double): Unit = {
-    _sum += v
-    _count += 1
+    _sum.lazySet(_sum.get + v)
+    _count.lazySet(_count.get + 1)
   }
 
   /**
    * Returns the number of elements added to the accumulator.
    * @since 2.0.0
    */
-  def count: Long = _count
+  def count: Long = _count.get
 
   /**
    * Returns the sum of elements added to the accumulator.
    * @since 2.0.0
    */
-  def sum: Double = _sum
+  def sum: Double = _sum.get
 
   /**
    * Returns the average of elements added to the accumulator.
    * @since 2.0.0
    */
-  def avg: Double = _sum / _count
+  def avg: Double = _sum.get / _count.get
 
   override def merge(other: AccumulatorV2[jl.Double, jl.Double]): Unit = other match {
     case o: DoubleAccumulator =>
-      _sum += o.sum
-      _count += o.count
+      _sum.lazySet(_sum.get + o.sum)
+      _count.lazySet(_count.get + o.count)
     case _ =>
       throw new UnsupportedOperationException(
         s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
   }
 
-  private[spark] def setValue(newValue: Double): Unit = _sum = newValue
+  private[spark] def setValue(newValue: Double): Unit = _sum.lazySet(newValue)
 
-  override def value: jl.Double = _sum
+  override def value: jl.Double = _sum.get
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -29,8 +29,8 @@ class SQLMetric(val metricType: String, initValue: Long = 0L) extends Accumulato
   // We may use -1 as initial value of the accumulator, if the accumulator is valid, we will
   // update it at the end of task and the value will be at least 0. Then we can filter out the -1
   // values before calculate max, min, etc.
-  private[this] var _value = initValue
-  private var _zeroValue = initValue
+  @volatile private[this] var _value = initValue
+  @volatile private var _zeroValue = initValue
 
   override def copy(): SQLMetric = {
     val newAcc = new SQLMetric(metricType, _value)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.metric
 
 import java.text.NumberFormat
+import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.AccumulableInfo
@@ -29,30 +30,30 @@ class SQLMetric(val metricType: String, initValue: Long = 0L) extends Accumulato
   // We may use -1 as initial value of the accumulator, if the accumulator is valid, we will
   // update it at the end of task and the value will be at least 0. Then we can filter out the -1
   // values before calculate max, min, etc.
-  @volatile private[this] var _value = initValue
-  @volatile private var _zeroValue = initValue
+  private[this] val _value = new AtomicLong(initValue)
+  private val _zeroValue = new AtomicLong(initValue)
 
   override def copy(): SQLMetric = {
-    val newAcc = new SQLMetric(metricType, _value)
-    newAcc._zeroValue = initValue
+    val newAcc = new SQLMetric(metricType, _value.get)
+    newAcc._zeroValue.lazySet(initValue)
     newAcc
   }
 
-  override def reset(): Unit = _value = _zeroValue
+  override def reset(): Unit = _value.lazySet(_zeroValue.get)
 
   override def merge(other: AccumulatorV2[Long, Long]): Unit = other match {
-    case o: SQLMetric => _value += o.value
+    case o: SQLMetric => _value.lazySet(_value.get + o.value)
     case _ => throw new UnsupportedOperationException(
       s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
   }
 
-  override def isZero(): Boolean = _value == _zeroValue
+  override def isZero(): Boolean = _value.get == _zeroValue.get
 
-  override def add(v: Long): Unit = _value += v
+  override def add(v: Long): Unit = _value.lazySet(_value.get + v)
 
-  def +=(v: Long): Unit = _value += v
+  def +=(v: Long): Unit = _value.lazySet(_value.get + v)
 
-  override def value: Long = _value
+  override def value: Long = _value.get
 
   // Provide special identifier as metadata so we can tell that this is a `SQLMetric` later
   override def toInfo(update: Option[Any], value: Option[Any]): AccumulableInfo = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `AtomicXXX.lazySet` to update a metric value which is much cheaper than writing a volatile value. The eventually set should be enough for metrics. Without them, the worse case is the user cannot see any metric updates on UI until a task finishes.

Unfortunately, there will be a performance regression comparing to Spark 2.0.0. Note: in Spark 1.6, accumulators have a volatile value, so there should not be any performance regression comparing to 1.6.
## How was this patch tested?

Jenkins tests
