### PR TITLE
[SPARK-18117][CORE] Add test for TaskSetBlacklist

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -84,7 +84,7 @@ private[spark] class TaskSetManager(
   var totalResultSize = 0L
   var calculatedTasks = 0
 
-  private val taskSetBlacklistHelperOpt: Option[TaskSetBlacklist] = {
+  private[scheduler] val taskSetBlacklistHelperOpt: Option[TaskSetBlacklist] = {
     if (BlacklistTracker.isBlacklistEnabled(conf)) {
       Some(new TaskSetBlacklist(conf, stageId, clock))
     } else {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -415,16 +415,14 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
    * in nodes and executors should be on that list.
    */
   private def testBlacklistPerformance(
+      testName: String,
       nodeBlacklist: Seq[String],
       execBlacklist: Seq[String]): Unit = {
     // Because scheduling involves shuffling the order of offers around, we run this test a few
     // times to cover more possibilities.  There are only 3 offers, which means 6 permutations,
-    // so 10 iterations is pretty good.  To avoid polluting test reports with 10 different tests,
-    // we run all iterations inside one test, but we still need to do proper setup and cleanup
-    // between each iteration.
+    // so 10 iterations is pretty good.
     (0 until 10).foreach { testItr =>
-      beforeEach()
-      try {
+      test(s"$testName: iteration $testItr") {
         // When an executor or node is blacklisted, we want to make sure that we don't try
         // scheduling each pending task, one by one, to discover they are all blacklisted.  This is
         // important for performance -- if we did check each task one-by-one, then responding to a
@@ -508,24 +506,20 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
           verify(stageToMockTaskSetBlacklist(0), never)
             .isExecutorBlacklistedForTask(meq(exec), anyInt())
         }
-      } finally {
-        afterEach()
       }
     }
   }
 
-  test("Blacklisted node for entire task set prevents per-task blacklist checks") {
-    testBlacklistPerformance(
-      nodeBlacklist = Seq("host1"),
-      execBlacklist = Seq())
-  }
+  testBlacklistPerformance(
+    testName = "Blacklisted node for entire task set prevents per-task blacklist checks",
+    nodeBlacklist = Seq("host1"),
+    execBlacklist = Seq())
 
-  test("Blacklisted executor for entire task set prevents per-task blacklist checks") {
-    testBlacklistPerformance(
-      nodeBlacklist = Seq(),
-      execBlacklist = Seq("executor3")
-    )
-  }
+  testBlacklistPerformance(
+    testName = "Blacklisted executor for entire task set prevents per-task blacklist checks",
+    nodeBlacklist = Seq(),
+    execBlacklist = Seq("executor3")
+  )
 
   test("abort stage if executor loss results in unschedulability from previously failed tasks") {
     // Make sure we can detect when a taskset becomes unschedulable from a blacklisting.  This

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -467,13 +467,13 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
         val nodesForBlacklistedExecutors = offers.filter { offer =>
           execBlacklist.contains(offer.executorId)
         }.map(_.host).toSet.toSeq
-        val nodesWithAnyBlacklisting = nodeBlacklist ++ nodesForBlacklistedExecutors
+        val nodesWithAnyBlacklisting = (nodeBlacklist ++ nodesForBlacklistedExecutors).toSet
         // Similarly, figure out which executors have any blacklisting.  This means all executors
         // that are explicitly blacklisted, plus all executors on nodes that are blacklisted.
         val execsForBlacklistedNodes = offers.filter { offer =>
           nodeBlacklist.contains(offer.host)
         }.map(_.executorId).toSeq
-        val executorsWithAnyBlacklisting = execBlacklist ++ execsForBlacklistedNodes
+        val executorsWithAnyBlacklisting = (execBlacklist ++ execsForBlacklistedNodes).toSet
 
         // Schedule a taskset, and make sure our test setup is correct -- we are able to schedule
         // a task on all executors that aren't blacklisted (whether that executor is a explicitly

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.scheduler
 
 import scala.collection.mutable.HashMap
 
-import org.mockito.Matchers.{anyInt, anyString, eq => matchEq}
+import org.mockito.Matchers.{anyInt, anyString, eq => meq}
 import org.mockito.Mockito.{atLeast, atMost, never, spy, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
@@ -466,9 +466,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       verify(stageToMockTaskSetBlacklist(0), never)
         .isExecutorBlacklistedForTaskSet(exec)
       verify(stageToMockTaskSetBlacklist(0), never)
-        .isNodeBlacklistedForTask(matchEq("host1"), anyInt())
+        .isNodeBlacklistedForTask(meq("host1"), anyInt())
       verify(stageToMockTaskSetBlacklist(0), never)
-        .isExecutorBlacklistedForTask(matchEq(exec), anyInt())
+        .isExecutorBlacklistedForTask(meq(exec), anyInt())
     }
     // now make sure checks were OK on stage 1
     (0 to 1).foreach { part =>
@@ -477,9 +477,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       verify(stageToMockTaskSetBlacklist(1), atMost(maxBlacklistChecks))
         .isNodeBlacklistedForTaskSet(anyString())
       verify(stageToMockTaskSetBlacklist(1), never)
-        .isNodeBlacklistedForTask(matchEq("host2"), anyInt())
+        .isNodeBlacklistedForTask(meq("host2"), anyInt())
       verify(stageToMockTaskSetBlacklist(1), never)
-        .isExecutorBlacklistedForTask(matchEq("executor3"), anyInt())
+        .isExecutorBlacklistedForTask(meq("executor3"), anyInt())
     }
     // stage 2 is unblacklisted, so nothing to check
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -476,7 +476,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
         val executorsWithAnyBlacklisting = execBlacklist ++ execsForBlacklistedNodes
 
         // Schedule a taskset, and make sure our test setup is correct -- we are able to schedule
-        // a task on all executors that aren't blacklisted (whether that executors is a explicitly
+        // a task on all executors that aren't blacklisted (whether that executor is a explicitly
         // blacklisted, or implicitly blacklisted via the node blacklist).
         val firstTaskAttempts = taskScheduler.resourceOffers(offers).flatten
         assert(firstTaskAttempts.size === offers.size - executorsWithAnyBlacklisting.size)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -22,11 +22,13 @@ import java.util.Random
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import org.mockito.Mockito.{mock, verify}
+import org.mockito.Matchers.{anyInt, anyString}
+import org.mockito.Mockito.{mock, never, spy, verify, when}
 
 import org.apache.spark._
 import org.apache.spark.internal.config
 import org.apache.spark.internal.Logging
+import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.{AccumulatorV2, ManualClock}
 
 class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
@@ -990,6 +992,46 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     val taskSet3 = FakeTask.createTaskSet(numTasks = 1, stageId = 1, stageAttemptId = 1)
     val manager3 = new TaskSetManager(sched, taskSet3, MAX_TASK_FAILURES, new ManualClock)
     assert(manager3.name === "TaskSet_1.1")
+  }
+
+  test("don't update blacklist for shuffle-fetch failures, preemption, denied commits, " +
+    "or killed tasks") {
+    // Setup a taskset, and fail some tasks for a fetch failure, preemption, denied commit,
+    // and killed task.
+    val conf = new SparkConf().
+      set(config.BLACKLIST_ENABLED, true)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(4)
+    val tsm = new TaskSetManager(sched, taskSet, 4)
+    // we need a spy so we can attach our mock blacklist
+    val tsmSpy = spy(tsm)
+    val blacklist = mock(classOf[TaskSetBlacklist])
+    when(tsmSpy.taskSetBlacklistHelperOpt).thenReturn(Some(blacklist))
+
+    // make some offers to our taskset, to get tasks we will fail
+    val taskDescs = Seq(
+      "exec1" -> "host1",
+      "exec2" -> "host1"
+    ).flatMap { case (exec, host) =>
+      // offer each executor twice (simulating 2 cores per executor)
+      (0 until 2).flatMap{ _ => tsmSpy.resourceOffer(exec, host, TaskLocality.ANY)}
+    }
+
+    // now fail those tasks
+    tsmSpy.handleFailedTask(taskDescs(0).taskId, TaskState.FAILED,
+      FetchFailed(BlockManagerId(taskDescs(0).executorId, "host1", 12345), 0, 0, 0, "ignored"))
+    tsmSpy.handleFailedTask(taskDescs(1).taskId, TaskState.FAILED,
+      ExecutorLostFailure(taskDescs(1).executorId, exitCausedByApp = false, reason = None))
+    tsmSpy.handleFailedTask(taskDescs(2).taskId, TaskState.FAILED,
+      TaskCommitDenied(0, 2, 0))
+    tsmSpy.handleFailedTask(taskDescs(3).taskId, TaskState.KILLED,
+      TaskKilled)
+
+    // Make sure that the blacklist ignored all of the task failures above, since they aren't
+    // the fault of the executor where the task was running.
+    verify(blacklist, never())
+      .updateBlacklistForFailedTask(anyString(), anyString(), anyInt())
   }
 
   private def createTaskResult(

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1017,6 +1017,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       // offer each executor twice (simulating 2 cores per executor)
       (0 until 2).flatMap{ _ => tsmSpy.resourceOffer(exec, host, TaskLocality.ANY)}
     }
+    assert(taskDescs.size === 4)
 
     // now fail those tasks
     tsmSpy.handleFailedTask(taskDescs(0).taskId, TaskState.FAILED,

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -995,7 +995,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   }
 
   test("don't update blacklist for shuffle-fetch failures, preemption, denied commits, " +
-    "or killed tasks") {
+      "or killed tasks") {
     // Setup a taskset, and fail some tasks for a fetch failure, preemption, denied commit,
     // and killed task.
     val conf = new SparkConf().


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds tests to verify the interaction between TaskSetBlacklist and
TaskSchedulerImpl.  TaskSetBlacklist was introduced by SPARK-17675 but
it neglected to add these tests.

This change does not fix any bugs -- it is just for increasing test
coverage.
## How was this patch tested?

Jenkins
