### PR TITLE
Set master URL configuration in scala example

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
@@ -42,6 +42,7 @@ object SparkSQLExample {
     // $example on:init_session$
     val spark = SparkSession
       .builder()
+      .master("local[*]")
       .appName("Spark SQL basic example")
       .config("spark.some.config.option", "some-value")
       .getOrCreate()


### PR DESCRIPTION
This is the Spark Scala example which was missing setting a master URL in Spark Session

Unit tested. Changes affect examples and documentation only

There is no UI change. It's a minor change in the example scala files.

Need to set master url to SparkSession for the example to run
