### PR TITLE
[SPARK-18066] [CORE] [TESTS] Add Pool usage policies test coverage for FIFO & FAIR Schedulers

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -37,8 +37,8 @@ private[spark] class Pool(
 
   val schedulableQueue = new ConcurrentLinkedQueue[Schedulable]
   val schedulableNameToSchedulable = new ConcurrentHashMap[String, Schedulable]
-  val weight = initWeight
-  val minShare = initMinShare
+  var weight = initWeight
+  var minShare = initMinShare
   var runningTasks = 0
   var priority = 0
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -37,8 +37,8 @@ private[spark] class Pool(
 
   val schedulableQueue = new ConcurrentLinkedQueue[Schedulable]
   val schedulableNameToSchedulable = new ConcurrentHashMap[String, Schedulable]
-  var weight = initWeight
-  var minShare = initMinShare
+  val weight = initWeight
+  val minShare = initMinShare
   var runningTasks = 0
   var priority = 0
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
@@ -191,11 +191,11 @@ private[spark] class FairSchedulableBuilder(val rootPool: Pool, conf: SparkConf)
         parentPool = new Pool(poolName, DEFAULT_SCHEDULING_MODE,
           DEFAULT_MINIMUM_SHARE, DEFAULT_WEIGHT)
         rootPool.addSchedulable(parentPool)
-        logWarning(("An Unconfigured pool is found. It is built with default configuration. " +
-          "This can happen when the file that pools are read from isn't set, or when that file " +
-          "doesn't contain the pool name specified by spark.scheduler.pool. " +
-          "Created pool: %s, schedulingMode: %s, minShare: %d, weight: %d").format(
-          poolName, DEFAULT_SCHEDULING_MODE, DEFAULT_MINIMUM_SHARE, DEFAULT_WEIGHT))
+        logWarning(s"A job was submitted with scheduler pool $poolName, which has not been " +
+          "configured. This can happen when the file that pools are read from isn't set, or " +
+          s"when that file doesn't contain $poolName. Created $poolName with default " +
+          s"configuration (schedulingMode: $DEFAULT_SCHEDULING_MODE, " +
+          s"minShare: $DEFAULT_MINIMUM_SHARE, weight: $DEFAULT_WEIGHT)")
       }
     }
     parentPool.addSchedulable(manager)

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
@@ -191,7 +191,7 @@ private[spark] class FairSchedulableBuilder(val rootPool: Pool, conf: SparkConf)
         parentPool = new Pool(poolName, DEFAULT_SCHEDULING_MODE,
           DEFAULT_MINIMUM_SHARE, DEFAULT_WEIGHT)
         rootPool.addSchedulable(parentPool)
