### PR TITLE
[SPARK-17637][Scheduler]Packed scheduling for Spark tasks across executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -223,4 +223,9 @@ package object config {
       " bigger files.")
     .longConf
     .createWithDefault(4 * 1024 * 1024)
+
+  private[spark] val SPARK_SCHEDULER_TASK_ASSIGNER = ConfigBuilder("spark.scheduler.taskAssigner")
+    .doc("The task assigner (roundrobin, packed, balanced) to schedule tasks on workers.")
+    .stringConf
+    .createWithDefault("roundrobin")
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
@@ -133,8 +133,8 @@ object TaskAssigner extends Logging {
     val className = {
       val name = assignerMap.get(assignerName.toLowerCase())
       name.getOrElse {
-        throw new SparkException(s"Task Assigner $assignerName is not available. " +
-          s"Please choose roundrobin, packed, or balanced.  roundrobin is used by default")
+        throw new SparkException(s"Task Assigner $assignerName is invalid. Available assigners " +
+          s"are roundrobin, packed, and balanced.  roundrobin is the default")
 
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.util.Utils
 
 /** Tracks the current state of the workers with available cores and assigned task list. */
-class OfferState(val workOffer: WorkerOffer) {
+private[scheduler] class OfferState(val workOffer: WorkerOffer) {
   /** The current remaining cores that can be allocated to tasks. */
   var coresAvailable: Int = workOffer.cores
   /** The list of tasks that are assigned to this WorkerOffer. */
@@ -38,7 +38,7 @@ class OfferState(val workOffer: WorkerOffer) {
  * extended to implement different task scheduling algorithms.
  * Together with [[org.apache.spark.scheduler.TaskScheduler TaskScheduler]], TaskAssigner
  * is used to assign tasks to workers with available cores. Internally, when TaskScheduler
- * perform task assignment given available workers, it first sorts the candidate tasksets,
+ * performs task assignment given available workers, it first sorts the candidate tasksets,
  * and then for each taskset, it takes a number of rounds to request TaskAssigner for task
  * assignment with different locality restrictions until there is either no qualified
  * workers or no valid tasks to be assigned.
@@ -50,7 +50,7 @@ class OfferState(val workOffer: WorkerOffer) {
  * First, TaskScheduler invokes construct() of TaskAssigner to initialize the its internal
  * worker states at the beginning of resource offering.
  *
- * Second, before each round of task assignment for a taskset, TaskScheduler invoke the init()
+ * Second, before each round of task assignment for a taskset, TaskScheduler invokes the init()
  * of TaskAssigner to initialize the data structure for the round.
  *
  * Third, when performing real task assignment, hasNext()/getNext() is used by TaskScheduler
@@ -83,9 +83,9 @@ private[scheduler] abstract class TaskAssigner {
   def init(): Unit
 
   /**
-   * Tests Whether there is offer available to be used inside of one round of Taskset assignment.
-   *  @return  `true` if a subsequent call to `next` will yield an element,
-   *           `false` otherwise.
+   * Tests whether there is offer available to be used inside of one round of Taskset assignment.
+   * @return  `true` if a subsequent call to `next` will yield an element,
+   *          `false` otherwise.
    */
   def hasNext: Boolean
 
@@ -152,7 +152,7 @@ class RoundRobinAssigner extends TaskAssigner {
 }
 
 /**
- * Assign the task to workers with the most available cores. It other words, BalancedAssigner tries
+ * Assign the task to workers with the most available cores. In other words, BalancedAssigner tries
  * to distribute the task across workers in a balanced way. Potentially, it may alleviate the
  * workers' memory pressure as less tasks running on the same workers, which also indicates that
  * the task itself can make use of more computation resources, e.g., hyper-thread, across clusters.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
@@ -76,7 +76,7 @@ private[scheduler] abstract class TaskAssigner {
 
   /** Invoked at the beginning of resource offering to construct the offer with the workoffers. */
   def construct(workOffer: Seq[WorkerOffer]): Unit = {
-    offer = workOffer.map(o => new OfferState(o))
+    offer = Random.shuffle(workOffer.map(o => new OfferState(o)))
   }
 
   /** Invoked at each round of Taskset assignment to initialize the internal structure. */
@@ -136,10 +136,6 @@ object TaskAssigner extends Logging {
 class RoundRobinAssigner extends TaskAssigner {
   private var currentOfferIndex = 0
 
-  override def construct(workOffer: Seq[WorkerOffer]): Unit = {
-    offer = Random.shuffle(workOffer.map(o => new OfferState(o)))
-  }
-
   override def init(): Unit = {
     currentOfferIndex = 0
   }
@@ -169,10 +165,6 @@ class BalancedAssigner extends TaskAssigner {
   }
   private val maxHeap: PriorityQueue[OfferState] = new PriorityQueue[OfferState]()
   private var currentOffer: OfferState = _
-
-  override def construct(workOffer: Seq[WorkerOffer]): Unit = {
-    offer = Random.shuffle(workOffer.map(o => new OfferState(o)))
-  }
 
   override def init(): Unit = {
     maxHeap.clear()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
@@ -133,8 +133,9 @@ object TaskAssigner extends Logging {
     val className = {
       val name = assignerMap.get(assignerName.toLowerCase())
       name.getOrElse {
-        logWarning(s"$assignerName cannot be constructed, fallback to default $roundrobin.")
-        roundrobin
+        throw new SparkException(s"Task Assigner $assignerName is not available. " +
+          s"Please choose roundrobin, packed, or balanced.  roundrobin is used by default")
+
       }
     }
     // The className is valid. No need to catch exceptions.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskAssigner.scala
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.PriorityQueue
+import scala.util.Random
+
+import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.SparkConf
+import org.apache.spark.util.Utils
+
+/** Tracking the current state of the workers with available cores and assigned task list. */
+class OfferState(val workOffer: WorkerOffer) {
+  // The current remaining cores that can be allocated to tasks.
+  var coresAvailable: Int = workOffer.cores
+  // The list of tasks that are assigned to this worker.
+  val tasks = new ArrayBuffer[TaskDescription](coresAvailable)
+}
+
+/**
+ * TaskAssigner is the base class for all task assigner implementations, and can be
+ * extended to implement different task scheduling algorithms.
+ * Together with [[org.apache.spark.scheduler.TaskScheduler TaskScheduler]], TaskAssigner
+ * is used to assign tasks to workers with available cores. Internally, TaskScheduler, requested
+ * to perform task assignment given available workers, first sorts the candidate tasksets,
+ * and then for each taskset, it takes a number of rounds to request TaskAssigner for task
+ * assignment with different the locality restrictions until there is either no qualified
+ * workers or no valid tasks to be assigned.
+ *
+ * TaskAssigner is responsible to maintain the worker availability state and task assignment
+ * information. The contract between [[org.apache.spark.scheduler.TaskScheduler TaskScheduler]]
+ * and TaskAssigner is as follows. First, TaskScheduler invokes construct() of TaskAssigner to
+ * initialize the its internal worker states at the beginning of resource offering. Before each
+ * round of task assignment for a taskset, TaskScheduler invoke the init() of TaskAssigner to
+ * initialize the data structure for the round. When performing real task assignment,
+ * hasNext()/getNext() is used by TaskScheduler to check the worker availability and retrieve
+ * current offering from TaskAssigner. Then offerAccepted is used by TaskScheduler to notify
+ * the TaskAssigner so that TaskAssigner can decide whether the current offer is valid or not for
+ * the next request. After task assignment is done, TaskScheduler invokes the tasks() to
+ * retrieve all the task assignment information, and eventually, invokes reset() method so that
+ * TaskAssigner can cleanup its internal maintained resources.
+ */
+
+private[scheduler] abstract class TaskAssigner {
+  var offer: Seq[OfferState] = _
+  var CPUS_PER_TASK = 1
+
+  def withCpuPerTask(CPUS_PER_TASK: Int): Unit = {
+    this.CPUS_PER_TASK = CPUS_PER_TASK
+  }
+
+  // The final assigned offer returned to TaskScheduler.
+  final def tasks: Seq[ArrayBuffer[TaskDescription]] = offer.map(_.tasks)
+
+  // Invoked at the beginning of resource offering to construct the offer with the workoffers.
+  def construct(workOffer: Seq[WorkerOffer]): Unit = {
+    offer = workOffer.map(o => new OfferState(o))
+  }
+
+  // Invoked at each round of Taskset assignment to initialize the internal structure.
+  def init(): Unit
+
+  // Whether there is offer available to be used inside of one round of Taskset assignment.
+  def hasNext: Boolean
+
+  // Returned the next assigned offer based on the task assignment strategy.
+  def getNext(): OfferState
+
+  // Invoked by the TaskScheduler to indicate whether the current offer is accepted or not so that
+  // the assigner can decide whether the current worker is valid for the next offering.
+  def offerAccepted(assigned: Boolean): Unit
+
+  // Invoked at the end of resource offering to release internally maintained resources.
+  // Subclass is responsible to release its own private resources.
+  def reset(): Unit = {
+    offer = null
+  }
+}
+
+object TaskAssigner extends Logging {
+  private val roundrobin = classOf[RoundRobinAssigner].getCanonicalName
+  private val packed = classOf[PackedAssigner].getCanonicalName
+  private val balanced = classOf[BalancedAssigner].getCanonicalName
+  private val assignerMap: Map[String, String] =
+    Map("roundrobin" -> roundrobin,
+      "packed" -> packed,
+      "balanced" -> balanced)
+
+  def init(conf: SparkConf): TaskAssigner = {
+    val assignerName = conf.get(config.SPARK_SCHEDULER_TASK_ASSIGNER.key, "roundrobin")
+      .toLowerCase()
+    val className = assignerMap.getOrElse(assignerName, roundrobin)
+    val CPUS_PER_TASK = conf.getInt("spark.task.cpus", 1)
+    val assigner = try {
+      logInfo(s"Constructing an assigner as $className")
+      Utils.classForName(className).getConstructor()
+        .newInstance().asInstanceOf[TaskAssigner]
+    } catch {
+      case _: Throwable =>
+        logInfo(s"$assignerName cannot be constructed, fallback to default $roundrobin.")
+        new RoundRobinAssigner()
+    }
+    assigner.withCpuPerTask(CPUS_PER_TASK)
+    assigner
+  }
+}
+
+/**
+ * Assign the task to workers with available cores in roundrobin manner.
+ */
+class RoundRobinAssigner extends TaskAssigner {
+  private var idx = 0
+
+  override def construct(workOffer: Seq[WorkerOffer]): Unit = {
+    offer = Random.shuffle(workOffer.map(o => new OfferState(o)))
+  }
+
+  override def init(): Unit = {
+    idx = 0
+  }
+
+  override def hasNext: Boolean = idx < offer.size
+
+  override def getNext(): OfferState = {
+    offer(idx)
+  }
+
+  override def offerAccepted(assigned: Boolean): Unit = {
+    idx += 1
+  }
+
+  override def reset(): Unit = {
+    super.reset
+    idx = 0
+  }
+}
+
+/**
+ * Assign the task to workers with the most available cores.
+ */
+class BalancedAssigner extends TaskAssigner {
+  private var maxHeap: PriorityQueue[OfferState] = _
+  private var currentOffer: OfferState = _
+
+  override def construct(workOffer: Seq[WorkerOffer]): Unit = {
+    offer = Random.shuffle(workOffer.map(o => new OfferState(o)))
+  }
+
+  implicit val ord: Ordering[OfferState] = new Ordering[OfferState] {
+    def compare(x: OfferState, y: OfferState): Int = {
+      return Ordering[Int].compare(x.coresAvailable, y.coresAvailable)
+    }
+  }
+
+  override def init(): Unit = {
+    maxHeap = new PriorityQueue[OfferState]()
+    offer.filter(_.coresAvailable >= CPUS_PER_TASK).foreach(maxHeap.enqueue(_))
+  }
+
+  override def hasNext: Boolean = maxHeap.nonEmpty
+
+  override def getNext(): OfferState = {
+    currentOffer = maxHeap.dequeue()
+    currentOffer
+  }
+
+  override def offerAccepted(assigned: Boolean): Unit = {
+    if (currentOffer.coresAvailable >= CPUS_PER_TASK && assigned) {
+      maxHeap.enqueue(currentOffer)
+    }
+  }
+
+  override def reset(): Unit = {
+    super.reset
+    maxHeap = null
+    currentOffer = null
+  }
+}
+
+/**
+ * Assign the task to workers with the least available cores. In other words, PackedAssigner tries
+ * to schedule tasks to fewer workers.  As a result, there will be idle workers without any tasks
+ * assigned if more than required workers are reserved. If the dynamic allocator is enabled,
+ * these idle workers will be released by driver. The released resources can then be allocated to
+ * other jobs by underling resource manager. This assigner can potentially reduce the resource
+ * reservation for a job.
+ */
+class PackedAssigner extends TaskAssigner {
+  private var sorted: Seq[OfferState] = _
+  private var idx = 0
+  private var currentOffer: OfferState = _
+
+  override def init(): Unit = {
+    idx = 0
+    sorted = offer.filter(_.coresAvailable >= CPUS_PER_TASK).sortBy(_.coresAvailable)
+  }
+
+  override def hasNext: Boolean = idx < sorted.size
+
+  override def getNext(): OfferState = {
+    currentOffer = sorted(idx)
+    currentOffer
+  }
+
+  override def offerAccepted(assigned: Boolean): Unit = {
+    if (currentOffer.coresAvailable < CPUS_PER_TASK || !assigned) {
+      idx += 1
+    }
+  }
+
+  override def reset(): Unit = {
+    super.reset
+    sorted = null
+    currentOffer = null
+    idx = 0
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -286,7 +286,7 @@ private[spark] class TaskSchedulerImpl(
   /**
    * Called by cluster manager to offer resources on slaves. We respond by asking our active task
    * sets for tasks in order of priority. We fill each node with tasks in a roundrobin, packed or
-   * balanced way based on the configured TaskAssigner
+   * balanced way based on the configured TaskAssigner.
    */
   def resourceOffers(offers: IndexedSeq[WorkerOffer]): Seq[Seq[TaskDescription]] = synchronized {
     // Mark each slave as alive and remember its hostname

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -285,8 +285,8 @@ private[spark] class TaskSchedulerImpl(
 
   /**
    * Called by cluster manager to offer resources on slaves. We respond by asking our active task
-   * sets for tasks in order of priority. We fill each node with tasks in a round-robin manner so
-   * that tasks are balanced across the cluster.
+   * sets for tasks in order of priority. We fill each node with tasks in a roundrobin, packed or
+   * balanced way based on the configured TaskAssigner
    */
   def resourceOffers(offers: IndexedSeq[WorkerOffer]): Seq[Seq[TaskDescription]] = synchronized {
     // Mark each slave as alive and remember its hostname

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -22,9 +22,7 @@ import java.util.{Timer, TimerTask}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
-import scala.collection.Set
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
-import scala.util.Random
 
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
@@ -60,7 +58,7 @@ private[spark] class TaskSchedulerImpl(
   def this(sc: SparkContext) = this(sc, sc.conf.get(config.MAX_TASK_FAILURES))
 
   val conf = sc.conf
-
+  private  val taskAssigner: TaskAssigner = TaskAssigner.init(conf)
   // How often to check for speculative tasks
   val SPECULATION_INTERVAL_MS = conf.getTimeAsMs("spark.speculation.interval", "100ms")
 
@@ -250,24 +248,26 @@ private[spark] class TaskSchedulerImpl(
   private def resourceOfferSingleTaskSet(
       taskSet: TaskSetManager,
       maxLocality: TaskLocality,
-      shuffledOffers: Seq[WorkerOffer],
-      availableCpus: Array[Int],
-      tasks: IndexedSeq[ArrayBuffer[TaskDescription]]) : Boolean = {
+      taskAssigner: TaskAssigner) : Boolean = {
     var launchedTask = false
-    for (i <- 0 until shuffledOffers.size) {
-      val execId = shuffledOffers(i).executorId
-      val host = shuffledOffers(i).host
-      if (availableCpus(i) >= CPUS_PER_TASK) {
+    taskAssigner.init()
+    while(taskAssigner.hasNext) {
+      var assigned = false
+      val currentOffer = taskAssigner.getNext()
+      val execId = currentOffer.workOffer.executorId
+      val host = currentOffer.workOffer.host
+      if (currentOffer.coresAvailable >= CPUS_PER_TASK) {
         try {
           for (task <- taskSet.resourceOffer(execId, host, maxLocality)) {
-            tasks(i) += task
+            currentOffer.tasks += task
             val tid = task.taskId
             taskIdToTaskSetManager(tid) = taskSet
             taskIdToExecutorId(tid) = execId
             executorIdToTaskCount(execId) += 1
-            availableCpus(i) -= CPUS_PER_TASK
-            assert(availableCpus(i) >= 0)
+            currentOffer.coresAvailable -= CPUS_PER_TASK
+            assert(currentOffer.coresAvailable >= 0)
             launchedTask = true
+            assigned = true
           }
         } catch {
           case e: TaskNotSerializableException =>
@@ -277,6 +277,7 @@ private[spark] class TaskSchedulerImpl(
             return launchedTask
         }
       }
+      taskAssigner.offerAccepted(assigned)
     }
     return launchedTask
   }
@@ -305,12 +306,8 @@ private[spark] class TaskSchedulerImpl(
         hostsByRack.getOrElseUpdate(rack, new HashSet[String]()) += o.host
       }
     }
+    taskAssigner.construct(offers)
 
-    // Randomly shuffle offers to avoid always placing tasks on the same set of workers.
-    val shuffledOffers = Random.shuffle(offers)
-    // Build a list of tasks to assign to each worker.
-    val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores))
-    val availableCpus = shuffledOffers.map(o => o.cores).toArray
     val sortedTaskSets = rootPool.getSortedTaskSetQueue
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
@@ -329,7 +326,7 @@ private[spark] class TaskSchedulerImpl(
       for (currentMaxLocality <- taskSet.myLocalityLevels) {
         do {
           launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(
-            taskSet, currentMaxLocality, shuffledOffers, availableCpus, tasks)
+            taskSet, currentMaxLocality, taskAssigner)
           launchedAnyTask |= launchedTaskAtCurrentMaxLocality
         } while (launchedTaskAtCurrentMaxLocality)
       }
@@ -337,10 +334,12 @@ private[spark] class TaskSchedulerImpl(
         taskSet.abortIfCompletelyBlacklisted(hostToExecutors)
       }
     }
-
+    val tasks = taskAssigner.tasks
+    taskAssigner.reset()
     if (tasks.size > 0) {
       hasLaunchedTask = true
     }
+
     return tasks
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -120,9 +120,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     roundrobin(taskScheduler)
   }
 
-  test("Roundrobin Fallback - fallbacks to default if the provided is invalid") {
-    val taskScheduler = setupScheduler("spark.scheduler.taskAssigner" -> "invalid")
-    roundrobin(taskScheduler)
+  test("Invalid - SparkException is thrown") {
+    intercept[SparkException] { setupScheduler("spark.scheduler.taskAssigner" -> "invalid")}
   }
 
   test("Balanced - Assigner balances the tasks to the worker with more free cores") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -120,8 +120,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     roundrobin(taskScheduler)
   }
 
-  test("Invalid - SparkException is thrown") {
-    intercept[SparkException] { setupScheduler("spark.scheduler.taskAssigner" -> "invalid")}
+  test("Invalid - Throws SparkException") {
+    intercept[SparkException] { setupScheduler("spark.scheduler.taskAssigner" -> "invalid") }
   }
 
   test("Balanced - Assigner balances the tasks to the worker with more free cores") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -189,7 +189,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       taskDescriptions.map(_.executorId)
     }
     val count = selectedExecutorIds.count(_ == workerOffers(0).executorId)
-    assert(count == 4)
+    assert(count == 4 || count == 0)
     assert(!failedTaskSet)
   }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1374,6 +1374,19 @@ Apart from these, the following properties are also available, and may be useful
     Should be greater than or equal to 1. Number of allowed retries = this value - 1.
   </td>
 </tr>
+<tr>
+  <td><code>spark.scheduler.taskAssigner</code></td>
+  <td>roundrobin</td>
+  <td>
+    The strategy of how to allocate tasks among workers with free cores. By default, roundrobin
+    with randomness is used, which tries to allocate task to workers with available cores in
+    roundrobin manner. In addition, packed and balanced is provided. The former tries to
+    allocate tasks to workers with the least free cores, resulting in tasks assigned to few
+    workers, which may help driver to release the reserved idle workers when dynamic
+    (spark.dynamicAllocation.enabled) is enabled. The latter tries to assign tasks across workers
+    in a balance way (allocating tasks to workers with most free cores).
+  </td>
+</tr>
 </table>
 
 #### Dynamic Allocation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1380,7 +1380,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The strategy of how to allocate tasks among workers with free cores. Three task
     assigners (roundrobin, packed, and balanced) are supported currently. By default, roundrobin
-    with randomness is used to allocate task to workers with available cores in a
+    with randomness is used to allocate tasks to workers with available cores in a
     roundrobin manner. The packed task assigner is used to allocate tasks to workers with the least
     free cores, resulting in tasks assigned to fewer workers, which may help driver to release the
     reserved idle workers when dynamic allocation(spark.dynamicAllocation.enabled) is enabled.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1378,13 +1378,14 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.taskAssigner</code></td>
   <td>roundrobin</td>
   <td>
-    The strategy of how to allocate tasks among workers with free cores. By default, roundrobin
+    The strategy of how to allocate tasks among workers with free cores. There are three task
+    assigners (roundrobin, packed, and balanced) are supported currently. By default, roundrobin
     with randomness is used, which tries to allocate task to workers with available cores in
-    roundrobin manner. In addition, packed and balanced is provided. The former tries to
-    allocate tasks to workers with the least free cores, resulting in tasks assigned to few
-    workers, which may help driver to release the reserved idle workers when dynamic
-    (spark.dynamicAllocation.enabled) is enabled. The latter tries to assign tasks across workers
-    in a balance way (allocating tasks to workers with most free cores).
+    roundrobin manner.The packed task assigner tries to allocate tasks to workers with the least
+    free cores, resulting in tasks assigned to few workers, which may help driver to release the
+    reserved idle workers when dynamic allocation(spark.dynamicAllocation.enabled) is enabled.
+    The balanced task assigner tries to assign tasks across workers in a balance way (allocating
+    tasks to workers with most free cores).
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1378,14 +1378,14 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.taskAssigner</code></td>
   <td>roundrobin</td>
   <td>
-    The strategy of how to allocate tasks among workers with free cores. There are three task
+    The strategy of how to allocate tasks among workers with free cores. Three task
     assigners (roundrobin, packed, and balanced) are supported currently. By default, roundrobin
-    with randomness is used, which tries to allocate task to workers with available cores in
-    roundrobin manner. The packed task assigner tries to allocate tasks to workers with the least
-    free cores, resulting in tasks assigned to few workers, which may help driver to release the
+    with randomness is used to allocate task to workers with available cores in a
+    roundrobin manner. The packed task assigner is used to allocate tasks to workers with the least
+    free cores, resulting in tasks assigned to fewer workers, which may help driver to release the
     reserved idle workers when dynamic allocation(spark.dynamicAllocation.enabled) is enabled.
-    The balanced task assigner tries to assign tasks across workers in a balance way (allocating
-    tasks to workers with most free cores).
+    The balanced task assigner is used to assign tasks across workers in a balanced way (allocating
+    tasks to workers with the most free cores).
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1379,13 +1379,14 @@ Apart from these, the following properties are also available, and may be useful
   <td>roundrobin</td>
   <td>
     The strategy of how to allocate tasks among workers with free cores. Three task
-    assigners (roundrobin, packed, and balanced) are supported currently. By default, roundrobin
-    with randomness is used to allocate tasks to workers with available cores in a
-    roundrobin manner. The packed task assigner is used to allocate tasks to workers with the least
-    free cores, resulting in tasks assigned to fewer workers, which may help driver to release the
-    reserved idle workers when dynamic allocation(spark.dynamicAllocation.enabled) is enabled.
-    The balanced task assigner is used to assign tasks across workers in a balanced way (allocating
-    tasks to workers with the most free cores).
+    assigners (roundrobin, packed, and balanced) are supported currently. By default, the
+    "roundrobin" task assigner is used to allocate tasks to workers with available cores in a
+    roundrobin manner with randomness. The "packed" task assigner is used to allocate tasks to
+    workers with the least free cores, resulting in tasks assigned to fewer workers, which may
+    help driver to release the reserved idle workers when dynamic
+    allocation(spark.dynamicAllocation.enabled) is enabled. The "balanced" task assigner is used
+    to assign tasks across workers in a balanced way (allocating tasks to workers with the most
+    free cores).
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1381,7 +1381,7 @@ Apart from these, the following properties are also available, and may be useful
     The strategy of how to allocate tasks among workers with free cores. There are three task
     assigners (roundrobin, packed, and balanced) are supported currently. By default, roundrobin
     with randomness is used, which tries to allocate task to workers with available cores in
-    roundrobin manner.The packed task assigner tries to allocate tasks to workers with the least
+    roundrobin manner. The packed task assigner tries to allocate tasks to workers with the least
     free cores, resulting in tasks assigned to few workers, which may help driver to release the
     reserved idle workers when dynamic allocation(spark.dynamicAllocation.enabled) is enabled.
     The balanced task assigner tries to assign tasks across workers in a balance way (allocating

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -31,10 +31,7 @@ class DataFrameWindowFunctionsSuite extends QueryTest with SharedSQLContext {
   test("reuse window partitionBy") {
     val df = Seq((1, "1"), (2, "2"), (1, "1"), (2, "2")).toDF("key", "value")
     val w = Window.partitionBy("key").orderBy("value")
-    val df1 = df.select(
-      lead("key", 1).over(w),
-      lead("value", 1).over(w))
-      df1.explain(true)
+
     checkAnswer(
       df.select(
         lead("key", 1).over(w),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -31,7 +31,10 @@ class DataFrameWindowFunctionsSuite extends QueryTest with SharedSQLContext {
   test("reuse window partitionBy") {
     val df = Seq((1, "1"), (2, "2"), (1, "1"), (2, "2")).toDF("key", "value")
     val w = Window.partitionBy("key").orderBy("value")
-
+    val df1 = df.select(
+      lead("key", 1).over(w),
+      lead("value", 1).over(w))
+      df1.explain(true)
     checkAnswer(
       df.select(
         lead("key", 1).over(w),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restructure the code and implement two new task assigner.
PackedAssigner: try to allocate tasks to the executors with least available cores, so that spark can release reserved executors when dynamic allocation is enabled.

BalancedAssigner: try to allocate tasks to the executors with more available cores in order to balance the workload across all executors.

By default, the original round robin assigner is used.

We test a pipeline, and new PackedAssigner save around 45% regarding the reserved cpu and memory with dynamic allocation enabled.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Both unit test in TaskSchedulerImplSuite and manual tests in production pipeline.
