### PR TITLE
[SPARK-17835][ML][MLlib] Optimize NaiveBayes mllib wrapper to eliminate extra pass on data

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -364,6 +364,7 @@ class NaiveBayes private (
     val nb = new NewNaiveBayes()
       .setModelType(modelType)
       .setSmoothing(lambda)
+      .setIsML(false)
 
     val dataset = data.map { case LabeledPoint(label, features) => (label, features.asML) }
       .toDF("label", "features")
@@ -377,6 +378,8 @@ class NaiveBayes private (
         theta(i)(j) = v
     }
 
+    require(newModel.oldLabels != null,
+      "The underlying ML NaiveBayes training does not produce labels.")
     new NaiveBayesModel(newModel.oldLabels, pi, theta, modelType)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -365,14 +365,8 @@ class NaiveBayes private (
       .setModelType(modelType)
       .setSmoothing(lambda)
 
-    val labels = data.map(_.label).distinct().collect().sorted
-
-    // Input labels for [[org.apache.spark.ml.classification.NaiveBayes]] must be
-    // in range [0, numClasses).
-    val dataset = data.map {
-      case LabeledPoint(label, features) =>
-        (labels.indexOf(label).toDouble, features.asML)
-    }.toDF("label", "features")
+    val dataset = data.map { case LabeledPoint(label, features) => (label, features.asML) }
+      .toDF("label", "features")
 
     val newModel = nb.fit(dataset)
 
@@ -383,7 +377,7 @@ class NaiveBayes private (
         theta(i)(j) = v
     }
 
-    new NaiveBayesModel(labels, pi, theta, modelType)
+    new NaiveBayesModel(newModel.oldLabels, pi, theta, modelType)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[SPARK-14077](https://issues.apache.org/jira/browse/SPARK-14077) copied the `NaiveBayes` implementation from mllib to ml and left mllib as a wrapper. However, there are some difference between mllib and ml to handle labels:
- mllib allow input labels as {-1, +1}, however, ml assumes the input labels in range [0, numClasses).
- mllib `NaiveBayesModel` expose `labels` but ml did not due to the assumption mention above.

During the copy in [SPARK-14077](https://issues.apache.org/jira/browse/SPARK-14077), we use
`val labels = data.map(_.label).distinct().collect().sorted`
to get the distinct labels firstly, and then encode the labels for training. It involves extra Spark job compared with the original implementation. Since `NaiveBayes` only do one pass aggregation during training, adding another one seems less efficient. We can get the labels in a single pass along with `NaiveBayes` training and send them to MLlib side.
## How was this patch tested?

Existing tests.
