### PR TITLE
[SPARK-17797] getNumClasses support non-double datatypes

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -108,7 +108,8 @@ abstract class Classifier[
       case Some(n: Int) => n
       case None =>
         // Get number of classes from dataset itself.
-        val maxLabelRow: Array[Row] = dataset.select(max($(labelCol))).take(1)
+        val maxLabelRow: Array[Row] = dataset.select(max(col($(labelCol)).cast(DoubleType)))
+          .take(1)
         if (maxLabelRow.isEmpty) {
           throw new SparkException("ML algorithm was given empty dataset.")
         }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -117,7 +117,7 @@ object MLTestingUtils extends SparkFunSuite {
       Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
     types.map { t =>
         val castDF = df.select(col(labelColName).cast(t), col(featuresColName))
-        t -> TreeTests.setMetadata(castDF, 2, labelColName, featuresColName)
+        t -> TreeTests.setMetadata(castDF, 0, labelColName, featuresColName)
       }.toMap
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1, modify `Classifier.getNumClasses` to support all numeric datatypes
2, modify `MLTestingUtils` to run estimator's `fit` without precomputed `numClasses`
## How was this patch tested?

unit tests, manual tests
