### PR TITLE
[SPARK-17773] [Input/Output] [branch-2.0] Add VoidObjectInspector

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -424,6 +424,9 @@ private[hive] trait HiveInspectors {
           null
         }
 
+    case _: VoidObjectInspector =>
+      (_: Any) => null // always be null for void object inspector
+
     case soi: StandardStructObjectInspector =>
       val schema = dataType.asInstanceOf[StructType]
       val wrappers = soi.getAllStructFieldRefs.asScala.zip(schema.fields).map {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
@@ -75,6 +75,7 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
 
   val data =
     Literal(true) ::
+    Literal(null) ::
     Literal(0.asInstanceOf[Byte]) ::
     Literal(0.asInstanceOf[Short]) ::
     Literal(0) ::


### PR DESCRIPTION
This is the PR for branch2.0: PR https://github.com/apache/spark/pull/15337

Added VoidObjectInspector to the list of PrimitiveObjectInspectors

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Executing following query was failing.
select SOME_UDAF*(a.arr)
from (
select Array(null) as arr from dim_one_row
) a

After the fix, I am getting the correct output:
res0: Array[org.apache.spark.sql.Row] = Array([null])

Author: Ergin Seyfe eseyfe@fb.com

Closes #15337 from seyfe/add_void_object_inspector.
