### PR TITLE
[SPARK-18559] [SQL] Fix HLL++ with small relative error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -307,6 +307,8 @@ case class HyperLogLogPlusPlus(
     val estimate = if (V > 0) {
       // Use linear counting for small cardinality estimates.
       val H = m * Math.log(m / V)
+      // HLL++ is defined only when p < 19, otherwise we need to fallback to HLL.
+      // The threshold `2.5 * m` is from the original HLL algorithm.
       if ((p < 19 && H <= THRESHOLDS(p - 4)) || E <= 2.5 * m) {
         H
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -92,8 +92,11 @@ case class HyperLogLogPlusPlus(
    */
   private[this] val p = Math.ceil(2.0d * Math.log(1.106d / relativeSD) / Math.log(2.0d)).toInt
 
-  require(p >= 4, "HLL++ requires at least 4 bits for addressing. " +
-    "Use a lower error, at most 27%.")
+  // THRESHOLDS, RAW_ESTIMATE_DATA and BIAS_DATA all have the same length 15, and we probe these
+  // arrays by (p - 4), so we need to guarantee 0 <= p - 4 <= 14.
+  require(p >= 4 && p < HyperLogLogPlusPlus.THRESHOLDS.length + 4,
+    "HLL++ requires at least 4 bits and at most 18 bits for addressing. " +
+    "The error should be in the range [0.3%, 39%].")
 
   /**
    * Shift used to extract the index of the register from the hashed value.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -94,9 +94,9 @@ case class HyperLogLogPlusPlus(
 
   // THRESHOLDS, RAW_ESTIMATE_DATA and BIAS_DATA all have the same length 15, and we probe these
   // arrays by (p - 4), so we need to guarantee 0 <= p - 4 <= 14.
-  require(p >= 4 && p < HyperLogLogPlusPlus.THRESHOLDS.length + 4,
-    "HLL++ requires at least 4 bits and at most 18 bits for addressing. " +
-    "The error should be in the range [0.3%, 39%].")
+  require(p >= 4 && p <= HyperLogLogPlusPlus.THRESHOLDS.length + 3,
+    s"HLL++ requires at least 4 bits and at most ${HyperLogLogPlusPlus.THRESHOLDS.length + 3} " +
+    "bits for addressing. The error should be in the range [0.22%, 39%].")
 
   /**
    * Shift used to extract the index of the register from the hashed value.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
@@ -51,12 +51,12 @@ class HyperLogLogPlusPlusSuite extends SparkFunSuite {
   }
 
   test("test invalid parameter relativeSD") {
-    // `relativeSD` should be in the range [0.003, 0.39].
+    // `relativeSD` should be in the range [0.22%, 39%].
     intercept[IllegalArgumentException] {
-      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.002d)
+      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.0023)
     }
     intercept[IllegalArgumentException] {
-      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.4d)
+      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.4)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
@@ -53,7 +53,7 @@ class HyperLogLogPlusPlusSuite extends SparkFunSuite {
   test("test invalid parameter relativeSD") {
     // `relativeSD` should be in the range [0.22%, 39%].
     intercept[IllegalArgumentException] {
-      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.0023)
+      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.0021)
     }
     intercept[IllegalArgumentException] {
       new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.4)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
@@ -50,6 +50,16 @@ class HyperLogLogPlusPlusSuite extends SparkFunSuite {
     assert(error < hll.trueRsd * 3.0d, "Error should be within 3 std. errors.")
   }
 
+  test("test invalid parameter relativeSD") {
+    // `relativeSD` should be in the range [0.003, 0.39].
+    intercept[IllegalArgumentException] {
+      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.002d)
+    }
+    intercept[IllegalArgumentException] {
+      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.4d)
+    }
+  }
+
   test("add nulls") {
     val (hll, input, buffer) = createEstimator(0.05)
     input.setNullAt(0)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlusSuite.scala
@@ -51,10 +51,7 @@ class HyperLogLogPlusPlusSuite extends SparkFunSuite {
   }
 
   test("test invalid parameter relativeSD") {
-    // `relativeSD` should be in the range [0.22%, 39%].
-    intercept[IllegalArgumentException] {
-      new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.0021)
-    }
+    // `relativeSD` should be at most 39%.
     intercept[IllegalArgumentException] {
       new HyperLogLogPlusPlus(new BoundReference(0, IntegerType, true), relativeSD = 0.4)
     }
@@ -93,7 +90,7 @@ class HyperLogLogPlusPlusSuite extends SparkFunSuite {
   test("deterministic cardinality estimation") {
     val repeats = 10
     testCardinalityEstimates(
-      Seq(0.1, 0.05, 0.025, 0.01),
+      Seq(0.1, 0.05, 0.025, 0.01, 0.001),
       Seq(100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000).map(_ * repeats),
       i => i / repeats,
       i => i / repeats)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `HyperLogLogPlusPlus`, if the relative error is so small that p >= 19, it will cause ArrayIndexOutOfBoundsException in `THRESHOLDS(p-4)` . We should check `p` and when p >= 19, regress to the original HLL result and use the small range correction they use.

The pr also fixes the upper bound in the log info in `require()`.
The upper bound is computed by:
```
val relativeSD = 1.106d / Math.pow(Math.E, p * Math.log(2.0d) / 2.0d)
```
which is derived from the equation for computing `p`:
```
val p = 2.0d * Math.log(1.106d / relativeSD) / Math.log(2.0d)
```

## How was this patch tested?

add test cases for:
1. checking validity of parameter relatvieSD
2. estimation with smaller relative error so that p >= 19