### PR TITLE
[SPARK-17513][SQL] Make StreamExecution garbage-collect its metadata

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetadataLog.scala
@@ -24,7 +24,7 @@ package org.apache.spark.sql.execution.streaming
  *  - Allow the user to query the latest batch id.
  *  - Allow the user to query the metadata object of a specified batch id.
  *  - Allow the user to query metadata objects in a range of batch ids.
- *  - Allow the user to remove obsolete metdata
+ *  - Allow the user to remove obsolete metadata
  */
 trait MetadataLog[T] {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetadataLog.scala
@@ -24,6 +24,7 @@ package org.apache.spark.sql.execution.streaming
  *  - Allow the user to query the latest batch id.
  *  - Allow the user to query the metadata object of a specified batch id.
  *  - Allow the user to query metadata objects in a range of batch ids.
+ *  - Allow the user to remove obsolete metdata
  */
 trait MetadataLog[T] {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -293,6 +293,7 @@ class StreamExecution(
 
       // Now that we have logged the new batch, no further processing will happen for
       // the previous batch, and it is safe to discard the old metadata.
+      // Note that purge is exclusive, i.e. it purges everything before currentBatchId.
       // NOTE: If StreamExecution implements pipeline parallelism (multiple batches in
       // flight at the same time), this cleanup logic will need to change.
       offsetLog.purge(currentBatchId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -295,7 +295,7 @@ class StreamExecution(
       // the previous batch, and it is safe to discard the old metadata.
       // NOTE: If StreamExecution implements pipeline parallelism (multiple batches in
       // flight at the same time), this cleanup logic will need to change.
-      offsetLog.purge(currentBatchId - 1)
+      offsetLog.purge(currentBatchId)
     } else {
       awaitBatchLock.lock()
       try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -125,7 +125,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter {
     )
   }
 
-  testQuietly("StreamExecution metadata garbarge collection") {
+  testQuietly("StreamExecution metadata garbage collection") {
     val inputData = MemoryStream[Int]
     val mapped = inputData.toDS().map(6 / _)
 
@@ -139,15 +139,13 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter {
       CheckAnswer(6, 3, 6, 3, 1, 1),
 
       // Three batches have run, but only one set of metadata should be present
-      AssertOnQuery(
-        q => {
-          val metadataLogDir = new java.io.File(q.offsetLog.metadataPath.toString)
-          val logFileNames = metadataLogDir.listFiles().toSeq.map(_.getName())
-          val toTest = logFileNames.filter(! _.endsWith(".crc")) // Workaround for SPARK-17475
-          toTest.size == 1 && toTest.head == "2"
-          true
-        }
-      )
+      AssertOnQuery("metadata log should contain only one file") { streamExecution =>
+        val metadataLogDir = new java.io.File(streamExecution.offsetLog.metadataPath.toString)
+        val logFileNames = metadataLogDir.listFiles().toSeq.map(_.getName())
+        val toTest = logFileNames.filter(!_.endsWith(".crc")) // Workaround for SPARK-17475
+        assert(toTest.size == 1 && toTest.head == "2")
+        true
+      }
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR modifies StreamExecution such that it discards metadata for batches that have already been fully processed. I used the purge method that was added as part of SPARK-17235.

This is based on work by @frreiss in #15067, but fixed the test case along with some typos.
## How was this patch tested?

A new test case in StreamingQuerySuite. The test case would fail without the changes in this pull request.
