### PR TITLE
[SPARK-18436][SQL]isin with a empty list throw exception

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -119,6 +119,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate
     with ImplicitCastInputTypes {
 
   require(list != null, "list should not be null")
+  require(list.nonEmpty, "list should not be empty")
 
   override def inputTypes: Seq[AbstractDataType] = value.dataType +: list.map(_.dataType)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
   when the list of `isin` is empty, the compileFilter will generate the sql string  using `IN()` .
And then connect to execute on sqlserver, it will throw exception:
```
Caused by: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '))' at line 1
```
It is a illeagal grammer for mysql.

   And execute `spark.sql("select * from test where key in()")`, the grammer is also illeagal and throw Exception:

```
mismatched input 'from' expecting {<EOF>, 'WHERE', 'GROUP', 'ORDER', 'HAVING', 'LIMIT', 'LATERAL', 'WINDOW', 'UNION', 'EXCEPT', 'MINUS', 'INTERSECT', 'SORT', 'CLUSTER', 'DISTRIBUTE'}(line 1, pos 9)

== SQL ==
select * from test where key in()
---------^^^

  at org.apache.spark.sql.catalyst.parser.ParseException.withCommand(ParseDriver.scala:197)
  at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parse(ParseDriver.scala:99)
```
   
   In this PR, add a list empty check in `case class In(value: Expression, list: Seq[Expression])`, so it can unify the action of the spark.sql() and the isin

## How was this patch tested?

**before**
>\>val filter = Array\[String\]()
>\>val jdbcDF = spark.read.format("jdbc").option("url", "jdbc:mysql://xxx").option("dbtable", "testdb.table").option("user", "xxx").option("password", "xxxx").option("driver","com.mysql.jdbc.Driver").load().filter($"id".isin(filter:_*))
```
16/11/18 09:31:25 ERROR executor.Executor: Exception in task 0.0 in stage 0.0 (TID 0)
com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '))' at line 1
```
**after**
>\>val filter = Array\[String\]()
>\>val jdbcDF = spark.read.format("jdbc").option("url", "jdbc:mysql://xxx").option("dbtable", "testdb.table").option("user", "xxx").option("password", "xxxx").option("driver","com.mysql.jdbc.Driver").load().filter($"id".isin(filter:_*))
```
java.lang.IllegalArgumentException: requirement failed: list should not be empty
  at scala.Predef$.require(Predef.scala:224)
  at org.apache.spark.sql.catalyst.expressions.In.<init>(predicates.scala:122)
  at org.apache.spark.sql.Column.isin(Column.scala:778)
  ... 48 elided
```

> \>spark.sql("select * from src where key in()")
```
org.apache.spark.sql.catalyst.parser.ParseException:
mismatched input 'from' expecting {<EOF>, 'WHERE', 'GROUP', 'ORDER', 'HAVING', 'LIMIT', 'LATERAL', 'WINDOW', 'UNION', 'EXCEPT', 'MINUS', 'INTERSECT', 'SORT', 'CLUSTER', 'DISTRIBUTE'}(line 1, pos 9)

== SQL ==
select * from src where key in()
---------^^^

  at org.apache.spark.sql.catalyst.parser.ParseException.withCommand(ParseDriver.scala:197)
  at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parse(ParseDriver.scala:99)
  at org.apache.spark.sql.execution.SparkSqlParser.parse(SparkSqlParser.scala:45)
  at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parsePlan(ParseDriver.scala:53)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:590)
  ... 48 elided
```
