### PR TITLE
[SPARK-17782][STREAMING][BUILD] Add Kafka 0.10 project to build modules

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -229,6 +229,17 @@ streaming_kafka = Module(
     ]
 )
 
+streaming_kafka-0-10 = Module(
+    name="streaming-kafka-0-10",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/kafka-0-10",
+        "external/kafka-0-10-assembly",
+    ],
+    sbt_test_goals=[
+        "streaming-kafka-0-10/test",
+    ]
+)
 
 streaming_flume_sink = Module(
     name="streaming-flume-sink",

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -229,7 +229,7 @@ streaming_kafka = Module(
     ]
 )
 
-streaming_kafka-0-10 = Module(
+streaming_kafka_0_10 = Module(
     name="streaming-kafka-0-10",
     dependencies=[streaming],
     source_file_regexes=[

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -158,7 +158,7 @@ class DirectKafkaStreamSuite
     ssc.stop()
   }
 
-  ignore("pattern based subscription") {
+  test("pattern based subscription") {
     val topics = List("pat1", "pat2", "advanced3")
     // Should match 2 out of 3 topics
     val pat = """pat\d""".r.pattern

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -158,7 +158,7 @@ class DirectKafkaStreamSuite
     ssc.stop()
   }
 
-  test("pattern based subscription") {
+  ignore("pattern based subscription") {
     val topics = List("pat1", "pat2", "advanced3")
     // Should match 2 out of 3 topics
     val pat = """pat\d""".r.pattern


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the Kafka 0.10 subproject to the build infrastructure. This makes sure Kafka 0.10 tests are only triggers when it or of its dependencies change.
