### PR TITLE
[SPARK-17574][Core] Cache ShuffleExchange RDD when the exchange is reused

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -54,7 +54,10 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   }
 
   def doExecute(): RDD[InternalRow] = {
-    child.execute()
+    child match {
+      case _: ShuffleExchange => child.execute().cache()
+      case _ => child.execute()
+    }
   }
 
   override protected[sql] def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have the rule `ReuseExchange` to reuse exchange in the physical plan. However, for a `ShuffleExchange` we still need to retrieve remote blocks again when the shuffle exchange is reused. We can cache the RDD of the reused `ShuffleExchange` to avoid transferring remote blocks again.
## How was this patch tested?

Manual tests show this patch can avoid transferring remote blocks again when a shuffle exchange is reused.
