### PR TITLE
[SPARK-17580][CORE]Add random UUID as app name while app name not define while creating …

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -371,7 +371,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     }
 
     if (!_conf.contains("spark.app.name")) {
-      _conf.setAppName(UUID.randomUUID().toString)
+      _conf.setAppName("SPARK-" + UUID.randomUUID().toString)
     }
 
     // System property spark.yarn.app.id must be set if user code ran by AM on a YARN cluster

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -369,8 +369,9 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     if (!_conf.contains("spark.master")) {
       throw new SparkException("A master URL must be set in your configuration")
     }
+
     if (!_conf.contains("spark.app.name")) {
-      throw new SparkException("An application name must be set in your configuration")
+      _conf.setAppName(UUID.randomUUID().toString)
     }
 
     // System property spark.yarn.app.id must be set if user code ran by AM on a YARN cluster

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -121,7 +121,7 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
   test("creating SparkContext without app name") {
     val conf = new SparkConf(false).setMaster("local")
     sc = new SparkContext(conf)
-    assert(sc.appName.length == 36)
+    assert(sc.appName.startsWith("SPARK-"))
   }
 
   test("creating SparkContext with both master and app name") {

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -120,7 +120,8 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
 
   test("creating SparkContext without app name") {
     val conf = new SparkConf(false).setMaster("local")
-    intercept[SparkException] { sc = new SparkContext(conf) }
+    sc = new SparkContext(conf)
+    assert(sc.appName.length == 36)
   }
 
   test("creating SparkContext with both master and app name") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Assign Random UUID as a app name while app name not define while creating spark context its also same in SparkSession so we should make this behaviour same.
## How was this patch tested?

Run all test cases
