### PR TITLE
[SPARK-18190][Build][SparkR] Fix R version to not the latest in AppVeyor

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -113,7 +113,7 @@ $env:HADOOP_HOME = "$hadoopPath/winutils-master/hadoop-$hadoopVer"
 Pop-Location
 
 # ========================== R
-$rVer = "3.3.1"
+$rVer = "3.3.0"
 $rToolsVer = "3.4.0"
 
 InstallR


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark supports the test on Windows via AppVeyor but not it seems failing to download R 3.3.1 after R 3.3.2 is released. It downloads given R version after checking if that is the latest or not via http://rversions.r-pkg.org/r-release because the URL.

For example, the latest one has the URL as below:

https://cran.r-project.org/bin/windows/base/R-3.3.1-win.exe

and the old one has the URL as below.

https://cran.r-project.org/bin/windows/base/old/3.3.0/R-3.3.0-win.exe

The problem is, it seems (_according to my observation, please check the main page_[1])  the versions of R on Windows are not always synced with the latest versions. It seems R 3.3.2 for Windows does not exist.

So, it seems currently we can't download R 3.3.1 from the old repository[2] . So, currently, AppVeyor tries to find R 3.3.1 in the old repository[2] as 3.3.2 is released but it does not exist because it seems R 3.3.2 for Windows is not there and R 3.3.1 is still the latest.


Therefore, this PR proposes to lower the R version into 3.3.0 rather than rely on the latest as  SparkR supports R 3.1+ if I recall correctly.

[1]https://cran.r-project.org
[2]https://cran.r-project.org/bin/windows/base/old


## How was this patch tested?

Manually via AppVeyor CI - https://ci.appveyor.com/project/spark-test/spark/build/43-test
