### PR TITLE
[SPARK-17556] [CORE] [SQL] Executor side broadcast for broadcast joins

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
@@ -48,7 +48,8 @@ private[spark] trait BroadcastFactory {
   def newExecutorBroadcast[T: ClassTag](
       value: T,
       id: Long,
-      nBlocks: Int): Broadcast[T]
+      nBlocks: Int,
+      cSums: Array[Int]): Broadcast[T]
 
   // Called from executor to put broadcast data to blockmanager.
   def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Seq[Int]

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
@@ -40,6 +40,17 @@ private[spark] trait BroadcastFactory {
    */
   def newBroadcast[T: ClassTag](value: T, isLocal: Boolean, id: Long): Broadcast[T]
 
+  /**
+   * create a new broadcast variable with a specified id. The different of the origin interface
+   * is that there is a new param `isExecutorSide` to tell the BroadCast it is a executor-side
+   * broadcast and should consider recovery when get block data failed.
+   */
+  def newBroadcast[T: ClassTag](
+      value: T,
+      isLocal: Boolean,
+      id: Long,
+      isExecutorSide: Boolean): Broadcast[T]
+
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit
 
   def stop(): Unit

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
@@ -45,11 +45,10 @@ private[spark] trait BroadcastFactory {
    * is that there is a new param `isExecutorSide` to tell the BroadCast it is a executor-side
    * broadcast and should consider recovery when get block data failed.
    */
-  def newBroadcast[T: ClassTag](
+  def newExecutorBroadcast[T: ClassTag](
       value: T,
       isLocal: Boolean,
-      id: Long,
-      isExecutorSide: Boolean): Broadcast[T]
+      id: Long): Broadcast[T]
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit
 

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
@@ -41,14 +41,17 @@ private[spark] trait BroadcastFactory {
   def newBroadcast[T: ClassTag](value: T, isLocal: Boolean, id: Long): Broadcast[T]
 
   /**
-   * create a new broadcast variable with a specified id. The different of the origin interface
+   * Creates a new broadcast variable with a specified id. The different of the origin interface
    * is that there is a new param `isExecutorSide` to tell the BroadCast it is a executor-side
    * broadcast and should consider recovery when get block data failed.
    */
   def newExecutorBroadcast[T: ClassTag](
       value: T,
-      isLocal: Boolean,
-      id: Long): Broadcast[T]
+      id: Long,
+      nBlocks: Int): Broadcast[T]
+
+  // Called from executor to put broadcast data to blockmanager.
+  def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Int
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit
 

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
@@ -48,8 +48,7 @@ private[spark] trait BroadcastFactory {
   def newExecutorBroadcast[T: ClassTag](
       value: T,
       id: Long,
-      nBlocks: Int,
-      cSums: Array[Int]): Broadcast[T]
+      nBlocks: Int): Broadcast[T]
 
   // Called from executor to put broadcast data to blockmanager.
   def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Seq[Int]

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastFactory.scala
@@ -48,10 +48,11 @@ private[spark] trait BroadcastFactory {
   def newExecutorBroadcast[T: ClassTag](
       value: T,
       id: Long,
-      nBlocks: Int): Broadcast[T]
+      nBlocks: Int,
+      cSums: Array[Int]): Broadcast[T]
 
   // Called from executor to put broadcast data to blockmanager.
-  def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Int
+  def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Seq[Int]
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit
 

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -67,7 +67,9 @@ private[spark] class BroadcastManager(
       hdfsBackupDir.foreach { dirPath =>
         try {
           val fs = dirPath.getFileSystem(SparkHadoopUtil.get.conf)
-          fs.delete(dirPath, true)
+          if (fs.exists(dirPath)) {
+            fs.delete(dirPath, true)
+          }
         } catch {
           case e: IOException =>
             logWarning(s"Failed to delete broadcast temp dir $dirPath.", e)

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -69,12 +69,11 @@ private[spark] class BroadcastManager(
   }
 
   // Called from driver to create broadcast with specified id
-  def newBroadcast[T: ClassTag](
+  def newExecutorBroadcast[T: ClassTag](
       value_ : T,
       isLocal: Boolean,
-      id: Long,
-      isExecutorSide: Boolean): Broadcast[T] = {
-    broadcastFactory.newBroadcast[T](value_, isLocal, id, isExecutorSide)
+      id: Long): Broadcast[T] = {
+    broadcastFactory.newExecutorBroadcast[T](value_, isLocal, id)
   }
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean) {
@@ -83,9 +82,9 @@ private[spark] class BroadcastManager(
 }
 
 /**
- * Marker trait to identify the shape in which tuples are broadcasted. This is used for executor-side
- * broadcast, typical examples of this are identity (tuples remain unchanged) or hashed (tuples are
- * converted into some hash index).
+ * Marker trait to identify the shape in which tuples are broadcasted. This is used for
+ * executor-side broadcast, typical examples of this are identity (tuples remain unchanged)
+ * or hashed (tuples are converted into some hash index).
  */
 trait TransFunc[T, U] extends Serializable {
   def transform(rows: Array[T]): U

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -59,21 +59,20 @@ private[spark] class BroadcastManager(
     broadcastFactory.newBroadcast[T](value_, isLocal, nextBroadcastId.getAndIncrement())
   }
 
-  // Called from executor to create broadcast with specified id
-  def newBroadcast[T: ClassTag](
+  // Called from executor to upload broadcast data to blockmanager.
+  def uploadBroadcast[T: ClassTag](
       value_ : T,
-      isLocal: Boolean,
       id: Long
-     ): Broadcast[T] = {
-    broadcastFactory.newBroadcast[T](value_, isLocal, id)
+     ): Int = {
+    broadcastFactory.uploadBroadcast[T](value_, id)
   }
 
   // Called from driver to create broadcast with specified id
   def newExecutorBroadcast[T: ClassTag](
       value_ : T,
-      isLocal: Boolean,
-      id: Long): Broadcast[T] = {
-    broadcastFactory.newExecutorBroadcast[T](value_, isLocal, id)
+      id: Long,
+      nBlocks: Int): Broadcast[T] = {
+    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks)
   }
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean) {

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -93,7 +93,7 @@ private[spark] class BroadcastManager(
   def uploadBroadcast[T: ClassTag](
       value_ : T,
       id: Long
-     ): Int = {
+     ): Seq[Int] = {
     broadcastFactory.uploadBroadcast[T](value_, id)
   }
 
@@ -101,8 +101,9 @@ private[spark] class BroadcastManager(
   def newExecutorBroadcast[T: ClassTag](
       value_ : T,
       id: Long,
-      nBlocks: Int): Broadcast[T] = {
-    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks)
+      nBlocks: Int,
+      cSums: Array[Int]): Broadcast[T] = {
+    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks, cSums)
   }
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean) {

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -101,9 +101,8 @@ private[spark] class BroadcastManager(
   def newExecutorBroadcast[T: ClassTag](
       value_ : T,
       id: Long,
-      nBlocks: Int,
-      cSums: Array[Int]): Broadcast[T] = {
-    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks, cSums)
+      nBlocks: Int): Broadcast[T] = {
+    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks)
   }
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean) {

--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -101,8 +101,9 @@ private[spark] class BroadcastManager(
   def newExecutorBroadcast[T: ClassTag](
       value_ : T,
       id: Long,
-      nBlocks: Int): Broadcast[T] = {
-    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks)
+      nBlocks: Int,
+      cSums: Array[Int]): Broadcast[T] = {
+    broadcastFactory.newExecutorBroadcast[T](value_, id, nBlocks, cSums)
   }
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean) {

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -74,7 +74,8 @@ private[spark] class TorrentBroadcast[T: ClassTag](
     obj: T,
     id: Long,
     isExecutorSide: Boolean = false,
-    @transient val nBlocks: Option[Int] = None)
+    nBlocks: Option[Int] = None,
+    cSums: Option[Array[Int]] = None)
   extends Broadcast[T](id) with Logging with Serializable {
 
   /**
@@ -93,7 +94,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
   /** Whether to generate checksum for blocks or not. */
   private var checksumEnabled: Boolean = false
   /** The checksum for all the blocks. */
-  private var checksums: Array[Int] = _
+  private var checksums: Array[Int] = cSums.getOrElse(null)
 
   private def setConf(conf: SparkConf) {
     compressionCodec = if (conf.getBoolean("spark.broadcast.compress", true)) {
@@ -103,7 +104,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
     }
     // Note: use getSizeAsKb (not bytes) to maintain compatibility if no units are provided
     blockSize = conf.getSizeAsKb("spark.broadcast.blockSize", "4m").toInt * 1024
-    checksumEnabled = conf.getBoolean("spark.broadcast.checksum", false)
+    checksumEnabled = conf.getBoolean("spark.broadcast.checksum", true)
   }
   setConf(SparkEnv.get.conf)
 

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -55,7 +55,7 @@ import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStrea
  * @param id A unique identifier for the broadcast variable.
  * @param isExecutorSide A identifier for executor broadcast variable.
  * @param nBlocks how many blocks for executor broadcast.
-  */
+ */
 private[spark] class TorrentBroadcast[T: ClassTag](
     obj: T,
     id: Long,
@@ -140,7 +140,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
         checksums(i) = calcChecksum(block)
       }
       val pieceId = BroadcastBlockId(id, "piece" + i)
-      blockManager.persistBroadcast(pieceId, block)
+      blockManager.persistBroadcastPiece(pieceId, block)
       val bytes = new ChunkedByteBuffer(block.duplicate())
       if (!blockManager.putBytes(pieceId, bytes, MEMORY_AND_DISK_SER, tellMaster = true)) {
         throw new SparkException(s"Failed to store $pieceId of $broadcastId in local BlockManager")
@@ -167,7 +167,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
           blocks(pid) = block
           releaseLock(pieceId)
         case None =>
-          bm.getRemoteBytes(pieceId).orElse(bm.getHdfsBytes(pieceId)) match {
+          bm.getRemoteBytes(pieceId).orElse(bm.getBroadcastPiece(pieceId)) match {
             case Some(b) =>
               if (checksumEnabled) {
                 val sum = calcChecksum(b.chunks(0))

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -53,8 +53,14 @@ import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStrea
  *
  * @param obj object to broadcast
  * @param id A unique identifier for the broadcast variable.
- */
-private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long, isExecutorSide: Boolean)
+ * @param isExecutorSide A identifier for executor broadcast variable.
+ * @param nBlocks how many blocks for executor broadcast.
+  */
+private[spark] class TorrentBroadcast[T: ClassTag](
+    obj: T,
+    id: Long,
+    isExecutorSide: Boolean = false,
+    nBlocks: Option[Int] = None)
   extends Broadcast[T](id) with Logging with Serializable {
 
   /**
@@ -84,14 +90,10 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long, isExecutorS
 
   private val broadcastId = BroadcastBlockId(id)
 
-  def setNumBlocks(n: Int): Unit = {
-    numBlocks = n
-  }
-
-  def getNumBlocks(): Int = numBlocks
+  def getNumBlocks: Int = numBlocks
 
   /** Total number of blocks this broadcast variable contains. */
-  private var numBlocks: Int = if (!isExecutorSide) writeBlocks(obj) else -1
+  private var numBlocks: Int = if (!isExecutorSide) writeBlocks(obj) else nBlocks.getOrElse(-1)
 
   /** Whether to generate checksum for blocks or not. */
   private var checksumEnabled: Boolean = false

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -71,7 +71,7 @@ import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStrea
  * @param nBlocks how many blocks for executor broadcast.
  */
 private[spark] class TorrentBroadcast[T: ClassTag](
-    obj: T,
+    @transient val obj: T,
     id: Long,
     isExecutorSide: Boolean = false,
     nBlocks: Option[Int] = None,

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -74,8 +74,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
     obj: T,
     id: Long,
     isExecutorSide: Boolean = false,
-    nBlocks: Option[Int] = None,
-    cSums: Option[Array[Int]] = None)
+    @transient val nBlocks: Option[Int] = None)
   extends Broadcast[T](id) with Logging with Serializable {
 
   /**
@@ -94,7 +93,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
   /** Whether to generate checksum for blocks or not. */
   private var checksumEnabled: Boolean = false
   /** The checksum for all the blocks. */
-  private var checksums: Array[Int] = cSums.getOrElse(null)
+  private var checksums: Array[Int] = _
 
   private def setConf(conf: SparkConf) {
     compressionCodec = if (conf.getBoolean("spark.broadcast.compress", true)) {
@@ -104,7 +103,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
     }
     // Note: use getSizeAsKb (not bytes) to maintain compatibility if no units are provided
     blockSize = conf.getSizeAsKb("spark.broadcast.blockSize", "4m").toInt * 1024
-    checksumEnabled = conf.getBoolean("spark.broadcast.checksum", true)
+    checksumEnabled = conf.getBoolean("spark.broadcast.checksum", false)
   }
   setConf(SparkEnv.get.conf)
 

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -93,7 +93,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
   def getNumBlocks: Int = numBlocks
 
   /** Total number of blocks this broadcast variable contains. */
-  private var numBlocks: Int = if (!isExecutorSide) writeBlocks(obj) else nBlocks.getOrElse(-1)
+  private val numBlocks: Int = if (!isExecutorSide) writeBlocks(obj) else nBlocks.getOrElse(-1)
 
   /** Whether to generate checksum for blocks or not. */
   private var checksumEnabled: Boolean = false

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -34,12 +34,11 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
     new TorrentBroadcast[T](value_, id, false)
   }
 
-  override def newBroadcast[T: ClassTag](
+  override def newExecutorBroadcast[T: ClassTag](
       value: T,
       isLocal: Boolean,
-      id: Long,
-      isExecutorSide: Boolean): Broadcast[T] = {
-    new TorrentBroadcast[T](value, id, isExecutorSide)
+      id: Long): Broadcast[T] = {
+    new TorrentBroadcast[T](value, id, true)
   }
 
   override def stop() { }

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -31,7 +31,15 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
   override def initialize(isDriver: Boolean, conf: SparkConf, securityMgr: SecurityManager) { }
 
   override def newBroadcast[T: ClassTag](value_ : T, isLocal: Boolean, id: Long): Broadcast[T] = {
-    new TorrentBroadcast[T](value_, id)
+    new TorrentBroadcast[T](value_, id, false)
+  }
+
+  override def newBroadcast[T: ClassTag](
+      value: T,
+      isLocal: Boolean,
+      id: Long,
+      isExecutorSide: Boolean): Broadcast[T] = {
+    new TorrentBroadcast[T](value, id, isExecutorSide)
   }
 
   override def stop() { }

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -31,14 +31,18 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
   override def initialize(isDriver: Boolean, conf: SparkConf, securityMgr: SecurityManager) { }
 
   override def newBroadcast[T: ClassTag](value_ : T, isLocal: Boolean, id: Long): Broadcast[T] = {
-    new TorrentBroadcast[T](value_, id, false)
+    new TorrentBroadcast[T](value_, id)
   }
 
   override def newExecutorBroadcast[T: ClassTag](
       value: T,
-      isLocal: Boolean,
-      id: Long): Broadcast[T] = {
-    new TorrentBroadcast[T](value, id, true)
+      id: Long,
+      nBlocks: Int): Broadcast[T] = {
+    new TorrentBroadcast[T](value, id, true, Option(nBlocks))
+  }
+
+  override def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Int = {
+    new TorrentBroadcast[T](value_, id).getNumBlocks
   }
 
   override def stop() { }

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -37,9 +37,8 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
   override def newExecutorBroadcast[T: ClassTag](
       value: T,
       id: Long,
-      nBlocks: Int,
-      cSums: Array[Int]): Broadcast[T] = {
-    new TorrentBroadcast[T](value, id, true, Option(nBlocks), Option(cSums))
+      nBlocks: Int): Broadcast[T] = {
+    new TorrentBroadcast[T](value, id, true, Option(nBlocks))
   }
 
   override def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Seq[Int] = {

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -42,7 +42,7 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
   }
 
   override def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Int = {
-    new TorrentBroadcast[T](value_, id).getNumBlocks
+    new TorrentBroadcast[T](value_, id, true).getNumBlocks
   }
 
   override def stop() { }

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -37,12 +37,14 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
   override def newExecutorBroadcast[T: ClassTag](
       value: T,
       id: Long,
-      nBlocks: Int): Broadcast[T] = {
-    new TorrentBroadcast[T](value, id, true, Option(nBlocks))
+      nBlocks: Int,
+      cSums: Array[Int]): Broadcast[T] = {
+    new TorrentBroadcast[T](value, id, true, Option(nBlocks), Option(cSums))
   }
 
-  override def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Int = {
-    new TorrentBroadcast[T](value_, id, true).getNumBlocks
+  override def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Seq[Int] = {
+    val executorBroadcast = new TorrentBroadcast[T](value_, id, true)
+    executorBroadcast.getNumBlocksAndChecksums
   }
 
   override def stop() { }

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcastFactory.scala
@@ -37,8 +37,9 @@ private[spark] class TorrentBroadcastFactory extends BroadcastFactory {
   override def newExecutorBroadcast[T: ClassTag](
       value: T,
       id: Long,
-      nBlocks: Int): Broadcast[T] = {
-    new TorrentBroadcast[T](value, id, true, Option(nBlocks))
+      nBlocks: Int,
+      cSums: Array[Int]): Broadcast[T] = {
+    new TorrentBroadcast[T](value, id, true, Option(nBlocks), Option(cSums))
   }
 
   override def uploadBroadcast[T: ClassTag](value_ : T, id: Long): Seq[Int] = {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -953,13 +953,13 @@ abstract class RDD[T: ClassTag](
           SparkEnv.get.broadcastManager
             .uploadBroadcast(transFunc.transform(iter.toArray), id).iterator
       }.collect()
+      val nblocks = numBlocksAndChecksums.head
 
       // then: create broadcast from driver, this will not write blocks
       val res = SparkEnv.get.broadcastManager.newExecutorBroadcast(
         transFunc.transform(Array.empty[T]),
         id,
-        numBlocksAndChecksums.head,
-        numBlocksAndChecksums.tail)
+        nblocks)
 
       val callSite = sc.getCallSite
       logInfo("Created executor side broadcast " + res.id + " from " + callSite.shortForm)

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -943,7 +943,8 @@ abstract class RDD[T: ClassTag](
    *
    * User should pass in a translate function to compute the broadcast value from the rdd.
    */
-  def broadcast[U: ClassTag](transFunc: TransFunc[T, U]): Broadcast[U] = withScope {
+  @Since("2.1.0")
+  private[spark] def broadcast[U: ClassTag](transFunc: TransFunc[T, U]): Broadcast[U] = withScope {
     val bc = if (partitions.size > 0) {
       val id = sc.env.broadcastManager.newBroadcastId
 
@@ -974,7 +975,14 @@ abstract class RDD[T: ClassTag](
     bc
   }
 
-  // executor-side broadcast api
+  /**
+   * Executor broadcast api, it broadcast the rdd to the cluster from executor, returning a
+   * [[org.apache.spark.broadcast.Broadcast]] object for reading it in distributed functions.
+   * The variable will be sent to each cluster only once.
+   *
+   * @param f is a translate function to compute the broadcast value from the rdd.
+   */
+  @Since("2.1.0")
   def broadcast[U: ClassTag](f: Iterator[T] => U): Broadcast[U] = withScope {
     val transFunc = new TransFunc[T, U] {
       override def transform(rows: Array[T]): U = {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -946,9 +946,10 @@ abstract class RDD[T: ClassTag](
   def broadcast[U: ClassTag](transFunc: TransFunc[T, U]): Broadcast[U] = withScope {
     val bc = if (partitions.size > 0) {
       val id = sc.env.broadcastManager.newBroadcastId
-      // create broadcast from driver, do not write blocks in driver.
-      val res = SparkEnv.get.broadcastManager.newBroadcast(
-        transFunc.transform(Array.empty[T]), false, id, true)
+
+      // create broadcast from driver, do not write blocks in driver when construct.
+      val res = SparkEnv.get.broadcastManager.newExecutorBroadcast(
+        transFunc.transform(Array.empty[T]), false, id)
 
       val numBlocks = coalesce(1).mapPartitions { iter =>
         // write blocks in executor.

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -953,13 +953,13 @@ abstract class RDD[T: ClassTag](
           SparkEnv.get.broadcastManager
             .uploadBroadcast(transFunc.transform(iter.toArray), id).iterator
       }.collect()
-      val nblocks = numBlocksAndChecksums.head
 
       // then: create broadcast from driver, this will not write blocks
       val res = SparkEnv.get.broadcastManager.newExecutorBroadcast(
         transFunc.transform(Array.empty[T]),
         id,
-        nblocks)
+        numBlocksAndChecksums.head,
+        numBlocksAndChecksums.tail)
 
       val callSite = sc.getCallSite
       logInfo("Created executor side broadcast " + res.id + " from " + callSite.shortForm)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -166,7 +166,7 @@ private[spark] class BlockManager(
    * service if configured.
    */
   def initialize(appId: String): Unit = {
-    val dir = conf.get("spark.hdfs.dir", "/tmp/spark/" + appId)
+    val dir = conf.get("spark.hdfs.dir", s"/tmp/spark/${appId}_blocks")
     hdfsDir = Option(new Path(dir))
 
     blockTransferService.init(this)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 import scala.util.Random
 import scala.util.control.NonFatal
 
-import org.apache.hadoop.fs.{PathFilter, Path, FileSystem}
+import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
 
 import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -79,18 +79,6 @@ private[spark] class BlockManager(
     conf.getBoolean("spark.shuffle.service.enabled", false)
 
   private[spark] var hdfsDir: Option[Path] = None
-
-  /**
-    * Set the current working dir from the outside param.
-    * Note: this will have a ambiguous problem if we check the dir with test case:
-    * `run Spark in yarn-client mode` and `run Python application in yarn-client mode` and
-    * `run Python application in yarn-cluster mode` and `external shuffle service`.
-    *
-    * @param dir only in yarn-mode, dir will be well defined and must be the staging dir.
-    */
-  private[spark] def initializeCurrentDir(dir: String): Unit = {
-
-  }
 
   val diskBlockManager = {
     // Only perform cleanup if an external service is not serving our shuffle files.

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -205,6 +205,9 @@ private[spark] class DiskBlockManager(conf: SparkConf, deleteFilesOnStop: Boolea
       }
       try {
         val fs = dirPath.getFileSystem(SparkHadoopUtil.get.conf)
+        if (!fs.exists(dirPath)) {
+          return
+        }
         val files = fs.listStatus(dirPath, fileFilter).map(_.getPath)
         for (file <- files) {
           if (fs.exists(file)) {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -22,14 +22,15 @@ import java.io.{File, IOException, ObjectInputStream, ObjectOutputStream}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.reflect.ClassTag
+
 import com.esotericsoftware.kryo.KryoException
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapred.{FileSplit, TextInputFormat}
+
 import org.apache.spark._
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.broadcast.TransFunc
 import org.apache.spark.rdd.RDDSuiteUtils._
-import org.apache.spark.storage.BroadcastBlockId
 import org.apache.spark.util.Utils
 
 class RDDSuite extends SparkFunSuite with SharedSparkContext {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -103,6 +103,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
   import DAGSchedulerSuite._
 
   val conf = new SparkConf
+  conf.set("spark.app.id", "DAGSchedulerSuite")
+
   /** Set of TaskSets the DAGScheduler has requested executed. */
   val taskSets = scala.collection.mutable.Buffer[TaskSet]()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/broadcastMode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/broadcastMode.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.catalyst.plans.physical
 
+import org.apache.spark.broadcast.TransFunc
 import org.apache.spark.sql.catalyst.InternalRow
 
 /**
  * Marker trait to identify the shape in which tuples are broadcasted. Typical examples of this are
  * identity (tuples remain unchanged) or hashed (tuples are converted into some hash index).
  */
-trait BroadcastMode {
+trait BroadcastMode extends TransFunc[InternalRow, Any]{
   def transform(rows: Array[InternalRow]): Any
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -49,7 +49,7 @@ case class BroadcastExchangeExec(
     "buildTime" -> SQLMetrics.createMetric(sparkContext, "time to build (ms)"),
     "broadcastTime" -> SQLMetrics.createMetric(sparkContext, "time to broadcast (ms)"),
     "collect_build_broadcastTime" -> SQLMetrics.createMetric(sparkContext,
-      "time to collect, build and broadcast (ms) in executor broadcast"))
+      "time to collect, build and broadcast (ms)"))
 
   override def outputPartitioning: Partitioning = BroadcastPartitioning(mode)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -160,7 +160,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       case (child, distribution) if child.outputPartitioning.satisfies(distribution) =>
         child
       case (child, BroadcastDistribution(mode)) =>
-        BroadcastExchangeExec(mode, child)
+        BroadcastExchangeExec(mode, child, conf)
       case (child, distribution) =>
         ShuffleExchange(createPartitioning(distribution, defaultNumPreShufflePartitions), child)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -154,6 +154,11 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val EXECUTOR_BROADCAST_N_ENABLED = SQLConfigBuilder("spark.sql.executorBroadcast.enabled")
+    .doc("When true, broadcast join use executor side broadcast.")
+    .booleanConf
+    .createWithDefault(true)
+
   val SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS =
     SQLConfigBuilder("spark.sql.adaptive.minNumPostShufflePartitions")
       .internal()
@@ -726,6 +731,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
     getConf(SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE)
 
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
+
+  def executorBroadcastEnabled: Boolean = getConf(EXECUTOR_BROADCAST_N_ENABLED)
 
   def minNumPostShufflePartitions: Int =
     getConf(SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1071,7 +1071,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
       agg.queryExecution.executedPlan.collectFirst {
         case ShuffleExchange(_, _: RDDScanExec, _) =>
-        case BroadcastExchangeExec(_, _: RDDScanExec) =>
+        case BroadcastExchangeExec(_, _: RDDScanExec, _) =>
       }.foreach { _ =>
         fail(
           "No Exchange should be inserted above RDDScanExec since the checkpointed Dataset " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -55,12 +55,12 @@ class ExchangeSuite extends SparkPlanTest with SharedSQLContext {
     val output = plan.output
     assert(plan sameResult plan)
 
-    val exchange1 = BroadcastExchangeExec(IdentityBroadcastMode, plan)
+    val exchange1 = BroadcastExchangeExec(IdentityBroadcastMode, plan, spark.sessionState.conf)
     val hashMode = HashedRelationBroadcastMode(output)
-    val exchange2 = BroadcastExchangeExec(hashMode, plan)
+    val exchange2 = BroadcastExchangeExec(hashMode, plan, spark.sessionState.conf)
     val hashMode2 =
       HashedRelationBroadcastMode(Alias(output.head, "id2")() :: Nil)
-    val exchange3 = BroadcastExchangeExec(hashMode2, plan)
+    val exchange3 = BroadcastExchangeExec(hashMode2, plan, spark.sessionState.conf)
     val exchange4 = ReusedExchangeExec(output, exchange3)
 
     assert(exchange1 sameResult exchange1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA: https://issues.apache.org/jira/browse/SPARK-17556
Design doc : 
https://issues.apache.org/jira/secure/attachment/12830668/executor%20broadcast.pdf

Added two api for RDD to perform executor side broadcast and apply it on sql's broadcast join.

[1].  `def broadcast[U: ClassTag](f: Iterator[T] => U): Broadcast[U]`

User only need pass a function to describe how to translate all the element of the rdd to the value they want to broadcast

[2]. `def broadcast[U: ClassTag](transFunc: TransFunc[T, U]): Broadcast[U]`

This is only used in spark sql(spark internal), TransFunc is a interface to describe how to translate all the element of the rdd to a single value.
TransFunc is inherited by BroadcastMode in spark sql.

When construct broadcast, firstly it write blocks to block manager from executor and then create `Broadcast` from driver(not write blocks)
## How was this patch tested?

added unit test and manual test.
