### PR TITLE
[SPARK-18167] [SQL] Also log all partitions when the SQLQuerySuite test flakes

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -594,9 +594,8 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
             // SPARK-18167 retry to investigate the flaky test. This should be reverted before
             // the release is cut.
             val retry = Try(getPartitionsByFilterMethod.invoke(hive, table, filter))
-            val full = Try(getAllPartitionsMethod.invoke(hive, table))
             logError("getPartitionsByFilter failed, retry success = " + retry.isSuccess)
-            logError("getPartitionsByFilter failed, full fetch success = " + full.isSuccess)
+            logError("all partitions: " + getAllPartitions(hive, table))
             throw e
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

One possibility for this test flaking is that we have corrupted the partition schema somehow in the tests, which causes the cast to decimal to fail in the call. This should at least show us the actual partition values.

## How was this patch tested?

Run it locally, it prints out something like `ArrayBuffer(test(partcol=0), test(partcol=1), test(partcol=2), test(partcol=3), test(partcol=4))`.
