### PR TITLE
[SPARK-17639][build] Add jce.jar to buildclasspath when building.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -417,7 +417,6 @@
         </os>
       </activation>
       <properties>
-        <path.separator>\</path.separator>
         <script.extension>.bat</script.extension>
       </properties>
     </profile>
@@ -429,7 +428,6 @@
         </os>
       </activation>
       <properties>
-        <path.separator>/</path.separator>
         <script.extension>.sh</script.extension>
       </properties>
     </profile>
@@ -450,7 +448,7 @@
               </execution>
             </executions>
             <configuration>
-              <executable>..${path.separator}R${path.separator}install-dev${script.extension}</executable>
+              <executable>..${file.separator}R${file.separator}install-dev${script.extension}</executable>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -2617,8 +2617,9 @@
               <configuration>
                 <compilerArgs combine.children="append">
                   <arg>-bootclasspath</arg>
-                  <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar:${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
+                  <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar${path.separator}${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                 </compilerArgs>
+                <verbose>true</verbose>
               </configuration>
             </plugin>
             <plugin>
@@ -2633,7 +2634,7 @@
                   <configuration>
                     <args combine.children="append">
                       <arg>-javabootclasspath</arg>
-                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar:${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
+                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar${path.separator}${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                     </args>
                   </configuration>
                 </execution>
@@ -2642,7 +2643,7 @@
                   <configuration>
                     <args combine.children="append">
                       <arg>-javabootclasspath</arg>
-                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar:${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
+                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar${path.separator}${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                     </args>
                   </configuration>
                 </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2617,7 +2617,7 @@
               <configuration>
                 <compilerArgs combine.children="append">
                   <arg>-bootclasspath</arg>
-                  <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar,${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
+                  <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar:${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                 </compilerArgs>
               </configuration>
             </plugin>
@@ -2633,7 +2633,7 @@
                   <configuration>
                     <args combine.children="append">
                       <arg>-javabootclasspath</arg>
-                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar,${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
+                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar:${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                     </args>
                   </configuration>
                 </execution>
@@ -2642,7 +2642,7 @@
                   <configuration>
                     <args combine.children="append">
                       <arg>-javabootclasspath</arg>
-                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar,${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
+                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar:${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                     </args>
                   </configuration>
                 </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2617,7 +2617,7 @@
               <configuration>
                 <compilerArgs combine.children="append">
                   <arg>-bootclasspath</arg>
-                  <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar</arg>
+                  <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar,${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                 </compilerArgs>
               </configuration>
             </plugin>
@@ -2633,7 +2633,7 @@
                   <configuration>
                     <args combine.children="append">
                       <arg>-javabootclasspath</arg>
-                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar</arg>
+                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar,${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                     </args>
                   </configuration>
                 </execution>
@@ -2642,7 +2642,7 @@
                   <configuration>
                     <args combine.children="append">
                       <arg>-javabootclasspath</arg>
-                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar</arg>
+                      <arg>${env.JAVA_7_HOME}/jre/lib/rt.jar,${env.JAVA_7_HOME}/jre/lib/jce.jar</arg>
                     </args>
                   </configuration>
                 </execution>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -280,7 +280,7 @@ object SparkBuild extends PomBuild {
       "-target", javacJVMVersion.value
     ) ++ sys.env.get("JAVA_7_HOME").toSeq.flatMap { jdk7 =>
       if (javacJVMVersion.value == "1.7") {
-        Seq("-bootclasspath", s"$jdk7/jre/lib/rt.jar:$jdk7/jre/lib/jce.jar")
+        Seq("-bootclasspath", s"$jdk7/jre/lib/rt.jar${File.pathSeparator}$jdk7/jre/lib/jce.jar")
       } else {
         Nil
       }
@@ -291,7 +291,7 @@ object SparkBuild extends PomBuild {
       "-sourcepath", (baseDirectory in ThisBuild).value.getAbsolutePath  // Required for relative source links in scaladoc
     ) ++ sys.env.get("JAVA_7_HOME").toSeq.flatMap { jdk7 =>
       if (javacJVMVersion.value == "1.7") {
-        Seq("-javabootclasspath", s"$jdk7/jre/lib/rt.jar:$jdk7/jre/lib/jce.jar")
+        Seq("-javabootclasspath", s"$jdk7/jre/lib/rt.jar${File.pathSeparator}$jdk7/jre/lib/jce.jar")
       } else {
         Nil
       }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -280,7 +280,7 @@ object SparkBuild extends PomBuild {
       "-target", javacJVMVersion.value
     ) ++ sys.env.get("JAVA_7_HOME").toSeq.flatMap { jdk7 =>
       if (javacJVMVersion.value == "1.7") {
-        Seq("-bootclasspath", s"$jdk7/jre/lib/rt.jar")
+        Seq("-bootclasspath", s"$jdk7/jre/lib/rt.jar,$jdk7/jre/lib/jce.jar")
       } else {
         Nil
       }
@@ -291,7 +291,7 @@ object SparkBuild extends PomBuild {
       "-sourcepath", (baseDirectory in ThisBuild).value.getAbsolutePath  // Required for relative source links in scaladoc
     ) ++ sys.env.get("JAVA_7_HOME").toSeq.flatMap { jdk7 =>
       if (javacJVMVersion.value == "1.7") {
-        Seq("-javabootclasspath", s"$jdk7/jre/lib/rt.jar")
+        Seq("-javabootclasspath", s"$jdk7/jre/lib/rt.jar,$jdk7/jre/lib/jce.jar")
       } else {
         Nil
       }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -280,7 +280,7 @@ object SparkBuild extends PomBuild {
       "-target", javacJVMVersion.value
     ) ++ sys.env.get("JAVA_7_HOME").toSeq.flatMap { jdk7 =>
       if (javacJVMVersion.value == "1.7") {
-        Seq("-bootclasspath", s"$jdk7/jre/lib/rt.jar,$jdk7/jre/lib/jce.jar")
+        Seq("-bootclasspath", s"$jdk7/jre/lib/rt.jar:$jdk7/jre/lib/jce.jar")
       } else {
         Nil
       }
@@ -291,7 +291,7 @@ object SparkBuild extends PomBuild {
       "-sourcepath", (baseDirectory in ThisBuild).value.getAbsolutePath  // Required for relative source links in scaladoc
     ) ++ sys.env.get("JAVA_7_HOME").toSeq.flatMap { jdk7 =>
       if (javacJVMVersion.value == "1.7") {
-        Seq("-javabootclasspath", s"$jdk7/jre/lib/rt.jar,$jdk7/jre/lib/jce.jar")
+        Seq("-javabootclasspath", s"$jdk7/jre/lib/rt.jar:$jdk7/jre/lib/jce.jar")
       } else {
         Nil
       }


### PR DESCRIPTION
This was missing, preventing code that uses javax.crypto to properly
compile in Spark.
