### PR TITLE
[SPARK-17703][SQL] Add unnamed version of addReferenceObj for minor objects.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -90,18 +90,9 @@ class CodegenContext {
    * Returns the code to access it.
    */
   def addReferenceObj(obj: Any): String = {
-    addReferenceObj(obj, null)
-  }
-
-  /**
-   * Add an object to `references`.
-   *
-   * Returns the code to access it.
-   */
-  def addReferenceObj(obj: Any, className: String): String = {
     val idx = references.length
     references += obj
-    val clsName = Option(className).getOrElse(obj.getClass.getName)
+    val clsName = obj.getClass.getName
     s"(($clsName) references[$idx])"
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -85,6 +85,27 @@ class CodegenContext {
   val references: mutable.ArrayBuffer[Any] = new mutable.ArrayBuffer[Any]()
 
   /**
+   * Add an object to `references`.
+   *
+   * Returns the code to access it.
+   */
+  def addReferenceObj(obj: Any): String = {
+    addReferenceObj(obj, null)
+  }
+
+  /**
+   * Add an object to `references`.
+   *
+   * Returns the code to access it.
+   */
+  def addReferenceObj(obj: Any, className: String): String = {
+    val idx = references.length
+    references += obj
+    val clsName = Option(className).getOrElse(obj.getClass.getName)
+    s"(($clsName) references[$idx])"
+  }
+
+  /**
    * Add an object to `references`, create a class member to access it.
    *
    * Returns the name of class member.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -88,6 +88,9 @@ class CodegenContext {
    * Add an object to `references`.
    *
    * Returns the code to access it.
+   *
+   * This is for minor objects not to store the object into field but refer it from the references
+   * field at the time of use because number of fields in class is limited so we should reduce it.
    */
   def addReferenceObj(obj: Any): String = {
     val idx = references.length

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -517,6 +517,9 @@ case class AssertTrue(child: Expression) extends UnaryExpression with ImplicitCa
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val eval = child.genCode(ctx)
+
+    // Use unnamed reference that doesn't create a local field here to reduce the number of fields
+    // because errMsgField is used only when the value is null or false.
     val errMsgField = ctx.addReferenceObj(errMsg)
     ExprCode(code = s"""${eval.code}
        |if (${eval.isNull} || !${eval.value}) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -517,7 +517,7 @@ case class AssertTrue(child: Expression) extends UnaryExpression with ImplicitCa
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val eval = child.genCode(ctx)
-    val errMsgField = ctx.addReferenceObj("errMsg", errMsg)
+    val errMsgField = ctx.addReferenceObj(errMsg)
     ExprCode(code = s"""${eval.code}
        |if (${eval.isNull} || !${eval.value}) {
        |  throw new RuntimeException($errMsgField);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -906,7 +906,7 @@ case class AssertNotNull(child: Expression, walkedTypePath: Seq[String])
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val childGen = child.genCode(ctx)
 
-    val errMsgField = ctx.addReferenceObj("errMsg", errMsg)
+    val errMsgField = ctx.addReferenceObj(errMsg)
 
     val code = s"""
       ${childGen.code}
@@ -941,7 +941,7 @@ case class GetExternalRowField(
   private val errMsg = s"The ${index}th field '$fieldName' of input row cannot be null."
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val errMsgField = ctx.addReferenceObj("errMsg", errMsg)
+    val errMsgField = ctx.addReferenceObj(errMsg)
     val row = child.genCode(ctx)
     val code = s"""
       ${row.code}
@@ -979,7 +979,7 @@ case class ValidateExternalType(child: Expression, expected: DataType)
   private val errMsg = s" is not a valid external type for schema of ${expected.simpleString}"
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val errMsgField = ctx.addReferenceObj("errMsg", errMsg)
+    val errMsgField = ctx.addReferenceObj(errMsg)
     val input = child.genCode(ctx)
     val obj = input.value
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -906,6 +906,8 @@ case class AssertNotNull(child: Expression, walkedTypePath: Seq[String])
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val childGen = child.genCode(ctx)
 
+    // Use unnamed reference that doesn't create a local field here to reduce the number of fields
+    // because errMsgField is used only when the value is null.
     val errMsgField = ctx.addReferenceObj(errMsg)
 
     val code = s"""
@@ -941,6 +943,8 @@ case class GetExternalRowField(
   private val errMsg = s"The ${index}th field '$fieldName' of input row cannot be null."
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    // Use unnamed reference that doesn't create a local field here to reduce the number of fields
+    // because errMsgField is used only when the field is null.
     val errMsgField = ctx.addReferenceObj(errMsg)
     val row = child.genCode(ctx)
     val code = s"""
@@ -979,6 +983,8 @@ case class ValidateExternalType(child: Expression, expected: DataType)
   private val errMsg = s" is not a valid external type for schema of ${expected.simpleString}"
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    // Use unnamed reference that doesn't create a local field here to reduce the number of fields
+    // because errMsgField is used only when the type doesn't match.
     val errMsgField = ctx.addReferenceObj(errMsg)
     val input = child.genCode(ctx)
     val obj = input.value


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are many minor objects in references, which are extracted to the generated class field, e.g. `errMsg` in `GetExternalRowField` or `ValidateExternalType`, but number of fields in class is limited so we should reduce the number.
This pr adds unnamed version of `addReferenceObj` for these minor objects not to store the object into field but refer it from the `references` field at the time of use.
## How was this patch tested?

Existing tests.
