### PR TITLE
[SPARK-18519][SQL] map type can not be used in EqualTo

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -183,21 +183,6 @@ trait CheckAnalysis extends PredicateHelper {
               s"join condition '${condition.sql}' " +
                 s"of type ${condition.dataType.simpleString} is not a boolean.")
 
-          case j @ Join(_, _, _, Some(condition)) =>
-            def checkValidJoinConditionExprs(expr: Expression): Unit = expr match {
-              case p: Predicate =>
-                p.asInstanceOf[Expression].children.foreach(checkValidJoinConditionExprs)
-              case e if e.dataType.isInstanceOf[BinaryType] =>
-                failAnalysis(s"binary type expression ${e.sql} cannot be used " +
-                  "in join conditions")
-              case e if e.dataType.isInstanceOf[MapType] =>
-                failAnalysis(s"map type expression ${e.sql} cannot be used " +
-                  "in join conditions")
-              case _ => // OK
-            }
-
-            checkValidJoinConditionExprs(condition)
-
           case Aggregate(groupingExprs, aggregateExprs, child) =>
             def checkValidAggregateExpression(expr: Expression): Unit = expr match {
               case aggExpr: AggregateExpression =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -412,6 +412,29 @@ case class EqualTo(left: Expression, right: Expression)
 
   override def inputType: AbstractDataType = AnyDataType
 
+  override def checkInputDataTypes(): TypeCheckResult = {
+    super.checkInputDataTypes() match {
+      case TypeCheckResult.TypeCheckSuccess =>
+        // TODO: although map type is not orderable, technically map type should be able to be used
+        // in equality comparison, remove this type check once we support it.
+        if (hasMapType(left.dataType)) {
+          TypeCheckResult.TypeCheckFailure("Cannot use map type in EqualTo, but the actual " +
+            s"input type is ${left.dataType.catalogString}.")
+        } else {
+          TypeCheckResult.TypeCheckSuccess
+        }
+      case failure => failure
+    }
+  }
+
+  private def hasMapType(dt: DataType): Boolean = dt match {
+    case _: MapType => true
+    case st: StructType => st.map(_.dataType).exists(hasMapType)
+    case a: ArrayType => hasMapType(a.elementType)
+    case udt: UserDefinedType[_] => hasMapType(udt.sqlType)
+    case _ => false
+  }
+
   override def symbol: String = "="
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = {
@@ -439,6 +462,29 @@ case class EqualTo(left: Expression, right: Expression)
 case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComparison {
 
   override def inputType: AbstractDataType = AnyDataType
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    super.checkInputDataTypes() match {
+      case TypeCheckResult.TypeCheckSuccess =>
+        // TODO: although map type is not orderable, technically map type should be able to be used
+        // in equality comparison, remove this type check once we support it.
+        if (hasMapType(left.dataType)) {
+          TypeCheckResult.TypeCheckFailure("Cannot use map type in EqualNullSafe, but the actual " +
+            s"input type is ${left.dataType.catalogString}.")
+        } else {
+          TypeCheckResult.TypeCheckSuccess
+        }
+      case failure => failure
+    }
+  }
+
+  private def hasMapType(dt: DataType): Boolean = dt match {
+    case _: MapType => true
+    case st: StructType => st.map(_.dataType).exists(hasMapType)
+    case a: ArrayType => hasMapType(a.elementType)
+    case udt: UserDefinedType[_] => hasMapType(udt.sqlType)
+    case _ => false
+  }
 
   override def symbol: String = "<=>"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -417,7 +417,7 @@ case class EqualTo(left: Expression, right: Expression)
       case TypeCheckResult.TypeCheckSuccess =>
         // TODO: although map type is not orderable, technically map type should be able to be used
         // in equality comparison, remove this type check once we support it.
-        if (hasMapType(left.dataType)) {
+        if (left.dataType.existsRecursively(_.isInstanceOf[MapType])) {
           TypeCheckResult.TypeCheckFailure("Cannot use map type in EqualTo, but the actual " +
             s"input type is ${left.dataType.catalogString}.")
         } else {
@@ -425,14 +425,6 @@ case class EqualTo(left: Expression, right: Expression)
         }
       case failure => failure
     }
-  }
-
-  private def hasMapType(dt: DataType): Boolean = dt match {
-    case _: MapType => true
-    case st: StructType => st.map(_.dataType).exists(hasMapType)
-    case a: ArrayType => hasMapType(a.elementType)
-    case udt: UserDefinedType[_] => hasMapType(udt.sqlType)
-    case _ => false
   }
 
   override def symbol: String = "="
@@ -468,7 +460,7 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
       case TypeCheckResult.TypeCheckSuccess =>
         // TODO: although map type is not orderable, technically map type should be able to be used
         // in equality comparison, remove this type check once we support it.
-        if (hasMapType(left.dataType)) {
+        if (left.dataType.existsRecursively(_.isInstanceOf[MapType])) {
           TypeCheckResult.TypeCheckFailure("Cannot use map type in EqualNullSafe, but the actual " +
             s"input type is ${left.dataType.catalogString}.")
         } else {
@@ -476,14 +468,6 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
         }
       case failure => failure
     }
-  }
-
-  private def hasMapType(dt: DataType): Boolean = dt match {
-    case _: MapType => true
-    case st: StructType => st.map(_.dataType).exists(hasMapType)
-    case a: ArrayType => hasMapType(a.elementType)
-    case udt: UserDefinedType[_] => hasMapType(udt.sqlType)
-    case _ => false
   }
 
   override def symbol: String = "<=>"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -465,34 +465,22 @@ class AnalysisErrorSuite extends AnalysisTest {
         "another aggregate function." :: Nil)
   }
 
