### PR TITLE
[SQL][STREAMING][TEST] Follow up to remove Option.contains for Scala 2.10 compatibility

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -216,7 +216,9 @@ trait StreamTest extends QueryTest with SharedSQLContext with Timeouts {
       }
     }
 
-    def isStreamWaitingAt(time: Long): Boolean = synchronized { waitStartTime.contains(time) }
+    def isStreamWaitingAt(time: Long): Boolean = synchronized {
+      waitStartTime == Some(time)
+    }
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scala 2.10 does not have Option.contains, which broke Scala 2.10 build. 
## How was this patch tested?

Locally compiled and ran sql/core unit tests in 2.10 
