### PR TITLE
[SPARK-17953] [Documentation] Fix typo in SparkSession scaladoc

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -64,7 +64,7 @@ import org.apache.spark.util.Utils
  *   SparkSession.builder()
  *     .master("local")
  *     .appName("Word Count")
- *     .config("spark.some.config.option", "some-value").
+ *     .config("spark.some.config.option", "some-value")
  *     .getOrCreate()
  * }}}
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Before:

``` scala
SparkSession.builder()
     .master("local")
     .appName("Word Count")
     .config("spark.some.config.option", "some-value").
     .getOrCreate()
```
### After:

``` scala
SparkSession.builder()
     .master("local")
     .appName("Word Count")
     .config("spark.some.config.option", "some-value")
     .getOrCreate()
```

There was one unexpected dot!
