### PR TITLE
[SPARK-17655][SQL]Remove unused variables declarations and definations in a WholeStageCodeGened stage

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -116,8 +116,10 @@ class CodegenContext {
 
   /**
    * Holding expressions' mutable states like `MonotonicallyIncreasingID.count` as a
-   * 3-tuple: java type, variable name, code to init it.
-   * As an example, ("int", "count", "count = 0;") will produce code:
+   * 4-tuple: java type, variable name, code to init it, flag marked if it can be replaced.
+   * If a state is a WholeStageCodegen result variable, the flag will be true to mark it as
+   * substitutable for the following generated one.
+   * As an example, ("int", "count", "count = 0;", false) will produce code:
    * {{{
    *   private int count;
    * }}}
@@ -133,7 +135,7 @@ class CodegenContext {
     mutable.ArrayBuffer.empty[(String, String, String, Boolean)]
 
   def addMutableState(javaType: String, variableName: String,
-                      initCode: String, isWholeStageResultVar: Boolean = false): Unit = {
+      initCode: String, isWholeStageResultVar: Boolean = false): Unit = {
     if (isWholeStageResultVar) {
       mutableStates = mutableStates.filterNot(state => (state._1 == javaType) && state._4)
       mutableStates += ((javaType, variableName, initCode, isWholeStageResultVar))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -72,11 +72,12 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       inputTypes: Seq[DataType],
       bufferHolder: String,
       isTopLevel: Boolean = false,
-      isResult: Boolean = false): String = {
+      isWholeStageResultVar: Boolean = false): String = {
     val rowWriterClass = classOf[UnsafeRowWriter].getName
     val rowWriter = ctx.freshName("rowWriter")
     ctx.addMutableState(rowWriterClass, rowWriter,
-      s"this.$rowWriter = new $rowWriterClass($bufferHolder, ${inputs.length});", isResult)
+      s"this.$rowWriter = new $rowWriterClass($bufferHolder, ${inputs.length});",
+      isWholeStageResultVar)
 
     val resetWriter = if (isTopLevel) {
       // For top level row writer, it always writes to the beginning of the global buffer holder,
@@ -294,10 +295,10 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
   }
 
   def createCode(
-                  ctx: CodegenContext,
-                  expressions: Seq[Expression],
-                  useSubexprElimination: Boolean = false,
-                  isWholeStageResultVar: Boolean = false): ExprCode = {
+      ctx: CodegenContext,
+      expressions: Seq[Expression],
+      useSubexprElimination: Boolean = false,
+      isWholeStageResultVar: Boolean = false): ExprCode = {
     val exprEvals = ctx.generateExpressions(expressions, useSubexprElimination)
     val exprTypes = expressions.map(_.dataType)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -431,7 +431,7 @@ case class CollapseCodegenStages(conf: SQLConf) extends Rule[SparkPlan] {
 
   private def supportCodegen(e: Expression): Boolean = e match {
     case e: LeafExpression => true
-    // CodegenFallback requires the input to be an InterRownal
+    // CodegenFallback requires the input to be an InternalRow
     case e: CodegenFallback => false
     case _ => true
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -133,7 +133,7 @@ trait CodegenSupport extends SparkPlan {
         // generate the code to create a UnsafeRow
         ctx.INPUT_ROW = row
         ctx.currentVars = outputVars
-        val ev = GenerateUnsafeProjection.createCode(ctx, colExprs, false)
+        val ev = GenerateUnsafeProjection.createCode(ctx, colExprs, false, true)
         val code = s"""
           |$evaluateInputs
           |${ev.code.trim}
@@ -431,7 +431,7 @@ case class CollapseCodegenStages(conf: SQLConf) extends Rule[SparkPlan] {
 
   private def supportCodegen(e: Expression): Boolean = e match {
     case e: LeafExpression => true
-    // CodegenFallback requires the input to be an InternalRow
+    // CodegenFallback requires the input to be an InterRownal
     case e: CodegenFallback => false
     case _ => true
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A WholeStageCodeGened stage with multiple CodegenSupport Operators generates unused result rows and their associated buffer holders and row writers, which can be removed.
## How was this patch tested?

existing ut.

cc @davies @rxin @srowen 
