### PR TITLE
[SPARK-18187][SS] CompactibleFileStreamLog should not rely on "compactInterval" to detect a compaction batch

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
@@ -66,7 +66,7 @@ class FileStreamSourceLog(
 
   override def add(batchId: Long, logs: Array[FileEntry]): Boolean = {
     if (super.add(batchId, logs)) {
-      if (isCompactionBatch(batchId, compactInterval)) {
+      if (isCompactionBatch(knownCompactionBatches, zeroBatch, batchId, compactInterval)) {
         fileEntryCache.put(batchId, logs)
       }
       true
@@ -80,7 +80,8 @@ class FileStreamSourceLog(
     val endBatchId = getLatest().map(_._1).getOrElse(0L)
 
     val (existedBatches, removedBatches) = (startBatchId to endBatchId).map { id =>
-      if (isCompactionBatch(id, compactInterval) && fileEntryCache.containsKey(id)) {
+      if (isCompactionBatch(knownCompactionBatches, zeroBatch, id, compactInterval)
+        && fileEntryCache.containsKey(id)) {
         (id, Some(fileEntryCache.get(id)))
       } else {
         val logs = super.get(id).map(_.filter(_.batchId == id))
@@ -99,7 +100,8 @@ class FileStreamSourceLog(
       if (latestBatchId < 0) {
         Map.empty[Long, Option[Array[FileEntry]]]
       } else {
-        val latestCompactedBatchId = getAllValidBatches(latestBatchId, compactInterval)(0)
+        val latestCompactedBatchId =
+          getAllValidBatches(knownCompactionBatches, zeroBatch, latestBatchId, compactInterval)(0)
         val allLogs = new mutable.HashMap[Long, mutable.ArrayBuffer[FileEntry]]
 
         super.get(latestCompactedBatchId).foreach { entries =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.io._
+import java.nio.charset.StandardCharsets._
+
+import scala.language.implicitConversions
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.sql.execution.streaming.FakeFileSystem._
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.test.SharedSQLContext
+
+class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext {
+
+  /** To avoid caching of FS objects */
+  override protected val sparkConf =
+    new SparkConf().set(s"spark.hadoop.fs.$scheme.impl.disable.cache", "true")
+
+  import CompactibleFileStreamLog._
+
+  test("getBatchIdFromFileName") {
+    assert(1234L === getBatchIdFromFileName("1234"))
+    assert(1234L === getBatchIdFromFileName("1234.compact"))
+    intercept[NumberFormatException] {
+      getBatchIdFromFileName("1234a")
+    }
+  }
+
+  test("isCompactionBatch") {
+    assert(false === isCompactionBatch(0, compactInterval = 3))
+    assert(false === isCompactionBatch(1, compactInterval = 3))
+    assert(true === isCompactionBatch(2, compactInterval = 3))
+    assert(false === isCompactionBatch(3, compactInterval = 3))
+    assert(false === isCompactionBatch(4, compactInterval = 3))
+    assert(true === isCompactionBatch(5, compactInterval = 3))
+  }
+
+  test("nextCompactionBatchId") {
+    assert(2 === nextCompactionBatchId(0, compactInterval = 3))
+    assert(2 === nextCompactionBatchId(1, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(2, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(3, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(4, compactInterval = 3))
+    assert(8 === nextCompactionBatchId(5, compactInterval = 3))
+  }
+
+  test("getValidBatchesBeforeCompactionBatch") {
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(0, compactInterval = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(1, compactInterval = 3)
+    }
+    assert(Seq(0, 1) === getValidBatchesBeforeCompactionBatch(2, compactInterval = 3))
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(3, compactInterval = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(4, compactInterval = 3)
+    }
+    assert(Seq(2, 3, 4) === getValidBatchesBeforeCompactionBatch(5, compactInterval = 3))
+  }
+
+  test("getAllValidBatches") {
+    assert(Seq(0) === getAllValidBatches(0, compactInterval = 3))
+    assert(Seq(0, 1) === getAllValidBatches(1, compactInterval = 3))
+    assert(Seq(2) === getAllValidBatches(2, compactInterval = 3))
+    assert(Seq(2, 3) === getAllValidBatches(3, compactInterval = 3))
+    assert(Seq(2, 3, 4) === getAllValidBatches(4, compactInterval = 3))
+    assert(Seq(5) === getAllValidBatches(5, compactInterval = 3))
+    assert(Seq(5, 6) === getAllValidBatches(6, compactInterval = 3))
+    assert(Seq(5, 6, 7) === getAllValidBatches(7, compactInterval = 3))
+    assert(Seq(8) === getAllValidBatches(8, compactInterval = 3))
+  }
+
+  test("batchIdToPath") {
+    withSQLConf(SQLConf.FILE_SINK_LOG_COMPACT_INTERVAL.key -> "3") {
+      withFileStreamSinkLog { sinkLog =>
+        assert("0" === sinkLog.batchIdToPath(0).getName)
+        assert("1" === sinkLog.batchIdToPath(1).getName)
+        assert("2.compact" === sinkLog.batchIdToPath(2).getName)
+        assert("3" === sinkLog.batchIdToPath(3).getName)
+        assert("4" === sinkLog.batchIdToPath(4).getName)
+        assert("5.compact" === sinkLog.batchIdToPath(5).getName)
+      }
+    }
+  }
+
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
@@ -35,6 +35,64 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
 
   import CompactibleFileStreamLog._
 
+  testWithUninterruptibleThread(
+    "correct results from multiples runs with different compact intervals") {
+    withTempDir { dir =>
+      def newFakeCompactibleFileStreamLog(compactInterval: Int): FakeCompactibleFileStreamLog =
+        new FakeCompactibleFileStreamLog(
+          _fileCleanupDelayMs = Long.MaxValue,
+          _compactInterval = compactInterval,
+          spark,
+          dir.getCanonicalPath)
+
+      var compactibleLog = newFakeCompactibleFileStreamLog(2)
+      assert(compactibleLog.knownCompactionBatches === Array())
+      assert(compactibleLog.zeroBatch === 0)
+      assert(compactibleLog.allFiles() === Array())
+
+      compactibleLog.add(0, Array("entry_0"))
+      compactibleLog.add(1, Array("entry_1")) // should compact
+
+      compactibleLog = newFakeCompactibleFileStreamLog(2)
+      assert(compactibleLog.knownCompactionBatches === Array(1))
+      assert(compactibleLog.zeroBatch === 2)
+      assert(compactibleLog.allFiles() === (0 to 1).map(idx => s"entry_$idx"))
+
+      compactibleLog.add(2, Array("entry_2"))
+      compactibleLog.add(3, Array("entry_3")) // should compact
+
+      compactibleLog = newFakeCompactibleFileStreamLog(3)
+      assert(compactibleLog.knownCompactionBatches === Array(1, 3))
+      assert(compactibleLog.zeroBatch === 4)
+      assert(compactibleLog.allFiles() === (0 to 3).map(idx => s"entry_$idx"))
+
+      compactibleLog.add(4, Array("entry_4"))
+      compactibleLog.add(5, Array("entry_5"))
+      compactibleLog.add(6, Array("entry_6")) // should compact
+
+      compactibleLog = newFakeCompactibleFileStreamLog(5)
+      assert(compactibleLog.knownCompactionBatches === Array(1, 3, 6))
+      assert(compactibleLog.zeroBatch === 7)
+      assert(compactibleLog.allFiles() === (0 to 6).map(idx => s"entry_$idx"))
+
+      compactibleLog.add(7, Array("entry_7"))
+      compactibleLog.add(8, Array("entry_8"))
+      compactibleLog.add(9, Array("entry_9"))
+      compactibleLog.add(10, Array("entry_10"))
+
+      compactibleLog = newFakeCompactibleFileStreamLog(2)
+      assert(compactibleLog.knownCompactionBatches === Array(1, 3, 6))
+      assert(compactibleLog.zeroBatch === 11)
+      assert(compactibleLog.allFiles() === (0 to 10).map(idx => s"entry_$idx"))
+    }
+  }
+
+  private val emptyKnownCompactionBatches = Array[Long]()
+  private val knownCompactionBatches = Array[Long](
+    1, 3, // produced with interval = 2
+    6     // produced with interval = 3
+  )
+
   /** -- testing of `object CompactibleFileStreamLog` begins -- */
 
   test("getBatchIdFromFileName") {
@@ -45,51 +103,278 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
     }
   }
 
+  test("isCompactionBatchFromFileName") {
+    assert(false === isCompactionBatchFromFileName("1234"))
+    assert(true === isCompactionBatchFromFileName("1234.compact"))
+  }
+
   test("isCompactionBatch") {
-    assert(false === isCompactionBatch(0, compactInterval = 3))
-    assert(false === isCompactionBatch(1, compactInterval = 3))
-    assert(true === isCompactionBatch(2, compactInterval = 3))
-    assert(false === isCompactionBatch(3, compactInterval = 3))
-    assert(false === isCompactionBatch(4, compactInterval = 3))
-    assert(true === isCompactionBatch(5, compactInterval = 3))
+    // test empty knownCompactionBatches cases
+    assert(false === isCompactionBatch(
+      emptyKnownCompactionBatches, zeroBatch = 0, batchId = 0, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      emptyKnownCompactionBatches, zeroBatch = 0, batchId = 1, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      emptyKnownCompactionBatches, zeroBatch = 0, batchId = 2, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      emptyKnownCompactionBatches, zeroBatch = 0, batchId = 3, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      emptyKnownCompactionBatches, zeroBatch = 0, batchId = 4, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      emptyKnownCompactionBatches, zeroBatch = 0, batchId = 5, compactInterval = 3))
+
+    // test non-empty knownCompactionBatches cases
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 0, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 1, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 2, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 3, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 4, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 5, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 6, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 7, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 8, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 9, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 7, batchId = 10, compactInterval = 3))
+
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 0, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 1, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 2, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 3, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 4, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 5, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 6, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 7, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 8, compactInterval = 3))
+    // notice the following one, it should be false !!!
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 9, compactInterval = 3))
+    for (batchId <- 10 until 20) {
+      assert(false === isCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, batchId = batchId, compactInterval = 3))
+    }
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 20, compactInterval = 3))
+    assert(false === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 21, compactInterval = 3))
+    assert(true === isCompactionBatch(
+      knownCompactionBatches, zeroBatch = 20, batchId = 22, compactInterval = 3))
   }
 
   test("nextCompactionBatchId") {
-    assert(2 === nextCompactionBatchId(0, compactInterval = 3))
-    assert(2 === nextCompactionBatchId(1, compactInterval = 3))
-    assert(5 === nextCompactionBatchId(2, compactInterval = 3))
-    assert(5 === nextCompactionBatchId(3, compactInterval = 3))
-    assert(5 === nextCompactionBatchId(4, compactInterval = 3))
-    assert(8 === nextCompactionBatchId(5, compactInterval = 3))
+    assert(2 === nextCompactionBatchId(zeroBatch = 0, batchId = 0, compactInterval = 3))
+    assert(2 === nextCompactionBatchId(zeroBatch = 0, batchId = 1, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(zeroBatch = 0, batchId = 2, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(zeroBatch = 0, batchId = 3, compactInterval = 3))
+    assert(5 === nextCompactionBatchId(zeroBatch = 0, batchId = 4, compactInterval = 3))
+    assert(8 === nextCompactionBatchId(zeroBatch = 0, batchId = 5, compactInterval = 3))
+    assert(8 === nextCompactionBatchId(zeroBatch = 0, batchId = 6, compactInterval = 3))
+    assert(9 === nextCompactionBatchId(zeroBatch = 7, batchId = 7, compactInterval = 3))
+    assert(9 === nextCompactionBatchId(zeroBatch = 7, batchId = 8, compactInterval = 3))
+    assert(12 === nextCompactionBatchId(zeroBatch = 7, batchId = 9, compactInterval = 3))
+    assert(12 === nextCompactionBatchId(zeroBatch = 7, batchId = 10, compactInterval = 3))
+    assert(12 === nextCompactionBatchId(zeroBatch = 7, batchId = 11, compactInterval = 3))
   }
 
   test("getValidBatchesBeforeCompactionBatch") {
+    // test empty knownCompactionBatches cases
     intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(0, compactInterval = 3)
+      getValidBatchesBeforeCompactionBatch(
+        emptyKnownCompactionBatches, zeroBatch = 0, compactionBatchId = 0, compactInterval = 3)
     }
     intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(1, compactInterval = 3)
+      getValidBatchesBeforeCompactionBatch(
+        emptyKnownCompactionBatches, zeroBatch = 0, compactionBatchId = 1, compactInterval = 3)
     }
-    assert(Seq(0, 1) === getValidBatchesBeforeCompactionBatch(2, compactInterval = 3))
+    assert(Seq(0, 1) ===
+      getValidBatchesBeforeCompactionBatch(
+        emptyKnownCompactionBatches, zeroBatch = 0, compactionBatchId = 2, compactInterval = 3))
     intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(3, compactInterval = 3)
+      getValidBatchesBeforeCompactionBatch(
+        emptyKnownCompactionBatches, zeroBatch = 0, compactionBatchId = 3, compactInterval = 3)
     }
     intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(4, compactInterval = 3)
+      getValidBatchesBeforeCompactionBatch(
+        emptyKnownCompactionBatches, zeroBatch = 0, compactionBatchId = 4, compactInterval = 3)
     }
-    assert(Seq(2, 3, 4) === getValidBatchesBeforeCompactionBatch(5, compactInterval = 3))
+    assert(Seq(2, 3, 4) ===
+      getValidBatchesBeforeCompactionBatch(
+        emptyKnownCompactionBatches, zeroBatch = 0, compactionBatchId = 5, compactInterval = 3))
+
+    // test non-empty knownCompactionBatches cases
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 7, compactionBatchId = 7, compactInterval = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 7, compactionBatchId = 8, compactInterval = 3)
+    }
+    assert(Seq(6, 7, 8) ===
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 7, compactionBatchId = 9, compactInterval = 3))
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 7, compactionBatchId = 10, compactInterval = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 7, compactionBatchId = 11, compactInterval = 3)
+    }
+    assert(Seq(9, 10, 11) ===
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 7, compactionBatchId = 12, compactInterval = 3))
+
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, compactionBatchId = 20, compactInterval = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, compactionBatchId = 21, compactInterval = 3)
+    }
+    assert((6 to 21) ===
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, compactionBatchId = 22, compactInterval = 3))
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, compactionBatchId = 23, compactInterval = 3)
+    }
+    intercept[AssertionError] {
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, compactionBatchId = 24, compactInterval = 3)
+    }
+    assert(Seq(22, 23, 24) ===
+      getValidBatchesBeforeCompactionBatch(
+        knownCompactionBatches, zeroBatch = 20, compactionBatchId = 25, compactInterval = 3))
   }
 
   test("getAllValidBatches") {
-    assert(Seq(0) === getAllValidBatches(0, compactInterval = 3))
-    assert(Seq(0, 1) === getAllValidBatches(1, compactInterval = 3))
-    assert(Seq(2) === getAllValidBatches(2, compactInterval = 3))
-    assert(Seq(2, 3) === getAllValidBatches(3, compactInterval = 3))
-    assert(Seq(2, 3, 4) === getAllValidBatches(4, compactInterval = 3))
-    assert(Seq(5) === getAllValidBatches(5, compactInterval = 3))
-    assert(Seq(5, 6) === getAllValidBatches(6, compactInterval = 3))
-    assert(Seq(5, 6, 7) === getAllValidBatches(7, compactInterval = 3))
-    assert(Seq(8) === getAllValidBatches(8, compactInterval = 3))
+    // test empty knownCompactionBatches cases
+    assert(
+      Seq(0) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 0, compactInterval = 3))
+    assert(
+      Seq(0, 1) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 1, compactInterval = 3))
+    assert(
+      Seq(2) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 2, compactInterval = 3))
+    assert(
+      Seq(2, 3) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 3, compactInterval = 3))
+    assert(
+      Seq(2, 3, 4) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 4, compactInterval = 3))
+    assert(
+      Seq(5) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 5, compactInterval = 3))
+    assert(
+      Seq(5, 6) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 6, compactInterval = 3))
+    assert(
+      Seq(5, 6, 7) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 7, compactInterval = 3))
+    assert(
+      Seq(8) === getAllValidBatches(
+        emptyKnownCompactionBatches, zeroBatch = 0, batchId = 8, compactInterval = 3))
+
+    // test non-empty knownCompactionBatches cases
+    assert(
+      Seq(0) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 0, compactInterval = 3))
+    assert(
+      Seq(1) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 1, compactInterval = 3))
+    assert(
+      Seq(1, 2) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 2, compactInterval = 3))
+    assert(
+      Seq(3) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 3, compactInterval = 3))
+    assert(
+      Seq(3, 4) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 4, compactInterval = 3))
+    assert(
+      Seq(3, 4, 5) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 5, compactInterval = 3))
+    assert(
+      Seq(6) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 6, compactInterval = 3))
+    assert(
+      Seq(6, 7) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 7, compactInterval = 3))
+    assert(
+      Seq(6, 7, 8) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 8, compactInterval = 3))
+    assert(
+      Seq(9) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 9, compactInterval = 3))
+    assert(
+      Seq(9, 10) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 10, compactInterval = 3))
+    assert(
+      Seq(9, 10, 11) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 11, compactInterval = 3))
+    assert(
+      Seq(12) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 12, compactInterval = 3))
+    assert(
+      Seq(12, 13) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 13, compactInterval = 3))
+    assert(
+      Seq(12, 13, 14) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 14, compactInterval = 3))
+    assert(
+      Seq(15) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 7, batchId = 15, compactInterval = 3))
+
+    assert(
+      (6 to 20) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 20, compactInterval = 3))
+    assert(
+      (6 to 21) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 21, compactInterval = 3))
+    assert(
+      Seq(22) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 22, compactInterval = 3))
+    assert(
+      Seq(22, 23) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 23, compactInterval = 3))
+    assert(
+      Seq(22, 23, 24) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 24, compactInterval = 3))
+    assert(
+      Seq(25) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 25, compactInterval = 3))
+    assert(
+      Seq(25, 26) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 26, compactInterval = 3))
+    assert(
+      Seq(25, 26, 27) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 27, compactInterval = 3))
+    assert(
+      Seq(28) === getAllValidBatches(
+        knownCompactionBatches, zeroBatch = 20, batchId = 28, compactInterval = 3))
   }
 
   /** -- testing of `object CompactibleFileStreamLog` ends -- */
