### PR TITLE
[SPARK-18434][ML][FOLLOWUP] Add checking for setSolver in GLM

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -227,11 +227,11 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    */
   @Since("2.0.0")
   def setSolver(value: String): this.type = {
-    require("irls" == value,
-      s"Solver $value was not supported. Supported options: irls")
+    require(supportedSolvers.contains(value),
+      s"Solver $value was not supported. Supported options: ${supportedSolvers.mkString(", ")}")
     set(solver, value)
   }
-  setDefault(solver -> "irls")
+  setDefault(solver -> IRLS)
 
   /**
    * Sets the link prediction (linear predictor) column name.
@@ -300,6 +300,13 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
   @Since("2.0.0")
   override def load(path: String): GeneralizedLinearRegression = super.load(path)
+
+  /** String name for "irls" solver. */
+  private[regression] val IRLS = "irls"
+
+  /** Set of solvers that GeneralizedLinearRegression supports. */
+  private[regression] val supportedSolvers = Array(IRLS)
+
 
   /** Set of family and link pairs that GeneralizedLinearRegression supports. */
   private[regression] lazy val supportedFamilyAndLinkPairs = Set(

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -226,7 +226,11 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * @group setParam
    */
   @Since("2.0.0")
-  def setSolver(value: String): this.type = set(solver, value)
+  def setSolver(value: String): this.type = {
+    require("irls" == value,
+      s"Solver $value was not supported. Supported options: irls")
+    set(solver, value)
+  }
   setDefault(solver -> "irls")
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -77,6 +77,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   extends Regressor[Vector, LinearRegression, LinearRegressionModel]
   with LinearRegressionParams with DefaultParamsWritable with Logging {
 
+  import LinearRegression._
+
   @Since("1.4.0")
   def this() = this(Identifiable.randomUID("linReg"))
 
@@ -174,11 +176,11 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    */
   @Since("1.6.0")
   def setSolver(value: String): this.type = {
-    require(Set("auto", "l-bfgs", "normal").contains(value),
-      s"Solver $value was not supported. Supported options: auto, l-bfgs, normal")
+    require(supportedSolvers.contains(value),
+      s"Solver $value was not supported. Supported options: ${supportedSolvers.mkString(", ")}")
     set(solver, value)
   }
-  setDefault(solver -> "auto")
+  setDefault(solver -> AUTO)
 
   /**
    * Suggested depth for treeAggregate (>= 2).
@@ -203,8 +205,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
         Instance(label, weight, features)
     }
 
-    if (($(solver) == "auto" &&
-      numFeatures <= WeightedLeastSquares.MAX_NUM_FEATURES) || $(solver) == "normal") {
+    if (($(solver) == AUTO &&
+      numFeatures <= WeightedLeastSquares.MAX_NUM_FEATURES) || $(solver) == NORMAL) {
       // For low dimensional data, WeightedLeastSquares is more efficient since the
       // training algorithm only requires one pass through the data. (SPARK-10668)
 
@@ -409,6 +411,18 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
 
 @Since("1.6.0")
 object LinearRegression extends DefaultParamsReadable[LinearRegression] {
+
+  /** String name for "auto" solver. */
+  private[regression] val AUTO = "auto"
+
+  /** String name for "l-bfgs" solver. */
+  private[regression] val LBFGS = "l-bfgs"
+
+  /** String name for "normal" solver. */
+  private[regression] val NORMAL = "normal"
+
+  /** Set of solvers that LinearRegression supports. */
+  private[regression] val supportedSolvers = Array(AUTO, LBFGS, NORMAL)
 
   @Since("1.6.0")
   override def load(path: String): LinearRegression = super.load(path)


### PR DESCRIPTION
## What changes were proposed in this pull request?
add checking in GLM.setSolver to forbidden unsupported solvers:
`val glm = new GeneralizedLinearRegression().setSolver("123")`

## How was this patch tested?
existing tests

cc @yanboliang 