### PR TITLE
[SPARK-18271][SQL]hash udf in HiveSessionCatalog.hiveFunctions is redundant

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -227,7 +227,6 @@ private[sql] class HiveSessionCatalog(
   // in_file, index, matchpath, ngrams, noop, noopstreaming, noopwithmap,
   // noopwithmapstreaming, parse_url_tuple, reflect2, windowingtablefunction.
   private val hiveFunctions = Seq(
-    "hash",
     "histogram_numeric",
     "percentile"
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

when lookupfunction in HiveSessionCatalog, first look up in spark's build-in functionRegistry, if it not existed, then look up the Hive'S build-in functions which are listed in Seq(hiveFunctions).

But the [hash] function is already in spark's build-in functionRegistry list, so it will never to go to look up in Hive's hiveFunctions list, so the [hash] function which is in Hive's hiveFunctions is redundant, we can remove it.