### PR TITLE
[CORE][Minor]:remove unused import in SparkContext.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -19,7 +19,7 @@ package org.apache.spark
 
 import java.io._
 import java.lang.reflect.Constructor
-import java.net.{MalformedURLException, URI}
+import java.net.{URI}
 import java.util.{Arrays, Locale, Properties, ServiceLoader, UUID}
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found one unused import in SparkContext.scala while auditing ML code.

Remove it.
## How was this patch tested?

Remove the unused import and compile successfully