### PR TITLE
[SPARK-18048][SQL] To make behaviour of If consistent, in case of true expression and false expression are of compatible data types.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -70,7 +70,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
       } else {
         ${falseEval.code}
         ${ev.isNull} = ${falseEval.isNull};
-        ${ev.value} = ${falseEval.value};
+        ${ev.value} = (${ctx.javaType(dataType)}) ${falseEval.value};
       }""")
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ConditionalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ConditionalExpressionSuite.scala
@@ -66,6 +66,19 @@ class ConditionalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper
     DataTypeTestUtils.propertyCheckSupported.foreach { dt =>
       checkConsistencyBetweenInterpretedAndCodegen(If, BooleanType, dt, dt)
     }
+
+    checkEvaluation(
+      If(Literal.create(true, BooleanType),
+        Literal.create(identity(1L), TimestampType),
+        Literal.create(identity(2), DateType)),
+      identity(1L))
+
+    checkEvaluation(
+      If(Literal.create(true, BooleanType),
+        Literal.create(identity(1), DateType),
+        Literal.create(identity(2L), TimestampType)),
+      identity(1))
+
   }
 
   test("case when") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds a type conversion from false value datatype to true value’s datatype.

Earlier, the expression If(Literal.create(true, BooleanType), Literal.create(identity(1), DateType), Literal.create(identity(2L), TimestampType))  was throwing Exception while the expression If(Literal.create(true, BooleanType), Literal.create(identity(1L), TimestampType), Literal.create(identity(2), DateType)) was working fine. So , if we interchange the true and false expressions, behaviour of the IF expression changes.
## How was this patch tested?

Added test case in ConditionalExpressionSuite.scala

jira entry for detail: https://issues.apache.org/jira/browse/SPARK-18048
