### PR TITLE
[SPARK-18551] [Web UI] [Core] [WIP] Add functionality to delete event logs from the History Server UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -77,7 +77,12 @@
       <td><span title="{{duration}}" class="durationClass">{{duration}}</span></td>
       <td>{{sparkUser}}</td>
       <td>{{lastUpdated}}</td>
-      <td><a href="{{uiroot}}/api/v1/applications/{{id}}/{{num}}/logs" class="btn btn-info btn-mini">Download</a></td>
+      <td>
+        <a href="{{uiroot}}/api/v1/applications/{{id}}/{{num}}/logs" class="btn btn-info btn-mini">Download</a>
+        <a href="{{uiroot}}/logs/delete/?appId={{id}}&attemptId={{attemptId}}"
+           onclick="if (window.confirm('Are you sure you want to delete the Event Log for {{id}} from the server?\n\nThis can not be undone!')) { this.parentNode.submit(); return true; } else { return false; }"
+           class="btn btn-danger btn-mini delete-app">Delete</a>
+      </td>
       {{/attempts}}
     </tr>
   {{/applications}}

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -21,6 +21,12 @@ function setAppLimit(val) {
     appLimit = val;
 }
 
+var deleteLogsEnabled = false;
+
+function setDeleteLogsEnabled(val) {
+    deleteLogsEnabled = val;
+}
+
 function makeIdNumeric(id) {
   var strs = id.split("_");
   if (strs.length < 3) {
@@ -180,6 +186,10 @@ $(document).ready(function() {
 
         $(selector).DataTable(conf);
         $('#hisotry-summary [data-toggle="tooltip"]').tooltip();
+
+        if (deleteLogsEnabled) {
+          $('.delete-app').css('display', 'inline-block');
+        }
       });
     });
 });

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -247,3 +247,7 @@ a.expandbutton {
   margin: 0;
   padding: 4px 0;
 }
+
+.delete-app {
+  display: none;
+}

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -144,4 +144,12 @@ private[history] abstract class ApplicationHistoryProvider {
    * @return html text to display when the application list is empty
    */
   def getEmptyListingHtml(): Seq[Node] = Seq.empty
+
+  /**
+   * Deletes the given application attempt event log file from the History Server event log
+   * directory. This action cannot be undone.
+   * @param appId The application ID.
+   * @param attemptId The application attempt ID (or None if there is no attempt ID).
+   */
+  def deleteLog(appId: String, attemptId: Option[String]): Unit
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -535,6 +535,25 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     }
   }
 
+  override def deleteLog(appId: String, attemptId: Option[String]): Unit = {
+    applications.get(appId) match {
+      case Some(appInfo) =>
+        appInfo.attempts.filter { attempt =>
+          attempt.attemptId.isEmpty || attemptId.isEmpty || attempt.attemptId.get == attemptId.get
+        }.foreach { attempt =>
+          try {
+            fs.delete(new Path(logDir, attempt.logPath), true)
+            applications.remove(appId)
+          } catch {
+            case e: AccessControlException =>
+              logInfo(s"No permission to delete ${attempt.logPath}, ignoring.")
+            case t: IOException =>
+              logError(s"IOException in cleaning ${attempt.logPath}", t)
+          }
+        }
+    }
+  }
+
   /**
    * Delete event logs from the log directory according to the clean policy defined by the user.
    */

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -551,6 +551,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
               logError(s"IOException in cleaning ${attempt.logPath}", t)
           }
         }
+      case None => logError(s"Can't delete, no application ${appId} found")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -60,7 +60,8 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
                 <div id="history-summary" class="span12 pagination"></div> ++
                 <script src={UIUtils.prependBaseUri("/static/utils.js")}></script> ++
                 <script src={UIUtils.prependBaseUri("/static/historypage.js")}></script> ++
-                <script>setAppLimit({parent.maxApplications})</script>
+                <script>setAppLimit({parent.maxApplications})</script> ++
+                <script>setDeleteLogsEnabled({parent.deleteLogsEnabled})</script>
             } else if (requestedIncomplete) {
               <h4>No incomplete applications found!</h4>
             } else if (eventLogsUnderProcessCount > 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sometimes a Spark user will only have access to a History Server to interact with their (past) applications. But without access to the server they can only delete applications through use of the FS Cleaner feature, which itself can only clean logs older than a set date. 

I've added functionality to delete individual event logs from the history server, added a request handler to call said function and added a button to the UI to call it. The code is based on the current cleanLogs and kill jobs/stages code. I've also set this functionality to off by default.

I've left this as WIP because I still need to add tests and documentation for the new code and have design questions that I need input on (commented inline below)

## How was this patch tested?

Manual testing and dev/run-tests

![spark18551](https://cloud.githubusercontent.com/assets/13952758/20547320/0c53fb4a-b0d0-11e6-9af9-3fd8f915557e.png)