### PR TITLE
[SPARK-17769][Core][Scheduler]Some FetchFailure refactoring

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1294,7 +1294,6 @@ class DAGScheduler(
                 DAGScheduler.RESUBMIT_TIMEOUT,
                 TimeUnit.MILLISECONDS)
             }
-
           }
           // Mark the map whose fetch failed as broken in the map stage
           if (mapId != -1) {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1292,7 +1292,8 @@ class DAGScheduler(
                   override def run(): Unit = eventProcessLoop.post(ResubmitFailedStages)
                 },
                 DAGScheduler.RESUBMIT_TIMEOUT,
-                TimeUnit.MILLISECONDS)
+                TimeUnit.MILLISECONDS
+              )
             }
           }
           // Mark the map whose fetch failed as broken in the map stage


### PR DESCRIPTION
## What changes were proposed in this pull request?

Readability rewrites.
Changed order of `failedStage.failedOnFetchAndShouldAbort(task.stageAttemptId)` and `disallowStageRetryForTest` evaluation.
Stage resubmission guard condition changed from `failedStages.isEmpty` to `!failedStages.contains(failedStage)`
Log all resubmission of stages
## How was this patch tested?

existing tests
