### PR TITLE
[SPARK-18161] [Python] Allow pickle to serialize >4 GB objects when possible (Python 3.4+) 

### DIFF
--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -21,7 +21,7 @@ import gc
 from tempfile import NamedTemporaryFile
 
 from pyspark.cloudpickle import print_exec
-from pyspark.broadcast import protocol
+from pyspark.serializers import protocol
 
 if sys.version < '3':
     import cPickle as pickle

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -21,6 +21,7 @@ import gc
 from tempfile import NamedTemporaryFile
 
 from pyspark.cloudpickle import print_exec
+from pyspark.broadcast import protocol
 
 if sys.version < '3':
     import cPickle as pickle
@@ -78,7 +79,7 @@ class Broadcast(object):
 
     def dump(self, value, f):
         try:
-            pickle.dump(value, f, 2)
+            pickle.dump(value, f, protocol)
         except pickle.PickleError:
             raise
         except Exception as e:

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -64,7 +64,7 @@ if sys.version < '3':
     from itertools import izip as zip
 else:
     import pickle
-    protocol = 3
+    protocol = min(pickle.HIGHEST_PROTOCOL, 4)
     xrange = range
 
 from pyspark import cloudpickle


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since pickle protocol 4 (available in Python 3.4+) allows for serialization of > 4 GB errors, use pickle protocol 4 when available in the Broadcast and PickleSerializer classes.
## How was this patch tested?

This was tested through pyspark shell and serializing a large numpy array with / without the changes.

Author: Sloane Simmons <sloanes dot k at gmail dot com>

This contribution is my original work and I license the work to the project under the project's open source license.
