### PR TITLE
[SPARK-18105] fix buffer overflow in LZ4

### DIFF
--- a/core/src/main/java/org/apache/spark/io/LZ4BlockInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/LZ4BlockInputStream.java
@@ -197,7 +197,7 @@ public final class LZ4BlockInputStream extends FilterInputStream {
         readFully(buffer, originalLen);
         break;
       case COMPRESSION_METHOD_LZ4:
-        if (compressedBuffer.length < originalLen) {
+        if (compressedBuffer.length < compressedLen) {
           compressedBuffer = new byte[Math.max(compressedLen, compressedBuffer.length * 3 / 2)];
         }
         readFully(compressedBuffer, compressedLen);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the LZ4BlockInputStream, there is a mistake that it use the originalLen as compressedLen, in the case that the compressed data is longer than original data, then compressedBuffer could overflow (some InputStream may does not check that), which cause it failed to decompress the buffer.

File a issue in uptream: https://github.com/jpountz/lz4-java/issues/89
## How was this patch tested?

Can't generate some dataset to reproduce this bug, will test it manually.
