### PR TITLE
[SPARK-17946][PYSPARK] Python crossJoin API similar to Scala

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -627,7 +627,7 @@ class DataFrame(object):
         return DataFrame(getattr(self._jdf, "as")(alias), self.sql_ctx)
 
     @ignore_unicode_prefix
-    @since(2.0)
+    @since(2.1)
     def crossJoin(self, other):
         """Returns the cartesian product with another :class:`DataFrame`
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -638,7 +638,8 @@ class DataFrame(object):
         >>> df2.select("name", "height").collect()
         [Row(name=u'Tom', height=80), Row(name=u'Bob', height=85)]
         >>> df.crossJoin(df2.select("height")).select("age", "name", "height").collect()
-        [Row(age=2, name=u'Alice', height=80), Row(age=2, name=u'Alice', height=85), Row(age=5, name=u'Bob', height=80), Row(age=5, name=u'Bob', height=85)]
+        [Row(age=2, name=u'Alice', height=80), Row(age=2, name=u'Alice', height=85),
+         Row(age=5, name=u'Bob', height=80), Row(age=5, name=u'Bob', height=85)]
         """
 
         jdf = self._jdf.crossJoin(other._jdf)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -629,9 +629,9 @@ class DataFrame(object):
     @ignore_unicode_prefix
     @since(2.1)
     def crossJoin(self, other):
-        """Returns the cartesian product with another :class:`DataFrame`
+        """Returns the cartesian product with another :class:`DataFrame`.
 
-        :param other: Right side of the cartesian product
+        :param other: Right side of the cartesian product.
 
         >>> df.select("age", "name").collect()
         [Row(age=2, name=u'Alice'), Row(age=5, name=u'Bob')]

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -774,7 +774,7 @@ class Dataset[T] private[sql](
    * @param right Right side of the join operation.
    *
    * @group untypedrel
-   * @since 2.0.0
+   * @since 2.1.0
    */
   def crossJoin(right: Dataset[_]): DataFrame = withPlan {
     Join(logicalPlan, right.logicalPlan, joinType = Cross, None)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a crossJoin function to the DataFrame API similar to that in Scala. Joins with no condition (cartesian products) must be specified with the crossJoin API
## How was this patch tested?

Added python tests to ensure that an AnalysisException if a cartesian product is specified without crossJoin(), and that cartesian products can execute if specified via crossJoin()

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark before opening a pull request.
