### PR TITLE
[SPARK-18179][SQL] Throws analysis exception with a proper message for unsupported argument types in reflect/java_method function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -61,6 +61,10 @@ case class CallMethodViaReflection(children: Seq[Expression])
       TypeCheckFailure("first two arguments should be string literals")
     } else if (!classExists) {
       TypeCheckFailure(s"class $className not found")
+    } else if (children.slice(2, children.length)
+        .exists(e => !CallMethodViaReflection.typeMapping.contains(e.dataType))) {
+      TypeCheckFailure("arguments from the third require boolean, byte, short, " +
+        "integer, long, float, double or string expressions")
     } else if (method == null) {
       TypeCheckFailure(s"cannot find a static method that matches the argument types in $className")
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflectionSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import java.sql.Timestamp
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckFailure
 import org.apache.spark.sql.types.{IntegerType, StringType}
@@ -83,6 +85,13 @@ class CallMethodViaReflectionSuite extends SparkFunSuite with ExpressionEvalHelp
     assert(CallMethodViaReflection(
       Seq(Literal(staticClassName), Literal(1))).checkInputDataTypes().isFailure)
     assert(createExpr(staticClassName, "method1").checkInputDataTypes().isSuccess)
+  }
+
+  test("unsupported type checking") {
+    val ret = createExpr(staticClassName, "method1", new Timestamp(1)).checkInputDataTypes()
+    assert(ret.isFailure)
+    val errorMsg = ret.asInstanceOf[TypeCheckFailure].message
+    assert(errorMsg.contains("arguments from the third require boolean, byte, short"))
   }
 
   test("invoking methods using acceptable types") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -35,7 +35,7 @@ class MiscFunctionsSuite extends QueryTest with SharedSQLContext {
       Row("m1one", "m1one"))
   }
 
