### PR TITLE
[SPARK-17671] Changed implementation of HistoryServer.getApplicationInfoList for lazy evaluation

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -179,17 +179,7 @@ class HistoryServer(
   }
 
   def getApplicationInfoList: Iterator[ApplicationInfo] = {
-    new Iterator[ApplicationInfo] {
-      private val appIter = getApplicationList().iterator
-
-      override def hasNext: Boolean = {
-        appIter.hasNext
-      }
-
-      override def next(): ApplicationInfo = {
-        ApplicationsListResource.appHistoryInfoToPublicAppInfo(appIter.next)
-      }
-    }
+    getApplicationList().iterator.map(ApplicationsListResource.appHistoryInfoToPublicAppInfo)
   }
 
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -179,7 +179,17 @@ class HistoryServer(
   }
 
   def getApplicationInfoList: Iterator[ApplicationInfo] = {
-    getApplicationList().iterator.map(ApplicationsListResource.appHistoryInfoToPublicAppInfo)
+    new Iterator[ApplicationInfo] {
+      private val appIter = getApplicationList().iterator
+
+      override def hasNext: Boolean = {
+        appIter.hasNext
+      }
+
+      override def next(): ApplicationInfo = {
+        ApplicationsListResource.appHistoryInfoToPublicAppInfo(appIter.next)
+      }
+    }
   }
 
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
@@ -40,42 +40,22 @@ private[v1] class ApplicationListResource(uiRoot: UIRoot) {
         status
       }
     }
+
+    val numApps = Option(limit).getOrElse(Integer.MAX_VALUE).asInstanceOf[Int]
     val includeCompleted = adjStatus.contains(ApplicationStatus.COMPLETED)
     val includeRunning = adjStatus.contains(ApplicationStatus.RUNNING)
-    val numApps = Option(limit).getOrElse(Integer.MAX_VALUE).asInstanceOf[Int]
-    
-    new Iterator[ApplicationInfo] {
-      private var appCount = 0
-      private var nextApp: Option[ApplicationInfo] = None
-
-      override def hasNext: Boolean = {
-        nextApp = None
-
-        while (nextApp == None && appCount < numApps && allApps.hasNext) {
-          val app = allApps.next
-          val anyRunning = app.attempts.exists(!_.completed)
-          // if any attempt is still running, we consider the app to also still be running
-          val statusOk = (!anyRunning && includeCompleted) ||
-            (anyRunning && includeRunning)
-          // keep the app if *any* attempts fall in the right time window
-          val dateOk = app.attempts.exists { attempt =>
-            attempt.startTime.getTime >= minDate.timestamp &&
-              attempt.startTime.getTime <= maxDate.timestamp
-          }
-
-          if (statusOk && dateOk) {
-            nextApp = Some(app)
-            appCount += 1
-          }
-        }
-
-        nextApp != None
+    allApps.filter { app =>
+      val anyRunning = app.attempts.exists(!_.completed)
+      // if any attempt is still running, we consider the app to also still be running
+      val statusOk = (!anyRunning && includeCompleted) ||
+        (anyRunning && includeRunning)
+      // keep the app if *any* attempts fall in the right time window
+      val dateOk = app.attempts.exists { attempt =>
+        attempt.startTime.getTime >= minDate.timestamp &&
+          attempt.startTime.getTime <= maxDate.timestamp
       }
-
-      override def next(): ApplicationInfo = {
-        nextApp.get
-      }
-    }
+      statusOk && dateOk
+    }.take(numApps)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
@@ -41,7 +41,7 @@ private[v1] class ApplicationListResource(uiRoot: UIRoot) {
       }
     }
 
-    val numApps = Option(limit).getOrElse(Integer.MAX_VALUE).asInstanceOf[Int]
+    val numApps = Option(limit).map(_.toInt).getOrElse(Integer.MAX_VALUE)
     val includeCompleted = adjStatus.contains(ApplicationStatus.COMPLETED)
     val includeRunning = adjStatus.contains(ApplicationStatus.RUNNING)
     allApps.filter { app =>
@@ -49,6 +49,7 @@ private[v1] class ApplicationListResource(uiRoot: UIRoot) {
       // if any attempt is still running, we consider the app to also still be running
       val statusOk = (!anyRunning && includeCompleted) ||
         (anyRunning && includeRunning)
+
       // keep the app if *any* attempts fall in the right time window
       val dateOk = app.attempts.exists { attempt =>
         attempt.startTime.getTime >= minDate.timestamp &&


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed implementation of HistoryServer.getApplicationInfoList() to lazily evaluation the time-consuming transformation. In this way, ApplicationListResource can return an iterator without evaluating the whole input iterator.
## How was this patch tested?

No API added. Just manual unit tests.
