### PR TITLE
[SPARK-17652] Fix confusing exception message while reserving capacity

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -285,19 +285,19 @@ public abstract class ColumnVector implements AutoCloseable {
         try {
           reserveInternal(newCapacity);
         } catch (OutOfMemoryError outOfMemoryError) {
-          throwUnsupportedException(newCapacity, requiredCapacity, outOfMemoryError);
+          throwUnsupportedException(requiredCapacity, outOfMemoryError);
         }
       } else {
-        throwUnsupportedException(newCapacity, requiredCapacity, null);
+        throwUnsupportedException(requiredCapacity, null);
       }
     }
   }
 
-  private void throwUnsupportedException(int newCapacity, int requiredCapacity, Throwable cause) {
-    String message = "Cannot reserve more than " + newCapacity +
-        " bytes in the vectorized reader (requested = " + requiredCapacity + " bytes). As a" +
-        " workaround, you can disable the vectorized reader by setting "
-        + SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() + " to false.";
+  private void throwUnsupportedException(int requiredCapacity, Throwable cause) {
+    String message = "Cannot reserve additional contiguous bytes in the vectorized reader " +
+        "(requested = " + requiredCapacity + " bytes). As a workaround, you can disable the " +
+        "vectorized reader by setting " + SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() +
+        " to false.";
 
     if (cause != null) {
       throw new RuntimeException(message, cause);

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -802,8 +802,8 @@ class ColumnarBatchSuite extends SparkFunSuite {
         // Over-allocating beyond MAX_CAPACITY throws an exception
         column.appendBytes(10, 0.toByte)
       }
-      assert(ex.getMessage.contains(s"Cannot reserve more than ${column.MAX_CAPACITY} bytes in " +
-        s"the vectorized reader"))
+      assert(ex.getMessage.contains(s"Cannot reserve additional contiguous bytes in the " +
+        s"vectorized reader"))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This minor patch fixes a confusing exception message while reserving additional capacity in the vectorized parquet reader.
## How was this patch tested?

Exisiting Unit Tests
