### PR TITLE
[SPARK-18493] Add missing python APIs: withWatermark and checkpoint to dataframe

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1692,7 +1692,6 @@ def _test():
     globs['sdf'] = sc.parallelize([Row(name='Tom', timestamp=1479441846),
                                    Row(name='Bob', timestamp=1479442946)]).toDF() \
         .select('name', from_unixtime('timestamp').alias('timestamp'))
-                
 
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.dataframe, globs=globs,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -361,6 +361,10 @@ class DataFrame(object):
 
         >>> df.withWatermark(df('timestamp'), '10 minutes')
         """
+        if not eventTime or type(eventTime) is not str:
+            raise TypeError("eventTime should be provided as a string")
+        if not delayThreshold or type(delayThreshold) is not str:
+            raise TypeError("delayThreshold should be provided as a string interval")
         jdf = self._jdf.withWatermark(eventTime, delayThreshold)
         return DataFrame(jdf, self.sql_ctx)
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -360,7 +360,7 @@ class DataFrame(object):
 
         .. note:: Experimental
 
-        >>> df.withWatermark('timestamp', '10 minutes')
+        >>> sdf.withWatermark('timestamp', '10 minutes')
         """
         if not eventTime or type(eventTime) is not str:
             raise TypeError("eventTime should be provided as a string")
@@ -1685,9 +1685,11 @@ def _test():
     globs['df3'] = sc.parallelize([Row(name='Alice', age=2),
                                    Row(name='Bob', age=5)]).toDF()
     globs['df4'] = sc.parallelize([Row(name='Alice', age=10, height=80),
-                                  Row(name='Bob', age=5, height=None),
-                                  Row(name='Tom', age=None, height=None),
-                                  Row(name=None, age=None, height=None)]).toDF()
+                                   Row(name='Bob', age=5, height=None),
+                                   Row(name='Tom', age=None, height=None),
+                                   Row(name=None, age=None, height=None)]).toDF()
+    globs['sdf'] = sc.parallelize([Row(name='Tom', timestamp=1479441846),
+                                   Row(name='Bob', timestamp=1479442946)]).toDF()
 
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.dataframe, globs=globs,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -361,6 +361,7 @@ class DataFrame(object):
         .. note:: Experimental
 
         >>> sdf.select('name', sdf.time.cast('timestamp')).withWatermark('time', '10 minutes')
+        DataFrame[name: string, time: timestamp]
         """
         if not eventTime or type(eventTime) is not str:
             raise TypeError("eventTime should be provided as a string")

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -360,7 +360,7 @@ class DataFrame(object):
 
         .. note:: Experimental
 
-        >>> df.withWatermark(df('timestamp'), '10 minutes')
+        >>> df.withWatermark(df.timestamp, '10 minutes')
         """
         if not eventTime or type(eventTime) is not str:
             raise TypeError("eventTime should be provided as a string")

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1673,6 +1673,7 @@ def _test():
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext, SparkSession
     import pyspark.sql.dataframe
+    from pyspark.sql.functions import from_unixtime
     globs = pyspark.sql.dataframe.__dict__.copy()
     sc = SparkContext('local[4]', 'PythonTest')
     globs['sc'] = sc
@@ -1689,7 +1690,9 @@ def _test():
                                    Row(name='Tom', age=None, height=None),
                                    Row(name=None, age=None, height=None)]).toDF()
     globs['sdf'] = sc.parallelize([Row(name='Tom', timestamp=1479441846),
-                                   Row(name='Bob', timestamp=1479442946)]).toDF()
+                                   Row(name='Bob', timestamp=1479442946)]).toDF().select('name',
+                                                                                         from_unixtime('timestamp'))
+                
 
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.dataframe, globs=globs,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -343,7 +343,8 @@ class DataFrame(object):
 
         Spark will use this watermark for several purposes:
           - To know when a given time window aggregation can be finalized and thus can be emitted
-           when using output modes that do not allow updates.
+            when using output modes that do not allow updates.
+
           - To minimize the amount of state that we need to keep for on-going aggregations.
 
         The current watermark is computed by looking at the `MAX(eventTime)` seen across

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -326,7 +326,7 @@ class DataFrame(object):
     def checkpoint(self, eager=True):
         """Returns a checkpointed version of this Dataset. Checkpointing can be used to truncate the
         logical plan of this DataFrame, which is especially useful in iterative algorithms where the
-        plan may grow exponentially. It will be saved to a file inside the checkpoint
+        plan may grow exponentially. It will be saved to files inside the checkpoint
         directory set with L{SparkContext.setCheckpointDir()}.
 
         :param eager: Whether to checkpoint this DataFrame immediately
@@ -360,7 +360,7 @@ class DataFrame(object):
 
         .. note:: Experimental
 
-        >>> sdf.withWatermark('timestamp', '10 minutes')
+        >>> sdf.select('name', sdf.time.cast('timestamp')).withWatermark('time', '10 minutes')
         """
         if not eventTime or type(eventTime) is not str:
             raise TypeError("eventTime should be provided as a string")
