### PR TITLE
[SPARK-17944] [DEPLOY] sbin/start-* scripts use of `hostname -f` fail with Solaris

### DIFF
--- a/sbin/start-master.sh
+++ b/sbin/start-master.sh
@@ -48,7 +48,14 @@ if [ "$SPARK_MASTER_PORT" = "" ]; then
 fi
 
 if [ "$SPARK_MASTER_HOST" = "" ]; then
-  SPARK_MASTER_HOST=`hostname -f`
+  case `uname` in
+      (SunOS)
+	  SPARK_MASTER_HOST="`/usr/sbin/check-hostname | awk '{print $NF}'`"
+	  ;;
+      (*)
+	  SPARK_MASTER_HOST="`hostname -f`"
+	  ;;
+  esac
 fi
 
 if [ "$SPARK_MASTER_WEBUI_PORT" = "" ]; then

--- a/sbin/start-mesos-dispatcher.sh
+++ b/sbin/start-mesos-dispatcher.sh
@@ -34,7 +34,14 @@ if [ "$SPARK_MESOS_DISPATCHER_PORT" = "" ]; then
 fi
 
 if [ "$SPARK_MESOS_DISPATCHER_HOST" = "" ]; then
-  SPARK_MESOS_DISPATCHER_HOST=`hostname -f`
+  case `uname` in
+      (SunOS)
+	  SPARK_MESOS_DISPATCHER_HOST="`/usr/sbin/check-hostname | awk '{print $NF}'`"
+	  ;;
+      (*)
+	  SPARK_MESOS_DISPATCHER_HOST="`hostname -f`"
+	  ;;
+  esac
 fi
 
 if [ "$SPARK_MESOS_DISPATCHER_NUM" = "" ]; then

--- a/sbin/start-slaves.sh
+++ b/sbin/start-slaves.sh
@@ -32,7 +32,14 @@ if [ "$SPARK_MASTER_PORT" = "" ]; then
 fi
 
 if [ "$SPARK_MASTER_HOST" = "" ]; then
-  SPARK_MASTER_HOST="`hostname -f`"
+  case `uname` in
+      (SunOS)
+	  SPARK_MASTER_HOST="`/usr/sbin/check-hostname | awk '{print $NF}'`"
+	  ;;
+      (*)
+	  SPARK_MASTER_HOST="`hostname -f`"
+	  ;;
+  esac
 fi
 
 # Launch the slaves


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modify sbin/start-master.sh, sbin/start-mesos-dispatcher.sh and sbin/start-slaves.sh to use the output of 'uname' to select which OS-specific command-line is used to determine the host's fully qualified host name.  
## How was this patch tested?

Tested by hand; starting on Solaris, Linux and macOS. 
