### PR TITLE
[SPARK-18166][MLlib] Fix Poisson GLM bug due to wrong requirement of response values

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -502,7 +502,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     override def initialize(y: Double, weight: Double): Double = {
       require(y >= 0.0, "The response variable of Poisson family " +
-        s"should be positive, but got $y")
+        s"should be non-negative, but got $y")
       y
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -501,7 +501,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     val defaultLink: Link = Log
 
     override def initialize(y: Double, weight: Double): Double = {
-      require(y > 0.0, "The response variable of Poisson family " +
+      require(y >= 0.0, "The response variable of Poisson family " +
         s"should be positive, but got $y")
       y
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -477,7 +477,6 @@ class GeneralizedLinearRegressionSuite
        }
        [1]  0.4272661 -0.1565423
        [1] -3.6911354  0.6214301  0.1295814
-
      */
     val expected = Seq(
       Vectors.dense(0.0, 0.4272661, -0.1565423),
@@ -495,21 +494,6 @@ class GeneralizedLinearRegressionSuite
       val actual = Vectors.dense(model.intercept, model.coefficients(0), model.coefficients(1))
       assert(actual ~= expected(idx) absTol 1e-4, "Model mismatch: GLM with poisson family, " +
         s"$link link and fitIntercept = $fitIntercept (with zero values).")
-
-      val familyLink = new FamilyAndLink(Poisson, Link.fromName(link))
-      model.transform(dataset).select("features", "prediction", "linkPrediction").collect()
-        .foreach {
-          case Row(features: DenseVector, prediction1: Double, linkPrediction1: Double) =>
-            val eta = BLAS.dot(features, model.coefficients) + model.intercept
-            val prediction2 = familyLink.fitted(eta)
-            val linkPrediction2 = eta
-            assert(prediction1 ~= prediction2 relTol 1E-5, "Prediction mismatch: GLM with " +
-              s"poisson family, $link link and fitIntercept = $fitIntercept. (with zero values)")
-            assert(linkPrediction1 ~= linkPrediction2 relTol 1E-5, "Link Prediction mismatch: " +
-              s"GLM with poisson family, $link link and fitIntercept = $fitIntercept " +
-              "(with zero values).")
-        }
-
       idx += 1
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -44,6 +44,7 @@ class GeneralizedLinearRegressionSuite
   @transient var datasetGaussianInverse: DataFrame = _
   @transient var datasetBinomial: DataFrame = _
   @transient var datasetPoissonLog: DataFrame = _
+  @transient var datasetPoissonLogWithZero: DataFrame = _
   @transient var datasetPoissonIdentity: DataFrame = _
   @transient var datasetPoissonSqrt: DataFrame = _
   @transient var datasetGammaInverse: DataFrame = _
@@ -83,11 +84,16 @@ class GeneralizedLinearRegressionSuite
       testData.toDF()
     }
 
-    // force some labels to be exactly zero
     datasetPoissonLog = generateGeneralizedLinearRegressionInput(
-      intercept = -1.5, coefficients = Array(0.22, 0.06), xMean = Array(2.9, 10.5),
+      intercept = 0.25, coefficients = Array(0.22, 0.06), xMean = Array(2.9, 10.5),
       xVariance = Array(0.7, 1.2), nPoints = 10000, seed, noiseLevel = 0.01,
-      family = "poisson", link = "log").map{x => LabeledPoint(if (x.label < 0.7) 0.0 else x.label, x.features)}.toDF()
+      family = "poisson", link = "log").toDF()
+
+    datasetPoissonLogWithZero = generateGeneralizedLinearRegressionInput(
+      intercept = -1.5, coefficients = Array(0.22, 0.06), xMean = Array(2.9, 10.5),
+      xVariance = Array(0.7, 1.2), nPoints = 100, seed, noiseLevel = 0.01,
+      family = "poisson", link = "log")
+      .map{x => LabeledPoint(if (x.label < 0.7) 0.0 else x.label, x.features)}.toDF()
 
     datasetPoissonIdentity = generateGeneralizedLinearRegressionInput(
       intercept = 2.5, coefficients = Array(2.2, 0.6), xMean = Array(2.9, 10.5),
@@ -140,6 +146,10 @@ class GeneralizedLinearRegressionSuite
       label + "," + features.toArray.mkString(",")
     }.repartition(1).saveAsTextFile(
       "target/tmp/GeneralizedLinearRegressionSuite/datasetPoissonLog")
+    datasetPoissonLogWithZero.rdd.map { case Row(label: Double, features: Vector) =>
+      label + "," + features.toArray.mkString(",")
+    }.repartition(1).saveAsTextFile(
+      "target/tmp/GeneralizedLinearRegressionSuite/datasetPoissonLogWithZero")
     datasetPoissonIdentity.rdd.map { case Row(label: Double, features: Vector) =>
       label + "," + features.toArray.mkString(",")
     }.repartition(1).saveAsTextFile(
@@ -394,8 +404,8 @@ class GeneralizedLinearRegressionSuite
          print(as.vector(coef(model)))
        }
 
