### PR TITLE
[SPARK-17526][Web UI]: Display the executor log links with the job failure message on Spark UI and Console

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -81,7 +81,8 @@ private[scheduler] case class ExecutorLost(execId: String, reason: ExecutorLossR
   extends DAGSchedulerEvent
 
 private[scheduler]
-case class TaskSetFailed(taskSet: TaskSet, reason: String, exception: Option[Throwable])
+case class TaskSetFailed(taskSet: TaskSet, reason: String, exception: Option[Throwable],
+    logUrlMap: Option[scala.collection.immutable.Map[String, String]] = None)
   extends DAGSchedulerEvent
 
 private[scheduler] case object ResubmitFailedStages extends DAGSchedulerEvent

--- a/core/src/main/scala/org/apache/spark/scheduler/StageInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/StageInfo.scala
@@ -44,6 +44,8 @@ class StageInfo(
   var completionTime: Option[Long] = None
   /** If the stage failed, the reason why. */
   var failureReason: Option[String] = None
+  /** if the stage failed, the log url maps */
+  var logUrlMap: Option[Map[String, String]] = None
 
   /**
    * Terminal values of accumulables updated during this stage, including all the user-defined
@@ -51,9 +53,10 @@ class StageInfo(
    */
   val accumulables = HashMap[Long, AccumulableInfo]()
 
-  def stageFailed(reason: String) {
+  def stageFailed(reason: String, url: Option[Map[String, String]] = None) {
     failureReason = Some(reason)
     completionTime = Some(System.currentTimeMillis)
+    logUrlMap = url
   }
 
   private[spark] def getStatusString: String = {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
@@ -40,7 +40,8 @@ class TaskInfo(
     val executorId: String,
     val host: String,
     val taskLocality: TaskLocality.TaskLocality,
-    val speculative: Boolean) {
+    val speculative: Boolean,
+    val logUrlMap: Option[Map[String, String]] = None) {
 
   /**
    * The time when the task started remotely getting the result. Will not be set if the

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -256,10 +256,11 @@ private[spark] class TaskSchedulerImpl(
     var launchedTask = false
     for (i <- 0 until shuffledOffers.size) {
       val execId = shuffledOffers(i).executorId
+      val logUrlMap = shuffledOffers(i).logUrlMap
       val host = shuffledOffers(i).host
       if (availableCpus(i) >= CPUS_PER_TASK) {
         try {
-          for (task <- taskSet.resourceOffer(execId, host, maxLocality)) {
+          for (task <- taskSet.resourceOffer(execId, host, maxLocality, logUrlMap)) {
             tasks(i) += task
             val tid = task.taskId
             taskIdToTaskSetManager(tid) = taskSet

--- a/core/src/main/scala/org/apache/spark/scheduler/WorkerOffer.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/WorkerOffer.scala
@@ -20,5 +20,7 @@ package org.apache.spark.scheduler
 /**
  * Represents free resources available on an executor.
  */
+
 private[spark]
-case class WorkerOffer(executorId: String, host: String, cores: Int)
+case class WorkerOffer(executorId: String, host: String, cores: Int,
+    logUrlMap: Option[Map[String, String]] = None)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -215,7 +215,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       // Filter out executors under killing
       val activeExecutors = executorDataMap.filterKeys(executorIsAlive)
       val workOffers = activeExecutors.map { case (id, executorData) =>
-        new WorkerOffer(id, executorData.executorHost, executorData.freeCores)
+        new WorkerOffer(id, executorData.executorHost, executorData.freeCores,
+          Some(executorData.logUrlMap))
       }.toSeq
       launchTasks(scheduler.resourceOffers(workOffers))
     }
@@ -234,7 +235,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       if (executorIsAlive(executorId)) {
         val executorData = executorDataMap(executorId)
         val workOffers = Seq(
-          new WorkerOffer(executorId, executorData.executorHost, executorData.freeCores))
+          new WorkerOffer(executorId, executorData.executorHost,
+            executorData.freeCores, Some(executorData.logUrlMap)))
         launchTasks(scheduler.resourceOffers(workOffers))
       }
     }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -312,6 +312,7 @@ private[ui] class StagePagedTable(
 
   private def failureReasonHtml(s: StageInfo): Seq[Node] = {
     val failureReason = s.failureReason.getOrElse("")
+    val logUrlMap = s.logUrlMap
     val isMultiline = failureReason.indexOf('\n') >= 0
     // Display the first line by default
     val failureReasonSummary = StringEscapeUtils.escapeHtml4(
@@ -333,7 +334,8 @@ private[ui] class StagePagedTable(
     } else {
       ""
     }
-    <td valign="middle">{failureReasonSummary}{details}</td>
+    val logUrls = logUrlMap.map(_.flatMap(x => Seq(<a href={x._2}>{x._1}</a>, "    ")))
+    <td valign="middle"><p>{logUrls.getOrElse("")}</p>{failureReasonSummary}{details}</td>
   }
 
   private def makeDescription(s: StageInfo, descriptionOption: Option[String]): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -254,6 +254,7 @@ private[spark] object JsonProtocol {
     val submissionTime = stageInfo.submissionTime.map(JInt(_)).getOrElse(JNothing)
     val completionTime = stageInfo.completionTime.map(JInt(_)).getOrElse(JNothing)
     val failureReason = stageInfo.failureReason.map(JString(_)).getOrElse(JNothing)
+    val logUrl = stageInfo.logUrlMap.map(mapToJson(_)).getOrElse(JNothing)
     ("Stage ID" -> stageInfo.stageId) ~
     ("Stage Attempt ID" -> stageInfo.attemptId) ~
     ("Stage Name" -> stageInfo.name) ~
@@ -264,6 +265,7 @@ private[spark] object JsonProtocol {
     ("Submission Time" -> submissionTime) ~
     ("Completion Time" -> completionTime) ~
     ("Failure Reason" -> failureReason) ~
+    ("Log Urls" -> logUrl) ~
     ("Accumulables" -> JArray(
       stageInfo.accumulables.values.map(accumulableInfoToJson).toList))
   }
@@ -277,6 +279,7 @@ private[spark] object JsonProtocol {
     ("Host" -> taskInfo.host) ~
     ("Locality" -> taskInfo.taskLocality.toString) ~
     ("Speculative" -> taskInfo.speculative) ~
+    ("Log Urls" -> taskInfo.logUrlMap.map(mapToJson(_)).getOrElse(JNothing)) ~
     ("Getting Result Time" -> taskInfo.gettingResultTime) ~
     ("Finish Time" -> taskInfo.finishTime) ~
     ("Failed" -> taskInfo.failed) ~
@@ -670,6 +673,7 @@ private[spark] object JsonProtocol {
     val submissionTime = Utils.jsonOption(json \ "Submission Time").map(_.extract[Long])
     val completionTime = Utils.jsonOption(json \ "Completion Time").map(_.extract[Long])
     val failureReason = Utils.jsonOption(json \ "Failure Reason").map(_.extract[String])
+    val logUrlMap = Utils.jsonOption(json \ "Log Urls").map(mapFromJson(_).toMap)
     val accumulatedValues = (json \ "Accumulables").extractOpt[List[JValue]] match {
       case Some(values) => values.map(accumulableInfoFromJson)
       case None => Seq[AccumulableInfo]()
@@ -680,6 +684,7 @@ private[spark] object JsonProtocol {
     stageInfo.submissionTime = submissionTime
     stageInfo.completionTime = completionTime
     stageInfo.failureReason = failureReason
+    stageInfo.logUrlMap = logUrlMap
     for (accInfo <- accumulatedValues) {
       stageInfo.accumulables(accInfo.id) = accInfo
     }
@@ -695,6 +700,7 @@ private[spark] object JsonProtocol {
     val host = (json \ "Host").extract[String]
     val taskLocality = TaskLocality.withName((json \ "Locality").extract[String])
     val speculative = (json \ "Speculative").extractOpt[Boolean].getOrElse(false)
+    val logUrlMap = Utils.jsonOption(json \ "Log Urls").map(mapFromJson(_).toMap)
     val gettingResultTime = (json \ "Getting Result Time").extract[Long]
     val finishTime = (json \ "Finish Time").extract[Long]
     val failed = (json \ "Failed").extract[Boolean]
@@ -705,7 +711,8 @@ private[spark] object JsonProtocol {
     }
 
     val taskInfo =
-      new TaskInfo(taskId, index, attempt, launchTime, executorId, host, taskLocality, speculative)
+      new TaskInfo(taskId, index, attempt, launchTime, executorId, host, taskLocality, speculative,
+        logUrlMap)
     taskInfo.gettingResultTime = gettingResultTime
     taskInfo.finishTime = finishTime
     taskInfo.failed = failed

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -73,7 +73,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       override def taskSetFailed(
           taskSet: TaskSet,
           reason: String,
-          exception: Option[Throwable]): Unit = {
+          exception: Option[Throwable],
+          logUrlMap: Option[scala.collection.immutable.Map[String, String]] = None): Unit = {
         // Normally the DAGScheduler puts this in the event loop, which will eventually fail
         // dependent jobs
         failedTaskSet = true

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -51,7 +51,8 @@ class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
   override def taskSetFailed(
       taskSet: TaskSet,
       reason: String,
-      exception: Option[Throwable]): Unit = {
+      exception: Option[Throwable],
+      logUrlMap: Option[scala.collection.immutable.Map[String, String]] = None): Unit = {
     taskScheduler.taskSetsFailed += taskSet.id
   }
 }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -44,7 +44,9 @@ object MimaExcludes {
       // [SPARK-16853][SQL] Fixes encoder error in DataSet typed select
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.sql.Dataset.select"),
       // [SPARK-16967] Move Mesos to Module
-      ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.SparkMasterRegex.MESOS_REGEX")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.SparkMasterRegex.MESOS_REGEX"),
+      // [SPARK-17526] Display the executor log links with the job failure message on Spark UI and Console
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.scheduler.TaskInfo.this")
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the executor log links with the job failure message on Spark UI and Console
## How was this patch tested?

The patch is manually tested. 

In Console:

ERROR TaskSetManager: Task 0 in stage 0.0 failed 4 times; stdout: stdout_log_link stderr: stderr_log_link; aborting job ...

In WebUI 

![screen shot 2016-09-13 at 9 33 06 am](https://cloud.githubusercontent.com/assets/4451616/18482552/72dd572a-7995-11e6-98be-9324f3750305.png)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
