### PR TITLE
[SPARK-17581] [SQL] Invalidate Statistics After Some ALTER TABLE Commands [WIP]

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -679,7 +679,8 @@ case class AlterTableSetLocationCommand(
           } else {
             table.withNewStorage(locationUri = Some(location))
           }
-        catalog.alterTable(newTable)
+        val newTableWithInvalidatedStats = newTable.copy(stats = None)
+        catalog.alterTable(newTableWithInvalidatedStats)
     }
     Seq.empty[Row]
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the recent statistics-related work, our focus is on how to generate and store the statistics. After `Analyze Table` commands, the statistics will not be changed unless users run the command again. However, Hive behaves differently. For example, `ALTER TABLE SET LOCATION` will invalidate the statistics, including `numRows` and `rawDataSize`.

```
hive> describe formatted t2;
...
Location:               hdfs://6b68a24121f4:9000/user/hive/warehouse/t2  
Table Type:             MANAGED_TABLE            
Table Parameters:        
    COLUMN_STATS_ACCURATE   true                
    numFiles                4                   
    numRows                 2                   
    rawDataSize             2                   
    totalSize               4                   
    transient_lastDdlTime   1464590855          
...
```

```
hive> alter table t2 set location 'hdfs://6b68a24121f4:9000/user/hive/warehouse/t1';
OK
Time taken: 0.113 seconds
```

```
hive> describe formatted t2;
...                  
Location:               hdfs://6b68a24121f4:9000/user/hive/warehouse/t1  
Table Type:             MANAGED_TABLE            
Table Parameters:        
    COLUMN_STATS_ACCURATE   false               
    last_modified_by        root                
    last_modified_time      1474178025          
    numFiles                4                   
    numRows                 -1                  
    rawDataSize             -1                  
    totalSize               4                   
...
```

This PR tries to fix the related issues.
### How was this patch tested?

Added test cases.
