### PR TITLE
[SPARK-17717][SQL] Add exist/find methods to Catalog.

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -46,7 +46,16 @@ object MimaExcludes {
       // [SPARK-16967] Move Mesos to Module
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.SparkMasterRegex.MESOS_REGEX"),
       // [SPARK-16240] ML persistence backward compatibility for LDA
-      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.clustering.LDA$")
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.clustering.LDA$"),
+      // [SPARK-17717] Add Find and Exists method to Catalog.
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.findDatabase"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.findTable"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.findFunction"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.findColumn"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.databaseExists"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.tableExists"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.functionExists"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.columnExists")
     )
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -102,6 +102,83 @@ abstract class Catalog {
   def listColumns(dbName: String, tableName: String): Dataset[Column]
 
   /**
+   * Find the database with the specified name. This returns [[None]] when no [[Database]] can be
+   * found.
+   *
+   * @since 2.1.0
+   */
+  def findDatabase(dbName: String): Option[Database]
+
+  /**
+   * Find the table with the specified name. This table can be a temporary table or a table in the
+   * current database. This returns [[None]] when no [[Table]] can be found.
+   *
+   * @since 2.1.0
+   */
+  def findTable(tableName: String): Option[Table]
+
+  /**
+   * Find the table with the specified name in the specified database. This returns [[None]] when
+   * no [[Table]] can be found.
+   *
+   * @since 2.1.0
+   */
+  def findTable(dbName: String, tableName: String): Option[Table]
+
+  /**
+   * Find the function with the specified name. This function can be a temporary function or a
+   * function in the current database. This returns [[None]] when no [[Function]] can be found.
+   *
+   * @since 2.1.0
+   */
+  def findFunction(functionName: String): Option[Function]
+
+  /**
+   * Find the function with the specified name. This returns [[None]] when no [[Function]] can be
+   * found.
+   *
+   * @since 2.1.0
+   */
+  def findFunction(dbName: String, functionName: String): Option[Function]
+
+  /**
+   * Check if the database with the specified name exists.
+   *
+   * @since 2.1.0
+   */
+  def databaseExists(dbName: String): Boolean
+
+  /**
+   * Check if the table with the specified name exists. This can either be a temporary table or a
+   * table in the current database.
+   *
+   * @since 2.1.0
+   */
+  def tableExists(tableName: String): Boolean
+
+  /**
+   * Check if the table with the specified name exists in the specified database.
+   *
+   * @since 2.1.0
+   */
+  def tableExists(dbName: String, tableName: String): Boolean
+
+  /**
+   * Check if the function with the specified name exists. This can either be a temporary function
+   * or a function in the current database.
+   *
+   * @since 2.1.0
+   */
+  def functionExists(functionName: String): Boolean
+
+  /**
+   * Check if the function with the specified name exists in the specified database.
+   *
+   * @since 2.1.0
+   */
+  def functionExists(dbName: String, functionName: String): Boolean
+
+  /**
    * :: Experimental ::
    * Creates an external table from the given path and returns the corresponding DataFrame.
    * It will use the default data source configured by spark.sql.sources.default.

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -102,44 +102,50 @@ abstract class Catalog {
   def listColumns(dbName: String, tableName: String): Dataset[Column]
 
   /**
-   * Find the database with the specified name. This returns [[None]] when no [[Database]] can be
-   * found.
+   * Find the database with the specified name. This throws an AnalysisException when the database
+   * cannot be found.
    *
    * @since 2.1.0
    */
-  def findDatabase(dbName: String): Option[Database]
+  @throws[AnalysisException]("database does not exist")
+  def findDatabase(dbName: String): Database
 
   /**
    * Find the table with the specified name. This table can be a temporary table or a table in the
-   * current database. This returns [[None]] when no [[Table]] can be found.
+   * current database. This throws an AnalysisException when the table cannot be found.
    *
    * @since 2.1.0
    */
-  def findTable(tableName: String): Option[Table]
+  @throws[AnalysisException]("table does not exist")
+  def findTable(tableName: String): Table
 
   /**
-   * Find the table with the specified name in the specified database. This returns [[None]] when
-   * no [[Table]] can be found.
+   * Find the table with the specified name in the specified database. This throws an
+   * AnalysisException when the table cannot be found.
    *
    * @since 2.1.0
    */
-  def findTable(dbName: String, tableName: String): Option[Table]
+  @throws[AnalysisException]("database or table does not exist")
+  def findTable(dbName: String, tableName: String): Table
 
   /**
    * Find the function with the specified name. This function can be a temporary function or a
-   * function in the current database. This returns [[None]] when no [[Function]] can be found.
+   * function in the current database. This throws an AnalysisException when the function cannot
+   * be found.
    *
    * @since 2.1.0
    */
-  def findFunction(functionName: String): Option[Function]
+  @throws[AnalysisException]("function does not exist")
+  def findFunction(functionName: String): Function
 
   /**
-   * Find the function with the specified name. This returns [[None]] when no [[Function]] can be
-   * found.
+   * Find the function with the specified name. This throws an AnalysisException when the function
+   * cannot be found.
    *
    * @since 2.1.0
    */
-  def findFunction(dbName: String, functionName: String): Option[Function]
+  @throws[AnalysisException]("database or function does not exist")
+  def findFunction(dbName: String, functionName: String): Function
 
   /**
    * Check if the database with the specified name exists.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -178,72 +178,63 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Find the database with the specified name. This returns [[None]] when no [[Database]] can be
-   * found.
+   * Find the database with the specified name. This throws an [[AnalysisException]] when no
+   * [[Database]] can be found.
    */
-  override def findDatabase(dbName: String): Option[Database] = {
+  override def findDatabase(dbName: String): Database = {
     if (sessionCatalog.databaseExists(dbName)) {
-      Some(makeDatabase(sessionCatalog.getDatabaseMetadata(dbName)))
+      makeDatabase(sessionCatalog.getDatabaseMetadata(dbName))
     } else {
-      None
+      throw new AnalysisException(s"The specified database $dbName does not exist.")
     }
   }
 
   /**
    * Find the table with the specified name. This table can be a temporary table or a table in the
-   * current database. This returns [[None]] when no [[Table]] can be found.
-   *
-   * @since 2.1.0
+   * current database. This throws an [[AnalysisException]] when no [[Table]] can be found.
    */
-  override def findTable(tableName: String): Option[Table] = {
+  override def findTable(tableName: String): Table = {
     findTable(null, tableName)
   }
 
   /**
-   * Find the table with the specified name in the specified database. This returns [[None]] when
-   * no [[Table]] can be found.
-   *
-   * @since 2.1.0
+   * Find the table with the specified name in the specified database. This throws an
+   * [[AnalysisException]] when no [[Table]] can be found.
    */
-  override def findTable(dbName: String, tableName: String): Option[Table] = {
+  override def findTable(dbName: String, tableName: String): Table = {
     val tableIdent = TableIdentifier(tableName, Option(dbName))
     val isTemporary = sessionCatalog.isTemporaryTable(tableIdent)
     if (isTemporary || sessionCatalog.tableExists(tableIdent)) {
-      Some(makeTable(tableIdent, isTemporary))
+      makeTable(tableIdent, isTemporary)
     } else {
-      None
+      throw new AnalysisException(s"The specified table $tableIdent does not exist.")
     }
   }
 
   /**
    * Find the function with the specified name. This function can be a temporary function or a
-   * function in the current database. This returns [[None]] when no [[Function]] can be found.
-   *
-   * @since 2.1.0
+   * function in the current database. This throws an [[AnalysisException]] when no [[Function]]
+   * can be found.
    */
-  override def findFunction(functionName: String): Option[Function] = {
+  override def findFunction(functionName: String): Function = {
     findFunction(null, functionName)
   }
 
   /**
    * Find the function with the specified name. This returns [[None]] when no [[Function]] can be
    * found.
-   *
-   * @since 2.1.0
    */
-  override def findFunction(dbName: String, functionName: String): Option[Function] = {
+  override def findFunction(dbName: String, functionName: String): Function = {
     val functionIdent = FunctionIdentifier(functionName, Option(dbName))
     if (sessionCatalog.functionExists(functionIdent)) {
-      Some(makeFunction(functionIdent))
+      makeFunction(functionIdent)
     } else {
-      None
+      throw new AnalysisException(s"The specified function $functionIdent does not exist.")
     }
   }
 
   /**
    * Check if the database with the specified name exists.
-   *
-   * @since 2.1.0
    */
   override def databaseExists(dbName: String): Boolean = {
     sessionCatalog.databaseExists(dbName)
@@ -252,8 +243,6 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   /**
    * Check if the table with the specified name exists. This can either be a temporary table or a
    * table in the current database.
-   *
-   * @since 2.1.0
    */
   override def tableExists(tableName: String): Boolean = {
     tableExists(null, tableName)
@@ -261,8 +250,6 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Check if the table with the specified name exists in the specified database.
-   *
-   * @since 2.1.0
    */
   override def tableExists(dbName: String, tableName: String): Boolean = {
     val tableIdent = TableIdentifier(tableName, Option(dbName))
@@ -272,8 +259,6 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   /**
    * Check if the function with the specified name exists. This can either be a temporary function
    * or a function in the current database.
-   *
-   * @since 2.1.0
    */
   override def functionExists(functionName: String): Boolean = {
     functionExists(null, functionName)
@@ -281,8 +266,6 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Check if the function with the specified name exists in the specified database.
-   *
-   * @since 2.1.0
    */
   override def functionExists(dbName: String, functionName: String): Boolean = {
     sessionCatalog.functionExists(FunctionIdentifier(functionName, Option(dbName)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -341,9 +341,9 @@ class CatalogSuite
   }
 
   test("find database") {
-    assert(spark.catalog.findDatabase("db10") === None)
+    intercept[AnalysisException](spark.catalog.findDatabase("db10"))
     withTempDatabase { db =>
-      assert(spark.catalog.findDatabase(db).map(_.name) === Some(db))
+      assert(spark.catalog.findDatabase(db).name === db)
     }
   }
 
@@ -351,24 +351,24 @@ class CatalogSuite
     withTempDatabase { db =>
       withTable(s"tbl_x", s"$db.tbl_y") {
         // Try to find non existing tables.
-        assert(spark.catalog.findTable("tbl_x") === None)
-        assert(spark.catalog.findTable("tbl_y") === None)
-        assert(spark.catalog.findTable(db, "tbl_y") === None)
+        intercept[AnalysisException](spark.catalog.findTable("tbl_x"))
+        intercept[AnalysisException](spark.catalog.findTable("tbl_y"))
+        intercept[AnalysisException](spark.catalog.findTable(db, "tbl_y"))
 
         // Create objects.
         createTempTable("tbl_x")
         createTable("tbl_y", Some(db))
 
         // Find a temporary table
-        assert(spark.catalog.findTable("tbl_x").map(_.name) === Some("tbl_x"))
+        assert(spark.catalog.findTable("tbl_x").name === "tbl_x")
 
         // Find a qualified table
-        assert(spark.catalog.findTable(db, "tbl_y").map(_.name) === Some("tbl_y"))
+        assert(spark.catalog.findTable(db, "tbl_y").name === "tbl_y")
 
         // Find an unqualified table using the current database
-        assert(spark.catalog.findTable("tbl_y") === None)
+        intercept[AnalysisException](spark.catalog.findTable("tbl_y"))
         spark.catalog.setCurrentDatabase(db)
-        assert(spark.catalog.findTable("tbl_y").map(_.name) === Some("tbl_y"))
+        assert(spark.catalog.findTable("tbl_y").name === "tbl_y")
       }
     }
   }
@@ -377,24 +377,24 @@ class CatalogSuite
     withTempDatabase { db =>
       withUserDefinedFunction("fn1" -> true, s"$db.fn2" -> false) {
         // Try to find non existing functions.
-        assert(spark.catalog.findFunction("fn1") === None)
-        assert(spark.catalog.findFunction("fn2") === None)
-        assert(spark.catalog.findFunction(db, "fn2") === None)
+        intercept[AnalysisException](spark.catalog.findFunction("fn1"))
+        intercept[AnalysisException](spark.catalog.findFunction("fn2"))
+        intercept[AnalysisException](spark.catalog.findFunction(db, "fn2"))
 
         // Create objects.
         createTempFunction("fn1")
         createFunction("fn2", Some(db))
 
         // Find a temporary function
-        assert(spark.catalog.findFunction("fn1").map(_.name) === Some("fn1"))
+        assert(spark.catalog.findFunction("fn1").name === "fn1")
 
         // Find a qualified function
-        assert(spark.catalog.findFunction(db, "fn2").map(_.name) === Some("fn2"))
+        assert(spark.catalog.findFunction(db, "fn2").name === "fn2")
 
         // Find an unqualified function using the current database
-        assert(spark.catalog.findFunction("fn2") === None)
+        intercept[AnalysisException](spark.catalog.findFunction("fn2"))
         spark.catalog.setCurrentDatabase(db)
-        assert(spark.catalog.findFunction("fn2").map(_.name) === Some("fn2"))
+        assert(spark.catalog.findFunction("fn2").name === "fn2")
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current user facing catalog does not implement methods for checking object existence or finding objects. You could theoretically do this using the `list*` commands, but this is rather cumbersome and can actually be costly when there are many objects. This PR adds `exists*` and `find*` methods for Databases, Table and Functions.
## How was this patch tested?

Added tests to `org.apache.spark.sql.internal.CatalogSuite`
