### PR TITLE
[SPARK-17796][SQL] Support wildcard character in filename for LOAD DATA LOCAL INPATH

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -252,7 +252,7 @@ case class LoadDataCommand(
           val fileSystem = FileSystems.getDefault
           val pathPattern = fileSystem.getPath(filePath)
           val dir = pathPattern.getParent.toString
-          val filePattern = pathPattern.getName(pathPattern.getNameCount - 1).toString
+          val filePattern = pathPattern.getFileName.toString
           if (dir.contains("*")) {
             throw new AnalysisException(
               s"LOAD DATA input path allows only filename wildcard: $path")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -252,7 +252,6 @@ case class LoadDataCommand(
           val fileSystem = FileSystems.getDefault
           val pathPattern = fileSystem.getPath(filePath)
           val dir = pathPattern.getParent.toString
-          val filePattern = pathPattern.getFileName.toString
           if (dir.contains("*")) {
             throw new AnalysisException(
               s"LOAD DATA input path allows only filename wildcard: $path")
@@ -262,8 +261,8 @@ case class LoadDataCommand(
           if (files == null) {
             false
           } else {
-            val matcher = fileSystem.getPathMatcher("glob:" + filePattern)
-            files.exists(f => matcher.matches(fileSystem.getPath(f.getName)))
+            val matcher = fileSystem.getPathMatcher("glob:" + pathPattern.toAbsolutePath)
+            files.exists(f => matcher.matches(fileSystem.getPath(f.getAbsolutePath)))
           }
         } else {
           new File(filePath).exists()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -249,9 +249,10 @@ case class LoadDataCommand(
         val uri = Utils.resolveURI(path)
         val filePath = uri.getPath()
         val exists = if (filePath.contains("*")) {
-          val splitPath = filePath.split(File.separator)
-          val filePattern = splitPath.last
-          val dir = splitPath.dropRight(1).mkString(File.separator)
+          val fileSystem = FileSystems.getDefault
+          val pathPattern = fileSystem.getPath(filePath)
+          val dir = pathPattern.getParent.toString
+          val filePattern = pathPattern.getName(pathPattern.getNameCount - 1).toString
           if (dir.contains("*")) {
             throw new AnalysisException(
               s"LOAD DATA input path allows only filename wildcard: $path")
@@ -261,8 +262,8 @@ case class LoadDataCommand(
           if (files == null) {
             false
           } else {
-            val matcher = FileSystems.getDefault.getPathMatcher("glob:" + filePattern)
-            files.exists(f => matcher.matches(FileSystems.getDefault.getPath(f.getName)))
+            val matcher = fileSystem.getPathMatcher("glob:" + filePattern)
+            files.exists(f => matcher.matches(fileSystem.getPath(f.getName)))
           }
         } else {
           new File(filePath).exists()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive.execution
 
+import java.io.{File, PrintWriter}
 import java.sql.{Date, Timestamp}
 
 import scala.sys.process.{Process, ProcessLogger}
@@ -1883,6 +1884,37 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         "SELECT 1 AS id, CAST('1990-02-24' AS DATE) AS pd, CAST('1990-02-24' AS TIMESTAMP) AS pt")
       checkAnswer(actual, expected)
       sql("DROP TABLE order")
+    }
+  }
+
+  test("SPARK-17796 Support wildcard character in filename for LOAD DATA LOCAL INPATH") {
+    withTempDir { dir =>
+      for (i <- 1 to 3) {
+        val writer = new PrintWriter(new File(s"$dir/part-r-0000$i"))
+        writer.write(s"$i")
+        writer.close()
+      }
+      for (i <- 5 to 7) {
+        val writer = new PrintWriter(new File(s"$dir/part-s-0000$i"))
+        writer.write(s"$i")
+        writer.close()
+      }
+
+      withTable("load_t") {
+        sql("CREATE TABLE load_t (a STRING)")
+        sql(s"LOAD DATA LOCAL INPATH '$dir/*part-r*' INTO TABLE load_t")
+        checkAnswer(sql("SELECT * FROM load_t"), Seq(Row("1"), Row("2"), Row("3")))
+
+        val m = intercept[AnalysisException] {
+          sql("LOAD DATA LOCAL INPATH '/non-exist-folder/*part*' INTO TABLE load_t")
+        }.getMessage
+        assert(m.contains("LOAD DATA input path does not exist"))
+
+        val m2 = intercept[AnalysisException] {
+          sql(s"LOAD DATA LOCAL INPATH '$dir*/*part*' INTO TABLE load_t")
+        }.getMessage
+        assert(m2.contains("LOAD DATA input path allows only filename wildcard"))
+      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -18,11 +18,13 @@
 package org.apache.spark.sql.hive.execution
 
 import java.io.{File, PrintWriter}
+import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 
 import scala.sys.process.{Process, ProcessLogger}
 import scala.util.Try
 
+import com.google.common.io.Files
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql._
@@ -1890,14 +1892,10 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("SPARK-17796 Support wildcard character in filename for LOAD DATA LOCAL INPATH") {
     withTempDir { dir =>
       for (i <- 1 to 3) {
-        val writer = new PrintWriter(new File(s"$dir/part-r-0000$i"))
-        writer.write(s"$i")
-        writer.close()
+        Files.write(s"$i", new File(s"$dir/part-r-0000$i"), StandardCharsets.UTF_8)
       }
       for (i <- 5 to 7) {
-        val writer = new PrintWriter(new File(s"$dir/part-s-0000$i"))
-        writer.write(s"$i")
-        writer.close()
+        Files.write(s"$i", new File(s"$dir/part-s-0000$i"), StandardCharsets.UTF_8)
       }
 
       withTable("load_t") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark 2.0 raises an `input path does not exist` AnalysisException if the file name contains '*'. It is misleading since it occurs when there exist some matched files. Also, it was a supported feature in Spark 1.6.2. This PR aims to support wildcard characters in filename for `LOAD DATA LOCAL INPATH` SQL command like Spark 1.6.2.

**Reported Error Scenario**

``` scala
scala> sql("CREATE TABLE t(a string)")
res0: org.apache.spark.sql.DataFrame = []

scala> sql("LOAD DATA LOCAL INPATH '/tmp/x*' INTO TABLE t")
org.apache.spark.sql.AnalysisException: LOAD DATA input path does not exist: /tmp/x*;
```
## How was this patch tested?

Pass the Jenkins test with a new test case.
