### PR TITLE
[SPARK-18526][SQL][KAFKA] Allow users to configure max.poll.records.

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -101,7 +101,7 @@ private[kafka010] class KafkaSourceProvider extends StreamSourceProvider
         .set(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
 
         // So that the driver does not pull too much data
-        .set(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, new java.lang.Integer(1))
+        .setIfUnset(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, new java.lang.Integer(1))
 
         // If buffer config is not set, set it to reasonable value to work around
         // buffer issues (see KAFKA-3135)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Kafka source for structured streaming the value of the property `max.poll.records` is set to a default of 1, ~this is very slow rate of reading~. This should be set to a higher value or at least user should be able to configure it.

## How was this patch tested?

Existing tests and by deploying to a cluster.
