### PR TITLE
[SPARK-17847][ML] Reduce shuffled data size of GaussianMixture & copy the implementation from mllib to ml

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -351,7 +351,7 @@ class GaussianMixture @Since("2.0.0") (
     val shouldDistributeGaussians = GaussianMixture.shouldDistributeGaussians(
       numClusters, numFeatures)
 
-    // TODO: Support users supplied initial GMM.
+    // TODO: SPARK-15785 Support users supplied initial GMM.
     val (weights, gaussians) = initRandom(instances, numClusters, numFeatures)
 
     var logLikelihood = Double.MinValue
@@ -429,17 +429,17 @@ class GaussianMixture @Since("2.0.0") (
   }
 
   /**
-   * Initialize weights and corresponding gaussians at random.
+   * Initialize weights and corresponding gaussian distributions at random.
    *
    * We start with uniform weights, a random mean from the data, and diagonal covariance matrices
    * using component variances derived from the samples.
    *
-   * @param instances The instances of training data.
+   * @param instances The training instances.
    * @param numClusters The number of clusters.
-   * @param numFeatures The number of features in training data.
-   * @return The initialized weights and corresponding gaussians. Note the covariance matrix of
-   *         multivariate gaussian distribution is symmetric and we only save the upper triangular
-   *         part as a dense vector.
+   * @param numFeatures The number of features of training instance.
+   * @return The initialized weights and corresponding gaussian distributions. Note the
+   *         covariance matrix of multivariate gaussian distribution is symmetric and
+   *         we only save the upper triangular part as a dense vector.
    */
   private def initRandom(
       instances: RDD[Vector],

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -335,12 +335,13 @@ class GaussianMixture @Since("2.0.0") (
 
     val sc = dataset.sparkSession.sparkContext
     val _k = $(k)
-    // Extract the number of features.
-    val numFeatures = dataset.select(col($(featuresCol))).first().getAs[Vector](0).size
 
     val instances: RDD[Vector] = dataset.select(col($(featuresCol))).rdd.map {
       case Row(features: Vector) => features
-    }
+    }.cache()
+
+    // Extract the number of features.
+    val numFeatures = instances.first().size
 
     val instr = Instrumentation.create(this, instances)
     instr.logParams(featuresCol, predictionCol, probabilityCol, k, maxIter, seed, tol)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -226,6 +226,21 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext
     assert(gmm.gaussians(0).cov ~== cov(0) absTol 1E-3)
     assert(gmm.gaussians(1).cov ~== cov(1) absTol 1E-3)
   }
+
+  test("upper triangular matrix unpacking") {
+    /*
+       The full symmetric matrix is as follows:
+       1.0 2.5 3.8 0.9
+       2.5 2.0 7.2 3.8
+       3.8 7.2 3.0 1.0
+       0.9 3.8 1.0 4.0
+     */
+    val triangularValues = Array(1.0, 2.5, 2.0, 3.8, 7.2, 3.0, 0.9, 3.8, 1.0, 4.0)
+    val symmetricValues = Array(1.0, 2.5, 3.8, 0.9, 2.5, 2.0, 7.2, 3.8,
+      3.8, 7.2, 3.0, 1.0, 0.9, 3.8, 1.0, 4.0)
+    val expected = GaussianMixture.unpackUpperTriangularMatrix(4, triangularValues)
+    assert(symmetricValues === expected)
+  }
 }
 
 object GaussianMixtureSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -144,30 +144,19 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext
       GaussianMixtureSuite.allParamSettings, checkModelData)
   }
 
