### PR TITLE
[SPARK-18487][SQL] Add completion listener to HashAggregate to avoid memory leak

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -234,12 +234,6 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
         row.writeToStream(out, buffer)
         count += 1
       }
-      // If iterator has more elements, we should consume them all. Otherwise under wholestage
-      // codegen, as we release resources after consuming all elements (e.g., HashAggregate), it
-      // will cause problems such as memory leak.
-      while (iter.hasNext) {
-        iter.next()
-      }
       out.writeInt(-1)
       out.flush()
       out.close()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -234,6 +234,12 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
         row.writeToStream(out, buffer)
         count += 1
       }
+      // If iterator has more elements, we should consume them all. Otherwise under wholestage
+      // codegen, as we release resources after consuming all elements (e.g., HashAggregate), it
+      // will cause problems such as memory leak.
+      while (iter.hasNext) {
+        iter.next()
+      }
       out.writeInt(-1)
       out.flush()
       out.close()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DataTypes, IntegerType, StringType, StructField, StructType}
 
 class DatasetSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -1050,6 +1050,20 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDataset(dsLong, arrayLong)
     checkDataset(dsDouble, arrayDouble)
     checkDataset(dsString, arrayString)
+  }
+
+  test("SPARK-18487: Consume all elements for show/take to avoid memory leak") {
+    val rng = new scala.util.Random(42)
+    val data = sparkContext.parallelize(Seq.tabulate(100) { i =>
+      Row(Array.fill(10)(rng.nextInt(10)))
+    })
+    val schema = StructType(Seq(
+      StructField("arr", DataTypes.createArrayType(DataTypes.IntegerType))
+    ))
+    val df = spark.createDataFrame(data, schema)
+    val exploded = df.select(struct(col("*")).as("star"), explode(col("arr")).as("a"))
+    val joined = exploded.join(exploded, "a").drop("a").distinct()
+    joined.show()
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1052,7 +1052,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDataset(dsString, arrayString)
   }
 
-  test("SPARK-18487: Consume all elements for show/take to avoid memory leak") {
+  test("SPARK-18487: Add completion listener to HashAggregate to avoid memory leak") {
     val rng = new scala.util.Random(42)
     val data = sparkContext.parallelize(Seq.tabulate(100) { i =>
       Row(Array.fill(10)(rng.nextInt(10)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

The methods such as Dataset.show and take use `Limit` (i.e., `CollectLimitExec`) which leverages SparkPlan.executeTake to efficiently collect required number of elements back to the driver.

However, under wholestage codege, we usually release resources after all elements are consumed (e.g., HashAggregate). In this case, we will not release the resources and cause memory leak with Dataset.show, for example.

An exception will be thrown in this case. This exception is thrown at `Executor` after it calls `taskMemoryManager.cleanUpAllAllocatedMemory` and finds there are memory not released after the task completion.

The exception looks like:

    [info] - SPARK-18487: Consume all elements for show/take to avoid memory leak *** FAILED *** (1 second, 73 milliseconds)
    [info]   org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 179.0 failed 1 times, most recent failure: Lost task 0.0 in stage 179.0 (TID 501, localhost, executor driver): org.apache.spark.SparkException: Managed memory leak detected; size = 33816576 bytes, TID = 501
    [info]  at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:295)
    [info]  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    [info]  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    [info]  at java.lang.Thread.run(Thread.java:745)
    [info] 
    [info] Driver stacktrace:
    [info]   at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$failJobAndIndependentS tages(DAGScheduler.scala:1436)
    [info]   at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1424)
    [info]   at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1423)
    [info]   at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
    [info]   at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
    [info]   at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:1423)
    [info]   at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:802)
    [info]   at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:802)
    [info]   at scala.Option.foreach(Option.scala:257)
    ...

This pr adds task completion listener to HashAggregate to avoid the memory leak.

## How was this patch tested?

Added test in DatasetSuite.

Please review https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark before opening a pull request.
