### PR TITLE
[SPARK-17689][SQL][STREAMING] added excludeFiles option for file source.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ListingFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ListingFileCatalog.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.FileNotFoundException
+import java.util.regex.Pattern
 
 import scala.collection.mutable
 
@@ -56,11 +57,11 @@ class ListingFileCatalog(
    * HDFS skip these files matching the configured regex-patterns from being picked up by Streaming
    * Job.
    */
-  private lazy val excludeFiles: Set[String] = parameters
-    .getOrElse("excludeFiles", ".*._COPYING_,_temporary").split(",").toSet
+  private lazy val excludeFiles: Set[Pattern] = parameters
+    .getOrElse("excludeFiles", ".*._COPYING_,_temporary").split(",").toSet.map(Pattern.compile)
 
   private def isExcludedFile(path: Path): Boolean = {
-    excludeFiles.map(path.getName.matches).fold(false)(_ || _)
+    excludeFiles.map(x => x.matcher(path.getName).matches).fold(false)(_ || _)
   }
 
   override def partitionSpec(): PartitionSpec = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ListingFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ListingFileCatalog.scala
@@ -57,7 +57,7 @@ class ListingFileCatalog(
    * Job.
    */
   private lazy val excludeFiles: Set[String] = parameters
-    .getOrElse("excludeFiles", ".*._COPYING_,.*_temporary").split(",").toSet
+    .getOrElse("excludeFiles", ".*._COPYING_,_temporary").split(",").toSet
 
   private def isExcludedFile(path: Path): Boolean = {
     excludeFiles.map(path.getName.matches).fold(false)(_ || _)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -459,7 +459,7 @@ object HadoopFsRelation extends Logging {
       // It's very expensive to create a JobConf(ClassUtil.findContainingJar() is slow)
       val jobConf = new JobConf(serializableConfiguration.value, this.getClass)
       val pathFilter = FileInputFormat.getInputPathFilter(jobConf)
-      paths.map(new Path(_)).flatMap { path =>
+      paths.filterNot(shouldFilterOut).map(new Path(_)).flatMap { path =>
         val fs = path.getFileSystem(serializableConfiguration.value)
         listLeafFiles(fs, fs.getFileStatus(path), pathFilter)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -195,7 +195,8 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * indicates a timestamp format. Custom date formats follow the formats at
    * `java.text.SimpleDateFormat`. This applies to timestamp type.</li>
    * </ul>
-   *
+   * <li>`excludeFiles` (default `.*._COPYING_,_temporary`: Exclude files and directories(comma
+   * separated list), which should not to be tracked by the streaming source.</li>
    * @since 2.0.0
    */
   @Experimental
@@ -258,6 +259,8 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    *     <li>`FAILFAST` : throws an exception when it meets corrupted records.</li>
    *   </ul>
    * </li>
+   * <li>`excludeFiles` (default `.*._COPYING_,_temporary`: Exclude files and directories(comma
+   * separated list), which should not to be tracked by the streaming source.</li>
    * </ul>
    *
    * @since 2.0.0
@@ -278,7 +281,8 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * Parquet part-files. This will override
    * `spark.sql.parquet.mergeSchema`.</li>
    * </ul>
-   *
+   * <li>`excludeFiles` (default `.*._COPYING_,_temporary`: Exclude files and directories(comma
+   * separated list), which should not to be tracked by the streaming source.</li>
    * @since 2.0.0
    */
   @Experimental
@@ -305,7 +309,8 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * <li>`maxFilesPerTrigger` (default: no max limit): sets the maximum number of new files to be
    * considered in every trigger.</li>
    * </ul>
-   *
+   * <li>`excludeFiles` (default `.*._COPYING_,_temporary`: Exclude files and directories(comma
+   * separated list), which should not to be tracked by the streaming source.</li>
    * @since 2.0.0
    */
   @Experimental

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -612,6 +612,24 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     }
   }
 
+  test("excludeFile option should exclude files specified.") {
+    withTempDirs { case (src, tmp) =>
+      val textStream = createFileStream("text", s"${src.getCanonicalPath}/*/",
+        options = Map("excludeFiles" -> "_temporary,.*_File"))
+      val filtered = textStream.filter($"value" contains "keep")
+      val filteredDir = new File(src, "_temporary")
+      val filteredDir2 = new File(src, "test_File")
+      val input = new File(src, "input")
+      testStream(filtered)(
+        AddTextFileData("drop7\nkeep8\nkeep9", input, tmp),
+        CheckAnswer("keep8", "keep9"),
+        AddTextFileData("drop1\nkeep2\nkeep3", filteredDir, tmp),
+        AddTextFileData("drop4\nkeep0\nkeep1", filteredDir2, tmp),
+        AddTextFileData("drop11\nkeep4\nkeep5", input, tmp),
+        CheckAnswer("keep8", "keep9", "keep4", "keep5")
+      )
+    }
+  }
   // =============== other tests ================
 
   test("read new files in partitioned table without globbing, should read partition data") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -392,7 +392,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with Timeouts {
 
           case a: AssertOnQuery =>
             verify(currentStream != null || lastStream != null,
-              "cannot assert when not stream has been started")
+              "cannot assert, when no stream has been started")
             val streamToAssert = Option(currentStream).getOrElse(lastStream)
             verify(a.condition(streamToAssert), s"Assert on query failed: ${a.message}")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

added excludeFiles specially( but not limited to) for excluding temporary files created during file copy(.*_COPYING) or creation(_temporary) in HDFS.
## How was this patch tested?

Contains a unit test.

Tested it while copying file and creating files, by deploying against real hdfs cluster.
