### PR TITLE
[SPARK-18360][SQL] default table path of tables in default database should depend on the location of default database

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -23,10 +23,10 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.hive.HiveExternalCatalog._
 import org.apache.spark.sql.hive.client.HiveClient
@@ -1368,6 +1368,46 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
               new StructType().add("i", "int").add("j", "string").json))
         hiveClient.createTable(tableDesc, ignoreIfExists = false)
         checkAnswer(spark.table("old"), Row(1, "a"))
+      }
+    }
+  }
+
+  test("SPARK-18360: default table path of tables in default database should depend on the " +
+    "location of default database") {
+    withTempDir { dir =>
+      val originalWarehouse = hiveClient.getConf("hive.metastore.warehouse.dir", "")
+      try {
+        hiveClient.runSqlHive(s"SET hive.metastore.warehouse.dir=${dir.toURI.getPath}")
+
+        val tableMeta = CatalogTable(
+          identifier = TableIdentifier("test_tbl", Some("default")),
+          tableType = CatalogTableType.MANAGED,
+          storage = CatalogStorageFormat.empty,
+          schema = new StructType().add("i", "int"),
+          provider = Some(DDLUtils.HIVE_PROVIDER))
+
+        withTable("test_tbl") {
+          hiveClient.createTable(tableMeta, ignoreIfExists = false)
+          val rawTable = hiveClient.getTable("default", "test_tbl")
+          // Hive will use the value of `hive.metastore.warehouse.dir` to generate default table
+          // location for tables in default database.
+          assert(rawTable.storage.locationUri.get.contains(dir.getAbsolutePath))
+        }
+
+        withTable("test_tbl") {
+          sharedState.externalCatalog.createTable(tableMeta, ignoreIfExists = false)
+          val readBack = sharedState.externalCatalog.getTable("default", "test_tbl")
+          val defaultDatabasePath = sharedState.externalCatalog.getDatabase("default").locationUri
+          // Spark SQL will use the location of default database to generate default table
+          // location for tables in default database.
+          assert(readBack.storage.locationUri.get.contains(defaultDatabasePath))
+        }
+      } finally {
+        if (originalWarehouse.isEmpty) {
+          hiveClient.runSqlHive("UNSET hive.metastore.warehouse.dir")
+        } else {
+          hiveClient.runSqlHive(s"SET hive.metastore.warehouse.dir=$originalWarehouse")
+        }
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current semantic of the warehouse config:

1. it's a static config, which means you can't change it once your spark application is launched.
2. Once a database is created, its location won't change even the warehouse path config is changed.
3. default database is a special case, although its location is fixed, but the locations of tables created in it are not. If a Spark app starts with warehouse path B(while the location of default database is A), then users create a table `tbl` in default database, its location will be `B/tbl` instead of `A/tbl`. If uses change the warehouse path config to C, and create another table `tbl2`, its location will still be `B/tbl2` instead of `C/tbl2`.

rule 3 doesn't make sense and I think we made it by mistake, not intentionally. Data source tables don't follow rule 3 and treat default database like normal ones.

This PR fixes hive serde tables to make it consistent with data source tables.

## How was this patch tested?

HiveSparkSubmitSuite