### PR TITLE
[SPARK-17653][SQL] Remove unnecessary distincts in multiple unions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -579,8 +579,13 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan] with PredicateHelpe
  * Combines all adjacent [[Union]] operators into a single [[Union]].
  */
 object CombineUnions extends Rule[LogicalPlan] {
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case Unions(children) => Union(children)
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
+    case Unions(children, isDistinct) =>
+      if (isDistinct) {
+        Distinct(Union(children))
+      } else {
+        Union(children)
+      }
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently for `Union [Distinct]`, a `Distinct` operator is necessary to be on the top of `Union`. Once there are adjacent `Union [Distinct]`,  there will be multiple `Distinct` in the query plan.

E.g.,

For a query like: select 1 a union select 2 b union select 3 c

Before this patch, its physical plan looks like:

```
*HashAggregate(keys=[a#13], functions=[])
+- Exchange hashpartitioning(a#13, 200)
   +- *HashAggregate(keys=[a#13], functions=[])
      +- Union
         :- *HashAggregate(keys=[a#13], functions=[])
         :  +- Exchange hashpartitioning(a#13, 200)
         :     +- *HashAggregate(keys=[a#13], functions=[])
         :        +- Union
         :           :- *Project [1 AS a#13]
         :           :  +- Scan OneRowRelation[]
         :           +- *Project [2 AS b#14]
         :              +- Scan OneRowRelation[]
         +- *Project [3 AS c#15]
            +- Scan OneRowRelation[]
```

Only the top distinct should be necessary.

After this patch, the physical plan looks like:

```
*HashAggregate(keys=[a#221], functions=[], output=[a#221])
+- Exchange hashpartitioning(a#221, 5)
   +- *HashAggregate(keys=[a#221], functions=[], output=[a#221])
      +- Union
         :- *Project [1 AS a#221]
         :  +- Scan OneRowRelation[]
         :- *Project [2 AS b#222]
         :  +- Scan OneRowRelation[]
         +- *Project [3 AS c#223]
            +- Scan OneRowRelation[]
```
## How was this patch tested?

Jenkins tests.
