### PR TITLE
[SPARK-18164][SQL]ForeachSink should fail the Spark job if `process` throws exception

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
@@ -77,6 +77,7 @@ class ForeachSink[T : Encoder](writer: ForeachWriter[T]) extends Sink with Seria
           case e: Throwable =>
             isFailed = true
             writer.close(e)
+            throw e
         }
         if (!isFailed) {
           writer.close(null)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
@@ -68,20 +68,16 @@ class ForeachSink[T : Encoder](writer: ForeachWriter[T]) extends Sink with Seria
       }
     datasetWithIncrementalExecution.foreachPartition { iter =>
       if (writer.open(TaskContext.getPartitionId(), batchId)) {
-        var isFailed = false
         try {
           while (iter.hasNext) {
             writer.process(iter.next())
           }
         } catch {
           case e: Throwable =>
-            isFailed = true
             writer.close(e)
             throw e
         }
-        if (!isFailed) {
-          writer.close(null)
-        }
+        writer.close(null)
       } else {
         writer.close(null)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the issue that ForeachSink didn't rethrow the exception.
## How was this patch tested?

The fixed unit test.
