### PR TITLE
[SPARK-17926][SQL][STREAMING] Added json for statuses

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -350,19 +350,19 @@ pyspark_sql = Module(
         "python/pyspark/sql"
     ],
     python_test_goals=[
-        #"pyspark.sql.types",
-        #"pyspark.sql.context",
-        #"pyspark.sql.session",
-        #"pyspark.sql.conf",
-        #"pyspark.sql.catalog",
-        #"pyspark.sql.column",
-        #"pyspark.sql.dataframe",
-        #"pyspark.sql.group",
-        #"pyspark.sql.functions",
-        #"pyspark.sql.readwriter",
+        "pyspark.sql.types",
+        "pyspark.sql.context",
+        "pyspark.sql.session",
+        "pyspark.sql.conf",
+        "pyspark.sql.catalog",
+        "pyspark.sql.column",
+        "pyspark.sql.dataframe",
+        "pyspark.sql.group",
+        "pyspark.sql.functions",
+        "pyspark.sql.readwriter",
         "pyspark.sql.streaming",
-        #"pyspark.sql.window",
-        #"pyspark.sql.tests",
+        "pyspark.sql.window",
+        "pyspark.sql.tests",
     ]
 )
 

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -350,19 +350,19 @@ pyspark_sql = Module(
         "python/pyspark/sql"
     ],
     python_test_goals=[
-        "pyspark.sql.types",
-        "pyspark.sql.context",
-        "pyspark.sql.session",
-        "pyspark.sql.conf",
-        "pyspark.sql.catalog",
-        "pyspark.sql.column",
-        "pyspark.sql.dataframe",
-        "pyspark.sql.group",
-        "pyspark.sql.functions",
-        "pyspark.sql.readwriter",
+        #"pyspark.sql.types",
+        #"pyspark.sql.context",
+        #"pyspark.sql.session",
+        #"pyspark.sql.conf",
+        #"pyspark.sql.catalog",
+        #"pyspark.sql.column",
+        #"pyspark.sql.dataframe",
+        #"pyspark.sql.group",
+        #"pyspark.sql.functions",
+        #"pyspark.sql.readwriter",
         "pyspark.sql.streaming",
-        "pyspark.sql.window",
-        "pyspark.sql.tests",
+        #"pyspark.sql.window",
+        #"pyspark.sql.tests",
     ]
 )
 

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -205,8 +205,7 @@ class StreamingQueryStatus(object):
         Pretty string of this query status.
 
         >>> print(sqs)
-        StreamingQueryStatus:
-            Query name: query
+        Status of query 'query'
             Query id: 1
             Status timestamp: 123
             Input rate: 15.5 rows/sec
@@ -220,7 +219,7 @@ class StreamingQueryStatus(object):
                 numRows.input.total: 100
                 triggerId: 5
             Source statuses [1 source]:
-                Source 1:    MySource1
+                Source 1 - MySource1
                     Available offset: #0
                     Input rate: 15.5 rows/sec
                     Processing rate: 23.5 rows/sec
@@ -228,7 +227,7 @@ class StreamingQueryStatus(object):
                         numRows.input.source: 100
                         latency.getOffset.source: 10
                         latency.getBatch.source: 20
