### PR TITLE
[SPARK-17972][SQL] Build Datasets upon `withCachedData` instead of `analyzed` to avoid slow query planning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -184,7 +184,7 @@ class Dataset[T] private[sql](
       case Union(children) if children.forall(hasSideEffects) =>
         LogicalRDD(queryExecution.analyzed.output, queryExecution.toRdd)(sparkSession)
       case _ =>
-        queryExecution.analyzed
+        queryExecution.withCachedData
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -66,11 +66,13 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
 
   lazy val withCachedData: LogicalPlan = {
     assertAnalyzed()
-    assertSupported()
     sparkSession.sharedState.cacheManager.useCachedData(analyzed)
   }
 
-  lazy val optimizedPlan: LogicalPlan = sparkSession.sessionState.optimizer.execute(withCachedData)
+  lazy val optimizedPlan: LogicalPlan = {
+    assertSupported()
+    sparkSession.sessionState.optimizer.execute(withCachedData)
+  }
 
   lazy val sparkPlan: SparkPlan = {
     SparkSession.setActiveSession(sparkSession)
@@ -226,6 +228,8 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
        |${stringOrError(logical.treeString(verbose = true))}
        |== Analyzed Logical Plan ==
        |$analyzedPlan
+       |== With cache data ==
+       |$withCachedData
        |== Optimized Logical Plan ==
        |${stringOrError(optimizedPlan.treeString(verbose = true))}
        |== Physical Plan ==

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -142,7 +142,7 @@ case class InMemoryRelation(
 
     cached.setName(
       tableName.map(n => s"In-memory table $n")
-        .getOrElse(StringUtils.abbreviate(child.toString, 1024)))
+        .getOrElse(StringUtils.abbreviate(child.simpleString, 1024)))
     _cachedColumnBuffers = cached
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(This PR is based on a PoC branch authored by @clockfly.)

Iterative ML code may easily create query plans that grow exponentially. We found that query planning time also increases exponentially even when all the sub-plan trees are cached.

The following snippet illustrates the problem:

``` scala
(0 until 6).foldLeft(Seq(1, 2, 3).toDS) { (plan, iteration) =>
  val start = System.currentTimeMillis()
  val result = plan.join(plan, "value").join(plan, "value").join(plan, "value").join(plan, "value")
  result.cache()
  System.out.println(s"Iteration $iteration takes time ${System.currentTimeMillis() - start} ms")
  result.as[Int]
}

// Iteration 0 takes time 9 ms
// Iteration 1 takes time 19 ms
// Iteration 2 takes time 61 ms
// Iteration 3 takes time 219 ms
// Iteration 4 takes time 830 ms
// Iteration 5 takes time 4080 ms
```

This is because when building a new Dataset, the new plan is always built upon `QueryExecution.analyzed`, which doesn't leverage existing cached plans. This PR tries to fix this issue by building new Datasets upon `QueryExecution.withCachedData` to leverage cached plans and avoid super slow query planning.

Here is the result of running 1,000 iterations using the same posted above after applying this PR:

```
Iteration 0 takes time 10 ms
Iteration 1 takes time 48 ms
Iteration 2 takes time 39 ms
Iteration 3 takes time 56 ms
Iteration 4 takes time 43 ms
Iteration 5 takes time 36 ms
Iteration 6 takes time 43 ms
Iteration 7 takes time 44 ms
Iteration 8 takes time 38 ms
Iteration 9 takes time 42 ms
...
Iteration 990 takes time 207 ms
Iteration 991 takes time 187 ms
Iteration 992 takes time 223 ms
Iteration 993 takes time 220 ms
Iteration 994 takes time 231 ms
Iteration 995 takes time 211 ms
Iteration 996 takes time 216 ms
Iteration 997 takes time 199 ms
Iteration 998 takes time 209 ms
Iteration 999 takes time 202 ms
```

Query planning time slows down much more slowly. This is mostly because cache manager query lookup slows down as entries stored in the cache manager grows. 

Many thanks to @clockfly, who investigated this issue and made an initial PoC.
## How was this patch tested?

Existing tests.
