### PR TITLE
Update spark-standalone.md to fix link

### DIFF
--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -348,7 +348,7 @@ Learn more about getting started with ZooKeeper [here](http://zookeeper.apache.o
 **Configuration**
 
 In order to enable this recovery mode, you can set SPARK_DAEMON_JAVA_OPTS in spark-env by configuring `spark.deploy.recoveryMode` and related spark.deploy.zookeeper.* configurations.
-For more information about these configurations please refer to the configurations (doc)[configurations.html#deploy]
+For more information about these configurations please refer to the [configuration doc](configuration.html#deploy)
 
 Possible gotcha: If you have multiple Masters in your cluster but fail to correctly configure the Masters to use ZooKeeper, the Masters will fail to discover each other and think they're all leaders. This will not lead to a healthy cluster state (as all Masters will schedule independently).
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Corrected a link to the configuration.html page, it was pointing to a page that does not exist (configurations.html).
## How was this patch tested?

Documentation change, verified in preview.
