### PR TITLE
[SPARK-17116][Pyspark] Allow parameters to be {string,value} dict at runtime

### DIFF
--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -59,6 +59,12 @@ class Estimator(Params):
             return [self.fit(dataset, paramMap) for paramMap in params]
         elif isinstance(params, dict):
             if params:
+                if isinstance(params.keys()[0],str):
+                    param_new = dict()
+                    for param, value in params.items():
+                        p = getattr(self, param)
+                        param_new.update({p: value})
+                    params=param_new
                 return self.copy(params)._fit(dataset)
             else:
                 return self._fit(dataset)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull allows a dictionary containing string as keys to be passed in the fit() method. Presently it only allows an instance of the Estimator to be passed as key.

## How was this patch tested?

This patch was manually tested on a local PC.



