### PR TITLE
[SPARK-17683][SQL] Support ArrayType in Literal.apply

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -17,11 +17,15 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import java.lang.{Boolean => jBoolean, Byte => jByte, Double => jDouble, Float => jFloat, Integer => jInteger, Long => jLong, Short => jShort}
+import java.math.{BigDecimal => jBigDecimal}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.util
 import java.util.Objects
 import javax.xml.bind.DatatypeConverter
+
+import scala.math.{BigDecimal, BigInt}
 
 import org.json4s.JsonAST._
 
@@ -47,7 +51,7 @@ object Literal {
     case s: String => Literal(UTF8String.fromString(s), StringType)
     case b: Boolean => Literal(b, BooleanType)
     case d: BigDecimal => Literal(Decimal(d), DecimalType(Math.max(d.precision, d.scale), d.scale))
-    case d: java.math.BigDecimal =>
+    case d: jBigDecimal =>
       Literal(Decimal(d), DecimalType(Math.max(d.precision, d.scale), d.scale()))
     case d: Decimal => Literal(d, DecimalType(Math.max(d.precision, d.scale), d.scale))
     case t: Timestamp => Literal(DateTimeUtils.fromJavaTimestamp(t), TimestampType)
@@ -71,32 +75,33 @@ object Literal {
    * functions in other files (e.g., HiveInspectors), so these functions need to merged into one.
    */
   private[this] def componentTypeToDataType(clz: Class[_]): DataType = clz match {
-    // primitive type
-    case c: Class[_] if c == java.lang.Short.TYPE => ShortType
-    case c: Class[_] if c == java.lang.Integer.TYPE => IntegerType
-    case c: Class[_] if c == java.lang.Long.TYPE => LongType
-    case c: Class[_] if c == java.lang.Double.TYPE => DoubleType
-    case c: Class[_] if c == java.lang.Byte.TYPE => ByteType
-    case c: Class[_] if c == java.lang.Float.TYPE => FloatType
-    case c: Class[_] if c == java.lang.Boolean.TYPE => BooleanType
+    // primitive types
+    case c: Class[_] if c == jShort.TYPE => ShortType
+    case c: Class[_] if c == jInteger.TYPE => IntegerType
+    case c: Class[_] if c == jLong.TYPE => LongType
+    case c: Class[_] if c == jDouble.TYPE => DoubleType
+    case c: Class[_] if c == jByte.TYPE => ByteType
+    case c: Class[_] if c == jFloat.TYPE => FloatType
+    case c: Class[_] if c == jBoolean.TYPE => BooleanType
 
-    // java class
-    case c: Class[_] if c == classOf[java.lang.String] => StringType
-    case c: Class[_] if c == classOf[java.sql.Date] => DateType
-    case c: Class[_] if c == classOf[java.sql.Timestamp] => TimestampType
-    case c: Class[_] if c == classOf[java.math.BigDecimal] => DecimalType.SYSTEM_DEFAULT
+    // java classes
+    case c: Class[_] if c == classOf[Date] => DateType
+    case c: Class[_] if c == classOf[Timestamp] => TimestampType
+    case c: Class[_] if c == classOf[jBigDecimal] => DecimalType.SYSTEM_DEFAULT
     case c: Class[_] if c == classOf[Array[Byte]] => BinaryType
-    case c: Class[_] if c == classOf[java.lang.Short] => ShortType
-    case c: Class[_] if c == classOf[java.lang.Integer] => IntegerType
-    case c: Class[_] if c == classOf[java.lang.Long] => LongType
-    case c: Class[_] if c == classOf[java.lang.Double] => DoubleType
-    case c: Class[_] if c == classOf[java.lang.Byte] => ByteType
-    case c: Class[_] if c == classOf[java.lang.Float] => FloatType
-    case c: Class[_] if c == classOf[java.lang.Boolean] => BooleanType
+    case c: Class[_] if c == classOf[jShort] => ShortType
+    case c: Class[_] if c == classOf[jInteger] => IntegerType
+    case c: Class[_] if c == classOf[jLong] => LongType
+    case c: Class[_] if c == classOf[jDouble] => DoubleType
+    case c: Class[_] if c == classOf[jByte] => ByteType
+    case c: Class[_] if c == classOf[jFloat] => FloatType
+    case c: Class[_] if c == classOf[jBoolean] => BooleanType
 
-    // scala class
-    case c: Class[_] if c == classOf[scala.math.BigInt] => DecimalType.SYSTEM_DEFAULT
-    case c: Class[_] if c == classOf[scala.math.BigDecimal] => DecimalType.SYSTEM_DEFAULT
+    // other scala classes
+    case c: Class[_] if c == classOf[String] => StringType
+    case c: Class[_] if c == classOf[BigInt] => DecimalType.SYSTEM_DEFAULT
+    case c: Class[_] if c == classOf[BigDecimal] => DecimalType.SYSTEM_DEFAULT
+    case c: Class[_] if c == classOf[CalendarInterval] => CalendarIntervalType
 
     case c: Class[_] if c.isArray => ArrayType(componentTypeToDataType(c.getComponentType))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -91,27 +91,27 @@ object Literal {
     case JavaBoolean.TYPE => BooleanType
 
     // java classes
-    case c: Class[_] if c == classOf[Date] => DateType
-    case c: Class[_] if c == classOf[Timestamp] => TimestampType
-    case c: Class[_] if c == classOf[JavaBigDecimal] => DecimalType.SYSTEM_DEFAULT
-    case c: Class[_] if c == classOf[Array[Byte]] => BinaryType
-    case c: Class[_] if c == classOf[JavaShort] => ShortType
-    case c: Class[_] if c == classOf[JavaInteger] => IntegerType
-    case c: Class[_] if c == classOf[JavaLong] => LongType
-    case c: Class[_] if c == classOf[JavaDouble] => DoubleType
-    case c: Class[_] if c == classOf[JavaByte] => ByteType
-    case c: Class[_] if c == classOf[JavaFloat] => FloatType
-    case c: Class[_] if c == classOf[JavaBoolean] => BooleanType
+    case _ if clz == classOf[Date] => DateType
+    case _ if clz == classOf[Timestamp] => TimestampType
+    case _ if clz == classOf[JavaBigDecimal] => DecimalType.SYSTEM_DEFAULT
+    case _ if clz == classOf[Array[Byte]] => BinaryType
+    case _ if clz == classOf[JavaShort] => ShortType
+    case _ if clz == classOf[JavaInteger] => IntegerType
+    case _ if clz == classOf[JavaLong] => LongType
+    case _ if clz == classOf[JavaDouble] => DoubleType
+    case _ if clz == classOf[JavaByte] => ByteType
+    case _ if clz == classOf[JavaFloat] => FloatType
+    case _ if clz == classOf[JavaBoolean] => BooleanType
 
     // other scala classes
-    case c: Class[_] if c == classOf[String] => StringType
-    case c: Class[_] if c == classOf[BigInt] => DecimalType.SYSTEM_DEFAULT
-    case c: Class[_] if c == classOf[BigDecimal] => DecimalType.SYSTEM_DEFAULT
-    case c: Class[_] if c == classOf[CalendarInterval] => CalendarIntervalType
+    case _ if clz == classOf[String] => StringType
+    case _ if clz == classOf[BigInt] => DecimalType.SYSTEM_DEFAULT
+    case _ if clz == classOf[BigDecimal] => DecimalType.SYSTEM_DEFAULT
+    case _ if clz == classOf[CalendarInterval] => CalendarIntervalType
 
-    case c: Class[_] if c.isArray => ArrayType(componentTypeToDataType(c.getComponentType))
+    case _ if clz.isArray => ArrayType(componentTypeToDataType(clz.getComponentType))
 
-    case c => throw new AnalysisException(s"Unsupported component type $c in arrays")
+    case _ => throw new AnalysisException(s"Unsupported component type $clz in arrays")
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -17,8 +17,14 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import java.lang.{Boolean => jBoolean, Byte => jByte, Double => jDouble, Float => jFloat, Integer => jInteger, Long => jLong, Short => jShort}
-import java.math.{BigDecimal => jBigDecimal}
+import java.lang.{Boolean => JavaBoolean}
+import java.lang.{Byte => JavaByte}
+import java.lang.{Double => JavaDouble}
+import java.lang.{Float => JavaFloat}
+import java.lang.{Integer => JavaInteger}
+import java.lang.{Long => JavaLong}
+import java.lang.{Short => JavaShort}
+import java.math.{BigDecimal => JavaBigDecimal}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.util
@@ -51,7 +57,7 @@ object Literal {
     case s: String => Literal(UTF8String.fromString(s), StringType)
     case b: Boolean => Literal(b, BooleanType)
     case d: BigDecimal => Literal(Decimal(d), DecimalType(Math.max(d.precision, d.scale), d.scale))
-    case d: jBigDecimal =>
+    case d: JavaBigDecimal =>
       Literal(Decimal(d), DecimalType(Math.max(d.precision, d.scale), d.scale()))
     case d: Decimal => Literal(d, DecimalType(Math.max(d.precision, d.scale), d.scale))
     case t: Timestamp => Literal(DateTimeUtils.fromJavaTimestamp(t), TimestampType)
@@ -76,26 +82,26 @@ object Literal {
    */
   private[this] def componentTypeToDataType(clz: Class[_]): DataType = clz match {
     // primitive types
-    case c: Class[_] if c == jShort.TYPE => ShortType
-    case c: Class[_] if c == jInteger.TYPE => IntegerType
-    case c: Class[_] if c == jLong.TYPE => LongType
-    case c: Class[_] if c == jDouble.TYPE => DoubleType
-    case c: Class[_] if c == jByte.TYPE => ByteType
-    case c: Class[_] if c == jFloat.TYPE => FloatType
-    case c: Class[_] if c == jBoolean.TYPE => BooleanType
+    case c: Class[_] if c == JavaShort.TYPE => ShortType
+    case c: Class[_] if c == JavaInteger.TYPE => IntegerType
+    case c: Class[_] if c == JavaLong.TYPE => LongType
+    case c: Class[_] if c == JavaDouble.TYPE => DoubleType
+    case c: Class[_] if c == JavaByte.TYPE => ByteType
+    case c: Class[_] if c == JavaFloat.TYPE => FloatType
+    case c: Class[_] if c == JavaBoolean.TYPE => BooleanType
 
     // java classes
     case c: Class[_] if c == classOf[Date] => DateType
     case c: Class[_] if c == classOf[Timestamp] => TimestampType
-    case c: Class[_] if c == classOf[jBigDecimal] => DecimalType.SYSTEM_DEFAULT
+    case c: Class[_] if c == classOf[JavaBigDecimal] => DecimalType.SYSTEM_DEFAULT
     case c: Class[_] if c == classOf[Array[Byte]] => BinaryType
-    case c: Class[_] if c == classOf[jShort] => ShortType
-    case c: Class[_] if c == classOf[jInteger] => IntegerType
-    case c: Class[_] if c == classOf[jLong] => LongType
-    case c: Class[_] if c == classOf[jDouble] => DoubleType
-    case c: Class[_] if c == classOf[jByte] => ByteType
-    case c: Class[_] if c == classOf[jFloat] => FloatType
-    case c: Class[_] if c == classOf[jBoolean] => BooleanType
+    case c: Class[_] if c == classOf[JavaShort] => ShortType
+    case c: Class[_] if c == classOf[JavaInteger] => IntegerType
+    case c: Class[_] if c == classOf[JavaLong] => LongType
+    case c: Class[_] if c == classOf[JavaDouble] => DoubleType
+    case c: Class[_] if c == classOf[JavaByte] => ByteType
+    case c: Class[_] if c == classOf[JavaFloat] => FloatType
+    case c: Class[_] if c == classOf[JavaBoolean] => BooleanType
 
     // other scala classes
     case c: Class[_] if c == classOf[String] => StringType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -65,7 +65,12 @@ object Literal {
       throw new RuntimeException("Unsupported literal type " + v.getClass + " " + v)
   }
 
-  private def componentTypeToDataType(clz: Class[_]): DataType = clz match {
+  /**
+   * Returns the Spark SQL DataType for a given class object. Since this type needs to be resolved
+   * in runtime, we use match-case idioms for class objects here. However, there are similar
+   * functions in other files (e.g., HiveInspectors), so these functions need to merged into one.
+   */
+  private[this] def componentTypeToDataType(clz: Class[_]): DataType = clz match {
     // primitive type
     case c: Class[_] if c == java.lang.Short.TYPE => ShortType
     case c: Class[_] if c == java.lang.Integer.TYPE => IntegerType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -82,13 +82,13 @@ object Literal {
    */
   private[this] def componentTypeToDataType(clz: Class[_]): DataType = clz match {
     // primitive types
-    case c: Class[_] if c == JavaShort.TYPE => ShortType
-    case c: Class[_] if c == JavaInteger.TYPE => IntegerType
-    case c: Class[_] if c == JavaLong.TYPE => LongType
-    case c: Class[_] if c == JavaDouble.TYPE => DoubleType
-    case c: Class[_] if c == JavaByte.TYPE => ByteType
-    case c: Class[_] if c == JavaFloat.TYPE => FloatType
-    case c: Class[_] if c == JavaBoolean.TYPE => BooleanType
+    case JavaShort.TYPE => ShortType
+    case JavaInteger.TYPE => IntegerType
+    case JavaLong.TYPE => LongType
+    case JavaDouble.TYPE => DoubleType
+    case JavaByte.TYPE => ByteType
+    case JavaFloat.TYPE => FloatType
+    case JavaBoolean.TYPE => BooleanType
 
     // java classes
     case c: Class[_] if c == classOf[Date] => DateType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.optimizer.SimpleTestOptimizer
 import org.apache.spark.sql.catalyst.plans.logical.{OneRowRelation, Project}
-import org.apache.spark.sql.catalyst.util.{ArrayData, MapData, GenericArrayData}
+import org.apache.spark.sql.catalyst.util.MapData
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.util.Utils
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.optimizer.SimpleTestOptimizer
 import org.apache.spark.sql.catalyst.plans.logical.{OneRowRelation, Project}
-import org.apache.spark.sql.catalyst.util.MapData
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData, GenericArrayData}
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.util.Utils
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -134,13 +134,13 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("unsupported types (map and struct) in literals") {
-    def checkUnsupportedTypeInLiteral(v: Any) = {
+    def checkUnsupportedTypeInLiteral(v: Any): Unit = {
       val errMsgMap = intercept[RuntimeException] {
         Literal(v)
       }
       assert(errMsgMap.getMessage.startsWith("Unsupported literal type"))
     }
-    checkUnsupportedTypeInLiteral(Map("key1" -> 1, "key2" ->2))
+    checkUnsupportedTypeInLiteral(Map("key1" -> 1, "key2" -> 2))
     checkUnsupportedTypeInLiteral(("mike", 29, 1.0))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -125,12 +125,17 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("array") {
-    def toCatalyst(a: Array[_], elementType: DataType): Any = {
-      CatalystTypeConverters.createToCatalystConverter(ArrayType(elementType))(a)
+    def checkArrayLiteral(a: Array[_], elementType: DataType): Unit = {
+      val toCatalyst = (a: Array[_], elementType: DataType) => {
+        CatalystTypeConverters.createToCatalystConverter(ArrayType(elementType))(a)
+      }
+      checkEvaluation(Literal(a), toCatalyst(a, elementType))
     }
-    checkEvaluation(Literal(Array(1, 2, 3)), toCatalyst(Array(1, 2, 3), IntegerType))
-    checkEvaluation(Literal(Array("a", "b", "c")), toCatalyst(Array("a", "b", "c"), StringType))
-    checkEvaluation(Literal(Array(1.0, 4.0)), toCatalyst(Array(1.0, 4.0), DoubleType))
+    checkArrayLiteral(Array(1, 2, 3), IntegerType)
+    checkArrayLiteral(Array("a", "b", "c"), StringType)
+    checkArrayLiteral(Array(1.0, 4.0), DoubleType)
+    checkArrayLiteral(Array(CalendarInterval.MICROS_PER_DAY, CalendarInterval.MICROS_PER_HOUR),
+      CalendarIntervalType)
   }
 
   test("unsupported types (map and struct) in literals") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is to add pattern-matching entries for array data in `Literal.apply`.
## How was this patch tested?

Added tests in `LiteralExpressionSuite`.
