### PR TITLE
[SPARK-18416][Structured Streaming] Fixed temp file leak in state store

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -523,7 +523,6 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
     store2.commit()   // commit should also create a temp file
     assert(numTempFiles === 0)
     assert(numDeltaFiles === 3)
-
   }
 
   def getDataFromFiles(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -500,7 +500,6 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
     }
 
     // Put should create a temp file
-    assert(numTempFiles === 0)
     put(store0, "a", 1)
     assert(numTempFiles === 1)
     assert(numDeltaFiles === 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -488,7 +488,6 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
       result
     }
 
-    // Increase version of the store
     val store0 = shouldNotCreateTempFile {
       StateStore.get(storeId, keySchema, valueSchema, 0, storeConf, hadoopConf)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -494,33 +494,40 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
       result
     }
 
+    // Getting the store should not create temp file
     val store0 = shouldNotCreateTempFile {
       StateStore.get(storeId, keySchema, valueSchema, 0, storeConf, hadoopConf)
     }
+
+    // Put should create a temp file
     assert(numTempFiles === 0)
-    put(store0, "a", 1)         // put should create a temp file
+    put(store0, "a", 1)
     assert(numTempFiles === 1)
     assert(numDeltaFiles === 0)
 
+    // Commit should remove temp file and create a delta file
     store0.commit()
     assert(numTempFiles === 0)
     assert(numDeltaFiles === 1)
 
+    // Remove should create a temp file
     val store1 = shouldNotCreateTempFile {
       StateStore.get(storeId, keySchema, valueSchema, 1, storeConf, hadoopConf)
     }
-    remove(store1, _ == "a") // remove should create a temp file
+    remove(store1, _ == "a")
     assert(numTempFiles === 1)
     assert(numDeltaFiles === 1)
 
+    // Commit should remove temp file and create a delta file
     store1.commit()
     assert(numTempFiles === 0)
     assert(numDeltaFiles === 2)
 
+    // Commit without any updates should create a delta file
     val store2 = shouldNotCreateTempFile {
       StateStore.get(storeId, keySchema, valueSchema, 2, storeConf, hadoopConf)
     }
-    store2.commit()   // commit should also create a temp file
+    store2.commit()
     assert(numTempFiles === 0)
     assert(numDeltaFiles === 3)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -468,7 +468,7 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
     assert(e.getCause.getMessage.contains("Failed to rename"))
   }
 
-  test("SPARK-XXXXX: do not create temp delta file until the store is updated") {
+  test("SPARK-18416: do not create temp delta file until the store is updated") {
     val dir = Utils.createDirectory(tempDir, Random.nextString(5)).toString
     val storeId = StateStoreId(dir, 0, 0)
     val storeConf = StateStoreConf.empty


### PR DESCRIPTION
## What changes were proposed in this pull request?

StateStore.get() causes temporary files to be created immediately, even if the store is not used to make updates for new version. The temp file is not closed as store.commit() is not called in those cases, thus keeping the output stream to temp file open forever.

This PR fixes it by opening the temp file only when there are updates being made.

## How was this patch tested?

New unit test

