### PR TITLE
[SPARK-17545] [SQL] Handle additional time offset formats of ISO 8601

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -137,7 +137,16 @@ object DateTimeUtils {
         Date.valueOf(s)
       }
     } else {
-      DatatypeConverter.parseDateTime(s).getTime()
+      val offsetRegEx = """^.*(([+-]\d\d)(\d\d)?)$""".r
+      s match {
+        case offsetRegEx(offset, hour, min) => {
+          min match {
+            case null => stringToTime(s.replaceAllLiterally(offset, hour + ":00"))
+            case _ => stringToTime(s.replaceAllLiterally(offset, hour + ":" + min))
+          }
+        }
+        case _ => DatatypeConverter.parseDateTime(s).getTime()
+      }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -151,9 +151,14 @@ class DateTimeUtilsSuite extends SparkFunSuite {
 
     c.set(1900, 0, 1, 0, 0, 0)
     assert(stringToTime("1900-01-01T00:00:00GMT-00:00") === c.getTime())
+    assert(stringToTime("1900-01-01T00:00:00GMT-0000") === c.getTime())
+    assert(stringToTime("1900-01-01T00:00:00GMT-00") === c.getTime())
 
     c.set(2000, 11, 30, 10, 0, 0)
     assert(stringToTime("2000-12-30T10:00:00Z") === c.getTime())
+    assert(stringToTime("2000-12-30T10:00:00+00:00") === c.getTime())
+    assert(stringToTime("2000-12-30T10:00:00+0000") === c.getTime())
+    assert(stringToTime("2000-12-30T10:00:00+00") === c.getTime())
 
     // Tests with set time zone.
     c.setTimeZone(TimeZone.getTimeZone("GMT-04:00"))
@@ -161,9 +166,13 @@ class DateTimeUtilsSuite extends SparkFunSuite {
 
     c.set(1900, 0, 1, 0, 0, 0)
     assert(stringToTime("1900-01-01T00:00:00-04:00") === c.getTime())
+    assert(stringToTime("1900-01-01T00:00:00-0400") === c.getTime())
+    assert(stringToTime("1900-01-01T00:00:00-04") === c.getTime())
 
     c.set(1900, 0, 1, 0, 0, 0)
     assert(stringToTime("1900-01-01T00:00:00GMT-04:00") === c.getTime())
+    assert(stringToTime("1900-01-01T00:00:00GMT-0400") === c.getTime())
+    assert(stringToTime("1900-01-01T00:00:00GMT-04") === c.getTime())
 
     // Tests with local time zone.
     c.setTimeZone(TimeZone.getDefault())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows flexibility in handling additional ISO 8601 time offset variants. The current parsing of ISO 8601 is exclusive to W3C's datetime note (and XML Schema datetime). This change will allow offset to be handled as "HH:MM", "HHMM" and "HH".

This is one suggested approach to handling these variants. The other suggestions are to switch back to SimpleDateFormat and utilize the 'X' pattern flag. Another suggestion is to wait for a future release of commons-lang. Either of these suggestions can be implemented later over top of this suggestion.
## How was this patch tested?

The patch was tested by running all existing unit tests and by augmenting the existing tests with additional assertions.
