### PR TITLE
[SPARK-18488][CORE]: Update the value of "spark.ui.port" after application started in cluster mode.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2208,7 +2208,7 @@ class SparkContext(config: SparkConf) extends Logging {
   }
 
   /** Post the environment update event once the task scheduler is ready */
-  private def postEnvironmentUpdate() {
+  private[spark] def postEnvironmentUpdate() {
     if (taskScheduler != null) {
       val schedulingMode = getSchedulingMode.toString
       val addedJarPaths = addedJars.keys.toSeq

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -124,6 +124,15 @@ private[spark] class SparkUI private (
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {
     getApplicationInfoList.find(_.id == appId)
   }
+
+  override def updateUIPort(port: Int): Unit = {
+    if (sc.isDefined) {
+      val sparkContext = sc.get
+      val sparkConf = sparkContext.conf
+      sparkConf.set(SparkUI.SPARK_UI_PORT, port.toString)
+      sparkContext.postEnvironmentUpdate()
+    }
+  }
 }
 
 private[spark] abstract class SparkUITab(parent: SparkUI, prefix: String)
@@ -139,9 +148,10 @@ private[spark] object SparkUI {
   val DEFAULT_POOL_NAME = "default"
   val DEFAULT_RETAINED_STAGES = 1000
   val DEFAULT_RETAINED_JOBS = 1000
+  val SPARK_UI_PORT = "spark.ui.port"
 
   def getUIPort(conf: SparkConf): Int = {
-    conf.getInt("spark.ui.port", SparkUI.DEFAULT_PORT)
+    conf.getInt(SparkUI.SPARK_UI_PORT, SparkUI.DEFAULT_PORT)
   }
 
   def createLiveUI(

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -138,6 +138,7 @@ private[spark] abstract class WebUI(
     try {
       val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
       serverInfo = Some(startJettyServer(host, port, sslOptions, handlers, conf, name))
+      updateUIPort(boundPort)
       logInfo(s"Bound $className to $host, and started at $webUrl")
     } catch {
       case e: Exception =>
@@ -161,6 +162,8 @@ private[spark] abstract class WebUI(
       s"Attempted to stop $className before binding to a server!")
     serverInfo.get.stop()
   }
+
+  protected def updateUIPort(boundPort: Int): Unit = {}
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In cluster mode, the "spark.ui.port" is initialized with 0, but not the real bound port.


after PR:

![image](https://cloud.githubusercontent.com/assets/7402327/20386405/71b7076c-acf6-11e6-82b5-be4c5584b419.png)


## How was this patch tested?
