### PR TITLE
[SPARK-18092][ML] Fix column prediction type error

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/BinaryClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/BinaryClassificationEvaluator.scala
@@ -78,11 +78,11 @@ class BinaryClassificationEvaluator @Since("1.4.0") (@Since("1.4.0") override va
 
     // TODO: When dataset metadata has been implemented, check rawPredictionCol vector length = 2.
     val scoreAndLabels =
-      dataset.select(col($(rawPredictionCol)).cast(DoubleType), col($(labelCol)).cast(DoubleType))
+      dataset.select(col($(rawPredictionCol)), col($(labelCol)).cast(DoubleType))
         .rdd
         .map {
         case Row(rawPrediction: Vector, label: Double) => (rawPrediction(1), label)
-        case Row(rawPrediction: Double, label: Double) => (rawPrediction, label)
+        case Row(rawPrediction: Float, label: Double) => (rawPrediction.toDouble, label)
       }
     val metrics = new BinaryClassificationMetrics(scoreAndLabels)
     val metric = $(metricName) match {

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/BinaryClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/BinaryClassificationEvaluator.scala
@@ -78,7 +78,9 @@ class BinaryClassificationEvaluator @Since("1.4.0") (@Since("1.4.0") override va
 
     // TODO: When dataset metadata has been implemented, check rawPredictionCol vector length = 2.
     val scoreAndLabels =
-      dataset.select(col($(rawPredictionCol)), col($(labelCol)).cast(DoubleType)).rdd.map {
+      dataset.select(col($(rawPredictionCol)).cast(DoubleType), col($(labelCol)).cast(DoubleType))
+        .rdd
+        .map {
         case Row(rawPrediction: Vector, label: Double) => (rawPrediction(1), label)
         case Row(rawPrediction: Double, label: Double) => (rawPrediction, label)
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
@@ -76,7 +76,9 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
     SchemaUtils.checkNumericType(schema, $(labelCol))
 
     val predictionAndLabels =
-      dataset.select(col($(predictionCol)), col($(labelCol)).cast(DoubleType)).rdd.map {
+      dataset.select(col($(predictionCol)).cast(DoubleType), col($(labelCol)).cast(DoubleType))
+        .rdd
+        .map {
         case Row(prediction: Double, label: Double) => (prediction, label)
       }
     val metrics = new MulticlassMetrics(predictionAndLabels)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cast column prediction's type to Double in both `BinaryClassificationEvaluator` and `MulticlassClassificationEvaluator` 
## How was this patch tested?

manual tests
