### PR TITLE
[SPARK-17767][SQL] Support user-provided ExternalCatalog

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -95,7 +95,7 @@ package object config {
   private[spark] val CATALOG_IMPLEMENTATION = ConfigBuilder("spark.sql.catalogImplementation")
     .internal()
     .stringConf
-    .checkValues(Set("hive", "in-memory"))
+    .checkValues(Set("hive", "in-memory", "provided"))
     .createWithDefault("in-memory")
 
   private[spark] val LISTENER_BUS_EVENT_QUEUE_SIZE =

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -87,7 +87,10 @@ object Main extends Logging {
     }
 
     val builder = SparkSession.builder.config(conf)
-    if (conf.get(CATALOG_IMPLEMENTATION.key, "hive").toLowerCase == "hive") {
+    if (conf.get(CATALOG_IMPLEMENTATION.key, "").toLowerCase == "provided") {
+      sparkSession = builder.enableProvidedCatalog().getOrCreate()
+      logInfo("Created Spark session with provided external catalog")
+    } else if (conf.get(CATALOG_IMPLEMENTATION.key, "hive").toLowerCase == "hive") {
       if (SparkSession.hiveClassesArePresent) {
         // In the case that the property is not set at all, builder's config
         // does not have this value set to 'hive' yet. The original default

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -58,6 +58,16 @@ object SQLConf {
     .stringConf
     .createWithDefault("${system:user.dir}/spark-warehouse")
 
+  val EXTERNAL_CATALOG_CLASS_NAME = ConfigBuilder("spark.sql.externalCatalog")
+    .internal()
+    .stringConf
+    .createWithDefault("org.apache.spark.sql.hive.HiveExternalCatalog")
+
+  val EXTERNAL_SESSION_STATE_CLASS_NAME = ConfigBuilder("spark.sql.externalSessionState")
+    .internal()
+    .stringConf
+    .createWithDefault("org.apache.spark.sql.hive.HiveSessionState")
+
   val OPTIMIZER_MAX_ITERATIONS = SQLConfigBuilder("spark.sql.optimizer.maxIterations")
     .internal()
     .doc("The max number of iterations the optimizer and analyzer runs.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -110,12 +110,11 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
 
 object SharedState {
 
-  private val HIVE_EXTERNAL_CATALOG_CLASS_NAME = "org.apache.spark.sql.hive.HiveExternalCatalog"
-
   private def externalCatalogClassName(conf: SparkConf): String = {
     conf.get(CATALOG_IMPLEMENTATION) match {
-      case "hive" => HIVE_EXTERNAL_CATALOG_CLASS_NAME
+      case "hive" => SQLConf.EXTERNAL_CATALOG_CLASS_NAME.defaultValueString
       case "in-memory" => classOf[InMemoryCatalog].getCanonicalName
+      case "provided" => conf.get(SQLConf.EXTERNAL_CATALOG_CLASS_NAME)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark supports ExternalCatalog, but the usage is limited to `HiveExternalCatalog` by using `private string` variables for class name holder. This PR aims to parameterize those variables as SQL configuration and supports `user-provided` ExternalCatalog and SessionState classes.

The following is an intended use case and a snippet of test case in this PR.

``` scala
val session = SparkSession.builder()
  .master("local")
  .config("spark.sql.externalCatalog", "org.apache.spark.sql.MyExternalCatalog")
  .config("spark.sql.externalSessionState", "org.apache.spark.sql.MySessionState")
  .enableProvidedCatalog()
  .getOrCreate()

assert(session.sharedState.externalCatalog.isInstanceOf[MyExternalCatalog])
assert(session.sessionState.isInstanceOf[MySessionState])
```
## How was this patch tested?

Pass the Jenkins test with a new test case.
