### PR TITLE
[SPARK-18471][MLLIB] In LBFGS, avoid sending huge vectors of 0

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -241,16 +241,28 @@ object LBFGS extends Logging {
       val bcW = data.context.broadcast(w)
       val localGradient = gradient
 
-      val (gradientSum, lossSum) = data.treeAggregate((Vectors.zeros(n), 0.0))(
-          seqOp = (c, v) => (c, v) match { case ((grad, loss), (label, features)) =>
-            val l = localGradient.compute(
-              features, label, bcW.value, grad)
-            (grad, loss + l)
-          },
-          combOp = (c1, c2) => (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>
-            axpy(1.0, grad2, grad1)
-            (grad1, loss1 + loss2)
-          })
+      /** Given (current accumulated gradient, current loss) and (label, features)
+       * tuples, updates the current gradient and current loss
+       */
+      val seqOp = (c: (Vector, Double), v: (Double, Vector)) => {
+            (c, v) match { case ((grad, loss), (label, features)) =>
+                val l = localGradient.compute(features, label, bcW.value, grad)
+                (grad, loss + l)
+            }
+      }
+
+      // Adds two (gradient, loss) tuples
+      val combOp = (c1: (Vector, Double), c2: (Vector, Double)) => {
+            (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>
+                axpy(1.0, grad2, grad1)
+                (grad1, loss1 + loss2)
+           }
+      }
+
+      val (gradientSum, lossSum) = data.mapPartitions(it => {
+        val inPartitionAggregated = it.aggregate((Vectors.zeros(n), 0.0))(seqOp, combOp)
+        Iterator(inPartitionAggregated)
+      }).treeReduce(combOp)
 
       /**
        * regVal is sum of weight squares if it's L2 updater;

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -244,25 +244,24 @@ object LBFGS extends Logging {
       /** Given (current accumulated gradient, current loss) and (label, features)
        * tuples, updates the current gradient and current loss
        */
-      val seqOp = (c: (Vector, Double), v: (Double, Vector)) => {
-            (c, v) match { case ((grad, loss), (label, features)) =>
-                val l = localGradient.compute(features, label, bcW.value, grad)
-                (grad, loss + l)
-            }
-      }
+      val seqOp = (c: (Vector, Double), v: (Double, Vector)) =>
+        (c, v) match {
+          case ((grad, loss), (label, features)) =>
+            val l = localGradient.compute(features, label, bcW.value, grad)
+            (grad, loss + l)
+        }
 
       // Adds two (gradient, loss) tuples
-      val combOp = (c1: (Vector, Double), c2: (Vector, Double)) => {
-            (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>
-                axpy(1.0, grad2, grad1)
-                (grad1, loss1 + loss2)
-           }
-      }
+      val combOp = (c1: (Vector, Double), c2: (Vector, Double)) =>
+        (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>
+            axpy(1.0, grad2, grad1)
+            (grad1, loss1 + loss2)
+       }
 
-      val (gradientSum, lossSum) = data.mapPartitions(it => {
+      val (gradientSum, lossSum) = data.mapPartitions { it => {
         val inPartitionAggregated = it.aggregate((Vectors.zeros(n), 0.0))(seqOp, combOp)
         Iterator(inPartitionAggregated)
-      }).treeReduce(combOp)
+      }}.treeReduce(combOp)
 
       /**
        * regVal is sum of weight squares if it's L2 updater;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The zero for the aggregation used to be shipped into a closure which is
higly problematic when this zero is big (100s of MB is typical for ML).
This change introduces a new overload of treeAggregate which only ships a
function able to generate this zero.

NB This review takes into account preliminary feedback from https://github.com/apache/spark/pull/15905

## How was this patch tested?

Unit tests for core module launched locally

## Licensing

This contribution is made on behalf of CRITEO (http://labs.criteo.com/) under the terms of the Apache 2.0 license.