### PR TITLE
[SPARK-18447][BUILD][DOCS]Fix `Note:`/`NOTE:`/`Note that` across Pyth…

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -106,7 +106,7 @@ private[python] class WritableToJavaConverter(
 }
 
 /**
- * A converter that converts common types to [[org.apache.hadoop.io.Writable]]. Note that array
+ * A converter that converts common types to [[org.apache.hadoop.io.Writable]]. @note Array
  * types are not supported since the user needs to subclass [[org.apache.hadoop.io.ArrayWritable]]
  * to set the type properly. See [[org.apache.spark.api.python.DoubleArrayWritable]] and
  * [[org.apache.spark.api.python.DoubleArrayToWritableConverter]] for an example. They are used in
@@ -115,7 +115,7 @@ private[python] class WritableToJavaConverter(
 private[python] class JavaToWritableConverter extends Converter[Any, Writable] {
 
   /**
-   * Converts common data types to [[org.apache.hadoop.io.Writable]]. Note that array types are not
+   * Converts common data types to [[org.apache.hadoop.io.Writable]]. @note Array types are not
    * supported out-of-the-box.
    */
   private def convertToWritable(obj: Any): Writable = {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -760,7 +760,7 @@ private[spark] object PythonRDD extends Logging {
 
   /**
    * Output a Python RDD of key-value pairs as a Hadoop SequenceFile using the Writable types
-   * we convert from the RDD's key and value types. Note that keys and values can't be
+   * we convert from the RDD's key and value types. @note Keys and values can't be
    * [[org.apache.hadoop.io.Writable]] types already, since Writables are not Java
    * `Serializable` and we can't peek at them. The `path` can be on any Hadoop file system.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

It seems that just like in Scala/Java there is inconsistency in the Python API too at some places,

Note:
NOTE:
Note that
'''Note:'''
@note
This PR proposes to fix those to @note to be consistent.

## How was this patch tested?

This was tested by searching in the editor for versions of "NOTE" in the python APIs and then fixing them to become consistence.

This PR is a sub-extension of #15889 