@@ -1689,9 +1689,8 @@ def _test():
                                    Row(name='Bob', age=5, height=None),
                                    Row(name='Tom', age=None, height=None),
                                    Row(name=None, age=None, height=None)]).toDF()
-    globs['sdf'] = sc.parallelize([Row(name='Tom', timestamp=1479441846),
-                                   Row(name='Bob', timestamp=1479442946)]).toDF() \
-        .select('name', from_unixtime('timestamp').alias('timestamp'))
+    globs['sdf'] = sc.parallelize([Row(name='Tom', time=1479441846),
+                                   Row(name='Bob', time=1479442946)]).toDF()
 
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.dataframe, globs=globs,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1690,8 +1690,8 @@ def _test():
                                    Row(name='Tom', age=None, height=None),
                                    Row(name=None, age=None, height=None)]).toDF()
     globs['sdf'] = sc.parallelize([Row(name='Tom', timestamp=1479441846),
-                                   Row(name='Bob', timestamp=1479442946)]).toDF().select('name',
-                                                                                         from_unixtime('timestamp'))
+                                   Row(name='Bob', timestamp=1479442946)]).toDF() \
+        .select('name', from_unixtime('timestamp').alias('timestamp'))
                 
 
     (failure_count, test_count) = doctest.testmod(

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -360,7 +360,7 @@ class DataFrame(object):
 
         .. note:: Experimental
 
-        >>> df.withWatermark(df.timestamp, '10 minutes')
+        >>> df.withWatermark('timestamp', '10 minutes')
         """
         if not eventTime or type(eventTime) is not str:
             raise TypeError("eventTime should be provided as a string")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -487,7 +487,7 @@ class Dataset[T] private[sql](
   /**
    * Eagerly checkpoint a Dataset and return the new Dataset. Checkpointing can be used to truncate
    * the logical plan of this Dataset, which is especially useful in iterative algorithms where the
-   * plan may grow exponentially. It will be saved to a file inside the checkpoint
+   * plan may grow exponentially. It will be saved to files inside the checkpoint
    * directory set with `SparkContext#setCheckpointDir`.
    *
    * @group basic
@@ -500,7 +500,7 @@ class Dataset[T] private[sql](
   /**
    * Returns a checkpointed version of this Dataset. Checkpointing can be used to truncate the
    * logical plan of this Dataset, which is especially useful in iterative algorithms where the
-   * plan may grow exponentially. It will be saved to a file inside the checkpoint
+   * plan may grow exponentially. It will be saved to files inside the checkpoint
    * directory set with `SparkContext#setCheckpointDir`.
    *
    * @group basic

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -485,7 +485,10 @@ class Dataset[T] private[sql](
   def isStreaming: Boolean = logicalPlan.isStreaming
 
   /**
-   * Returns a checkpointed version of this Dataset.
+   * Eagerly checkpoint a Dataset and return the new Dataset. Checkpointing can be used to truncate
+   * the logical plan of this Dataset, which is especially useful in iterative algorithms where the
+   * plan may grow exponentially. It will be saved to a file inside the checkpoint
+   * directory set with `SparkContext#setCheckpointDir`.
    *
    * @group basic
    * @since 2.1.0
@@ -495,7 +498,10 @@ class Dataset[T] private[sql](
   def checkpoint(): Dataset[T] = checkpoint(eager = true)
 
   /**
-   * Returns a checkpointed version of this Dataset.
+   * Returns a checkpointed version of this Dataset. Checkpointing can be used to truncate the
+   * logical plan of this Dataset, which is especially useful in iterative algorithms where the
+   * plan may grow exponentially. It will be saved to a file inside the checkpoint
+   * directory set with `SparkContext#setCheckpointDir`.
    *
    * @group basic
    * @since 2.1.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds two of the newly added methods of `Dataset`s to Python:
`withWatermark` and `checkpoint`

## How was this patch tested?

Doc tests