### PR TITLE
[SPARK-17540][SparkR][Spark Core] fix SparkR array serde type problem when length == 0

### DIFF
--- a/R/pkg/R/serialize.R
+++ b/R/pkg/R/serialize.R
@@ -163,10 +163,10 @@ writeType <- function(con, class) {
 
 # Used to pass arrays where all the elements are of the same type
 writeArray <- function(con, arr) {
-  # TODO: Empty lists are given type "character" right now.
-  # This may not work if the Java side expects array of any other type.
+  # When array length == 0, mark the data type as NULL,
+  # and scala side will generate Array[Nothing] with length == 0
   if (length(arr) == 0) {
-    elemType <- class("somestring")
+    elemType <- class(NULL)
   } else {
     elemType <- getSerdeType(arr[[1]])
   }

--- a/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
@@ -161,10 +161,17 @@ private[spark] object SerDe {
     (0 until len).map(_ => readString(in)).toArray
   }
 
+  def readZeroLengthArr(in: DataInputStream): Array[Nothing] = {
+    val len = readInt(in)
+    require(len == 0)
+    new Array(0)
+  }
+
   // All elements of an array must be of the same type
   def readArray(dis: DataInputStream): Array[_] = {
     val arrType = readObjectType(dis)
     arrType match {
+      case 'n' => readZeroLengthArr(dis)
       case 'i' => readIntArr(dis)
       case 'c' => readStringArr(dis)
       case 'd' => readDoubleArr(dis)


### PR DESCRIPTION
## What changes were proposed in this pull request?

when r-side param is a zero array, because it doesn't contains type info,
java-side cannot generate the correct array object.

now I think about two ways: 
### Discuss
1. java-side regard the r-side passed zero array as `null`, but in this way we cannot distinguish `null` value and zero array for this param. 
2. when java-side read the zero array param passed from r-side, we check the java-side interface's param type, so that we can generate the correct zero array object. But it will complicate the code.
## How was this patch tested?

N/A
