### PR TITLE
[SPARK-17718] [Update MLib Classification Documentation]

### DIFF
--- a/docs/mllib-linear-methods.md
+++ b/docs/mllib-linear-methods.md
@@ -78,6 +78,9 @@ methods `spark.mllib` supports:
   </tbody>
 </table>
 
+A binary label y is denoted as either +1 (positive) or −1 (negative), which is convenient
+for the formulation.
+
 ### Regularizers
 
 The purpose of the


### PR DESCRIPTION
## What changes were proposed in this pull request?

The loss function here for logistic regression is confusing. It seems to imply that spark uses only -1 and 1 class labels. However it uses 0,1. Added detailed documentation to avoid confusion.
