### PR TITLE
[SPARK-17763][SQL] JacksonParser silently parses null as 0 when the field is not nullable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -354,14 +354,14 @@ class JacksonParser(
       parser: JsonParser,
       dataType: DataType,
       nullable: Boolean = true)(f: PartialFunction[JsonToken, Any]): Any = {
-    val nullParser = makeNullConverter(nullable)
+    val nullConverter = makeNullConverter(nullable)
     parser.getCurrentToken match {
       case FIELD_NAME =>
         // There are useless FIELD_NAMEs between START_OBJECT and END_OBJECT tokens
         parser.nextToken()
         parseJsonToken(parser, dataType, nullable)(f)
 
-      case null | VALUE_NULL => nullParser.apply(parser)
+      case null | VALUE_NULL => nullConverter.apply(parser)
 
       case other => f.applyOrElse(other, failedConversion(parser, dataType, nullable))
     }
@@ -375,13 +375,13 @@ class JacksonParser(
       parser: JsonParser,
       dataType: DataType,
       nullable: Boolean): PartialFunction[JsonToken, Any] = {
-    val nullParser = makeNullConverter(nullable)
+    val nullConverter = makeNullConverter(nullable)
 
     {
       case VALUE_STRING if parser.getTextLength < 1 =>
         // If conversion is failed, this produces `null` rather than throwing exception.
         // This will protect the mismatch of types.
-        nullParser.apply(parser)
+        nullConverter.apply(parser)
 
       case token =>
         // We cannot parse this token based on the given data type. So, we throw a


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes handling not nullable field properly in `JacksonParser`. For example, the codes below:

``` scala
val testJson = """{"nullInt":null}""" :: Nil
val testSchema = StructType(StructField("nullInt", IntegerType, false) :: Nil)
val data = spark.sparkContext.parallelize(testJson)
spark.read.schema(testSchema).json(data).show()
```

prints

**Before**

```
+-------+
|nullInt|
+-------+
|      0|
+-------+
```

**After**

```
org.apache.spark.sql.catalyst.json.NotAllowedNullException: Null not allowed: {"nullInt":null}
    at org.apache.spark.sql.catalyst.json.JacksonParser.failedRecord(JacksonParser.scala:131)
    at org.apache.spark.sql.catalyst.json.JacksonParser.parse(JacksonParser.scala:472)
...
```
## How was this patch tested?

Unit test in`JsonSuite`.
