### PR TITLE
[SPARK-18169][SQL] Suppress warnings when dropping views on a dropped table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -202,6 +202,7 @@ case class DropTableCommand(
       sparkSession.sharedState.cacheManager.uncacheQuery(
         sparkSession.table(tableName.quotedString))
     } catch {
+      case ae: AnalysisException if ae.getMessage.contains("Table or view not found") =>
       case NonFatal(e) => log.warn(e.toString, e)
     }
     catalog.refreshTable(tableName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache Spark 2.x shows an **AnalysisException** warning message when dropping a **view** on a dropped table. This does not happen on dropping **temporary views**. Also, Spark 1.6.x does not show warnings. We had better suppress this to be more consistent in Spark 2.x and with Spark 1.6.x.

``` scala
scala> sql("create table t(a int)")

scala> sql("create view v as select * from t")

scala> sql("create temporary view tv as select * from t")

scala> sql("drop table t")

scala> sql("drop view tv")

scala> sql("drop view v")
16/10/29 15:50:03 WARN DropTableCommand: org.apache.spark.sql.AnalysisException: Table or view not found: `default`.`t`; line 1 pos 91;
'SubqueryAlias v, `default`.`v`
+- 'Project ['gen_attr_0 AS a#19]
   +- 'SubqueryAlias t
      +- 'Project ['gen_attr_0]
         +- 'SubqueryAlias gen_subquery_0
            +- 'Project ['a AS gen_attr_0#18]
               +- 'UnresolvedRelation `default`.`t`

org.apache.spark.sql.AnalysisException: Table or view not found: `default`.`t`; line 1 pos 91;
'SubqueryAlias v, `default`.`v`
+- 'Project ['gen_attr_0 AS a#19]
   +- 'SubqueryAlias t
      +- 'Project ['gen_attr_0]
         +- 'SubqueryAlias gen_subquery_0
            +- 'Project ['a AS gen_attr_0#18]
               +- 'UnresolvedRelation `default`.`t`
...
res5: org.apache.spark.sql.DataFrame = []
```

Note that this is different case of dropping non-exist views. For those cases, Spark raises **NoSuchTableException**.
## How was this patch tested?

Manual because this is a suppression of warning message.
