### PR TITLE
[SPARK-15902][PySpark] Add deprecation warning if python version below Python 2.7

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -24,7 +24,7 @@ import sys
 import threading
 from threading import RLock
 from tempfile import NamedTemporaryFile
-
+import warnings
 from pyspark import accumulators
 from pyspark.accumulators import Accumulator
 from pyspark.broadcast import Broadcast
@@ -42,6 +42,8 @@ from pyspark.profiler import ProfilerCollector, BasicProfiler
 if sys.version > '3':
     xrange = range
 
+if sys.version < '2.7':
+    warnings.warn("Deprecated in 2.1.0. Use Python 2.7+ instead", DeprecationWarning)
 
 __all__ = ['SparkContext']
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Deprecation warning if we detect we are running in Python 2.6.
(Please fill in changes proposed in this fix)

## How was this patch tested?
locally using different python profiles. 