### PR TITLE
[SPARK-16845][SQL] `GeneratedClass$SpecificOrdering` grows beyond 64 KB

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -72,7 +72,7 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
    * Generates the code for ordering based on the given order.
    */
   def genComparisons(ctx: CodegenContext, ordering: Seq[SortOrder]): String = {
-    val comparisons = ordering.map { order =>
+    def comparisons(orderingGroup: Seq[SortOrder]) = orderingGroup.map { order =>
       val eval = order.child.genCode(ctx)
       val asc = order.isAscending
       val isNullA = ctx.freshName("isNullA")
@@ -118,7 +118,45 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
           }
       """
     }.mkString("\n")
-    comparisons
+
+    /*
+     * 40 = 7000 bytes / 170 (around 170 bytes per ordering comparison).
+     * The maximum byte code size to be compiled for HotSpot is 8000 bytes.
+     * We should keep less than 8000 bytes.
+     */
+    val numberOfComparisonsThreshold = 40
+
+    if (ordering.size <= numberOfComparisonsThreshold) {
+      s"""
+         |  InternalRow ${ctx.INPUT_ROW} = null;  // Holds current row being evaluated.
+         |  ${comparisons(ordering)}
+      """.stripMargin
+    } else {
+      val groupedOrderingItr = ordering.grouped(numberOfComparisonsThreshold)
+      var groupedOrderingLength = 0
+      groupedOrderingItr.zipWithIndex.foreach { case (orderingGroup, i) =>
+        groupedOrderingLength += 1
+        val funcName = s"compare_$i"
+        val funcCode =
+          s"""
+             |private int $funcName(InternalRow a, InternalRow b) {
+             |  InternalRow ${ctx.INPUT_ROW} = null;  // Holds current row being evaluated.
+             |  ${comparisons(orderingGroup)}
+             |  return 0;
+             |}
+          """.stripMargin
+        ctx.addNewFunction(funcName, funcCode)
+      }
+
+      (0 to groupedOrderingLength - 1).map { i =>
+        s"""
+           |result = compare_$i(a, b);
+           |if (result != 0) {
+           |  return result;
+           |}
+        """.stripMargin
+      }.mkString("")
+    }
   }
 
   protected def create(ordering: Seq[SortOrder]): BaseOrdering = {
@@ -142,7 +180,7 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
         ${ctx.declareAddedFunctions()}
 
         public int compare(InternalRow a, InternalRow b) {
-          InternalRow ${ctx.INPUT_ROW} = null;  // Holds current row being evaluated.
+          int result;
           $comparisons
           return 0;
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
@@ -127,4 +127,14 @@ class OrderingSuite extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
   }
+
+  test("SPARK-16845: GeneratedClass$SpecificOrdering grows beyond 64 KB") {
+    val sortOrder = Literal("abc").asc
+
+    // This is passing prior to SPARK-16845, and it should also be passing after SPARK-16845
+    GenerateOrdering.generate(Array.fill(40)(sortOrder))
+
+    // This is FAILING prior to SPARK-16845, but it should be passing after SPARK-16845
+    GenerateOrdering.generate(Array.fill(450)(sortOrder))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prior to this patch, we'll generate `compare(...)` for `GeneratedClass$SpecificOrdering` like below, leading to Janino exceptions saying the code grows beyond 64 KB.

``` scala
/* 005 */ class SpecificOrdering extends org.apache.spark.sql.catalyst.expressions.codegen.BaseOrdering {
/* ..... */   ...
/* 10969 */   private int compare(InternalRow a, InternalRow b) {
/* 10970 */     InternalRow i = null;  // Holds current row being evaluated.
/* 10971 */
/* 1.... */     code for comparing field0
/* 1.... */     code for comparing field1
/* 1.... */     ...
/* 1.... */     code for comparing field449
/* 15012 */
/* 15013 */     return 0;
/* 15014 */   }
/* 15015 */ }
```

This patch would break `compare(...)` into smaller `compare_xxx(...)` methods when necessary; then we'll get generated `compare(...)` like:

``` scala
/* 001 */ public SpecificOrdering generate(Object[] references) {
/* 002 */   return new SpecificOrdering(references);
/* 003 */ }
/* 004 */
/* 005 */ class SpecificOrdering extends org.apache.spark.sql.catalyst.expressions.codegen.BaseOrdering {
/* 006 */
/* 007 */     ...
/* 10968 */
/* 10969 */   private int compare_0(InternalRow a, InternalRow b) {
/* 10970 */     InternalRow i = null;  // Holds current row being evaluated.
/* 10971 */
/* 10972 */     i = a;
/* 10973 */     boolean isNullA;
/* 10974 */     UTF8String primitiveA;
/* 10975 */     {
/* 10976 */
/* 10977 */       Object obj = ((Expression) references[0]).eval(null);
/* 10978 */       UTF8String value = (UTF8String) obj;
/* 10979 */       isNullA = false;
/* 10980 */       primitiveA = value;
/* 10981 */     }
/* 10982 */     i = b;
/* 10983 */     boolean isNullB;
/* 10984 */     UTF8String primitiveB;
/* 10985 */     {
/* 10986 */
/* 10987 */       Object obj = ((Expression) references[0]).eval(null);
/* 10988 */       UTF8String value = (UTF8String) obj;
/* 10989 */       isNullB = false;
/* 10990 */       primitiveB = value;
/* 10991 */     }
/* 10992 */     if (isNullA && isNullB) {
/* 10993 */       // Nothing
/* 10994 */     } else if (isNullA) {
/* 10995 */       return -1;
/* 10996 */     } else if (isNullB) {
/* 10997 */       return 1;
/* 10998 */     } else {
/* 10999 */       int comp = primitiveA.compare(primitiveB);
/* 11000 */       if (comp != 0) {
/* 11001 */         return comp;
/* 11002 */       }
/* 11003 */     }
/* 11004 */
/* 11005 */     ...
/* 12258 */
/* 12259 */     i = a;
/* 12260 */     boolean isNullA39;
/* 12261 */     UTF8String primitiveA39;
/* 12262 */     {
/* 12263 */
/* 12264 */       Object obj39 = ((Expression) references[39]).eval(null);
/* 12265 */       UTF8String value39 = (UTF8String) obj39;
/* 12266 */       isNullA39 = false;
/* 12267 */       primitiveA39 = value39;
/* 12268 */     }
/* 12269 */     i = b;
/* 12270 */     boolean isNullB39;
/* 12271 */     UTF8String primitiveB39;
/* 12272 */     {
/* 12273 */
/* 12274 */       Object obj39 = ((Expression) references[39]).eval(null);
/* 12275 */       UTF8String value39 = (UTF8String) obj39;
/* 12276 */       isNullB39 = false;
/* 12277 */       primitiveB39 = value39;
/* 12278 */     }
/* 12279 */     if (isNullA39 && isNullB39) {
/* 12280 */       // Nothing
/* 12281 */     } else if (isNullA39) {
/* 12282 */       return -1;
/* 12283 */     } else if (isNullB39) {
/* 12284 */       return 1;
/* 12285 */     } else {
/* 12286 */       int comp = primitiveA39.compare(primitiveB39);
/* 12287 */       if (comp != 0) {
/* 12288 */         return comp;
/* 12289 */       }
/* 12290 */     }
/* 12291 */
/* 12292 */     return 0;
/* 12293 */   }
/* 12294 */   
/* 12295 */   ...
/* 14949 */   
/* 14950 */   public int compare(InternalRow a, InternalRow b) {
/* 14951 */     int result;
/* 14952 */
/* 14953 */     result = compare_0(a, b);
/* 14954 */     if (result != 0) {
/* 14955 */       return result;
/* 14956 */     }
/* 14957 */
/* 14958 */     result = compare_1(a, b);
/* 14959 */     if (result != 0) {
/* 14960 */       return result;
/* 14961 */     }
/* 14962 */
/* 14963 */     ...
/* 15007 */
/* 15008 */     result = compare_11(a, b);
/* 15009 */     if (result != 0) {
/* 15010 */       return result;
/* 15011 */     }
/* 15012 */
/* 15013 */     return 0;
/* 15014 */   }
/* 15015 */ }
```
## How was this patch tested?
- A new added test case which
  - would fail prior to this patch
  - would pass with this patch
- ordering correctness should already be covered by existing tests like those in `OrderingSuite`
