### PR TITLE
[SPARK-17909][SQL] we should create table before writing out the data in CTAS

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -439,7 +439,7 @@ case class DataSource(
   /** Writes the given [[DataFrame]] out to this [[DataSource]]. */
   def write(
       mode: SaveMode,
-      data: DataFrame): BaseRelation = {
+      data: DataFrame): Unit = {
     if (data.schema.map(_.dataType).exists(_.isInstanceOf[CalendarIntervalType])) {
       throw new AnalysisException("Cannot save interval data type into external storage.")
     }
@@ -515,8 +515,6 @@ case class DataSource(
             data.logicalPlan,
             mode)
         sparkSession.sessionState.executePlan(plan).toRdd
-        // Replace the schema with that of the DataFrame we just wrote out to avoid re-inferring it.
-        copy(userSpecifiedSchema = Some(data.schema.asNullable)).resolveRelation()
 
       case _ =>
         sys.error(s"${providingClass.getCanonicalName} does not allow create table as select.")


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `CreateDataSourceTableAsSelectCommand`, we write out the data to the table location before create table, because we assume the data schema may change after it has been written out. However, we may only change the schema's nullability. We can still create table first, with regarding all columns are nullable.
## How was this patch tested?

existing tests.
