### PR TITLE
[SPARK-17678][REPL][Branch-1.6] Honor spark.replClassServer.port in scala-2.11 repl

### DIFF
--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -36,7 +36,9 @@ object Main extends Logging {
     "-Yrepl-outdir", s"${outputDir.getAbsolutePath}",
     "-classpath", getAddedJars.mkString(File.pathSeparator)), true)
   // the creation of SecurityManager has to be lazy so SPARK_YARN_MODE is set if needed
-  lazy val classServer = new HttpServer(conf, outputDir, new SecurityManager(conf))
+  val classServerPort = conf.getInt("spark.replClassServer.port", 0)
+  lazy val classServer =
+    new HttpServer(conf, outputDir, new SecurityManager(conf), classServerPort, "HTTP class server")
   var sparkContext: SparkContext = _
   var sqlContext: SQLContext = _
   var interp = new SparkILoop // this is a public var because tests reset it.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark 1.6 Scala-2.11 repl doesn't honor "spark.replClassServer.port" configuration, so user cannot set a fixed port number through "spark.replClassServer.port".
## How was this patch tested?

N/A
