### PR TITLE
[SPARK-17157][SPARKR]: Add multiclass logistic regression SparkR Wrapper

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -43,7 +43,8 @@ exportMethods("glm",
               "spark.isoreg",
               "spark.gaussianMixture",
               "spark.als",
-              "spark.kstest")
+              "spark.kstest",
+              "spark.logit")
 
 # Job group lifecycle management methods
 export("setJobGroup",

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1371,6 +1371,10 @@ setGeneric("spark.gaussianMixture",
              standardGeneric("spark.gaussianMixture")
            })
 
+#' @rdname spark.logit
+#' @export
+setGeneric("spark.logit", function(data, formula, ...) { standardGeneric("spark.logit") })
+
 #' @param object a fitted ML model object.
 #' @param path the directory where the model is saved.
 #' @param ... additional argument(s) passed to the method.

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -754,8 +754,9 @@ setMethod("spark.logit", signature(data = "SparkDataFrame", formula = "formula")
             }
 
             jobj <- callJStatic("org.apache.spark.ml.r.LogisticRegressionWrapper", "fit",
-                                data@sdf, formula, as.numeric(regParam), as.numeric(elasticNetParam),
-                                as.integer(maxIter), as.numeric(tol), as.logical(fitIntercept),
+                                data@sdf, formula, as.numeric(regParam),
+                                as.numeric(elasticNetParam), as.integer(maxIter),
+                                as.numeric(tol), as.logical(fitIntercept),
                                 as.character(family), as.logical(standardization),
                                 as.numeric(threshold), thresholds,
                                 as.character(weightCol), as.integer(aggregationDepth))

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -783,7 +783,7 @@ setMethod("predict", signature(object = "LogisticRegressionModel"),
 #' @return \code{summary} returns the Binary Logistic regression results of a given model as lists. Note that
 #'                        Multinomial logistic regression summary is not available now.
 #' @rdname spark.logit
-#' @aliases spark.logit,SparkDataFrame,formula-method
+#' @aliases summary,LogisticRegressionModel-method
 #' @export
 #' @note summary(LogisticRegressionModel) since 2.1.0
 setMethod("summary", signature(object = "LogisticRegressionModel"),

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -664,8 +664,8 @@ setMethod("predict", signature(object = "KMeansModel"),
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
 #'                operators are supported, including '~', '.', ':', '+', and '-'.
 #' @param regParam the regularization parameter. Default is 0.0.
-#' @param elasticNetParam the ElasticNet mixing parameter. For alpha = 0, the penalty is an L2 penalty.
-#'                        For alpha = 1, it is an L1 penalty. For 0 < alpha < 1, the penalty is a combination
+#' @param elasticNetParam the ElasticNet mixing parameter. For alpha = 0.0, the penalty is an L2 penalty.
+#'                        For alpha = 1.0, it is an L1 penalty. For 0.0 < alpha < 1.0, the penalty is a combination
 #'                        of L1 and L2. Default is 0.0 which is an L2 penalty.
 #' @param maxIter maximum iteration number.
 #' @param tol convergence tolerance of iterations.
@@ -674,7 +674,7 @@ setMethod("predict", signature(object = "KMeansModel"),
 #'               Supported options:
 #'                 \itemize{
 #'                   \item{"auto": Automatically select the family based on the number of classes:
-#'                           If numClasses == 1 || numClasses == 2, set to "binomial".
+#'                           If number of classes == 1 || number of classes == 2, set to "binomial".
 #'                           Else, set to "multinomial".}
 #'                   \item{"binomial": Binary logistic regression with pivoting.}
 #'                   \item{"multinomial": Multinomial logistic (softmax) regression without pivoting.
@@ -712,8 +712,8 @@ setMethod("predict", signature(object = "KMeansModel"),
 #' label <- c(1.0, 1.0, 1.0, 0.0, 0.0)
 #' feature <- c(1.1419053, 0.9194079, -0.9498666, -1.1069903, 0.2809776)
 #' binary_data <- as.data.frame(cbind(label, feature))
-#' binary_df <- suppressWarnings(createDataFrame(binary_data))
-#' blr_model <- spark.logit(binary_df, label ~ feature, threshold = 1.0)
+#' binary_df <- createDataFrame(binary_data)
+#' blr_model <- spark.logit(binary_df, label ~ feature, thresholds = 1.0)
 #' blr_predict <- collect(select(predict(blr_model, binary_df), "prediction"))
 #'
 #' # summary of binary logistic regression
@@ -723,9 +723,10 @@ setMethod("predict", signature(object = "KMeansModel"),
 #' path <- "path/to/model"
 #' write.ml(blr_model, path)
 #'
-#' # can also read back the saved model and print
+#' # can also read back the saved model and predict
+#' Note that summary deos not work on loaded model
 #' savedModel <- read.ml(path)
-#' summary(savedModel)
+#' blr_predict2 <- collect(select(predict(savedModel, binary_df), "prediction"))
 #'
 #' # multinomial logistic regression
 #'
@@ -737,6 +738,7 @@ setMethod("predict", signature(object = "KMeansModel"),
 #' data <- as.data.frame(cbind(label, feature1, feature2, feature3, feature4))
 #' df <- createDataFrame(data)
 #'
+#' Note that summary of multinomial logistic regression is not implemented yet
 #' model <- spark.logit(df, label ~ ., family = "multinomial", thresholds=c(0, 1, 1))
 #' predict1 <- collect(select(predict(model, df), "prediction"))
 #' }
@@ -799,20 +801,15 @@ setMethod("summary", signature(object = "LogisticRegressionModel"),
 
             pr <- dataFrame(callJMethod(jobj, "pr"))
 
-            fMeasureByThreshold <-
-              dataFrame(callJMethod(jobj, "fMeasureByThreshold"))
+            fMeasureByThreshold <- dataFrame(callJMethod(jobj, "fMeasureByThreshold"))
 
-            precisionByThreshold <-
-              dataFrame(callJMethod(jobj, "precisionByThreshold"))
+            precisionByThreshold <- dataFrame(callJMethod(jobj, "precisionByThreshold"))
 
-            recallByThreshold <-
-              dataFrame(callJMethod(jobj, "recallByThreshold"))
+            recallByThreshold <- dataFrame(callJMethod(jobj, "recallByThreshold"))
 
-            totalIterations <-
-              callJMethod(jobj, "totalIterations")
+            totalIterations <- callJMethod(jobj, "totalIterations")
 
-            objectiveHistory <-
-              callJMethod(jobj, "objectiveHistory")
+            objectiveHistory <- callJMethod(jobj, "objectiveHistory")
 
             list(roc = roc, areaUnderROC = areaUnderROC, pr = pr,
                  fMeasureByThreshold = fMeasureByThreshold,

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -755,8 +755,9 @@ setMethod("spark.logit", signature(data = "SparkDataFrame", formula = "formula")
 
             jobj <- callJStatic("org.apache.spark.ml.r.LogisticRegressionWrapper", "fit",
                                 data@sdf, formula, as.numeric(regParam), as.numeric(elasticNetParam),
-                                as.integer(maxIter), as.numeric(tol), as.logical(fitIntercept), as.character(family),
-                                as.logical(standardization), as.numeric(threshold), thresholds,
+                                as.integer(maxIter), as.numeric(tol), as.logical(fitIntercept),
+                                as.character(family), as.logical(standardization),
+                                as.numeric(threshold), thresholds,
                                 as.character(weightCol), as.integer(aggregationDepth))
             new("LogisticRegressionModel", jobj = jobj)
           })
@@ -833,8 +834,10 @@ setMethod("summary", signature(object = "LogisticRegressionModel"),
             } else {
               callJMethod(jobj, "objectiveHistory")
             }
-            list(roc = roc, areaUnderROC = areaUnderROC, pr = pr, fMeasureByThreshold = fMeasureByThreshold,
-                 precisionByThreshold= precisionByThreshold, recallByThreshold = recallByThreshold,
+            list(roc = roc, areaUnderROC = areaUnderROC, pr = pr,
+                 fMeasureByThreshold = fMeasureByThreshold,
+                 precisionByThreshold = precisionByThreshold,
+                 recallByThreshold = recallByThreshold,
                  totalIterations = totalIterations, objectiveHistory = objectiveHistory)
           })
 

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -706,16 +706,37 @@ setMethod("predict", signature(object = "KMeansModel"),
 #' @examples
 #' \dontrun{
 #' sparkR.session()
-#' data <- list(list(7.0, 0.0), list(5.0, 1.0), list(3.0, 2.0),
-#'         list(5.0, 3.0), list(1.0, 4.0))
-#' df <- createDataFrame(data, c("label", "feature"))
+#' # binary logistic regression
+#' label <- c(1.0, 1.0, 1.0, 0.0, 0.0)
+#' feature <- c(1.1419053, 0.9194079, -0.9498666, -1.1069903, 0.2809776)
+#' binary_data <- as.data.frame(cbind(label, feature))
+#' binary_df <- suppressWarnings(createDataFrame(binary_data))
+#' blr_model <- spark.logit(binary_df, label ~ feature, threshold = 1.0)
+#' blr_predict <- collect(select(predict(blr_model, binary_df), "prediction"))
+#'
+#' # summary of binary logistic regression
+#' blr_summary <- summary(blr_model)
+#' blr_fmeasure <- collect(select(blr_summary$fMeasureByThreshold, "threshold", "F-Measure"))
 #' # save fitted model to input path
 #' path <- "path/to/model"
-#' write.ml(model, path)
+#' write.ml(blr_model, path)
 #'
 #' # can also read back the saved model and print
 #' savedModel <- read.ml(path)
 #' summary(savedModel)
+#'
+#' # multinomial logistic regression
+#'
+#' label <- c(0.0, 1.0, 2.0, 0.0, 0.0)
+#' feature1 <- c(4.845940, 5.64480, 7.430381, 6.464263, 5.555667)
+#' feature2 <- c(2.941319, 2.614812, 2.162451, 3.339474, 2.970987)
+#' feature3 <- c(1.322733, 1.348044, 3.861237, 9.686976, 3.447130)
+#' feature4 <- c(1.3246388, 0.5510444, 0.9225810, 1.2147881, 1.6020842)
+#' data <- as.data.frame(cbind(label, feature1, feature2, feature3, feature4))
+#' df <- suppressWarnings(createDataFrame(data))
+#'
+#' model <- spark.logit(df, label ~ ., family = "multinomial", thresholds=c(0, 1, 1))
+#' predict1 <- collect(select(predict(model, df), "prediction"))
 #' }
 #' @note spark.logit since 2.1.0
 setMethod("spark.logit", signature(data = "SparkDataFrame", formula = "formula"),
@@ -786,19 +807,19 @@ setMethod("summary", signature(object = "LogisticRegressionModel"),
             fMeasureByThreshold <- if (is.loaded) {
               NULL
             } else {
-              callJMethod(jobj, "fMeasureByThreshold")
+              dataFrame(callJMethod(jobj, "fMeasureByThreshold"))
             }
 
             precisionByThreshold <- if (is.loaded) {
               NULL
             } else {
-              callJMethod(jobj, "precisionByThreshold")
+              dataFrame(callJMethod(jobj, "precisionByThreshold"))
             }
 
             recallByThreshold <- if (is.loaded) {
               NULL
             } else {
-              callJMethod(jobj, "recallByThreshold")
+              dataFrame(callJMethod(jobj, "recallByThreshold"))
             }
 
             totalIterations <- if (is.loaded) {

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -777,6 +777,7 @@ setMethod("predict", signature(object = "LogisticRegressionModel"),
 
 #  Get the summary of an LogisticRegressionModel
 
+#' @param object an LogisticRegressionModel fitted by \code{spark.logit}
 #' @return \code{summary} returns the Binary Logistic regression results of a given model as lists. Note that
 #'                        Multinomial logistic regression summary is not available now.
 #' @rdname spark.logit

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -588,6 +588,7 @@ test_that("spark.isotonicRegression", {
 })
 
 test_that("spark.logit", {
+  # test binary logistic regression
   label <- c(1.0, 1.0, 1.0, 0.0, 0.0)
   feature <- c(1.1419053, 0.9194079, -0.9498666, -1.1069903, 0.2809776)
   binary_data <- as.data.frame(cbind(label, feature))
@@ -596,6 +597,47 @@ test_that("spark.logit", {
   blr_model <- spark.logit(binary_df, label ~ feature, threshold = 1.0)
   blr_predict <- collect(select(predict(blr_model, binary_df), "prediction"))
   expect_equal(blr_predict$prediction, c(0, 0, 0, 0, 0))
+  blr_model1 <- spark.logit(binary_df, label ~ feature, threshold = 0.0)
+  blr_predict1 <- collect(select(predict(blr_model1, binary_df), "prediction"))
+  expect_equal(blr_predict1$prediction, c(1, 1, 1, 1, 1))
+
+  # test summary of binary logistic regression
+  blr_summary <- summary(blr_model)
+  blr_fmeasure <- collect(select(blr_summary$fMeasureByThreshold, "threshold", "F-Measure"))
+  expect_equal(blr_fmeasure$threshold, c(0.8221347, 0.7884005, 0.6674709, 0.3785437, 0.3434487),
+               tolerance = 1e-4)
+  expect_equal(blr_fmeasure$'F-Measure', c(0.5000000, 0.8000000, 0.6666667, 0.8571429, 0.7500000),
+               tolerance = 1e-4)
+  blr_precision <- collect(select(blr_summary$precisionByThreshold, "threshold", "precision"))
+  expect_equal(blr_precision$precision, c(1.0000000, 1.0000000, 0.6666667, 0.7500000, 0.6000000),
+               tolerance = 1e-4)
+  blr_recall <- collect(select(blr_summary$recallByThreshold, "threshold", "recall"))
+  expect_equal(blr_recall$recall, c(0.3333333, 0.6666667, 0.6666667, 1.0000000, 1.0000000),
+               tolerance = 1e-4)
+
+  # test model save and read
+  modelPath <- tempfile(pattern = "spark-logisticRegression", fileext = ".tmp")
+  write.ml(blr_model, modelPath)
+  expect_error(write.ml(blr_model, modelPath))
+  write.ml(blr_model, modelPath, overwrite = TRUE)
+  blr_model2 <- read.ml(modelPath)
+  blr_predict2 <- collect(select(predict(blr_model2, binary_df), "prediction"))
+  expect_equal(blr_predict$prediction, blr_predict2$prediction)
+
+  # test multinomial logistic regression
+  label <- c(0.0, 1.0, 2.0, 0.0, 0.0)
+  feature1 <- c(4.845940, 5.64480, 7.430381, 6.464263, 5.555667)
+  feature2 <- c(2.941319, 2.614812, 2.162451, 3.339474, 2.970987)
+  feature3 <- c(1.322733, 1.348044, 3.861237, 9.686976, 3.447130)
+  feature4 <- c(1.3246388, 0.5510444, 0.9225810, 1.2147881, 1.6020842)
+  data <- as.data.frame(cbind(label, feature1, feature2, feature3, feature4))
+  df <- suppressWarnings(createDataFrame(data))
+
+  model <- spark.logit(df, label ~ ., family = "multinomial", thresholds=c(0, 1, 1))
+  predict1 <- collect(select(predict(model, df), "prediction"))
+  expect_equal(predict1$prediction, c(0, 0, 0, 0, 0))
+  # Summary of multinomial logistic regression is not implemented yet
+  expect_error(summary(model))
 })
 
 test_that("spark.gaussianMixture", {

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -633,7 +633,7 @@ test_that("spark.logit", {
   data <- as.data.frame(cbind(label, feature1, feature2, feature3, feature4))
   df <- suppressWarnings(createDataFrame(data))
 
-  model <- spark.logit(df, label ~., family = "multinomial", thresholds=c(0, 1, 1))
+  model <- spark.logit(df, label ~., family = "multinomial", thresholds = c(0, 1, 1))
   predict1 <- collect(select(predict(model, df), "prediction"))
   expect_equal(predict1$prediction, c(0, 0, 0, 0, 0))
   # Summary of multinomial logistic regression is not implemented yet

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -606,7 +606,7 @@ test_that("spark.logit", {
   blr_fmeasure <- collect(select(blr_summary$fMeasureByThreshold, "threshold", "F-Measure"))
   expect_equal(blr_fmeasure$threshold, c(0.8221347, 0.7884005, 0.6674709, 0.3785437, 0.3434487),
                tolerance = 1e-4)
-  expect_equal(blr_fmeasure$'F-Measure', c(0.5000000, 0.8000000, 0.6666667, 0.8571429, 0.7500000),
+  expect_equal(blr_fmeasure$"F-Measure", c(0.5000000, 0.8000000, 0.6666667, 0.8571429, 0.7500000),
                tolerance = 1e-4)
   blr_precision <- collect(select(blr_summary$precisionByThreshold, "threshold", "precision"))
   expect_equal(blr_precision$precision, c(1.0000000, 1.0000000, 0.6666667, 0.7500000, 0.6000000),
@@ -633,7 +633,7 @@ test_that("spark.logit", {
   data <- as.data.frame(cbind(label, feature1, feature2, feature3, feature4))
   df <- suppressWarnings(createDataFrame(data))
 
-  model <- spark.logit(df, label ~ ., family = "multinomial", thresholds=c(0, 1, 1))
+  model <- spark.logit(df, label ~., family = "multinomial", thresholds=c(0, 1, 1))
   predict1 <- collect(select(predict(model, df), "prediction"))
   expect_equal(predict1$prediction, c(0, 0, 0, 0, 0))
   # Summary of multinomial logistic regression is not implemented yet

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -594,10 +594,10 @@ test_that("spark.logit", {
   binary_data <- as.data.frame(cbind(label, feature))
   binary_df <- createDataFrame(binary_data)
 
-  blr_model <- spark.logit(binary_df, label ~ feature, threshold = 1.0)
+  blr_model <- spark.logit(binary_df, label ~ feature, thresholds = 1.0)
   blr_predict <- collect(select(predict(blr_model, binary_df), "prediction"))
   expect_equal(blr_predict$prediction, c(0, 0, 0, 0, 0))
-  blr_model1 <- spark.logit(binary_df, label ~ feature, threshold = 0.0)
+  blr_model1 <- spark.logit(binary_df, label ~ feature, thresholds = 0.0)
   blr_predict1 <- collect(select(predict(blr_model1, binary_df), "prediction"))
   expect_equal(blr_predict1$prediction, c(1, 1, 1, 1, 1))
 
@@ -623,6 +623,8 @@ test_that("spark.logit", {
   blr_model2 <- read.ml(modelPath)
   blr_predict2 <- collect(select(predict(blr_model2, binary_df), "prediction"))
   expect_equal(blr_predict$prediction, blr_predict2$prediction)
+  expect_error(summary(blr_model2))
+  unlink(modelPath)
 
   # test multinomial logistic regression
   label <- c(0.0, 1.0, 2.0, 0.0, 0.0)

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -592,7 +592,7 @@ test_that("spark.logit", {
   label <- c(1.0, 1.0, 1.0, 0.0, 0.0)
   feature <- c(1.1419053, 0.9194079, -0.9498666, -1.1069903, 0.2809776)
   binary_data <- as.data.frame(cbind(label, feature))
-  binary_df <- suppressWarnings(createDataFrame(binary_data))
+  binary_df <- createDataFrame(binary_data)
 
   blr_model <- spark.logit(binary_df, label ~ feature, threshold = 1.0)
   blr_predict <- collect(select(predict(blr_model, binary_df), "prediction"))
@@ -631,7 +631,7 @@ test_that("spark.logit", {
   feature3 <- c(1.322733, 1.348044, 3.861237, 9.686976, 3.447130)
   feature4 <- c(1.3246388, 0.5510444, 0.9225810, 1.2147881, 1.6020842)
   data <- as.data.frame(cbind(label, feature1, feature2, feature3, feature4))
-  df <- suppressWarnings(createDataFrame(data))
+  df <- createDataFrame(data)
 
   model <- spark.logit(df, label ~., family = "multinomial", thresholds = c(0, 1, 1))
   predict1 <- collect(select(predict(model, df), "prediction"))

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -587,6 +587,17 @@ test_that("spark.isotonicRegression", {
   unlink(modelPath)
 })
 
+test_that("spark.logit", {
+  label <- c(1.0, 1.0, 1.0, 0.0, 0.0)
+  feature <- c(1.1419053, 0.9194079, -0.9498666, -1.1069903, 0.2809776)
+  binary_data <- as.data.frame(cbind(label, feature))
+  binary_df <- suppressWarnings(createDataFrame(binary_data))
+
+  blr_model <- spark.logit(binary_df, label ~ feature, threshold = 1.0)
+  blr_predict <- collect(select(predict(blr_model, binary_df), "prediction"))
+  expect_equal(blr_predict$prediction, c(0, 0, 0, 0, 0))
+})
+
 test_that("spark.gaussianMixture", {
   # R code to reproduce the result.
   # nolint start

--- a/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.r
+
+import org.apache.hadoop.fs.Path
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.classification.{BinaryLogisticRegressionSummary, LogisticRegression, LogisticRegressionModel}
+import org.apache.spark.ml.feature.RFormula
+import org.apache.spark.ml.util._
+import org.apache.spark.sql.{DataFrame, Dataset}
+
+private[r] class LogisticRegressionWrapper private (
+    val pipeline: PipelineModel,
+    val features: Array[String],
+    val isLoaded: Boolean = false) extends MLWritable {
+
+  private val logisticRegressionModel: LogisticRegressionModel =
+    pipeline.stages(1).asInstanceOf[LogisticRegressionModel]
+
+  lazy val totalIterations: Int = logisticRegressionModel.summary.totalIterations
+
+  lazy val objectiveHistory: Array[Double] = logisticRegressionModel.summary.objectiveHistory
+
+  lazy val roc: DataFrame =
+    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary].roc
+
+  lazy val areaUnderROC: Double =
+    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary].areaUnderROC
+
+  lazy val pr: DataFrame =
+    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary].pr
+
+  lazy val fMeasureByThreshold: DataFrame =
+    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary]
+      .fMeasureByThreshold
+
+  lazy val precisionByThreshold: DataFrame =
+    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary]
+      .precisionByThreshold
+
+  lazy val recallByThreshold: DataFrame =
+    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary]
+      .recallByThreshold
+
+  def transform(dataset: Dataset[_]): DataFrame = {
+    pipeline.transform(dataset).drop(logisticRegressionModel.getFeaturesCol)
+  }
+
+  override def write: MLWriter = new LogisticRegressionWrapper.LogisticRegressionWrapperWriter(this)
+}
+
+private[r] object LogisticRegressionWrapper
+    extends MLReadable[LogisticRegressionWrapper] {
+
+  def fit( // scalastyle:ignore
+      data: DataFrame,
+      formula: String,
+      regParam: Double,
+      elasticNetParam: Double,
+      maxIter: Int,
+      tol: Double,
+      fitIntercept: Boolean,
+      family: String,
+      standardization: Boolean,
+      threshold: Double,
+      thresholds: Array[Double],
+      weightCol: String,
+      aggregationDepth: Int
+      ): LogisticRegressionWrapper = {
+
+    val rFormula = new RFormula()
+      .setFormula(formula)
+      .setFeaturesCol("features")
+    RWrapperUtils.checkDataColumns(rFormula, data)
+    val rFormulaModel = rFormula.fit(data)
+
+    // get feature names from output schema
+    val schema = rFormulaModel.transform(data).schema
+    val featureAttrs = AttributeGroup.fromStructField(schema(rFormulaModel.getFeaturesCol))
+      .attributes.get
+    val features = featureAttrs.map(_.name.get)
+
+    // assemble and fit the pipeline
+    val logisticRegression = new LogisticRegression()
+      .setRegParam(regParam)
+      .setElasticNetParam(elasticNetParam)
+      .setMaxIter(maxIter)
+      .setTol(tol)
+      .setFitIntercept(fitIntercept)
+      .setFamily(family)
+      .setStandardization(standardization)
+      .setThreshold(threshold)
+      .setWeightCol(weightCol)
+      .setAggregationDepth(aggregationDepth)
+      .setFeaturesCol(rFormula.getFeaturesCol)
+
+    if (thresholds != null) {
+      logisticRegression.setThresholds(thresholds)
+    }
+
+    val pipeline = new Pipeline()
+      .setStages(Array(rFormulaModel, logisticRegression))
+      .fit(data)
+
+    new LogisticRegressionWrapper(pipeline, features)
+  }
+
+  override def read: MLReader[LogisticRegressionWrapper] = new LogisticRegressionWrapperReader
+
+  override def load(path: String): LogisticRegressionWrapper = super.load(path)
+
+  class LogisticRegressionWrapperWriter(instance: LogisticRegressionWrapper) extends MLWriter {
+
+    override protected def saveImpl(path: String): Unit = {
+      val rMetadataPath = new Path(path, "rMetadata").toString
+      val pipelinePath = new Path(path, "pipeline").toString
+
+      val rMetadata = ("class" -> instance.getClass.getName) ~
+        ("features" -> instance.features.toSeq)
+      val rMetadataJson: String = compact(render(rMetadata))
+      sc.parallelize(Seq(rMetadataJson), 1).saveAsTextFile(rMetadataPath)
+
+      instance.pipeline.save(pipelinePath)
+    }
+  }
+
+  class LogisticRegressionWrapperReader extends MLReader[LogisticRegressionWrapper] {
+
+    override def load(path: String): LogisticRegressionWrapper = {
+      implicit val format = DefaultFormats
+      val rMetadataPath = new Path(path, "rMetadata").toString
+      val pipelinePath = new Path(path, "pipeline").toString
+
+      val rMetadataStr = sc.textFile(rMetadataPath, 1).first()
+      val rMetadata = parse(rMetadataStr)
+      val features = (rMetadata \ "features").extract[Array[String]]
+
+      val pipeline = PipelineModel.load(pipelinePath)
+      new LogisticRegressionWrapper(pipeline, features, true)
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
@@ -82,7 +82,6 @@ private[r] object LogisticRegressionWrapper
       fitIntercept: Boolean,
       family: String,
       standardization: Boolean,
-      threshold: Double,
       thresholds: Array[Double],
       weightCol: String,
       aggregationDepth: Int,
@@ -109,14 +108,15 @@ private[r] object LogisticRegressionWrapper
       .setFitIntercept(fitIntercept)
       .setFamily(family)
       .setStandardization(standardization)
-      .setThreshold(threshold)
       .setWeightCol(weightCol)
       .setAggregationDepth(aggregationDepth)
       .setFeaturesCol(rFormula.getFeaturesCol)
       .setProbabilityCol(probability)
 
-    if (thresholds != null) {
+    if (thresholds.length > 1) {
       logisticRegression.setThresholds(thresholds)
+    } else {
+      logisticRegression.setThreshold(thresholds(0))
     }
 
     val pipeline = new Pipeline()

--- a/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
@@ -85,12 +85,12 @@ private[r] object LogisticRegressionWrapper
       threshold: Double,
       thresholds: Array[Double],
       weightCol: String,
-      aggregationDepth: Int
+      aggregationDepth: Int,
+      probability: String
       ): LogisticRegressionWrapper = {
 
     val rFormula = new RFormula()
       .setFormula(formula)
-      .setFeaturesCol("features")
     RWrapperUtils.checkDataColumns(rFormula, data)
     val rFormulaModel = rFormula.fit(data)
 
@@ -113,6 +113,7 @@ private[r] object LogisticRegressionWrapper
       .setWeightCol(weightCol)
       .setAggregationDepth(aggregationDepth)
       .setFeaturesCol(rFormula.getFeaturesCol)
+      .setProbabilityCol(probability)
 
     if (thresholds != null) {
       logisticRegression.setThresholds(thresholds)

--- a/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/LogisticRegressionWrapper.scala
@@ -41,26 +41,20 @@ private[r] class LogisticRegressionWrapper private (
 
   lazy val objectiveHistory: Array[Double] = logisticRegressionModel.summary.objectiveHistory
 
-  lazy val roc: DataFrame =
-    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary].roc
-
-  lazy val areaUnderROC: Double =
-    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary].areaUnderROC
-
-  lazy val pr: DataFrame =
-    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary].pr
-
-  lazy val fMeasureByThreshold: DataFrame =
+  lazy val blrSummary =
     logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary]
-      .fMeasureByThreshold
 
-  lazy val precisionByThreshold: DataFrame =
-    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary]
-      .precisionByThreshold
+  lazy val roc: DataFrame = blrSummary.roc
 
-  lazy val recallByThreshold: DataFrame =
-    logisticRegressionModel.summary.asInstanceOf[BinaryLogisticRegressionSummary]
-      .recallByThreshold
+  lazy val areaUnderROC: Double = blrSummary.areaUnderROC
+
+  lazy val pr: DataFrame = blrSummary.pr
+
+  lazy val fMeasureByThreshold: DataFrame = blrSummary.fMeasureByThreshold
+
+  lazy val precisionByThreshold: DataFrame = blrSummary.precisionByThreshold
+
+  lazy val recallByThreshold: DataFrame = blrSummary.recallByThreshold
 
   def transform(dataset: Dataset[_]): DataFrame = {
     pipeline.transform(dataset).drop(logisticRegressionModel.getFeaturesCol)
@@ -157,7 +151,7 @@ private[r] object LogisticRegressionWrapper
       val features = (rMetadata \ "features").extract[Array[String]]
 
       val pipeline = PipelineModel.load(pipelinePath)
-      new LogisticRegressionWrapper(pipeline, features, true)
+      new LogisticRegressionWrapper(pipeline, features, isLoaded = true)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
@@ -54,6 +54,8 @@ private[r] object RWrappers extends MLReader[Object] {
         GaussianMixtureWrapper.load(path)
       case "org.apache.spark.ml.r.ALSWrapper" =>
         ALSWrapper.load(path)
+      case "org.apache.spark.ml.r.LogisticRegressionWrapper" =>
+        LogisticRegressionWrapper.load(path)
       case _ =>
         throw new SparkException(s"SparkR read.ml does not support load $className")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As we discussed in #14818, I added a separate R wrapper spark.logit for logistic regression. 

This single interface supports both binary and multinomial logistic regression. It also has "predict" and "summary" for binary logistic regression. 
## How was this patch tested?

New unit tests are added.
