### PR TITLE
[SPARK-17650] malformed url's throw exceptions before bricking Executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -709,9 +709,7 @@ private[spark] object Utils extends Logging {
           uri.toURL
         } catch {
           case e: MalformedURLException =>
-            val msg = s"URI (${uri.toString}) is not a valid URL."
-            logError(msg)
-            val ex = new MalformedURLException(msg)
+            val ex = new MalformedURLException(s"URI (${uri.toString}) is not a valid URL.")
             ex.initCause(e)
             throw ex
         }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -698,6 +698,28 @@ private[spark] object Utils extends Logging {
   }
 
   /**
+   * Validate that a given URI is actually a valid URL as well.
+   * @param uri The URI to validate
+   */
+  @throws[MalformedURLException]("when the URI is an invalid URL")
+  def validateURL(uri: URI): Unit = {
+    Option(uri.getScheme).getOrElse("file") match {
+      case "http" | "https" | "ftp" =>
+        try {
+          uri.toURL
+        } catch {
+          case e: MalformedURLException =>
+            val msg = s"URI (${uri.toString}) is not a valid URL."
+            logError(msg)
+            val ex = new MalformedURLException(msg)
+            ex.initCause(e)
+            throw ex
+        }
+      case _ => // will not be turned into a URL anyway
+    }
+  }
+
+  /**
    * Get the path of a temporary directory.  Spark's local directories can be configured through
    * multiple settings, which are used with the following precedence:
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a malformed URL was sent to Executors through `sc.addJar` and `sc.addFile`, the executors become unusable, because they constantly throw `MalformedURLException`s and can never acknowledge that the file or jar is just bad input.

This PR tries to fix that problem by making sure MalformedURLs can never be submitted through `sc.addJar` and `sc.addFile`. Another solution would be to blacklist bad files and jars on Executors. Maybe fail the first time, and then ignore the second time (but print a warning message).
## How was this patch tested?

Unit tests in SparkContextSuite
