### PR TITLE
[SPARK-17672] Spark 2.0 history server web Ui takes too long for a single application

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -279,7 +279,8 @@ private[history] class ApplicationCache(
     time(metrics.loadTimer) {
       operations.getAppUI(appId, attemptId) match {
         case Some(LoadedAppUI(ui, updateState)) =>
-          val completed = ui.getApplicationInfoList.exists(_.attempts.last.completed)
+          val completed = ui.getApplicationInfo(appId)
+            .map(_.attempts.last.completed).getOrElse(false)
           if (completed) {
             // completed spark UIs are attached directly
             operations.attachSparkUI(appId, attemptId, ui, completed)

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -279,8 +279,7 @@ private[history] class ApplicationCache(
     time(metrics.loadTimer) {
       operations.getAppUI(appId, attemptId) match {
         case Some(LoadedAppUI(ui, updateState)) =>
-          val completed = ui.getApplicationInfo(appId)
-            .map(_.attempts.last.completed).getOrElse(false)
+          val completed = ui.getApplicationInfoList.exists(_.attempts.last.completed)
           if (completed) {
             // completed spark UIs are attached directly
             operations.attachSparkUI(appId, attemptId, ui, completed)

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -109,4 +109,11 @@ private[history] abstract class ApplicationHistoryProvider {
   @throws(classOf[SparkException])
   def writeEventLogs(appId: String, attemptId: Option[String], zipStream: ZipOutputStream): Unit
 
+  /**
+    * Returns an ApplicationHistoryInfo for the appId
+    *
+    * @return ApplicationHistoryInfo of one appId if exists
+    */
+  def getApplicationInfo(appId: String): Option[ApplicationHistoryInfo]
+
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -110,10 +110,10 @@ private[history] abstract class ApplicationHistoryProvider {
   def writeEventLogs(appId: String, attemptId: Option[String], zipStream: ZipOutputStream): Unit
 
   /**
-    * Returns an ApplicationHistoryInfo for the appId
-    *
-    * @return ApplicationHistoryInfo of one appId if exists
-    */
+   * Returns an ApplicationHistoryInfo for the appId.
+   *
+   * @return ApplicationHistoryInfo of one appId if exists.
+   */
   def getApplicationInfo(appId: String): Option[ApplicationHistoryInfo]
 
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -224,6 +224,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   override def getListing(): Iterable[FsApplicationHistoryInfo] = applications.values
 
+  override def getApplicationInfo(appId: String): Option[FsApplicationHistoryInfo] = {
+    applications.get(appId)
+  }
+
   override def getAppUI(appId: String, attemptId: Option[String]): Option[LoadedAppUI] = {
     try {
       applications.get(appId).flatMap { appInfo =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -182,6 +182,10 @@ class HistoryServer(
     getApplicationList().iterator.map(ApplicationsListResource.appHistoryInfoToPublicAppInfo)
   }
 
+  def getApplicationInfo(appId: String): Option[ApplicationInfo] = {
+    provider.getApplicationInfo(appId).map(ApplicationsListResource.appHistoryInfoToPublicAppInfo)
+  }
+
   override def writeEventLogs(
       appId: String,
       attemptId: Option[String],

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
@@ -222,6 +222,7 @@ private[spark] object ApiRootResource {
 private[spark] trait UIRoot {
   def getSparkUI(appKey: String): Option[SparkUI]
   def getApplicationInfoList: Iterator[ApplicationInfo]
+  def getApplicationInfo(appId: String): Option[ApplicationInfo]
 
   /**
    * Write the event logs for the given app to the [[ZipOutputStream]] instance. If attemptId is

--- a/core/src/main/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
@@ -24,7 +24,7 @@ private[v1] class OneApplicationResource(uiRoot: UIRoot) {
 
   @GET
   def getApp(@PathParam("appId") appId: String): ApplicationInfo = {
-    val apps = uiRoot.getApplicationInfoList.find { _.id == appId }
+    val apps = uiRoot.getApplicationInfo(appId)
     apps.getOrElse(throw new NotFoundException("unknown app: " + appId))
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -126,6 +126,10 @@ private[spark] class SparkUI private (
       ))
     ))
   }
+
+  def getApplicationInfo(appId: String): Option[ApplicationInfo] = {
+    throw new UnsupportedOperationException()
+  }
 }
 
 private[spark] abstract class SparkUITab(parent: SparkUI, prefix: String)

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -128,27 +128,7 @@ private[spark] class SparkUI private (
   }
 
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {
-    if (appId == this.appId) {
-      Some(new ApplicationInfo(
-        id = appId,
-        name = appName,
-        coresGranted = None,
-        maxCores = None,
-        coresPerExecutor = None,
-        memoryPerExecutorMB = None,
-        attempts = Seq(new ApplicationAttemptInfo(
-          attemptId = None,
-          startTime = new Date(startTime),
-          endTime = new Date(-1),
-          duration = 0,
-          lastUpdated = new Date(startTime),
-          sparkUser = "",
-          completed = false
-        ))
-      ))
-    } else {
-      None
-    }
+    getApplicationInfoList.find(_.id == appId)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -128,7 +128,27 @@ private[spark] class SparkUI private (
   }
 
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {
-    throw new UnsupportedOperationException()
+    if (appId == this.appId) {
+      Some(new ApplicationInfo(
+        id = appId,
+        name = appName,
+        coresGranted = None,
+        maxCores = None,
+        coresPerExecutor = None,
+        memoryPerExecutorMB = None,
+        attempts = Seq(new ApplicationAttemptInfo(
+          attemptId = None,
+          startTime = new Date(startTime),
+          endTime = new Date(-1),
+          duration = 0,
+          lastUpdated = new Date(startTime),
+          sparkUser = "",
+          completed = false
+        ))
+      ))
+    } else {
+      None
+    }
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new API getApplicationInfo(appId: String) in class ApplicationHistoryProvider and class SparkUI to get app info. In this change, FsHistoryProvider can directly fetch one app info in O(1) time complexity compared to O(n) before the change which used an Iterator.find() interface.

Both ApplicationCache and OneApplicationResource classes adopt this new api.
## How was this patch tested?

 manual tests