-       [1]  0.5306608 -0.1993461
-       [1] -4.6023688  0.7566674  0.1632284
+       [1] 0.22999393 0.08047088
+       [1] 0.25022353 0.21998599 0.05998621
 
        data <- read.csv("path", header=FALSE)
        for (formula in c(f1, f2)) {
@@ -416,8 +426,8 @@ class GeneralizedLinearRegressionSuite
        [1] 2.5000480 2.1999972 0.5999968
      */
     val expected = Seq(
-      Vectors.dense(0.0, 0.5306608, -0.1993461),
-      Vectors.dense(-4.6023688,  0.7566674,  0.1632284),
+      Vectors.dense(0.0, 0.22999393, 0.08047088),
+      Vectors.dense(0.25022353, 0.21998599, 0.05998621),
       Vectors.dense(0.0, 2.2929501, 0.8119415),
       Vectors.dense(2.5012730, 2.1999407, 0.5999107),
       Vectors.dense(0.0, 2.2958947, 0.8090515),
@@ -454,7 +464,55 @@ class GeneralizedLinearRegressionSuite
     }
   }
 
+  test("generalized linear regression: poisson family against glm (with zero values)") {
+    /*
+       R code:
+       f1 <- data$V1 ~ data$V2 + data$V3 - 1
+       f2 <- data$V1 ~ data$V2 + data$V3
 
+       data <- read.csv("path", header=FALSE)
+       for (formula in c(f1, f2)) {
+         model <- glm(formula, family="poisson", data=data)
+         print(as.vector(coef(model)))
+       }
+       [1]  0.4272661 -0.1565423
+       [1] -3.6911354  0.6214301  0.1295814
+
+     */
+    val expected = Seq(
+      Vectors.dense(0.0, 0.4272661, -0.1565423),
+      Vectors.dense(-3.6911354, 0.6214301, 0.1295814))
+
+    import GeneralizedLinearRegression._
+
+    var idx = 0
+    val link = "log"
+    val dataset = datasetPoissonLogWithZero
+    for (fitIntercept <- Seq(false, true)) {
+      val trainer = new GeneralizedLinearRegression().setFamily("poisson").setLink(link)
+        .setFitIntercept(fitIntercept).setLinkPredictionCol("linkPrediction")
+      val model = trainer.fit(dataset)
+      val actual = Vectors.dense(model.intercept, model.coefficients(0), model.coefficients(1))
+      assert(actual ~= expected(idx) absTol 1e-4, "Model mismatch: GLM with poisson family, " +
+        s"$link link and fitIntercept = $fitIntercept (with zero values).")
+
+      val familyLink = new FamilyAndLink(Poisson, Link.fromName(link))
+      model.transform(dataset).select("features", "prediction", "linkPrediction").collect()
+        .foreach {
+          case Row(features: DenseVector, prediction1: Double, linkPrediction1: Double) =>
+            val eta = BLAS.dot(features, model.coefficients) + model.intercept
+            val prediction2 = familyLink.fitted(eta)
+            val linkPrediction2 = eta
+            assert(prediction1 ~= prediction2 relTol 1E-5, "Prediction mismatch: GLM with " +
+              s"poisson family, $link link and fitIntercept = $fitIntercept. (with zero values)")
+            assert(linkPrediction1 ~= linkPrediction2 relTol 1E-5, "Link Prediction mismatch: " +
+              s"GLM with poisson family, $link link and fitIntercept = $fitIntercept " +
+              "(with zero values).")
+        }
+
+      idx += 1
+    }
+  }
 
   test("generalized linear regression: gamma family against glm") {
     /*

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -83,10 +83,11 @@ class GeneralizedLinearRegressionSuite
       testData.toDF()
     }
 
+    // force some labels to be exactly zero
     datasetPoissonLog = generateGeneralizedLinearRegressionInput(
-      intercept = 0.25, coefficients = Array(0.22, 0.06), xMean = Array(2.9, 10.5),
+      intercept = -1.5, coefficients = Array(0.22, 0.06), xMean = Array(2.9, 10.5),
       xVariance = Array(0.7, 1.2), nPoints = 10000, seed, noiseLevel = 0.01,
-      family = "poisson", link = "log").toDF()
+      family = "poisson", link = "log").map{x => LabeledPoint(if (x.label < 0.7) 0.0 else x.label, x.features)}.toDF()
 
     datasetPoissonIdentity = generateGeneralizedLinearRegressionInput(
       intercept = 2.5, coefficients = Array(2.2, 0.6), xMean = Array(2.9, 10.5),
@@ -393,8 +394,8 @@ class GeneralizedLinearRegressionSuite
          print(as.vector(coef(model)))
        }
 
-       [1] 0.22999393 0.08047088
-       [1] 0.25022353 0.21998599 0.05998621
+       [1]  0.5306608 -0.1993461
+       [1] -4.6023688  0.7566674  0.1632284
 
        data <- read.csv("path", header=FALSE)
        for (formula in c(f1, f2)) {
@@ -415,8 +416,8 @@ class GeneralizedLinearRegressionSuite
        [1] 2.5000480 2.1999972 0.5999968
      */
     val expected = Seq(
-      Vectors.dense(0.0, 0.22999393, 0.08047088),
-      Vectors.dense(0.25022353, 0.21998599, 0.05998621),
+      Vectors.dense(0.0, 0.5306608, -0.1993461),
+      Vectors.dense(-4.6023688,  0.7566674,  0.1632284),
       Vectors.dense(0.0, 2.2929501, 0.8119415),
       Vectors.dense(2.5012730, 2.1999407, 0.5999107),
       Vectors.dense(0.0, 2.2958947, 0.8090515),
@@ -452,6 +453,8 @@ class GeneralizedLinearRegressionSuite
       }
     }
   }
+
+
 
   test("generalized linear regression: gamma family against glm") {
     /*


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current implementation of Poisson GLM seems to allow only positive values. This is incorrect since the support of Poisson includes the origin. The bug is easily fixed by changing the test of the Poisson variable from  'require(y **>** 0.0' to  'require(y **>=** 0.0'. 

@mengxr  @srowen 
