### PR TITLE
[SPARK-17062][MESOS] Fix 2.10 compilation

### DIFF
--- a/mesos/src/test/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcherArgumentsSuite.scala
+++ b/mesos/src/test/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcherArgumentsSuite.scala
@@ -55,7 +55,7 @@ class MesosClusterDispatcherArgumentsSuite extends SparkFunSuite
     assert(Option(mesosDispClusterArgs.masterUrl).isDefined)
     assert(mesosDispClusterArgs.masterUrl == masterUrl.stripPrefix("mesos://"))
     assert(Option(mesosDispClusterArgs.zookeeperUrl).isDefined)
-    assert(mesosDispClusterArgs.zookeeperUrl contains zookeeperUrl)
+    assert(mesosDispClusterArgs.zookeeperUrl == Some(zookeeperUrl))
     assert(mesosDispClusterArgs.name == name)
     assert(mesosDispClusterArgs.webUiPort == webUiPort.toInt)
     assert(mesosDispClusterArgs.port == port.toInt)


### PR DESCRIPTION
https://github.com/apache/spark/commit/ea77c81ec0db27ea4709f71dc080d00167505a7d breaks scala 2.10 compilation. This PR fixes yet another `Option.contains` related compilation error.
