### PR TITLE
[SPARK-14914][CORE][SQL] Skip/fix some test cases on Windows due to limitation of Windows

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -23,7 +23,7 @@ import java.net._
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 import java.util.{Locale, Properties, Random, UUID}
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
@@ -37,7 +37,6 @@ import scala.io.Source
 import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.{ControlThrowable, NonFatal}
-
 import com.google.common.io.{ByteStreams, Files => GFiles}
 import com.google.common.net.InetAddresses
 import org.apache.commons.lang3.SystemUtils
@@ -48,7 +47,6 @@ import org.apache.log4j.PropertyConfigurator
 import org.eclipse.jetty.util.MultiException
 import org.json4s._
 import org.slf4j.Logger
-
 import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
@@ -1015,7 +1013,9 @@ private[spark] object Utils extends Logging {
    */
   def isSymlink(file: File): Boolean = {
     if (file == null) throw new NullPointerException("File must not be null")
-    if (isWindows) return false
+    if (isWindows) {
+      return Files.isSymbolicLink(Paths.get(file.toURI))
+    }
     val fileInCanonicalDir = if (file.getParent() == null) {
       file
     } else {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1014,17 +1014,7 @@ private[spark] object Utils extends Logging {
    * Check to see if file is a symbolic link.
    */
   def isSymlink(file: File): Boolean = {
-    if (file == null) throw new NullPointerException("File must not be null")
-    if (isWindows) {
-      return Files.isSymbolicLink(Paths.get(file.toURI))
-    }
-    val fileInCanonicalDir = if (file.getParent() == null) {
-      file
-    } else {
-      new File(file.getParentFile().getCanonicalFile(), file.getName())
-    }
-
-    !fileInCanonicalDir.getCanonicalFile().equals(fileInCanonicalDir.getAbsoluteFile())
+    return Files.isSymbolicLink(Paths.get(file.toURI))
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -37,6 +37,7 @@ import scala.io.Source
 import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.{ControlThrowable, NonFatal}
+
 import com.google.common.io.{ByteStreams, Files => GFiles}
 import com.google.common.net.InetAddresses
 import org.apache.commons.lang3.SystemUtils
@@ -47,6 +48,7 @@ import org.apache.log4j.PropertyConfigurator
 import org.eclipse.jetty.util.MultiException
 import org.json4s._
 import org.slf4j.Logger
+
 import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -649,8 +649,13 @@ class SparkSubmitSuite
   // NOTE: This is an expensive operation in terms of time (10 seconds+). Use sparingly.
   private def runSparkSubmit(args: Seq[String]): Unit = {
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
+    val sparkSubmit = if (Utils.isWindows) {
+      Seq(new File("..\\bin\\spark-submit.cmd").getAbsolutePath) ++ args
+    } else {
+      Seq("./bin/spark-submit") ++ args
+    }
     val process = Utils.executeCommand(
-      Seq("./bin/spark-submit") ++ args,
+      sparkSubmit,
       new File(sparkHome),
       Map("SPARK_TESTING" -> "1", "SPARK_HOME" -> sparkHome))
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -649,13 +649,8 @@ class SparkSubmitSuite
   // NOTE: This is an expensive operation in terms of time (10 seconds+). Use sparingly.
   private def runSparkSubmit(args: Seq[String]): Unit = {
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
-    val sparkSubmit = if (Utils.isWindows) {
-      Seq(new File("..\\bin\\spark-submit.cmd").getAbsolutePath) ++ args
-    } else {
-      Seq("./bin/spark-submit") ++ args
-    }
     val process = Utils.executeCommand(
-      sparkSubmit,
+      Seq("./bin/spark-submit") ++ args,
       new File(sparkHome),
       Map("SPARK_TESTING" -> "1", "SPARK_HOME" -> sparkHome))
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -652,7 +652,7 @@ class SparkSubmitSuite
     val sparkSubmitFile = if (Utils.isWindows) {
       new File("..\\bin\\spark-submit.cmd")
     } else {
-      new File("./bin/spark-submit.cmd")
+      new File("../bin/spark-submit")
     }
     val process = Utils.executeCommand(
       Seq(sparkSubmitFile.getCanonicalPath) ++ args,

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -649,13 +649,13 @@ class SparkSubmitSuite
   // NOTE: This is an expensive operation in terms of time (10 seconds+). Use sparingly.
   private def runSparkSubmit(args: Seq[String]): Unit = {
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
-    val sparkSubmit = if (Utils.isWindows) {
-      Seq(new File("..\\bin\\spark-submit.cmd").getAbsolutePath) ++ args
+    val sparkSubmitFile = if (Utils.isWindows) {
+      new File("..\\bin\\spark-submit.cmd")
     } else {
-      Seq("./bin/spark-submit") ++ args
+      new File("./bin/spark-submit.cmd")
     }
     val process = Utils.executeCommand(
-      sparkSubmit,
+      Seq(sparkSubmitFile.getCanonicalPath) ++ args,
       new File(sparkHome),
       Map("SPARK_TESTING" -> "1", "SPARK_HOME" -> sparkHome))
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -126,7 +126,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("SPARK-3697: ignore directories that cannot be read.") {
-    // setReadable doesn't work on windows for directories
+    // setReadable(...) does not work on Windows. Please refer JDK-6728842.
     assume(!Utils.isWindows)
     val logFile1 = newLogFile("new1", None, inProgress = false)
     writeFile(logFile1, true, None,

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -126,6 +126,8 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("SPARK-3697: ignore directories that cannot be read.") {
+    // setReadable doesn't work on windows for directories
+    assume(!Utils.isWindows)
     val logFile1 = newLogFile("new1", None, inProgress = false)
     writeFile(logFile1, true, None,
       SparkListenerApplicationStart("app1-1", Some("app1-1"), 1L, "test", None),

--- a/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
@@ -27,6 +27,8 @@ import org.apache.spark.util.Utils
 class DiskStoreSuite extends SparkFunSuite {
 
   test("reads of memory-mapped and non memory-mapped files are equivalent") {
+    // It will cause error when we tried to re-open the filestore and the
+    // memory-mapped byte buffer tot he file has not been GC on Windows.
     assume(!Utils.isWindows)
     val confKey = "spark.storage.memoryMapThreshold"
 

--- a/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
@@ -22,10 +22,12 @@ import java.util.Arrays
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.util.io.ChunkedByteBuffer
+import org.apache.spark.util.Utils
 
 class DiskStoreSuite extends SparkFunSuite {
 
   test("reads of memory-mapped and non memory-mapped files are equivalent") {
+    assume(!Utils.isWindows)
     val confKey = "spark.storage.memoryMapThreshold"
 
     // Create a non-trivial (not all zeros) byte array

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -719,12 +719,8 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val buffer = new CircularBuffer(25)
     val stream = new PrintStream(buffer, true, "UTF-8")
 
-    // scalastyle:off println
-    // Note: println will append '\r\n' in windows,
-    // so there will be one more byte comparing to Unix/Linux.
-    stream.print("test circular test circular test circular test circular test circular\n")
-    // scalastyle:on println
-    assert(buffer.toString === "t circular test circular\n")
+    stream.print("test circular test circular test circular test circular test circular")
+    assert(buffer.toString === "st circular test circular")
   }
 
   test("nanSafeCompareDoubles") {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -719,8 +719,9 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val buffer = new CircularBuffer(25)
     val stream = new PrintStream(buffer, true, "UTF-8")
 
-    stream.print("test circular test circular test circular test circular test circular")
-    assert(buffer.toString === "st circular test circular")
+    // Note: println will append '\r\n' in windows,
+    // so there will be one more byte comparing to Unix/Linux.
+    stream.print("test circular test circular test circular test circular test circular\n")
   }
 
   test("nanSafeCompareDoubles") {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -719,9 +719,12 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val buffer = new CircularBuffer(25)
     val stream = new PrintStream(buffer, true, "UTF-8")
 
+    // scalastyle:off println
     // Note: println will append '\r\n' in windows,
     // so there will be one more byte comparing to Unix/Linux.
     stream.print("test circular test circular test circular test circular test circular\n")
+    // scalastyle:on println
+    assert(buffer.toString === "t circular test circular\n")
   }
 
   test("nanSafeCompareDoubles") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -83,6 +83,8 @@ class CreateTableAsSelectSuite
   }
 
   test("CREATE TABLE USING AS SELECT based on the file without write permission") {
+    // setWritable(boolean) doesn't work on Windows
+    assume(!Utils.isWindows)
     val childPath = new File(path.toString, "child")
     path.mkdir()
     path.setWritable(false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -82,7 +82,7 @@ class CreateTableAsSelectSuite
   }
 
   test("CREATE TABLE USING AS SELECT based on the file without write permission") {
-    // setWritable(boolean) does not work on Windows. Please refer JDK-6728842.
+    // setWritable(...) does not work on Windows. Please refer JDK-6728842.
     assume(!Utils.isWindows)
     val childPath = new File(path.toString, "child")
     path.mkdir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
@@ -83,7 +82,7 @@ class CreateTableAsSelectSuite
   }
 
   test("CREATE TABLE USING AS SELECT based on the file without write permission") {
-    // setWritable(boolean) doesn't work on Windows
+    // setWritable(boolean) does not work on Windows. Please refer JDK-6728842.
     assume(!Utils.isWindows)
     val childPath = new File(path.toString, "child")
     path.mkdir()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to fix/skip some tests failed on Windows. This PR takes over https://github.com/apache/spark/pull/12696.

**Before**
- **SparkSubmitSuite**
  
  ```
  [info] - launch simple application with spark-submit *** FAILED *** (202 milliseconds)
  [info]   java.io.IOException: Cannot run program "./bin/spark-submit" (in directory "C:\projects\spark"): CreateProcess error=2, The system cannot find the file specifie
  
  [info] - includes jars passed in through --jars *** FAILED *** (1 second, 625 milliseconds)
  [info]   java.io.IOException: Cannot run program "./bin/spark-submit" (in directory "C:\projects\spark"): CreateProcess error=2, The system cannot find the file specified
  ```
- **DiskStoreSuite**
  
  ```
  [info] - reads of memory-mapped and non memory-mapped files are equivalent *** FAILED *** (1 second, 78 milliseconds)
  [info]   diskStoreMapped.remove(blockId) was false (DiskStoreSuite.scala:41)
  ```

**After**
- **SparkSubmitSuite**
  
  ```
  [info] - launch simple application with spark-submit (578 milliseconds)
  [info] - includes jars passed in through --jars (1 second, 875 milliseconds)
  ```
- **DiskStoreSuite**
  
  ```
  [info] DiskStoreSuite:
  [info] - reads of memory-mapped and non memory-mapped files are equivalent !!! CANCELED !!! (766 milliseconds
  ```

For `CreateTableAsSelectSuite` and `FsHistoryProviderSuite`, I could not reproduce as the Java version seems higher than the one that has the bugs about `setReadable(..)` and `setWritable(...)` but as they are bugs reported clearly, it'd be sensible to skip those. We should revert the changes for both back as soon as we drop the support of Java 7.
## How was this patch tested?

Manually tested via AppVeyor.

Closes #12696
