### PR TITLE
[SPARK-17922] [SQL] ClassCastException ..GeneratedClass$GeneratedIterator cannot be cast to ...expressions.UnsafeProjection

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -616,8 +616,11 @@ class CodegenContext {
     val blocks = new ArrayBuffer[String]()
     val blockBuilder = new StringBuilder()
     for (code <- expressions) {
-      // We can't know how many byte code will be generated, so use number of bytes as limit
-      if (blockBuilder.length > 60 * 1000) {
+      // We can't know how many bytecode will be generated, so use the length of source code
+      // as metric. A method should not go beyond 8K, otherwise it will not be JITted, should
+      // also not be too small, or it will have many function calls (for wide table), see the
+      // results in BenchmarkWideTable.
+      if (blockBuilder.length > 1024) {
         blocks += blockBuilder.toString()
         blockBuilder.clear()
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DelegateClassLoader.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DelegateClassLoader.scala
@@ -1,0 +1,37 @@
+package org.apache.spark.sql.catalyst.util
+/*
+ * See : https://issues.apache.org/jira/browse/SPARK-17922. 
+ * Janino compiler internally creates a byteclassloader (http://grepcode.com/file/repo1.maven.org/maven2/org.codehaus.janino/janino/2.5.15/org/codehaus/janino/ByteArrayClassLoader.java#ByteArrayClassLoader)
+ * to load the compiled generated class. But this class loader doesnot override load class to load the class from byte array for the generated class.
+ * Instead the call first goes to parent class loader and if somehow the classloader finds the old generatedClass( all the generated class names are same)
+ * it will incorrectly load the old generated class. This class loader will be used to intercept delegation to parent if the class has to be loaded by the current byte class loader.
+ * This will be set as the parent class loader for janino compiler in CodeGenerator.doCompile
+ * Special classloader to skip delegating to parent class loader when the class name is same as the generated class name.
+ * Because that class should be loaded by the current class loader 
+ */
+class DelegateClassLoader(parent:ClassLoader, skipClass: String) extends ClassLoader(parent) {
+  override def findClass(name: String): Class[_] = {
+    if(checkClassName(name)) {
+      return null
+    }
+    super.findClass(name)
+  }
+
+  override def loadClass(name: String): Class[_] = {
+     if(checkClassName(name)) {
+      return null
+    }
+    super.loadClass(name)
+  }
+
+  override def loadClass(name: String, resolve: Boolean): Class[_] = {
+     if(checkClassName(name)) {
+      return null
+    }
+    super.loadClass(name, resolve)
+  }
+  
+  def checkClassName(name: String): Boolean = {
+    skipClass.equals(name)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Janino compiler internally creates a byteclassloader (http://grepcode.com/file/repo1.maven.org/maven2/org.codehaus.janino/janino/2.5.15/org/codehaus/janino/ByteArrayClassLoader.java#ByteArrayClassLoader) to load the compiled generated class. But this class loader doesnot override load class to load the class from byte array for the generated class. Instead the call first goes to parent class loader and if somehow the classloader finds the old generatedClass( all the generated class names are same) it will incorrectly load the old generated class. This class loader will be used to intercept delegation to parent if the class has to be loaded by the current byte class loader. This will be set as the parent class loader for janino compiler in CodeGenerator.doCompile.

Special classloader to skip delegating to parent class loader when the class name is same as the generated class name. Because that class should be loaded by the current class loader 
## How was this patch tested?

manual tests
