### PR TITLE
[WIP] [SPARK-18067] [SQL] SortMergeJoin adds shuffle if join predicates have non partitioned columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -255,6 +255,7 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
 
   override def guarantees(other: Partitioning): Boolean = other match {
     case o: HashPartitioning => this.semanticEquals(o)
+    case o: PartitioningCollection => o.partitionings.exists(this.guarantees)
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -50,7 +50,11 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       numPartitions: Int): Partitioning = {
     requiredDistribution match {
       case AllTuples => SinglePartition
-      case ClusteredDistribution(clustering) => HashPartitioning(clustering, numPartitions)
+      case ClusteredDistribution(clustering) if clustering.size == 1 =>
+        HashPartitioning(clustering, numPartitions)
+      case ClusteredDistribution(clustering) =>
+        PartitioningCollection(
+          clustering.map(expression => HashPartitioning(Seq(expression), numPartitions)))
       case OrderedDistribution(ordering) => RangePartitioning(ordering, numPartitions)
       case dist => sys.error(s"Do not know how to satisfy distribution $dist")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/SPARK-18067 for discussion. Putting out a PR to get some feedback about the approach.

Assume that there are two tables with columns `key` and `value` both hash partitioned over `key`. Assume these are the partitions for the children:

| partitions | child 1 | child 2 |
| --- | --- | --- |
| partition 0 | [0, 0, 0, 3] | [0, 0, 3, 3] |
| partition 1 | [1, 4, 4] | [4] |
| partition 2 | [2, 2] | [2, 5, 5, 5] |

Since we have _all_ the same values of `key` in a given partition, we can evaluate other join predicates like (`tableA.value` = `tableB.value`) right there without needing any shuffle.

What is previously being done i.e. `HashPartitioning(key, value)` expects  over rows with same value of `pmod( hash(key, value))` to be in the same partition and does not take advantage of the fact that we already have rows with same `key` packed together. 

This PR uses `PartitioningCollection` instead of `HashPartitioning` for expected partitioning.

Query:

```
val df = (0 until 16).map(i => (i, i * 2)).toDF("i", "j").coalesce(1)
df.write.format("org.apache.spark.sql.hive.orc.OrcFileFormat").bucketBy(8, "i").sortBy("i").saveAsTable("tableA")
df.write.format("org.apache.spark.sql.hive.orc.OrcFileFormat").bucketBy(8, "i").sortBy("i").saveAsTable("tableB")

hc.sql("SELECT * FROM tableA a JOIN tableB b ON a.i=b.i AND a.j=b.j").explain(true)
```

Before:

```
*SortMergeJoin [i#38, j#39], [i#40, j#41], Inner
:- *Sort [i#38 ASC NULLS FIRST, j#39 ASC NULLS FIRST], false, 0
:  +- Exchange hashpartitioning(i#38, j#39, 200)
:     +- *Project [i#38, j#39]
:        +- *Filter (isnotnull(i#38) && isnotnull(j#39))
:           +- *FileScan orc default.tablea[i#38,j#39] Batched: false, Format: ORC, Location: ListingFileCatalog[file:/Users/tejasp/Desktop/dev/tp-spark-2/spark/spark-warehouse/tablea], PartitionFilters: [], PushedFilters: [IsNotNull(i), IsNotNull(j)], ReadSchema: struct<i:int,j:int>
+- *Sort [i#40 ASC NULLS FIRST, j#41 ASC NULLS FIRST], false, 0
   +- Exchange hashpartitioning(i#40, j#41, 200)
      +- *Project [i#40, j#41]
         +- *Filter (isnotnull(i#40) && isnotnull(j#41))
            +- *FileScan orc default.tableb[i#40,j#41] Batched: false, Format: ORC, Location: ListingFileCatalog[file:/Users/tejasp/Desktop/dev/tp-spark-2/spark/spark-warehouse/tableb], PartitionFilters: [], PushedFilters: [IsNotNull(i), IsNotNull(j)], ReadSchema: struct<i:int,j:int>
```

After:

```
== Physical Plan ==
*SortMergeJoin [i#38, j#39], [i#40, j#41], Inner
:- *Sort [i#38 ASC NULLS FIRST, j#39 ASC NULLS FIRST], false, 0
:  +- *Project [i#38, j#39]
:     +- *Filter (isnotnull(j#39) && isnotnull(i#38))
:        +- *FileScan orc default.tablea[i#38,j#39] Batched: false, Format: ORC, Location: ListingFileCatalog[file:/Users/tejasp/Desktop/dev/tp-spark/spark-warehouse/tablea], PartitionFilters: [], PushedFilters: [IsNotNull(j), IsNotNull(i)], ReadSchema: struct<i:int,j:int>
+- *Sort [i#40 ASC NULLS FIRST, j#41 ASC NULLS FIRST], false, 0
   +- *Project [i#40, j#41]
      +- *Filter (isnotnull(j#41) && isnotnull(i#40))
         +- *FileScan orc default.tableb[i#40,j#41] Batched: false, Format: ORC, Location: ListingFileCatalog[file:/Users/tejasp/Desktop/dev/tp-spark/spark-warehouse/tableb], PartitionFilters: [], PushedFilters: [IsNotNull(j), IsNotNull(i)], ReadSchema: struct<i:int,j:int>
```
## How was this patch tested?

WIP. I need to add tests for:
- [ ] Check if the planner is not introducing extra `Shuffle` for such query
- [ ]  Check if the compatibility among `PartitioningCollection` and `HashPartitioning` makes sense.
