### PR TITLE
[SPARK-18403][SQL] Temporarily disable flaky ObjectHashAggregateSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ObjectHashAggregateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ObjectHashAggregateSuite.scala
@@ -326,7 +326,8 @@ class ObjectHashAggregateSuite
             // Currently Spark SQL doesn't support evaluating distinct aggregate function together
             // with aggregate functions without partial aggregation support.
             if (!(aggs.contains(withoutPartial) && aggs.contains(withDistinct))) {
-              test(
+              // TODO Re-enables them after fixing SPARK-18403
+              ignore(
                 s"randomized aggregation test - " +
                   s"${names.mkString("[", ", ", "]")} - " +
                   s"${if (withGroupingKeys) "with" else "without"} grouping keys - " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Randomized tests in `ObjectHashAggregateSuite` is being flaky and breaks PR builds. This PR disables them temporarily to bring back the PR build.

## How was this patch tested?

N/A