### PR TITLE
[SPARK-18010][Core] Reduce work performed for building up the application list for the History Server app list UI page

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -77,10 +77,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   import FsHistoryProvider._
 
-  private val NOT_STARTED = "<Not Started>"
-
-  private val SPARK_HISTORY_FS_NUM_REPLAY_THREADS = "spark.history.fs.numReplayThreads"
-
   // Interval between safemode checks.
   private val SAFEMODE_CHECK_INTERVAL_S = conf.getTimeAsSeconds(
     "spark.history.fs.safemodeCheck.interval", "5s")
@@ -684,6 +680,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
 private[history] object FsHistoryProvider {
   val DEFAULT_LOG_DIR = "file:/tmp/spark-events"
+
+  private val NOT_STARTED = "<Not Started>"
+
+  private val SPARK_HISTORY_FS_NUM_REPLAY_THREADS = "spark.history.fs.numReplayThreads"
 
   val APPL_START_EVENT_PREFIX = "{\"Event\":\"SparkListenerApplicationStart\""
 

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -48,10 +48,10 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
    *        are parsed and replayed.
    */
   def replay(
-    logData: InputStream,
-    sourceName: String,
-    maybeTruncated: Boolean = false,
-    eventsFilter: (String) => Boolean = ReplayListenerBus.SELECT_ALL_FILTER): Unit = {
+      logData: InputStream,
+      sourceName: String,
+      maybeTruncated: Boolean = false,
+      eventsFilter: (String) => Boolean = ReplayListenerBus.SELECT_ALL_FILTER): Unit = {
     var currentLine: String = null
     var lineNumber: Int = 1
     try {
@@ -69,7 +69,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
               throw jpe
             } else {
               logWarning(s"Got JsonParseException from log file $sourceName" +
-                           s" at line $lineNumber, the file might not have finished writing cleanly.")
+                s" at line $lineNumber, the file might not have finished writing cleanly.")
             }
         }
         lineNumber += 1

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -51,36 +51,46 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
       logData: InputStream,
       sourceName: String,
       maybeTruncated: Boolean = false,
-      eventsFilter: (String) => Boolean = (s: String) => true): Unit = {
-    var currentLine: String = null
-    var lineNumber: Int = 1
+      eventsFilter: (String) => Boolean = ReplayListenerBus.SELECT_ALL_FILTER): Unit = {
     try {
-      val lines = Source.fromInputStream(logData).getLines()
-      while (lines.hasNext) {
-        currentLine = lines.next()
+      val lineEntries = Source.fromInputStream(logData)
+        .getLines()
+        .zipWithIndex
+        .filter(entry => eventsFilter(entry._1))
+
+      var entry: (String, Int) = ("", 0)
+
+      while (lineEntries.hasNext) {
         try {
-          if (eventsFilter(currentLine)) {
-            postToAll(JsonProtocol.sparkEventFromJson(parse(currentLine)))
-          }
+          entry = lineEntries.next()
+          postToAll(JsonProtocol.sparkEventFromJson(parse(entry._1)))
         } catch {
           case jpe: JsonParseException =>
             // We can only ignore exception from last line of the file that might be truncated
-            if (!maybeTruncated || lines.hasNext) {
+            if (!maybeTruncated || lineEntries.hasNext) {
               throw jpe
             } else {
               logWarning(s"Got JsonParseException from log file $sourceName" +
-                s" at line $lineNumber, the file might not have finished writing cleanly.")
+                s" at line number ${entry._2}, the file might not have finished writing cleanly.")
             }
+          case ioe: IOException =>
+            throw ioe
+          case e: Exception =>
+            logError (s"Exception parsing Spark event log $sourceName" +
+              s" at line number: ${entry._2}", e)
         }
-        lineNumber += 1
       }
     } catch {
       case ioe: IOException =>
         throw ioe
       case e: Exception =>
         logError(s"Exception parsing Spark event log: $sourceName", e)
-        logError(s"Malformed line #$lineNumber: $currentLine\n")
     }
   }
+}
 
