### PR TITLE
[SPARK-17508][PYSPARK][ML] PySpark treat Param values None same as not setting the Param

### DIFF
--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -425,13 +425,13 @@ class Params(Identifiable):
         Sets user-supplied params.
         """
         for param, value in kwargs.items():
-            p = getattr(self, param)
             if value is not None:
+                p = getattr(self, param)
                 try:
                     value = p.typeConverter(value)
                 except TypeError as e:
                     raise TypeError('Invalid param value given for param "%s". %s' % (p.name, e))
-            self._paramMap[p] = value
+                self._paramMap[p] = value
         return self
 
     def _clear(self, param):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -247,14 +247,14 @@ class TestParams(HasMaxIter, HasInputCol, HasSeed):
     A subclass of Params mixed with HasMaxIter, HasInputCol and HasSeed.
     """
     @keyword_only
-    def __init__(self, seed=None):
+    def __init__(self, maxIter=None, inputCol=None, seed=None):
         super(TestParams, self).__init__()
         self._setDefault(maxIter=10)
         kwargs = self.__init__._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
-    def setParams(self, seed=None):
+    def setParams(self, maxIter=None, inputCol=None, seed=None):
         """
         setParams(self, seed=None)
         Sets params for this test.
@@ -388,6 +388,16 @@ class ParamTests(PySparkTestCase):
         model = Word2Vec().setWindowSize(6)
         # Check windowSize is set properly
         self.assertEqual(model.getWindowSize(), 6)
+
+    def test_param_value_None(self):
+        tp = TestParams()
+        self.assertFalse(tp.isSet(tp.inputCol), "inputCol is not set initially")
+        tp.setParams(inputCol=None)
+        self.assertFalse(tp.isSet(tp.inputCol), "Value of None should not change param")
+        tp.setParams(inputCol="input")
+        self.assertTrue(tp.isSet(tp.inputCol), "inputCol should now be set")
+        tp.setParams(inputCol=None)
+        self.assertTrue(tp.isSet(tp.inputCol), "inputCol should still be set")
 
 
 class FeatureTests(SparkSessionTestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

In PySpark, if params are set with a value of `None` it will get converted by Py4J to a typed value and usually result in an error.  For the case of string params, it will assign them a `null` value and lead to a `java.lang.NullPointerException`.  From the user perspective, this is not the expected outcome and can be confusing.  

This change causes PySpark to not set Params with a value of `None`, and they will be treated the same as not being set.  If a Param is already set, then attempting to set a value of `None` will have no effect.  This is mostly useful for a user that could be automating Param settings or wrapping classes that use Params.
## How was this patch tested?

Added new unit tests for setting a Param to `None` and ran existing PySpark-ml tests.
