### PR TITLE
[SPARK-18144][SQL] logging StreamingQueryListener$QueryStartedEvent

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -902,7 +902,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.memory.offHeap.size</code></td>
   <td>0</td>
   <td>
-    The absolute amount of memory (in terms by bytes) which can be used for off-heap allocation.
+    The absolute amount of memory in bytes which can be used for off-heap allocation.
     This setting has no impact on heap memory usage, so if your executors' total memory consumption must fit within some hard limit then be sure to shrink your JVM heap size accordingly.
     This must be set to a positive value when <code>spark.memory.offHeap.enabled=true</code>.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -902,7 +902,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.memory.offHeap.size</code></td>
   <td>0</td>
   <td>
-    The absolute amount of memory in bytes which can be used for off-heap allocation.
+    The absolute amount of memory (in terms by bytes) which can be used for off-heap allocation.
     This setting has no impact on heap memory usage, so if your executors' total memory consumption must fit within some hard limit then be sure to shrink your JVM heap size accordingly.
     This must be set to a positive value when <code>spark.memory.offHeap.enabled=true</code>.
   </td>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
@@ -39,12 +39,7 @@ class StreamingQueryListenerBus(sparkListenerBus: LiveListenerBus)
    * be dispatched to all StreamingQueryListener in the thread of the Spark listener bus.
    */
   def post(event: StreamingQueryListener.Event) {
-    event match {
-      case s: QueryStartedEvent =>
-        postToAll(s)
-      case _ =>
-        sparkListenerBus.post(event)
-    }
+    sparkListenerBus.post(event)
   }
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
@@ -53,11 +53,10 @@ class StreamingQueryListenerBus(sparkListenerBus: LiveListenerBus)
     event match {
       case e: StreamingQueryListener.Event =>
         // SPARK-18144: we broadcast QueryStartedEvent to all listeners attached to this bus
-        // synchronously and to listeners attached to LiveListenerBus asynchronously. Therefore,
+        // synchronously and the ones attached to LiveListenerBus asynchronously. Therefore,
         // we need to ignore QueryStartedEvent if this method is called within SparkListenerBus
         // thread
-        if (Thread.currentThread().getName != "SparkListenerBus" ||
-          !e.isInstanceOf[QueryStartedEvent]) {
+        if (!LiveListenerBus.withinListenerThread.value || !e.isInstanceOf[QueryStartedEvent]) {
           postToAll(e)
         }
       case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
@@ -43,7 +43,7 @@ class StreamingQueryListenerBus(sparkListenerBus: LiveListenerBus)
       case s: QueryStartedEvent =>
         sparkListenerBus.post(s)
         // post to local listeners to trigger callbacks
-        postToAll(event)
+        postToAll(s)
       case _ =>
         sparkListenerBus.post(event)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
@@ -41,7 +41,7 @@ class StreamingQueryListenerBus(sparkListenerBus: LiveListenerBus)
   def post(event: StreamingQueryListener.Event) {
     event match {
       case s: QueryStartedEvent =>
-        sparkListenerBus.postToAll(s)
+        sparkListenerBus.post(s)
         // post to local listeners to trigger callbacks
         postToAll(event)
       case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
@@ -39,7 +39,14 @@ class StreamingQueryListenerBus(sparkListenerBus: LiveListenerBus)
    * be dispatched to all StreamingQueryListener in the thread of the Spark listener bus.
    */
   def post(event: StreamingQueryListener.Event) {
-    sparkListenerBus.post(event)
+    event match {
+      case s: QueryStartedEvent =>
+        sparkListenerBus.postToAll(s)
+        // post to local listeners to trigger callbacks
+        postToAll(event)
+      case _ =>
+        sparkListenerBus.post(event)
+    }
   }
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -290,7 +290,10 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging {
     // A StreamingQueryListener that gets the query status after the first completed trigger
     val listener = new StreamingQueryListener {
       @volatile var firstStatus: StreamingQueryStatus = null
-      override def onQueryStarted(queryStarted: QueryStartedEvent): Unit = { }
+      var queryStartedEvent = 0
+      override def onQueryStarted(queryStarted: QueryStartedEvent): Unit = {
+        queryStartedEvent += 1
+      }
       override def onQueryProgress(queryProgress: QueryProgressEvent): Unit = {
        if (firstStatus == null) firstStatus = queryProgress.queryStatus
       }
@@ -303,6 +306,8 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging {
       q.processAllAvailable()
       eventually(timeout(streamingTimeout)) {
         assert(listener.firstStatus != null)
+        // test if QueryStartedEvent callback is called for only once
+        assert(listener.queryStartedEvent === 1)
       }
       listener.firstStatus
     } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -290,7 +290,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging {
     // A StreamingQueryListener that gets the query status after the first completed trigger
     val listener = new StreamingQueryListener {
       @volatile var firstStatus: StreamingQueryStatus = null
-      var queryStartedEvent = 0
+      @volatile var queryStartedEvent = 0
       override def onQueryStarted(queryStarted: QueryStartedEvent): Unit = {
         queryStartedEvent += 1
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR fixes the bug that the QueryStartedEvent is not logged

the postToAll() in the original code is actually calling StreamingQueryListenerBus.postToAll() which has no listener at all....we shall post by sparkListenerBus.postToAll(s) and this.postToAll() to trigger local listeners as well as the listeners registered in LiveListenerBus

@zsxwing 
## How was this patch tested?

The following snapshot shows that QueryStartedEvent has been logged correctly

![image](https://cloud.githubusercontent.com/assets/678008/19821553/007a7d28-9d2d-11e6-9f13-49851559cdaa.png)