+private[spark] object ReplayListenerBus {
+
+  // utility filter that selects all event logs during replay
+  val SELECT_ALL_FILTER = (eventString: String) => true
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -48,43 +48,38 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
    *        are parsed and replayed.
    */
   def replay(
-      logData: InputStream,
-      sourceName: String,
-      maybeTruncated: Boolean = false,
-      eventsFilter: (String) => Boolean = ReplayListenerBus.SELECT_ALL_FILTER): Unit = {
+    logData: InputStream,
+    sourceName: String,
+    maybeTruncated: Boolean = false,
+    eventsFilter: (String) => Boolean = ReplayListenerBus.SELECT_ALL_FILTER): Unit = {
+    var currentLine: String = null
+    var lineNumber: Int = 1
     try {
-      val lineEntries = Source.fromInputStream(logData)
-        .getLines()
-        .zipWithIndex
-        .filter(entry => eventsFilter(entry._1))
-
-      var entry: (String, Int) = ("", 0)
-
-      while (lineEntries.hasNext) {
+      val lines = Source.fromInputStream(logData).getLines()
+      while (lines.hasNext) {
+        currentLine = lines.next()
         try {
-          entry = lineEntries.next()
-          postToAll(JsonProtocol.sparkEventFromJson(parse(entry._1)))
+          if (eventsFilter(currentLine)) {
+            postToAll(JsonProtocol.sparkEventFromJson(parse(currentLine)))
+          }
         } catch {
           case jpe: JsonParseException =>
             // We can only ignore exception from last line of the file that might be truncated
-            if (!maybeTruncated || lineEntries.hasNext) {
+            if (!maybeTruncated || lines.hasNext) {
               throw jpe
             } else {
               logWarning(s"Got JsonParseException from log file $sourceName" +
-                s" at line number ${entry._2}, the file might not have finished writing cleanly.")
+                           s" at line $lineNumber, the file might not have finished writing cleanly.")
             }
-          case ioe: IOException =>
-            throw ioe
-          case e: Exception =>
-            logError (s"Exception parsing Spark event log $sourceName" +
-              s" at line number: ${entry._2}", e)
         }
+        lineNumber += 1
       }
     } catch {
       case ioe: IOException =>
         throw ioe
       case e: Exception =>
         logError(s"Exception parsing Spark event log: $sourceName", e)
+        logError(s"Malformed line #$lineNumber: $currentLine\n")
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -55,7 +55,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
       eventsFilter: ReplayEventsFilter = SELECT_ALL_FILTER): Unit = {
 
     var currentLine: String = null
-    var lineNumber: Int = -1
+    var lineNumber: Int = 0
 
     try {
       val lineEntries = Source.fromInputStream(logData)
@@ -68,7 +68,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
           val entry = lineEntries.next()
 
           currentLine = entry._1
-          lineNumber = entry._2
+          lineNumber = entry._2 + 1
 
           postToAll(JsonProtocol.sparkEventFromJson(parse(currentLine)))
         } catch {
@@ -80,7 +80,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
               throw jpe
             } else {
               logWarning(s"Got JsonParseException from log file $sourceName" +
-                s" at line ${lineNumber + 1}, the file might not have finished writing cleanly.")
+                s" at line $lineNumber, the file might not have finished writing cleanly.")
             }
         }
       }
@@ -89,7 +89,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
         throw ioe
       case e: Exception =>
         logError(s"Exception parsing Spark event log: $sourceName", e)
-        logError(s"Malformed line #${lineNumber + 1}: ${currentLine}\n")
+        logError(s"Malformed line #$lineNumber: $currentLine\n")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

allow ReplayListenerBus to skip deserialising and replaying certain events using an inexpensive check of the event log entry. Use this to ensure that when event log replay is triggered for building the application list, we get the ReplayListenerBus to skip over all but the few events needed for our immediate purpose. Refer [SPARK-18010] for the motivation behind this change.
## How was this patch tested?

Tested with existing HistoryServer and ReplayListener unit test suites. All tests pass.

Please review https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark before opening a pull request.