-  test("reflect and java_method throws an analysis exception for unsupported types") {
+  test("reflect and java_method throw an analysis exception for unsupported types") {
     val df = Seq((new Timestamp(1), Decimal(10))).toDF("a", "b")
     val className = ReflectClass.getClass.getName.stripSuffix("$")
     val messageOne = intercept[AnalysisException] {
@@ -57,7 +57,7 @@ class MiscFunctionsSuite extends QueryTest with SharedSQLContext {
         "integer, long, float, double or string expressions"))
   }
 
-  test("reflect and java_method throws an analysis exception for non-existing method/class") {
+  test("reflect and java_method throw an analysis exception for non-existing method/class") {
     val df = Seq((1, "one")).toDF("a", "b")
     val className = ReflectClass.getClass.getName.stripSuffix("$")
     val messageOne = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,10 +17,7 @@
 
 package org.apache.spark.sql
 
-import java.sql.Timestamp
-
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types.Decimal
 
 class MiscFunctionsSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -33,47 +30,6 @@ class MiscFunctionsSuite extends QueryTest with SharedSQLContext {
         s"reflect('$className', 'method1', a, b)",
         s"java_method('$className', 'method1', a, b)"),
       Row("m1one", "m1one"))
-  }
-
-  test("reflect and java_method throw an analysis exception for unsupported types") {
-    val df = Seq((new Timestamp(1), Decimal(10))).toDF("a", "b")
-    val className = ReflectClass.getClass.getName.stripSuffix("$")
-    val messageOne = intercept[AnalysisException] {
-      df.selectExpr(
-        s"reflect('$className', 'method1', a, b)").collect()
-    }.getMessage
-
-    assert(messageOne.contains(
-      "arguments from the third require boolean, byte, short, " +
-        "integer, long, float, double or string expressions"))
-
-    val messageTwo = intercept[AnalysisException] {
-      df.selectExpr(
-        s"java_method('$className', 'method1', a, b)").collect()
-    }.getMessage
-
-    assert(messageTwo.contains(
-      "arguments from the third require boolean, byte, short, " +
-        "integer, long, float, double or string expressions"))
-  }
-
-  test("reflect and java_method throw an analysis exception for non-existing method/class") {
-    val df = Seq((1, "one")).toDF("a", "b")
-    val className = ReflectClass.getClass.getName.stripSuffix("$")
-    val messageOne = intercept[AnalysisException] {
-      df.selectExpr(
-        s"reflect('$className', 'abcde', a, b)").collect()
-    }.getMessage
-
-    assert(messageOne.contains(
-      "cannot find a static method that matches the argument types in"))
-
-    val messageTwo = intercept[AnalysisException] {
-      df.selectExpr(
-        s"reflect('abcd', 'method1', a, b)").collect()
-    }.getMessage
-
-    assert(messageTwo.contains("class abcd not found"))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,7 +17,10 @@
 
 package org.apache.spark.sql
 
+import java.sql.Timestamp
+
 import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.types.Decimal
 
 class MiscFunctionsSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -30,6 +33,47 @@ class MiscFunctionsSuite extends QueryTest with SharedSQLContext {
         s"reflect('$className', 'method1', a, b)",
         s"java_method('$className', 'method1', a, b)"),
       Row("m1one", "m1one"))
+  }
+
+  test("reflect and java_method throws an analysis exception for unsupported types") {
+    val df = Seq((new Timestamp(1), Decimal(10))).toDF("a", "b")
+    val className = ReflectClass.getClass.getName.stripSuffix("$")
+    val messageOne = intercept[AnalysisException] {
+      df.selectExpr(
+        s"reflect('$className', 'method1', a, b)").collect()
+    }.getMessage
+
+    assert(messageOne.contains(
+      "arguments from the third require boolean, byte, short, " +
+        "integer, long, float, double or string expressions"))
+
+    val messageTwo = intercept[AnalysisException] {
+      df.selectExpr(
+        s"java_method('$className', 'method1', a, b)").collect()
+    }.getMessage
+
+    assert(messageTwo.contains(
+      "arguments from the third require boolean, byte, short, " +
+        "integer, long, float, double or string expressions"))
+  }
+
+  test("reflect and java_method throws an analysis exception for non-existing method/class") {
+    val df = Seq((1, "one")).toDF("a", "b")
+    val className = ReflectClass.getClass.getName.stripSuffix("$")
+    val messageOne = intercept[AnalysisException] {
+      df.selectExpr(
+        s"reflect('$className', 'abcde', a, b)").collect()
+    }.getMessage
+
+    assert(messageOne.contains(
+      "cannot find a static method that matches the argument types in"))
+
+    val messageTwo = intercept[AnalysisException] {
+      df.selectExpr(
+        s"reflect('abcd', 'method1', a, b)").collect()
+    }.getMessage
+
+    assert(messageTwo.contains("class abcd not found"))
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes throwing an `AnalysisException` with a proper message rather than `NoSuchElementException` with the message ` key not found: TimestampType` when unsupported types are given to `reflect` and `java_method` functions.

```scala
spark.range(1).selectExpr("reflect('java.lang.String', 'valueOf', cast('1990-01-01' as timestamp))")
```

produces

**Before**

```
java.util.NoSuchElementException: key not found: TimestampType
  at scala.collection.MapLike$class.default(MapLike.scala:228)
  at scala.collection.AbstractMap.default(Map.scala:59)
  at scala.collection.MapLike$class.apply(MapLike.scala:141)
  at scala.collection.AbstractMap.apply(Map.scala:59)
  at org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection$$anonfun$findMethod$1$$anonfun$apply$1.apply(CallMethodViaReflection.scala:159)
...
```

**After**

```
cannot resolve 'reflect('java.lang.String', 'valueOf', CAST('1990-01-01' AS TIMESTAMP))' due to data type mismatch: arguments from the third require boolean, byte, short, integer, long, float, double or string expressions; line 1 pos 0;
'Project [unresolvedalias(reflect(java.lang.String, valueOf, cast(1990-01-01 as timestamp)), Some(<function1>))]
+- Range (0, 1, step=1, splits=Some(2))
...
```

Added message is,

```
arguments from the third require boolean, byte, short, integer, long, float, double or string expressions
```

## How was this patch tested?

Tests added in `CallMethodViaReflection`.