### PR TITLE
[SPARK-18123][SQL] Use db column names instead of RDD column ones during JDBC Writing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -60,7 +60,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
 
     val conn = JdbcUtils.createConnectionFactory(jdbcOptions)()
     try {
-      val tableSchema = JdbcUtils.getSchema(conn, url, table)
+      val tableSchema = JdbcUtils.getSchemaOption(conn, url, table)
       val tableExists = tableSchema.isDefined
       val isCaseSensitive = sqlContext.conf.caseSensitiveAnalysis
       if (tableExists) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -57,13 +57,13 @@ class JdbcRelationProvider extends CreatableRelationProvider
     val table = jdbcOptions.table
     val createTableOptions = jdbcOptions.createTableOptions
     val isTruncate = jdbcOptions.isTruncate
+    val isCaseSensitive = sqlContext.conf.caseSensitiveAnalysis
 
     val conn = JdbcUtils.createConnectionFactory(jdbcOptions)()
     try {
-      val tableSchema = JdbcUtils.getSchemaOption(conn, url, table)
-      val tableExists = tableSchema.isDefined
-      val isCaseSensitive = sqlContext.conf.caseSensitiveAnalysis
+      val tableExists = JdbcUtils.tableExists(conn, url, table)
       if (tableExists) {
+        val tableSchema = JdbcUtils.getSchemaOption(conn, url, table)
         mode match {
           case SaveMode.Overwrite =>
             if (isTruncate && isCascadingTruncateTable(url) == Some(false)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -66,21 +66,22 @@ class JdbcRelationProvider extends CreatableRelationProvider
       if (tableExists) {
         mode match {
           case SaveMode.Overwrite =>
-            val savingSchema = if (isTruncate && isCascadingTruncateTable(url) == Some(false)) {
+            val normalizedSchema = if (isTruncate && isCascadingTruncateTable(url) == Some(false)) {
               // In this case, we should truncate table and then load.
               truncateTable(conn, table)
-              JdbcUtils.getSavingSchema(df.schema, tableSchema.get, caseSensitive)
+              JdbcUtils.normalizeSchema(df.schema, tableSchema.get, caseSensitive)
             } else {
               // Otherwise, do not truncate the table, instead drop and recreate it
               dropTable(conn, table)
               createTable(df.schema, url, table, createTableOptions, conn)
               df.schema
             }
-            saveTable(df, url, table, savingSchema, jdbcOptions)
+            saveTable(df, url, table, normalizedSchema, jdbcOptions)
 
           case SaveMode.Append =>
-            val savingSchema = JdbcUtils.getSavingSchema(df.schema, tableSchema.get, caseSensitive)
-            saveTable(df, url, table, savingSchema, jdbcOptions)
+            val normalizedSchema =
+              JdbcUtils.normalizeSchema(df.schema, tableSchema.get, caseSensitive)
+            saveTable(df, url, table, normalizedSchema, jdbcOptions)
 
           case SaveMode.ErrorIfExists =>
             throw new AnalysisException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -123,7 +123,7 @@ object JdbcUtils extends Logging {
         if (nameMap.isDefinedAt(x.name)) {
           dialect.quoteIdentifier(x.name)
         } else if (lowercaseNameMap.isDefinedAt(x.name.toLowerCase)) {
-          dialect.quoteIdentifier(nameMap(x.name.toLowerCase))
+          dialect.quoteIdentifier(lowercaseNameMap(x.name.toLowerCase))
         } else {
           throw new SQLException(s"""Column "${x.name}" not found""")
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -618,8 +618,7 @@ object JdbcUtils extends Logging {
         conn.setTransactionIsolation(finalIsolationLevel)
       }
       val stmt = insertStatement(conn, table, schema, dialect)
-      val setters: Array[JDBCValueSetter] = schema.fields.map(_.dataType)
-        .map(makeSetter(conn, dialect, _)).toArray
+      val setters = schema.fields.map(f => makeSetter(conn, dialect, f.dataType))
       val numFields = schema.fields.length
 
       try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -703,6 +703,7 @@ object JdbcUtils extends Logging {
     val getConnection: () => Connection = createConnectionFactory(options)
     val batchSize = options.batchSize
     val isolationLevel = options.isolationLevel
+
     val insertStmt = getInsertStatement(table, rddSchema, tableSchema, isCaseSensitive, dialect)
     val repartitionedDF = options.numPartitions match {
       case Some(n) if n <= 0 => throw new IllegalArgumentException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -706,7 +706,8 @@ object JdbcUtils extends Logging {
       df: DataFrame,
       url: String,
       table: String,
-      schema: StructType,
+      tableSchema: StructType,
+      isCaseSensitive: Boolean,
       options: JDBCOptions): Unit = {
     val dialect = JdbcDialects.get(url)
     val nullTypes: Array[Int] = df.schema.fields.map { field =>
@@ -716,6 +717,7 @@ object JdbcUtils extends Logging {
     val getConnection: () => Connection = createConnectionFactory(options)
     val batchSize = options.batchSize
     val isolationLevel = options.isolationLevel
+    val schema = normalizeSchema(df.schema, tableSchema, isCaseSensitive)
     val repartitionedDF = options.numPartitions match {
       case Some(n) if n <= 0 => throw new IllegalArgumentException(
         s"Invalid value `$n` for parameter `${JDBCOptions.JDBC_NUM_PARTITIONS}` in table writing " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -228,9 +228,10 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     val df2 = spark.createDataFrame(sparkContext.parallelize(arr2x3), schema3)
 
     df.write.jdbc(url, "TEST.INCOMPATIBLETEST", new Properties())
-    intercept[org.apache.spark.SparkException] {
+    val m = intercept[AnalysisException] {
       df2.write.mode(SaveMode.Append).jdbc(url, "TEST.INCOMPATIBLETEST", new Properties())
-    }
+    }.getMessage
+    assert(m.contains("Column \"seq\" not found"))
   }
 
   test("INSERT to JDBC Datasource") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.{AnalysisException, Row, SaveMode}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
@@ -177,7 +177,7 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     df.write.jdbc(url, "TEST.APPENDTEST", new Properties())
 
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
-      val m = intercept[SparkException] {
+      val m = intercept[AnalysisException] {
         df2.write.mode(SaveMode.Append).jdbc(url, "TEST.APPENDTEST", new Properties())
       }.getMessage
       assert(m.contains("Column \"NAME\" not found"))
@@ -202,7 +202,7 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     assert(1 === spark.read.jdbc(url1, "TEST.TRUNCATETEST", properties).count())
     assert(2 === spark.read.jdbc(url1, "TEST.TRUNCATETEST", properties).collect()(0).length)
 
-    val m = intercept[SparkException] {
+    val m = intercept[AnalysisException] {
       df3.write.mode(SaveMode.Overwrite).option("truncate", true)
         .jdbc(url1, "TEST.TRUNCATETEST", properties)
     }.getMessage

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -27,6 +27,7 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -175,14 +176,14 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
 
     df.write.jdbc(url, "TEST.APPENDTEST", new Properties())
 
-    withSQLConf("spark.sql.caseSensitive" -> "true") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
       val m = intercept[SparkException] {
         df2.write.mode(SaveMode.Append).jdbc(url, "TEST.APPENDTEST", new Properties())
       }.getMessage
       assert(m.contains("Column \"NAME\" not found"))
     }
 
-    withSQLConf("spark.sql.caseSensitive" -> "false") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       df2.write.mode(SaveMode.Append).jdbc(url, "TEST.APPENDTEST", new Properties())
       assert(3 === spark.read.jdbc(url, "TEST.APPENDTEST", new Properties()).count())
       assert(2 === spark.read.jdbc(url, "TEST.APPENDTEST", new Properties()).collect()(0).length)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -24,7 +24,6 @@ import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, Row, SaveMode}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.internal.SQLConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache Spark supports the following cases **by quoting RDD column names** while saving through JDBC.
- Allow reserved keyword as a column name, e.g., 'order'.
- Allow mixed-case colume names like the following, e.g., `[a: int, A: int]`.
  
  ``` scala
  scala> val df = sql("select 1 a, 1 A")
  df: org.apache.spark.sql.DataFrame = [a: int, A: int]
  ...
  scala> df.write.mode("overwrite").format("jdbc").options(option).save()
  scala> df.write.mode("append").format("jdbc").options(option).save()
  ```

This PR aims to use **database column names** instead of RDD column ones in order to support the following additionally.
Note that this case succeeds with `MySQL`, but fails on `Postgres`/`Oracle` before.

``` scala
val df1 = sql("select 1 a")
val df2 = sql("select 1 A")
...
df1.write.mode("overwrite").format("jdbc").options(option).save()
df2.write.mode("append").format("jdbc").options(option).save()
```
## How was this patch tested?

Pass the Jenkins test with a new testcase.
