### PR TITLE
[SPARK-18297][YARN] Fail if SparkContext run a new Thread in yarn-clu…

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -415,7 +415,6 @@ private[spark] class ApplicationMaster(
           throw new IllegalStateException("SparkContext is null but app is still running!")
         }
       }
-      userClassThread.join()
     } catch {
       case e: SparkException if e.getCause().isInstanceOf[TimeoutException] =>
         logError(
@@ -665,6 +664,7 @@ private[spark] class ApplicationMaster(
     userThread.setContextClassLoader(userClassLoader)
     userThread.setName("Driver")
     userThread.start()
+    userThread.join()
     userThread
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Program SparkContext can't run in user thread in yarn-cluster mode.

logs
```
16/11/02 11:16:47 INFO yarn.ApplicationMaster: Starting the user application in a separate Thread
16/11/02 11:16:47 INFO yarn.ApplicationMaster: Waiting for spark context initialization
16/11/02 11:16:47 INFO yarn.ApplicationMaster: Waiting for spark context initialization ... 
16/11/02 11:16:47 INFO yarn.ApplicationMaster: Final app status: SUCCEEDED, exitCode: 0

```

Please review https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark before opening a pull request.

…ster mode.

```
public static void main(String[] args) {
        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(new Thread(new Runnable() {
            @Override
            public void run() {
                SparkConf conf = new SparkConf();
                conf.setAppName("SparkDemo");
                JavaSparkContext sparkContext = new JavaSparkContext(conf);
                JavaRDD<String> array = sparkContext.parallelize(Lists.newArrayList("1", "2", "3", "4"));
                System.out.println(array.count());
            }
        }), 0, 5000, TimeUnit.MILLISECONDS);
    }
```
Fix this program can't run correctly.