### PR TITLE
[SPARKR][SPARK-17762] invokeJava fails when serialized argument list is larger than INT_MAX bytes

### DIFF
--- a/R/pkg/R/backend.R
+++ b/R/pkg/R/backend.R
@@ -83,6 +83,11 @@ invokeJava <- function(isStatic, objId, methodName, ...) {
     }
   }
 
+  maxByteSize <- if (exists(".maxArgByteSize", .sparkREnv)) {
+    as.numeric(get(".maxArgByteSize", envir = .sparkREnv))
+  } else {
+    .Machine$integer.max * 10
+  }
 
   rc <- rawConnection(raw(0), "r+")
 
@@ -92,7 +97,7 @@ invokeJava <- function(isStatic, objId, methodName, ...) {
 
   args <- list(...)
   writeInt(rc, length(args))
-  writeArgs(rc, args)
+  writeArgs(rc, args, maxArgSize = maxByteSize)
 
   # Construct the whole request message to send it once,
   # avoiding write-write-read pattern in case of Nagle's algorithm.

--- a/R/pkg/R/serialize.R
+++ b/R/pkg/R/serialize.R
@@ -136,8 +136,17 @@ serializeRow <- function(row) {
 }
 
 writeRaw <- function(con, batch) {
+  dataSize <- length(batch)
   writeInt(con, length(batch))
-  writeBin(batch, con, endian = "big")
+
+  LENTMAX <- 2147483000 # Slightly less than R_LEN_T_MAX macro in R
+  sizeVec <- c(rep(LENTMAX, dataSize %/% LENTMAX), dataSize %% LENTMAX)
+
+  curIndex <- 1
+  for (sizeIndex in cumsum(sizeVec)) {
+    writeBin(batch[curIndex:sizeIndex], con, endian = "big")
+    curIndex <- sizeIndex + 1
+  }
 }
 
 writeType <- function(con, class) {

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -394,6 +394,16 @@ sparkR.session <- function(
                                 sparkConfigMap,
                                 enableHiveSupport)
     assign(".sparkRsession", sparkSession, envir = .sparkREnv)
+
+    # Set maximum size of serialized data that can be sent as invokeJava arguments
+    assign(
+      ".maxArgByteSize",
+      callJMethod(
+        callJMethod(sparkSession, "conf"),
+        "get",
+        "spark.r.maxArgByteSize",
+        toString(.Machine$integer.max * 10)),
+      envir = .sparkREnv)
   }
   sparkSession
 }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -395,16 +395,14 @@ sparkR.session <- function(
                                 enableHiveSupport)
     assign(".sparkRsession", sparkSession, envir = .sparkREnv)
 
-    # Set maximum size of serialized data that can be sent as invokeJava arguments
-    assign(
-      ".maxArgByteSize",
-      callJMethod(
-        callJMethod(sparkSession, "conf"),
-        "get",
-        "spark.r.maxArgByteSize",
-        toString(.Machine$integer.max * 10)),
-      envir = .sparkREnv)
   }
+
+  # Set maximum size of serialized data that can be sent as invokeJava arguments
+  assign(
+    ".maxArgByteSize",
+    sparkR.conf("spark.r.maxArgByteSize", toString(.Machine$integer.max * 10)),
+    envir = .sparkREnv)
+
   sparkSession
 }
 

--- a/R/pkg/inst/tests/testthat/test_serialize.R
+++ b/R/pkg/inst/tests/testthat/test_serialize.R
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+library(testthat)
+
+context("Serialization implementation")
+
+test_that("writeRaw can write multiple batches", {
+  vec <- 1:100
+  batch <- serialize(vec, connection = NULL)
+
+  fileName1 <- tempfile()
+  conn1 <- file(fileName1, "wb")
+  writeRaw(conn1, batch, maxBatchSize = 20)
+  close(conn1)
+
+  fileName2 <- tempfile()
+  conn2 <- file(fileName2, "wb")
+  writeRaw(conn2, batch)
+  close(conn2)
+
+  expect_equal(file.info(fileName1)$size, file.info(fileName2)$size)
+})


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Updates implementation of `writeRaw` to call `writeBin` on smaller chunks of data when we are dealing with a large batch
## How was this patch tested?
- New unit tests in `test_serialize.R`
