### PR TITLE
[SPARK-17921] failfast on checkpointLocation specified for memory streams

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -222,9 +222,13 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
 
       val sink = new MemorySink(df.schema, outputMode)
       val resultDf = Dataset.ofRows(df.sparkSession, new MemoryPlan(sink))
+      if (extraOptions.get("checkpointLocation").isDefined) {
+        throw new AnalysisException("Memory streams do not recover from checkpoints. Please " +
+          "remove the 'checkpointLocation' option.")
+      }
       val query = df.sparkSession.sessionState.streamingQueryManager.startQuery(
         extraOptions.get("queryName"),
-        extraOptions.get("checkpointLocation"),
+        None,
         df,
         sink,
         outputMode,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -125,6 +125,21 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
     }
   }
 
+  test("memory streams don't accept checkpoint location") {
+    val e = intercept[AnalysisException] {
+      spark.readStream
+        .format("org.apache.spark.sql.streaming.test")
+        .load()
+        .writeStream
+        .format("memory")
+        .option("checkpointLocation", "some/place")
+        .start("over/the/rainbow")
+    }
+    Seq("Memory", "do not recover", "checkpoints", "'checkpointLocation'").foreach { s =>
+      assert(e.getMessage.toLowerCase.contains(s.toLowerCase))
+    }
+  }
+
   test("resolve default source") {
     spark.readStream
       .format("org.apache.spark.sql.streaming.test")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The checkpointLocation option in memory streams in StructuredStreaming is not used during recovery. However, it can use this location if it is being set. However, during recovery, if this location was set, we get an exception saying that we will not use this location for recovery, please delete it.
It's better to just fail before you start the stream in the first place
## How was this patch tested?

Unit tests
