### PR TITLE
[SPARK-17604][SQL][Streaming] Supprt purging aged file entries in FileStreamSourceLog

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -47,8 +47,8 @@ class FileStreamSource(
     fs.makeQualified(new Path(path))  // can contains glob patterns
   }
 
-  private val metadataLog =
-    new FileStreamSourceLog(FileStreamSourceLog.VERSION, sparkSession, metadataPath)
+  private val metadataLog = new FileStreamSourceLog(FileStreamSourceLog.VERSION, sparkSession,
+    metadataPath, sourceOptions.maxFileAgeMs)
   private var maxBatchId = metadataLog.getLatest().map(_._1).getOrElse(-1L)
 
   /** Maximum number of new files to be considered in each batch */
@@ -58,9 +58,7 @@ class FileStreamSource(
   // Visible for testing and debugging in production.
   val seenFiles = new SeenFilesMap(sourceOptions.maxFileAgeMs)
 
-  metadataLog.allFiles().foreach { entry =>
-    seenFiles.add(entry)
-  }
+  metadataLog.allFiles().foreach { entry => seenFiles.add(entry) }
   seenFiles.purge()
 
   logInfo(s"maxFilesPerBatch = $maxFilesPerBatch, maxFileAge = ${sourceOptions.maxFileAgeMs}")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.streaming
 
 import java.io.File
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 import scala.util.Random
 
@@ -90,8 +91,8 @@ class FileStreamSourceSuite extends SparkFunSuite with SharedSQLContext {
         classOf[ExistsThrowsExceptionFileSystem].getName)
       // add the metadata entries as a pre-req
       val dir = new File(temp, "dir") // use non-existent directory to test whether log make the dir
-      val metadataLog =
-        new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark, dir.getAbsolutePath)
+      val metadataLog = new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark,
+        dir.getAbsolutePath, TimeUnit.DAYS.toMillis(7))
       assert(metadataLog.add(0, Array(FileEntry(s"$scheme:///file1", 100L, 0))))
 
       val newSource = new FileStreamSource(spark, s"$scheme:///", "parquet", StructType(Nil),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently with [SPARK-15698](https://issues.apache.org/jira/browse/SPARK-15698), FileStreamSource metadata log will be compacted periodically (10 batches by default), this means compacted batch file will contain whole file entries been processed. With the time passed, the compacted batch file will be accumulated to a very large file.

With [SPARK-17165](https://issues.apache.org/jira/browse/SPARK-17165), now FileStreamSource doesn't track the aged file entry in memory, but in the log we still keep the full logs, this is not necessary and quite time-consuming during recovery. So here propose to also add file entry purging ability to remove aged file entries.
## How was this patch tested?

Unit test added.
