### PR TITLE
[HOT-FIX][SQL][TESTS] Remove unused function in `SparkSqlParserSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -116,16 +116,6 @@ class SparkSqlParserSuite extends PlanTest {
     )
   }
 
-  private def createTempViewUsing(
-      table: String,
-      database: Option[String] = None,
-      schema: Option[StructType] = None,
-      replace: Boolean = true,
-      provider: String = "parquet",
-      options: Map[String, String] = Map.empty): LogicalPlan = {
-    CreateTempViewUsing(TableIdentifier(table, database), schema, replace, provider, options)
-  }
-
   private def createTable(
       table: String,
       database: Option[String] = None,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The function `SparkSqlParserSuite.createTempViewUsing` is not used for now and causes build failure, this PR simply removes it.
## How was this patch tested?

N/A
