### PR TITLE
[SPARK-17578][Docs] Add spark.app.name default value for spark session

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,9 +111,9 @@ of the most common options to set are:
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td><code>spark.app.name</code></td>
-  <td>(none)/(random)</td>
+  <td>(random)</td>
   <td>
-    The name of your application, For SparkSession default value is random UUID. This will appear in the UI and in log data.
+    The name of your application. This will appear in the UI and in log data.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,9 +111,9 @@ of the most common options to set are:
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td><code>spark.app.name</code></td>
-  <td>(none)</td>
+  <td>(none)/(random)</td>
   <td>
-    The name of your application. This will appear in the UI and in log data.
+    The name of your application, For SparkSession default value is random UUID. This will appear in the UI and in log data.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modify spark.app.name configuration for spark session
## How was this patch tested?

run all test cases and generate documentation

![appname](https://cloud.githubusercontent.com/assets/8075390/18609970/9eba2f2c-7d2c-11e6-8d3b-e45691db59b9.png)
