### PR TITLE
[SPARK-17782][STREAMING][KAFKA] eliminate race condition of poll twice

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/ConsumerStrategy.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/ConsumerStrategy.scala
@@ -159,6 +159,7 @@ private case class SubscribePattern[K, V](
       // we've called poll, we must pause or next poll may consume messages and set position
       consumer.pause(consumer.assignment())
     }
+
     consumer
   }
 }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/ConsumerStrategy.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/ConsumerStrategy.scala
@@ -104,6 +104,8 @@ private case class Subscribe[K, V](
       toSeek.asScala.foreach { case (topicPartition, offset) =>
           consumer.seek(topicPartition, offset)
       }
+      // we've called poll, we must pause or next poll may consume messages and set position
+      consumer.pause(consumer.assignment())
     }
 
     consumer
@@ -154,8 +156,9 @@ private case class SubscribePattern[K, V](
       toSeek.asScala.foreach { case (topicPartition, offset) =>
           consumer.seek(topicPartition, offset)
       }
+      // we've called poll, we must pause or next poll may consume messages and set position
+      consumer.pause(consumer.assignment())
     }
-
     consumer
   }
 }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -223,7 +223,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
 
   override def start(): Unit = {
     val c = consumer
-    c.poll(0)
+    assert(c.poll(0).isEmpty, "Driver shouldn't consume messages; pause if you poll during setup")
     if (currentOffsets.isEmpty) {
       currentOffsets = c.assignment().asScala.map { tp =>
         tp -> c.position(tp)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kafka consumers can't subscribe or maintain heartbeat without polling, but polling ordinarily consumes messages and adjusts position.  We don't want this on the driver, so we poll with a timeout of 0 and pause all topicpartitions.

Some consumer strategies that seek to particular positions have to poll first, but they weren't pausing immediately thereafter.  Thus, there was a race condition where the second poll() in the DStream start method might actually adjust consumer position.

Eliminated (or at least drastically reduced the chance of) the race condition via pausing in the relevant consumer strategies, and assert on startup that no messages were consumed.
## How was this patch tested?

I reliably reproduced the intermittent test failure by inserting a thread.sleep directly before returning from SubscribePattern.  The suggested fix eliminated the failure.