-  test("Join can't work on binary and map types") {
-    val plan =
-      Join(
-        LocalRelation(
-          AttributeReference("a", BinaryType)(exprId = ExprId(2)),
-          AttributeReference("b", IntegerType)(exprId = ExprId(1))),
-        LocalRelation(
-          AttributeReference("c", BinaryType)(exprId = ExprId(4)),
-          AttributeReference("d", IntegerType)(exprId = ExprId(3))),
-        Cross,
-        Some(EqualTo(AttributeReference("a", BinaryType)(exprId = ExprId(2)),
-          AttributeReference("c", BinaryType)(exprId = ExprId(4)))))
+  test("Join can work on binary types but can't work on map types") {
+    val left = LocalRelation('a.binary, 'b.map(StringType, StringType))
+    val right = LocalRelation('c.binary, 'd.map(StringType, StringType))
 
-    assertAnalysisError(plan, "binary type expression `a` cannot be used in join conditions" :: Nil)
+    val plan1 = left.join(
+      right,
+      joinType = Cross,
+      condition = Some('a === 'c))
 
-    val plan2 =
-      Join(
-        LocalRelation(
-          AttributeReference("a", MapType(IntegerType, StringType))(exprId = ExprId(2)),
-          AttributeReference("b", IntegerType)(exprId = ExprId(1))),
-        LocalRelation(
-          AttributeReference("c", MapType(IntegerType, StringType))(exprId = ExprId(4)),
-          AttributeReference("d", IntegerType)(exprId = ExprId(3))),
-        Cross,
-        Some(EqualTo(AttributeReference("a", MapType(IntegerType, StringType))(exprId = ExprId(2)),
-          AttributeReference("c", MapType(IntegerType, StringType))(exprId = ExprId(4)))))
+    assertAnalysisSuccess(plan1)
 
-    assertAnalysisError(plan2, "map type expression `a` cannot be used in join conditions" :: Nil)
+    val plan2 = left.join(
+      right,
+      joinType = Cross,
+      condition = Some('b === 'd))
+    assertAnalysisError(plan2, "Cannot use map type in EqualTo" :: Nil)
   }
 
   test("PredicateSubQuery is used outside of a filter") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -111,6 +111,8 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertErrorForDifferingTypes(GreaterThan('intField, 'booleanField))
     assertErrorForDifferingTypes(GreaterThanOrEqual('intField, 'booleanField))
 
+    assertError(EqualTo('mapField, 'mapField), "Cannot use map type in EqualTo")
+    assertError(EqualNullSafe('mapField, 'mapField), "Cannot use map type in EqualNullSafe")
     assertError(LessThan('mapField, 'mapField),
       s"requires ${TypeCollection.Ordered.simpleString} type")
     assertError(LessThanOrEqual('mapField, 'mapField),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Technically map type is not orderable, but can be used in equality comparison. However, due to the limitation of the current implementation, map type can't be used in equality comparison so that it can't be join key or grouping key.

This PR makes this limitation explicit, to avoid wrong result.

## How was this patch tested?

updated tests.