### PR TITLE
[DOCS] Update docs to not suggest to package Spark before running tests.

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -221,8 +221,6 @@ The following is an example of a command to run the tests:
 
     ./build/mvn -Pyarn -Phadoop-2.3 -Phive -Phive-thriftserver test
 
-Note, previously some tests required Spark to be packaged first before running them, so an explicit `mvn package` with `-DskipTests` was required before running `mvn test`. That is no longer required.
-
 The ScalaTest plugin also supports running only a specific Scala test suite as follows:
 
     ./build/mvn -P... -Dtest=none -DwildcardSuites=org.apache.spark.repl.ReplSuite test
@@ -237,8 +235,6 @@ or a Java test:
 The following is an example of a command to run the tests:
 
     ./build/sbt -Pyarn -Phadoop-2.3 -Phive -Phive-thriftserver test
-
-Note, previously some tests required Spark to be packaged first before running them, so an explicit `build/sbt package` was required the first time. That is no longer required.
 
 To run only a specific test suite as follows:
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -217,10 +217,11 @@ For help in setting up IntelliJ IDEA or Eclipse for Spark development, and troub
 Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin).
 Note that tests should not be run as root or an admin user.
 
-Some of the tests require Spark to be packaged first, so always run `mvn package` with `-DskipTests` the first time.  The following is an example of a correct (build, test) sequence:
+The following is an example of a command to run the tests:
 
-    ./build/mvn -Pyarn -Phadoop-2.3 -DskipTests -Phive -Phive-thriftserver clean package
     ./build/mvn -Pyarn -Phadoop-2.3 -Phive -Phive-thriftserver test
+
+Note, previously some tests required Spark to be packaged first before running them, so an explicit `mvn package` with `-DskipTests` was required before running `mvn test`. That is no longer required.
 
 The ScalaTest plugin also supports running only a specific Scala test suite as follows:
 
@@ -233,10 +234,11 @@ or a Java test:
 
 ## Testing with SBT
 
-Some of the tests require Spark to be packaged first, so always run `build/sbt package` the first time.  The following is an example of a correct (build, test) sequence:
+The following is an example of a command to run the tests:
 
-    ./build/sbt -Pyarn -Phadoop-2.3 -Phive -Phive-thriftserver package
     ./build/sbt -Pyarn -Phadoop-2.3 -Phive -Phive-thriftserver test
+
+Note, previously some tests required Spark to be packaged first before running them, so an explicit `build/sbt package` was required the first time. That is no longer required.
 
 To run only a specific test suite as follows:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update docs to not suggest to package Spark before running tests.
## How was this patch tested?

Not creating a JIRA since this pretty small. We haven't had the need to run mvn package before mvn test since 1.6 at least, or so I am told. So, updating the docs to not be misguiding.
