### PR TITLE
[SPARK-18146] [SQL] Avoid using Union to chain together create table and repair partition commands

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -388,7 +388,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           partitionColumnNames = partitioningColumns.getOrElse(Nil),
           bucketSpec = getBucketSpec
         )
-        val result = df.sparkSession.sessionState.executePlan(
+        df.sparkSession.sessionState.executePlan(
           CreateTable(tableDesc, mode, Some(df.logicalPlan))).toRdd
         if (tableDesc.partitionColumnNames.nonEmpty &&
             df.sparkSession.sqlContext.conf.manageFilesourcePartitions) {
@@ -396,7 +396,6 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           df.sparkSession.sessionState.executePlan(
             AlterTableRecoverPartitionsCommand(tableDesc.identifier)).toRdd
         }
-        result
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -388,16 +388,15 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           partitionColumnNames = partitioningColumns.getOrElse(Nil),
           bucketSpec = getBucketSpec
         )
-        val createCmd = CreateTable(tableDesc, mode, Some(df.logicalPlan))
-        val cmd = if (tableDesc.partitionColumnNames.nonEmpty &&
+        val result = df.sparkSession.sessionState.executePlan(
+          CreateTable(tableDesc, mode, Some(df.logicalPlan)))
+        if (tableDesc.partitionColumnNames.nonEmpty &&
             df.sparkSession.sqlContext.conf.manageFilesourcePartitions) {
           // Need to recover partitions into the metastore so our saved data is visible.
-          val recoverPartitionCmd = AlterTableRecoverPartitionsCommand(tableDesc.identifier)
-          Union(createCmd, recoverPartitionCmd)
-        } else {
-          createCmd
+          df.sparkSession.sessionState.executePlan(
+            AlterTableRecoverPartitionsCommand(tableDesc.identifier))
         }
-        df.sparkSession.sessionState.executePlan(cmd).toRdd
+        result.toRdd
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -254,8 +254,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
       )
     }
 
-    df.sparkSession.sessionState.
-    (
+    df.sparkSession.sessionState.executePlan(
       InsertIntoTable(
         table = UnresolvedRelation(tableIdent),
         partition = Map.empty[String, Option[String]],

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -390,14 +390,14 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           bucketSpec = getBucketSpec
         )
         val result = df.sparkSession.sessionState.executePlan(
-          CreateTable(tableDesc, mode, Some(df.logicalPlan)))
+          CreateTable(tableDesc, mode, Some(df.logicalPlan))).toRdd
         if (tableDesc.partitionColumnNames.nonEmpty &&
             df.sparkSession.sqlContext.conf.manageFilesourcePartitions) {
           // Need to recover partitions into the metastore so our saved data is visible.
-          //df.sparkSession.sessionState.executePlan(
-          //  AlterTableRecoverPartitionsCommand(tableDesc.identifier))
+          df.sparkSession.sessionState.executePlan(
+            AlterTableRecoverPartitionsCommand(tableDesc.identifier)).toRdd
         }
-        result.toRdd
+        result
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -254,7 +254,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
       )
     }
 
-    df.sparkSession.sessionState.executePlan(
+    df.sparkSession.sessionState.
+    (
       InsertIntoTable(
         table = UnresolvedRelation(tableIdent),
         partition = Map.empty[String, Option[String]],
@@ -393,8 +394,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         if (tableDesc.partitionColumnNames.nonEmpty &&
             df.sparkSession.sqlContext.conf.manageFilesourcePartitions) {
           // Need to recover partitions into the metastore so our saved data is visible.
-          df.sparkSession.sessionState.executePlan(
-            AlterTableRecoverPartitionsCommand(tableDesc.identifier))
+          //df.sparkSession.sessionState.executePlan(
+          //  AlterTableRecoverPartitionsCommand(tableDesc.identifier))
         }
         result.toRdd
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The behavior of union is not well defined here. It is safer to explicitly execute these commands in order. The other use of `Union` in this way will be removed by https://github.com/apache/spark/pull/15633
## How was this patch tested?

Existing tests.

cc @yhuai @cloud-fan 
