### PR TITLE
[SPARK-18407] Inferred partition columns cause assertion error in StructuredStreaming

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -45,7 +45,7 @@ class FileStreamSource(
 
   private val qualifiedBasePath: Path = {
     val fs = new Path(path).getFileSystem(sparkSession.sessionState.newHadoopConf())
-    fs.makeQualified(new Path(path))  // can contains glob patterns
+    fs.makeQualified(new Path(path))  // can contain glob patterns
   }
 
   private val optionsWithPartitionBasePath = sourceOptions.optionMapWithoutPath ++ {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -440,7 +440,6 @@ class StreamExecution(
           LocalRelation(output)
         }
     }
-    println(replacements)
     // Rewire the plan to use the new attributes that were returned by the source.
     val replacementMap = AttributeMap(replacements)
     val triggerLogicalPlan = withNewSources transformAllExpressions {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -440,7 +440,7 @@ class StreamExecution(
           LocalRelation(output)
         }
     }
-
+    println(replacements)
     // Rewire the plan to use the new attributes that were returned by the source.
     val replacementMap = AttributeMap(replacements)
     val triggerLogicalPlan = withNewSources transformAllExpressions {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -411,7 +411,9 @@ class StreamExecution(
           val newPlanOutput = newPlan.output
           output.foreach { out =>
             val outputInNewPlan = newPlanOutput.find { newPlanOut =>
-              out.name == newPlanOut.name && out.dataType == newPlanOut.dataType
+              out.name.toLowerCase == newPlanOut.name.toLowerCase &&
+                // the line below means that we don't support schema evolution for now
+                out.dataType == newPlanOut.dataType
             }.getOrElse {
               throw new AnalysisException(
                 s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1017,7 +1017,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         .mode("overwrite")
         .parquet(src.toString)
       val sdf = spark.readStream
-        .schema(StructType(Seq(StructField("id", LongType)))) // omit 'part'
+        .schema(StructType(Seq(StructField("ID", LongType)))) // omit 'part' also change case
         .format("parquet")
         .load(src.toString)
       try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1017,7 +1017,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         .mode("overwrite")
         .parquet(src.toString)
       val sdf = spark.readStream
-        .schema(StructType(Seq(StructField("ID", LongType)))) // omit 'part' also change case
+        .schema(StructType(Seq(StructField("id", LongType)))) // omit 'part'
         .format("parquet")
         .load(src.toString)
       try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1009,6 +1009,33 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     val options = new FileStreamOptions(Map("maxfilespertrigger" -> "1"))
     assert(options.maxFilesPerTrigger == Some(1))
   }
+
+  test("SPARK-18407: Prune inferred partition columns from execution if not specified in schema") {
+    withTempDirs { case (src, tmp) =>
+      spark.range(4).select('id, 'id % 4 as 'part).coalesce(1).write
+        .partitionBy("part")
+        .mode("overwrite")
+        .parquet(src.toString)
+      val sdf = spark.readStream
+        .schema(StructType(Seq(StructField("id", LongType)))) // omit 'part'
+        .format("parquet")
+        .load(src.toString)
+      try {
+        val sq = sdf.writeStream
+          .queryName("assertion_test")
+          .format("memory")
+          .start()
+        // used to throw an assertion error
+        sq.processAllAvailable()
+        checkAnswer(
+          spark.table("assertion_test"),
+          Row(0) :: Row(1) :: Row(2) :: Row(3) :: Nil
+        )
+      } finally {
+        spark.streams.active.foreach(_.stop())
+      }
+    }
+  }
 }
 
 class FileStreamSourceStressTestSuite extends FileStreamSourceTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?

It turns out we are a bit enthusiastic when providing users partition columns when they read the data even if they didn't specify it in their schema. This causes an assertion error in Streaming jobs, because the `Attribute`s of a given trigger don't match the `Attribute`s returned by the DataSource. The DataSource returns additional partition columns all the time.

While this is weird behavior for batch as well IMHO, because someone asked for a specific schema, but we returned them something else, apparently this behavior existed since Spark 1.6. I didn't try older versions. Anyway, I tried fixing this by not enforcing a strict size check, but by picking out the columns that we want from the batch DataSource.

## How was this patch tested?

Regression test