### PR TITLE
[SPARK-17882][SparkR] Fix swallowed exception in RBackendHandler

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/r/RBackendHandler.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackendHandler.scala
@@ -168,7 +168,7 @@ private[r] class RBackendHandler(server: RBackend)
       }
     } catch {
       case e: Exception =>
-        logError(s"$methodName on $objId failed")
+        logError(s"$methodName on $objId failed", e)
         writeInt(dos, -1)
         // Writing the error message of the cause for the exception. This will be returned
         // to user in the R process.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log exception that is swallowed in handleMethodCall. This allows invoked Java issues to be easily debugged when using SparkR.
## How was this patch tested?

Manual tests to verify the logged exception shows up.
