### PR TITLE
[SPARK-17718] [DOCS] [MLLIB] Make loss function formulation label note clearer in MLlib docs

### DIFF
--- a/docs/mllib-linear-methods.md
+++ b/docs/mllib-linear-methods.md
@@ -78,6 +78,11 @@ methods `spark.mllib` supports:
   </tbody>
 </table>
 
+Note that, in the mathematical formulation above, a binary label $y$ is denoted as either
+$+1$ (positive) or $-1$ (negative), which is convenient for the formulation.
+*However*, the negative label is represented by $0$ in `spark.mllib` instead of $-1$, to be consistent with
+multiclass labeling.
+
 ### Regularizers
 
 The purpose of the
@@ -136,10 +141,6 @@ multiclass classification problems.
 For both methods, `spark.mllib` supports L1 and L2 regularized variants.
 The training data set is represented by an RDD of [LabeledPoint](mllib-data-types.html) in MLlib,
 where labels are class indices starting from zero: $0, 1, 2, \ldots$.
-Note that, in the mathematical formulation in this guide, a binary label $y$ is denoted as either
-$+1$ (positive) or $-1$ (negative), which is convenient for the formulation.
-*However*, the negative label is represented by $0$ in `spark.mllib` instead of $-1$, to be consistent with
-multiclass labeling.
 
 ### Linear Support Vector Machines (SVMs)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move note about labels being +1/-1 in formulation only to be just under the table of formulations.
## How was this patch tested?

Doc build
