### PR TITLE
[SPARK-18174] [SQL] [DO-NOT-MERGE] Avoid Implicit Type Cast in Arguments of Expressions Extending String2StringExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -230,7 +230,7 @@ case class Elt(children: Seq[Expression])
 }
 
 
-trait String2StringExpression extends ImplicitCastInputTypes {
+trait String2StringExpression extends ExpectsInputTypes {
   self: UnaryExpression =>
 
   def convert(v: UTF8String): UTF8String

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -449,6 +449,24 @@ class StringFunctionsSuite extends QueryTest with SharedSQLContext {
       df2.selectExpr("str_to_map(a)"),
       Seq(Row(Map("a" -> "1", "b" -> "2", "c" -> "3")))
     )
+  }
 
+  test("String2StringExpression - no implicit type casting") {
+    def checkTypeErrorMsg(funcName: String): Unit = {
+      val df = Seq(345).toDF("a")
+      val expectedMsg = "argument 1 requires string type, however, '`a`' is of int type"
+      // non-string type of arguments is unacceptable
+      val e = intercept[AnalysisException] {
+        df.selectExpr(s"$funcName(a)")
+      }.getMessage
+      assert(e.contains(expectedMsg))
+    }
+
+    checkTypeErrorMsg("reverse")
+    checkTypeErrorMsg("lower")
+    checkTypeErrorMsg("upper")
+    checkTypeErrorMsg("ltrim")
+    checkTypeErrorMsg("rtrim")
+    checkTypeErrorMsg("trim")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

For the expressions that extend `String2StringExpression` (including, `lower`, `upper`, `ltrim`, `rtrim`, `trim` and `reverse`), `Analyzer` should not implicitly cast the arguments to string. Instead, if users input the some data types instead of string, we should issue an exception for this misuse.
### How was this patch tested?

Added a test case in the `StringFunctionsSuite`
