### PR TITLE
[SPARK-18079] [SQL] CollectLimitExec.executeToIterator should perform per-partition limits

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -36,6 +36,9 @@ case class CollectLimitExec(limit: Int, child: SparkPlan) extends UnaryExecNode 
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = SinglePartition
   override def executeCollect(): Array[InternalRow] = child.executeTake(limit)
+  override def executeToIterator(): Iterator[InternalRow] = {
+    LocalLimitExec(limit, child).executeToIterator().take(limit)
+  }
   private val serializer: Serializer = new UnsafeRowSerializer(child.output.size)
   protected override def doExecute(): RDD[InternalRow] = {
     val locallyLimited = child.execute().mapPartitionsInternal(_.take(limit))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2692,6 +2692,21 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     assert(numRecordsRead.value === 10)
   }
 
+  test("SPARK-18079: CollectLimitExec.executeToIterator should perform per-partition limits") {
+    val numRecordsRead = spark.sparkContext.longAccumulator
+    val iter = spark.range(1, 100, 1, numPartitions = 10).map { x =>
+      numRecordsRead.add(1)
+      x
+    }.limit(1).toLocalIterator()
+    var localCount = 0
+    while (iter.hasNext) {
+      iter.next()
+      localCount += 1
+    }
+    assert(numRecordsRead.value === 1)
+    assert(localCount === 1)
+  }
+
   test("CREATE TABLE USING should not fail if a same-name temp view exists") {
     withTable("same_name") {
       withTempView("same_name") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds a partition local limit to the executeToIterator method.
## How was this patch tested?

Added a test to SQLQuerySuite to ensure that only the limited amount is read from the partition.