-  test("univariate dense data with two clusters") {
+  test("univariate dense/sparse data with two clusters") {
     val weights = Array(2.0 / 3.0, 1.0 / 3.0)
     val means = Array(Vectors.dense(5.1604), Vectors.dense(-4.3673))
     val covs = Array(Matrices.dense(1, 1, Array(0.86644)), Matrices.dense(1, 1, Array(1.1098)))
     val gaussians = means.zip(covs).map { case (mean, cov) =>
       new MultivariateGaussian(mean, cov)
     }
-
     val expected = new GaussianMixtureModel("dummy", weights, gaussians)
-    val actual = new GaussianMixture().setK(2).setSeed(seed).fit(denseDataset)
-    modelEquals(expected, actual)
-  }
 
-  test("univariate sparse data with two clusters") {
-    val weights = Array(2.0 / 3.0, 1.0 / 3.0)
-    val means = Array(Vectors.dense(5.1604), Vectors.dense(-4.3673))
-    val covs = Array(Matrices.dense(1, 1, Array(0.86644)), Matrices.dense(1, 1, Array(1.1098)))
-    val gaussians = means.zip(covs).map { case (mean, cov) =>
-      new MultivariateGaussian(mean, cov)
+    Seq(denseDataset, sparseDataset).foreach { dataset =>
+      val actual = new GaussianMixture().setK(2).setSeed(seed).fit(dataset)
+      modelEquals(expected, actual)
     }
-
-    val expected = new GaussianMixtureModel("dummy", weights, gaussians)
-    val actual = new GaussianMixture().setK(2).setSeed(seed).fit(sparseDataset)
-    modelEquals(expected, actual)
   }
 
   test("check distributed decomposition") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -280,6 +280,7 @@ object GaussianMixtureSuite extends SparkFunSuite {
   def modelEquals(m1: GaussianMixtureModel, m2: GaussianMixtureModel): Unit = {
     assert(m1.weights.length === m2.weights.length)
     for (i <- m1.weights.indices) {
+      assert(m1.weights(i) ~== m2.weights(i) absTol 1E-3)
       assert(m1.gaussians(i).mean ~== m2.gaussians(i).mean absTol 1E-3)
       assert(m1.gaussians(i).cov ~== m2.gaussians(i).cov absTol 1E-3)
     }

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -178,15 +178,10 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> weights = model.weights
     >>> len(weights)
     3
-    >>> model.gaussiansDF.show()
-    +--------------------+--------------------+
-    |                mean|                 cov|
-    +--------------------+--------------------+
-    |[0.82500000140229...|0.005625000000006...|
-    |[-0.4777098016092...|0.167969502720916...|
-    |[-0.4472625243352...|0.167304119758233...|
-    +--------------------+--------------------+
-    ...
+    >>> model.gaussiansDF.select("mean").head()
+    Row(mean=DenseVector([0.825, 0.8675]))
+    >>> model.gaussiansDF.select("cov").head()
+    Row(cov=DenseMatrix(2, 2, [0.0056, -0.0051, -0.0051, 0.0046], False))
     >>> transformed = model.transform(df).select("features", "prediction")
     >>> rows = transformed.collect()
     >>> rows[4].prediction == rows[5].prediction
@@ -205,15 +200,10 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     False
     >>> model2.weights == model.weights
     True
-    >>> model2.gaussiansDF.show()
-    +--------------------+--------------------+
-    |                mean|                 cov|
-    +--------------------+--------------------+
-    |[0.82500000140229...|0.005625000000006...|
-    |[-0.4777098016092...|0.167969502720916...|
-    |[-0.4472625243352...|0.167304119758233...|
-    +--------------------+--------------------+
-    ...
+    >>> model2.gaussiansDF.select("mean").head()
+    Row(mean=DenseVector([0.825, 0.8675]))
+    >>> model2.gaussiansDF.select("cov").head()
+    Row(cov=DenseMatrix(2, 2, [0.0056, -0.0051, -0.0051, 0.0046], False))
 
     .. versionadded:: 2.0.0
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Copy `GaussianMixture` implementation from mllib to ml, then we can add new features to it.
I left mllib `GaussianMixture` untouched, unlike some other algorithms to wrap the ml implementation. For the following reasons:
- mllib `GaussianMixture` allows k == 1, but ml does not.
- mllib `GaussianMixture` supports setting initial model, but ml does not support currently. (We will definitely add this feature for ml in the future)

We can get around these issues to make mllib as a wrapper calling into ml, but I'd prefer to leave mllib untouched which can make ml clean.

Meanwhile, There is a big performance improvement for `GaussianMixture` in this PR. Since the covariance matrix of multivariate gaussian distribution is symmetric, we can only store the upper triangular part of the matrix and it will greatly reduce the shuffled data size. In my test, this change will reduce shuffled data size by about 50% and accelerate the job execution.

Before this PR:
![image](https://cloud.githubusercontent.com/assets/1962026/19641622/4bb017ac-9996-11e6-8ece-83db184b620a.png)
After this PR:
![image](https://cloud.githubusercontent.com/assets/1962026/19641635/629c21fe-9996-11e6-91e9-83ab74ae0126.png)
## How was this patch tested?

Existing tests and added new tests.
