### PR TITLE
[SPARK-17598] [SQL] [Web UI] User-friendly name for Spark Thrift Server in web UI

### DIFF
--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -53,4 +53,4 @@ fi
 
 export SUBMIT_USAGE_FUNCTION=usage
 
-exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 "$@"
+exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Thrift JDBC/ODBC Server" "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The name of Spark Thrift JDBC/ODBC Server in web UI reflects the name of the class, i.e. org.apache.spark.sql.hive.thrift.HiveThriftServer2. I changed it to Thrift JDBC/ODBC Server (like Spark shell for spark-shell) as recommended by @jaceklaskowski. Note the user can still change the name adding `--name "App Name"` parameter to the start script as before
## How was this patch tested?

By running the script with various parameters and checking the web ui

![screen shot 2016-09-27 at 12 19 12 pm](https://cloud.githubusercontent.com/assets/13952758/18888329/aebca47c-84ac-11e6-93d0-6e98684977c5.png)
