### PR TITLE
[MINOR][SQL] Add prettyName for current_database function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -618,6 +618,7 @@ case class CurrentDatabase() extends LeafExpression with Unevaluable {
   override def dataType: DataType = StringType
   override def foldable: Boolean = true
   override def nullable: Boolean = false
+  override def prettyName: String = "current_database"
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a `prettyname` for current_database function.
## How was this patch tested?

Manually.

Before:

```
scala> sql("select current_database()").show
+-----------------+
|currentdatabase()|
+-----------------+
|          default|
+-----------------+
```

After:

```
scala> sql("select current_database()").show
+------------------+
|current_database()|
+------------------+
|           default|
+------------------+
```
