### PR TITLE
[SPARK-18391] Openstack deployment mode for any Spark version since 1.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ options for deployment:
 * [Submitting Applications](submitting-applications.html): packaging and deploying applications
 * Deployment modes:
   * [Amazon EC2](https://github.com/amplab/spark-ec2): scripts that let you launch a cluster on EC2 in about 5 minutes
+  * [Openstack](https://github.com/ispras/spark-openstack): scripts that let you launch a cluster with any version since 1.0 in about 10 minutes (and optional additional tools)
   * [Standalone Deploy Mode](spark-standalone.html): launch a standalone cluster quickly without a third-party cluster manager
   * [Mesos](running-on-mesos.html): deploy a private cluster using
       [Apache Mesos](http://mesos.apache.org)


### PR DESCRIPTION
This change adds a link to universal way to deploy Apache Spark since 1.0 up to 2.0.1 with any supported version of Hadoop in Openstack environment.

We utilize vanilla images (nothing pre-installed is needed; note it works only for cloud images of OS [but it's reasonable])

We support YARN-mode, Apache Ignite, NFS-mount, Jupyter notebooks, etc as optional on-demand options.

All the work is licensed Apache 2.0 explicitly.

The scenario was developed at Institute for System Programming of the Russian Academy of Sciences.