### PR TITLE
[SPARK-17412][DOC] All test should not be run by `root` or any admin user

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -141,7 +141,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
 
     val provider = new FsHistoryProvider(createTestConf())
     updateAndCheck(provider) { list =>
-      list.size should be (1)
+      list.size should be (if (System.getProperty("user.name").equals("root")) 2 else 1)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -141,7 +141,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
 
     val provider = new FsHistoryProvider(createTestConf())
     updateAndCheck(provider) { list =>
-      list.size should be (if (System.getProperty("user.name").equals("root")) 2 else 1)
+      list.size should be (1)
     }
   }
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -214,7 +214,8 @@ For help in setting up IntelliJ IDEA or Eclipse for Spark development, and troub
 
 # Running Tests
 
-Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin). All tests should not be run by `root` or any admin user.
+Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin).
+Note that tests should not be run as root or an admin user.
 
 Some of the tests require Spark to be packaged first, so always run `mvn package` with `-DskipTests` the first time.  The following is an example of a correct (build, test) sequence:
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -214,7 +214,7 @@ For help in setting up IntelliJ IDEA or Eclipse for Spark development, and troub
 
 # Running Tests
 
-Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin).
+Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin). All tests should not be run by `root` or any admin user.
 
 Some of the tests require Spark to be packaged first, so always run `mvn package` with `-DskipTests` the first time.  The following is an example of a correct (build, test) sequence:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`FsHistoryProviderSuite` fails if `root` user runs it. The test case **SPARK-3697: ignore directories that cannot be read** depends on `setReadable(false, false)` to make test data files and expects the number of accessible files is 1. But, `root` can access all files, so it returns 2.

This PR adds the assumption explicitly on doc. `building-spark.md`.
## How was this patch tested?

This is a documentation change.
