### PR TITLE
[SPARK-18399][SQL][DOCUMENTATION] Examples in SparkSQL/DataFrame/DataSets guide fails with default configuration

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
@@ -60,7 +60,8 @@ object SparkSQLExample {
 
   private def runBasicDataFrameExample(spark: SparkSession): Unit = {
     // $example on:create_df$
-    val df = spark.read.json("examples/src/main/resources/people.json")
+    val df = spark.read.json(
+      "file:///" + System.getProperty("user.dir") + "/examples/src/main/resources/people.json")
 
     // Displays the content of the DataFrame to stdout
     df.show()
@@ -179,7 +180,8 @@ object SparkSQLExample {
     primitiveDS.map(_ + 1).collect() // Returns: Array(2, 3, 4)
 
     // DataFrames can be converted to a Dataset by providing a class. Mapping will be done by name
-    val path = "examples/src/main/resources/people.json"
+    val path =
+      "file:///" + System.getProperty("user.dir") + "/examples/src/main/resources/people.json"
     val peopleDS = spark.read.json(path).as[Person]
     peopleDS.show()
     // +----+-------+
@@ -199,7 +201,8 @@ object SparkSQLExample {
 
     // Create an RDD of Person objects from a text file, convert it to a Dataframe
     val peopleDF = spark.sparkContext
-      .textFile("examples/src/main/resources/people.txt")
+      .textFile(
+        "file:///" + System.getProperty("user.dir") + "/examples/src/main/resources/people.txt")
       .map(_.split(","))
       .map(attributes => Person(attributes(0), attributes(1).trim.toInt))
       .toDF()
@@ -240,7 +243,8 @@ object SparkSQLExample {
     import spark.implicits._
     // $example on:programmatic_schema$
     // Create an RDD
-    val peopleRDD = spark.sparkContext.textFile("examples/src/main/resources/people.txt")
+    val peopleRDD = spark.sparkContext.textFile(
+      "file:///" + System.getProperty("user.dir") + "/examples/src/main/resources/people.txt")
 
     // The schema is encoded in a string
     val schemaString = "name age"


### PR DESCRIPTION
## What changes were proposed in this pull request?

With default configuration, examples in Spark SQL, DataFrames and Datasets Guide result in a failure since they try to access HDFS while the paths of people.json, people.txt are assumed to be in local file system.

## How was this patch tested?

I test this with manual test: running examples of SparkSQL/DataFrame/DataSets with default configuration. With this fix, it works well without configuring HDFS.

