### PR TITLE
[SPARK-17821][SQL] Support And and Or in Expression Canonicalize

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
@@ -62,8 +62,12 @@ object Canonicalize extends {
     case a: Add => orderCommutative(a, { case Add(l, r) => Seq(l, r) }).reduce(Add)
     case m: Multiply => orderCommutative(m, { case Multiply(l, r) => Seq(l, r) }).reduce(Multiply)
 
-    case o: Or => orderCommutative(o, { case Or(l, r) => Seq(l, r) }).reduce(Or)
-    case a: And => orderCommutative(a, { case And(l, r) => Seq(l, r)}).reduce(And)
+    case o: Or =>
+      orderCommutative(o, { case Or(l, r) if l.deterministic && r.deterministic => Seq(l, r) })
+        .reduce(Or)
+    case a: And =>
+      orderCommutative(a, { case And(l, r) if l.deterministic && r.deterministic => Seq(l, r)})
+        .reduce(And)
 
     case EqualTo(l, r) if l.hashCode() > r.hashCode() => EqualTo(r, l)
     case EqualNullSafe(l, r) if l.hashCode() > r.hashCode() => EqualNullSafe(r, l)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
@@ -62,6 +62,9 @@ object Canonicalize extends {
     case a: Add => orderCommutative(a, { case Add(l, r) => Seq(l, r) }).reduce(Add)
     case m: Multiply => orderCommutative(m, { case Multiply(l, r) => Seq(l, r) }).reduce(Multiply)
 
+    case o: Or => orderCommutative(o, { case Or(l, r) => Seq(l, r) }).reduce(Or)
+    case a: And => orderCommutative(a, { case And(l, r) => Seq(l, r)}).reduce(And)
+
     case EqualTo(l, r) if l.hashCode() > r.hashCode() => EqualTo(r, l)
     case EqualNullSafe(l, r) if l.hashCode() > r.hashCode() => EqualNullSafe(r, l)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -82,21 +82,37 @@ class ExpressionSetSuite extends SparkFunSuite {
 
   setTest(1, aUpper > bUpper && aUpper <= 10, aUpper <= 10 && aUpper > bUpper)
   setTest(1,
-    aUpper > bUpper &&
-      bUpper > 100 &&
-      aUpper <= 10,
-    bUpper > 100 &&
-      aUpper <= 10 &&
-      aUpper > bUpper)
+    aUpper > bUpper && bUpper > 100 && aUpper <= 10,
+    bUpper > 100 && aUpper <= 10 && aUpper > bUpper)
 
   setTest(1, aUpper > bUpper || aUpper <= 10, aUpper <= 10 || aUpper > bUpper)
   setTest(1,
-    aUpper > bUpper ||
-      bUpper > 100 ||
-      aUpper <= 10,
-    bUpper > 100 ||
-      aUpper <= 10 ||
-      aUpper > bUpper)
+    aUpper > bUpper || bUpper > 100 || aUpper <= 10,
+    bUpper > 100 || aUpper <= 10 || aUpper > bUpper)
+
+  setTest(1,
+    bUpper > 100 || aUpper <= 10 && aUpper > bUpper,
+    bUpper > 100 || (aUpper <= 10 && aUpper > bUpper))
+
+  setTest(1,
+    aUpper > 10 && bUpper < 10 || aUpper >= bUpper,
+    (bUpper < 10 && aUpper > 10) || aUpper >= bUpper)
+
+  setTest(1,
+    bUpper > 100 || aUpper < 100 && bUpper <= aUpper || aUpper >= 10 && bUpper >= 50,
+    (aUpper >= 10 && bUpper >= 50) || bUpper > 100 || (aUpper < 100 && bUpper <= aUpper),
+    (bUpper >= 50 && aUpper >= 10) || (bUpper <= aUpper && aUpper < 100) || bUpper > 100)
+
+  setTest(1,
+    bUpper > 100 && aUpper < 100 && bUpper <= aUpper || aUpper >= 10 && bUpper >= 50,
+    (aUpper >= 10 && bUpper >= 50) || (aUpper < 100 && bUpper > 100 && bUpper <= aUpper),
+    (bUpper >= 50 && aUpper >= 10) || (bUpper <= aUpper && aUpper < 100 && bUpper > 100))
+
+  setTest(1,
+    aUpper >= 10 || bUpper <= 10 && aUpper === bUpper && aUpper < 100 || bUpper >= 100,
+    aUpper === bUpper && aUpper < 100 && bUpper <= 10 || bUpper >= 100 || aUpper >= 10,
+    aUpper < 100 && bUpper <= 10 && aUpper === bUpper || aUpper >= 10 || bUpper >= 100,
+    ((bUpper <= 10 && aUpper === bUpper) && aUpper < 100) || (aUpper >= 10 || bUpper >= 100))
 
   // Don't reorder non-deterministic expression in AND/OR.
   setTest(2, Rand(1L) > aUpper && aUpper <= 10, aUpper <= 10 && Rand(1L) > aUpper)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -98,6 +98,25 @@ class ExpressionSetSuite extends SparkFunSuite {
       aUpper <= 10 ||
       aUpper > bUpper)
 
+  // Don't reorder non-deterministic expression in AND/OR.
+  setTest(2, Rand(1L) > aUpper && aUpper <= 10, aUpper <= 10 && Rand(1L) > aUpper)
+  setTest(2,
+    aUpper > bUpper &&
+      bUpper > 100 &&
+      Rand(1L) > aUpper,
+    bUpper > 100 &&
+      Rand(1L) > aUpper &&
+      aUpper > bUpper)
+
+  setTest(2, Rand(1L) > aUpper || aUpper <= 10, aUpper <= 10 || Rand(1L) > aUpper)
+  setTest(2,
+    aUpper > bUpper ||
+      aUpper <= Rand(1L) ||
+      aUpper <= 10,
+    aUpper <= Rand(1L) ||
+      aUpper <= 10 ||
+      aUpper > bUpper)
+
   test("add to / remove from set") {
     val initialSet = ExpressionSet(aUpper + 1 :: Nil)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -80,6 +80,24 @@ class ExpressionSetSuite extends SparkFunSuite {
   setTest(1, Not(aUpper >= 1), aUpper < 1, Not(Literal(1) <= aUpper), Literal(1) > aUpper)
   setTest(1, Not(aUpper <= 1), aUpper > 1, Not(Literal(1) >= aUpper), Literal(1) < aUpper)
 
+  setTest(1, aUpper > bUpper && aUpper <= 10, aUpper <= 10 && aUpper > bUpper)
+  setTest(1,
+    aUpper > bUpper &&
+      bUpper > 100 &&
+      aUpper <= 10,
+    bUpper > 100 &&
+      aUpper <= 10 &&
+      aUpper > bUpper)
+
+  setTest(1, aUpper > bUpper || aUpper <= 10, aUpper <= 10 || aUpper > bUpper)
+  setTest(1,
+    aUpper > bUpper ||
+      bUpper > 100 ||
+      aUpper <= 10,
+    bUpper > 100 ||
+      aUpper <= 10 ||
+      aUpper > bUpper)
+
   test("add to / remove from set") {
     val initialSet = ExpressionSet(aUpper + 1 :: Nil)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `Canonicalize` object doesn't support `And` and `Or`. So we can compare canonicalized form of predicates consistently. We should add the support.
## How was this patch tested?

Jenkins tests.
