### PR TITLE
[SPARK-18187][STREAMING] CompactibleFileStreamLog should not use "compactInterval" direcly with user setting.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
@@ -41,7 +41,7 @@ class FileStreamSourceLog(
   protected override def compactInterval: Int = {
     val compactIntervalCfg = sparkSession.sessionState.conf.fileSourceLogCompactInterval
 
-    // SPARK-18187: "compactInterval" can be reset by user in the first time. In case it is changed,
+    // SPARK-18187: "compactInterval" can be set by user in the first time. In case it is changed,
     // we should check and update it:
     //
     // 1. If there is no '.compact' file, we can use user setting directly.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
@@ -38,8 +38,42 @@ class FileStreamSourceLog(
   import CompactibleFileStreamLog._
 
   // Configurations about metadata compaction
-  protected override val compactInterval =
-    sparkSession.sessionState.conf.fileSourceLogCompactInterval
+  protected override def compactInterval: Int = {
+    val compactIntervalCfg = sparkSession.sessionState.conf.fileSourceLogCompactInterval
+
+    // SPARK-18187: "compactInterval" can be reset by user in the first time. In case it is changed,
+    // we should check and update it:
+    //
+    // 1. If there is no '.compact' file, we can use user setting directly.
+    // 2. If there are two or more '.compact' files, we use the interval of patch id suffix with
+    // '.compact' as compactInterval.
+    // 3. If there is just one '.compact', we can find the nearest value around 'compactIntervalCfg'
+    // to make the 'latest compact batch id' satisfying 'modular arithmetic'.
+    val compactibleBatchIds = getCompactBatchIds()
+    if (compactibleBatchIds.length == 0) {
+      compactIntervalCfg
+    } else if (compactibleBatchIds.length >=2) {
+      val latestBatchId = compactibleBatchIds(0)
+      val penultimateBatchId = compactibleBatchIds(1)
+      (latestBatchId - penultimateBatchId).toInt
+    } else {
+      // Find the nearest value around 'compactIntervalCfg' to make the 'latest compact batch id'
+      // satisfying 'modular arithmetic'.
+      val latestBatchId = compactibleBatchIds(0)
+      for(i <- 0 to compactIntervalCfg) {
+        if ((latestBatchId + 1) % (compactIntervalCfg + i) == 0) {
+          return compactIntervalCfg + i
+        }
+
+        if ((latestBatchId + 1) % (compactIntervalCfg - i) == 0) {
+          return compactIntervalCfg - i
+        }
+      }
+
+      // This is unexpected in the code path, make compiler happy.
+      compactIntervalCfg
+    }
+  }
   require(compactInterval > 0,
     s"Please set ${SQLConf.FILE_SOURCE_LOG_COMPACT_INTERVAL.key} (was $compactInterval) to a " +
       s"positive value.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
@@ -60,7 +60,7 @@ class FileStreamSourceLog(
       // Find the nearest value around 'compactIntervalCfg' to make the 'latest compact batch id'
       // satisfying 'modular arithmetic'.
       val latestBatchId = compactibleBatchIds(0)
-      for(i <- 0 to compactIntervalCfg) {
+      for(i <- 0 until compactIntervalCfg) {
         if ((latestBatchId + 1) % (compactIntervalCfg + i) == 0) {
           return compactIntervalCfg + i
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -63,7 +63,7 @@ class HDFSMetadataLog[T: ClassTag](sparkSession: SparkSession, path: String)
   /**
    * A `PathFilter` to filter only batch files
    */
-  private val batchFilesFilter = new PathFilter {
+  protected val batchFilesFilter = new PathFilter {
     override def accept(path: Path): Boolean = isBatchFile(path)
   }
 
@@ -230,6 +230,14 @@ class HDFSMetadataLog[T: ClassTag](sparkSession: SparkSession, path: String)
       }
     }
     None
+  }
+
+  def getCompactBatchIds(): Array[Long] = {
+    fileManager.list(metadataPath, batchFilesFilter)
+      .filter(f => f.getPath.toString.endsWith(CompactibleFileStreamLog.COMPACT_FILE_SUFFIX))
+      .map(f => pathToBatchId(f.getPath))
+      .sorted
+      .reverse
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -63,7 +63,7 @@ class HDFSMetadataLog[T: ClassTag](sparkSession: SparkSession, path: String)
   /**
    * A `PathFilter` to filter only batch files
    */
-  protected val batchFilesFilter = new PathFilter {
+  private val batchFilesFilter = new PathFilter {
     override def accept(path: Path): Boolean = isBatchFile(path)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -945,7 +945,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         val fileStream = createFileStream("text", src.getCanonicalPath)
         val filtered = fileStream.filter($"value" contains "keep")
         val updateConf = new mutable.HashMap[String, String]()
-        updateConf.put(SQLConf.FILE_SOURCE_LOG_COMPACT_INTERVAL.key, "4")
+        updateConf.put(SQLConf.FILE_SOURCE_LOG_COMPACT_INTERVAL.key, "5")
 
         testStream(filtered)(
           AddTextFileData("drop1\nkeep2\nkeep3", src, tmp),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.streaming
 
 import java.io.File
 
+import scala.collection.mutable
+
 import org.scalatest.PrivateMethodTester
 import org.scalatest.time.SpanSugar._
 
@@ -942,6 +944,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       ) {
         val fileStream = createFileStream("text", src.getCanonicalPath)
         val filtered = fileStream.filter($"value" contains "keep")
+        val updateConf = new mutable.HashMap[String, String]()
+        updateConf.put(SQLConf.FILE_SOURCE_LOG_COMPACT_INTERVAL.key, "4")
 
         testStream(filtered)(
           AddTextFileData("drop1\nkeep2\nkeep3", src, tmp),
@@ -954,7 +958,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
           CheckAnswer("keep2", "keep3", "keep5", "keep6", "keep8", "keep9"),
           AssertOnQuery(verify(_)(2L, 3)),
           StopStream,
-          StartStream(),
+          StartStream(pairs = updateConf),
           AssertOnQuery(verify(_)(2L, 3)),
           AddTextFileData("drop10\nkeep11", src, tmp),
           CheckAnswer("keep2", "keep3", "keep5", "keep6", "keep8", "keep9", "keep11"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

CompactibleFileStreamLog relys on "compactInterval" to detect a compaction batch. If the "compactInterval" is reset by user, CompactibleFileStreamLog will return wrong answer, resulting data loss. This PR procides a way to check the validity of 'compactInterval', and calculate an appropriate value.

## How was this patch tested?

When restart a stream, we change the 'spark.sql.streaming.fileSource.log.compactInterval' different with the former one.
