### PR TITLE
 [SPARK-17631] [SQL] Add HttpStreamSink for structured streaming. 

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -127,6 +127,12 @@
       <artifactId>xbean-asm5-shaded</artifactId>
       <scope>test</scope>
     </dependency>
+	<dependency>
+      <groupId>com.sparkjava</groupId>
+      <artifactId>spark-core</artifactId>
+      <version>2.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -5,3 +5,4 @@ org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 org.apache.spark.sql.execution.datasources.text.TextFileFormat
 org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
 org.apache.spark.sql.execution.streaming.TextSocketSourceProvider
+org.apache.spark.sql.execution.streaming.HttpStreamSink

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HttpStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HttpStreamSink.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.io.{BufferedReader, InputStreamReader, PrintWriter}
+import java.net.{UnknownHostException, URL, URLConnection}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql._
+import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
+import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.util.Utils
+
+class HttpSink(options: Map[String, String]) extends Sink with Logging {
+  override def addBatch(batchId: Long, data: DataFrame): Unit = synchronized {
+    val dataFormat: HttpDataFormat = {
+      val className = options.getOrElse("format.class",
+        "org.apache.spark.sql.execution.streaming.HttpDataToStringDefault")
+      createObject[HttpDataFormat](className)
+    }
+    data.collect().foreach(dataSeq => {
+        post(dataFormat.format(dataSeq.toSeq))
+    })
+  }
+
+  private def createObject[T<:AnyRef](className: String, args: AnyRef*): T = {
+    val klass = Utils.classForName(className).asInstanceOf[Class[T]]
+    val constructor = klass.getConstructor(args.map(_.getClass): _*)
+    constructor.newInstance(args: _*)
+  }
+
+  private def post(param: String): Unit = {
+    val url: URL = new URL(options.get("url").get)
+    val connection: URLConnection = url.openConnection
+    connection.setDoInput(true)
+    connection.setDoOutput(true)
+    val writer = new PrintWriter(connection.getOutputStream)
+    try {
+      writer.print(param)
+      writer.flush()
+    } catch {
+      case cause: Throwable => {
+        logError("Post http request error: ", cause)
+      }
+    } finally {
+      writer.close()
+    }
+    val reader = new BufferedReader(new InputStreamReader(connection.getInputStream))
+    try {
+      val it = reader.lines().iterator()
+      var lines: String = ""
+      while (it.hasNext()) {
+        lines += it.next()
+      }
+      logTrace("Http request post result: " + lines)
+    } catch {
+      case cause: Throwable => {
+        logError("Read http result error: ", cause)
+      }
+    } finally {
+      reader.close()
+    }
+  }
+}
+
+trait HttpDataFormat{
+  def format(data: Seq[Any]): String
+}
+
+class HttpDataToStringDefault extends HttpDataFormat {
+  def format(data: Seq[Any]) : String = {
+    return data.mkString(", ")
+  }
+}
+
+class HttpStreamSink extends StreamSinkProvider with DataSourceRegister{
+  def createSink(
+                  sqlContext: SQLContext,
+                  parameters: Map[String, String],
+                  partitionColumns: Seq[String],
+                  outputMode: OutputMode): Sink = {
+    if (!parameters.contains("url")) {
+      throw new AnalysisException("Http url should be set: .option(\"url\", \"...\").")
+    }
+    new HttpSink(parameters)
+  }
+
+  def shortName(): String = "http"
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/HttpStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/HttpStreamSinkSuite.scala
@@ -1,0 +1,38 @@
+package org.apache.spark.sql.execution.streaming
+
+import java.util
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{StructField, StructType, StringType}
+import spark.{Route, Spark, Request, Response}
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.test.SharedSQLContext
+import org.scalatest.BeforeAndAfter
+
+class HttpStreamSinkSuite extends StreamTest with SharedSQLContext with BeforeAndAfter{
+  import testImplicits._
+  after {
+    sqlContext.streams.active.foreach(_.stop())
+  }
+  test("http sink"){
+    var output: String = ""
+    Spark.port(3775)
+    Spark.get("/welcome/:vistor", new Route{
+      override def handle(req: Request, resp: Response) : Object = {
+        val name: String = req.params(":vistor")
+        output = name
+        return s"welcome $name"
+      }
+    })
+    val input = MemoryStream[String]
+    val query = input.toDF().writeStream
+      .outputMode("complete")
+      .format("http")
+      .option("url", "http://localhost:3775/welcome")
+      .start()
+    input.addData("Jerry")
+    CheckAnswer(Row(output))
+    query.awaitTermination()
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/HttpStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/HttpStreamSinkSuite.scala
@@ -1,11 +1,8 @@
 package org.apache.spark.sql.execution.streaming
 
-import java.util
+import spark.{Response, Request, Route, Spark}
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{StructField, StructType, StringType}
-import spark.{Route, Spark, Request, Response}
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.test.SharedSQLContext
 import org.scalatest.BeforeAndAfter


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a class HttpStreamSink for structured streaming. This class extends StreamSinkProvider and DataSourceRegister. Streaming query results can be sinked to http server if we configure DataStreamWrite with .format("http").option("url", yourHttpUrl).
e.g.

val query = counts.writeStream
.outputMode("append")
.format("http")
.option("url", "yourHttpUrl")
.start()
## How was this patch tested?

Use HttpStreamSinkSuite to test
