### PR TITLE
[SPARK-18467][SQL] Extracts method for preparing arguments from StaticInvoke, Invoke and NewInstance and modify to short circuit if arguments have null when `needNullCheck == true`.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -150,7 +150,7 @@ case class StaticInvoke(
     val code = s"""
       $argCode
       boolean ${ev.isNull} = $resultIsNull;
-      final $javaType ${ev.value} = ${ev.isNull} ? ${ctx.defaultValue(dataType)} : $callFunc;
+      final $javaType ${ev.value} = $resultIsNull ? ${ctx.defaultValue(dataType)} : $callFunc;
       $postNullCheck
      """
     ev.copy(code = code)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -65,7 +65,7 @@ trait InvokeLike extends Expression with NonSQLExpression {
     } else {
       "false"
     }
-    val argValues = arguments.zipWithIndex.map { case (e, i) =>
+    val argValues = arguments.map { e =>
       val argValue = ctx.freshName("argValue")
       ctx.addMutableState(ctx.javaType(e.dataType), argValue, "")
       argValue

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -205,8 +205,9 @@ case class Invoke(
 
     val evaluateArguments = if (arguments.nonEmpty) {
       s"""
-        if (!${obj.isNull}) {
+        if (!${ev.isNull}) {
           $argCode
+          ${ev.isNull} = $resultIsNull;
         }
       """
     } else {
@@ -253,8 +254,8 @@ case class Invoke(
 
     val code = s"""
       ${obj.code}
+      boolean ${ev.isNull} = ${obj.isNull};
       $evaluateArguments
-      boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
       $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${ev.isNull}) {
         $evaluate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types._
 /**
  * Common base class for [[StaticInvoke]], [[Invoke]], and [[NewInstance]].
  */
-trait InvokeLike extends Expression {
+trait InvokeLike {
 
   def arguments: Seq[Expression]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types._
 /**
  * Common base class for [[StaticInvoke]], [[Invoke]], and [[NewInstance]].
  */
-trait InvokeLike {
+trait InvokeLike extends Expression with NonSQLExpression {
 
   def arguments: Seq[Expression]
 
@@ -129,7 +129,7 @@ case class StaticInvoke(
     dataType: DataType,
     functionName: String,
     arguments: Seq[Expression] = Nil,
-    propagateNull: Boolean = true) extends Expression with InvokeLike with NonSQLExpression {
+    propagateNull: Boolean = true) extends InvokeLike {
 
   val objectName = staticObject.getName.stripSuffix("$")
 
@@ -185,7 +185,7 @@ case class Invoke(
     functionName: String,
     dataType: DataType,
     arguments: Seq[Expression] = Nil,
-    propagateNull: Boolean = true) extends Expression with InvokeLike with NonSQLExpression {
+    propagateNull: Boolean = true) extends InvokeLike {
 
   override def nullable: Boolean = true
   override def children: Seq[Expression] = targetObject +: arguments
@@ -294,7 +294,7 @@ case class NewInstance(
     arguments: Seq[Expression],
     propagateNull: Boolean,
     dataType: DataType,
-    outerPointer: Option[() => AnyRef]) extends Expression with InvokeLike with NonSQLExpression {
+    outerPointer: Option[() => AnyRef]) extends InvokeLike {
   private val className = cls.getName
 
   override def nullable: Boolean = propagatingNull

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -242,15 +242,16 @@ case class Invoke(
 
     val code = s"""
       ${obj.code}
+      boolean ${ev.isNull} = true;
+      $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${obj.isNull}) {
         $argCode
+        ${ev.isNull} = $resultIsNull;
+        if (!${ev.isNull}) {
+          $evaluate
+        }
+        $postNullCheck
       }
-      boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
-      $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
-      if (!${ev.isNull}) {
-        $evaluate
-      }
-      $postNullCheck
      """
     ev.copy(code = code)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -316,13 +316,7 @@ case class NewInstance(
 
     val outer = outerPointer.map(func => Literal.fromObject(func()).genCode(ctx))
 
-    var isNull = ev.isNull
-    val prepareIsNull = if (needNullCheck) {
-      s"boolean $isNull = $resultIsNull;"
-    } else {
-      isNull = "false"
-      ""
-    }
+    ev.isNull = resultIsNull
 
     val constructorCall = outer.map { gen =>
       s"${gen.value}.new ${cls.getSimpleName}($argString)"
@@ -333,10 +327,9 @@ case class NewInstance(
     val code = s"""
       $argCode
       ${outer.map(_.code).getOrElse("")}
-      $prepareIsNull
-      final $javaType ${ev.value} = $isNull ? ${ctx.defaultValue(javaType)} : $constructorCall;
+      final $javaType ${ev.value} = ${ev.isNull} ? ${ctx.defaultValue(javaType)} : $constructorCall;
     """
-    ev.copy(code = code, isNull = isNull)
+    ev.copy(code = code)
   }
 
   override def toString: String = s"newInstance($cls)"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -203,16 +203,6 @@ case class Invoke(
 
     val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
 
-    val evaluateArguments = if (arguments.nonEmpty) {
-      s"""
-        if (!${obj.isNull}) {
-          $argCode
-        }
-      """
-    } else {
-      ""
-    }
-
     val returnPrimitive = method.isDefined && method.get.getReturnType.isPrimitive
     val needTryCatch = method.isDefined && method.get.getExceptionTypes.nonEmpty
 
@@ -253,7 +243,9 @@ case class Invoke(
 
     val code = s"""
       ${obj.code}
-      $evaluateArguments
+      if (!${obj.isNull}) {
+        $argCode
+      }
       boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
       $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${ev.isNull}) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -203,17 +203,6 @@ case class Invoke(
 
     val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
 
-    val evaluateArguments = if (arguments.nonEmpty) {
-      s"""
-        if (!${obj.isNull}) {
-          $argCode
-          ${ev.isNull} = $resultIsNull;
-        }
-      """
-    } else {
-      ""
-    }
-
     val returnPrimitive = method.isDefined && method.get.getReturnType.isPrimitive
     val needTryCatch = method.isDefined && method.get.getExceptionTypes.nonEmpty
 
@@ -254,8 +243,10 @@ case class Invoke(
 
     val code = s"""
       ${obj.code}
-      boolean ${ev.isNull} = ${obj.isNull};
-      $evaluateArguments
+      if (!${obj.isNull}) {
+        $argCode
+      }
+      boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
       $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${ev.isNull}) {
         $evaluate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -205,7 +205,7 @@ case class Invoke(
 
     val evaluateArguments = if (arguments.nonEmpty) {
       s"""
-        if (!${ev.isNull}) {
+        if (!${obj.isNull}) {
           $argCode
           ${ev.isNull} = $resultIsNull;
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -333,12 +333,8 @@ case class NewInstance(
       $argCode
       ${outer.map(_.code).getOrElse("")}
       $prepareIsNull
-    """ +
-      (if (needNullCheck) {
-        s"final $javaType ${ev.value} = $isNull ? ${ctx.defaultValue(javaType)} : $constructorCall;"
-      } else {
-        s"final $javaType ${ev.value} = $constructorCall;"
-      })
+      final $javaType ${ev.value} = $isNull ? ${ctx.defaultValue(javaType)} : $constructorCall;
+    """
     ev.copy(code = code, isNull = isNull)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -41,6 +41,20 @@ trait InvokeLike extends Expression {
 
   def propagateNull: Boolean
 
+  /**
+   * Prepares codes for arguments.
+   *
+   * - generate codes for argument.
+   * - use ctx.splitExpressions() not to exceed 64kb JVM limit while preparing arguments.
+   * - avoid some of nullabilty checking which are not needed because the expression is not
+   *   nullable.
+   * - when progagateNull == true, short circuit if we found one of arguments is null because
+   *   preparing rest of arguments can be skipped in the case.
+   *
+   * @param ctx a [[CodegenContext]]
+   * @param ev an [[ExprCode]] with unique terms.
+   * @return (code to prepare arguments, argument string, code to set isNull)
+   */
   def prepareArguments(ctx: CodegenContext, ev: ExprCode): (String, String, String) = {
 
     val argsHaveNull =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -54,10 +54,9 @@ trait InvokeLike extends Expression with NonSQLExpression {
    *   preparing rest of arguments can be skipped in the case.
    *
    * @param ctx a [[CodegenContext]]
-   * @param ev an [[ExprCode]] with unique terms.
    * @return (code to prepare arguments, argument string, result of argument null check)
    */
-  def prepareArguments(ctx: CodegenContext, ev: ExprCode): (String, String, String) = {
+  def prepareArguments(ctx: CodegenContext): (String, String, String) = {
 
     val resultIsNull = if (needNullCheck) {
       val resultIsNull = ctx.freshName("resultIsNull")
@@ -136,7 +135,7 @@ case class StaticInvoke(
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val javaType = ctx.javaType(dataType)
 
-    val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
+    val (argCode, argString, resultIsNull) = prepareArguments(ctx)
 
     val callFunc = s"$objectName.$functionName($argString)"
 
@@ -201,7 +200,7 @@ case class Invoke(
     val javaType = ctx.javaType(dataType)
     val obj = targetObject.genCode(ctx)
 
-    val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
+    val (argCode, argString, resultIsNull) = prepareArguments(ctx)
 
     val returnPrimitive = method.isDefined && method.get.getReturnType.isPrimitive
     val needTryCatch = method.isDefined && method.get.getExceptionTypes.nonEmpty
@@ -312,7 +311,7 @@ case class NewInstance(
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val javaType = ctx.javaType(dataType)
 
-    val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
+    val (argCode, argString, resultIsNull) = prepareArguments(ctx)
 
     val outer = outerPointer.map(func => Literal.fromObject(func()).genCode(ctx))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -47,10 +47,10 @@ trait InvokeLike {
    * Prepares codes for arguments.
    *
    * - generate codes for argument.
-   * - use ctx.splitExpressions() not to exceed 64kb JVM limit while preparing arguments.
+   * - use ctx.splitExpressions() to not exceed 64kb JVM limit while preparing arguments.
    * - avoid some of nullabilty checking which are not needed because the expression is not
    *   nullable.
-   * - when progagateNull == true, short circuit if we found one of arguments is null because
+   * - when progagatingNull == true, short circuit if we found one of arguments is null because
    *   preparing rest of arguments can be skipped in the case.
    *
    * @param ctx a [[CodegenContext]]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -205,9 +205,8 @@ case class Invoke(
 
     val evaluateArguments = if (arguments.nonEmpty) {
       s"""
-        if (!${ev.isNull}) {
+        if (!${obj.isNull}) {
           $argCode
-          ${ev.isNull} = $resultIsNull;
         }
       """
     } else {
@@ -254,8 +253,8 @@ case class Invoke(
 
     val code = s"""
       ${obj.code}
-      boolean ${ev.isNull} = ${obj.isNull};
       $evaluateArguments
+      boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
       $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${ev.isNull}) {
         $evaluate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -203,6 +203,16 @@ case class Invoke(
 
     val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
 
+    val evaluateArguments = if (arguments.nonEmpty) {
+      s"""
+        if (!${obj.isNull}) {
+          $argCode
+        }
+      """
+    } else {
+      ""
+    }
+
     val returnPrimitive = method.isDefined && method.get.getReturnType.isPrimitive
     val needTryCatch = method.isDefined && method.get.getExceptionTypes.nonEmpty
 
@@ -243,9 +253,7 @@ case class Invoke(
 
     val code = s"""
       ${obj.code}
-      if (!${obj.isNull}) {
-        $argCode
-      }
+      $evaluateArguments
       boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
       $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${ev.isNull}) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -76,19 +76,16 @@ trait InvokeLike {
       val reset = s"$containsNullInArguments = false;"
       val argCodes = arguments.zipWithIndex.map { case (e, i) =>
         val expr = e.genCode(ctx)
+        val updateContainsNull = if (e.nullable) {
+          s"$containsNullInArguments = ${expr.isNull};"
+        } else {
+          ""
+        }
         s"""
           if (!$containsNullInArguments) {
             ${expr.code}
-        """ +
-          (if (e.nullable) {
-            s"""
-              $containsNullInArguments = ${expr.isNull};
-              ${argValues(i)} = ${expr.value};
-            """
-          } else {
-            s"${argValues(i)} = ${expr.value};"
-          }) +
-        """
+            $updateContainsNull
+            ${argValues(i)} = ${expr.value};
           }
         """
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -322,7 +322,7 @@ case class NewInstance(
     val outer = outerPointer.map(func => Literal.fromObject(func()).genCode(ctx))
 
     var isNull = ev.isNull
-    val prepareIsNull = if (propagateNull && arguments.exists(_.nullable)) {
+    val prepareIsNull = if (propagatingNull) {
       s"boolean $isNull = false;"
     } else {
       isNull = "false"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -203,6 +203,17 @@ case class Invoke(
 
     val (argCode, argString, resultIsNull) = prepareArguments(ctx, ev)
 
+    val evaluateArguments = if (arguments.nonEmpty) {
+      s"""
+        if (!${ev.isNull}) {
+          $argCode
+          ${ev.isNull} = $resultIsNull;
+        }
+      """
+    } else {
+      ""
+    }
+
     val returnPrimitive = method.isDefined && method.get.getReturnType.isPrimitive
     val needTryCatch = method.isDefined && method.get.getExceptionTypes.nonEmpty
 
@@ -240,10 +251,11 @@ case class Invoke(
     } else {
       ""
     }
+
     val code = s"""
       ${obj.code}
-      $argCode
-      boolean ${ev.isNull} = ${obj.isNull} || $resultIsNull;
+      boolean ${ev.isNull} = ${obj.isNull};
+      $evaluateArguments
       $javaType ${ev.value} = ${ctx.defaultValue(dataType)};
       if (!${ev.isNull}) {
         $evaluate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -180,6 +180,8 @@ case class StaticInvoke(
  * @param functionName The name of the method to call.
  * @param dataType The expected return type of the function.
  * @param arguments An optional list of expressions, whos evaluation will be passed to the function.
+ * @param propagateNull When true, and any of the arguments is null, null will be returned instead
+ *                      of calling the function.
  */
 case class Invoke(
     targetObject: Expression,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr extracts method for preparing arguments from `StaticInvoke`, `Invoke` and `NewInstance` and modify to short circuit if arguments have `null` when `propageteNull == true`.

The steps are as follows:

1. Introduce `InvokeLike` to extract common logic from `StaticInvoke`, `Invoke` and `NewInstance` to prepare arguments.
`StaticInvoke` and `Invoke` had a risk to exceed 64kb JVM limit to prepare arguments but after this patch they can handle them because they share the preparing code of NewInstance, which handles the limit well.

2. Remove unneeded null checking and fix nullability of `NewInstance`.
Avoid some of nullabilty checking which are not needed because the expression is not nullable.

3. Modify to short circuit if arguments have `null` when `needNullCheck == true`.
If `needNullCheck == true`, preparing arguments can be skipped if we found one of them is `null`, so modified to short circuit in the case.

## How was this patch tested?

Existing tests.
