### PR TITLE
[SPARK-16808][Core] prepend base URI for links on main history server

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -296,7 +296,7 @@ object HistoryServer extends Logging {
 
   private[history] def getAttemptURI(appId: String, attemptId: Option[String]): String = {
     val attemptSuffix = attemptId.map { id => s"/$id" }.getOrElse("")
-    s"${HistoryServer.UI_PATH_PREFIX}/${appId}${attemptSuffix}"
+    UIUtils.prependBaseUri(s"${HistoryServer.UI_PATH_PREFIX}/${appId}${attemptSuffix}")
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make the 2.0.x Spark UI links work on systems with proxy servers by prepending the spark.ui.proxyBase or APPLICATION_WEB_PROXY_BASE to links on the first page.  This is a regression from 1.6.x (although that was fixed at the caller).

Fixing it in the getAttemptURI places the entire URI generation in one place like done for other URI's in history making future regressions less likely.

## How was this patch tested?

Tested manually and dev/run-tests

@andrewor14 

the contribution is original work and I license the work to the project under the project's open source license