### PR TITLE
	[SPARK-17845][SQL] More self-evident window function frame boundary API

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1870,7 +1870,27 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
     def test_window_functions_cumulative_sum(self):
         df = self.spark.createDataFrame([("one", 1), ("two", 2)], ["key", "value"])
         from pyspark.sql import functions as F
-        sel = df.select(df.key, F.sum(df.value).over(Window.rowsBetween(-sys.maxsize, 0)))
+
+        # Test cumulative sum
+        sel = df.select(df.key,
+            F.sum(df.value).over(Window.rowsBetween(Window.unboundedPreceding, 0)))
+        rs = sorted(sel.collect())
+        expected = [("one", 1), ("two", 3)]
+        for r, ex in zip(rs, expected):
+            self.assertEqual(tuple(r), ex[:len(r)])
+
+        # Test boundary values less than JVM's Long.MinValue and make sure we don't overflow
+        sel = df.select(df.key,
+            F.sum(df.value).over(Window.rowsBetween(Window.unboundedPreceding - 1, 0)))
+        rs = sorted(sel.collect())
+        expected = [("one", 1), ("two", 3)]
+        for r, ex in zip(rs, expected):
+            self.assertEqual(tuple(r), ex[:len(r)])
+
+        # Test boundary values greater than JVM's Long.MaxValue and make sure we don't overflow
+        frame_end = Window.unboundedFollowing + 1
+        sel = df.select(df.key,
+            F.sum(df.value).over(Window.rowsBetween(Window.currentRow, frame_end)))
         rs = sorted(sel.collect())
         expected = [("one", 1), ("two", 3)]
         for r, ex in zip(rs, expected):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1892,7 +1892,7 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
         sel = df.select(df.key,
             F.sum(df.value).over(Window.rowsBetween(Window.currentRow, frame_end)))
         rs = sorted(sel.collect())
-        expected = [("one", 1), ("two", 3)]
+        expected = [("one", 3), ("two", 2)]
         for r, ex in zip(rs, expected):
             self.assertEqual(tuple(r), ex[:len(r)])
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1872,7 +1872,8 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
         from pyspark.sql import functions as F
 
         # Test cumulative sum
