### PR TITLE
[SPARK-17947] [SQL] Add Doc and Comment about spark.sql.debug

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -917,7 +917,7 @@ object StaticSQLConf {
     .createWithDefault(4000)
 
   // When enabling the debug, Spark SQL internal table properties are not filtered out; however,
-  // Some related DDL commands (e.g., Analyze Table and CREATE TABLE LIKE) might not work properly.
+  // some related DDL commands (e.g., Analyze Table and CREATE TABLE LIKE) might not work properly.
   val DEBUG_MODE = buildConf("spark.sql.debug")
     .internal()
     .doc("Only used for internal debugging. Not all functions are supported when it is enabled.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -917,7 +917,7 @@ object StaticSQLConf {
     .createWithDefault(4000)
 
   // When enabling the debug, Spark SQL internal table properties are not filtered out; however,
-  // some related DDL commands (e.g., Analyze Table and CREATE TABLE LIKE) might not work properly.
+  // some related DDL commands (e.g., ANALYZE TABLE and CREATE TABLE LIKE) might not work properly.
   val DEBUG_MODE = buildConf("spark.sql.debug")
     .internal()
     .doc("Only used for internal debugging. Not all functions are supported when it is enabled.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -916,8 +916,11 @@ object StaticSQLConf {
     .intConf
     .createWithDefault(4000)
 
+  // When enabling the debug, Spark SQL internal table properties are not filtered out; however,
+  // Some related DDL commands (e.g., Analyze Table and CREATE TABLE LIKE) might not work properly.
   val DEBUG_MODE = buildConf("spark.sql.debug")
     .internal()
+    .doc("Only used for internal debugging. Not all functions are supported when it is enabled.")
     .booleanConf
     .createWithDefault(false)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Just document the impact of `spark.sql.debug`:

When enabling the debug, Spark SQL internal table properties are not filtered out; however, some related DDL commands (e.g., Analyze Table and CREATE TABLE LIKE) might not work properly.
### How was this patch tested?

N/A
