### PR TITLE
[SPARK-18093][SQL] Fix default value test in SQLConfSuite to work rega…

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -215,18 +215,15 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("default value of WAREHOUSE_PATH") {
-    def appendTrailingSlashIfNecessary(path: String): String = {
-      if (!path.endsWith("/")) path + "/" else path
-    }
 
     val original = spark.conf.get(SQLConf.WAREHOUSE_PATH)
     try {
       // to get the default value, always unset it
       spark.conf.unset(SQLConf.WAREHOUSE_PATH.key)
       // JVM adds a trailing slash if the directory exists and leaves it as-is, if it doesn't
-      // In our comparison, add trailing slash to both sides if necessary, to account for both cases
-      assert(appendTrailingSlashIfNecessary(new Path(Utils.resolveURI("spark-warehouse"))
-        .toString) === appendTrailingSlashIfNecessary(spark.sessionState.conf.warehousePath))
+      // In our comparison, strip trailing slash off of both sides, to account for such cases
+      assert(new Path(Utils.resolveURI("spark-warehouse")).toString.stripSuffix("/") === spark
+        .sessionState.conf.warehousePath.stripSuffix("/"))
     } finally {
       sql(s"set ${SQLConf.WAREHOUSE_PATH}=$original")
     }


### PR DESCRIPTION
…rdless of warehouse dir's existence
## What changes were proposed in this pull request?

Appending a trailing slash, if there already isn't one for the 
sake comparison of the two paths. It doesn't take away from
the essence of the check, but removes any potential mismatch
due to lack of trailing slash.
## How was this patch tested?

Ran unit tests and they passed.
