### PR TITLE
[SPARK-17881] [SQL] Aggregation function for generating string histograms

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -235,6 +235,7 @@ object FunctionRegistry {
     expression[Remainder]("%"),
 
     // aggregate functions
+    expression[StringHistogram]("string_histogram"),
     expression[HyperLogLogPlusPlus]("approx_count_distinct"),
     expression[Average]("avg"),
     expression[Corr]("corr"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/StringHistogram.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/StringHistogram.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import java.nio.ByteBuffer
+
+import scala.collection.immutable.TreeMap
+import scala.collection.mutable
+
+import com.google.common.primitives.{Ints, Longs}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription}
+import org.apache.spark.sql.catalyst.expressions.aggregate.StringHistogram.StringHistogramInfo
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * The StringHistogram function returns the histogram bins - (distinct value, frequency) pairs
+ * for a string column.
+ * @param child child expression that can produce column value with `child.eval(inputRow)`
+ * @param numBinsExpression The maximum number of bins. When the number of distinct values is
+ *                          larger than this, the function will return an empty result.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(col, numBins) - Returns histogram bins with the maximum number of bins allowed.")
+case class StringHistogram(
+    child: Expression,
+    numBinsExpression: Expression,
+    override val mutableAggBufferOffset: Int,
+    override val inputAggBufferOffset: Int) extends TypedImperativeAggregate[StringHistogramInfo] {
+
+  def this(child: Expression, numBinsExpression: Expression) = {
+    this(child, numBinsExpression, 0, 0)
+  }
+
+  // Mark as lazy so that numBinsExpression is not evaluated during tree transformation.
+  private lazy val numBins: Int = numBinsExpression.eval().asInstanceOf[Int]
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val defaultCheck = super.checkInputDataTypes()
+    if (defaultCheck.isFailure) {
+      defaultCheck
+    } else if (!numBinsExpression.foldable) {
+      TypeCheckFailure(s"The maximum number of bins provided must be a constant literal")
+    } else if (numBins <= 0) {
+      TypeCheckFailure(
+        s"The maximum number of bins provided must be a positive integer literal (current value" +
+          s" = $numBins)")
+    } else {
+      TypeCheckSuccess
+    }
+  }
+
+  override def update(buffer: StringHistogramInfo, input: InternalRow): Unit = {
+    if (buffer.invalid) {
+      return
+    }
+    val evaluated = child.eval(input)
+    if (evaluated != null) {
+      val str = evaluated.asInstanceOf[UTF8String]
+      if (buffer.bins.contains(str)) {
+        buffer.bins.update(str, buffer.bins(str) + 1)
+      } else {
+        if (buffer.bins.size >= numBins) {
+          // clear the buffer and mark it as invalid
+          buffer.bins.clear()
+          buffer.invalid = true
+        } else {
+          buffer.bins.put(str, 1)
+        }
+      }
+    }
+  }
+
+  override def merge(buffer: StringHistogramInfo, other: StringHistogramInfo): Unit = {
+    if (buffer.invalid || other.invalid) {
+      buffer.bins.clear()
+      return
+    }
+    other.bins.foreach { case (key, value) =>
+      if (buffer.bins.contains(key)) {
+        buffer.bins.update(key, buffer.bins(key) + value)
+      } else {
+        if (buffer.bins.size >= numBins) {
+          // clear the buffer and mark it as invalid
+          buffer.bins.clear()
+          buffer.invalid = true
+          return
+        } else {
+          buffer.bins.put(key, value)
+        }
+      }
+    }
+  }
+
+  override def eval(buffer: StringHistogramInfo): Any = {
+    val sorted = TreeMap[UTF8String, Long](buffer.bins.toSeq: _*)
+    ArrayBasedMapData(sorted.keys.toArray, sorted.values.toArray)
+  }
+
+  override def serialize(buffer: StringHistogramInfo): Array[Byte] = {
+    StringHistogram.serializer.serialize(buffer)
+  }
+
+  override def deserialize(storageFormat: Array[Byte]): StringHistogramInfo = {
+    StringHistogram.serializer.deserialize(storageFormat)
+  }
+
+  override def createAggregationBuffer(): StringHistogramInfo = new StringHistogramInfo()
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): StringHistogram = {
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+  }
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): StringHistogram = {
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, IntegerType)
+
+  override def nullable: Boolean = false
+
+  override def dataType: DataType = MapType(StringType, LongType)
+
+  override def children: Seq[Expression] = Seq(child, numBinsExpression)
+
+  override def prettyName: String = "string_histogram"
+}
+
+object StringHistogram {
+
+  /**
+   * StringHistogramInfo maintains frequency of each distinct value.
+   * @param invalid This is to mark the HashMap as invalid when its size (ndv of the column)
+   *                exceeds numBins, because we won't generate string histograms in that case.
+   * @param bins A HashMap to maintain frequency of each distinct value.
+   */
+  case class StringHistogramInfo(
+      var invalid: Boolean = false,
+      bins: mutable.HashMap[UTF8String, Long] = mutable.HashMap.empty[UTF8String, Long])
+
+  class StringHistogramInfoSerializer {
+
+    private final def length(info: StringHistogramInfo): Int = {
+      // invalid, size of bins
+      var len: Int = Ints.BYTES + Ints.BYTES
+      info.bins.foreach { case (key, value) =>
+        // length of key, key, value
+        len += Ints.BYTES + key.getBytes.length + Longs.BYTES
+      }
+      len
+    }
+
+    final def serialize(obj: StringHistogramInfo): Array[Byte] = {
+      val buffer = ByteBuffer.wrap(new Array(length(obj)))
+      buffer.putInt(if (obj.invalid) 0 else 1)
+      buffer.putInt(obj.bins.size)
+      obj.bins.foreach { case (key, value) =>
+        val bytes = key.getBytes
+        buffer.putInt(bytes.length)
+        buffer.put(bytes)
+        buffer.putLong(value)
+      }
+      buffer.array()
+    }
+
+    final def deserialize(bytes: Array[Byte]): StringHistogramInfo = {
+      val buffer = ByteBuffer.wrap(bytes)
+      val invalid = if (buffer.getInt == 0) true else false
+      val size = buffer.getInt
+      val bins = new mutable.HashMap[UTF8String, Long]
+      var i = 0
+      while (i < size) {
+        val keyLength = buffer.getInt
+        var j = 0
+        val bytes = new Array[Byte](keyLength)
+        while (j < keyLength) {
+          bytes(j) = buffer.get()
+          j += 1
+        }
+        val value = buffer.getLong
+        bins.put(UTF8String.fromBytes(bytes), value)
+        i += 1
+      }
+      StringHistogramInfo(invalid, bins)
+    }
+  }
+
+  val serializer: StringHistogramInfoSerializer = new StringHistogramInfoSerializer
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/StringHistogramSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/StringHistogramSuite.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import scala.collection.immutable.TreeMap
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckFailure
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, GenericInternalRow, Literal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.StringHistogram.{StringHistogramInfo, StringHistogramInfoSerializer}
+import org.apache.spark.sql.catalyst.util.MapData
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+
+class StringHistogramSuite extends SparkFunSuite {
+
+  test("serialize and de-serialize") {
+    def compareEquals(left: StringHistogramInfo, right: StringHistogramInfo): Boolean = {
+      left.invalid == right.invalid && left.bins.equals(right.bins)
+    }
+
+    val serializer = new StringHistogramInfoSerializer
+    // Check empty serialize and de-serialize
+    val emptyBuffer = new StringHistogramInfo()
+    assert(compareEquals(emptyBuffer, serializer.deserialize(serializer.serialize(emptyBuffer))))
+
+    val random = new java.util.Random()
+    val data = Seq("a", "bb", "ccc").map { s =>
+      (UTF8String.fromString(s), random.nextInt(10000).toLong)
+    }
+    val buffer = new StringHistogramInfo()
+    data.foreach { case (key, value) =>
+      buffer.bins.put(key, value)
+    }
+    assert(compareEquals(buffer, serializer.deserialize(serializer.serialize(buffer))))
+
+    val agg = new StringHistogram(BoundReference(0, StringType, nullable = true), Literal(10))
+    assert(compareEquals(agg.deserialize(agg.serialize(buffer)), buffer))
+  }
+
+  private def checkResult(data: Seq[UTF8String], result: Any): Unit = {
+    val expectedMap = data.groupBy(w => w).mapValues(_.length.toLong)
+    val expectedSortedMap = TreeMap[UTF8String, Long](expectedMap.toSeq: _*)
+    result match {
+      case mapData: MapData =>
+        val keys = mapData.keyArray().toArray[UTF8String](StringType)
+        val values = mapData.valueArray().toArray[Long](LongType)
+        assert(expectedSortedMap.keys.toArray.sameElements(keys))
+        assert(expectedSortedMap.values.toArray.sameElements(values))
+    }
+  }
+
+  test("class StringHistogram, high level interface, update, merge, eval...") {
+    val data = Seq("a", "bb", "a", "ccc", "dddd", "a").map(UTF8String.fromString)
+    val childExpression = BoundReference(0, StringType, nullable = true)
+    val numBinsExpression = Literal(10)
+    val agg = new StringHistogram(childExpression, numBinsExpression)
+
+    assert(!agg.nullable)
+    val group1 = 0 until data.length / 2
+    val group1Buffer = agg.createAggregationBuffer()
+    group1.foreach { index =>
+      val input = InternalRow(data(index))
+      agg.update(group1Buffer, input)
+    }
+
+    val group2 = data.length / 2 until data.length
+    val group2Buffer = agg.createAggregationBuffer()
+    group2.foreach { index =>
+      val input = InternalRow(data(index))
+      agg.update(group2Buffer, input)
+    }
+
+    val mergeBuffer = agg.createAggregationBuffer()
+    agg.merge(mergeBuffer, group1Buffer)
+    agg.merge(mergeBuffer, group2Buffer)
+    checkResult(data, agg.eval(mergeBuffer))
+  }
+
+  test("class StringHistogram, low level interface, update, merge, eval...") {
+    val childExpression = BoundReference(0, StringType, nullable = true)
+    val inputAggregationBufferOffset = 1
+    val mutableAggregationBufferOffset = 2
+    val numBins = 10
+
+    // Phase one, partial mode aggregation
+    val agg = new StringHistogram(childExpression, Literal(numBins))
+      .withNewInputAggBufferOffset(inputAggregationBufferOffset)
+      .withNewMutableAggBufferOffset(mutableAggregationBufferOffset)
+
+    val mutableAggBuffer = new GenericInternalRow(
+      new Array[Any](mutableAggregationBufferOffset + 1))
+    agg.initialize(mutableAggBuffer)
+    val data = Seq("a", "bb", "a", "ccc", "dddd", "a").map(UTF8String.fromString)
+    data.foreach { s =>
+      agg.update(mutableAggBuffer, InternalRow(s))
+    }
+    agg.serializeAggregateBufferInPlace(mutableAggBuffer)
+
+    // Serialize the aggregation buffer
+    val serialized = mutableAggBuffer.getBinary(mutableAggregationBufferOffset)
+    val inputAggBuffer = new GenericInternalRow(Array[Any](null, serialized))
+
+    // Phase 2: final mode aggregation
+    // Re-initialize the aggregation buffer
+    agg.initialize(mutableAggBuffer)
+    agg.merge(mutableAggBuffer, inputAggBuffer)
+    checkResult(data, agg.eval(mutableAggBuffer))
+  }
+
+  test("fails analysis if inputs are illegal") {
+    def assertEqual(left: TypeCheckResult, right: TypeCheckResult): Unit = {
+      assert(left == right)
+    }
+
+    val attribute = AttributeReference("a", StringType)()
+    var wrongNumBins = new StringHistogram(
+      attribute, numBinsExpression = AttributeReference("b", IntegerType)())
+    assertEqual(
+      wrongNumBins.checkInputDataTypes(),
+      TypeCheckFailure("The maximum number of bins provided must be a constant literal"))
+
+    wrongNumBins = new StringHistogram(attribute, numBinsExpression = Literal(-1))
+    assertEqual(
+      wrongNumBins.checkInputDataTypes(),
+      TypeCheckFailure(
+        "The maximum number of bins provided must be a positive integer literal (current value = " +
+          "-1)"))
+
+    wrongNumBins = new StringHistogram(attribute, numBinsExpression = Literal(0.5))
+    var typeCheckResult = wrongNumBins.checkInputDataTypes()
+    assert(typeCheckResult.isFailure && typeCheckResult.asInstanceOf[TypeCheckFailure]
+      .message.contains("requires int type"))
+
+    val wrongAttribute = new StringHistogram(AttributeReference("a", IntegerType)(), Literal(1000))
+    typeCheckResult = wrongAttribute.checkInputDataTypes()
+    assert(typeCheckResult.isFailure && typeCheckResult.asInstanceOf[TypeCheckFailure]
+      .message.contains("requires string type"))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringHistogramQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringHistogramQuerySuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.test.SharedSQLContext
+
+
+class StringHistogramQuerySuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  private val table = "string_histogram_test"
+  private val col = "col"
+  private def query(numBins: Int) = s"SELECT string_histogram($col, $numBins) FROM $table"
+
+  test("null handling") {
+    withTempView(table) {
+      val nullString: String = null
+      // Empty input row
+      Seq(nullString).toDF(col).createOrReplaceTempView(table)
+      checkAnswer(sql(query(numBins = 2)), Row(Map.empty))
+
+      // Add some non-empty row
+      Seq(nullString, "a", nullString).toDF(col).createOrReplaceTempView(table)
+      checkAnswer(sql(query(numBins = 2)), Row(Map(("a", 1))))
+    }
+  }
+
+  test("returns empty result when ndv exceeds numBins") {
+    withTempView(table) {
+      spark.sparkContext.makeRDD(Seq("a", "bb", "ccc", "dddd", "a"), 2).toDF(col)
+        .createOrReplaceTempView(table)
+      // One partial exceeds numBins during update()
+      checkAnswer(sql(query(numBins = 2)), Row(Map.empty))
+      // Exceeding numBins during merge()
+      checkAnswer(sql(query(numBins = 3)), Row(Map.empty))
+    }
+  }
+
+  test("multiple columns") {
+    withTempView(table) {
+      Seq(("a", null, "c"),
+        (null, "bb", "cc"),
+        ("a", "bbb", "ccc"),
+        ("aaaa", "bb", "c")
+      ).toDF("c1", "c2", "c3").createOrReplaceTempView(table)
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT
+             |  string_histogram(c1, 2),
+             |  string_histogram(c2, 1),
+             |  string_histogram(c3, 3)
+             |FROM $table
+           """.stripMargin),
+        Row(Map(("a", 2), ("aaaa", 1)), Map.empty, Map(("c", 2), ("cc", 1), ("ccc", 1)))
+      )
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This work is a part of [SPARK-17074](https://issues.apache.org/jira/browse/SPARK-17074) to generate histogram statistics.
This agg function generates equi-width histograms in the form of Map(value: String, frequency: Long) for string type columns, with a maximum number of histogram bins. It returns a empty result if the ndv(number of distinct value) of the column exceeds the maximum number allowed.
## How was this patch tested?

add test cases
