### PR TITLE
[SPARK-17628][Streaming][Examples] change name "StreamingExamples" to be "StreamingExamplesUtils", more descriptive

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaCustomReceiver.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaCustomReceiver.java
@@ -64,7 +64,7 @@ public class JavaCustomReceiver extends Receiver<String> {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
 
     // Create the context with a 1 second batch size
     SparkConf sparkConf = new SparkConf().setAppName("JavaCustomReceiver");

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaDirectKafkaWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaDirectKafkaWordCount.java
@@ -57,7 +57,7 @@ public final class JavaDirectKafkaWordCount {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
 
     String brokers = args[0];
     String topics = args[1];

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaFlumeEventCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaFlumeEventCount.java
@@ -49,7 +49,7 @@ public final class JavaFlumeEventCount {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
 
     String host = args[0];
     int port = Integer.parseInt(args[1]);

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaKafkaWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaKafkaWordCount.java
@@ -63,7 +63,7 @@ public final class JavaKafkaWordCount {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
     SparkConf sparkConf = new SparkConf().setAppName("JavaKafkaWordCount");
     // Create the context with 2 seconds batch size
     JavaStreamingContext jssc = new JavaStreamingContext(sparkConf, new Duration(2000));

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaNetworkWordCount.java
@@ -54,7 +54,7 @@ public final class JavaNetworkWordCount {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
 
     // Create the context with a 1 second batch size
     SparkConf sparkConf = new SparkConf().setAppName("JavaNetworkWordCount");

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaQueueStream.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaQueueStream.java
@@ -41,7 +41,7 @@ public final class JavaQueueStream {
 
   public static void main(String[] args) throws Exception {
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
     SparkConf sparkConf = new SparkConf().setAppName("JavaQueueStream");
 
     // Create the context

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaSqlNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaSqlNetworkWordCount.java
@@ -58,7 +58,7 @@ public final class JavaSqlNetworkWordCount {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
 
     // Create the context with a 1 second batch size
     SparkConf sparkConf = new SparkConf().setAppName("JavaSqlNetworkWordCount");

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaStatefulNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaStatefulNetworkWordCount.java
@@ -56,7 +56,7 @@ public class JavaStatefulNetworkWordCount {
       System.exit(1);
     }
 
-    StreamingExamples.setStreamingLogLevels();
+    StreamingExamplesUtils.setStreamingLogLevels();
 
     // Create the context with a 1 second batch size
     SparkConf sparkConf = new SparkConf().setAppName("JavaStatefulNetworkWordCount");

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/CustomReceiver.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/CustomReceiver.scala
@@ -44,7 +44,7 @@ object CustomReceiver {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     // Create the context with a 1 second batch size
     val sparkConf = new SparkConf().setAppName("CustomReceiver")

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKafkaWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKafkaWordCount.scala
@@ -46,7 +46,7 @@ object DirectKafkaWordCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     val Array(brokers, topics) = args
 

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/FlumeEventCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/FlumeEventCount.scala
@@ -47,7 +47,7 @@ object FlumeEventCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     val Array(host, IntParam(port)) = args
 

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/FlumePollingEventCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/FlumePollingEventCount.scala
@@ -44,7 +44,7 @@ object FlumePollingEventCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     val Array(host, IntParam(port)) = args
 

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/HdfsWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/HdfsWordCount.scala
@@ -39,7 +39,7 @@ object HdfsWordCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
     val sparkConf = new SparkConf().setAppName("HdfsWordCount")
     // Create the context
     val ssc = new StreamingContext(sparkConf, Seconds(2))

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/KafkaWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/KafkaWordCount.scala
@@ -46,7 +46,7 @@ object KafkaWordCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     val Array(zkQuorum, group, topics, numThreads) = args
     val sparkConf = new SparkConf().setAppName("KafkaWordCount")

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/NetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/NetworkWordCount.scala
@@ -40,7 +40,7 @@ object NetworkWordCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     // Create the context with a 1 second batch size
     val sparkConf = new SparkConf().setAppName("NetworkWordCount")

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/QueueStream.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/QueueStream.scala
@@ -27,7 +27,7 @@ object QueueStream {
 
   def main(args: Array[String]) {
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
     val sparkConf = new SparkConf().setAppName("QueueStream")
     // Create the context
     val ssc = new StreamingContext(sparkConf, Seconds(1))

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/RawNetworkGrep.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/RawNetworkGrep.scala
@@ -43,7 +43,7 @@ object RawNetworkGrep {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     val Array(IntParam(numStreams), host, IntParam(port), IntParam(batchMillis)) = args
     val sparkConf = new SparkConf().setAppName("RawNetworkGrep")

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/SqlNetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/SqlNetworkWordCount.scala
@@ -44,7 +44,7 @@ object SqlNetworkWordCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     // Create the context with a 2 second batch size
     val sparkConf = new SparkConf().setAppName("SqlNetworkWordCount")

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/StatefulNetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/StatefulNetworkWordCount.scala
@@ -41,7 +41,7 @@ object StatefulNetworkWordCount {
       System.exit(1)
     }
 
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
 
     val sparkConf = new SparkConf().setAppName("StatefulNetworkWordCount")
     // Create the context with a 1 second batch size

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/StreamingExamplesUtils.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/StreamingExamplesUtils.scala
@@ -22,7 +22,7 @@ import org.apache.log4j.{Level, Logger}
 import org.apache.spark.internal.Logging
 
 /** Utility functions for Spark Streaming examples. */
-object StreamingExamples extends Logging {
+object StreamingExamplesUtils extends Logging {
 
   /** Set reasonable logging levels for streaming if the user has not configured log4j. */
   def setStreamingLogLevels() {

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/clickstream/PageViewStream.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/clickstream/PageViewStream.scala
@@ -18,7 +18,7 @@
 // scalastyle:off println
 package org.apache.spark.examples.streaming.clickstream
 
-import org.apache.spark.examples.streaming.StreamingExamples
+import org.apache.spark.examples.streaming.StreamingExamplesUtils
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 
 // scalastyle:off
@@ -42,7 +42,7 @@ object PageViewStream {
                          " errorRatePerZipCode, activeUserCount, popularUsersSeen")
       System.exit(1)
     }
-    StreamingExamples.setStreamingLogLevels()
+    StreamingExamplesUtils.setStreamingLogLevels()
     val metric = args(0)
     val host = args(1)
     val port = args(2).toInt


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-17628
## What changes were proposed in this pull request?

`object StreamingExamples` is more of a utility object, and the name is too general. here changing it to be `StreamingExamplesUtils`

```
/** Utility functions for Spark Streaming examples. */
object StreamingExamples extends Logging {

  /** Set reasonable logging levels for streaming if the user has not configured log4j. */
  def setStreamingLogLevels() {
    val log4jInitialized = Logger.getRootLogger.getAllAppenders.hasMoreElements
    if (!log4jInitialized) {
      // We first log something to initialize Spark's default logging, then we override the
      // logging level.
      logInfo("Setting log level to [WARN] for streaming example." +
        " To override add a custom log4j.properties to the classpath.")
      Logger.getRootLogger.setLevel(Level.WARN)
    }
  }
}
```
## How was this patch tested?

Tested manually on local laptop
