### PR TITLE
[SPARK-18246][SQL] Throws an exception before execution for unsupported types in Json, CSV and text functionailities

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -496,6 +496,21 @@ case class JsonToStruct(schema: StructType, options: Map[String, String], child:
 
   override def dataType: DataType = schema
 
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (StringType.acceptsType(child.dataType)) {
+      try {
+        JacksonUtils.verifySchema(schema)
+        TypeCheckResult.TypeCheckSuccess
+      } catch {
+        case e: UnsupportedOperationException =>
+          TypeCheckResult.TypeCheckFailure(e.getMessage)
+      }
+    } else {
+      TypeCheckResult.TypeCheckFailure(
+        s"$prettyName requires that the expression is a string expression.")
+    }
+  }
+
   override def nullSafeEval(json: Any): Any = {
     try parser.parse(json.toString).head catch {
       case _: SparkSQLJsonProcessingException => null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonUtils.scala
@@ -50,7 +50,7 @@ object JacksonUtils {
 
       case _ =>
         throw new UnsupportedOperationException(
-          s"Unable to convert column $name of type ${dataType.simpleString} to JSON.")
+          s"Unsupported type ${dataType.simpleString} of column $name in JSON conversion.")
     }
 
     schema.foreach(field => verifyType(field.name, field.dataType))

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -330,7 +330,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
         parsedOptions)
     }
     if (parsedOptions.failFast) {
-      // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
+      // We can fail before starting to parse in case of "FAILFAST" mode. In case of "PERMISIVE"
       // mode, it allows to read values as null for unsupported types. In case of "DROPMALFORMED"
       // mode, it drops records only containing non-null values in unsupported types.
       JacksonUtils.verifySchema(schema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -331,8 +331,8 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     }
     if (parsedOptions.failFast) {
       // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
-      // mode, allows to read values as null for unsupported types. In case of "DROPMALFORMED"
-      // mode, drops records only containing non-null values in unsupported types.
+      // mode, it allows to read values as null for unsupported types. In case of "DROPMALFORMED"
+      // mode, it drops records only containing non-null values in unsupported types.
       JacksonUtils.verifySchema(schema)
     }
     val parsed = jsonRDD.mapPartitions { iter =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.Partition
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.json.{JacksonParser, JSONOptions}
+import org.apache.spark.sql.catalyst.json.{JacksonParser, JacksonUtils, JSONOptions}
 import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.jdbc._
@@ -328,6 +328,12 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
         jsonRDD,
         columnNameOfCorruptRecord,
         parsedOptions)
+    }
+    if (parsedOptions.failFast) {
+      // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
+      // mode, allows to read values as null for unsupported types. In case of "DROPMALFORMED"
+      // mode, drops records only containing non-null values in unsupported types.
+      JacksonUtils.verifySchema(schema)
     }
     val parsed = jsonRDD.mapPartitions { iter =>
       val parser = new JacksonParser(schema, columnNameOfCorruptRecord, parsedOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -144,7 +144,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
     if (csvOptions.failFast) {
-      // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
+      // We can fail before starting to parse in case of "FAILFAST" mode. In case of "PERMISIVE"
       // mode, it allows to read values as null for unsupported types. In case of "DROPMALFORMED"
       // mode, it drops records only containing non-null values in unsupported types. We should use
       // `requiredSchema` instead of whole schema `dataSchema` here to not to break the original

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -145,8 +145,8 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
 
     if (csvOptions.failFast) {
       // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
-      // mode, allows to read values as null for unsupported types. In case of "DROPMALFORMED"
-      // mode, drops records only containing non-null values in unsupported types. We should use
+      // mode, it allows to read values as null for unsupported types. In case of "DROPMALFORMED"
+      // mode, it drops records only containing non-null values in unsupported types. We should use
       // `requiredSchema` instead of whole schema `dataSchema` here to not to break the original
       // behaviour.
       verifySchema(requiredSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -231,18 +231,18 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
   }
 
   private def verifySchema(schema: StructType): Unit = {
-    def verifyType(name: String, dataType: DataType): Unit = dataType match {
-        case ByteType | ShortType | IntegerType | LongType | FloatType |
-             DoubleType | BooleanType | _: DecimalType | TimestampType |
-             DateType | StringType =>
+    def verifyType(dataType: DataType): Unit = dataType match {
+      case ByteType | ShortType | IntegerType | LongType | FloatType |
+           DoubleType | BooleanType | _: DecimalType | TimestampType |
+           DateType | StringType =>
 
-        case udt: UserDefinedType[_] => verifyType(name, udt.sqlType)
+      case udt: UserDefinedType[_] => verifyType(udt.sqlType)
 
-        case _ =>
-          throw new UnsupportedOperationException(
-            s"Unable to convert column $name of type ${dataType.simpleString} to CSV.")
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"CSV data source does not support ${dataType.simpleString} data type.")
     }
 
-    schema.foreach(field => verifyType(field.name, field.dataType))
+    schema.foreach(field => verifyType(field.dataType))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -32,7 +32,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.json.{JacksonGenerator, JacksonParser, JSONOptions}
+import org.apache.spark.sql.catalyst.json.{JacksonGenerator, JacksonParser, JacksonUtils, JSONOptions}
 import org.apache.spark.sql.catalyst.util.CompressionCodecs
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.text.TextOutputWriter
@@ -75,6 +75,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
+    JacksonUtils.verifySchema(dataSchema)
     val conf = job.getConfiguration
     val parsedOptions: JSONOptions = new JSONOptions(options)
     parsedOptions.compressionCodec.foreach { codec =>
@@ -109,6 +110,15 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     val parsedOptions: JSONOptions = new JSONOptions(options)
     val columnNameOfCorruptRecord = parsedOptions.columnNameOfCorruptRecord
       .getOrElse(sparkSession.sessionState.conf.columnNameOfCorruptRecord)
+
+    if (parsedOptions.failFast) {
+      // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
+      // mode, allows to read values as null for unsupported types. In case of "DROPMALFORMED"
+      // mode, drops records only containing non-null values in unsupported types. We should use
+      // `requiredSchema` instead of whole schema `dataSchema` here to not to break the original
+      // behaviour.
+      JacksonUtils.verifySchema(requiredSchema)
+    }
 
     (file: PartitionedFile) => {
       val linesReader = new HadoopFileLinesReader(file, broadcastedHadoopConf.value.value)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -113,8 +113,8 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
 
     if (parsedOptions.failFast) {
       // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
-      // mode, allows to read values as null for unsupported types. In case of "DROPMALFORMED"
-      // mode, drops records only containing non-null values in unsupported types. We should use
+      // mode, it allows to read values as null for unsupported types. In case of "DROPMALFORMED"
+      // mode, it drops records only containing non-null values in unsupported types. We should use
       // `requiredSchema` instead of whole schema `dataSchema` here to not to break the original
       // behaviour.
       JacksonUtils.verifySchema(requiredSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -112,7 +112,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       .getOrElse(sparkSession.sessionState.conf.columnNameOfCorruptRecord)
 
     if (parsedOptions.failFast) {
-      // We can fail before starting to parse in cast of "FAILFAST" mode. In case of "PERMISIVE"
+      // We can fail before starting to parse in case of "FAILFAST" mode. In case of "PERMISIVE"
       // mode, it allows to read values as null for unsupported types. In case of "DROPMALFORMED"
       // mode, it drops records only containing non-null values in unsupported types. We should use
       // `requiredSchema` instead of whole schema `dataSchema` here to not to break the original

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -44,13 +44,14 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def shortName(): String = "text"
 
   private def verifySchema(schema: StructType): Unit = {
-    if (schema.size != 1) {
-      throw new AnalysisException(
+    if (schema.size > 1) {
+      throw new UnsupportedOperationException(
         s"Text data source supports only a single column, and you have ${schema.size} columns.")
     }
+
     val tpe = schema(0).dataType
     if (tpe != StringType) {
-      throw new AnalysisException(
+      throw new UnsupportedOperationException(
         s"Text data source supports only a string column, but you have ${tpe.simpleString}.")
     }
   }
@@ -95,9 +96,7 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
-    assert(
-      requiredSchema.length <= 1,
-      "Text data source only produces a single data column named \"value\".")
+    verifySchema(dataSchema)
 
     val broadcastedHadoopConf =
       sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -48,7 +48,6 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
       throw new UnsupportedOperationException(
         s"Text data source supports only a single column, and you have ${schema.size} columns.")
     }
-
     val tpe = schema(0).dataType
     if (tpe != StringType) {
       throw new UnsupportedOperationException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -95,7 +95,10 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
-    verifySchema(dataSchema)
+    if (requiredSchema.nonEmpty) {
+      // `requiredSchema` can be empty when the projected column is only the partitioned column.
+      verifySchema(requiredSchema)
+    }
 
     val broadcastedHadoopConf =
       sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -44,7 +44,7 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override def shortName(): String = "text"
 
   private def verifySchema(schema: StructType): Unit = {
-    if (schema.size > 1) {
+    if (schema.size != 1) {
       throw new UnsupportedOperationException(
         s"Text data source supports only a single column, and you have ${schema.size} columns.")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -132,7 +132,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(from_json($"value", schema)).collect()
     }
     assert(e.getMessage.contains(
-      "Unable to convert column a of type calendarinterval to JSON."))
+      "Unsupported type calendarinterval of column a in JSON conversion"))
   }
 
   test("to_json") {
@@ -151,7 +151,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(to_json($"c")).collect()
     }
     assert(e.getMessage.contains(
-      "Unable to convert column a of type calendarinterval to JSON."))
+      "Unsupported type calendarinterval of column a in JSON conversion"))
   }
 
   test("roundtrip in to_json and from_json") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -123,6 +123,18 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null) :: Nil)
   }
 
+  test("from_json unsupported type") {
+    val df = Seq("""{"a" 1}""").toDS()
+    val schema = new StructType().add("a", CalendarIntervalType)
+
+    val e = intercept[AnalysisException]{
+      // Unsupported type throws an exception
+      df.select(from_json($"value", schema)).collect()
+    }
+    assert(e.getMessage.contains(
+      "Unable to convert column a of type calendarinterval to JSON."))
+  }
+
   test("to_json") {
     val df = Seq(Tuple1(Tuple1(1))).toDF("a")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -669,7 +669,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     withTempDir { dir =>
       val csvDir = new File(dir, "csv").getCanonicalPath
       var msg = intercept[UnsupportedOperationException] {
-        Seq((1, "Tesla")).toDF("a", "b").selectExpr("struct(a, b) as a").write.csv(csvDir)
+        Seq((1, "Tesla")).toDF("a", "b").selectExpr("struct(a, b)").write.csv(csvDir)
       }.getMessage
       assert(msg.contains("CSV data source does not support struct<a:int,b:string> data type"))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -671,23 +671,23 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       var msg = intercept[UnsupportedOperationException] {
         Seq((1, "Tesla")).toDF("a", "b").selectExpr("struct(a, b) as a").write.csv(csvDir)
       }.getMessage
-      assert(msg.contains("Unable to convert column a of type struct<a:int,b:string> to CSV"))
+      assert(msg.contains("CSV data source does not support struct<a:int,b:string> data type"))
 
       msg = intercept[UnsupportedOperationException] {
         Seq((1, Map("Tesla" -> 3))).toDF("id", "cars").write.csv(csvDir)
       }.getMessage
-      assert(msg.contains("Unable to convert column cars of type map<string,int> to CSV"))
+      assert(msg.contains("CSV data source does not support map<string,int> data type"))
 
       msg = intercept[UnsupportedOperationException] {
         Seq((1, Array("Tesla", "Chevy", "Ford"))).toDF("id", "brands").write.csv(csvDir)
       }.getMessage
-      assert(msg.contains("Unable to convert column brands of type array<string> to CSV"))
+      assert(msg.contains("CSV data source does not support array<string> data type"))
 
       msg = intercept[UnsupportedOperationException] {
         Seq((1, new UDT.MyDenseVector(Array(0.25, 2.25, 4.25)))).toDF("id", "vectors")
           .write.csv(csvDir)
       }.getMessage
-      assert(msg.contains("Unable to convert column vectors of type array<double> to CSV"))
+      assert(msg.contains("CSV data source does not support array<double> data type"))
     }
   }
 
@@ -725,7 +725,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
         spark.read.schema(schema).option("mode", "FAILFAST").csv(path.getAbsolutePath).collect()
       }.getMessage
 
-      assert(msg.contains("Unable to convert column a of type array<double> to CSV"))
+      assert(msg.contains("CSV data source does not support array<double> data type"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1125,6 +1125,16 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
 
     assert(df.collect().isEmpty)
 
+    val nullRdd = sparkContext.parallelize(Seq("""{"a": null}"""))
+    // Read JSON data from RDD
+    val nullDf = spark.read
+      .option("mode", "DROPMALFORMED")
+      .schema(schema)
+      .json(nullRdd)
+
+    // This succeeds to read null even thought it is unsupported.
+    assert(nullDf.collect().head.get(0) == null)
+
     withTempPath { path =>
       // Read JSON data from files.
       rdd.saveAsTextFile(path.getAbsolutePath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1133,7 +1133,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
       .json(nullRdd)
 
     // This succeeds to read null even thought it is unsupported.
-    assert(nullDf.collect().head.get(0) == null)
+    checkAnswer(nullDf, Row(null))
 
     withTempPath { path =>
       // Read JSON data from files.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1068,7 +1068,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     }
 
     assert(exceptionOne.getMessage.contains(
-      "Unable to convert column a of type calendarinterval to JSON."))
+      "Unsupported type calendarinterval of column a in JSON conversion."))
 
     val exceptionTwo = intercept[UnsupportedOperationException] {
       // Read JSON data from files.
@@ -1083,7 +1083,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     }
 
     assert(exceptionTwo.getMessage.contains(
-      "Unable to convert column a of type calendarinterval to JSON."))
+      "Unsupported type calendarinterval of column a in JSON conversion."))
   }
 
   test("Corrupt records: DROPMALFORMED mode") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 class TextSuite extends QueryTest with SharedSQLContext {
@@ -51,16 +51,18 @@ class TextSuite extends QueryTest with SharedSQLContext {
   }
 
   test("error handling for invalid schema") {
-    val tempFile = Utils.createTempDir()
-    tempFile.delete()
+    withTempPath { path =>
+      var message = intercept[UnsupportedOperationException] {
+        spark.range(2).write.text(path.getCanonicalPath)
+      }.getMessage
+      assert(message.contains(
+        "Text data source supports only a string column, but you have bigint."))
 
-    val df = spark.range(2)
-    intercept[AnalysisException] {
-      df.write.text(tempFile.getCanonicalPath)
-    }
-
-    intercept[AnalysisException] {
-      spark.range(2).select(df("id"), df("id") + 1).write.text(tempFile.getCanonicalPath)
+      message = intercept[UnsupportedOperationException] {
+        spark.range(2).selectExpr("'a'", "'b'").write.text(path.getCanonicalPath)
+      }.getMessage
+      assert(message.contains(
+        "Text data source supports only a single column, and you have 2 columns."))
     }
   }
 
@@ -151,6 +153,24 @@ class TextSuite extends QueryTest with SharedSQLContext {
           checkAnswer(df2, expected)
         }
       }
+    }
+  }
+
+  test("error handling for unsupported data types.") {
+    withTempPath { path =>
+      var msg = intercept[UnsupportedOperationException] {
+        Seq((1, "Tesla"))
+          .toDF("a", "b").selectExpr("struct(a, b) as a").write.text(path.getAbsolutePath)
+      }.getMessage
+      assert(msg.contains(
+        "Text data source supports only a string column, but you have struct<a:int,b:string>."))
+
+      msg = intercept[UnsupportedOperationException] {
+        val schema = StructType(StructField("a", LongType, true) :: Nil)
+        spark.range(1).write.text(path.getAbsolutePath)
+        spark.read.schema(schema).text(path.getAbsolutePath).collect()
+      }.getMessage
+      assert(msg.contains("Text data source supports only a string column, but you have bigint."))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR includes several fixes as below:

**Case 1 `read.json(rdd)`** - throws an exception before the execution for unsupported types.

```scala
import org.apache.spark.sql.types._
val rdd = spark.sparkContext.parallelize(1 to 100).map(i => s"""{"a": "str$i"}""")
val schema = new StructType().add("a", CalendarIntervalType)
spark.read.schema(schema).option("mode", "FAILFAST").json(rdd).show()
```


**Case 2 `read.json(path)`** - throws an exception before the execution for unsupported types.

```scala
import org.apache.spark.sql.types._
val path = "/tmp/aa"
val rdd = spark.sparkContext.parallelize(1 to 100).map(i => s"""{"a": "str$i"}""").saveAsTextFile(path)
val schema = new StructType().add("a", CalendarIntervalType)
spark.read.schema(schema).option("mode", "FAILFAST").json(path).show()
```

**Case 3 `read.csv(path)`** - throws an exception before the execution for unsupported types.

```scala
import org.apache.spark.sql.types._
val path = "/tmp/bb"
val rdd = spark.sparkContext.parallelize(1 to 100).saveAsTextFile(path)
val schema = new StructType().add("a", CalendarIntervalType)
spark.read.schema(schema).option("mode", "FAILFAST").csv(path).show()
```

**Case 4 `read.text(path)`** -  throws an exception before the execution for unsupported types  rather than printing incorrect values.

```scala
import org.apache.spark.sql.types._
val path = "/tmp/cc"
val rdd = spark.sparkContext.parallelize(1 to 100).saveAsTextFile(path)
val schema = new StructType().add("a", LongType)
spark.read.schema(schema).text(path).show()
```

currently this prints as below:

```
+-----------+
|          a|
+-----------+
|68719476738|
|68719476738|
|68719476738|
...
```

whereas actual content is

```
1
2
3
...
```

**Case 5 `from_json(...)`** - throws analysis exception for unsupported types (`to_json` is already throwing an analysis exception).

```scala
import org.apache.spark.sql.types._
import org.apache.spark.sql.functions._
import spark.implicits._

val df = Seq("""{"a" 1}""").toDS()
val schema = new StructType().add("a", CalendarIntervalType)
df.select(from_json($"value", schema)).collect()
```

**Case 6 `write.json(path)` _(this is a potential issue)_** - adds the schema check in writing

Currently, it seems JSON conversion does not support only `CalendarIntervalType` but this case seems already covered as below:

```scala
sql("SELECT interval 1 seconds as a").write.json("tmp/123")
```

```
Cannot save interval data type into external storage.;
org.apache.spark.sql.AnalysisException: Cannot save interval data type into external storage.;
	at org.apache.spark.sql.execution.datasources.DataSource.write(DataSource.scala:462)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:215)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:198)
```

However, it'd be safe if we add this check like the other text-based datasources. We might add some more types in the future.

In more details for **Case 1**, **Case 2** and **Case 3**, there are parsing modes, `FAILFAST`, `DROPMALFORMED` and `PERMISSIVE`. The original behaviour is,

  - `FAILFAST` - fails if it meets the unsupported type when parsing

  - `DROPMALFORMED` -  drops record having non-null values in the unsupported types. Otherwise, it reads it as `null`.

  - `PERMISSIVE` -  allows to read the values as null for unsupported types.

In case of `FAILFAST`, we can fail right after only checking the schema.

## How was this patch tested?

Unit tests in `JsonSuite`, `CSVSuite`, `TextSuite` and `JsonFunctionsSuite`.
