### PR TITLE
[SPARK-17795] [Web UI] Sorting on stage or job tables doesn’t reload page on that table

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -216,6 +216,7 @@ private[ui] class AllJobsPage(parent: JobsTab) extends WebUIPage("") {
 
   private def jobsTable(
       request: HttpServletRequest,
+      tableHeaderId: String,
       jobTag: String,
       jobs: Seq[JobUIData]): Seq[Node] = {
     val allParameters = request.getParameterMap.asScala.toMap
@@ -256,6 +257,7 @@ private[ui] class AllJobsPage(parent: JobsTab) extends WebUIPage("") {
     try {
       new JobPagedTable(
         jobs,
+        tableHeaderId,
         jobTag,
         UIUtils.prependBaseUri(parent.basePath),
         "jobs", // subPath
@@ -288,9 +290,9 @@ private[ui] class AllJobsPage(parent: JobsTab) extends WebUIPage("") {
       val completedJobs = listener.completedJobs.reverse.toSeq
       val failedJobs = listener.failedJobs.reverse.toSeq
 
-      val activeJobsTable = jobsTable(request, "activeJob", activeJobs)
-      val completedJobsTable = jobsTable(request, "completedJob", completedJobs)
-      val failedJobsTable = jobsTable(request, "failedJob", failedJobs)
+      val activeJobsTable = jobsTable(request, "active", "activeJob", activeJobs)
+      val completedJobsTable = jobsTable(request, "completed", "completedJob", completedJobs)
+      val failedJobsTable = jobsTable(request, "failed", "failedJob", failedJobs)
 
       val shouldShowActiveJobs = activeJobs.nonEmpty
       val shouldShowCompletedJobs = completedJobs.nonEmpty
@@ -486,6 +488,7 @@ private[ui] class JobDataSource(
 }
 private[ui] class JobPagedTable(
     data: Seq[JobUIData],
+    tableHeaderId: String,
     jobTag: String,
     basePath: String,
     subPath: String,
@@ -528,12 +531,13 @@ private[ui] class JobPagedTable(
       s"&$pageNumberFormField=$page" +
       s"&$jobTag.sort=$encodedSortColumn" +
       s"&$jobTag.desc=$desc" +
-      s"&$pageSizeFormField=$pageSize"
+      s"&$pageSizeFormField=$pageSize" +
+      s"#$tableHeaderId"
   }
 
   override def goButtonFormPath: String = {
     val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
-    s"$parameterPath&$jobTag.sort=$encodedSortColumn&$jobTag.desc=$desc"
+    s"$parameterPath&$jobTag.sort=$encodedSortColumn&$jobTag.desc=$desc#$tableHeaderId"
   }
 
   override def headers: Seq[Node] = {
@@ -557,7 +561,8 @@ private[ui] class JobPagedTable(
             parameterPath +
               s"&$jobTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
               s"&$jobTag.desc=${!desc}" +
-              s"&$jobTag.pageSize=$pageSize")
+              s"&$jobTag.pageSize=$pageSize" +
+              s"#$tableHeaderId")
           val arrow = if (desc) "&#x25BE;" else "&#x25B4;" // UP or DOWN
 
           <th class={cssClass}>
@@ -572,7 +577,8 @@ private[ui] class JobPagedTable(
             val headerLink = Unparsed(
               parameterPath +
                 s"&$jobTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
-                s"&$jobTag.pageSize=$pageSize")
+                s"&$jobTag.pageSize=$pageSize" +
+                s"#$tableHeaderId")
 
             <th class={cssClass}>
               <a href={headerLink}>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -41,19 +41,19 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       val subPath = "stages"
 
       val activeStagesTable =
-        new StageTableBase(request, activeStages, "activeStage", parent.basePath, subPath,
+        new StageTableBase(request, activeStages, "active", "activeStage", parent.basePath, subPath,
           parent.progressListener, parent.isFairScheduler,
           killEnabled = parent.killEnabled, isFailedStage = false)
       val pendingStagesTable =
-        new StageTableBase(request, pendingStages, "pendingStage", parent.basePath, subPath,
-          parent.progressListener, parent.isFairScheduler,
+        new StageTableBase(request, pendingStages, "pending", "pendingStage", parent.basePath,
+          subPath, parent.progressListener, parent.isFairScheduler,
           killEnabled = false, isFailedStage = false)
       val completedStagesTable =
-        new StageTableBase(request, completedStages, "completedStage", parent.basePath, subPath,
-          parent.progressListener, parent.isFairScheduler,
+        new StageTableBase(request, completedStages, "completed", "completedStage", parent.basePath,
+          subPath, parent.progressListener, parent.isFairScheduler,
           killEnabled = false, isFailedStage = false)
       val failedStagesTable =
-        new StageTableBase(request, failedStages, "failedStage", parent.basePath, subPath,
+        new StageTableBase(request, failedStages, "failed", "failedStage", parent.basePath, subPath,
           parent.progressListener, parent.isFairScheduler,
           killEnabled = false, isFailedStage = true)
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -230,20 +230,27 @@ private[ui] class JobPage(parent: JobsTab) extends WebUIPage("job") {
 
       val basePath = "jobs/job"
 
+      val pendingOrSkippedTableId =
+        if (isComplete) {
+          "pending"
+        } else {
+          "skipped"
+        }
+
       val activeStagesTable =
-        new StageTableBase(request, activeStages, "activeStage", parent.basePath,
+        new StageTableBase(request, activeStages, "active", "activeStage", parent.basePath,
           basePath, parent.jobProgresslistener, parent.isFairScheduler,
           killEnabled = parent.killEnabled, isFailedStage = false)
       val pendingOrSkippedStagesTable =
-        new StageTableBase(request, pendingOrSkippedStages, "pendingStage", parent.basePath,
-          basePath, parent.jobProgresslistener, parent.isFairScheduler,
+        new StageTableBase(request, pendingOrSkippedStages, pendingOrSkippedTableId, "pendingStage",
+          parent.basePath, basePath, parent.jobProgresslistener, parent.isFairScheduler,
           killEnabled = false, isFailedStage = false)
       val completedStagesTable =
-        new StageTableBase(request, completedStages, "completedStage", parent.basePath,
+        new StageTableBase(request, completedStages, "completed", "completedStage", parent.basePath,
           basePath, parent.jobProgresslistener, parent.isFairScheduler,
           killEnabled = false, isFailedStage = false)
       val failedStagesTable =
-        new StageTableBase(request, failedStages, "failedStage", parent.basePath,
+        new StageTableBase(request, failedStages, "failed", "failedStage", parent.basePath,
           basePath, parent.jobProgresslistener, parent.isFairScheduler,
           killEnabled = false, isFailedStage = true)
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -44,7 +44,7 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
       }
       val shouldShowActiveStages = activeStages.nonEmpty
       val activeStagesTable =
-        new StageTableBase(request, activeStages, "activeStage", parent.basePath, "stages/pool",
+        new StageTableBase(request, activeStages, "", "activeStage", parent.basePath, "stages/pool",
           parent.progressListener, parent.isFairScheduler, parent.killEnabled,
           isFailedStage = false)
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -34,6 +34,7 @@ import org.apache.spark.util.Utils
 private[ui] class StageTableBase(
     request: HttpServletRequest,
     stages: Seq[StageInfo],
+    tableHeaderID: String,
     stageTag: String,
     basePath: String,
     subPath: String,
@@ -77,6 +78,7 @@ private[ui] class StageTableBase(
   val toNodeSeq = try {
     new StagePagedTable(
       stages,
+      tableHeaderID,
       stageTag,
       basePath,
       subPath,
@@ -131,6 +133,7 @@ private[ui] class MissingStageTableRowData(
 /** Page showing list of all ongoing and recently finished stages */
 private[ui] class StagePagedTable(
     stages: Seq[StageInfo],
+    tableHeaderId: String,
     stageTag: String,
     basePath: String,
     subPath: String,
@@ -173,12 +176,13 @@ private[ui] class StagePagedTable(
       s"&$pageNumberFormField=$page" +
       s"&$stageTag.sort=$encodedSortColumn" +
       s"&$stageTag.desc=$desc" +
-      s"&$pageSizeFormField=$pageSize"
+      s"&$pageSizeFormField=$pageSize" +
+      s"#$tableHeaderId"
   }
 
   override def goButtonFormPath: String = {
     val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
-    s"$parameterPath&$stageTag.sort=$encodedSortColumn&$stageTag.desc=$desc"
+    s"$parameterPath&$stageTag.sort=$encodedSortColumn&$stageTag.desc=$desc#$tableHeaderId"
   }
 
   override def headers: Seq[Node] = {
@@ -226,7 +230,8 @@ private[ui] class StagePagedTable(
             parameterPath +
               s"&$stageTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
               s"&$stageTag.desc=${!desc}" +
-              s"&$stageTag.pageSize=$pageSize")
+              s"&$stageTag.pageSize=$pageSize") +
+              s"#$tableHeaderId"
           val arrow = if (desc) "&#x25BE;" else "&#x25B4;" // UP or DOWN
 
           <th>
@@ -241,7 +246,8 @@ private[ui] class StagePagedTable(
             val headerLink = Unparsed(
               parameterPath +
                 s"&$stageTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
-                s"&$stageTag.pageSize=$pageSize")
+                s"&$stageTag.pageSize=$pageSize") +
+                s"#$tableHeaderId"
 
             <th>
               <a href={headerLink}>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added anchor on table header id to sorting links on job and stage tables. This make the page reload after a sort load the page at the sorted table. 

This only changes page load behavior so no UI changes
## How was this patch tested?

manually tested and dev/run-tests
