### PR TITLE
[SPARK-18222][CORE][SQL][ML] Use math instead of Math

### DIFF
--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/UTF8StringPropertyCheckSuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/UTF8StringPropertyCheckSuite.scala
@@ -77,7 +77,7 @@ class UTF8StringPropertyCheckSuite extends FunSuite with GeneratorDrivenProperty
 
   test("compare") {
     forAll { (s1: String, s2: String) =>
-      assert(Math.signum(toUTF8(s1).compareTo(toUTF8(s2))) === Math.signum(s1.compareTo(s2)))
+      assert(math.signum(toUTF8(s1).compareTo(toUTF8(s2))) === math.signum(s1.compareTo(s2)))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/api/r/RBackendHandler.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackendHandler.scala
@@ -103,7 +103,7 @@ private[r] class RBackendHandler(server: RBackend)
         "spark.r.heartBeatInterval", SparkRDefaults.DEFAULT_HEARTBEAT_INTERVAL)
       val backendConnectionTimeout = conf.getInt(
         "spark.r.backendConnectionTimeout", SparkRDefaults.DEFAULT_CONNECTION_TIMEOUT)
-      val interval = Math.min(heartBeatInterval, backendConnectionTimeout - 1)
+      val interval = math.min(heartBeatInterval, backendConnectionTimeout - 1)
 
       execService.scheduleAtFixedRate(pingRunner, interval, interval, TimeUnit.SECONDS)
       handleMethodCall(isStatic, objId, methodName, numArgs, dis, dos)

--- a/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
@@ -144,7 +144,7 @@ private[spark] object SerDe {
       if (java.lang.Double.isNaN(seconds)) {
         null
       } else {
-        val sec = Math.floor(seconds).toLong
+        val sec = math.floor(seconds).toLong
         val t = new Timestamp(sec * 1000L)
         t.setNanos(((seconds - sec) * 1e9).toInt)
         t

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -91,7 +91,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   // Number of threads used to replay event logs.
   private val NUM_PROCESSING_THREADS = conf.getInt(SPARK_HISTORY_FS_NUM_REPLAY_THREADS,
-    Math.ceil(Runtime.getRuntime.availableProcessors() / 4f).toInt)
+    math.ceil(Runtime.getRuntime.availableProcessors() / 4f).toInt)
 
   private val logDir = conf.getOption("spark.history.fs.logDirectory")
     .map { d => Utils.resolveURI(d).toString }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -103,7 +103,7 @@ private[spark] class Executor(
 
   // Max size of direct result. If task result is bigger than this, we use the block manager
   // to send the result back.
-  private val maxDirectResultSize = Math.min(
+  private val maxDirectResultSize = math.min(
     conf.getSizeAsBytes("spark.task.maxDirectResultSize", 1L << 20),
     RpcUtils.maxMessageSizeBytes(conf))
 

--- a/core/src/main/scala/org/apache/spark/input/FixedLengthBinaryInputFormat.scala
+++ b/core/src/main/scala/org/apache/spark/input/FixedLengthBinaryInputFormat.scala
@@ -74,7 +74,7 @@ private[spark] class FixedLengthBinaryInputFormat
     if (defaultSize < recordLength) {
       recordLength.toLong
     } else {
-      (Math.floor(defaultSize / recordLength) * recordLength).toLong
+      (math.floor(defaultSize / recordLength) * recordLength).toLong
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/input/FixedLengthBinaryRecordReader.scala
+++ b/core/src/main/scala/org/apache/spark/input/FixedLengthBinaryRecordReader.scala
@@ -63,7 +63,7 @@ private[spark] class FixedLengthBinaryRecordReader
   override def getProgress: Float = {
     splitStart match {
       case x if x == splitEnd => 0.0.toFloat
-      case _ => Math.min(
+      case _ => math.min(
         ((currentPosition - splitStart) / (splitEnd - splitStart)).toFloat, 1.0
       ).toFloat
     }

--- a/core/src/main/scala/org/apache/spark/input/WholeTextFileInputFormat.scala
+++ b/core/src/main/scala/org/apache/spark/input/WholeTextFileInputFormat.scala
@@ -54,7 +54,7 @@ private[spark] class WholeTextFileInputFormat
   def setMinPartitions(context: JobContext, minPartitions: Int) {
     val files = listStatus(context).asScala
     val totalLen = files.map(file => if (file.isDirectory) 0L else file.getLen).sum
-    val maxSplitSize = Math.ceil(totalLen * 1.0 /
+    val maxSplitSize = math.ceil(totalLen * 1.0 /
       (if (minPartitions == 0) 1 else minPartitions)).toLong
     super.setMaxSplitSize(maxSplitSize)
   }

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -171,7 +171,7 @@ private[spark] class UnifiedMemoryManager private[memory] (
     if (numBytes > storagePool.memoryFree) {
       // There is not enough free memory in the storage pool, so try to borrow free memory from
       // the execution pool.
-      val memoryBorrowedFromExecution = Math.min(executionPool.memoryFree, numBytes)
+      val memoryBorrowedFromExecution = math.min(executionPool.memoryFree, numBytes)
       executionPool.decrementPoolSize(memoryBorrowedFromExecution)
       storagePool.incrementPoolSize(memoryBorrowedFromExecution)
     }

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -89,13 +89,13 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
           // If we didn't find any rows after the previous iteration, quadruple and retry.
           // Otherwise, interpolate the number of partitions we need to try, but overestimate it
           // by 50%. We also cap the estimation in the end.
-          if (results.size == 0) {
+          if (results.isEmpty) {
             numPartsToTry = partsScanned * 4
           } else {
             // the left side of max is >=1 whenever partsScanned >= 2
-            numPartsToTry = Math.max(1,
+            numPartsToTry = math.max(1,
               (1.5 * num * partsScanned / results.size).toInt - partsScanned)
-            numPartsToTry = Math.min(numPartsToTry, partsScanned * 4)
+            numPartsToTry = math.min(numPartsToTry, partsScanned * 4)
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -88,7 +88,7 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
     val rddToFilter: RDD[P] = self.partitioner match {
       case Some(rp: RangePartitioner[K, V]) =>
         val partitionIndicies = (rp.getPartition(lower), rp.getPartition(upper)) match {
-          case (l, u) => Math.min(l, u) to Math.max(l, u)
+          case (l, u) => math.min(l, u) to math.max(l, u)
         }
         PartitionPruningRDD.create(self, partitionIndicies.contains)
       case _ =>

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1297,7 +1297,7 @@ abstract class RDD[T: ClassTag](
    * an exception if called on an RDD of `Nothing` or `Null`.
    */
   def take(num: Int): Array[T] = withScope {
-    val scaleUpFactor = Math.max(conf.getInt("spark.rdd.limit.scaleUpFactor", 4), 2)
+    val scaleUpFactor = math.max(conf.getInt("spark.rdd.limit.scaleUpFactor", 4), 2)
     if (num == 0) {
       new Array[T](0)
     } else {
@@ -1316,8 +1316,8 @@ abstract class RDD[T: ClassTag](
             numPartsToTry = partsScanned * scaleUpFactor
           } else {
             // the left side of max is >=1 whenever partsScanned >= 2
-            numPartsToTry = Math.max((1.5 * num * partsScanned / buf.size).toInt - partsScanned, 1)
-            numPartsToTry = Math.min(numPartsToTry, partsScanned * scaleUpFactor)
+            numPartsToTry = math.max((1.5 * num * partsScanned / buf.size).toInt - partsScanned, 1)
+            numPartsToTry = math.min(numPartsToTry, partsScanned * scaleUpFactor)
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -382,7 +382,7 @@ private[spark] class BlockManager(
       status: BlockStatus,
       droppedMemorySize: Long = 0L): Boolean = {
     val storageLevel = status.storageLevel
-    val inMemSize = Math.max(status.memSize, droppedMemorySize)
+    val inMemSize = math.max(status.memSize, droppedMemorySize)
     val onDiskSize = status.diskSize
     master.updateBlockInfo(blockManagerId, blockId, storageLevel, inMemSize, onDiskSize)
   }

--- a/core/src/test/scala/org/apache/spark/PartitioningSuite.scala
+++ b/core/src/test/scala/org/apache/spark/PartitioningSuite.scala
@@ -247,7 +247,7 @@ class PartitioningSuite extends SparkFunSuite with SharedSparkContext with Priva
     assert(abs(rdd.variance - rdd.popVariance) < 1e-14)
     assert(abs(rdd.stdev - rdd.popStdev) < 1e-14)
     assert(abs(2.0 - rdd.sampleVariance) < 1e-14)
-    assert(abs(Math.sqrt(2.0) - rdd.sampleStdev) < 1e-14)
+    assert(abs(math.sqrt(2.0) - rdd.sampleStdev) < 1e-14)
     assert(stats.max === 4.0)
     assert(stats.min === 2.0)
 

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -584,7 +584,7 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     val p = new Partitioner {
       def numPartitions: Int = 2
 
-      def getPartition(key: Any): Int = Math.abs(key.hashCode() % 2)
+      def getPartition(key: Any): Int = math.abs(key.hashCode() % 2)
     }
     val shuffled = pairs.partitionBy(p)
 

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -48,13 +48,13 @@ class MapStatusSuite extends SparkFunSuite {
   }
 
   test("MapStatus should never report non-empty blocks' sizes as 0") {
-    import Math._
     for (
       numSizes <- Seq(1, 10, 100, 1000, 10000);
       mean <- Seq(0L, 100L, 10000L, Int.MaxValue.toLong);
       stddev <- Seq(0.0, 0.01, 0.5, 1.0)
     ) {
-      val sizes = Array.fill[Long](numSizes)(abs(round(Random.nextGaussian() * stddev)) + mean)
+      val sizes = Array.fill[Long](numSizes)(
+        math.abs(math.round(Random.nextGaussian() * stddev)) + mean)
       val status = MapStatus(BlockManagerId("a", "b", 10), sizes)
       val status1 = compressAndDecompressMapStatus(status)
       for (i <- 0 until numSizes) {

--- a/core/src/test/scala/org/apache/spark/util/random/RandomSamplerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/RandomSamplerSuite.scala
@@ -115,7 +115,7 @@ class RandomSamplerSuite extends SparkFunSuite with Matchers {
     assert(n > 0)
     assert(cdf1(n-1) == 1.0)
     assert(cdf2(n-1) == 1.0)
-    cdf1.zip(cdf2).map { x => Math.abs(x._1 - x._2) }.max
+    cdf1.zip(cdf2).map { x => math.abs(x._1 - x._2) }.max
   }
 
   // Returns the median KS 'D' statistic between two samples, over (m) sampling trials

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -174,10 +174,10 @@ private[kafka010] case class KafkaSource(
             val prorate = limit * (size / total)
             logDebug(s"rateLimit $tp prorated amount is $prorate")
             // Don't completely starve small topicpartitions
-            val off = begin + (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            val off = begin + (if (prorate < 1) math.ceil(prorate) else math.floor(prorate)).toLong
             logDebug(s"rateLimit $tp new offset is $off")
             // Paranoia, make sure not to return an offset that's past end
-            Math.min(end, off)
+            math.min(end, off)
           }.getOrElse(end)
       }
     }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceRDD.scala
@@ -95,7 +95,7 @@ private[kafka010] class KafkaSourceRDD(
     val parts = nonEmptyPartitions.foldLeft(Map[Int, Int]()) { (result, part) =>
       val remain = num - result.values.sum
       if (remain > 0) {
-        val taken = Math.min(remain, part.offsetRange.size)
+        val taken = math.min(remain, part.offsetRange.size)
         result + (part.index -> taken.toInt)
       } else {
         result

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -139,14 +139,14 @@ private[spark] class DirectKafkaInputDStream[K, V](
     val effectiveRateLimitPerPartition = estimatedRateLimit.filter(_ > 0) match {
       case Some(rate) =>
         val lagPerPartition = offsets.map { case (tp, offset) =>
-          tp -> Math.max(offset - currentOffsets(tp), 0)
+          tp -> math.max(offset - currentOffsets(tp), 0)
         }
         val totalLag = lagPerPartition.values.sum
 
         lagPerPartition.map { case (tp, lag) =>
-          val backpressureRate = Math.round(lag / totalLag.toFloat * rate)
+          val backpressureRate = math.round(lag / totalLag.toFloat * rate)
           tp -> (if (maxRateLimitPerPartition > 0) {
-            Math.min(backpressureRate, maxRateLimitPerPartition)} else backpressureRate)
+            math.min(backpressureRate, maxRateLimitPerPartition)} else backpressureRate)
         }
       case None => offsets.map { case (tp, offset) => tp -> maxRateLimitPerPartition }
     }
@@ -171,7 +171,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
       // position should be minimum offset per topicpartition
       msgs.asScala.foldLeft(Map[TopicPartition, Long]()) { (acc, m) =>
         val tp = new TopicPartition(m.topic, m.partition)
-        val off = acc.get(tp).map(o => Math.min(o, m.offset)).getOrElse(m.offset)
+        val off = acc.get(tp).map(o => math.min(o, m.offset)).getOrElse(m.offset)
         acc + (tp -> off)
       }.foreach { case (tp, off) =>
           logInfo(s"poll(0) returned messages, seeking $tp to $off to compensate")
@@ -206,7 +206,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
     maxMessagesPerPartition(offsets).map { mmp =>
       mmp.map { case (tp, messages) =>
           val uo = offsets(tp)
-          tp -> Math.min(currentOffsets(tp) + messages, uo)
+          tp -> math.min(currentOffsets(tp) + messages, uo)
       }
     }.getOrElse(offsets)
   }
@@ -286,7 +286,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
     while (null != osr) {
       val tp = osr.topicPartition
       val x = m.get(tp)
-      val offset = if (null == x) { osr.untilOffset } else { Math.max(x.offset, osr.untilOffset) }
+      val offset = if (null == x) { osr.untilOffset } else { math.max(x.offset, osr.untilOffset) }
       m.put(tp, new OffsetAndMetadata(offset))
       osr = commitQueue.poll()
     }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
@@ -111,7 +111,7 @@ private[spark] class KafkaRDD[K, V](
     val parts = nonEmptyPartitions.foldLeft(Map[Int, Int]()) { (result, part) =>
       val remain = num - result.values.sum
       if (remain > 0) {
-        val taken = Math.min(remain, part.count)
+        val taken = math.min(remain, part.count)
         result + (part.index -> taken.toInt)
       } else {
         result

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -596,7 +596,7 @@ class DirectKafkaStreamSuite
       collectedData.clear()       // Empty this buffer on each pass.
       estimator.updateRate(rate)  // Set a new rate.
       // Expect blocks of data equal to "rate", scaled by the interval length in secs.
-      val expectedSize = Math.round(rate * batchIntervalMilliseconds * 0.001)
+      val expectedSize = math.round(rate * batchIntervalMilliseconds * 0.001)
       eventually(timeout(5.seconds), interval(10 milliseconds)) {
         // Assert that rate estimator values are used to determine maxMessagesPerPartition.
         // Funky "-" in message makes the complete assertion message read better.

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
@@ -99,14 +99,14 @@ class DirectKafkaInputDStream[
     val effectiveRateLimitPerPartition = estimatedRateLimit.filter(_ > 0) match {
       case Some(rate) =>
         val lagPerPartition = offsets.map { case (tp, offset) =>
-          tp -> Math.max(offset - currentOffsets(tp), 0)
+          tp -> math.max(offset - currentOffsets(tp), 0)
         }
         val totalLag = lagPerPartition.values.sum
 
         lagPerPartition.map { case (tp, lag) =>
-          val backpressureRate = Math.round(lag / totalLag.toFloat * rate)
+          val backpressureRate = math.round(lag / totalLag.toFloat * rate)
           tp -> (if (maxRateLimitPerPartition > 0) {
-            Math.min(backpressureRate, maxRateLimitPerPartition)} else backpressureRate)
+            math.min(backpressureRate, maxRateLimitPerPartition)} else backpressureRate)
         }
       case None => offsets.map { case (tp, offset) => tp -> maxRateLimitPerPartition }
     }
@@ -149,7 +149,7 @@ class DirectKafkaInputDStream[
     maxMessagesPerPartition(offsets).map { mmp =>
       mmp.map { case (tp, messages) =>
         val lo = leaderOffsets(tp)
-        tp -> lo.copy(offset = Math.min(currentOffsets(tp) + messages, lo.offset))
+        tp -> lo.copy(offset = math.min(currentOffsets(tp) + messages, lo.offset))
       }
     }.getOrElse(leaderOffsets)
   }

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -88,7 +88,7 @@ class KafkaRDD[
     val parts = nonEmptyPartitions.foldLeft(Map[Int, Int]()) { (result, part) =>
       val remain = num - result.values.sum
       if (remain > 0) {
-        val taken = Math.min(remain, part.count)
+        val taken = math.min(remain, part.count)
         result + (part.index -> taken.toInt)
       } else {
         result

--- a/external/kafka-0-8/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-8/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -447,7 +447,7 @@ class DirectKafkaStreamSuite
       collectedData.clear()       // Empty this buffer on each pass.
       estimator.updateRate(rate)  // Set a new rate.
       // Expect blocks of data equal to "rate", scaled by the interval length in secs.
-      val expectedSize = Math.round(rate * batchIntervalMilliseconds * 0.001)
+      val expectedSize = math.round(rate * batchIntervalMilliseconds * 0.001)
       eventually(timeout(5.seconds), interval(batchIntervalMilliseconds.milliseconds)) {
         // Assert that rate estimator values are used to determine maxMessagesPerPartition.
         // Funky "-" in message makes the complete assertion message read better.

--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -162,7 +162,7 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * {{{
    * val rawGraph: Graph[(), ()] = Graph.textFile("hdfs://file")
    * val root = 42
-   * var bfsGraph = rawGraph.mapVertices[Int]((vid, data) => if (vid == root) 0 else Math.MaxValue)
+   * var bfsGraph = rawGraph.mapVertices[Int]((vid, data) => if (vid == root) 0 else Int.MaxValue)
    * }}}
    *
    */

--- a/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -673,7 +673,7 @@ private[spark] class MesosClusterScheduler(
           state.finishDate = Some(new Date())
           val retryState: Option[MesosClusterRetryState] = state.driverDescription.retryState
           val (retries, waitTimeSec) = retryState
-            .map { rs => (rs.retries + 1, Math.min(maxRetryWaitTime, rs.waitTime * 2)) }
+            .map { rs => (rs.retries + 1, math.min(maxRetryWaitTime, rs.waitTime * 2)) }
             .getOrElse{ (1, 1) }
           val nextRetry = new Date(new Date().getTime + waitTimeSec * 1000L)
 

--- a/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -402,8 +402,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           launchTasks = true
           val taskId = newMesosTaskId()
           val offerCPUs = getResource(resources, "cpus").toInt
-          val taskGPUs = Math.min(
-            Math.max(0, maxGpus - totalGpusAcquired), getResource(resources, "gpus").toInt)
+          val taskGPUs = math.min(
+            math.max(0, maxGpus - totalGpusAcquired), getResource(resources, "gpus").toInt)
 
           val taskCPUs = executorCores(offerCPUs)
           val taskMemory = executorMemory(sc)

--- a/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -213,7 +213,7 @@ trait MesosSchedulerUtils extends Logging {
           r.getType == Value.Type.SCALAR &&
           r.getScalar.getValue > 0.0 &&
           r.getName == resourceName) {
-          val usage = Math.min(remain, r.getScalar.getValue)
+          val usage = math.min(remain, r.getScalar.getValue)
           requestedResources += createResource(resourceName, usage, Some(r.getRole))
           remain -= usage
           createResource(resourceName, r.getScalar.getValue - usage, Some(r.getRole))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RandomProjection.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RandomProjection.scala
@@ -77,7 +77,7 @@ class RandomProjectionModel private[ml] (
   override protected[ml] val hashFunction: (Vector) => Vector = {
     key: Vector => {
       val hashValues: Array[Double] = randUnitVectors.map({
-        randUnitVector => Math.floor(BLAS.dot(key, randUnitVector) / $(bucketLength))
+        randUnitVector => math.floor(BLAS.dot(key, randUnitVector) / $(bucketLength))
       })
       Vectors.dense(hashValues)
     }
@@ -85,7 +85,7 @@ class RandomProjectionModel private[ml] (
 
   @Since("2.1.0")
   override protected[ml] def keyDistance(x: Vector, y: Vector): Double = {
-    Math.sqrt(Vectors.sqdist(x, y))
+    math.sqrt(Vectors.sqdist(x, y))
   }
 
   @Since("2.1.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -344,7 +344,7 @@ private[spark] object GradientBoostedTrees extends Logging {
           validationInput, validatePredError, baseLearnerWeights(m), baseLearners(m), loss)
         validatePredErrorCheckpointer.update(validatePredError)
         val currentValidateError = validatePredError.values.mean()
-        if (bestValidateError - currentValidateError < validationTol * Math.max(
+        if (bestValidateError - currentValidateError < validationTol * math.max(
           currentValidateError, 0.01)) {
           doneLearning = true
         } else if (currentValidateError < bestValidateError) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -288,7 +288,7 @@ class BlockMatrix @Since("1.3.0") (
 
       vectors.foreach { case (blockColIdx: Int, vec: BV[Double]) =>
         val offset = colsPerBlock * blockColIdx
-        wholeVector(offset until Math.min(cols, offset + colsPerBlock)) := vec
+        wholeVector(offset until math.min(cols, offset + colsPerBlock)) := vec
       }
       new IndexedRow(rowIdx, Vectors.fromBreeze(wholeVector))
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/GradientDescent.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/GradientDescent.scala
@@ -305,7 +305,7 @@ object GradientDescent extends Logging {
     // This represents the difference of updated weights in the iteration.
     val solutionVecDiff: Double = norm(previousBDV - currentBDV)
 
-    solutionVecDiff < convergenceTol * Math.max(norm(currentBDV), 1.0)
+    solutionVecDiff < convergenceTol * math.max(norm(currentBDV), 1.0)
   }
 
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -150,6 +150,13 @@ This file is divided into 3 sections:
       // scalastyle:on println]]></customMessage>
   </check>
 
+  <!-- As of SPARK-18222, use scala.math instead of java.lang.Math -->
+  <check customId="scalamath" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+    <parameters><parameter name="regex">^Math$</parameter></parameters>
+    <customMessage>Use Scala Math classes (package scala.math.*) instead
+      of Java Lang Math (package java.lang.Math.*)</customMessage>
+  </check>
+
   <check customId="visiblefortesting" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">@VisibleForTesting</parameter></parameters>
     <customMessage><![CDATA[

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -90,7 +90,7 @@ case class HyperLogLogPlusPlus(
    * lower than the requested error. Use the <code>trueRsd</code> method to get the actual RSD
    * value.
    */
-  private[this] val p = Math.ceil(2.0d * Math.log(1.106d / relativeSD) / Math.log(2.0d)).toInt
+  private[this] val p = math.ceil(2.0d * math.log(1.106d / relativeSD) / math.log(2.0d)).toInt
 
   require(p >= 4, "HLL++ requires at least 4 bits for addressing. " +
     "Use a lower error, at most 27%.")
@@ -210,7 +210,7 @@ case class HyperLogLogPlusPlus(
       var i = 0
       var mask = REGISTER_WORD_MASK
       while (idx < m && i < REGISTERS_PER_WORD) {
-        word |= Math.max(word1 & mask, word2 & mask)
+        word |= math.max(word1 & mask, word2 & mask)
         mask <<= REGISTER_SIZE
         i += 1
         idx += 1
@@ -305,7 +305,7 @@ case class HyperLogLogPlusPlus(
     // Estimate the cardinality.
     val estimate = if (V > 0) {
       // Use linear counting for small cardinality estimates.
-      val H = m * Math.log(m / V)
+      val H = m * math.log(m / V)
       if (H <= THRESHOLDS(p - 4)) {
         H
       } else {
@@ -316,7 +316,7 @@ case class HyperLogLogPlusPlus(
     }
 
     // Round to the nearest long value.
-    Math.round(estimate)
+    math.round(estimate)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -108,7 +108,7 @@ case class Stack(children: Seq[Expression])
     extends Expression with Generator with CodegenFallback {
 
   private lazy val numRows = children.head.eval().asInstanceOf[Int]
-  private lazy val numFields = Math.ceil((children.length - 1.0) / numRows).toInt
+  private lazy val numFields = math.ceil((children.length - 1.0) / numRows).toInt
 
   override def checkInputDataTypes(): TypeCheckResult = {
     if (children.length <= 1) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -45,10 +45,10 @@ object Literal {
     case s: Short => Literal(s, ShortType)
     case s: String => Literal(UTF8String.fromString(s), StringType)
     case b: Boolean => Literal(b, BooleanType)
-    case d: BigDecimal => Literal(Decimal(d), DecimalType(Math.max(d.precision, d.scale), d.scale))
+    case d: BigDecimal => Literal(Decimal(d), DecimalType(math.max(d.precision, d.scale), d.scale))
     case d: java.math.BigDecimal =>
-      Literal(Decimal(d), DecimalType(Math.max(d.precision, d.scale), d.scale()))
-    case d: Decimal => Literal(d, DecimalType(Math.max(d.precision, d.scale), d.scale))
+      Literal(Decimal(d), DecimalType(math.max(d.precision, d.scale), d.scale()))
+    case d: Decimal => Literal(d, DecimalType(math.max(d.precision, d.scale), d.scale))
     case t: Timestamp => Literal(DateTimeUtils.fromJavaTimestamp(t), TimestampType)
     case d: Date => Literal(DateTimeUtils.fromJavaDate(d), DateType)
     case a: Array[Byte] => Literal(a, BinaryType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -92,10 +92,10 @@ object DateTimeUtils {
 
   // we should use the exact day as Int, for example, (year, month, day) -> day
   def millisToDays(millisUtc: Long): SQLDate = {
-    // SPARK-6785: use Math.floor so negative number of days (dates before 1970)
+    // SPARK-6785: use math.floor so negative number of days (dates before 1970)
     // will correctly work as input for function toJavaDate(Int)
     val millisLocal = millisUtc + threadLocalLocalTimeZone.get().getOffset(millisUtc)
-    Math.floor(millisLocal.toDouble / MILLIS_PER_DAY).toInt
+    math.floor(millisLocal.toDouble / MILLIS_PER_DAY).toInt
   }
 
   // reverse of millisToDays
@@ -864,7 +864,7 @@ object DateTimeUtils {
       if (guess != offset) {
         // fallback to do the reverse lookup using java.sql.Timestamp
         // this should only happen near the start or end of DST
-        val days = Math.floor(millisLocal.toDouble / MILLIS_PER_DAY).toInt
+        val days = math.floor(millisLocal.toDouble / MILLIS_PER_DAY).toInt
         val year = getYear(days)
         val month = getMonth(days)
         val day = getDayOfMonth(days)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
@@ -120,8 +120,8 @@ object NumberConverter {
    */
   def convert(n: Array[Byte], fromBase: Int, toBase: Int ): UTF8String = {
     if (fromBase < Character.MIN_RADIX || fromBase > Character.MAX_RADIX
-        || Math.abs(toBase) < Character.MIN_RADIX
-        || Math.abs(toBase) > Character.MAX_RADIX) {
+        || math.abs(toBase) < Character.MIN_RADIX
+        || math.abs(toBase) > Character.MAX_RADIX) {
       return null
     }
 
@@ -153,14 +153,14 @@ object NumberConverter {
       v = -v
       negative = true
     }
-    decode(v, Math.abs(toBase), temp)
+    decode(v, math.abs(toBase), temp)
 
     // Find the first non-zero digit or the last digits if all are zero.
     val firstNonZeroPos = {
       val firstNonZero = temp.indexWhere( _ != 0)
       if (firstNonZero != -1) firstNonZero else temp.length - 1
     }
-    byte2char(Math.abs(toBase), firstNonZeroPos, temp)
+    byte2char(math.abs(toBase), firstNonZeroPos, temp)
 
     var resultStartPos = firstNonZeroPos
     if (negative && toBase < 0) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -328,7 +328,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def + (that: Decimal): Decimal = {
     if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
-      Decimal(longVal + that.longVal, Math.max(precision, that.precision), scale)
+      Decimal(longVal + that.longVal, math.max(precision, that.precision), scale)
     } else {
       Decimal(toBigDecimal + that.toBigDecimal)
     }
@@ -336,7 +336,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def - (that: Decimal): Decimal = {
     if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
-      Decimal(longVal - that.longVal, Math.max(precision, that.precision), scale)
+      Decimal(longVal - that.longVal, math.max(precision, that.precision), scale)
     } else {
       Decimal(toBigDecimal - that.toBigDecimal)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -106,7 +106,7 @@ object RandomDataGenerator {
       } else {
         // Struct
         // TODO: do empty structs make sense?
-        val n = Math.max(rand.nextInt(numFields), 1)
+        val n = math.max(rand.nextInt(numFields), 1)
         val nested = randomNestedSchema(rand, n, acceptedTypes)
         fields += new StructField("col_" + i, nested, rand.nextBoolean())
         numFields -= n

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -129,7 +129,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
         val error = count / accuracy
         val percentiles = arrayData.toDoubleArray()
         assert(percentiles.zip(expectedPercentiles)
-          .forall(pair => Math.abs(pair._1 - pair._2) < error))
+          .forall(pair => math.abs(pair._1 - pair._2) < error))
     }
   }
 
@@ -162,7 +162,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     agg.initialize(mutableAggBuffer)
     agg.merge(mutableAggBuffer, inputAggBuffer)
     val expectedPercentile = dataCount * percentage
-    assert(Math.abs(agg.eval(mutableAggBuffer).asInstanceOf[Double] - expectedPercentile) < 0.1)
+    assert(math.abs(agg.eval(mutableAggBuffer).asInstanceOf[Double] - expectedPercentile) < 0.1)
   }
 
   test("class ApproximatePercentile, sql string") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -472,7 +472,7 @@ case class FileSourceScanExec(
     val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
     val bytesPerCore = totalBytes / defaultParallelism
 
-    val maxSplitBytes = Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+    val maxSplitBytes = math.min(defaultMaxSplitBytes, math.max(openCostInBytes, bytesPerCore))
     logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
       s"open cost is considered as scanning $openCostInBytes bytes.")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -318,13 +318,13 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
         // If we didn't find any rows after the previous iteration, quadruple and retry.
         // Otherwise, interpolate the number of partitions we need to try, but overestimate
         // it by 50%. We also cap the estimation in the end.
-        val limitScaleUpFactor = Math.max(sqlContext.conf.limitScaleUpFactor, 2)
+        val limitScaleUpFactor = math.max(sqlContext.conf.limitScaleUpFactor, 2)
         if (buf.isEmpty) {
           numPartsToTry = partsScanned * limitScaleUpFactor
         } else {
           // the left side of max is >=1 whenever partsScanned >= 2
-          numPartsToTry = Math.max((1.5 * n * partsScanned / buf.size).toInt - partsScanned, 1)
-          numPartsToTry = Math.min(numPartsToTry, partsScanned * limitScaleUpFactor)
+          numPartsToTry = math.max((1.5 * n * partsScanned / buf.size).toInt - partsScanned, 1)
+          numPartsToTry = math.min(numPartsToTry, partsScanned * limitScaleUpFactor)
         }
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -344,7 +344,7 @@ case class HashAggregateExec(
     // update peak execution memory
     val mapMemory = hashMap.getPeakMemoryUsedBytes
     val sorterMemory = Option(sorter).map(_.getPeakMemoryUsedBytes).getOrElse(0L)
-    val maxMemory = Math.max(mapMemory, sorterMemory)
+    val maxMemory = math.max(mapMemory, sorterMemory)
     val metrics = TaskContext.get().taskMetrics()
     peakMemory.add(maxMemory)
     metrics.incPeakExecutionMemory(maxMemory)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -415,7 +415,7 @@ class TungstenAggregationIterator(
       if (!hasNext) {
         val mapMemory = hashMap.getPeakMemoryUsedBytes
         val sorterMemory = Option(externalSorter).map(_.getPeakMemoryUsedBytes).getOrElse(0L)
-        val maxMemory = Math.max(mapMemory, sorterMemory)
+        val maxMemory = math.max(mapMemory, sorterMemory)
         val metrics = TaskContext.get().taskMetrics()
         peakMemory += maxMemory
         spillSize += metrics.memoryBytesSpilled - spillSizeBefore

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -598,8 +598,8 @@ case class AlterTableRecoverPartitionsCommand(
 
       // Set the number of parallelism to prevent following file listing from generating many tasks
       // in case of large #defaultParallelism.
-      val numParallelism = Math.min(serializedPaths.length,
-        Math.min(spark.sparkContext.defaultParallelism, 10000))
+      val numParallelism = math.min(serializedPaths.length,
+        math.min(spark.sparkContext.defaultParallelism, 10000))
       // gather the fast stats for all the partitions otherwise Hive metastore will list all the
       // files for all the new partitions in sequential way, which is super slow.
       logInfo(s"Gather the fast stats in parallel using $numParallelism tasks.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -320,7 +320,7 @@ object PartitioningAwareFileIndex extends Logging {
 
     // Set the number of parallelism to prevent following file listing from generating many tasks
     // in case of large #defaultParallelism.
-    val numParallelism = Math.min(paths.size, 10000)
+    val numParallelism = math.min(paths.size, 10000)
 
     val statusMap = sparkContext
       .parallelize(serializedPaths, numParallelism)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/InferSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/InferSchema.scala
@@ -154,15 +154,15 @@ private[sql] object InferSchema {
           // when we see a Java BigInteger, we use DecimalType.
           case BIG_INTEGER | BIG_DECIMAL =>
             val v = parser.getDecimalValue
-            if (Math.max(v.precision(), v.scale()) <= DecimalType.MAX_PRECISION) {
-              DecimalType(Math.max(v.precision(), v.scale()), v.scale())
+            if (math.max(v.precision(), v.scale()) <= DecimalType.MAX_PRECISION) {
+              DecimalType(math.max(v.precision(), v.scale()), v.scale())
             } else {
               DoubleType
             }
           case FLOAT | DOUBLE if configOptions.prefersDecimal =>
             val v = parser.getDecimalValue
-            if (Math.max(v.precision(), v.scale()) <= DecimalType.MAX_PRECISION) {
-              DecimalType(Math.max(v.precision(), v.scale()), v.scale())
+            if (math.max(v.precision(), v.scale()) <= DecimalType.MAX_PRECISION) {
+              DecimalType(math.max(v.precision(), v.scale()), v.scale())
             } else {
               DoubleType
             }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -578,7 +578,7 @@ object ParquetFileFormat extends Logging {
 
     // Set the number of partitions to prevent following schema reads from generating many tasks
     // in case of a small number of parquet files.
-    val numParallelism = Math.min(Math.max(partialFileStatusInfo.size, 1),
+    val numParallelism = math.min(math.max(partialFileStatusInfo.size, 1),
       sparkSession.sparkContext.defaultParallelism)
 
     // Issues a Spark job to read Parquet schema in parallel.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -595,9 +595,9 @@ private[parquet] object ParquetSchemaConverter {
 
   // Max precision of a decimal value stored in `numBytes` bytes
   def maxPrecisionForBytes(numBytes: Int): Int = {
-    Math.round(                               // convert double to long
-      Math.floor(Math.log10(                  // number of base-10 digits
-        Math.pow(2, 8 * numBytes - 1) - 1)))  // max value stored in numBytes
+    math.round(                               // convert double to long
+      math.floor(math.log10(                  // number of base-10 digits
+        math.pow(2, 8 * numBytes - 1) - 1)))  // max value stored in numBytes
       .asInstanceOf[Int]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -670,7 +670,7 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     var offset: Long = Platform.LONG_ARRAY_OFFSET
     val end = len * 8L + Platform.LONG_ARRAY_OFFSET
     while (offset < end) {
-      val size = Math.min(buffer.length, (end - offset).toInt)
+      val size = math.min(buffer.length, (end - offset).toInt)
       Platform.copyMemory(arr, offset, buffer, Platform.BYTE_ARRAY_OFFSET, size)
       writeBuffer(buffer, 0, size)
       offset += size
@@ -710,7 +710,7 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     var offset: Long = Platform.LONG_ARRAY_OFFSET
     val end = length * 8L + Platform.LONG_ARRAY_OFFSET
     while (offset < end) {
-      val size = Math.min(buffer.length, (end - offset).toInt)
+      val size = math.min(buffer.length, (end - offset).toInt)
       readBuffer(buffer, 0, size)
       Platform.copyMemory(buffer, Platform.BYTE_ARRAY_OFFSET, array, offset, size)
       offset += size

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -86,7 +86,7 @@ class ApproximatePercentileQuerySuite extends QueryTest with SharedSQLContext {
       val errors = accuracies.map { accuracy =>
         val df = spark.sql(s"SELECT percentile_approx(col, 0.25, $accuracy) FROM $table")
         val approximatePercentile = df.collect().head.getDouble(0)
-        val error = Math.abs(approximatePercentile - expectedPercentile)
+        val error = math.abs(approximatePercentile - expectedPercentile)
         error
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -93,7 +93,7 @@ class UDFSuite extends QueryTest with SharedSQLContext {
   }
 
   test("ZeroArgument UDF") {
-    spark.udf.register("random0", () => { math.random()})
+    spark.udf.register("random0", () => { math.random})
     assert(sql("SELECT random0()").head().getDouble(0) >= 0.0)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -93,7 +93,7 @@ class UDFSuite extends QueryTest with SharedSQLContext {
   }
 
   test("ZeroArgument UDF") {
-    spark.udf.register("random0", () => { Math.random()})
+    spark.udf.register("random0", () => { math.random()})
     assert(sql("SELECT random0()").head().getDouble(0) >= 0.0)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
@@ -105,7 +105,7 @@ class ColumnTypeSuite extends SparkFunSuite with Logging {
     val converter = CatalystTypeConverters.createToScalaConverter(columnType.dataType)
     val seq = (0 until 4).map(_ => proj(makeRandomRow(columnType)).copy())
     val totalSize = seq.map(_.getSizeInBytes).sum
-    val bufferSize = Math.max(DEFAULT_BUFFER_SIZE, totalSize)
+    val bufferSize = math.max(DEFAULT_BUFFER_SIZE, totalSize)
 
     test(s"$columnType append/extract") {
       val buffer = ByteBuffer.allocate(bufferSize).order(ByteOrder.nativeOrder())

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -59,7 +59,7 @@ case class InsertIntoHiveTable(
   private def executionId: String = {
     val rand: Random = new Random
     val format = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss_SSS", Locale.US)
-    "hive_" + format.format(new Date) + "_" + Math.abs(rand.nextLong)
+    "hive_" + format.format(new Date) + "_" + math.abs(rand.nextLong)
   }
 
   private def getStagingDir(inputPath: Path, hadoopConf: Configuration): Path = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -64,8 +64,8 @@ class UDFSuite
   }
 
   test("UDF case insensitive") {
-    spark.udf.register("random0", () => { Math.random() })
-    spark.udf.register("RANDOM1", () => { Math.random() })
+    spark.udf.register("random0", () => { math.random() })
+    spark.udf.register("RANDOM1", () => { math.random() })
     spark.udf.register("strlenScala", (_: String).length + (_: Int))
     assert(sql("SELECT RANDOM0() FROM src LIMIT 1").head().getDouble(0) >= 0.0)
     assert(sql("SELECT RANDOm1() FROM src LIMIT 1").head().getDouble(0) >= 0.0)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -64,8 +64,8 @@ class UDFSuite
   }
 
   test("UDF case insensitive") {
-    spark.udf.register("random0", () => { math.random() })
-    spark.udf.register("RANDOM1", () => { math.random() })
+    spark.udf.register("random0", () => { math.random })
+    spark.udf.register("RANDOM1", () => { math.random })
     spark.udf.register("strlenScala", (_: String).length + (_: Int))
     assert(sql("SELECT RANDOM0() FROM src LIMIT 1").head().getDouble(0) >= 0.0)
     assert(sql("SELECT RANDOm1() FROM src LIMIT 1").head().getDouble(0) >= 0.0)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use `scala.math` instead of `java.lang.Math`.
Using cmd `find . -name '*.scala' | xargs -i bash -c 'egrep "Math\." -n {} && echo {}'` to generate modification candidates.

## How was this patch tested?
existing tests