### PR TITLE
[SPARK-17123][SQL][BRANCH-2.0] Use type-widened encoder for DataFrame for set operations

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.sql.{Date, Timestamp}
 import java.util.UUID
 
 import scala.language.postfixOps
@@ -1584,5 +1585,20 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
         }
       }
     }
+  }
+
+  test("SPARK-17123: Performing set operations that combine non-scala native types") {
+    val dates = Seq(
+      (BigDecimal.valueOf(1), new Timestamp(2)),
+      (BigDecimal.valueOf(4), new Timestamp(5))
+    ).toDF("timestamp", "decimal")
+
+    val widenTypedRows = Seq(
+      (10.5D, "string")
+    ).toDF("timestamp", "decimal")
+
+    dates.union(widenTypedRows).collect()
+    dates.except(widenTypedRows).collect()
+    dates.intersect(widenTypedRows).collect()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1591,11 +1591,11 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val dates = Seq(
       (BigDecimal.valueOf(1), new Timestamp(2)),
       (BigDecimal.valueOf(4), new Timestamp(5))
-    ).toDF("timestamp", "decimal")
+    ).toDF("decimal", "timestamp")
 
     val widenTypedRows = Seq(
       (10.5D, "string")
-    ).toDF("timestamp", "decimal")
+    ).toDF("decimal", "timestamp")
 
     dates.union(widenTypedRows).collect()
     dates.except(widenTypedRows).collect()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR backports https://github.com/apache/spark/pull/15072

Please note that the test code is a bit different with the master as https://github.com/apache/spark/pull/14786 was only merged into master and therefore, it does not support type-widening between `DateType` and `TimestampType`.

So, both types were taken out from the test.
## How was this patch tested?

Unit test in `DataFrameSuite`.
