### PR TITLE
[SPARK-17605][SPARK_SUBMIT] Add option spark.usePython and spark.useR for applications that use both pyspark and sparkr

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -70,6 +70,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var proxyUser: String = null
   var principal: String = null
   var keytab: String = null
+  var usePython: Boolean = false
+  var useR: Boolean = false
 
   // Standalone cluster mode only
   var supervise: Boolean = false
@@ -186,6 +188,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       .getOrElse(sparkProperties.get("spark.executor.instances").orNull)
     keytab = Option(keytab).orElse(sparkProperties.get("spark.yarn.keytab")).orNull
     principal = Option(principal).orElse(sparkProperties.get("spark.yarn.principal")).orNull
+    usePython = isPython || sparkProperties.getOrElse("spark.usePython", "false").toBoolean
+    useR = isR || sparkProperties.getOrElse("spark.useR", "false").toBoolean
 
     // Try to set main class from JAR if no --class argument is given
     if (mainClass == null && !isPython && !isR && primaryResource != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is mostly for yarn mode, standalone mode don't need to distribute resources (sparkr.zip, pyspark.zip and etc) if I understand correctly. Add 2 options spark.usePython and spark.useR, so that any project using both sparkR and pyspark can leverage these 2 options. 
## How was this patch tested?

Use the following command to launch SparkPi and notice pyspark.zip, sparkr.zip and py4j are all distirbuted to executors. 

```
bin/spark-submit --master yarn-client --conf spark.useR=true --conf spark.usePython=true --class org.apache.spark.examples.SparkPi examples/target/original-spark-examples_2.11-2.1.0-SNAPSHOT.jar
```

Client output

```
16/09/20 16:25:15 INFO Client: Uploading resource file:/private/var/folders/dp/hmchg5dd3vbcvds26q91spdw0000gp/T/spark-1fa45f53-e75e-4671-bf75-1ef554a3dda5/__spark_libs__3260692671624418275.zip -> hdfs://localhost:9009/user/jzhang/.sparkStaging/application_1474162755082_0035/__spark_libs__3260692671624418275.zip
16/09/20 16:25:16 INFO Client: Uploading resource file:/Users/jzhang/github/spark/R/lib/sparkr.zip#sparkr -> hdfs://localhost:9009/user/jzhang/.sparkStaging/application_1474162755082_0035/sparkr.zip
16/09/20 16:25:17 INFO Client: Uploading resource file:/Users/jzhang/github/spark/python/lib/pyspark.zip -> hdfs://localhost:9009/user/jzhang/.sparkStaging/application_1474162755082_0035/pyspark.zip
16/09/20 16:25:17 INFO Client: Uploading resource file:/Users/jzhang/github/spark/python/lib/py4j-0.10.3-src.zip -> hdfs://localhost:9009/user/jzhang/.sparkStaging/application_1474162755082_0035/py4j-0.10.3-src.zip
16/09/20 16:25:17 INFO Client: Uploading resource file:/private/var/folders/dp/hmchg5dd3vbcvds26q91spdw0000gp/T/spark-1fa45f53-e75e-4671-bf75-1ef554a3dda5/__spark_conf__2718308972579262508.zip -> hdfs://localhost:9009/user/jzhang/.sparkStaging/application_1474162755082_0035/__spark_conf__.zip
```
