### PR TITLE
[SPARK-17676][CORE] FsHistoryProvider should ignore hidden files

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -291,9 +291,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           try {
             val prevFileSize = fileToAppInfo.get(entry.getPath()).map{_.fileSize}.getOrElse(0L)
             !entry.isDirectory() &&
-              // FsHistoryProvider generates a hidden file which can't be read, and the user may
-              // generate others which can't be read.  Accidentally reading a garbage file is safe,
-              // but we would log an error which can be scary to the end-user.
+              // FsHistoryProvider generates a hidden file which can't be read.  Accidentally
+              // reading a garbage file is safe, but we would log an error which can be scary to
+              // the end-user.
               !entry.getPath().getName().startsWith(".") &&
               prevFileSize < entry.getLen()
           } catch {

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -291,6 +291,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           try {
             val prevFileSize = fileToAppInfo.get(entry.getPath()).map{_.fileSize}.getOrElse(0L)
             !entry.isDirectory() &&
+              // FsHistoryProvider generates a hidden file which can't be read, and the user may
+              // generate others which can't be read.  Accidentally reading a garbage file is safe,
+              // but we would log an error which can be scary to the end-user.
               !entry.getPath().getName().startsWith(".") &&
               prevFileSize < entry.getLen()
           } catch {

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -290,7 +290,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .filter { entry =>
           try {
             val prevFileSize = fileToAppInfo.get(entry.getPath()).map{_.fileSize}.getOrElse(0L)
-            !entry.isDirectory() && prevFileSize < entry.getLen()
+            !entry.isDirectory() &&
+              !entry.getPath().getName().startsWith(".") &&
+              prevFileSize < entry.getLen()
           } catch {
             case e: AccessControlException =>
               // Do not use "logInfo" since these messages can get pretty noisy if printed on


### PR DESCRIPTION
## What changes were proposed in this pull request?

FsHistoryProvider was writing a hidden file (to check the fs's clock).
Even though it deleted the file immediately, sometimes another thread
would try to scan the files on the fs in-between, and then there would
be an error msg logged which was very misleading for the end-user.
(The logged error was harmless, though.)
## How was this patch tested?

I added one unit test, but to be clear, that test was passing before.  The actual change in behavior in that test is just logging (after the change, there is no more logged error), which I just manually verified.
