### PR TITLE
SPARK-12347 [ML][WIP] Add a script to test Spark ML examples.

### DIFF
--- a/dev/test-examples.py
+++ b/dev/test-examples.py
@@ -1,0 +1,152 @@
+import os
+import os.path
+import subprocess
+from threading import Lock, Thread
+from sparktestsupport import SPARK_HOME
+import logging
+import sys
+from optparse import OptionParser
+import tempfile
+import time
+if sys.version < '3':
+    import Queue
+else:
+    import queue as Queue
+
+EXAMPLES_DIR = os.path.join(SPARK_HOME, "examples/src/main/")
+examples_failed = []
+
+LOG_FILE = os.path.join(SPARK_HOME, "logs/spark-examples.log")
+LOGGER = logging.getLogger()
+
+FAILURE_REPORTING_LOCK = Lock()
+
+
+def put_python_examples(task_queue):
+    python_examples = os.path.join(EXAMPLES_DIR, "python/")
+    for dirpath, dirnames, filenames in os.walk(python_examples):
+        for f in filenames:
+            print os.path.join(dirpath, f)
+
+
+def run_example(example):
+    if example.endswith('.scala') or example.endswith('.java'):
+        _bin = "bin/run-example"
+    else:
+        _bin = "bin/spark-submit"
+    spark_submit = os.path.join(SPARK_HOME, _bin)
+    cmd = [spark_submit, "--master", "local[4]", example]
+    LOGGER.info("Will run {}".format(example))
+    try:
+        per_test_output = tempfile.TemporaryFile()
+        retcode = subprocess.Popen(cmd,
+                                   stdout=per_test_output,
+                                   stderr=per_test_output).wait()
+    except:
+        LOGGER.exception("Got exception while running %s", example)
+        os._exit(1)
+    if retcode != 0:
+        try:
+            with FAILURE_REPORTING_LOCK:
+                with open(LOG_FILE, 'ab') as log_file:
+                    per_test_output.seek(0)
+                    log_file.write(example + ' ' + '*' * 72 + '\n')
+                    log_file.writelines(per_test_output)
+                per_test_output.seek(0)
+                per_test_output.close()
+        except:
+            LOGGER.exception(
+                "Got an exception while trying to print failed test output")
+        finally:
+            LOGGER.error("\033[91m" + " FAILED " + example +
+                         '; see logs. \033[0m')
+    else:
+        LOGGER.info("Finished %s" % example)
+
+
+def parse_opts():
+    parser = OptionParser()
+    parser.add_option(
+        "-p",
+        "--parallelism",
+        type="int",
+        default=4,
+        help="The number of suites to test in parallel (default %default)")
+    parser.add_option("--verbose",
+                      action="store_true",
+                      help="Enable additional debug logging")
+    parser.add_option(
+        "--languages",
+        type="string",
+        default="r,python,java,scala".split(','),
+        help="A comma-separated list of Python modules to test (default: %default)")
+
+    (opts, args) = parser.parse_args()
+    if args:
+        parser.error("Unsupported arguments: %s" % ' '.join(args))
+    if opts.parallelism < 1:
+        parser.error("Parallelism cannot be less than 1")
+    return opts
+
+
+def process_queue(task_queue):
+    while True:
+        try:
+            example = task_queue.get_nowait()
+        except Queue.Empty:
+            break
+        try:
+            run_example(example)
+        finally:
+            task_queue.task_done()
+
+
+def main():
+    opts = parse_opts()
+    if (opts.verbose):
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logging.basicConfig(stream=sys.stdout,
+                        level=log_level,
+                        format="%(message)s")
+    if os.path.exists(LOG_FILE):
+        os.remove(LOG_FILE)
+    LOGGER.info("Running Spark Examples tests. Output is in %s", LOG_FILE)
+    if os.path.exists(LOG_FILE):
+        os.remove(LOG_FILE)
+    task_queue = Queue.Queue()
+
+    def put_tests(task_queue, language):
+        lang_path = os.path.join(EXAMPLES_DIR, lang)
+        for dirpath, dirnames, filenames in os.walk(lang_path):
+            for f in filenames:
+                if os.path.splitext(f)[-1] in ['.py', '.R', '.java', '.scala']:
+                    task_queue.put(os.path.join(dirpath, f))
+
+    for lang in opts.languages.split(','):
+        put_tests(task_queue, lang)
+
+    start_time = time.time()
+    for _ in range(opts.parallelism):
+        worker = Thread(target=process_queue, args=(task_queue, ))
+        worker.daemon = True
+        worker.start()
+    try:
+        process_queue(task_queue)
+        task_queue.join()
+    except (KeyboardInterrupt, SystemExit):
+        print "System exit due to interrupt"
+        sys.exit(-1)
+    total_duration = time.time() - start_time
+    LOGGER.info("Tests passed in %i seconds", total_duration)
+
+
+def _main():
+    for dirpath, dirnames, filenames in os.walk():
+        for f in filenames:
+            print os.path.join(dirpath, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/test-examples.py
+++ b/dev/test-examples.py
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import os.path
 import subprocess

--- a/examples/example-args.yml
+++ b/examples/example-args.yml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+python:
+  ml: []
+  mllib: []
+  sql: []
+  streaming: []
+  als.py: []
+  pi.py: 3
+  wordcount.py: 300
+
+scala:
+java:
+r:

--- a/examples/src/main/python/sort.py
+++ b/examples/src/main/python/sort.py
@@ -23,9 +23,11 @@ from pyspark.sql import SparkSession
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: sort <file>", file=sys.stderr)
-        exit(-1)
+    """
+    Usage: sort <file>
+    """
+
+    filename = "../resources/people.txt" if len(sys.argv) != 2 else sys.args[1]
 
     spark = SparkSession\
         .builder\

--- a/examples/src/main/python/wordcount.py
+++ b/examples/src/main/python/wordcount.py
@@ -24,16 +24,17 @@ from pyspark.sql import SparkSession
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: wordcount <file>", file=sys.stderr)
-        exit(-1)
+    """
+    Usage: wordcount <file>
+    """
+    filename = "../resources/people.txt" if len(sys.argv) != 2 else sys.args[1]
 
     spark = SparkSession\
         .builder\
         .appName("PythonWordCount")\
         .getOrCreate()
 
-    lines = spark.read.text(sys.argv[1]).rdd.map(lambda r: r[0])
+    lines = spark.read.text(filename).rdd.map(lambda r: r[0])
     counts = lines.flatMap(lambda x: x.split(' ')) \
                   .map(lambda x: (x, 1)) \
                   .reduceByKey(add)


### PR DESCRIPTION
This PR addresses [SPARK-12347](https://issues.apache.org/jira/browse/SPARK-12347?jql=project%20%3D%20SPARK%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20ML%20ORDER%20BY%20priority%20DESC) and may also be helpful for [SPARK-15571](https://issues.apache.org/jira/browse/SPARK-15571).
## What changes were proposed in this pull request?

This PR adds a python script to drive all the examples located in the `examples` subdirectory. It should be able to streamline the testing of the examples in R, Python, Scala and Java to see if any of them has incompatible behavior with the codebase.
## How was this patch tested?

This PR is not yet fully ready for merging. I would like to have some reviews for how it works best for those who will indeed be using this script. For now, it introduces the following features:
- [ ] Configuring according to environment variables.
- [ ] **Run those examples requiring arguments to be passed in.**
- [x] select examples of a specific language to run (R, Python, Scala or Java)
- [x] running in parallem (like that in run-test.py)

Note that the last TODO is really important, for that I would like to hear suggestions from the reviewers for how it should should be best implemented. For now, I think one good way will be to have comments as directives in the example code. Like how `# $example on$` are introduced to facilitate doc generation. We can do something similar to hint what arguments should be passed in for testing. Otherwise, we can always fall back to the way we discussed in the JIRA [SPARK-12347](https://issues.apache.org/jira/browse/SPARK-12347)

Also, some of the functionality replicates that in run-tests.py. Perhaps we can find a way to integrate both?