@@ -98,6 +383,7 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
     withFakeCompactibleFileStreamLog(
       fileCleanupDelayMs = Long.MaxValue,
       compactInterval = 3,
+      existingFiles = Seq(),
       compactibleLog => {
         assert("0" === compactibleLog.batchIdToPath(0).getName)
         assert("1" === compactibleLog.batchIdToPath(1).getName)
@@ -106,12 +392,36 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
         assert("4" === compactibleLog.batchIdToPath(4).getName)
         assert("5.compact" === compactibleLog.batchIdToPath(5).getName)
       })
+
+    withFakeCompactibleFileStreamLog(
+      fileCleanupDelayMs = Long.MaxValue,
+      compactInterval = 3,
+      existingFiles = Seq(
+        "0", "1.compact",
+        "2", "3.compact",
+        "4", "5"
+      ),
+      compactibleLog => {
+        assert("0" === compactibleLog.batchIdToPath(0).getName)
+        assert("1.compact" === compactibleLog.batchIdToPath(1).getName)
+        assert("2" === compactibleLog.batchIdToPath(2).getName)
+        assert("3.compact" === compactibleLog.batchIdToPath(3).getName)
+        assert("4" === compactibleLog.batchIdToPath(4).getName)
+        assert("5" === compactibleLog.batchIdToPath(5).getName)
+        assert("6" === compactibleLog.batchIdToPath(6).getName)
+        assert("7" === compactibleLog.batchIdToPath(7).getName)
+        assert("8.compact" === compactibleLog.batchIdToPath(8).getName)
+        assert("9" === compactibleLog.batchIdToPath(9).getName)
+        assert("10" === compactibleLog.batchIdToPath(10).getName)
+        assert("11.compact" === compactibleLog.batchIdToPath(11).getName)
+      })
   }
 
   test("serialize") {
     withFakeCompactibleFileStreamLog(
       fileCleanupDelayMs = Long.MaxValue,
       compactInterval = 3,
+      existingFiles = Seq(),
       compactibleLog => {
         val logs = Array("entry_1", "entry_2", "entry_3")
         val expected = s"""${FakeCompactibleFileStreamLog.VERSION}
@@ -132,6 +442,7 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
     withFakeCompactibleFileStreamLog(
       fileCleanupDelayMs = Long.MaxValue,
       compactInterval = 3,
+      existingFiles = Seq(),
       compactibleLog => {
         val logs = s"""${FakeCompactibleFileStreamLog.VERSION}
             |"entry_1"
@@ -151,12 +462,13 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
     withFakeCompactibleFileStreamLog(
       fileCleanupDelayMs = Long.MaxValue,
       compactInterval = 3,
+      existingFiles = Seq(),
       compactibleLog => {
         for (batchId <- 0 to 10) {
           compactibleLog.add(batchId, Array("some_path_" + batchId))
           val expectedFiles = (0 to batchId).map { id => "some_path_" + id }
           assert(compactibleLog.allFiles() === expectedFiles)
-          if (isCompactionBatch(batchId, 3)) {
+          if (isCompactionBatch(emptyKnownCompactionBatches, batchId, 0, 3)) {
             // Since batchId is a compaction batch, the batch log file should contain all logs
             assert(compactibleLog.get(batchId).getOrElse(Nil) === expectedFiles)
           }
@@ -169,6 +481,7 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
     withFakeCompactibleFileStreamLog(
       fileCleanupDelayMs = 0,
       compactInterval = 3,
+      existingFiles = Seq(),
       compactibleLog => {
         val fs = compactibleLog.metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
 
@@ -201,14 +514,23 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
   private def withFakeCompactibleFileStreamLog(
     fileCleanupDelayMs: Long,
     compactInterval: Int,
+    existingFiles: Seq[String],
     f: FakeCompactibleFileStreamLog => Unit
   ): Unit = {
-    withTempDir { file =>
+    withTempDir { dir =>
+      val tmpLog = new FakeCompactibleFileStreamLog(
+        fileCleanupDelayMs,
+        compactInterval,
+        spark,
+        dir.getCanonicalPath)
+      for (existingFile <- existingFiles) {
+        tmpLog.serialize(Array(), new FileOutputStream(new File(dir, existingFile)))
+      }
       val compactibleLog = new FakeCompactibleFileStreamLog(
         fileCleanupDelayMs,
         compactInterval,
         spark,
-        file.getCanonicalPath)
+        dir.getCanonicalPath)
       f(compactibleLog)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -29,61 +29,6 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
   import CompactibleFileStreamLog._
   import FileStreamSinkLog._
 
-  test("getBatchIdFromFileName") {
-    assert(1234L === getBatchIdFromFileName("1234"))
-    assert(1234L === getBatchIdFromFileName("1234.compact"))
-    intercept[NumberFormatException] {
-      getBatchIdFromFileName("1234a")
-    }
-  }
-
-  test("isCompactionBatch") {
-    assert(false === isCompactionBatch(0, compactInterval = 3))
-    assert(false === isCompactionBatch(1, compactInterval = 3))
-    assert(true === isCompactionBatch(2, compactInterval = 3))
-    assert(false === isCompactionBatch(3, compactInterval = 3))
-    assert(false === isCompactionBatch(4, compactInterval = 3))
-    assert(true === isCompactionBatch(5, compactInterval = 3))
-  }
-
-  test("nextCompactionBatchId") {
-    assert(2 === nextCompactionBatchId(0, compactInterval = 3))
-    assert(2 === nextCompactionBatchId(1, compactInterval = 3))
-    assert(5 === nextCompactionBatchId(2, compactInterval = 3))
-    assert(5 === nextCompactionBatchId(3, compactInterval = 3))
-    assert(5 === nextCompactionBatchId(4, compactInterval = 3))
-    assert(8 === nextCompactionBatchId(5, compactInterval = 3))
-  }
-
-  test("getValidBatchesBeforeCompactionBatch") {
-    intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(0, compactInterval = 3)
-    }
-    intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(1, compactInterval = 3)
-    }
-    assert(Seq(0, 1) === getValidBatchesBeforeCompactionBatch(2, compactInterval = 3))
-    intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(3, compactInterval = 3)
-    }
-    intercept[AssertionError] {
-      getValidBatchesBeforeCompactionBatch(4, compactInterval = 3)
-    }
-    assert(Seq(2, 3, 4) === getValidBatchesBeforeCompactionBatch(5, compactInterval = 3))
-  }
-
-  test("getAllValidBatches") {
-    assert(Seq(0) === getAllValidBatches(0, compactInterval = 3))
-    assert(Seq(0, 1) === getAllValidBatches(1, compactInterval = 3))
-    assert(Seq(2) === getAllValidBatches(2, compactInterval = 3))
-    assert(Seq(2, 3) === getAllValidBatches(3, compactInterval = 3))
-    assert(Seq(2, 3, 4) === getAllValidBatches(4, compactInterval = 3))
-    assert(Seq(5) === getAllValidBatches(5, compactInterval = 3))
-    assert(Seq(5, 6) === getAllValidBatches(6, compactInterval = 3))
-    assert(Seq(5, 6, 7) === getAllValidBatches(7, compactInterval = 3))
-    assert(Seq(8) === getAllValidBatches(8, compactInterval = 3))
-  }
-
   test("compactLogs") {
     withFileStreamSinkLog { sinkLog =>
       val logs = Seq(
@@ -181,19 +126,6 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
       assert(expected === sinkLog.deserialize(new ByteArrayInputStream(logs.getBytes(UTF_8))))
 
       assert(Nil === sinkLog.deserialize(new ByteArrayInputStream(VERSION.getBytes(UTF_8))))
-    }
-  }
-
-  test("batchIdToPath") {
-    withSQLConf(SQLConf.FILE_SINK_LOG_COMPACT_INTERVAL.key -> "3") {
-      withFileStreamSinkLog { sinkLog =>
-        assert("0" === sinkLog.batchIdToPath(0).getName)
-        assert("1" === sinkLog.batchIdToPath(1).getName)
-        assert("2.compact" === sinkLog.batchIdToPath(2).getName)
-        assert("3" === sinkLog.batchIdToPath(3).getName)
-        assert("4" === sinkLog.batchIdToPath(4).getName)
-        assert("5.compact" === sinkLog.batchIdToPath(5).getName)
-      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -29,6 +29,12 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
   import CompactibleFileStreamLog._
   import FileStreamSinkLog._
 
+  private val emptyKnownCompactionBatches = Array[Long]()
+  private val knownCompactionBatches = Array[Long](
+    1, 3, // produced with interval = 2
+    6     // produced with interval = 3
+  )
+
   test("compactLogs") {
     withFileStreamSinkLog { sinkLog =>
       val logs = Seq(
@@ -140,7 +146,7 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSQLContext {
             id => newFakeSinkFileStatus("/a/b/" + id, FileStreamSinkLog.ADD_ACTION)
           }
           assert(sinkLog.allFiles() === expectedFiles)
-          if (isCompactionBatch(batchId, 3)) {
+          if (isCompactionBatch(emptyKnownCompactionBatches, batchId, 0, 3)) {
             // Since batchId is a compaction batch, the batch log file should contain all logs
             assert(sinkLog.get(batchId).getOrElse(Nil) === expectedFiles)
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -907,7 +907,11 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       val fileSource = (execution invokePrivate _sources()).head.asInstanceOf[FileStreamSource]
       val metadataLog = fileSource invokePrivate _metadataLog()
 
-      if (isCompactionBatch(batchId, 2)) {
+      if (isCompactionBatch(
+        metadataLog.asInstanceOf[CompactibleFileStreamLog[AnyRef]].knownCompactionBatches,
+        metadataLog.asInstanceOf[CompactibleFileStreamLog[AnyRef]].zeroBatch,
+        batchId,
+        2)) {
         val path = metadataLog.batchIdToPath(batchId)
 
         // Assert path name should be ended with compact suffix.


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem

Right now `CompactibleFileStreamLog` uses `compactInterval` to check if a batch is a compaction batch. However, since this conf is controlled by the user, they may just change it, and `CompactibleFileStreamLog` will just silently return the wrong answer.

### Changes

With this patch the `compactInterval` configuration should only be used when deciding if we should perform a new compaction. The identification of a compaction vs a delta is done by looking for the compact suffix.

In more details, upon each start/restart, we first examine what metadata files were there, what files among them are compacted files. We introduce `knownCompactionBatches` to hold the existing compaction batches before this run, and `zeroBatch` to hold the first batch this run should write to.

Thus we can support the following situations:

```
  (1) a fresh run
  (2) the previous run with `compactInterval` = 2
      0
  (3) the previous run with `compactInterval` = 2
      0   1.compact
  (4) previous runs with `compactInterval` = 2 and `compactInterval` = 5
      0   1.compact    2   3.compact   4.compact
  (5) previous runs with `compactInterval` = 2 and `compactInterval` = 5
      0   1.compact    2   3.compact   4.compact   5   6   7   8
```
 with:
```
  (1) `knownCompactionBatches` = (), `zeroBatch` = 0
  (2) `knownCompactionBatches` = (), `zeroBatch` = 1
  (3) `knownCompactionBatches` = (1), `zeroBatch` = 2
  (4) `knownCompactionBatches` = (1, 3, 4), `zeroBatch` = 5
  (5) `knownCompactionBatches` = (1, 3, 4), `zeroBatch` = 9
```

Note this appoach does not require the `compactInteral` for a new run must be consistent with previous runs.

## How was this patch tested?

added test cases