### PR TITLE
[SPARK-17537] [SQL] Reading parquet schema from driver directly when there is only one file to touch

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -742,7 +742,7 @@ object ParquetFileFormat extends Logging {
               s"Failed merging schema of file ${footer.getFile}:\n${schema.treeString}", cause)
           }
         }
-        some(mergedSchema)
+        Some(mergedSchema)
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`spark.read.parquet("parquet/dir")` would issue a spark job to read parquet schema. When `spark.sql.parquet.mergeSchema` are set to false (the default value), there is often only one file to read, so there is no need to issue a spark job to do it. In this case, we can read it from driver directly instead of issuing a spark job. This could reduce the infer schema latency from several hundreds milliseconds to around ten milliseconds in my environment.
## How was this patch tested?

manually tested
