### PR TITLE
[Spark-14761][SQL] Reject invalid join methods  when join columns are not specified in PySpark DataFrame join.

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -640,25 +640,23 @@ class DataFrame(object):
         if on is not None and not isinstance(on, list):
             on = [on]
 
-        if on is None or len(on) == 0:
+        if on is not None:
+            if isinstance(on[0], basestring):
+                on = self._jseq(on)
+            else:
+                assert isinstance(on[0], Column), "on should be Column or list of Column"
+                if len(on) > 1:
+                    on = reduce(lambda x, y: x.__and__(y), on)
+                else:
+                    on = on[0]
+
+        if on is None and how is None:
             jdf = self._jdf.crossJoin(other._jdf)
-        elif isinstance(on[0], basestring):
-            if how is None:
-                jdf = self._jdf.join(other._jdf, self._jseq(on), "inner")
-            else:
-                assert isinstance(how, basestring), "how should be basestring"
-                jdf = self._jdf.join(other._jdf, self._jseq(on), how)
         else:
-            assert isinstance(on[0], Column), "on should be Column or list of Column"
-            if len(on) > 1:
-                on = reduce(lambda x, y: x.__and__(y), on)
-            else:
-                on = on[0]
             if how is None:
-                jdf = self._jdf.join(other._jdf, on._jc, "inner")
-            else:
-                assert isinstance(how, basestring), "how should be basestring"
-                jdf = self._jdf.join(other._jdf, on._jc, how)
+                how = "inner"
+            assert isinstance(how, basestring), "how should be basestring"
+            jdf = self._jdf.join(other._jdf, on._jc, how)
         return DataFrame(jdf, self.sql_ctx)
 
     @since(1.6)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -649,6 +649,7 @@ class DataFrame(object):
                     on = reduce(lambda x, y: x.__and__(y), on)
                 else:
                     on = on[0]
+                on = on._jc
 
         if on is None and how is None:
             jdf = self._jdf.crossJoin(other._jdf)
@@ -656,7 +657,7 @@ class DataFrame(object):
             if how is None:
                 how = "inner"
             assert isinstance(how, basestring), "how should be basestring"
-            jdf = self._jdf.join(other._jdf, on._jc, how)
+            jdf = self._jdf.join(other._jdf, on, how)
         return DataFrame(jdf, self.sql_ctx)
 
     @since(1.6)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1510,20 +1510,9 @@ class SQLTests(ReusedPySparkTestCase):
 
     # Regression test for invalid join methods when on is None, Spark-14761
     def test_invalid_join_method(self):
-        df1 = self.sqlCtx.createDataFrame([("Alice", 5), ("Bob", 8)], ["name", "age"])
-        df2 = self.sqlCtx.createDataFrame([("Alice", 80), ("Bob", 90)], ["name", "height"])
-        self.assertRaises(AnalysisException, lambda: df1.join(df2, how="invalid-join-type"))
-
-        result = df1.join(df2, how="inner").select(df1.name, df2.height).collect()
-        self.assertEqual(
-            result,
-            [
-                Row(name=u'Alice', height=80),
-                Row(name=u'Alice', height=90),
-                Row(name=u'Bob', height=80),
-                Row(name=u'Bob', height=90)
-            ]
-        )
+        df1 = self.spark.createDataFrame([("Alice", 5), ("Bob", 8)], ["name", "age"])
+        df2 = self.spark.createDataFrame([("Alice", 80), ("Bob", 90)], ["name", "height"])
+        self.assertRaises(IllegalArgumentException, lambda: df1.join(df2, how="invalid-join-type"))
 
     def test_conf(self):
         spark = self.spark

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1508,6 +1508,23 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
         self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
 
+    # Regression test for invalid join methods when on is None, Spark-14761
+    def test_invalid_join_method(self):
+        df1 = self.sqlCtx.createDataFrame([("Alice", 5), ("Bob", 8)], ["name", "age"])
+        df2 = self.sqlCtx.createDataFrame([("Alice", 80), ("Bob", 90)], ["name", "height"])
+        self.assertRaises(AnalysisException, lambda: df1.join(df2, how="invalid-join-type"))
+
+        result = df1.join(df2, how="inner").select(df1.name, df2.height).collect()
+        self.assertEqual(
+            result,
+            [
+                Row(name=u'Alice', height=80),
+                Row(name=u'Alice', height=90),
+                Row(name=u'Bob', height=80),
+                Row(name=u'Bob', height=90)
+            ]
+        )
+
     def test_conf(self):
         spark = self.spark
         spark.conf.set("bogo", "sipeo")


### PR DESCRIPTION
## What changes were proposed in this pull request?

In PySpark, the invalid join type will not throw error for the following join:
`df1.join(df2, how='not-a-valid-join-type')`

The signature of the join is:
`def join(self, other, on=None, how=None):`
The existing code completely ignores the `how` parameter when `on` is `None`. This patch will process the arguments passed to join and pass in to JVM Spark SQL Analyzer, which will validate the join type passed.
## How was this patch tested?

Used manual and existing test suites.
