### PR TITLE
[Minor][ML] Avoid 2D array flatten in NB training.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -177,7 +177,7 @@ class NaiveBayes @Since("1.5.0") (
     val numDocuments = aggregated.map(_._2._1).sum
 
     val piArray = Array.fill[Double](numLabels)(0.0)
-    val thetaArrays = Array.fill[Double](numLabels, numFeatures)(0.0)
+    val thetaArray = Array.fill[Double](numLabels * numFeatures)(0.0)
 
     val lambda = $(smoothing)
     val piLogDenom = math.log(numDocuments + numLabels * lambda)
@@ -193,14 +193,14 @@ class NaiveBayes @Since("1.5.0") (
       }
       var j = 0
       while (j < numFeatures) {
-        thetaArrays(i)(j) = math.log(sumTermFreqs(j) + lambda) - thetaLogDenom
+        thetaArray(i * numFeatures + j) = math.log(sumTermFreqs(j) + lambda) - thetaLogDenom
         j += 1
       }
       i += 1
     }
 
     val pi = Vectors.dense(piArray)
-    val theta = new DenseMatrix(numLabels, thetaArrays(0).length, thetaArrays.flatten, true)
+    val theta = new DenseMatrix(numLabels, numFeatures, thetaArray, true)
     new NaiveBayesModel(uid, pi, theta)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -176,8 +176,8 @@ class NaiveBayes @Since("1.5.0") (
     val numLabels = aggregated.length
     val numDocuments = aggregated.map(_._2._1).sum
 
-    val piArray = Array.fill[Double](numLabels)(0.0)
-    val thetaArray = Array.fill[Double](numLabels * numFeatures)(0.0)
+    val piArray = new Array[Double](numLabels)
+    val thetaArray = new Array[Double](numLabels * numFeatures)
 
     val lambda = $(smoothing)
     val piLogDenom = math.log(numDocuments + numLabels * lambda)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid 2D array flatten in `NaiveBayes` training, since flatten method might be expensive (It will create another array and copy data there).
## How was this patch tested?

Existing tests.
