### PR TITLE
[SPARK-17346][SQL][Tests]Fix the flaky topic deletion in KafkaSourceStressSuite

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.util.Random
 
 import org.apache.kafka.clients.producer.RecordMetadata
-import org.scalatest.BeforeAndAfter
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql.execution.streaming._
@@ -344,7 +343,7 @@ class KafkaSourceSuite extends KafkaSourceTest {
 }
 
 
-class KafkaSourceStressSuite extends KafkaSourceTest with BeforeAndAfter {
+class KafkaSourceStressSuite extends KafkaSourceTest {
 
   import testImplicits._
 
@@ -356,13 +355,6 @@ class KafkaSourceStressSuite extends KafkaSourceTest with BeforeAndAfter {
 
   private def nextInt(start: Int, end: Int): Int = {
     start + Random.nextInt(start + end - 1)
-  }
-
-  after {
-    for (topic <-
-         testUtils.getAllTopicsAndPartitionSize().toMap.keys.filter(_.startsWith("stress"))) {
-      testUtils.deleteTopic(topic)
-    }
   }
 
   test("stress test with multiple topics and partitions")  {

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
@@ -359,7 +359,8 @@ class KafkaSourceStressSuite extends KafkaSourceTest with BeforeAndAfter {
   }
 
   after {
-    for (topic <- testUtils.getAllTopicsAndPartitionSize().toMap.keys.filter(!_.startsWith("__"))) {
+    for (topic <-
+         testUtils.getAllTopicsAndPartitionSize().toMap.keys.filter(_.startsWith("stress"))) {
       testUtils.deleteTopic(topic)
     }
   }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
@@ -359,7 +359,7 @@ class KafkaSourceStressSuite extends KafkaSourceTest with BeforeAndAfter {
   }
 
   after {
-    for (topic <- testUtils.getAllTopicsAndPartitionSize().toMap.keys) {
+    for (topic <- testUtils.getAllTopicsAndPartitionSize().toMap.keys.filter(!_.startsWith("__"))) {
       testUtils.deleteTopic(topic)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A follow up Pr for SPARK-17346 to fix flaky `org.apache.spark.sql.kafka010.KafkaSourceStressSuite`.

Test log: https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.4/1855/testReport/junit/org.apache.spark.sql.kafka010/KafkaSourceStressSuite/_It_is_not_a_test_/

Looks like deleting the Kafka internal topic `__consumer_offsets` is flaky. This PR just simply ignores internal topics.
## How was this patch tested?

Existing tests.
