### PR TITLE
[SPARK-18022][SQL] java.lang.NullPointerException instead of real exception when saving DF to MySQL

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -607,7 +607,7 @@ object JdbcUtils extends Logging {
     } catch {
       case e: SQLException =>
         val cause = e.getNextException
-        if (e.getCause != cause) {
+        if (cause != null && e.getCause != cause) {
           if (e.getCause == null) {
             e.initCause(cause)
           } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

On null next exception in JDBC, don't init it as cause or suppressed
## How was this patch tested?

Existing tests
