### PR TITLE
FIX: AggregatedDialect does not quote identifier correctly

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -41,4 +41,8 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
   override def getJDBCType(dt: DataType): Option[JdbcType] = {
     dialects.flatMap(_.getJDBCType(dt)).headOption
   }
+
+  override def quoteIdentifier(colName: String): String = {
+    dialects.head.quoteIdentifier(colName)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we write an custom MySQL Dialect and register it, it will be fused as an AggregatedDialect. But AggregatedDialect does not override quoteIdentifier method, so it will use JDBCDialect's quoteIdentifier method, quote identifier with ", which is not correct.
## How was this patch tested?

I have manually test this patch. It works as expected. 