-            Sink status:     MySink
+            Sink status - MySink
                 Committed offsets: [#1, -]
         """
         return self._jsqs.toString()
@@ -366,7 +365,7 @@ class SourceStatus(object):
         Pretty string of this source status.
 
         >>> print(sqs.sourceStatuses[0])
-        SourceStatus:    MySource1
+        Status of source MySource1
             Available offset: #0
             Input rate: 15.5 rows/sec
             Processing rate: 23.5 rows/sec
@@ -457,7 +456,7 @@ class SinkStatus(object):
         Pretty string of this source status.
 
         >>> print(sqs.sinkStatus)
-        SinkStatus:    MySink
+        Status of sink MySink
             Committed offsets: [#1, -]
         """
         return self._jss.toString()

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SinkStatus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SinkStatus.scala
@@ -40,15 +40,15 @@ class SinkStatus private(
     val offsetDesc: String) {
 
   /** The compact JSON representation of this status. */
-  lazy val json: String = compact(render(jsonValue))
+  def json: String = compact(render(jsonValue))
 
   /** The pretty (i.e. indented) JSON representation of this status. */
-  lazy val prettyJson: String = pretty(render(jsonValue))
+  def prettyJson: String = pretty(render(jsonValue))
 
-  override lazy val toString: String =
+  override def toString: String =
     "Status of sink " + indent(prettyString).trim
 
-  private[sql] lazy val jsonValue: JValue = {
+  private[sql] def jsonValue: JValue = {
     ("description" -> JString(description)) ~
     ("offsetDesc" -> JString(offsetDesc))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SinkStatus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SinkStatus.scala
@@ -17,6 +17,11 @@
 
 package org.apache.spark.sql.streaming
 
+import org.json4s._
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.streaming.StreamingQueryStatus.indent
 
@@ -34,8 +39,19 @@ class SinkStatus private(
     val description: String,
     val offsetDesc: String) {
 
-  override def toString: String =
-    "SinkStatus:" + indent(prettyString)
+  /** The compact JSON representation of this status. */
+  lazy val json: String = compact(render(jsonValue))
+
+  /** The pretty (i.e. indented) JSON representation of this status. */
+  lazy val prettyJson: String = pretty(render(jsonValue))
+
+  override lazy val toString: String =
+    "Status of sink " + indent(prettyString).trim
+
+  private[sql] lazy val jsonValue: JValue = {
+    ("description" -> JString(description)) ~
+    ("offsetDesc" -> JString(offsetDesc))
+  }
 
   private[sql] def prettyString: String = {
     s"""$description

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SourceStatus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SourceStatus.scala
@@ -54,15 +54,15 @@ class SourceStatus private(
     val triggerDetails: ju.Map[String, String]) {
 
   /** The compact JSON representation of this status. */
-  lazy val json: String = compact(render(jsonValue))
+  def json: String = compact(render(jsonValue))
 
   /** The pretty (i.e. indented) JSON representation of this status. */
-  lazy val prettyJson: String = pretty(render(jsonValue))
+  def prettyJson: String = pretty(render(jsonValue))
 
-  override lazy val toString: String =
+  override def toString: String =
     "Status of source " + indent(prettyString).trim
 
-  private[sql] lazy val jsonValue: JValue = {
+  private[sql] def jsonValue: JValue = {
     ("description" -> JString(description)) ~
     ("offsetDesc" -> JString(offsetDesc)) ~
     ("inputRate" -> JDouble(inputRate)) ~
@@ -70,7 +70,7 @@ class SourceStatus private(
     ("triggerDetails" -> JsonProtocol.mapToJson(triggerDetails.asScala))
   }
 
-  private[sql] lazy val prettyString: String = {
+  private[sql] def prettyString: String = {
     val triggerDetailsLines =
       triggerDetails.asScala.map { case (k, v) => s"$k: $v" }
     s"""$description

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryStatus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryStatus.scala
@@ -66,12 +66,12 @@ class StreamingQueryStatus private(
   import StreamingQueryStatus._
 
   /** The compact JSON representation of this status. */
-  lazy val json: String = compact(render(jsonValue))
+  def json: String = compact(render(jsonValue))
 
   /** The pretty (i.e. indented) JSON representation of this status. */
-  lazy val prettyJson: String = pretty(render(jsonValue))
+  def prettyJson: String = pretty(render(jsonValue))
 
-  override lazy val toString: String = {
+  override def toString: String = {
     val sourceStatusLines = sourceStatuses.zipWithIndex.map { case (s, i) =>
       s"Source ${i + 1} - " + indent(s.prettyString).trim
     }
@@ -95,7 +95,7 @@ class StreamingQueryStatus private(
     s"Status of query '$name'\n${indent(allLines)}"
   }
 
-  private[sql] lazy val jsonValue: JValue = {
+  private[sql] def jsonValue: JValue = {
     ("name" -> JString(name)) ~
     ("id" -> JInt(id)) ~
     ("timestamp" -> JInt(timestamp)) ~

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusSuite.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.SparkFunSuite
+
+class StreamingQueryStatusSuite extends SparkFunSuite {
+  test("toString") {
+    assert(StreamingQueryStatus.testStatus.sourceStatuses(0).toString ===
+      """
+        |Status of source MySource1
+        |    Available offset: #0
+        |    Input rate: 15.5 rows/sec
+        |    Processing rate: 23.5 rows/sec
+        |    Trigger details:
+        |        numRows.input.source: 100
+        |        latency.getOffset.source: 10
+        |        latency.getBatch.source: 20
+      """.stripMargin.trim, "SourceStatus.toString does not match")
+
+    assert(StreamingQueryStatus.testStatus.sinkStatus.toString ===
+      """
+        |Status of sink MySink
+        |    Committed offsets: [#1, -]
+      """.stripMargin.trim, "SinkStatus.toString does not match")
+
+    assert(StreamingQueryStatus.testStatus.toString ===
+      """
+        |Status of query 'query'
+        |    Query id: 1
+        |    Status timestamp: 123
+        |    Input rate: 15.5 rows/sec
+        |    Processing rate 23.5 rows/sec
+        |    Latency: 345.0 ms
+        |    Trigger details:
+        |        isDataPresentInTrigger: true
+        |        isTriggerActive: true
+        |        latency.getBatch.total: 20
+        |        latency.getOffset.total: 10
+        |        numRows.input.total: 100
+        |        triggerId: 5
+        |    Source statuses [1 source]:
+        |        Source 1 - MySource1
+        |            Available offset: #0
+        |            Input rate: 15.5 rows/sec
+        |            Processing rate: 23.5 rows/sec
+        |            Trigger details:
+        |                numRows.input.source: 100
+        |                latency.getOffset.source: 10
+        |                latency.getBatch.source: 20
+        |    Sink status - MySink
+        |        Committed offsets: [#1, -]
+      """.stripMargin.trim, "StreamingQueryStatus.toString does not match")
+
+  }
+
+  test("json") {
+    assert(StreamingQueryStatus.testStatus.json ===
+      """
+        |{"sourceStatuses":[{"description":"MySource1","offsetDesc":"#0","inputRate":15.5,
+        |"processingRate":23.5,"triggerDetails":{"numRows.input.source":"100",
+        |"latency.getOffset.source":"10","latency.getBatch.source":"20"}}],
+        |"sinkStatus":{"description":"MySink","offsetDesc":"[#1, -]"}}
+      """.stripMargin.replace("\n", "").trim)
+  }
+
+  test("prettyJson") {
+    assert(
+      StreamingQueryStatus.testStatus.prettyJson ===
+        """
+          |{
+          |  "sourceStatuses" : [ {
+          |    "description" : "MySource1",
+          |    "offsetDesc" : "#0",
+          |    "inputRate" : 15.5,
+          |    "processingRate" : 23.5,
+          |    "triggerDetails" : {
+          |      "numRows.input.source" : "100",
+          |      "latency.getOffset.source" : "10",
+          |      "latency.getBatch.source" : "20"
+          |    }
+          |  } ],
+          |  "sinkStatus" : {
+          |    "description" : "MySink",
+          |    "offsetDesc" : "[#1, -]"
+          |  }
+          |}
+        """.stripMargin.trim)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

StreamingQueryStatus exposed through StreamingQueryListener often needs to be recorded (similar to SparkListener events). This PR adds `.json` and `.prettyJson` to `StreamingQueryStatus`, `SourceStatus` and `SinkStatus`.
## How was this patch tested?

New unit tests
