### PR TITLE
[SPARK-17627] Mark Streaming Providers Experimental

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -112,8 +112,10 @@ trait SchemaRelationProvider {
 }
 
 /**
+ * ::Experimental::
  * Implemented by objects that can produce a streaming [[Source]] for a specific format or system.
  */
+@Experimental
 trait StreamSourceProvider {
 
   /** Returns the name and schema of the source that can be used to continually read data. */
@@ -132,8 +134,10 @@ trait StreamSourceProvider {
 }
 
 /**
+ * ::Experimental::
  * Implemented by objects that can produce a streaming [[Sink]] for a specific format or system.
  */
+@Experimental
 trait StreamSinkProvider {
   def createSink(
       sqlContext: SQLContext,


### PR DESCRIPTION
All of structured streaming is experimental in its first release.  We missed the annotation on two of the APIs.
