### PR TITLE
[SPARK-18235][ML] ml.ALSModel function parity: ALSModel should support recommendforAll

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -276,7 +276,7 @@ class ALSModel private[ml] (
    * Recommends top items for all users.
    *
    * @param num how many items to return for every user.
-   * @return a DataFrame that stores recommendations two columns: `user` and `ratings`, where
+   * @return a DataFrame that stores recommendations in two columns: `user` and `ratings`, where
    *         every row contains a userID and an array of [[Rating]] objects which contains the
    *         same userId, recommended itemID and "score".
    */
@@ -307,7 +307,6 @@ class ALSModel private[ml] (
       .map(r => (r.getInt(0), r.getSeq[Float](1).toArray.map(_.toDouble)))
     val itemFeatures = itemFactors.select("id", "features").rdd
       .map(r => (r.getInt(0), r.getSeq[Float](1).toArray.map(_.toDouble)))
-
     new MatrixFactorizationModel(rank, userFeatures, itemFeatures)
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -450,6 +450,20 @@ class ALSSuite
       implicitPrefs = true, seed = 0)
   }
 
+  test("recommend for all") {
+    val spark = this.spark
+    import spark.implicits._
+    val (ratings, _) = genExplicitTestData(numUsers = 4, numItems = 4, rank = 1)
+    val model = new ALS().fit(ratings.toDF())
+    val items = model.recommendItemsForUsers(2)
+    assert(items.count() == 4
+      && items.select("ratings").rdd.collect().forall(_.getSeq[Rating[Int]](0).length == 2))
+
+    val users = model.recommendUsersForItems(2)
+    assert(users.count() == 4
+      && users.select("ratings").rdd.collect().forall(_.getSeq[Rating[Int]](0).length == 2))
+  }
+
   test("read/write") {
     import ALSSuite._
     val (ratings, _) = genExplicitTestData(numUsers = 4, numItems = 4, rank = 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?
jira: https://issues.apache.org/jira/browse/SPARK-18235 
For function parity with MatrixFactorizationModel, ALS model should support API:
recommendUsersForProducts
recommendProductsForUsers

I try to avoid code duplication by invoking the MLlib MatrixFactorizationModel directly. 

## How was this patch tested?
new test case
