### PR TITLE
[MINOR][Documentation] Mention that short names can be used in data sources not only for built-in sources

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -421,9 +421,10 @@ In the simplest form, the default data source (`parquet` unless otherwise config
 
 You can also manually specify the data source that will be used along with any extra options
 that you would like to pass to the data source. Data sources are specified by their fully qualified
-name (i.e., `org.apache.spark.sql.parquet`), but for built-in sources you can also use their short
-names (`json`, `parquet`, `jdbc`, `orc`, `libsvm`, `csv`, `text`). DataFrames loaded from any data
-source type can be converted into other types using this syntax.
+name (i.e., `org.apache.spark.sql.parquet`) or short name specified in
+`DataSourceRegister.shortName()` in their implementation. For built-in sources you can use their
+short names(`json`, `parquet`, `jdbc`, `orc`, `libsvm`, `csv`, `text`). DataFrames loaded from any
+data source type can be converted into other types using this syntax.
 
 <div class="codetabs">
 <div data-lang="scala"  markdown="1">


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to fix the documentation in order to mention the short names can be used for other external data sources as well (not only built-in ones).
## How was this patch tested?

Manually built the docs.

**Before**

![2016-10-19 9 41 52](https://cloud.githubusercontent.com/assets/6477701/19502094/62646872-95e5-11e6-9574-cdde36ab5195.png)

**After**

![2016-10-19 10 07 30](https://cloud.githubusercontent.com/assets/6477701/19502091/608252b2-95e5-11e6-8c3c-60baa0ba3c7d.png)
