### PR TITLE
[SPARK-17513] [STREAMING] [SQL] Make StreamExecution garbage-collect its metadata

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetadataLog.scala
@@ -24,6 +24,7 @@ package org.apache.spark.sql.execution.streaming
  *  - Allow the user to query the latest batch id.
  *  - Allow the user to query the metadata object of a specified batch id.
  *  - Allow the user to query metadata objects in a range of batch ids.
+ *  - Allow the user to remove obsolete metdata
  */
 trait MetadataLog[T] {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -295,7 +295,7 @@ class StreamExecution(
       // the previous batch, and it is safe to discard the old metadata.
       // NOTE: If StreamExecution implements pipeline parallelism (multiple batches in
       // flight at the same time), this cleanup logic will need to change.
-      offsetLog.purge(currentBatchId - 1)
+      offsetLog.purge(currentBatchId)
     } else {
       awaitBatchLock.lock()
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR modifies StreamExecution such that it discards metadata for batches that have already been fully processed. I used the `purge` method that was added as part of SPARK-17235.
## How was this patch tested?

I added a test case to verify that old metadata log files are correctly purged. 
I also ran the entire regression suite.
