### PR TITLE
[SPARK-18047][Core] Spark worker port should be greater than 1023

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -56,7 +56,7 @@ private[deploy] class Worker(
   private val port = rpcEnv.address.port
 
   Utils.checkHost(host, "Expected hostname")
-  assert (port > 0)
+  assert (port > 1023)
 
   // A scheduled executor used to send messages at the specified time.
   private val forwordMessageScheduler =


### PR DESCRIPTION
## What changes were proposed in this pull request?

The port numbers in the range from 0 to 1023 are the well-known ports (system ports) .

They are widely used by system network services. Such as Telnet(23), Simple Mail Transfer Protocol(25) and Domain Name System(53).

Work port should avoid using this ports .
## How was this patch tested?

None 
