### PR TITLE
[SPARK-18345][STRUCTURED STREAMING] Structured Streaming quick examples fails with default configuration

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -209,7 +209,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) {
         }
       }.getOrElse {
         if (useTempCheckpointLocation) {
-          Utils.createTempDir(namePrefix = s"temporary").getCanonicalPath
+          "file:///" + Utils.createTempDir(namePrefix = "temporary").getCanonicalPath
         } else {
           throw new AnalysisException(
             "checkpointLocation must be specified either " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes failure of a quick example of structured streaming with default configuration, because of failure of HDFS connection. 
* Fix to add prefix "file:///" when useTempCheckpointLocation is enabled.

## How was this patch tested?

I test this with manual test: running a quick example of structured streaming with default configuration. With this fix, it works well without configuring HDFS.