### PR TITLE
[SPARK-18500][SQL] Make GenericStrategy be able to prune plans by itself after placeholders are replaced.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/QueryPlanner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/QueryPlanner.scala
@@ -49,9 +49,6 @@ abstract class GenericStrategy[PhysicalPlan <: TreeNode[PhysicalPlan]] extends L
  * of the remaining operators in the tree, it can call [[planLater]], which returns a placeholder
  * object that will be filled in using other available strategies.
  *
- * TODO: RIGHT NOW ONLY ONE PLAN IS RETURNED EVER...
- *       PLAN SPACE EXPLORATION WILL BE IMPLEMENTED LATER.
- *
  * @tparam PhysicalPlan The type of physical plan produced by this [[QueryPlanner]]
  */
 abstract class QueryPlanner[PhysicalPlan <: TreeNode[PhysicalPlan]] {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/QueryPlanner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/QueryPlanner.scala
@@ -35,6 +35,9 @@ abstract class GenericStrategy[PhysicalPlan <: TreeNode[PhysicalPlan]] extends L
    */
   protected def planLater(plan: LogicalPlan): PhysicalPlan
 
+  /** Prunes bad plans to prevent combinatorial explosion. */
+  def prunePlans(plans: Iterator[PhysicalPlan]): Iterator[PhysicalPlan] = plans
+
   def apply(plan: LogicalPlan): Seq[PhysicalPlan]
 }
 
@@ -58,34 +61,39 @@ abstract class QueryPlanner[PhysicalPlan <: TreeNode[PhysicalPlan]] {
   def plan(plan: LogicalPlan): Iterator[PhysicalPlan] = {
     // Obviously a lot to do here still...
 
-    // Collect physical plan candidates.
-    val candidates = strategies.iterator.flatMap(_(plan))
+    val plans = strategies.iterator.flatMap { strategy =>
+      // Collect physical plan candidates.
+      val candidates = strategy(plan)
 
-    // The candidates may contain placeholders marked as [[planLater]],
-    // so try to replace them by their child plans.
-    val plans = candidates.flatMap { candidate =>
-      val placeholders = collectPlaceholders(candidate)
+      // The candidates may contain placeholders marked as [[planLater]],
+      // so try to replace them by their child plans.
+      val plans = candidates.iterator.flatMap { candidate =>
+        val placeholders = collectPlaceholders(candidate)
 
-      if (placeholders.isEmpty) {
-        // Take the candidate as is because it does not contain placeholders.
-        Iterator(candidate)
-      } else {
-        // Plan the logical plan marked as [[planLater]] and replace the placeholders.
-        placeholders.iterator.foldLeft(Iterator(candidate)) {
-          case (candidatesWithPlaceholders, (placeholder, logicalPlan)) =>
-            // Plan the logical plan for the placeholder.
-            val childPlans = this.plan(logicalPlan)
+        if (placeholders.isEmpty) {
+          // Take the candidate as is because it does not contain placeholders.
+          Iterator(candidate)
+        } else {
+          // Plan the logical plan marked as [[planLater]] and replace the placeholders.
+          placeholders.iterator.foldLeft(Iterator(candidate)) {
+            case (candidatesWithPlaceholders, (placeholder, logicalPlan)) =>
+              // Plan the logical plan for the placeholder.
+              val childPlans = this.plan(logicalPlan)
 
-            candidatesWithPlaceholders.flatMap { candidateWithPlaceholders =>
-              childPlans.map { childPlan =>
-                // Replace the placeholder by the child plan
-                candidateWithPlaceholders.transformUp {
-                  case p if p == placeholder => childPlan
+              candidatesWithPlaceholders.flatMap { candidateWithPlaceholders =>
+                childPlans.map { childPlan =>
+                  // Replace the placeholder by the child plan
+                  candidateWithPlaceholders.transformUp {
+                    case p if p == placeholder => childPlan
+                  }
                 }
               }
-            }
+          }
         }
       }
+
+      // Prune bad plans by the strategy itself after the placeholders are replaced.
+      strategy.prunePlans(plans)
     }
 
     val pruned = prunePlans(plans)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlannerSuite.scala
@@ -51,6 +51,7 @@ class SparkPlannerSuite extends SharedSQLContext {
       }
     }
 
+    val original = spark.experimental.extraStrategies
     try {
       spark.experimental.extraStrategies = TestStrategy :: Nil
 
@@ -59,7 +60,7 @@ class SparkPlannerSuite extends SharedSQLContext {
       assert(ds.collect().toSeq === Seq("a", "b", "c", "d", "e", "f"))
       assert(planned === 4)
     } finally {
-      spark.experimental.extraStrategies = Nil
+      spark.experimental.extraStrategies = original
     }
   }
 
@@ -93,6 +94,7 @@ class SparkPlannerSuite extends SharedSQLContext {
       }
     }
 
+    val original = spark.experimental.extraStrategies
     try {
       spark.experimental.extraStrategies = TestStrategy :: Nil
 
@@ -101,7 +103,7 @@ class SparkPlannerSuite extends SharedSQLContext {
       assert(ds.collect().toSeq === Seq("a", "b", "c", "d", "e", "f"))
       assert(planned === 4)
     } finally {
-      spark.experimental.extraStrategies = Nil
+      spark.experimental.extraStrategies = original
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds a functionality to `GenericStrategy` to be able to prune bad physical plans by itself after their placeholders are replaced.

## How was this patch tested?

Added a test to check if the strategy can prune plans by itself.