### PR TITLE
[SPARK-15917][CORE] Added support for number of executors in Standalone [WIP]

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -456,8 +456,6 @@ object SparkSubmit {
 
       // Yarn only
       OptionAssigner(args.queue, YARN, ALL_DEPLOY_MODES, sysProp = "spark.yarn.queue"),
-      OptionAssigner(args.numExecutors, YARN, ALL_DEPLOY_MODES,
-        sysProp = "spark.executor.instances"),
       OptionAssigner(args.jars, YARN, ALL_DEPLOY_MODES, sysProp = "spark.yarn.dist.jars"),
       OptionAssigner(args.files, YARN, ALL_DEPLOY_MODES, sysProp = "spark.yarn.dist.files"),
       OptionAssigner(args.archives, YARN, ALL_DEPLOY_MODES, sysProp = "spark.yarn.dist.archives"),
@@ -469,6 +467,8 @@ object SparkSubmit {
         sysProp = "spark.executor.cores"),
       OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN, ALL_DEPLOY_MODES,
         sysProp = "spark.executor.memory"),
+      OptionAssigner(args.numExecutors, STANDALONE | YARN, ALL_DEPLOY_MODES,
+        sysProp = "spark.executor.instances"),
       OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS, ALL_DEPLOY_MODES,
         sysProp = "spark.cores.max"),
       OptionAssigner(args.files, LOCAL | STANDALONE | MESOS, ALL_DEPLOY_MODES,

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -637,6 +637,14 @@ private[deploy] class Master(
       }
       freeWorkers = freeWorkers.filter(canLaunchExecutor)
     }
+
+    // Check to see if we managed to launch the requested number of executors
+    val numExecutorsLaunched = assignedExecutors.sum
+    if(numExecutorsLaunched != app.executorLimit) {
+      logWarning(s"Failed to launch the requested number of executors due to resource limits : " +
+        s"only $numExecutorsLaunched executors instead of ${app.executorLimit}")
+    }
+
     assignedCores
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -638,11 +638,13 @@ private[deploy] class Master(
       freeWorkers = freeWorkers.filter(canLaunchExecutor)
     }
 
+    val numExecutorsScheduled = assignedExecutors.sum
+    val numExecutorsLaunched = app.executors.size
     // Check to see if we managed to launch the requested number of executors
-    val numExecutorsLaunched = assignedExecutors.sum
-    if(numUsable != 0 && numExecutorsLaunched != app.executorLimit) {
+    if(numUsable != 0 && numExecutorsLaunched != app.executorLimit &&
+      numExecutorsScheduled != app.executorLimit) {
       logWarning(s"Failed to launch the requested number of executors due to resource limits : " +
-        s"only $numExecutorsLaunched executors instead of ${app.executorLimit}")
+        s"only $numExecutorsScheduled executors instead of ${app.executorLimit}")
     }
 
     assignedCores

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -641,7 +641,7 @@ private[deploy] class Master(
     val numExecutorsScheduled = assignedExecutors.sum
     val numExecutorsLaunched = app.executors.size
     // Check to see if we managed to launch the requested number of executors
-    if(numUsable != 0 && numExecutorsLaunched != app.executorLimit &&
+    if (numUsable != 0 && numExecutorsLaunched != app.executorLimit &&
       numExecutorsScheduled != app.executorLimit) {
       logWarning(s"Failed to launch the requested number of executors due to resource limits : " +
         s"only $numExecutorsScheduled executors instead of ${app.executorLimit}")

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -640,7 +640,7 @@ private[deploy] class Master(
 
     // Check to see if we managed to launch the requested number of executors
     val numExecutorsLaunched = assignedExecutors.sum
-    if(numExecutorsLaunched != app.executorLimit) {
+    if(numUsable != 0 && numExecutorsLaunched != app.executorLimit) {
       logWarning(s"Failed to launch the requested number of executors due to resource limits : " +
         s"only $numExecutorsLaunched executors instead of ${app.executorLimit}")
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -99,7 +99,7 @@ private[spark] class StandaloneSchedulerBackend(
       if (Utils.isDynamicAllocationEnabled(conf)) {
         Some(0)
       } else {
-        None
+        sc.conf.getOption("spark.executor.instances").map(_.toInt)
       }
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
       appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor, initialExecutorLimit)

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -57,6 +57,7 @@ class SparkSubmitOptionParser {
   protected final String PY_FILES = "--py-files";
   protected final String REPOSITORIES = "--repositories";
   protected final String STATUS = "--status";
+  protected final String EXECUTOR_CORES = "--executor-cores";
   protected final String TOTAL_EXECUTOR_CORES = "--total-executor-cores";
 
   // Options that do not take arguments.
@@ -70,11 +71,12 @@ class SparkSubmitOptionParser {
 
   // YARN-only options.
   protected final String ARCHIVES = "--archives";
-  protected final String EXECUTOR_CORES = "--executor-cores";
   protected final String KEYTAB = "--keytab";
-  protected final String NUM_EXECUTORS = "--num-executors";
   protected final String PRINCIPAL = "--principal";
   protected final String QUEUE = "--queue";
+
+  // Standalone and YARN options.
+  protected final String NUM_EXECUTORS = "--num-executors";
 
   /**
    * This is the canonical list of spark-submit options. Each entry in the array contains the


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in standalone mode it is not possible to set the number of executors by using the `--num-executors` or  `spark.executor.instances` property. Instead, as many executors as possible will be spawned based on the available resources and the properties set. 
This patch corrects that to support the number of executors property. 

Here's the new behavior : 
- If the `executor.cores` property isn't set, we will try to spawn one executor on each worker taking all of the cores available (like the default value) while the number of workers < number of executors requested. If we can't launch the specified number of executors, a warning is logged. 
- If the `executor.cores` property is set (repeat the same logic for `executor.memory`):
  - and `executor.instances` \* `executor.cores` <= `cores.max`, then `executor.instances` will be spawned,
  - and `executor.instances` \* `executor.cores` > `cores.max`, then as many executors will be spawned as it is possible - basically the previous behavior when only executor.cores was set - but we also log a warning saying we couldn't spawn the requested number of executors,

In the case where `executor.memory` is set, all constraints are taken into account based on the number of cores and memory per worker assigned (same logic as with the cores). 
## How was this patch tested?

I tested this patch by running a simple Spark app in standalone mode and specifying the `--num-executors` or `spark.executor.instances property`, and checking if the number of executors was coherent based on the available resources and the requested number of executors. 
I plan on testing this patch by adding tests in `MasterSuite` and running the usual `/dev/run-tests`. 
