### PR TITLE
[SPARK-17477][SQL] SparkSQL cannot handle schema evolution from Int -> Long when parquet files have Int as its type while hive metastore has Long as its type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -218,12 +218,12 @@ private[parquet] class ParquetRowConverter(
         new ParquetPrimitiveConverter(updater)
 
       /**
-        * When reading a hive table of parquet files with schema evolution from
-        * Int to Long and if hive metastore has Long as its type while parquet files
-        * have Int, SparkSQL need to figure out the actual type in the parquet
-        * files. Otherwise, it will result in java.lang.ClassCastException:
-        * [[MutableLong]] cannot be cast to [[MutableInt]].
-        */
+       * [SPARK-17477] When reading a hive table of parquet files with schema evolution
+       * from Int to Long and if hive metastore has Long as its type while parquet files
+       * have Int, SparkSQL need to figure out the actual type in the parquet files.
+       * Otherwise, it will result in java.lang.ClassCastException: [[MutableLong]] cannot
+       * be cast to [[MutableInt]].
+       */
       case LongType =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using SparkSession in Spark 2.0 to read a Hive table which is stored as parquet files and if there has been a schema evolution from int to long of a column, we will get java.lang.ClassCastException: org.apache.spark.sql.catalyst.expressions.MutableLong cannot be cast to org.apache.spark.sql.catalyst.expressions.MutableInt. To be specific, if there are some old parquet files using int for the column while some new parquet files use long and the Hive metastore uses Long as its type, the aforementioned exception will be thrown. Because Hive and Presto deem this kind of schema evolution is valid, this PR allows writing a int value when its table schema is long in hive metastore.

This is for non-vectorized parquet reader only.
## How was this patch tested?

Manual test to create parquet files with int type in the schema and create hive table using long as its type. Then perform spark.sql("select \* from table") to query all data from this table.