-        sel = df.select(df.key,
+        sel = df.select(
+            df.key,
             F.sum(df.value).over(Window.rowsBetween(Window.unboundedPreceding, 0)))
         rs = sorted(sel.collect())
         expected = [("one", 1), ("two", 3)]
@@ -1880,7 +1881,8 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
             self.assertEqual(tuple(r), ex[:len(r)])
 
         # Test boundary values less than JVM's Long.MinValue and make sure we don't overflow
-        sel = df.select(df.key,
+        sel = df.select(
+            df.key,
             F.sum(df.value).over(Window.rowsBetween(Window.unboundedPreceding - 1, 0)))
         rs = sorted(sel.collect())
         expected = [("one", 1), ("two", 3)]
@@ -1889,7 +1891,8 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
 
         # Test boundary values greater than JVM's Long.MaxValue and make sure we don't overflow
         frame_end = Window.unboundedFollowing + 1
-        sel = df.select(df.key,
+        sel = df.select(
+            df.key,
             F.sum(df.value).over(Window.rowsBetween(Window.currentRow, frame_end)))
         rs = sorted(sel.collect())
         expected = [("one", 3), ("two", 2)]

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -36,8 +36,8 @@ class Window(object):
 
     For example:
 
-    >>> # PARTITION BY country ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    >>> window = Window.partitionBy("country").orderBy("date").rowsBetween(-sys.maxsize, 0)
+    >>> # ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    >>> window = Window.orderBy("date").rowsBetween(Window.unboundedPreceding, Window.currentRow)
 
     >>> # PARTITION BY country ORDER BY date RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING
     >>> window = Window.orderBy("date").partitionBy("country").rangeBetween(-3, 3)
@@ -46,6 +46,16 @@ class Window(object):
 
     .. versionadded:: 1.4
     """
+
+    _JAVA_MIN_LONG = -(1 << 63)  # -9223372036854775808
+    _JAVA_MAX_LONG = (1 << 63) - 1  # 9223372036854775807
+
+    unboundedPreceding = _JAVA_MIN_LONG
+
+    unboundedFollowing = _JAVA_MAX_LONG
+
+    currentRow = 0
+
     @staticmethod
     @since(1.4)
     def partitionBy(*cols):
@@ -77,15 +87,21 @@ class Window(object):
         For example, "0" means "current row", while "-1" means the row before
         the current row, and "5" means the fifth row after the current row.
 
+        We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
+        and ``Window.currentRow`` to specify special boundary values, rather than using integral
+        values directly.
+
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``-sys.maxsize`` (or lower).
+                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      any value less than or equal to -9223372036854775808.
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``sys.maxsize`` (or higher).
+                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    any value greater than or equal to 9223372036854775807.
         """
-        if start <= -sys.maxsize:
-            start = WindowSpec._JAVA_MIN_LONG
-        if end >= sys.maxsize:
-            end = WindowSpec._JAVA_MAX_LONG
+        if start <= Window._JAVA_MIN_LONG:
+            start = Window.unboundedPreceding
+        if end >= Window._JAVA_MAX_LONG:
+            end = Window.unboundedFollowing
         sc = SparkContext._active_spark_context
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rowsBetween(start, end)
         return WindowSpec(jspec)
@@ -101,15 +117,21 @@ class Window(object):
         "0" means "current row", while "-1" means one off before the current row,
         and "5" means the five off after the current row.
 
+        We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
+        and ``Window.currentRow`` to specify special boundary values, rather than using integral
+        values directly.
+
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``-sys.maxsize`` (or lower).
+                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      any value less than or equal to -9223372036854775808.
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``sys.maxsize`` (or higher).
+                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    any value greater than or equal to 9223372036854775807.
         """
-        if start <= -sys.maxsize:
-            start = WindowSpec._JAVA_MIN_LONG
-        if end >= sys.maxsize:
-            end = WindowSpec._JAVA_MAX_LONG
+        if start <= Window._JAVA_MIN_LONG:
+            start = Window.unboundedPreceding
+        if end >= Window._JAVA_MAX_LONG:
+            end = Window.unboundedFollowing
         sc = SparkContext._active_spark_context
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rangeBetween(start, end)
         return WindowSpec(jspec)
@@ -126,9 +148,6 @@ class WindowSpec(object):
 
     .. versionadded:: 1.4
     """
-
-    _JAVA_MAX_LONG = (1 << 63) - 1
-    _JAVA_MIN_LONG = - (1 << 63)
 
     def __init__(self, jspec):
         self._jspec = jspec
@@ -160,15 +179,21 @@ class WindowSpec(object):
         For example, "0" means "current row", while "-1" means the row before
         the current row, and "5" means the fifth row after the current row.
 
+        We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
+        and ``Window.currentRow`` to specify special boundary values, rather than using integral
+        values directly.
+
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``-sys.maxsize`` (or lower).
+                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      any value less than or equal to -9223372036854775808.
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``sys.maxsize`` (or higher).
+                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    any value greater than or equal to 9223372036854775807.
         """
-        if start <= -sys.maxsize:
-            start = self._JAVA_MIN_LONG
-        if end >= sys.maxsize:
-            end = self._JAVA_MAX_LONG
+        if start <= Window._JAVA_MIN_LONG:
+            start = Window.unboundedPreceding
+        if end >= Window._JAVA_MAX_LONG:
+            end = Window.unboundedFollowing
         return WindowSpec(self._jspec.rowsBetween(start, end))
 
     @since(1.4)
@@ -180,15 +205,21 @@ class WindowSpec(object):
         "0" means "current row", while "-1" means one off before the current row,
         and "5" means the five off after the current row.
 
+        We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
+        and ``Window.currentRow`` to specify special boundary values, rather than using integral
+        values directly.
+
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``-sys.maxsize`` (or lower).
+                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      any value less than or equal to -9223372036854775808.
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``sys.maxsize`` (or higher).
+                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    any value greater than or equal to 9223372036854775807.
         """
-        if start <= -sys.maxsize:
-            start = self._JAVA_MIN_LONG
-        if end >= sys.maxsize:
-            end = self._JAVA_MAX_LONG
+        if start <= Window._JAVA_MIN_LONG:
+            start = Window.unboundedPreceding
+        if end >= Window._JAVA_MAX_LONG:
+            end = Window.unboundedFollowing
         return WindowSpec(self._jspec.rangeBetween(start, end))
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.catalyst.expressions._
  *
  * {{{
  *   // PARTITION BY country ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
- *   Window.partitionBy("country").orderBy("date").rowsBetween(Long.MinValue, 0)
+ *   Window.partitionBy("country").orderBy("date")
+ *     .rowsBetween(Window.unboundedPreceding, Window.currentRow)
  *
  *   // PARTITION BY country ORDER BY date ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING
  *   Window.partitionBy("country").orderBy("date").rowsBetween(-3, 3)
@@ -75,6 +76,41 @@ object Window {
   }
 
   /**
+   * Value representing the last row in the partition, equivalent to "UNBOUNDED PRECEDING" in SQL.
+   * This can be used to specify the frame boundaries:
+   *
+   * {{{
+   *   Window.rowsBetween(Window.unboundedPreceding, Window.currentRow)
+   * }}}
+   *
+   * @since 2.1.0
+   */
+  def unboundedPreceding: Long = Long.MinValue
+
+  /**
+   * Value representing the last row in the partition, equivalent to "UNBOUNDED FOLLOWING" in SQL.
+   * This can be used to specify the frame boundaries:
+   *
+   * {{{
+   *   Window.rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+   * }}}
+   *
+   * @since 2.1.0
+   */
+  def unboundedFollowing: Long = Long.MaxValue
+
+  /**
+   * Value representing the current row. This can be used to specify the frame boundaries:
+   *
+   * {{{
+   *   Window.rowsBetween(Window.unboundedPreceding, Window.currentRow)
+   * }}}
+   *
+   * @since 2.1.0
+   */
+  def currentRow: Long = 0
+
+  /**
    * Creates a [[WindowSpec]] with the frame boundaries defined,
    * from `start` (inclusive) to `end` (inclusive).
    *
@@ -82,10 +118,14 @@ object Window {
    * "current row", while "-1" means the row before the current row, and "5" means the fifth row
    * after the current row.
    *
-   * @param start boundary start, inclusive.
-   *              The frame is unbounded if this is the minimum long value.
-   * @param end boundary end, inclusive.
-   *            The frame is unbounded if this is the maximum long value.
+   * We recommend users use [[Window.unboundedPreceding]], [[Window.unboundedFollowing]],
+   * and [[Window.currentRow]] to specify special boundary values, rather than using integral
+   * values directly.
+   *
+   * @param start boundary start, inclusive. The frame is unbounded if this is
+   *              the minimum long value ([[Window.unboundedPreceding]]).
+   * @param end boundary end, inclusive. The frame is unbounded if this is the
+   *            maximum long value  ([[Window.unboundedFollowing]]).
    * @since 2.1.0
    */
   // Note: when updating the doc for this method, also update WindowSpec.rowsBetween.
@@ -101,10 +141,14 @@ object Window {
    * while "-1" means one off before the current row, and "5" means the five off after the
    * current row.
    *
-   * @param start boundary start, inclusive.
-   *              The frame is unbounded if this is the minimum long value.
-   * @param end boundary end, inclusive.
-   *            The frame is unbounded if this is the maximum long value.
+   * We recommend users use [[Window.unboundedPreceding]], [[Window.unboundedFollowing]],
+   * and [[Window.currentRow]] to specify special boundary values, rather than using integral
+   * values directly.
+   *
+   * @param start boundary start, inclusive. The frame is unbounded if this is
+   *              the minimum long value ([[Window.unboundedPreceding]]).
+   * @param end boundary end, inclusive. The frame is unbounded if this is the
+   *            maximum long value  ([[Window.unboundedFollowing]]).
    * @since 2.1.0
    */
   // Note: when updating the doc for this method, also update WindowSpec.rangeBetween.

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/WindowSpec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/WindowSpec.scala
@@ -86,10 +86,14 @@ class WindowSpec private[sql](
    * "current row", while "-1" means the row before the current row, and "5" means the fifth row
    * after the current row.
    *
-   * @param start boundary start, inclusive.
-   *              The frame is unbounded if this is the minimum long value.
-   * @param end boundary end, inclusive.
-   *            The frame is unbounded if this is the maximum long value.
+   * We recommend users use [[Window.unboundedPreceding]], [[Window.unboundedFollowing]],
+   * and [[Window.currentRow]] to specify special boundary values, rather than using integral
+   * values directly.
+   *
+   * @param start boundary start, inclusive. The frame is unbounded if this is
+   *              the minimum long value ([[Window.unboundedPreceding]]).
+   * @param end boundary end, inclusive. The frame is unbounded if this is the
+   *            maximum long value  ([[Window.unboundedFollowing]]).
    * @since 1.4.0
    */
   // Note: when updating the doc for this method, also update Window.rowsBetween.
@@ -104,10 +108,14 @@ class WindowSpec private[sql](
    * while "-1" means one off before the current row, and "5" means the five off after the
    * current row.
    *
-   * @param start boundary start, inclusive.
-   *              The frame is unbounded if this is the minimum long value.
-   * @param end boundary end, inclusive.
-   *            The frame is unbounded if this is the maximum long value.
+   * We recommend users use [[Window.unboundedPreceding]], [[Window.unboundedFollowing]],
+   * and [[Window.currentRow]] to specify special boundary values, rather than using integral
+   * values directly.
+   *
+   * @param start boundary start, inclusive. The frame is unbounded if this is
+   *              the minimum long value ([[Window.unboundedPreceding]]).
+   * @param end boundary end, inclusive. The frame is unbounded if this is the
+   *            maximum long value  ([[Window.unboundedFollowing]]).
    * @since 1.4.0
    */
   // Note: when updating the doc for this method, also update Window.rangeBetween.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.{DataType, LongType, StructType}
 /**
  * Window function testing for DataFrame API.
  */
-class DataFrameWindowSuite extends QueryTest with SharedSQLContext {
+class DataFrameWindowFunctionsSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
 
   test("reuse window partitionBy") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowSuite.scala
@@ -54,7 +54,8 @@ class DataFrameWindowSuite extends QueryTest with SharedSQLContext {
     val df = Seq(("one", 1), ("two", 2)).toDF("key", "value")
     // Running (cumulative) sum
     checkAnswer(
-      df.select('key, sum("value").over(Window.rowsBetween(Long.MinValue, 0))),
+      df.select('key, sum("value").over(
+        Window.rowsBetween(Window.unboundedPreceding, Window.currentRow))),
       Row("one", 1) :: Row("two", 3) :: Nil
     )
   }
@@ -156,9 +157,11 @@ class DataFrameWindowSuite extends QueryTest with SharedSQLContext {
       df.select(
         $"key",
         last("key").over(
-          Window.partitionBy($"value").orderBy($"key").rowsBetween(0, Long.MaxValue)),
+          Window.partitionBy($"value").orderBy($"key")
+            .rowsBetween(Window.currentRow, Window.unboundedFollowing)),
         last("key").over(
-          Window.partitionBy($"value").orderBy($"key").rowsBetween(Long.MinValue, 0)),
+          Window.partitionBy($"value").orderBy($"key")
+            .rowsBetween(Window.unboundedPreceding, Window.currentRow)),
         last("key").over(Window.partitionBy($"value").orderBy($"key").rowsBetween(-1, 1))),
       Seq(Row(1, 1, 1, 1), Row(2, 3, 2, 3), Row(3, 3, 3, 3), Row(1, 4, 1, 2), Row(2, 4, 2, 4),
         Row(4, 4, 4, 4)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch improves the window function frame boundary API to make it more obvious to read and to use. The two high level changes are:
1. Create Window.currentRow, Window.unboundedPreceding, Window.unboundedFollowing to indicate the special values in frame boundaries. These methods map to the special integral values so we are not breaking backward compatibility here. This change makes the frame boundaries more self-evident (instead of Long.MinValue, it becomes Window.unboundedPreceding).
2. In Python, for any value less than or equal to JVM's Long.MinValue, treat it as Window.unboundedPreceding. For any value larger than or equal to JVM's Long.MaxValue, treat it as Window.unboundedFollowing. Before this change, if the user specifies any value that is less than Long.MinValue but not -sys.maxsize (e.g. -sys.maxsize + 1), the number we pass over to the JVM would overflow, resulting in a frame that does not make sense.

Code example required to specify a frame before this patch:

```
Window.rowsBetween(-Long.MinValue, 0)
```

While the above code should still work, the new way is more obvious to read:

```
Window.rowsBetween(Window.unboundedPreceding, Window.currentRow)
```
## How was this patch tested?
- Updated DataFrameWindowSuite (for Scala/Java)
- Updated test_window_functions_cumulative_sum (for Python)
- Renamed DataFrameWindowSuite DataFrameWindowFunctionsSuite to better reflect its purpose
