### PR TITLE
[SPARK-16808][Core] History Server main page does not honor APPLICATION_WEB_PROXY_BASE

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -68,16 +68,16 @@
   <tbody>
   {{#applications}}
     <tr>
-      <td class="rowGroupColumn"><span title="{{id}}"><a href="/history/{{id}}/{{num}}/jobs/">{{id}}</a></span></td>
+      <td class="rowGroupColumn"><span title="{{id}}"><a href="{{uiroot}}/history/{{id}}/{{num}}/jobs/">{{id}}</a></span></td>
       <td class="rowGroupColumn">{{name}}</td>
       {{#attempts}}
-      <td class="attemptIDSpan"><a href="/history/{{id}}/{{attemptId}}/jobs/">{{attemptId}}</a></td>
+      <td class="attemptIDSpan"><a href="{{uiroot}}/history/{{id}}/{{attemptId}}/jobs/">{{attemptId}}</a></td>
       <td>{{startTime}}</td>
       <td>{{endTime}}</td>
       <td><span title="{{duration}}" class="durationClass">{{duration}}</span></td>
       <td>{{sparkUser}}</td>
       <td>{{lastUpdated}}</td>
-      <td><a href="/api/v1/applications/{{id}}/{{num}}/logs" class="btn btn-info btn-mini">Download</a></td>
+      <td><a href="{{uiroot}}/api/v1/applications/{{id}}/{{num}}/logs" class="btn btn-info btn-mini">Download</a></td>
       {{/attempts}}
     </tr>
   {{/applications}}

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -120,7 +120,7 @@ $(document).ready(function() {
       }
 
       var data = {
-        "uiroot": (typeof uiRoot != 'undefined') ? uiRoot : "",
+        "uiroot": uiRoot,
         "applications": array
         }
 

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -119,7 +119,11 @@ $(document).ready(function() {
         }
       }
 
-      var data = {"applications": array}
+      var data = {
+        "uiroot": (typeof uiRoot != 'undefined') ? uiRoot : "",
+        "applications": array
+        }
+
       $.get("static/historypage-template.html", function(template) {
         historySummary.append(Mustache.render($(template).filter("#history-summary-template").html(),data));
         var selector = "#history-summary-table";

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -15,6 +15,12 @@
  * limitations under the License.
  */
 
+var uiRoot = "";
+
+function setUIRoot(val) {
+    uiRoot = val;
+}
+
 function collapseTablePageLoad(name, table){
   if (window.localStorage.getItem(name) == "true") {
     // Set it to false so that the click function can revert it

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -143,6 +143,12 @@ class HistoryServer(
     appCache.stop()
   }
 
+  // For testing - override stop timeout used by jetty
+  private[history] def setStopTimeout(timeout: Long): Unit = {
+    assert(serverInfo.isDefined, "HistoryServer must be bound before setting stop timeout")
+    serverInfo.get.server.setStopTimeout(timeout)
+  }
+
   /** Attach a reconstructed UI to this server. Only valid after bind(). */
   override def attachSparkUI(
       appId: String,

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -143,12 +143,6 @@ class HistoryServer(
     appCache.stop()
   }
 
-  // For testing - override stop timeout used by jetty
-  private[history] def setStopTimeout(timeout: Long): Unit = {
-    assert(serverInfo.isDefined, "HistoryServer must be bound before setting stop timeout")
-    serverInfo.get.server.setStopTimeout(timeout)
-  }
-
   /** Attach a reconstructed UI to this server. Only valid after bind(). */
   override def attachSparkUI(
       appId: String,

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -171,6 +171,7 @@ private[spark] object UIUtils extends Logging {
     <script src={prependBaseUri("/static/timeline-view.js")}></script>
     <script src={prependBaseUri("/static/log-view.js")}></script>
     <script src={prependBaseUri("/static/webui.js")}></script>
+    <script type="text/javascript">var uiRoot={Unparsed(s""""${UIUtils.uiRoot}"""")}</script>
   }
 
   def vizHeaderNodes: Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -171,7 +171,7 @@ private[spark] object UIUtils extends Logging {
     <script src={prependBaseUri("/static/timeline-view.js")}></script>
     <script src={prependBaseUri("/static/log-view.js")}></script>
     <script src={prependBaseUri("/static/webui.js")}></script>
-    <script type="text/javascript">var uiRoot={Unparsed(s""""${UIUtils.uiRoot}"""")}</script>
+    <script>setUIRoot('{UIUtils.uiRoot}')</script>
   }
 
   def vizHeaderNodes: Seq[Node] = {

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -310,7 +310,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         }
 
         val proxyidx = sb.indexOf(uiRoot)
-        sb.delete(proxyidx, proxyidx+uiRoot.length).toString
+        sb.delete(proxyidx, proxyidx + uiRoot.length).toString
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -321,29 +321,32 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       getWebClient.getOptions.setThrowExceptionOnScriptError(false)
     }
 
-    val url = s"http://localhost:$port"
+    try {
+      val url = s"http://localhost:$port"
 
-    go to s"$url$uiRoot"
+      go to s"$url$uiRoot"
 
-    // expect the ajax call to finish in 5 seconds
-    implicitlyWait(org.scalatest.time.Span(5, org.scalatest.time.Seconds))
+      // expect the ajax call to finish in 5 seconds
+      implicitlyWait(org.scalatest.time.Span(5, org.scalatest.time.Seconds))
 
-    // once this findAll call returns, we know the ajax load of the table completed
-    findAll(ClassNameQuery("odd"))
+      // once this findAll call returns, we know the ajax load of the table completed
+      findAll(ClassNameQuery("odd"))
 
-    val links = findAll(TagNameQuery("a"))
-      .map(_.attribute("href"))
-      .filter(_.isDefined)
-      .map(_.get)
-      .filter(_.startsWith(url)).toList
+      val links = findAll(TagNameQuery("a"))
+        .map(_.attribute("href"))
+        .filter(_.isDefined)
+        .map(_.get)
+        .filter(_.startsWith(url)).toList
 
-    contextHandler.stop()
-    quit()
+      // there are atleast some URL links that were generated via javascript,
+      // and they all contain the spark.ui.proxyBase (uiRoot)
+      links.length should be > 4
+      all(links) should startWith(url + uiRoot)
+    } finally {
+      contextHandler.stop()
+      quit()
+    }
 
-    // there are atleast some URL links that were generated via javascript,
-    // and they all contain the spark.ui.proxyBase (uiRoot)
-    links.length should be > 4
-    all(links) should startWith(url + uiRoot)
   }
 
   test("incomplete apps get refreshed") {

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -294,12 +294,6 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     server.initialize()
     server.bind()
 
-    // the test browses to a web page that invokes an ajax call.
-    // this appears to make jetty wait for upto 30 seconds before
-    // the server.stop() call would return after this test.
-    // Here, instructing Jetty not to use this "graceful shutdown" timeout.
-    server.setStopTimeout(-1)
-
     val port = server.boundPort
 
     val servlet = new ProxyServlet {
@@ -343,6 +337,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .map(_.get)
       .filter(_.startsWith(url)).toList
 
+    contextHandler.stop()
     quit()
 
     // there are atleast some URL links that were generated via javascript,

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -29,6 +29,8 @@ import com.codahale.metrics.Counter
 import com.google.common.io.{ByteStreams, Files}
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.eclipse.jetty.proxy.ProxyServlet
+import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods._
@@ -258,7 +260,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     getContentAndCode("foobar")._1 should be (HttpServletResponse.SC_NOT_FOUND)
   }
 
-  test("relative links are prefixed with uiRoot (spark.ui.proxyBase)") {
+  test("static relative links are prefixed with uiRoot (spark.ui.proxyBase)") {
     val proxyBaseBeforeTest = System.getProperty("spark.ui.proxyBase")
     val uiRoot = Option(System.getenv("APPLICATION_WEB_PROXY_BASE")).getOrElse("/testwebproxybase")
     val page = new HistoryPage(server)
@@ -273,6 +275,79 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     val urls = response \\ "@href" map (_.toString)
     val siteRelativeLinks = urls filter (_.startsWith("/"))
     all (siteRelativeLinks) should startWith (uiRoot)
+  }
+
+  test("ajax rendered relative links are prefixed with uiRoot (spark.ui.proxyBase)") {
+
+    val proxyBaseBeforeTest = System.getProperty("spark.ui.proxyBase")
+    val uiRoot = "/testwebproxybase"
+    System.setProperty("spark.ui.proxyBase", uiRoot)
+
+    server.stop()
+
+    val conf = new SparkConf()
+      .set("spark.history.fs.logDirectory", logDir)
+      .set("spark.history.fs.update.interval", "0")
+      .set("spark.testing", "true")
+
+    provider = new FsHistoryProvider(conf)
+    provider.checkForLogs()
+    val securityManager = new SecurityManager(conf)
+
+    server = new HistoryServer(conf, provider, securityManager, 18080)
+    server.initialize()
+    server.bind()
+    val port = server.boundPort
+
+    val servlet = new ProxyServlet {
+      override def rewriteTarget(request: HttpServletRequest): String = {
+        // servlet acts like a proxy that redirects calls made on
+        // spark.ui.proxyBase context path to the normal servlet handlers operating off "/"
+        val sb = request.getRequestURL()
+
+        if (request.getQueryString() != null) {
+          sb.append (s"?${request.getQueryString()}")
+        }
+
+        val proxyidx = sb.indexOf(uiRoot)
+        sb.delete(proxyidx, proxyidx+uiRoot.length).toString
+      }
+    }
+
+    val contextHandler = new ServletContextHandler
+    val holder = new ServletHolder(servlet)
+    contextHandler.setContextPath(uiRoot)
+    contextHandler.addServlet(holder, "/")
+    server.attachHandler(contextHandler)
+
+    implicit val webDriver: WebDriver = new HtmlUnitDriver (true) {
+      getWebClient.getOptions.setThrowExceptionOnScriptError(false)
+    }
+
+    val url = s"http://localhost:$port"
+
+    go to s"$url$uiRoot"
+
+    // expect the ajax call to finish in 5 seconds
+    implicitlyWait(org.scalatest.time.Span(5, org.scalatest.time.Seconds))
+
+    // once this findAll call returns, we know the ajax load of the table completed
+    findAll (ClassNameQuery("odd"))
+
+    val links = findAll (TagNameQuery("a"))
+      .map (_.attribute("href"))
+      .filter(_.isDefined)
+      .map (_.get)
+      .filter(_.startsWith(url)).toList
+
+    System.setProperty("spark.ui.proxyBase", Option(proxyBaseBeforeTest).getOrElse(""))
+
+    quit()
+
+    // there are atleast some URL links that were generated via javascript,
+    // and they all contain the spark.ui.proxyBase (uiRoot)
+    links.length should be > 4
+    all (links) should startWith (url + uiRoot)
   }
 
   test("incomplete apps get refreshed") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Application links generated on the history server UI no longer (regression from 1.6) contain the configured spark.ui.proxyBase in the links. To address this, made the uiRoot available globally to all javascripts for Web UI. Updated the mustache template (historypage-template.html) to include the uiroot for rendering links to the applications. 

The existing test was not sufficient to verify the scenario where ajax call is used to populate the application listing template, so added a new selenium test case to cover this scenario.

## How was this patch tested?

Existing tests and a new unit test. 
No visual changes to the UI.


