### PR TITLE
[SPARK-17940][SQL] Fixed a typo in LAST function and improved its usage string

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -29,10 +29,14 @@ import org.apache.spark.sql.types._
  * a single partition, and we use a single reducer to do the aggregation.).
  */
 @ExpressionDescription(
-  usage = """_FUNC_(expr) - Returns the first value of `child` for a group of rows.
-    _FUNC_(expr,isIgnoreNull=false) - Returns the first value of `child` for a group of rows.
-      If isIgnoreNull is true, returns only non-null values. Note that in most cases the
-      result is nondeterministic.
+  usage =
+    """
+      _FUNC_(expr) - Returns the first value of `child` for a group of rows.
+
+      _FUNC_(expr, isIgnoreNull=false) - Returns the first value of `child` for a group of rows.
+      If isIgnoreNull is true, returns only non-null values.
+
+      Note that in most cases the result is nondeterministic.
     """)
 case class First(child: Expression, ignoreNullsExpr: Expression) extends DeclarativeAggregate {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """_FUNC_(expr) - Returns the first value of `child` for a group of rows.
     _FUNC_(expr,isIgnoreNull=false) - Returns the first value of `child` for a group of rows.
-      If isIgnoreNull is true, returns only non-null values.
+      If isIgnoreNull is true, returns only non-null values. Note that in most cases the
+      result is nondeterministic.
     """)
 case class First(child: Expression, ignoreNullsExpr: Expression) extends DeclarativeAggregate {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -29,10 +29,14 @@ import org.apache.spark.sql.types._
  * a single partition, and we use a single reducer to do the aggregation.).
  */
 @ExpressionDescription(
-  usage = """_FUNC_(expr) - Returns the last value of `child` for a group of rows.
-    _FUNC_(expr,isIgnoreNull=false) - Returns the last value of `child` for a group of rows.
-      If isIgnoreNull is true, returns only non-null values. Note that in most cases the
-      result is nondeterministic.
+  usage =
+    """
+      _FUNC_(expr) - Returns the last value of `child` for a group of rows.
+
+      _FUNC_(expr, isIgnoreNull) - Returns the last value of `child` for a group of rows.
+      If isIgnoreNull is true, returns only non-null values.
+
+      Note that in most cases the result is nondeterministic.
     """)
 case class Last(child: Expression, ignoreNullsExpr: Expression) extends DeclarativeAggregate {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -29,9 +29,10 @@ import org.apache.spark.sql.types._
  * a single partition, and we use a single reducer to do the aggregation.).
  */
 @ExpressionDescription(
-  usage = """_FUNC_(expr,isIgnoreNull) - Returns the last value of `child` for a group of rows.
+  usage = """_FUNC_(expr) - Returns the last value of `child` for a group of rows.
     _FUNC_(expr,isIgnoreNull=false) - Returns the last value of `child` for a group of rows.
-      If isIgnoreNull is true, returns only non-null values.
+      If isIgnoreNull is true, returns only non-null values. Note that in most cases the
+      result is nondeterministic.
     """)
 case class Last(child: Expression, ignoreNullsExpr: Expression) extends DeclarativeAggregate {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -29,7 +29,10 @@ import org.apache.spark.sql.types._
  * a single partition, and we use a single reducer to do the aggregation.).
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr,isIgnoreNull) - Returns the last value of `child` for a group of rows.")
+  usage = """_FUNC_(expr,isIgnoreNull) - Returns the last value of `child` for a group of rows.
+    _FUNC_(expr,isIgnoreNull=false) - Returns the last value of `child` for a group of rows.
+      If isIgnoreNull is true, returns only non-null values.
+    """)
 case class Last(child: Expression, ignoreNullsExpr: Expression) extends DeclarativeAggregate {
 
   def this(child: Expression) = this(child, Literal.create(false, BooleanType))
@@ -37,7 +40,7 @@ case class Last(child: Expression, ignoreNullsExpr: Expression) extends Declarat
   private val ignoreNulls: Boolean = ignoreNullsExpr match {
     case Literal(b: Boolean, BooleanType) => b
     case _ =>
-      throw new AnalysisException("The second argument of First should be a boolean literal.")
+      throw new AnalysisException("The second argument of Last should be a boolean literal.")
   }
 
   override def children: Seq[Expression] = child :: ignoreNullsExpr :: Nil


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Fixed a a typo in the LAST function error message
- Also improved its usage string to match the FIRST function
## How was this patch tested?

Existing tests.
