### PR TITLE
[SPARK-18240][ML][PySpark] Add Summary of BiKMeans and GMM in pyspark

### DIFF
--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -133,7 +133,7 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
 @inherit_doc
 class GaussianMixtureSummary(ClusteringSummary):
     """
-    Summary of BisectingKMeans algorithms.
+    Summary of GaussianMixture algorithms.
 
     .. versionadded:: 2.1.0
     """

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -185,50 +185,21 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> model.hasSummary
     True
     >>> summary = model.summary
-    >>> summary.predictions.show()
-    +-------------+----------+--------------------+
-    |     features|prediction|         probability|
-    +-------------+----------+--------------------+
-    | [-0.1,-0.05]|         0|[0.99609496160777...|
-    | [-0.01,-0.1]|         1|[2.89091615598232...|
-    |    [0.9,0.8]|         1|[2.23789457321856...|
-    | [0.75,0.935]|         1|[2.85667101481575...|
-    |[-0.83,-0.68]|         0|[0.99843788373650...|
-    |[-0.91,-0.76]|         0|[0.99850085851896...|
-    +-------------+----------+--------------------+
-    ...
+    >>> transformed = model.transform(df)
+    >>> summary.predictions.collect() == transformed.collect()
+    True
+    >>> summary.probability.collect() == transformed.select("probability").collect()
+    True
+    >>> summary.cluster.collect() == transformed.select("prediction").collect()
+    True
     >>> summary.predictionCol
-    'prediction'
+    u'prediction'
     >>> summary.featuresCol
-    'features'
+    u'features'
     >>> summary.k
     3
-    >>> summary.probability.show()
-    +--------------------+
-    |         probability|
-    +--------------------+
-    |[0.99609496160777...|
-    |[2.89091615598232...|
-    |[2.23789457321856...|
-    |[2.85667101481575...|
-    |[0.99843788373650...|
-    |[0.99850085851896...|
-    +--------------------+
-    ...
-    >>> summary.cluster.show()
-    +----------+
-    |prediction|
-    +----------+
-    |         0|
-    |         1|
-    |         1|
-    |         1|
-    |         0|
-    |         0|
-    +----------+
-    ...
-    >>> summary.clusterSizes
-    [3, 3, 0]
+    >>> len(summary.clusterSizes)
+    3
     >>> weights = model.weights
     >>> len(weights)
     3
@@ -241,7 +212,6 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     |[-0.4472625243352...|0.167304119758233...|
     +--------------------+--------------------+
     ...
-    >>> transformed = model.transform(df).select("features", "prediction")
     >>> rows = transformed.collect()
     >>> rows[4].prediction == rows[5].prediction
     True
@@ -545,9 +515,9 @@ class BisectingKMeans(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     +---------+----------+
     ...
     >>> summary.predictionCol
-    'prediction'
+    u'prediction'
     >>> summary.featuresCol
-    'features'
+    u'features'
     >>> summary.k
     2
     >>> summary.cluster.show()

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -17,14 +17,70 @@
 
 from pyspark import since, keyword_only
 from pyspark.ml.util import *
-from pyspark.ml.wrapper import JavaEstimator, JavaModel
+from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaWrapper
 from pyspark.ml.param.shared import *
 from pyspark.ml.common import inherit_doc
 
-__all__ = ['BisectingKMeans', 'BisectingKMeansModel',
-           'KMeans', 'KMeansModel',
+__all__ = ['BisectingKMeans', 'BisectingKMeansModel', 'BisectingKMeansSummary',
+           'KMeans', 'KMeansModel', 'KMeansSummary',
            'GaussianMixture', 'GaussianMixtureModel',
            'LDA', 'LDAModel', 'LocalLDAModel', 'DistributedLDAModel']
+
+
+class ClusteringSummary(JavaWrapper):
+    """
+    Summary of clustering algorithms.
+
+    .. versionadded:: 2.1.0
+    """
+
+    @property
+    @since("2.1.0")
+    def predictions(self):
+        """
+        Dataframe produced by the model's `transform` method.
+        """
+        return self._call_java("predictions")
+
+    @property
+    @since("2.1.0")
+    def predictionCol(self):
+        """
+        Column of predicted clusters in `predictions`.
+        """
+        return self._call_java("predictionCol")
+
+    @property
+    @since("2.1.0")
+    def featuresCol(self):
+        """
+        Column of features clusters in `predictions`.
+        """
+        return self._call_java("featuresCol")
+
+    @property
+    @since("2.1.0")
+    def k(self):
+        """
+        Number of clusters.
+        """
+        return self._call_java("k")
+
+    @property
+    @since("2.1.0")
+    def cluster(self):
+        """
+        Cluster centers of the transformed data.
+        """
+        return self._call_java("cluster")
+
+    @property
+    @since("2.1.0")
+    def clusterSizes(self):
+        """
+        Size of (number of data points in) each cluster.
+        """
+        return self._call_java("clusterSizes")
 
 
 class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
@@ -55,6 +111,40 @@ class GaussianMixtureModel(JavaModel, JavaMLWritable, JavaMLReadable):
         The DataFrame has two columns: mean (Vector) and cov (Matrix).
         """
         return self._call_java("gaussiansDF")
+
+    @property
+    @since("2.1.0")
+    def summary(self):
+        """
+        Gets summary of model on training set.
+        """
+        java_gmm_summary = self._call_java("summary")
+        return GaussianMixtureSummary(java_gmm_summary)
+
+    @property
+    @since("2.1.0")
+    def hasSummary(self):
+        """
+        Indicates whether a summary exists for this model instance.
+        """
+        return self._call_java("hasSummary")
+
+
+@inherit_doc
+class GaussianMixtureSummary(ClusteringSummary):
+    """
+    Summary of BisectingKMeans algorithms.
+
+    .. versionadded:: 2.1.0
+    """
+
+    @property
+    @since("2.1.0")
+    def probability(self):
+        """
+        Probability of each cluster.
+        """
+        return self._call_java("probability")
 
 
 @inherit_doc
@@ -201,6 +291,32 @@ class KMeansModel(JavaModel, JavaMLWritable, JavaMLReadable):
         """
         return self._call_java("computeCost", dataset)
 
+    @property
+    @since("2.1.0")
+    def summary(self):
+        """
+        Gets summary of model on training set.
+        """
+        java_km_summary = self._call_java("summary")
+        return KMeansSummary(java_km_summary)
+
+    @property
+    @since("2.1.0")
+    def hasSummary(self):
+        """
+        Indicates whether a summary exists for this model instance.
+        """
+        return self._call_java("hasSummary")
+
+
+@inherit_doc
+class KMeansSummary(ClusteringSummary):
+    """
+    Summary of KMeans algorithms.
+
+    .. versionadded:: 2.1.0
+    """
+
 
 @inherit_doc
 class KMeans(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIter, HasTol, HasSeed,
@@ -345,6 +461,32 @@ class BisectingKMeansModel(JavaModel, JavaMLWritable, JavaMLReadable):
         and their corresponding cluster centers.
         """
         return self._call_java("computeCost", dataset)
+
+    @property
+    @since("2.1.0")
+    def summary(self):
+        """
+        Gets summary of model on training set.
+        """
+        java_bkm_summary = self._call_java("summary")
+        return BisectingKMeansSummary(java_bkm_summary)
+
+    @property
+    @since("2.1.0")
+    def hasSummary(self):
+        """
+        Indicates whether a summary exists for this model instance.
+        """
+        return self._call_java("hasSummary")
+
+
+@inherit_doc
+class BisectingKMeansSummary(ClusteringSummary):
+    """
+    Summary of BisectingKMeans algorithms.
+
+    .. versionadded:: 2.1.0
+    """
 
 
 @inherit_doc

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -192,10 +192,10 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     True
     >>> summary.cluster.collect() == transformed.select("prediction").collect()
     True
-    >>> summary.predictionCol
-    u'prediction'
-    >>> summary.featuresCol
-    u'features'
+    >>> summary.predictionCol == "prediction"
+    True
+    >>> summary.featuresCol == "features"
+    True
     >>> summary.k
     3
     >>> len(summary.clusterSizes)
@@ -514,10 +514,10 @@ class BisectingKMeans(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     |[8.0,9.0]|         1|
     +---------+----------+
     ...
-    >>> summary.predictionCol
-    u'prediction'
-    >>> summary.featuresCol
-    u'features'
+    >>> summary.predictionCol == "prediction"
+    True
+    >>> summary.featuresCol == "features"
+    True
     >>> summary.k
     2
     >>> summary.cluster.show()

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -22,8 +22,8 @@ from pyspark.ml.param.shared import *
 from pyspark.ml.common import inherit_doc
 
 __all__ = ['BisectingKMeans', 'BisectingKMeansModel', 'BisectingKMeansSummary',
-           'KMeans', 'KMeansModel', 'KMeansSummary',
-           'GaussianMixture', 'GaussianMixtureModel',
+           'KMeans', 'KMeansModel',
+           'GaussianMixture', 'GaussianMixtureModel', 'GaussianMixtureSummary',
            'LDA', 'LDAModel', 'LocalLDAModel', 'DistributedLDAModel']
 
 
@@ -182,6 +182,53 @@ class GaussianMixture(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> gm = GaussianMixture(k=3, tol=0.0001,
     ...                      maxIter=10, seed=10)
     >>> model = gm.fit(df)
+    >>> model.hasSummary
+    True
+    >>> summary = model.summary
+    >>> summary.predictions.show()
+    +-------------+----------+--------------------+
+    |     features|prediction|         probability|
+    +-------------+----------+--------------------+
+    | [-0.1,-0.05]|         0|[0.99609496160777...|
+    | [-0.01,-0.1]|         1|[2.89091615598232...|
+    |    [0.9,0.8]|         1|[2.23789457321856...|
+    | [0.75,0.935]|         1|[2.85667101481575...|
+    |[-0.83,-0.68]|         0|[0.99843788373650...|
+    |[-0.91,-0.76]|         0|[0.99850085851896...|
+    +-------------+----------+--------------------+
+    ...
+    >>> summary.predictionCol
+    'prediction'
+    >>> summary.featuresCol
+    'features'
+    >>> summary.k
+    3
+    >>> summary.probability.show()
+    +--------------------+
+    |         probability|
+    +--------------------+
+    |[0.99609496160777...|
+    |[2.89091615598232...|
+    |[2.23789457321856...|
+    |[2.85667101481575...|
+    |[0.99843788373650...|
+    |[0.99850085851896...|
+    +--------------------+
+    ...
+    >>> summary.cluster.show()
+    +----------+
+    |prediction|
+    +----------+
+    |         0|
+    |         1|
+    |         1|
+    |         1|
+    |         0|
+    |         0|
+    +----------+
+    ...
+    >>> summary.clusterSizes
+    [3, 3, 0]
     >>> weights = model.weights
     >>> len(weights)
     3
@@ -290,32 +337,6 @@ class KMeansModel(JavaModel, JavaMLWritable, JavaMLReadable):
         for this model on the given data.
         """
         return self._call_java("computeCost", dataset)
-
-    @property
-    @since("2.1.0")
-    def summary(self):
-        """
-        Gets summary of model on training set.
-        """
-        java_km_summary = self._call_java("summary")
-        return KMeansSummary(java_km_summary)
-
-    @property
-    @since("2.1.0")
-    def hasSummary(self):
-        """
-        Indicates whether a summary exists for this model instance.
-        """
-        return self._call_java("hasSummary")
-
-
-@inherit_doc
-class KMeansSummary(ClusteringSummary):
-    """
-    Summary of KMeans algorithms.
-
-    .. versionadded:: 2.1.0
-    """
 
 
 @inherit_doc
@@ -510,6 +531,37 @@ class BisectingKMeans(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
     >>> df = spark.createDataFrame(data, ["features"])
     >>> bkm = BisectingKMeans(k=2, minDivisibleClusterSize=1.0)
     >>> model = bkm.fit(df)
+    >>> model.hasSummary
+    True
+    >>> summary = model.summary
+    >>> summary.predictions.show()
+    +---------+----------+
+    | features|prediction|
+    +---------+----------+
+    |[0.0,0.0]|         0|
+    |[1.0,1.0]|         0|
+    |[9.0,8.0]|         1|
+    |[8.0,9.0]|         1|
+    +---------+----------+
+    ...
+    >>> summary.predictionCol
+    'prediction'
+    >>> summary.featuresCol
+    'features'
+    >>> summary.k
+    2
+    >>> summary.cluster.show()
+    +----------+
+    |prediction|
+    +----------+
+    |         0|
+    |         0|
+    |         1|
+    |         1|
+    +----------+
+    ...
+    >>> summary.clusterSizes
+    [2, 2]
     >>> centers = model.clusterCenters()
     >>> len(centers)
     2

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import array
 import sys
 if sys.version > '3':
@@ -24,7 +25,6 @@ if sys.version > '3':
 from abc import ABCMeta
 import copy
 import numpy as np
-import warnings
 
 from py4j.java_gateway import JavaObject
 

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-import warnings
-
 from pyspark import since, keyword_only
 from pyspark.ml.param.shared import *
 from pyspark.ml.util import *


### PR DESCRIPTION
## What changes were proposed in this pull request?
1, create class `ClusteringSummary`
2, add summary of BiKMeans and GMM by extends `ClusteringSummary`
3, remove two unused imports

## How was this patch tested?
added tests in clustering.py and local tests in pyspark

