### PR TITLE
[SPARK-17984][YARN][Mesos][Deploy][WIP] Added support for executor launch with leading arguments

### DIFF
--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -40,7 +40,7 @@
 # - SPARK_EXECUTOR_CORES, Number of cores for the executors (Default: 1).
 # - SPARK_EXECUTOR_MEMORY, Memory per Executor (e.g. 1000M, 2G) (Default: 1G)
 # - SPARK_DRIVER_MEMORY, Memory for Driver (e.g. 1000M, 2G) (Default: 1G)
-# - SPARK_COMMAND_PREFIX, Command string added in front of normal spark comamnds
+# - SPARK_EXECUTOR_LAUNCH_PREFIX, Command string added in front of Spark executor
 
 # Options for the daemons used in the standalone deploy mode
 # - SPARK_MASTER_HOST, to bind the master to a different IP address or hostname

--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -40,6 +40,7 @@
 # - SPARK_EXECUTOR_CORES, Number of cores for the executors (Default: 1).
 # - SPARK_EXECUTOR_MEMORY, Memory per Executor (e.g. 1000M, 2G) (Default: 1G)
 # - SPARK_DRIVER_MEMORY, Memory for Driver (e.g. 1000M, 2G) (Default: 1G)
+# - SPARK_COMMAND_PREFIX, Command string added in front of normal spark comamnds
 
 # Options for the daemons used in the standalone deploy mode
 # - SPARK_MASTER_HOST, to bind the master to a different IP address or hostname

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -209,10 +209,12 @@ private[yarn] class ExecutorRunnable(
     YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
 
     // Add support for extra executor prefix.
-    val commandPrefix = (if (sys.env.contains("SPARK_COMMAND_PREFIX")) sys.env.get("SPARK_COMMAND_PREFIX") else "")
+    val commandPrefix = (if (sys.env.contains("SPARK_COMMAND_PREFIX"))
+    	sys.env.get("SPARK_COMMAND_PREFIX") else "");
 
     val commands = prefixEnv ++ Seq(
-      commandPrefix + " " + YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) + "/bin/java",
+      commandPrefix + " " + YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) +
+        "/bin/java",
       "-server") ++
       javaOpts ++
       Seq("org.apache.spark.executor.CoarseGrainedExecutorBackend",

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -193,7 +193,8 @@ private[yarn] class ExecutorRunnable(
     */
 
     // For log4j configuration to reference
-    javaOpts += ("-Dspark.yarn.app.container.log.dir=" + ApplicationConstants.LOG_DIR_EXPANSION_VAR)
+    javaOpts += ("-Dspark.yarn.app.container.log.dir=" 
+          + ApplicationConstants.LOG_DIR_EXPANSION_VAR)
     YarnCommandBuilderUtils.addPermGenSizeOpt(javaOpts)
 
     val userClassPath = Client.getUserClasspath(sparkConf).flatMap { uri =>
@@ -209,11 +210,11 @@ private[yarn] class ExecutorRunnable(
     YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
 
     // Add support for extra executor prefix.
-    val commandPrefix = (if (sys.env.contains("SPARK_COMMAND_PREFIX"))
-    	sys.env.get("SPARK_COMMAND_PREFIX") else "");
+    val executorCommandPrefix = (if (sys.env.contains("SPARK_EXECUTOR_LAUNCH_PREFIX"))
+    	sys.env.get("SPARK_EXECUTOR_LAUNCH_PREFIX") else "");
 
     val commands = prefixEnv ++ Seq(
-      commandPrefix + " " + YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) +
+      executorCommandPrefix + " " + YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) +
         "/bin/java",
       "-server") ++
       javaOpts ++

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -207,8 +207,12 @@ private[yarn] class ExecutorRunnable(
     }.toSeq
 
     YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
+
+    // Add support for extra executor prefix.
+    val commandPrefix = (if (sys.env.contains("SPARK_COMMAND_PREFIX")) sys.env.get("SPARK_COMMAND_PREFIX") else "")
+
     val commands = prefixEnv ++ Seq(
-      YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) + "/bin/java",
+      commandPrefix + " " + YarnSparkHadoopUtil.expandEnvironment(Environment.JAVA_HOME) + "/bin/java",
       "-server") ++
       javaOpts ++
       Seq("org.apache.spark.executor.CoarseGrainedExecutorBackend",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sometimes it is rather useful if Spark can run with leading extra arguments. 

For example, currently Spark is unaware of NUMA, which leads a performance boost when there are many remote memory allocations. 

So with this patch, it is possible to run Spark with leading commands. 
This patch is not only for NUMA support, but a more general one that makes it possible to integrate Spark with `valgrind` or some trace analysis tools. 
In a word, it pvovides many possibilities to do performance tuning in different use cases.

**TODO**
Currently it only works for YARN. Following features for Mesos and Standalone are on the way...
## How was this patch tested?

It was tested using BigBench on the cluster described below:

```
Cluster Topo: 1 Master + 4 Slaves (Spark on Yarn)
CPU: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz(72 Cores)
Memory: 128GB(2 NUMA Nodes)
NIC: 1x10Gb/Sec
Disk: Write -1.5GB/Sec, Read- 5GB/Sec
SW Version: Hadoop-5.7.0 + Spark-2.0.0
```

More testing is still being made and this thread will be updated then. Because this is considered to be useful feature, so we would like to publish it out here.
## How to use?

Currently it is using environment variable `SPARK_COMMAND_PREFIX` to provide a prefix command before spark (only works for YARN now).
Let's take `strace` as an example. 
In `spark-env.sh` file, specify the following:

```
SPARK_COMMAND_PREFIX="strace -ttT"
```

By doing this, Spark will be launched under the above `strace`, thus some information about the time each syscall was made and how long each syscall took will be given.

For more information about how to use `strace`, please refer to the [man page](https://linux.die.net/man/1/strace).
