### PR TITLE
[SPARK-17524] [TESTS] Use specified spark.buffer.pageSize

### DIFF
--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -338,9 +338,8 @@ public class RowBasedKeyValueBatchSuite {
 
   @Test
   public void appendRowUntilExceedingPageSize() throws Exception {
-    // Use of this property prevents issues when running on a two core machine
-    // A developer may override this size to 1 MB not 64 MB, so use that if so
-    int pageSizeToUse = Integer.parseInt(System.getProperty("spark.buffer.pageSize"));
+    // Use default size or spark.buffer.pageSize if specified
+    int pageSizeToUse = (int) memoryManager.pageSizeBytes();
     RowBasedKeyValueBatch batch = RowBasedKeyValueBatch.allocate(keySchema,
             valueSchema, taskMemoryManager, pageSizeToUse); //enough capacity
     try {

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -338,15 +338,18 @@ public class RowBasedKeyValueBatchSuite {
 
   @Test
   public void appendRowUntilExceedingPageSize() throws Exception {
+    // Use of this property prevents issues when running on a two core machine
+    // A developer may override this size to 1 MB not 64 MB, so use that if so
+    int pageSizeToUse = Integer.parseInt(System.getProperty("spark.buffer.pageSize"));
     RowBasedKeyValueBatch batch = RowBasedKeyValueBatch.allocate(keySchema,
-            valueSchema, taskMemoryManager, 64 * 1024 * 1024); //enough capacity
+            valueSchema, taskMemoryManager, pageSizeToUse); //enough capacity
     try {
       UnsafeRow key = makeKeyRow(1, "A");
       UnsafeRow value = makeValueRow(1, 1);
       int recordLength = 8 + key.getSizeInBytes() + value.getSizeInBytes() + 8;
       int totalSize = 4;
       int numRows = 0;
-      while (totalSize + recordLength < 64 * 1024 * 1024) { // default page size
+      while (totalSize + recordLength < pageSizeToUse) {
         appendRow(batch, key, value);
         totalSize += recordLength;
         numRows++;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR has the appendRowUntilExceedingPageSize test in RowBasedKeyValueBatchSuite use whatever spark.buffer.pageSize value a user has specified to prevent a test failure for anyone testing Apache Spark on a box with a reduced page size. The test is currently hardcoded to use the default page size which is 64 MB so this minor PR is a test improvement
## How was this patch tested?

Existing unit tests with 1 MB page size and with 64 MB (the default) page size
