### PR TITLE
[SPARK-18466] added withFilter method to RDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -388,6 +388,14 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
+    * Return a new RDD containing only the elements that satisfy a predicate.
+    * This is an alias for filter so that RDDs can be used in for comprehensions without causing the
+    * compiler to complain.
+    */
+  @inline
+  final def withFilter(f: T => Boolean): RDD[T] = filter(f)
+
+  /**
    * Return a new RDD containing the distinct elements in this RDD.
    */
   def distinct(numPartitions: Int)(implicit ord: Ordering[T] = null): RDD[T] = withScope {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -70,6 +70,7 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     assert(!nums.isEmpty())
     assert(nums.max() === 4)
     assert(nums.min() === 1)
+    assert((for (n <- nums if n > 2) yield n).collect().toList === List(3, 4))
     val partitionSums = nums.mapPartitions(iter => Iterator(iter.sum))
     assert(partitionSums.collect().toList === List(3, 7))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A `withFilter` method has been added to `RDD` as an alias for the `filter` method. When using `for` comprehensions, the Scala compiler prefers (and as of 2.12, _requires_) the lazy `withFilter` method, only falling back to using the `filter` method (which, for regular collections, is non-lazy, but for RDDs is lazy). Prior to Scala 2.12, this fallback causes the compiler to emit a warning, and as of Scala 2.12, it results in an error.

## How was this patch tested?

`RDDSuite` was updated by adding a line to "basic operations" that duplicates the behavior of the `filter` test, but uses a `for` comprehension instead of a direct method call.


