### PR TITLE
[SPARK-17625] [SQL] set expectedOutputAttributes when converting SimpleCatalogRelation to LogicalRelation

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -22,7 +22,9 @@ import java.math.MathContext
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.{AccumulatorSuite, SparkException}
-import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.analysis.UnresolvedException
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.execution.aggregate
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, CartesianProductExec, SortMergeJoinExec}
@@ -2305,18 +2307,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       checkAnswer(
         sql("SELECT i, j FROM tbl"),
         Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Row(4, "d") :: Nil)
-    }
-  }
-
-  test("data source table created in InMemoryCatalog should guarantee resolving consistency") {
-    val table = "tbl"
-    withTable("tbl") {
-      sql("CREATE TABLE tbl(i INT, j STRING) USING parquet")
-      val tableIdent = spark.sessionState.sqlParser.parseTableIdentifier(table)
-      val relation = spark.sessionState.catalog.lookupRelation(tableIdent)
-      val expr = relation.resolve("i")
-      val plan = Dataset.ofRows(spark, Project(Seq(expr), relation))
-      plan.queryExecution.assertAnalyzed()
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When converting `SimpleCatalogRelation` to `LogicalRelation`, we also need to set `expectedOutputAttributes`, then the output in `LogicalRelation` is the attributes in `expectedOutputAttributes`, otherwise, it will use its schema to generate new attributes (and new exprId's), so the output of LogicalRelation will be different from output of SimpleCatalogRelation.

As a result, if we have a table in `InMemoryCatalog`, we can't lookup it (get a `SimpleCatalogRelation`) and then use it to compose `LogicalPlan`s.
## How was this patch tested?

add a test case
