### PR TITLE
[SPARK-18121][SQL] Unable to query global temp views when hive support is enabled

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -65,6 +65,20 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   import hiveContext._
   import spark.implicits._
 
+  test("query global temp view") {
+    val df = Seq(1).toDF("i1")
+    df.createGlobalTempView("tbl1")
+    checkAnswer(spark.sql("select * from global_temp.tbl1"), Row(1))
+    spark.sql("drop view global_temp.tbl1")
+  }
+
+  test("non-existent global temp view") {
+    val message = intercept[AnalysisException] {
+      spark.sql("select * from global_temp.nonexistentview")
+    }.getMessage
+    assert(message.contains("Table or view not found"))
+  }
+
   test("script") {
     val scriptFilePath = getTestResourcePath("test_script.sh")
     if (testCommandAvailable("bash") && testCommandAvailable("echo | sed")) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -68,13 +68,15 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("query global temp view") {
     val df = Seq(1).toDF("i1")
     df.createGlobalTempView("tbl1")
-    checkAnswer(spark.sql("select * from global_temp.tbl1"), Row(1))
-    spark.sql("drop view global_temp.tbl1")
+    val global_temp_db = spark.conf.get("spark.sql.globalTempDatabase")
+    checkAnswer(spark.sql(s"select * from ${global_temp_db}.tbl1"), Row(1))
+    spark.sql(s"drop view ${global_temp_db}.tbl1")
   }
 
   test("non-existent global temp view") {
+    val global_temp_db = spark.conf.get("spark.sql.globalTempDatabase")
     val message = intercept[AnalysisException] {
-      spark.sql("select * from global_temp.nonexistentview")
+      spark.sql(s"select * from ${global_temp_db}.nonexistentview")
     }.getMessage
     assert(message.contains("Table or view not found"))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Issue: 
Querying on a global temp view throws Table or view not found exception. 

Fix:
Update the lookupRelation in HiveSessionCatalog to check for global temp views similar to the SessionCatalog.lookupRelation.

Before fix: 
Querying on a global temp view ( for. e.g.:  select \* from global_temp.v1)  throws Table or view not found exception

After fix: 
Query succeeds and returns the right result. 
## How was this patch tested?
- Two unit tests are added to check for global temp view for the code path when hive support is enabled.
- Regression unit tests were run successfully. ( build/sbt -Phive hive/test, build/sbt sql/test, build/sbt catalyst/test)
