### PR TITLE
[SPARK-17499][SPARKR][FOLLOWUP] Check null first for layers in spark.mlp to avoid warnings in test results

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -696,7 +696,10 @@ setMethod("predict", signature(object = "KMeansModel"),
 setMethod("spark.mlp", signature(data = "SparkDataFrame"),
           function(data, layers, blockSize = 128, solver = "l-bfgs", maxIter = 100,
                    tol = 1E-6, stepSize = 0.03, seed = NULL) {
-            layers <- suppressWarnings(as.integer(na.omit(layers)))
+            if (is.null(layers)) {
+              stop ("layers must be a integer vector with length > 1.")
+            }
+            layers <- as.integer(na.omit(layers))
             if (length(layers) <= 1) {
               stop ("layers must be a integer vector with length > 1.")
             }

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -696,7 +696,7 @@ setMethod("predict", signature(object = "KMeansModel"),
 setMethod("spark.mlp", signature(data = "SparkDataFrame"),
           function(data, layers, blockSize = 128, solver = "l-bfgs", maxIter = 100,
                    tol = 1E-6, stepSize = 0.03, seed = NULL) {
-            layers <- as.integer(na.omit(layers))
+            layers <- suppressWarnings(as.integer(na.omit(layers)))
             if (length(layers) <= 1) {
               stop ("layers must be a integer vector with length > 1.")
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some tests in `test_mllib.r` are as below:

``` r
expect_error(spark.mlp(df, layers = NULL), "layers must be a integer vector with length > 1.")
expect_error(spark.mlp(df, layers = c()), "layers must be a integer vector with length > 1.")
```

The problem is, `is.na` is internally called via `na.omit` in `spark.mlp` which causes warnings as below:

```
Warnings -----------------------------------------------------------------------
1. spark.mlp (@test_mllib.R#400) - is.na() applied to non-(list or vector) of type 'NULL'

2. spark.mlp (@test_mllib.R#401) - is.na() applied to non-(list or vector) of type 'NULL'
```
## How was this patch tested?

Manually tested. Also, Jenkins tests and AppVeyor.
