### PR TITLE
[SPARK-18260] Make from_json null safe

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -498,8 +498,7 @@ case class JsonToStruct(schema: StructType, options: Map[String, String], child:
   override def children: Seq[Expression] = child :: Nil
 
   override def eval(input: InternalRow): Any = {
-    try parser.parse(child.eval(input).toString).head catch {
-      case _: NullPointerException => null
+    try Option(child.eval(input)).map(json => parser.parse(json.toString).head).orNull catch {
       case _: SparkSQLJsonProcessingException => null
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -499,6 +499,7 @@ case class JsonToStruct(schema: StructType, options: Map[String, String], child:
 
   override def eval(input: InternalRow): Any = {
     try parser.parse(child.eval(input).toString).head catch {
+      case _: NullPointerException => null
       case _: SparkSQLJsonProcessingException => null
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -498,7 +498,9 @@ case class JsonToStruct(schema: StructType, options: Map[String, String], child:
   override def children: Seq[Expression] = child :: Nil
 
   override def eval(input: InternalRow): Any = {
-    try Option(child.eval(input)).map(json => parser.parse(json.toString).head).orNull catch {
+    val json = child.eval(input)
+    if (json == null) return null
+    try parser.parse(json.toString).head catch {
       case _: SparkSQLJsonProcessingException => null
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -344,6 +344,14 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
   }
 
+  test("from_json null input column") {
+    val schema = StructType(StructField("a", IntegerType) :: Nil)
+    checkEvaluation(
+      JsonToStruct(schema, Map.empty, Literal(null)),
+      null
+    )
+  }
+
   test("to_json") {
     val schema = StructType(StructField("a", IntegerType) :: Nil)
     val struct = Literal.create(create_row(1), schema)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql
 
-import java.io.File
-
 import org.apache.spark.sql.functions.{from_json, struct, to_json}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{CalendarIntervalType, IntegerType, StructType}

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -116,7 +116,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Row(null)) :: Nil)
   }
 
-  test("from_json null column") {
+  test("from_json null column with parquet source") {
     withTempDir { dir =>
       Seq("""{"a": 1}""").toDF("value").write.parquet(new File(dir, "p=x").toString)
       Seq("""{"a": 2}""").toDF("record").write.parquet(new File(dir, "p=y").toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -116,18 +116,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Row(null)) :: Nil)
   }
 
-  test("from_json null column with parquet source") {
-    withTempDir { dir =>
-      Seq("""{"a": 1}""").toDF("value").write.parquet(new File(dir, "p=x").toString)
-      Seq("""{"a": 2}""").toDF("record").write.parquet(new File(dir, "p=y").toString)
-      val schema = new StructType().add("a", IntegerType)
-      val df = spark.read.parquet(dir.toString)
-      checkAnswer(
-        df.select(from_json($"value", schema)),
-        Row(Row(1)) :: Row(null) :: Nil)
-    }
-  }
-
   test("from_json invalid json") {
     val df = Seq("""{"a" 1}""").toDS()
     val schema = new StructType().add("a", IntegerType)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`from_json` is currently not safe against `null` rows. This PR adds a fix and a regression test for it.

## How was this patch tested?

Regression test