-        logInfo(("An Unconfigured pool is found. It is built with default configuration. " +
+        logWarning(("An Unconfigured pool is found. It is built with default configuration. " +
           "This can happen when the file that pools are read from isn't set, or when that file " +
           "doesn't contain the pool name specified by spark.scheduler.pool. " +
           "Created pool: %s, schedulingMode: %s, minShare: %d, weight: %d").format(

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
@@ -191,7 +191,10 @@ private[spark] class FairSchedulableBuilder(val rootPool: Pool, conf: SparkConf)
         parentPool = new Pool(poolName, DEFAULT_SCHEDULING_MODE,
           DEFAULT_MINIMUM_SHARE, DEFAULT_WEIGHT)
         rootPool.addSchedulable(parentPool)
-        logInfo("Created pool: %s, schedulingMode: %s, minShare: %d, weight: %d".format(
+        logInfo(("An Unconfigured pool is found. It is built with default configuration. " +
+          "This can happen when the file that pools are read from isn't set, or when that file " +
+          "doesn't contain the pool name specified by spark.scheduler.pool. " +
+          "Created pool: %s, schedulingMode: %s, minShare: %d, weight: %d").format(
           poolName, DEFAULT_SCHEDULING_MODE, DEFAULT_MINIMUM_SHARE, DEFAULT_WEIGHT))
       }
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -203,9 +203,9 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
   }
 
   /**
-    * spark.scheduler.pool property should be ignored for the FIFO scheduler,
-    * because pools are only needed for fair scheduling.
-    */
+   * spark.scheduler.pool property should be ignored for the FIFO scheduler,
+   * because pools are only needed for fair scheduling.
+   */
   test("FIFO scheduler uses root pool and not spark.scheduler.pool property") {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -33,7 +33,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
   val SCHEDULER_ALLOCATION_FILE_PROPERTY = "spark.scheduler.allocation.file"
   val TEST_POOL = "testPool"
 
-  private def createTaskSetManager(stageId: Int, numTasks: Int, taskScheduler: TaskSchedulerImpl)
+  def createTaskSetManager(stageId: Int, numTasks: Int, taskScheduler: TaskSchedulerImpl)
     : TaskSetManager = {
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
       new FakeTask(stageId, i, Nil)
@@ -41,7 +41,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     new TaskSetManager(taskScheduler, new TaskSet(tasks, stageId, 0, 0, null), 0)
   }
 
-  private def scheduleTaskAndVerifyId(taskId: Int, rootPool: Pool, expectedStageId: Int): Unit = {
+  def scheduleTaskAndVerifyId(taskId: Int, rootPool: Pool, expectedStageId: Int): Unit = {
     val taskSetQueue = rootPool.getSortedTaskSetQueue
     val nextTaskSetToSchedule =
       taskSetQueue.find(t => (t.runningTasks + t.tasksSuccessful) < t.numTasks)

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -202,7 +202,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     verifyPool(rootPool, "pool_with_surrounded_whitespace", 3, 2, FAIR)
   }
 
-  test("FIFO Scheduler just uses root pool") {
+  test("SPARK-18066: FIFO Scheduler just uses root pool") {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)
 
@@ -222,11 +222,12 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
 
     assert(rootPool.getSchedulableByName(TEST_POOL) == null)
     assert(rootPool.schedulableQueue.size == 2)
-    assert(rootPool.getSchedulableByName(taskSetManager0.name) eq taskSetManager0)
-    assert(rootPool.getSchedulableByName(taskSetManager1.name) eq taskSetManager1)
+    assert(rootPool.getSchedulableByName(taskSetManager0.name) === taskSetManager0)
+    assert(rootPool.getSchedulableByName(taskSetManager1.name) === taskSetManager1)
   }
 
-  test("FAIR Scheduler uses default pool when spark.scheduler.pool property is not set") {
+  test("SPARK-18066: FAIR Scheduler uses default pool when spark.scheduler.pool property is not " +
+    "set") {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)
 
@@ -242,7 +243,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     val defaultPool = rootPool.getSchedulableByName(schedulableBuilder.DEFAULT_POOL_NAME)
     assert(defaultPool != null)
     assert(defaultPool.schedulableQueue.size == 1)
-    assert(defaultPool.getSchedulableByName(taskSetManager0.name) eq taskSetManager0)
+    assert(defaultPool.getSchedulableByName(taskSetManager0.name) === taskSetManager0)
 
     // FAIR Scheduler uses default pool when spark.scheduler.pool property is not set
     val taskSetManager1 = createTaskSetManager(stageId = 1, numTasks = 1, taskScheduler)
@@ -250,7 +251,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     schedulableBuilder.addTaskSetManager(taskSetManager1, new Properties())
 
     assert(defaultPool.schedulableQueue.size == 2)
-    assert(defaultPool.getSchedulableByName(taskSetManager1.name) eq taskSetManager1)
+    assert(defaultPool.getSchedulableByName(taskSetManager1.name) === taskSetManager1)
 
     // FAIR Scheduler uses default pool when spark.scheduler.pool property is set as default pool
     val taskSetManager2 = createTaskSetManager(stageId = 2, numTasks = 1, taskScheduler)
@@ -262,10 +263,11 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     schedulableBuilder.addTaskSetManager(taskSetManager2, properties)
 
     assert(defaultPool.schedulableQueue.size == 3)
-    assert(defaultPool.getSchedulableByName(taskSetManager2.name) eq taskSetManager2)
+    assert(defaultPool.getSchedulableByName(taskSetManager2.name) === taskSetManager2)
   }
 
-  test("FAIR Scheduler creates a new pool when spark.scheduler.pool property points non-existent") {
+  test("SPARK-18066: FAIR Scheduler creates a new pool when spark.scheduler.pool property points " +
+    "non-existent") {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)
 
@@ -290,7 +292,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     assert(testPool.schedulingMode == schedulableBuilder.DEFAULT_SCHEDULING_MODE)
     assert(testPool.minShare == schedulableBuilder.DEFAULT_MINIMUM_SHARE)
     assert(testPool.weight == schedulableBuilder.DEFAULT_WEIGHT)
-    assert(testPool.getSchedulableByName(taskSetManager.name) eq taskSetManager)
+    assert(testPool.getSchedulableByName(taskSetManager.name) === taskSetManager)
   }
 
   private def verifyPool(rootPool: Pool, poolName: String, expectedInitMinShare: Int,

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -245,7 +245,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     schedulableBuilder.addTaskSetManager(taskSetManager0, null)
 
     val defaultPool = rootPool.getSchedulableByName(schedulableBuilder.DEFAULT_POOL_NAME)
-    assert(defaultPool != null)
+    assert(defaultPool !== null)
     assert(defaultPool.schedulableQueue.size === 1)
     assert(defaultPool.getSchedulableByName(taskSetManager0.name) === taskSetManager0)
 
@@ -280,21 +280,16 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     // by spark.scheduler.pool).
     schedulableBuilder.addTaskSetManager(taskSetManager, properties)
 
-    val testPool = rootPool.getSchedulableByName(TEST_POOL)
-    assert(testPool != null)
-    assert(testPool.schedulingMode === schedulableBuilder.DEFAULT_SCHEDULING_MODE)
-    assert(testPool.minShare === schedulableBuilder.DEFAULT_MINIMUM_SHARE)
-    assert(testPool.weight === schedulableBuilder.DEFAULT_WEIGHT)
-
     verifyPool(rootPool, TEST_POOL, schedulableBuilder.DEFAULT_MINIMUM_SHARE,
       schedulableBuilder.DEFAULT_WEIGHT, schedulableBuilder.DEFAULT_SCHEDULING_MODE)
+    val testPool = rootPool.getSchedulableByName(TEST_POOL)
     assert(testPool.getSchedulableByName(taskSetManager.name) === taskSetManager)
   }
 
   private def verifyPool(rootPool: Pool, poolName: String, expectedInitMinShare: Int,
                          expectedInitWeight: Int, expectedSchedulingMode: SchedulingMode): Unit = {
     val selectedPool = rootPool.getSchedulableByName(poolName)
-    assert(selectedPool != null)
+    assert(selectedPool !== null)
     assert(selectedPool.minShare === expectedInitMinShare)
     assert(selectedPool.weight === expectedInitWeight)
     assert(selectedPool.schedulingMode === expectedSchedulingMode)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following FIFO & FAIR Schedulers Pool usage cases need to have unit test coverage :
- FIFO Scheduler just uses **root pool** so even if `spark.scheduler.pool` property is set, related pool is not created and `TaskSetManagers` are added to **root pool**.
- FAIR Scheduler uses `default pool` when `spark.scheduler.pool` property is not set. This can be happened when 
  - `Properties` object is **null**, 
  - `Properties` object is **empty**(`new Properties()`), 
  - **default pool** is set(`spark.scheduler.pool=default`).
- FAIR Scheduler creates a **new pool** with **default values** when `spark.scheduler.pool` property points a **non-existent** pool. This can be happened when **scheduler allocation file** is not set or it does not contain related pool.
## How was this patch tested?

New Unit tests are added.
