### PR TITLE
[SPARK-17523] Support to generate build info file when building Spark in Windows

### DIFF
--- a/build/spark-build-info.ps1
+++ b/build/spark-build-info.ps1
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script generates the build info for spark and places it into the spark-version-info.properties file.
+# Arguments:
+#   RESOURCE_DIR - The target directory where properties file would be created. [./core/target/extra-resources]
+#   SPARK_VERSION - The current version of spark
+
+param (
+  [string]$RESOURCE_DIR,
+  [string]$SPARK_VERSION
+)
+
+if (-not (Test-Path $RESOURCE_DIR)) {
+  mkdir $RESOURCE_DIR
+}
+$SPARK_BUILD_INFO="$RESOURCE_DIR\spark-version-info.properties"
+
+function echo_build_properties {
+  echo version=$SPARK_VERSION
+  echo user=$env:USERNAME
+  echo revision=$(git rev-parse HEAD)
+  echo branch=$(git rev-parse --abbrev-ref HEAD)
+  echo date=$((Get-date).ToUniversalTime().toString("yyyy-MM-ddThh:mm:ssZ"))
+  echo url=$(git config --get remote.origin.url)
+}
+
+echo_build_properties > $SPARK_BUILD_INFO

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -370,6 +370,11 @@
                   <arg value="${project.build.directory}/extra-resources"/>
                   <arg value="${project.version}"/>
                 </exec>
+                <exec executable="powershell.exe">
+                  <arg value="${project.basedir}/../build/spark-build-info.ps1"/>
+                  <arg value="${project.build.directory}/extra-resources"/>
+                  <arg value="${project.version}"/>
+                </exec>
               </target>
             </configuration>
             <goals>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -457,9 +457,12 @@ object SparkBuild extends PomBuild {
 object Core {
   lazy val settings = Seq(
     resourceGenerators in Compile += Def.task {
-      val buildScript = baseDirectory.value + "/../build/spark-build-info"
+      val isWindows = if (sys.props("os.name").startsWith("Windows")) true else false
+      val buildScript = baseDirectory.value + (if (isWindows) "/../build/spark-build-info.ps1" else "/../build/spark-build-info")
       val targetDir = baseDirectory.value + "/target/extra-resources/"
-      val command = Seq("bash", buildScript, targetDir, version.value)
+      val command = if (isWindows) {
+        Seq("powershell.exe", buildScript, targetDir, version.value)
+      } else Seq("bash", buildScript, targetDir, version.value)
       Process(command).!!
       val propsFile = baseDirectory.value / "target" / "extra-resources" / "spark-version-info.properties"
       Seq(propsFile)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if we build Spark, it will generate a `spark-version-info.properties` and merged into `spark-core_2.11-*.jar`. However, the script `build/spark-build-info` which generates this file can only be executed with bash environment.
Without this file, errors like below will happen when submitting Spark application, which break the whole submitting phrase at beginning.

``` Java
RROR ApplicationMaster: Uncaught exception: 
org.apache.spark.SparkException: Exception thrown in awaitResult: 
    at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:194)
    at org.apache.spark.deploy.yarn.ApplicationMaster.runDriver(ApplicationMaster.scala:394)
    at org.apache.spark.deploy.yarn.ApplicationMaster.run(ApplicationMaster.scala:247)
    at org.apache.spark.deploy.yarn.ApplicationMaster$$anonfun$main$1.apply$mcV$sp(ApplicationMaster.scala:759)
    at org.apache.spark.deploy.SparkHadoopUtil$$anon$1.run(SparkHadoopUtil.scala:67)
    at org.apache.spark.deploy.SparkHadoopUtil$$anon$1.run(SparkHadoopUtil.scala:66)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:422)
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
    at org.apache.spark.deploy.SparkHadoopUtil.runAsSparkUser(SparkHadoopUtil.scala:66)
    at org.apache.spark.deploy.yarn.ApplicationMaster$.main(ApplicationMaster.scala:757)
    at org.apache.spark.deploy.yarn.ApplicationMaster.main(ApplicationMaster.scala)
Caused by: java.util.concurrent.ExecutionException: Boxed Error
    at scala.concurrent.impl.Promise$.resolver(Promise.scala:55)
    at scala.concurrent.impl.Promise$.scala$concurrent$impl$Promise$$resolveTry(Promise.scala:47)
    at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:244)
    at scala.concurrent.Promise$class.tryFailure(Promise.scala:112)
    at scala.concurrent.impl.Promise$DefaultPromise.tryFailure(Promise.scala:153)
    at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:648)
Caused by: java.lang.ExceptionInInitializerError
    at org.apache.spark.package$.<init>(package.scala:91)
    at org.apache.spark.package$.<clinit>(package.scala)
    at org.apache.spark.SparkContext$$anonfun$3.apply(SparkContext.scala:187)
    at org.apache.spark.SparkContext$$anonfun$3.apply(SparkContext.scala:187)
    at org.apache.spark.internal.Logging$class.logInfo(Logging.scala:54)
    at org.apache.spark.SparkContext.logInfo(SparkContext.scala:76)
    at org.apache.spark.SparkContext.<init>(SparkContext.scala:187)
    at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2287)
    at org.apache.spark.sql.SparkSession$Builder$$anonfun$6.apply(SparkSession.scala:822)
    at org.apache.spark.sql.SparkSession$Builder$$anonfun$6.apply(SparkSession.scala:814)
    at scala.Option.getOrElse(Option.scala:121)
    at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:814)
    at org.apache.spark.examples.SparkPi$.main(SparkPi.scala:31)
    at org.apache.spark.examples.SparkPi.main(SparkPi.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:630)
Caused by: org.apache.spark.SparkException: Error while locating file spark-version-info.properties
    at org.apache.spark.package$SparkBuildInfo$.liftedTree1$1(package.scala:75)
    at org.apache.spark.package$SparkBuildInfo$.<init>(package.scala:61)
    at org.apache.spark.package$SparkBuildInfo$.<clinit>(package.scala)
    ... 19 more
Caused by: java.lang.NullPointerException
    at java.util.Properties$LineReader.readLine(Properties.java:434)
    at java.util.Properties.load0(Properties.java:353)
    at java.util.Properties.load(Properties.java:341)
    at org.apache.spark.package$SparkBuildInfo$.liftedTree1$1(package.scala:64)
    ... 21 more
```

I add `build/spark-build-info.ps1` to generate `spark-version-info.properties` file in Windows, and modify `core/pom.xml` and `project/SparkBuild.scala` to support this scenario when building Spark with maven or sbt.
## How was this patch tested?

Tested on my local Windows 10 machine, which generated the  `spark-version-info.properties` under `core/target/extra-resources` folder as expected.
