### PR TITLE
[MINOR][ML]:remove redundant comment in LogisticRegression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -78,7 +78,6 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
   /**
    * Param for the name of family which is a description of the label distribution
    * to be used in the model.
-   * Supported options: "auto", "multinomial", "binomial".
    * Supported options:
    *  - "auto": Automatically select the family based on the number of classes:
    *            If numClasses == 1 || numClasses == 2, set to "binomial".


### PR DESCRIPTION
## What changes were proposed in this pull request?

While adding R wrapper for LogisticRegression, I found one extra comment. It is minor and I just remove it.
## How was this patch tested?

Unit tests
