### PR TITLE
[SPARK-18535][UI][YARN] Redact sensitive information from Spark logs and UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -223,4 +223,13 @@ package object config {
       " bigger files.")
     .longConf
     .createWithDefault(4 * 1024 * 1024)
+
+  private[spark] val SECRET_REDACTION_PATTERN =
+    ConfigBuilder("spark.secret.redactionPattern")
+      .doc("Scala regex(case-sensitive) to decide which Spark configuration properties and " +
+        "environment variables in driver and executor environments contain sensitive information." +
+        " When this regex matches the property or environment variable name, its value is " +
+        "redacted from the environment UI and various logs like YARN and event logs")
+      .stringConf
+      .createWithDefault("secret|password|SECRET|PASSWORD")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -225,11 +225,11 @@ package object config {
     .createWithDefault(4 * 1024 * 1024)
 
   private[spark] val SECRET_REDACTION_PATTERN =
-    ConfigBuilder("spark.secret.redactionPattern")
-      .doc("Scala regex(case-sensitive) to decide which Spark configuration properties and " +
-        "environment variables in driver and executor environments contain sensitive information." +
-        " When this regex matches the property or environment variable name, its value is " +
-        "redacted from the environment UI and various logs like YARN and event logs")
+    ConfigBuilder("spark.redacton.regex")
+      .doc("Regex to decide which Spark configuration properties and environment variables in " +
+        "driver and executor environments contain sensitive information. When this regex matches " +
+        "a property , its value is redacted from the environment UI and various logs like YARN " +
+        "and event logs")
       .stringConf
-      .createWithDefault("secret|password|SECRET|PASSWORD")
+      .createWithDefault("(?i)secret|password")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -228,8 +228,8 @@ package object config {
     ConfigBuilder("spark.redaction.regex")
       .doc("Regex to decide which Spark configuration properties and environment variables in " +
         "driver and executor environments contain sensitive information. When this regex matches " +
-        "a property , its value is redacted from the environment UI and various logs like YARN " +
-        "and event logs")
+        "a property, its value is redacted from the environment UI and various logs like YARN " +
+        "and event logs.")
       .stringConf
       .createWithDefault("(?i)secret|password")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -225,7 +225,7 @@ package object config {
     .createWithDefault(4 * 1024 * 1024)
 
   private[spark] val SECRET_REDACTION_PATTERN =
-    ConfigBuilder("spark.redacton.regex")
+    ConfigBuilder("spark.redaction.regex")
       .doc("Regex to decide which Spark configuration properties and environment variables in " +
         "driver and executor environments contain sensitive information. When this regex matches " +
         "a property , its value is redacted from the environment UI and various logs like YARN " +

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -233,13 +233,10 @@ private[spark] class EventLoggingListener(
     }
   }
 
-
   private def redactEvent(event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
     // "Spark Properties" entry will always exist because the map is always populated with it.
     val props = event
-      .environmentDetails
-      .get("Spark Properties")
-      .get
+      .environmentDetails("Spark Properties")
     val redactedProps = Utils.redact(sparkConf, props)
     val redactedEnvironmentDetails = event.environmentDetails +
       ("Spark Properties" -> redactedProps)

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -233,7 +233,8 @@ private[spark] class EventLoggingListener(
     }
   }
 
-  private def redactEvent(event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
+  private[spark] def redactEvent(event: SparkListenerEnvironmentUpdate):
+  SparkListenerEnvironmentUpdate = {
     // "Spark Properties" entry will always exist because the map is always populated with it.
     val props = event
       .environmentDetails("Spark Properties")

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -236,11 +236,11 @@ private[spark] class EventLoggingListener(
 
   private def redactEvent(event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
     // "Spark Properties" entry will always exist because the map is always populated with it.
-    val redactedProps = event
+    val props = event
       .environmentDetails
       .get("Spark Properties")
       .get
-      .map(Utils.redact(sparkConf))
+    val redactedProps = Utils.redact(sparkConf, props)
     val redactedEnvironmentDetails = event.environmentDetails +
       ("Spark Properties" -> redactedProps)
     SparkListenerEnvironmentUpdate(redactedEnvironmentDetails)

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -234,7 +234,7 @@ private[spark] class EventLoggingListener(
   }
 
   private[spark] def redactEvent(
-    event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
+      event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
     // "Spark Properties" entry will always exist because the map is always populated with it.
     val redactedProps = Utils.redact(sparkConf, event.environmentDetails("Spark Properties"))
     val redactedEnvironmentDetails = event.environmentDetails +

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -233,12 +233,10 @@ private[spark] class EventLoggingListener(
     }
   }
 
-  private[spark] def redactEvent(event: SparkListenerEnvironmentUpdate):
-  SparkListenerEnvironmentUpdate = {
+  private[spark] def redactEvent(
+    event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
     // "Spark Properties" entry will always exist because the map is always populated with it.
-    val props = event
-      .environmentDetails("Spark Properties")
-    val redactedProps = Utils.redact(sparkConf, props)
+    val redactedProps = Utils.redact(sparkConf, event.environmentDetails("Spark Properties"))
     val redactedEnvironmentDetails = event.environmentDetails +
       ("Spark Properties" -> redactedProps)
     SparkListenerEnvironmentUpdate(redactedEnvironmentDetails)

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -22,21 +22,16 @@ import javax.servlet.http.HttpServletRequest
 import scala.xml.Node
 
 import org.apache.spark.ui.{UIUtils, WebUIPage}
+import org.apache.spark.util.Utils
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
 
-  private def removePass(kv: (String, String)): (String, String) = {
-    if (kv._1.toLowerCase.contains("password") || kv._1.toLowerCase.contains("secret")) {
-      (kv._1, "******")
-    } else kv
-  }
-
   def render(request: HttpServletRequest): Seq[Node] = {
     val runtimeInformationTable = UIUtils.listingTable(
       propertyHeader, jvmRow, listener.jvmInformation, fixedWidth = true)
-    val sparkPropertiesTable = UIUtils.listingTable(
-      propertyHeader, propertyRow, listener.sparkProperties.map(removePass), fixedWidth = true)
+    val sparkPropertiesTable = UIUtils.listingTable(propertyHeader, propertyRow, listener
+      .sparkProperties.map(Utils.redact(parent.conf)), fixedWidth = true)
     val systemPropertiesTable = UIUtils.listingTable(
       propertyHeader, propertyRow, listener.systemProperties, fixedWidth = true)
     val classpathEntriesTable = UIUtils.listingTable(

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -30,8 +30,9 @@ private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") 
   def render(request: HttpServletRequest): Seq[Node] = {
     val runtimeInformationTable = UIUtils.listingTable(
       propertyHeader, jvmRow, listener.jvmInformation, fixedWidth = true)
-    val sparkPropertiesTable = UIUtils.listingTable(propertyHeader, propertyRow, listener
-      .sparkProperties.map(Utils.redact(parent.conf)), fixedWidth = true)
+    val sparkPropertiesTable = UIUtils.listingTable(propertyHeader, propertyRow,
+      Utils.redact(parent.conf, listener.sparkProperties), fixedWidth = true)
+
     val systemPropertiesTable = UIUtils.listingTable(
       propertyHeader, propertyRow, listener.systemProperties, fixedWidth = true)
     val classpathEntriesTable = UIUtils.listingTable(

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentTab.scala
@@ -23,6 +23,7 @@ import org.apache.spark.ui._
 
 private[ui] class EnvironmentTab(parent: SparkUI) extends SparkUITab(parent, "environment") {
   val listener = parent.environmentListener
+  val conf = parent.conf
   attachPage(new EnvironmentPage(this))
 }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2558,11 +2558,14 @@ private[spark] object Utils extends Logging {
 
   private[util] val REDACTION_REPLACEMENT_TEXT = "*********(redacted)"
 
-  def redact(conf: SparkConf)(kv: (String, String)): (String, String) = {
+  def redact(conf: SparkConf, kvs: Seq[(String, String)]): Seq[(String, String)] = {
     val redactionPattern = conf.get(SECRET_REDACTION_PATTERN).r
-    if (redactionPattern.findFirstIn(kv._1).isDefined) {
-      (kv._1, REDACTION_REPLACEMENT_TEXT)
-    } else kv
+    kvs.map { kv =>
+      if (redactionPattern.findFirstIn(kv._1).isDefined) {
+        (kv._1, REDACTION_REPLACEMENT_TEXT)
+      }
+      else kv
+    }
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -55,7 +55,7 @@ import org.slf4j.Logger
 import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{DYN_ALLOCATION_INITIAL_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS, EXECUTOR_INSTANCES}
+import org.apache.spark.internal.config._
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.{DeserializationStream, SerializationStream, SerializerInstance}
 import org.apache.spark.util.logging.RollingFileAppender
@@ -2555,6 +2555,15 @@ private[spark] object Utils extends Logging {
       sparkJars.map(_.split(",")).map(_.filter(_.nonEmpty)).toSeq.flatten
     }
   }
+
+  private[util] val REDACTION_REPLACEMENT_TEXT = "*********(redacted)"
+  def redact(conf: SparkConf)(kv: (String, String)): (String, String) = {
+    val redactionPattern = conf.get(SECRET_REDACTION_PATTERN).r
+    if (redactionPattern.findFirstIn(kv._1).isDefined) {
+      (kv._1, REDACTION_REPLACEMENT_TEXT)
+    } else kv
+  }
+
 }
 
 private[util] object CallerContext extends Logging {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2562,9 +2562,9 @@ private[spark] object Utils extends Logging {
     val redactionPattern = conf.get(SECRET_REDACTION_PATTERN).r
     kvs.map { kv =>
       redactionPattern.findFirstIn(kv._1)
-        .map{ ignore => (kv._1, REDACTION_REPLACEMENT_TEXT) }
+        .map { ignore => (kv._1, REDACTION_REPLACEMENT_TEXT) }
         .getOrElse(kv)
-      }
+    }
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2557,6 +2557,7 @@ private[spark] object Utils extends Logging {
   }
 
   private[util] val REDACTION_REPLACEMENT_TEXT = "*********(redacted)"
+
   def redact(conf: SparkConf)(kv: (String, String)): (String, String) = {
     val redactionPattern = conf.get(SECRET_REDACTION_PATTERN).r
     if (redactionPattern.findFirstIn(kv._1).isDefined) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2561,11 +2561,10 @@ private[spark] object Utils extends Logging {
   def redact(conf: SparkConf, kvs: Seq[(String, String)]): Seq[(String, String)] = {
     val redactionPattern = conf.get(SECRET_REDACTION_PATTERN).r
     kvs.map { kv =>
-      if (redactionPattern.findFirstIn(kv._1).isDefined) {
-        (kv._1, REDACTION_REPLACEMENT_TEXT)
+      redactionPattern.findFirstIn(kv._1)
+        .map{ ignore => (kv._1, REDACTION_REPLACEMENT_TEXT) }
+        .getOrElse(kv)
       }
-      else kv
-    }
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -95,6 +95,30 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     }
   }
 
+  test("Event logging with password redaction") {
+    val secretPassword = "secret_password"
+    val conf = getLoggingConf(testDirPath, None).set("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
+      secretPassword)
+    sc = new SparkContext("local-cluster[2,2,1024]", "test", conf)
+    assert(sc.eventLogger.isDefined)
+    val eventLogger = sc.eventLogger.get
+
+    sc.parallelize(1 to 10000).count()
+    sc.stop()
+
+    val logData = EventLoggingListener.openEventLog(new Path(eventLogger.logPath), fileSystem)
+    val eventLog = Source.fromInputStream(logData).mkString
+    // Make sure nothing secret shows up anywhere
+    assert(!eventLog.contains(secretPassword), s"Secret password ($secretPassword) not redacted " +
+      s"from event logs:\n $eventLog")
+    val expected = """"spark.executorEnv.HADOOP_CREDSTORE_PASSWORD":"*********(redacted)""""
+    // Make sure every occurrence of the property is accompanied by a redaction text.
+    val regex = """"spark.executorEnv.HADOOP_CREDSTORE_PASSWORD":"([^"]*)"""".r
+    val matches = regex.findAllIn(eventLog)
+    assert(matches.nonEmpty)
+    matches.foreach(matched => assert(matched.equals(expected)))
+  }
+
   test("Log overwriting") {
     val logUri = EventLoggingListener.getLogPath(testDir.toURI, "test", None)
     val logPath = new URI(logUri).getPath

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -116,7 +116,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val regex = """"spark.executorEnv.HADOOP_CREDSTORE_PASSWORD":"([^"]*)"""".r
     val matches = regex.findAllIn(eventLog)
     assert(matches.nonEmpty)
-    matches.foreach(matched => assert(matched.equals(expected)))
+    matches.foreach{ matched => assert(matched.equals(expected)) }
   }
 
   test("Log overwriting") {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -990,7 +990,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     sparkConf.set("spark.regular.property", "not_a_secret")
 
     // Redact sensitive information
-    val redactedConf = sparkConf.getAll.map(Utils.redact(sparkConf)).toMap
+    val redactedConf = Utils.redact(sparkConf, sparkConf.getAll).toMap
 
     // Assert that secret information got redacted while the regular property remained the same
     secretKeys.foreach { key =>

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -991,7 +991,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val redactedConf = Utils.redact(sparkConf, sparkConf.getAll).toMap
 
     // Assert that secret information got redacted while the regular property remained the same
-    secretKeys.foreach { key => assert(redactedConf(key) == Utils.REDACTION_REPLACEMENT_TEXT) }
-    assert(redactedConf("spark.regular.property") == "not_a_secret")
+    secretKeys.foreach { key => assert(redactedConf(key) === Utils.REDACTION_REPLACEMENT_TEXT) }
+    assert(redactedConf("spark.regular.property") === "not_a_secret")
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -979,13 +979,11 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val sparkConf = new SparkConf
 
     // Set some secret keys
-    val secretKeys = Seq("" +
+    val secretKeys = Seq(
       "spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
       "spark.my.password",
       "spark.my.sECreT")
-    secretKeys.foreach { key =>
-      sparkConf.set(key, "secret_password")
-    }
+    secretKeys.foreach { key => sparkConf.set(key, "secret_password") }
     // Set a non-secret key
     sparkConf.set("spark.regular.property", "not_a_secret")
 
@@ -993,9 +991,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val redactedConf = Utils.redact(sparkConf, sparkConf.getAll).toMap
 
     // Assert that secret information got redacted while the regular property remained the same
-    secretKeys.foreach { key =>
-      assert(redactedConf.get(key).get == Utils.REDACTION_REPLACEMENT_TEXT)
-    }
-    assert(redactedConf.get("spark.regular.property").get == "not_a_secret")
+    secretKeys.foreach { key => assert(redactedConf(key) == Utils.REDACTION_REPLACEMENT_TEXT) }
+    assert(redactedConf("spark.regular.property") == "not_a_secret")
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,6 +357,16 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.secret.redactionPattern</code></td>
+  <td>secret|password|SECRET|PASSWORD</td>
+  <td>
+    Scala regex(case-sensitive) to decide which Spark configuration properties and environment
+    variables in driver and executor environments contain sensitive information. When this
+    regex matches the property or environment variable name, its value is redacted from the
+    environment UI and various logs like YARN and event logs.
+  </td>
+</tr>
+<tr>
   <td><code>spark.python.profile</code></td>
   <td>false</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,13 +357,12 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.secret.redactionPattern</code></td>
-  <td>secret|password|SECRET|PASSWORD</td>
+  <td><code>spark.redaction.regex</code></td>
+  <td>(?i)secret|password</td>
   <td>
-    Scala regex(case-sensitive) to decide which Spark configuration properties and environment
-    variables in driver and executor environments contain sensitive information. When this
-    regex matches the property or environment variable name, its value is redacted from the
-    environment UI and various logs like YARN and event logs.
+    Regex to decide which Spark configuration properties and environment variables in driver and
+    executor environments contain sensitive information. When this regex matches a property, its
+    value is redacted from the environment UI and various logs like YARN and event logs.
   </td>
 </tr>
 <tr>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -74,7 +74,7 @@ private[yarn] class ExecutorRunnable(
     |===============================================================================
     |YARN executor launch context:
     |  env:
-    |${env.map(Utils.redact(sparkConf)).map { case (k, v) => s"    $k -> $v\n" }.mkString}
+    |${Utils.redact(sparkConf, env.toSeq).map { case (k, v) => s"    $k -> $v\n" }.mkString}
     |  command:
     |    ${commands.mkString(" \\ \n      ")}
     |

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -36,7 +36,6 @@ import org.apache.hadoop.yarn.ipc.YarnRPC
 import org.apache.hadoop.yarn.util.{ConverterUtils, Records}
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
-import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher.YarnCommandBuilderUtils
@@ -75,7 +74,7 @@ private[yarn] class ExecutorRunnable(
     |===============================================================================
     |YARN executor launch context:
     |  env:
-    |${env.map { case (k, v) => s"    $k -> $v\n" }.mkString}
+    |${env.map(Utils.redact(sparkConf)).map { case (k, v) => s"    $k -> $v\n" }.mkString}
     |  command:
     |    ${commands.mkString(" \\ \n      ")}
     |


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds a new property called `spark.secret.redactionPattern` that
allows users to specify a scala regex to decide which Spark configuration
properties and environment variables in driver and executor environments
contain sensitive information. When this regex matches the property or
environment variable name, its value is redacted from the environment UI and
various logs like YARN and event logs.

This change uses this property to redact information from event logs and YARN
logs. It also, updates the UI code to adhere to this property instead of
hardcoding the logic to decipher which properties are sensitive.

Here's an image of the UI post-redaction:
![image](https://cloud.githubusercontent.com/assets/1709451/20506215/4cc30654-b007-11e6-8aee-4cde253fba2f.png)

Here's the text in the YARN logs, post-redaction:
``HADOOP_CREDSTORE_PASSWORD -> *********(redacted)``

Here's the text in the event logs, post-redaction:
``...,"spark.executorEnv.HADOOP_CREDSTORE_PASSWORD":"*********(redacted)","spark.yarn.appMasterEnv.HADOOP_CREDSTORE_PASSWORD":"*********(redacted)",...``

## How was this patch tested?
1. Unit tests are added to ensure that redaction works.
2. A YARN job reading data off of S3 with confidential information
(hadoop credential provider password) being provided in the environment
variables of driver and executor. And, afterwards, logs were grepped to make
sure that no mention of secret password was present. It was also ensure that
the job was able to read the data off of S3 correctly, thereby ensuring that
the sensitive information was being trickled down to the right places to read
the data.
3. The event logs were checked to make sure no mention of secret password was
present.
4. UI environment tab was checked to make sure there was no secret information
being displayed.