### PR TITLE
[SPARK-13983][SQL] HiveThriftServer2 can not get "--hiveconf" or ''--hivevar" variables since 1.6 version (both multi-session and single session)

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.history.HiveHistory;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.processors.SetProcessor;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hive.common.util.HiveVersionInfo;
@@ -69,6 +68,7 @@ import org.apache.hive.service.cli.operation.MetadataOperation;
 import org.apache.hive.service.cli.operation.Operation;
 import org.apache.hive.service.cli.operation.OperationManager;
 import org.apache.hive.service.cli.thrift.TProtocolVersion;
+import org.apache.hive.service.ql.processors.SparkSQLSetProcessor;
 import org.apache.hive.service.server.ThreadWithGarbageCleanup;
 
 /**
@@ -209,7 +209,7 @@ public class HiveSessionImpl implements HiveSession {
       String key = entry.getKey();
       if (key.startsWith("set:")) {
         try {
-          SetProcessor.setVariable(key.substring(4), entry.getValue());
+          SparkSQLSetProcessor.setVariable(key.substring(4), entry.getValue());
         } catch (Exception e) {
           throw new HiveSQLException(e);
         }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/ql/processors/SparkSQLSetProcessor.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/ql/processors/SparkSQLSetProcessor.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.service.ql.processors;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.parse.VariableSubstitution;
+import org.apache.hadoop.hive.ql.processors.SetProcessor;
+import org.apache.hadoop.hive.ql.session.SessionState;
+
+public class SparkSQLSetProcessor extends SetProcessor {
+
+    public static int setVariable(String varname, String varvalue) throws Exception {
+        SessionState ss = SessionState.get();
+        if(varvalue.contains("\n")) {
+            ss.err.println("Warning: Value had a \\n character in it.");
+        }
+
+        varname = varname.trim();
+        if(varname.startsWith("env:")) {
+            ss.err.println("env:* variables can not be set.");
+            return 1;
+        } else {
+            String propName;
+            if(varname.startsWith("system:")) {
+                propName = varname.substring("system:".length());
+                System.getProperties().setProperty(propName,
+                        (new VariableSubstitution()).substitute(ss.getConf(), varvalue));
+            } else if(varname.startsWith("hiveconf:")) {
+                propName = varname.substring("hiveconf:".length());
+                setConf(varname, propName, varvalue, true);
+            } else if(varname.startsWith("hivevar:")) {
+                propName = varname.substring("hivevar:".length());
+                ss.getHiveVariables().put(propName,
+                        (new VariableSubstitution()).substitute(ss.getConf(), varvalue));
+            } else if(varname.startsWith("metaconf:")) {
+                propName = varname.substring("metaconf:".length());
+                Hive hive = Hive.get(ss.getConf());
+                hive.setMetaConf(propName,
+                        (new VariableSubstitution()).substitute(ss.getConf(), varvalue));
+            } else {
+                setConf(varname, varname, varvalue, true);
+            }
+
+            return 0;
+        }
+    }
+
+    private static void setConf(String varname, String key, String varvalue, boolean register)
+            throws IllegalArgumentException {
+        HiveConf conf = SessionState.get().getConf();
+        String value = (new VariableSubstitution()).substitute(conf, varvalue);
+        if(conf.getBoolVar(HiveConf.ConfVars.HIVECONFVALIDATION)) {
+            HiveConf.ConfVars confVars = HiveConf.getConfVars(key);
+            if(confVars != null) {
+                if(!confVars.isType(value)) {
+                    StringBuilder fail1 = new StringBuilder();
+                    fail1.append("\'SET ").append(varname).append('=').append(varvalue);
+                    fail1.append("\' FAILED because ").append(key).append(" expects ");
+                    fail1.append(confVars.typeString()).append(" type value.");
+                    throw new IllegalArgumentException(fail1.toString());
+                }
+
+                String fail = confVars.validate(value);
+                if(fail != null) {
+                    StringBuilder message = new StringBuilder();
+                    message.append("\'SET ").append(varname).append('=').append(varvalue);
+                    message.append("\' FAILED in validation : ").append(fail).append('.');
+                    throw new IllegalArgumentException(message.toString());
+                }
+            } else if(key.startsWith("hive.")) {
+                throw new IllegalArgumentException("hive configuration " + key +
+                        " does not exists.");
+            }
+        }
+
+        conf.verifyAndSet(key, value);
+        if(register) {
+            SessionState.get().getOverriddenConfigurations().put(key, value);
+        }
+
+    }
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -158,11 +158,8 @@ private[hive] object SparkSQLCLIDriver extends Logging {
 
     // Respect the configurations set by --hiveconf from the command line
     // (based on Hive's CliDriver).
-    val it = sessionState.getOverriddenConfigurations.entrySet().iterator()
-    while (it.hasNext) {
-      val kv = it.next()
-      SparkSQLEnv.sqlContext.setConf(kv.getKey, kv.getValue)
-    }
+    setConfMap(sessionState.getOverriddenConfigurations)
+    setConfMap(sessionState.getHiveVariables)
 
     if (sessionState.execString != null) {
       System.exit(cli.processLine(sessionState.execString))
@@ -264,6 +261,14 @@ private[hive] object SparkSQLCLIDriver extends Logging {
   def isRemoteMode(state: CliSessionState): Boolean = {
     //    sessionState.isRemoteMode
     state.isHiveServerQuery
+  }
+
+  def setConfMap(confMap: java.util.Map[String, String]): Unit = {
+    val iterator = confMap.entrySet().iterator()
+    while (iterator.hasNext) {
+      val kv = iterator.next()
+      SparkSQLEnv.sqlContext.setConf(kv.getKey, kv.getValue)
+    }
   }
 
 }

--- a/sql/hive-thriftserver/src/test/resources/TestSQL.sql
+++ b/sql/hive-thriftserver/src/test/resources/TestSQL.sql
@@ -1,0 +1,1 @@
+select date_add('${today}', -1)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -283,4 +283,10 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       "SET conf3;" -> "conftest"
     )
   }
+
+  test("Apply hivevar from cli command with -f") {
+    val sqlFile = Thread.currentThread().getContextClassLoader.getResource("TestSQL.sql")
+    runCliWithin(2.minute, Seq("--hivevar", "today=2016-10-10", "-f",
+      sqlFile.getFile))(s"" -> "2016-10-09")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can't get variables like [this way](https://github.com/pwendell/hive/blob/release-1.2.1-spark/ql/src/java/org/apache/hadoop/hive/ql/parse/VariableSubstitution.java#L38) after [SPARK-10810](https://issues.apache.org/jira/browse/SPARK-10810). but based on one SQLContext per session,  we can set variables to SQLContext. this is similar to [SPARK-15730](https://issues.apache.org/jira/browse/SPARK-15730)
 Thus, this PR is to set `--hivevar` and `--hiveconf` variables to `SQLContext` and then `VariableSubstitution` can substitution these variables.
## How was this patch tested?

Added test cases for spark-sql
and manual test beeline
