### PR TITLE
[YARN][DOC] Remove non-Yarn specific configurations from running-on-yarn.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,13 +156,6 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
- <td><code>spark.executor.instances</code></td>
-  <td><code>2</code></td>
-  <td>
-    The number of executors for static allocation. With <code>spark.dynamicAllocation.enabled</code>, the initial set of executors will be at least this large.
-  </td>
-</tr>
-<tr>
   <td><code>spark.extraListeners</code></td>
   <td>(none)</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,13 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
+ <td><code>spark.executor.instances</code></td>
+  <td><code>2</code></td>
+  <td>
+    The number of executors for static allocation. With <code>spark.dynamicAllocation.enabled</code>, the initial set of executors will be at least this large.
+  </td>
+</tr>
+<tr>
   <td><code>spark.extraListeners</code></td>
   <td>(none)</td>
   <td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -118,19 +118,6 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
 </tr>
 <tr>
-  <td><code>spark.driver.memory</code></td>
-  <td>1g</td>
-  <td>
-    Amount of memory to use for the driver process, i.e. where SparkContext is initialized.
-    (e.g. <code>1g</code>, <code>2g</code>).
-
-    <br /><em>Note:</em> In client mode, this config must not be set through the <code>SparkConf</code>
-    directly in your application, because the driver JVM has already started at that point.
-    Instead, please set this through the <code>--driver-memory</code> command line option
-    or in your default properties file.
-  </td>
-</tr>
-<tr>
   <td><code>spark.driver.cores</code></td>
   <td><code>1</code></td>
   <td>
@@ -238,20 +225,6 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1 in YARN mode, all the available cores on the worker in standalone mode.</td>
   <td>
     The number of cores to use on each executor. For YARN and standalone mode only.
-  </td>
-</tr>
-<tr>
- <td><code>spark.executor.instances</code></td>
-  <td><code>2</code></td>
-  <td>
-    The number of executors for static allocation. With <code>spark.dynamicAllocation.enabled</code>, the initial set of executors will be at least this large.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.executor.memory</code></td>
-  <td>1g</td>
-  <td>
-    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>).
   </td>
 </tr>
 <tr>
@@ -493,6 +466,20 @@ To use a custom metrics.properties for the application master and executors, upd
   Java Regex to filter the log files which match the defined exclude pattern
   and those log files will not be aggregated in a rolling fashion. If the log file
   name matches both the include and the exclude pattern, this file will be excluded eventually.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.yarn.report.interval</code></td>
+  <td>1s</td>
+  <td>
+  Interval between reports of the current app status in Yarn cluster mode.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.yarn.services</code></td>
+  <td>Nil</td>
+  <td>
+  A comma-separated list of class names of services to add to the scheduler.
   </td>
 </tr>
 </table>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -118,15 +118,6 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
 </tr>
 <tr>
-  <td><code>spark.driver.cores</code></td>
-  <td><code>1</code></td>
-  <td>
-    Number of cores used by the driver in YARN cluster mode.
-    Since the driver is run in the same JVM as the YARN Application Master in cluster mode, this also controls the cores used by the YARN Application Master.
-    In client mode, use <code>spark.yarn.am.cores</code> to control the number of cores used by the YARN Application Master instead.
-  </td>
-</tr>
-<tr>
   <td><code>spark.yarn.am.cores</code></td>
   <td><code>1</code></td>
   <td>
@@ -221,10 +212,10 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
 </tr>
 <tr>
-  <td><code>spark.executor.cores</code></td>
-  <td>1 in YARN mode, all the available cores on the worker in standalone mode.</td>
+ <td><code>spark.executor.instances</code></td>
+  <td><code>2</code></td>
   <td>
-    The number of cores to use on each executor. For YARN and standalone mode only.
+    The number of executors for static allocation. With <code>spark.dynamicAllocation.enabled</code>, the initial set of executors will be at least this large.
   </td>
 </tr>
 <tr>
@@ -466,20 +457,6 @@ To use a custom metrics.properties for the application master and executors, upd
   Java Regex to filter the log files which match the defined exclude pattern
   and those log files will not be aggregated in a rolling fashion. If the log file
   name matches both the include and the exclude pattern, this file will be excluded eventually.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.yarn.report.interval</code></td>
-  <td>1s</td>
-  <td>
-  Interval between reports of the current app status in YARN cluster mode.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.yarn.services</code></td>
-  <td>(none)</td>
-  <td>
-  A comma-separated list of class names of services to add to the scheduler.
   </td>
 </tr>
 </table>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -472,12 +472,12 @@ To use a custom metrics.properties for the application master and executors, upd
   <td><code>spark.yarn.report.interval</code></td>
   <td>1s</td>
   <td>
-  Interval between reports of the current app status in Yarn cluster mode.
+  Interval between reports of the current app status in YARN cluster mode.
   </td>
 </tr>
 <tr>
   <td><code>spark.yarn.services</code></td>
-  <td>Nil</td>
+  <td>(none)</td>
   <td>
   A comma-separated list of class names of services to add to the scheduler.
   </td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `spark.driver.memory`, `spark.executor.memory`,  `spark.driver.cores`, and `spark.executor.cores` from `running-on-yarn.md` as they are not Yarn-specific, and they are also defined in`configuration.md`.

## How was this patch tested?
Build passed & Manually check.