### PR TITLE
[SPARK-18572][SQL] Add a method `listPartitionNames` to `ExternalCatalog`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -192,9 +192,12 @@ abstract class ExternalCatalog {
   /**
    * List the names of all partitions that belong to the specified table, assuming it exists.
    *
-   * A partial partition spec may optionally be provided to filter the partitions returned.
-   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
-   * then a partial spec of (a='1') will return the first two only.
+   * For a table with partition columns p1, p2, p3, each partition name is formatted as
+   * `p1=v1/p2=v2/p3=v3`. Each partition column name and value is an escaped path name, and can be
+   * decoded with the `ExternalCatalogUtils.unescapePathName` method.
+   *
+   * A partial partition spec may optionally be provided to filter the partitions returned, as
+   * described in the `listPartitions` method.
    *
    * @param db database name
    * @param table table name
@@ -227,7 +230,7 @@ abstract class ExternalCatalog {
    *
    * @param db database name
    * @param table table name
-   * @param predicates  partition-pruning predicates
+   * @param predicates partition-pruning predicates
    */
   def listPartitionsByFilter(
       db: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -198,7 +198,7 @@ abstract class ExternalCatalog {
    *
    * @param db database name
    * @param table table name
-   * @param partialSpec  partition spec
+   * @param partialSpec partition spec
    */
   def listPartitionNames(
       db: String,
@@ -214,7 +214,7 @@ abstract class ExternalCatalog {
    *
    * @param db database name
    * @param table table name
-   * @param partialSpec  partition spec
+   * @param partialSpec partition spec
    */
   def listPartitions(
       db: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -195,10 +195,6 @@ abstract class ExternalCatalog {
    * A partial partition spec may optionally be provided to filter the partitions returned.
    * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
    * then a partial spec of (a='1') will return the first two only.
-   *
-   * We provide a default implementation here which simply delegates to the `listPartitions`
-   * method. For efficiency's sake, overriding this method is recommended for external catalogs
-   * that can list partition names directly.
    * @param db database name
    * @param table table name
    * @param partialSpec  partition spec
@@ -206,20 +202,7 @@ abstract class ExternalCatalog {
   def listPartitionNames(
       db: String,
       table: String,
-      partialSpec: Option[TablePartitionSpec] = None): Seq[String] = {
-    def getPartName(spec: TablePartitionSpec, partColNames: Seq[String]): String = {
-      partColNames.map { name =>
-        ExternalCatalogUtils.escapePathName(name) + "=" +
-          ExternalCatalogUtils.escapePathName(spec(name))
-      }.mkString("/")
-    }
-
-    val catalogTable = getTable(db, table)
-
-    listPartitions(db, table, partialSpec).map { p =>
-      getPartName(p.spec, catalogTable.partitionColumnNames)
-    }
-  }
+      partialSpec: Option[TablePartitionSpec] = None): Seq[String]
 
   /**
    * List the metadata of all partitions that belong to the specified table, assuming it exists.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -196,6 +196,8 @@ abstract class ExternalCatalog {
    * `p1=v1/p2=v2/p3=v3`. Each partition column name and value is an escaped path name, and can be
    * decoded with the `ExternalCatalogUtils.unescapePathName` method.
    *
+   * The returned sequence is sorted as strings.
+   *
    * A partial partition spec may optionally be provided to filter the partitions returned, as
    * described in the `listPartitions` method.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -195,6 +195,7 @@ abstract class ExternalCatalog {
    * A partial partition spec may optionally be provided to filter the partitions returned.
    * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
    * then a partial spec of (a='1') will return the first two only.
+   *
    * @param db database name
    * @param table table name
    * @param partialSpec  partition spec
@@ -210,6 +211,7 @@ abstract class ExternalCatalog {
    * A partial partition spec may optionally be provided to filter the partitions returned.
    * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
    * then a partial spec of (a='1') will return the first two only.
+   *
    * @param db database name
    * @param table table name
    * @param partialSpec  partition spec

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -28,6 +28,7 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.escapePathName
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.StringUtils
 
@@ -496,7 +497,7 @@ class InMemoryCatalog(
 
     listPartitions(db, table, partialSpec).map { partition =>
       partitionColumnNames.map { name =>
-        name + "=" + partition.spec(name)
+        escapePathName(name) + "=" + escapePathName(partition.spec(name))
       }.mkString("/")
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -488,6 +488,19 @@ class InMemoryCatalog(
     }
   }
 
+  override def listPartitionNames(
+      db: String,
+      table: String,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[String] = synchronized {
+    val partitionColumnNames = getTable(db, table).partitionColumnNames
+
+    listPartitions(db, table, partialSpec).map { partition =>
+      partitionColumnNames.map { name =>
+        name + "=" + partition.spec(name)
+      }.mkString("/")
+    }
+  }
+
   override def listPartitions(
       db: String,
       table: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -499,7 +499,7 @@ class InMemoryCatalog(
       partitionColumnNames.map { name =>
         escapePathName(name) + "=" + escapePathName(partition.spec(name))
       }.mkString("/")
-    }
+    }.sorted
   }
 
   override def listPartitions(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -749,6 +749,23 @@ class SessionCatalog(
   }
 
   /**
+   * List the names of all partitions that belong to the specified table, assuming it exists.
+   *
+   * A partial partition spec may optionally be provided to filter the partitions returned.
+   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
+   * then a partial spec of (a='1') will return the first two only.
+   */
+  def listPartitionNames(
+      tableName: TableIdentifier,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[String] = {
+    val db = formatDatabaseName(tableName.database.getOrElse(getCurrentDatabase))
+    val table = formatTableName(tableName.table)
+    requireDbExists(db)
+    requireTableExists(TableIdentifier(table, Option(db)))
+    externalCatalog.listPartitionNames(db, table, partialSpec)
+  }
+
+  /**
    * List the metadata of all partitions that belong to the specified table, assuming it exists.
    *
    * A partial partition spec may optionally be provided to filter the partitions returned.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -762,6 +762,9 @@ class SessionCatalog(
     val table = formatTableName(tableName.table)
     requireDbExists(db)
     requireTableExists(TableIdentifier(table, Option(db)))
+    partialSpec.foreach { spec =>
+      requirePartialMatchedPartitionSpec(Seq(spec), getTableMetadata(tableName))
+    }
     externalCatalog.listPartitionNames(db, table, partialSpec)
   }
 
@@ -779,6 +782,9 @@ class SessionCatalog(
     val table = formatTableName(tableName.table)
     requireDbExists(db)
     requireTableExists(TableIdentifier(table, Option(db)))
+    partialSpec.foreach { spec =>
+      requirePartialMatchedPartitionSpec(Seq(spec), getTableMetadata(tableName))
+    }
     externalCatalog.listPartitions(db, table, partialSpec)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -729,13 +729,6 @@ case class ShowPartitionsCommand(
     AttributeReference("partition", StringType, nullable = false)() :: Nil
   }
 
-  private def getPartName(spec: TablePartitionSpec, partColNames: Seq[String]): String = {
-    partColNames.map { name =>
-      ExternalCatalogUtils.escapePathName(name) + "=" +
-        ExternalCatalogUtils.escapePathName(spec(name))
-    }.mkString(File.separator)
-  }
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableMetadata(tableName)
@@ -772,10 +765,7 @@ case class ShowPartitionsCommand(
       }
     }
 
-    val partNames = catalog.listPartitions(tableName, spec).map { p =>
-      getPartName(p.spec, table.partitionColumnNames)
-    }
-
+    val partNames = catalog.listPartitionNames(tableName, spec)
     partNames.map(Row(_))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -161,8 +161,8 @@ case class DataSourceAnalysis(conf: CatalystConf) extends Rule[LogicalPlan] {
       insert.copy(partition = parts.map(p => (p._1, None)), child = Project(projectList, query))
 
 
-    case i @ logical.InsertIntoTable(
-           l @ LogicalRelation(t: HadoopFsRelation, _, table), part, query, overwrite, false)
+    case logical.InsertIntoTable(
+      l @ LogicalRelation(t: HadoopFsRelation, _, table), _, query, overwrite, false)
         if query.resolved && t.schema.sameType(query.schema) =>
 
       // Sanity checks
@@ -192,11 +192,19 @@ case class DataSourceAnalysis(conf: CatalystConf) extends Rule[LogicalPlan] {
       var initialMatchingPartitions: Seq[TablePartitionSpec] = Nil
       var customPartitionLocations: Map[TablePartitionSpec, String] = Map.empty
 
+      val staticPartitionKeys: TablePartitionSpec = if (overwrite.enabled) {
+        overwrite.staticPartitionKeys.map { case (k, v) =>
+          (partitionSchema.map(_.name).find(_.equalsIgnoreCase(k)).get, v)
+        }
+      } else {
+        Map.empty
+      }
+
       // When partitions are tracked by the catalog, compute all custom partition locations that
       // may be relevant to the insertion job.
       if (partitionsTrackedByCatalog) {
         val matchingPartitions = t.sparkSession.sessionState.catalog.listPartitions(
-          l.catalogTable.get.identifier, Some(overwrite.staticPartitionKeys))
+          l.catalogTable.get.identifier, Some(staticPartitionKeys))
         initialMatchingPartitions = matchingPartitions.map(_.spec)
         customPartitionLocations = getCustomPartitionLocations(
           t.sparkSession, l.catalogTable.get, outputPath, matchingPartitions)
@@ -223,14 +231,6 @@ case class DataSourceAnalysis(conf: CatalystConf) extends Rule[LogicalPlan] {
           }
         }
         t.location.refresh()
-      }
-
-      val staticPartitionKeys: TablePartitionSpec = if (overwrite.enabled) {
-        overwrite.staticPartitionKeys.map { case (k, v) =>
-          (partitionSchema.map(_.name).find(_.equalsIgnoreCase(k)).get, v)
-        }
-      } else {
-        Map.empty
       }
 
       val insertCmd = InsertIntoHadoopFsRelationCommand(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -244,13 +244,22 @@ object PartitioningUtils {
 
   /**
    * Given a partition path fragment, e.g. `fieldOne=1/fieldTwo=2`, returns a parsed spec
-   * for that fragment, e.g. `Map(("fieldOne", "1"), ("fieldTwo", "2"))`.
+   * for that fragment as a `TablePartitionSpec`, e.g. `Map(("fieldOne", "1"), ("fieldTwo", "2"))`.
    */
   def parsePathFragment(pathFragment: String): TablePartitionSpec = {
+    parsePathFragmentAsSeq(pathFragment).toMap
+  }
+
+  /**
+   * Given a partition path fragment, e.g. `fieldOne=1/fieldTwo=2`, returns a parsed spec
+   * for that fragment as a `Seq[(String, String)]`, e.g.
+   * `Seq(("fieldOne", "1"), ("fieldTwo", "2"))`.
+   */
+  def parsePathFragmentAsSeq(pathFragment: String): Seq[(String, String)] = {
     pathFragment.split("/").map { kv =>
       val pair = kv.split("=", 2)
       (unescapePathName(pair(0)), unescapePathName(pair(1)))
-    }.toMap
+    }
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -933,10 +933,10 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       db: String,
       table: String,
       partialSpec: Option[TablePartitionSpec] = None): Seq[String] = withClient {
-    val actualPartColNames = getTable(db, table).partitionColumnNames
+    val catalogTable = getTable(db, table)
+    val actualPartColNames = catalogTable.partitionColumnNames
     val clientPartitionNames =
-      client.getPartitionNames(db, table, partialSpec.map(lowerCasePartitionSpec))
-    // No need to sort the results, because according to the Hive wiki Hive sorts them for us
+      client.getPartitionNames(catalogTable, partialSpec.map(lowerCasePartitionSpec))
     clientPartitionNames.map { partName =>
       val partSpec = PartitioningUtils.parsePathFragmentAsSeq(partName)
       partSpec.map { case (partName, partValue) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -936,6 +936,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     val actualPartColNames = getTable(db, table).partitionColumnNames
     val clientPartitionNames =
       client.getPartitionNames(db, table, partialSpec.map(lowerCasePartitionSpec))
+    // No need to sort the results, because according to the Hive wiki Hive sorts them for us
     clientPartitionNames.map { partName =>
       val partSpec = PartitioningUtils.parsePathFragmentAsSeq(partName)
       partSpec.map { case (partName, partValue) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -159,17 +159,8 @@ private[hive] trait HiveClient {
   /**
    * Returns the partition names for the given table that match the supplied partition spec.
    * If no partition spec is specified, all partitions are returned.
-   */
-  final def getPartitionNames(
-      db: String,
-      table: String,
-      partialSpec: Option[TablePartitionSpec]): Seq[String] = {
-    getPartitionNames(getTable(db, table), partialSpec)
-  }
-
-  /**
-   * Returns the partition names for the given table that match the supplied partition spec.
-   * If no partition spec is specified, all partitions are returned.
+   *
+   * The returned sequence is sorted as strings.
    */
   def getPartitionNames(
       table: CatalogTable,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -156,6 +156,25 @@ private[hive] trait HiveClient {
     }
   }
 
+  /**
+   * Returns the partition names for the given table that match the supplied partition spec.
+   * If no partition spec is specified, all partitions are returned.
+   */
+  final def getPartitionNames(
+      db: String,
+      table: String,
+      partialSpec: Option[TablePartitionSpec]): Seq[String] = {
+    getPartitionNames(getTable(db, table), partialSpec)
+  }
+
+  /**
+   * Returns the partition names for the given table that match the supplied partition spec.
+   * If no partition spec is specified, all partitions are returned.
+   */
+  def getPartitionNames(
+      table: CatalogTable,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[String]
+
   /** Returns the specified partition or None if it does not exist. */
   final def getPartitionOption(
       db: String,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -522,17 +522,21 @@ private[hive] class HiveClientImpl(
   /**
    * Returns the partition names for the given table that match the supplied partition spec.
    * If no partition spec is specified, all partitions are returned.
+   *
+   * The returned sequence is sorted as strings.
    */
   override def getPartitionNames(
       table: CatalogTable,
       partialSpec: Option[TablePartitionSpec] = None): Seq[String] = withHiveState {
-    partialSpec match {
-      case None =>
-        // -1 for result limit means "no limit/return all"
-        client.getPartitionNames(table.database, table.identifier.table, -1).asScala
-      case Some(s) =>
-        client.getPartitionNames(table.database, table.identifier.table, s.asJava, -1).asScala
-    }
+    val hivePartitionNames =
+      partialSpec match {
+        case None =>
+          // -1 for result limit means "no limit/return all"
+          client.getPartitionNames(table.database, table.identifier.table, -1)
+        case Some(s) =>
+          client.getPartitionNames(table.database, table.identifier.table, s.asJava, -1)
+      }
+    hivePartitionNames.asScala.sorted
   }
 
   override def getPartitionOption(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -519,6 +519,20 @@ private[hive] class HiveClientImpl(
     client.alterPartitions(table, newParts.map { p => toHivePartition(p, hiveTable) }.asJava)
   }
 
+  /**
+   * Returns the partition names for the given table that match the supplied partition spec.
+   * If no partition spec is specified, all partitions are returned.
+   */
+  override def getPartitionNames(
+      table: CatalogTable,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[String] = withHiveState {
+    partialSpec match {
+      case None => client.getPartitionNames(table.database, table.identifier.table, -1).asScala
+      case Some(s) =>
+        client.getPartitionNames(table.database, table.identifier.table, s.asJava, -1).asScala
+    }
+  }
+
   override def getPartitionOption(
       table: CatalogTable,
       spec: TablePartitionSpec): Option[CatalogTablePartition] = withHiveState {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -527,7 +527,9 @@ private[hive] class HiveClientImpl(
       table: CatalogTable,
       partialSpec: Option[TablePartitionSpec] = None): Seq[String] = withHiveState {
     partialSpec match {
-      case None => client.getPartitionNames(table.database, table.identifier.table, -1).asScala
+      case None =>
+        // "-1" means "do not limit the number of results"
+        client.getPartitionNames(table.database, table.identifier.table, -1).asScala
       case Some(s) =>
         client.getPartitionNames(table.database, table.identifier.table, s.asJava, -1).asScala
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -528,7 +528,7 @@ private[hive] class HiveClientImpl(
       partialSpec: Option[TablePartitionSpec] = None): Seq[String] = withHiveState {
     partialSpec match {
       case None =>
-        // "-1" means "do not limit the number of results"
+        // -1 for result limit means "no limit/return all"
         client.getPartitionNames(table.database, table.identifier.table, -1).asScala
       case Some(s) =>
         client.getPartitionNames(table.database, table.identifier.table, s.asJava, -1).asScala

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -254,6 +254,11 @@ class VersionsSuite extends SparkFunSuite with Logging {
         "default", "src_part", partitions, ignoreIfExists = true)
     }
 
+    test(s"$version: getPartitionNames(catalogTable)") {
+      assert(testPartitionCount ==
+        client.getPartitionNames(client.getTable("default", "src_part")).size)
+    }
+
     test(s"$version: getPartitions(catalogTable)") {
       assert(testPartitionCount ==
         client.getPartitions(client.getTable("default", "src_part")).size)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -255,8 +255,8 @@ class VersionsSuite extends SparkFunSuite with Logging {
     }
 
     test(s"$version: getPartitionNames(catalogTable)") {
-      assert(testPartitionCount ==
-        client.getPartitionNames(client.getTable("default", "src_part")).size)
+      val partitionNames = (1 to testPartitionCount).map(key2 => s"key1=1/key2=$key2")
+      assert(partitionNames == client.getPartitionNames(client.getTable("default", "src_part")))
     }
 
     test(s"$version: getPartitions(catalogTable)") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -53,25 +53,28 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         |TBLPROPERTIES('prop1Key'="prop1Val", '`prop2Key`'="prop2Val")
       """.stripMargin)
     sql("CREATE TABLE parquet_tab3(col1 int, `col 2` int)")
-    sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)")
-    sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 1) SELECT 1, 1")
-    sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 2) SELECT 2, 2")
-    sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 2) SELECT 3, 3")
-    sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 3) SELECT 3, 3")
+
+    // NB: some table partition column names in this test suite have upper-case characters to test
+    // column name case preservation. Do not lowercase these partition names without good reason.
+    sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (Year int, Month int)")
+    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2015, Month = 1) SELECT 1, 1")
+    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2015, Month = 2) SELECT 2, 2")
+    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2016, Month = 2) SELECT 3, 3")
+    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2016, Month = 3) SELECT 3, 3")
     sql(
       """
         |CREATE TABLE parquet_tab5 (price int, qty int)
-        |PARTITIONED BY (year int, month int, hour int, minute int, sec int, extra int)
+        |PARTITIONED BY (Year int, Month int, hour int, minute int, sec int, extra int)
       """.stripMargin)
     sql(
       """
         |INSERT INTO parquet_tab5
-        |PARTITION(year = 2016, month = 3, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
+        |PARTITION(Year = 2016, Month = 3, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
       """.stripMargin)
     sql(
       """
         |INSERT INTO parquet_tab5
-        |PARTITION(year = 2016, month = 4, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
+        |PARTITION(Year = 2016, Month = 4, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
       """.stripMargin)
     sql("CREATE VIEW parquet_view1 as select * from parquet_tab4")
   }
@@ -183,7 +186,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       sql(
         """
           |CREATE TABLE part_table (employeeID INT, employeeName STRING)
-          |PARTITIONED BY (c STRING, d STRING)
+          |PARTITIONED BY (C STRING, d STRING)
           |ROW FORMAT DELIMITED
           |FIELDS TERMINATED BY '|'
           |LINES TERMINATED BY '\n'
@@ -195,24 +198,24 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       }
 
       intercept[AnalysisException] {
-        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1")""")
+        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1")""")
       }
       intercept[AnalysisException] {
         sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(d="1")""")
       }
       intercept[AnalysisException] {
-        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", k="2")""")
+        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", k="2")""")
       }
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", d="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", d="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '2'"),
         sql("SELECT * FROM non_part_table").collect())
 
       // Different order of partition columns.
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(d="1", c="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(d="1", C="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '2' AND d = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '2' AND d = '1'"),
         sql("SELECT * FROM non_part_table").collect())
     }
   }
@@ -296,38 +299,38 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       sql(
         """
           |CREATE TABLE part_table (employeeID INT, employeeName STRING)
-          |PARTITIONED BY (c STRING, d STRING)
+          |PARTITIONED BY (C STRING, d STRING)
           |ROW FORMAT DELIMITED
           |FIELDS TERMINATED BY '|'
           |LINES TERMINATED BY '\n'
         """.stripMargin)
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", d="1")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", d="1")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '1'"),
         testResults)
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", d="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", d="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '2'"),
         testResults)
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="2", d="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="2", d="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '2' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '2' AND d = '2'"),
         testResults)
 
-      sql("TRUNCATE TABLE part_table PARTITION(c='1', d='1')")
+      sql("TRUNCATE TABLE part_table PARTITION(C='1', d='1')")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '1'"),
         Seq.empty[Row])
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '2'"),
         testResults)
 
-      sql("TRUNCATE TABLE part_table PARTITION(c='1')")
+      sql("TRUNCATE TABLE part_table PARTITION(C='1')")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1'"),
         Seq.empty[Row])
 
       sql("TRUNCATE TABLE part_table")
@@ -341,40 +344,40 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
   test("show partitions - show everything") {
     checkAnswer(
       sql("show partitions parquet_tab4"),
-      Row("year=2015/month=1") ::
-        Row("year=2015/month=2") ::
-        Row("year=2016/month=2") ::
-        Row("year=2016/month=3") :: Nil)
+      Row("Year=2015/Month=1") ::
+        Row("Year=2015/Month=2") ::
+        Row("Year=2016/Month=2") ::
+        Row("Year=2016/Month=3") :: Nil)
 
     checkAnswer(
       sql("show partitions default.parquet_tab4"),
-      Row("year=2015/month=1") ::
-        Row("year=2015/month=2") ::
-        Row("year=2016/month=2") ::
-        Row("year=2016/month=3") :: Nil)
+      Row("Year=2015/Month=1") ::
+        Row("Year=2015/Month=2") ::
+        Row("Year=2016/Month=2") ::
+        Row("Year=2016/Month=3") :: Nil)
   }
 
   test("show partitions - show everything more than 5 part keys") {
     checkAnswer(
       sql("show partitions parquet_tab5"),
-      Row("year=2016/month=3/hour=10/minute=10/sec=10/extra=1") ::
-        Row("year=2016/month=4/hour=10/minute=10/sec=10/extra=1") :: Nil)
+      Row("Year=2016/Month=3/hour=10/minute=10/sec=10/extra=1") ::
+        Row("Year=2016/Month=4/hour=10/minute=10/sec=10/extra=1") :: Nil)
   }
 
   test("show partitions - filter") {
     checkAnswer(
-      sql("show partitions default.parquet_tab4 PARTITION(year=2015)"),
-      Row("year=2015/month=1") ::
-        Row("year=2015/month=2") :: Nil)
+      sql("show partitions default.parquet_tab4 PARTITION(Year=2015)"),
+      Row("Year=2015/Month=1") ::
+        Row("Year=2015/Month=2") :: Nil)
 
     checkAnswer(
-      sql("show partitions default.parquet_tab4 PARTITION(year=2015, month=1)"),
-      Row("year=2015/month=1") :: Nil)
+      sql("show partitions default.parquet_tab4 PARTITION(Year=2015, Month=1)"),
+      Row("Year=2015/Month=1") :: Nil)
 
     checkAnswer(
-      sql("show partitions default.parquet_tab4 PARTITION(month=2)"),
-      Row("year=2015/month=2") ::
-        Row("year=2016/month=2") :: Nil)
+      sql("show partitions default.parquet_tab4 PARTITION(Month=2)"),
+      Row("Year=2015/Month=2") ::
+        Row("Year=2016/Month=2") :: Nil)
   }
 
   test("show partitions - empty row") {
@@ -408,14 +411,18 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
   test("show partitions - datasource") {
     withTable("part_datasrc") {
-      val df = (1 to 3).map(i => (i, s"val_$i", i * 2)).toDF("a", "b", "c")
+      val df = (1 to 3).map(i => (i, s"val_$i", i * 2)).toDF("A", "b", "c")
       df.write
-        .partitionBy("a")
+        .partitionBy("A")
         .format("parquet")
         .mode(SaveMode.Overwrite)
         .saveAsTable("part_datasrc")
 
-      assert(sql("SHOW PARTITIONS part_datasrc").count() == 3)
+      checkAnswer(
+        sql("SHOW PARTITIONS part_datasrc"),
+        Row("A=1") ::
+          Row("A=2") ::
+          Row("A=3") :: Nil)
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -53,28 +53,25 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         |TBLPROPERTIES('prop1Key'="prop1Val", '`prop2Key`'="prop2Val")
       """.stripMargin)
     sql("CREATE TABLE parquet_tab3(col1 int, `col 2` int)")
-
-    // NB: some table partition column names in this test suite have upper-case characters to test
-    // column name case preservation. Do not lowercase these partition names without good reason.
-    sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (Year int, Month int)")
-    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2015, Month = 1) SELECT 1, 1")
-    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2015, Month = 2) SELECT 2, 2")
-    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2016, Month = 2) SELECT 3, 3")
-    sql("INSERT INTO parquet_tab4 PARTITION(Year = 2016, Month = 3) SELECT 3, 3")
+    sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)")
+    sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 1) SELECT 1, 1")
+    sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 2) SELECT 2, 2")
+    sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 2) SELECT 3, 3")
+    sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 3) SELECT 3, 3")
     sql(
       """
         |CREATE TABLE parquet_tab5 (price int, qty int)
-        |PARTITIONED BY (Year int, Month int, hour int, minute int, sec int, extra int)
+        |PARTITIONED BY (year int, month int, hour int, minute int, sec int, extra int)
       """.stripMargin)
     sql(
       """
         |INSERT INTO parquet_tab5
-        |PARTITION(Year = 2016, Month = 3, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
+        |PARTITION(year = 2016, month = 3, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
       """.stripMargin)
     sql(
       """
         |INSERT INTO parquet_tab5
-        |PARTITION(Year = 2016, Month = 4, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
+        |PARTITION(year = 2016, month = 4, hour = 10, minute = 10, sec = 10, extra = 1) SELECT 3, 3
       """.stripMargin)
     sql("CREATE VIEW parquet_view1 as select * from parquet_tab4")
   }
@@ -186,7 +183,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       sql(
         """
           |CREATE TABLE part_table (employeeID INT, employeeName STRING)
-          |PARTITIONED BY (C STRING, d STRING)
+          |PARTITIONED BY (c STRING, d STRING)
           |ROW FORMAT DELIMITED
           |FIELDS TERMINATED BY '|'
           |LINES TERMINATED BY '\n'
@@ -198,24 +195,24 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       }
 
       intercept[AnalysisException] {
-        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1")""")
+        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1")""")
       }
       intercept[AnalysisException] {
         sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(d="1")""")
       }
       intercept[AnalysisException] {
-        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", k="2")""")
+        sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", k="2")""")
       }
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", d="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", d="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '2'"),
         sql("SELECT * FROM non_part_table").collect())
 
       // Different order of partition columns.
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(d="1", C="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(d="1", c="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '2' AND d = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '2' AND d = '1'"),
         sql("SELECT * FROM non_part_table").collect())
     }
   }
@@ -299,38 +296,38 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       sql(
         """
           |CREATE TABLE part_table (employeeID INT, employeeName STRING)
-          |PARTITIONED BY (C STRING, d STRING)
+          |PARTITIONED BY (c STRING, d STRING)
           |ROW FORMAT DELIMITED
           |FIELDS TERMINATED BY '|'
           |LINES TERMINATED BY '\n'
         """.stripMargin)
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", d="1")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", d="1")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '1'"),
         testResults)
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="1", d="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="1", d="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '2'"),
         testResults)
 
-      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(C="2", d="2")""")
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE part_table PARTITION(c="2", d="2")""")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '2' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '2' AND d = '2'"),
         testResults)
 
-      sql("TRUNCATE TABLE part_table PARTITION(C='1', d='1')")
+      sql("TRUNCATE TABLE part_table PARTITION(c='1', d='1')")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '1'"),
         Seq.empty[Row])
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1' AND d = '2'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1' AND d = '2'"),
         testResults)
 
-      sql("TRUNCATE TABLE part_table PARTITION(C='1')")
+      sql("TRUNCATE TABLE part_table PARTITION(c='1')")
       checkAnswer(
-        sql("SELECT employeeID, employeeName FROM part_table WHERE C = '1'"),
+        sql("SELECT employeeID, employeeName FROM part_table WHERE c = '1'"),
         Seq.empty[Row])
 
       sql("TRUNCATE TABLE part_table")
@@ -344,40 +341,40 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
   test("show partitions - show everything") {
     checkAnswer(
       sql("show partitions parquet_tab4"),
-      Row("Year=2015/Month=1") ::
-        Row("Year=2015/Month=2") ::
-        Row("Year=2016/Month=2") ::
-        Row("Year=2016/Month=3") :: Nil)
+      Row("year=2015/month=1") ::
+        Row("year=2015/month=2") ::
+        Row("year=2016/month=2") ::
+        Row("year=2016/month=3") :: Nil)
 
     checkAnswer(
       sql("show partitions default.parquet_tab4"),
-      Row("Year=2015/Month=1") ::
-        Row("Year=2015/Month=2") ::
-        Row("Year=2016/Month=2") ::
-        Row("Year=2016/Month=3") :: Nil)
+      Row("year=2015/month=1") ::
+        Row("year=2015/month=2") ::
+        Row("year=2016/month=2") ::
+        Row("year=2016/month=3") :: Nil)
   }
 
   test("show partitions - show everything more than 5 part keys") {
     checkAnswer(
       sql("show partitions parquet_tab5"),
-      Row("Year=2016/Month=3/hour=10/minute=10/sec=10/extra=1") ::
-        Row("Year=2016/Month=4/hour=10/minute=10/sec=10/extra=1") :: Nil)
+      Row("year=2016/month=3/hour=10/minute=10/sec=10/extra=1") ::
+        Row("year=2016/month=4/hour=10/minute=10/sec=10/extra=1") :: Nil)
   }
 
   test("show partitions - filter") {
     checkAnswer(
-      sql("show partitions default.parquet_tab4 PARTITION(Year=2015)"),
-      Row("Year=2015/Month=1") ::
-        Row("Year=2015/Month=2") :: Nil)
+      sql("show partitions default.parquet_tab4 PARTITION(year=2015)"),
+      Row("year=2015/month=1") ::
+        Row("year=2015/month=2") :: Nil)
 
     checkAnswer(
-      sql("show partitions default.parquet_tab4 PARTITION(Year=2015, Month=1)"),
-      Row("Year=2015/Month=1") :: Nil)
+      sql("show partitions default.parquet_tab4 PARTITION(year=2015, month=1)"),
+      Row("year=2015/month=1") :: Nil)
 
     checkAnswer(
-      sql("show partitions default.parquet_tab4 PARTITION(Month=2)"),
-      Row("Year=2015/Month=2") ::
-        Row("Year=2016/Month=2") :: Nil)
+      sql("show partitions default.parquet_tab4 PARTITION(month=2)"),
+      Row("year=2015/month=2") ::
+        Row("year=2016/month=2") :: Nil)
   }
 
   test("show partitions - empty row") {
@@ -411,18 +408,14 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
   test("show partitions - datasource") {
     withTable("part_datasrc") {
-      val df = (1 to 3).map(i => (i, s"val_$i", i * 2)).toDF("A", "b", "c")
+      val df = (1 to 3).map(i => (i, s"val_$i", i * 2)).toDF("a", "b", "c")
       df.write
-        .partitionBy("A")
+        .partitionBy("a")
         .format("parquet")
         .mode(SaveMode.Overwrite)
         .saveAsTable("part_datasrc")
 
-      checkAnswer(
-        sql("SHOW PARTITIONS part_datasrc"),
-        Row("A=1") ::
-          Row("A=2") ::
-          Row("A=3") :: Nil)
+      assert(sql("SHOW PARTITIONS part_datasrc").count() == 3)
     }
   }
 }


### PR DESCRIPTION
(Link to Jira issue: https://issues.apache.org/jira/browse/SPARK-18572)

## What changes were proposed in this pull request?

Currently Spark answers the `SHOW PARTITIONS` command by fetching all of the table's partition metadata from the external catalog and constructing partition names therefrom. The Hive client has a `getPartitionNames` method which is many times faster for this purpose, with the performance improvement scaling with the number of partitions in a table.

To test the performance impact of this PR, I ran the `SHOW PARTITIONS` command on two Hive tables with large numbers of partitions. One table has ~17,800 partitions, and the other has ~95,000 partitions. For the purposes of this PR, I'll call the former table `table1` and the latter table `table2`. I ran 5 trials for each table with before-and-after versions of this PR. The results are as follows:

Spark at bdc8153, `SHOW PARTITIONS table1`, times in seconds:
7.901
3.983
4.018
4.331
4.261

Spark at bdc8153, `SHOW PARTITIONS table2`
(Timed out after 10 minutes with a `SocketTimeoutException`.)

Spark at this PR, `SHOW PARTITIONS table1`, times in seconds:
3.801
0.449
0.395
0.348
0.336

Spark at this PR, `SHOW PARTITIONS table2`, times in seconds:
5.184
1.63
1.474
1.519
1.41

Taking the best times from each trial, we get a 12x performance improvement for a table with ~17,800 partitions and at least a 426x improvement for a table with ~95,000 partitions. More significantly, the latter command doesn't even complete with the current code in master.

This is actually a patch we've been using in-house at VideoAmp since Spark 1.1. It's made all the difference in the practical usability of our largest tables. Even with tables with about 1,000 partitions there's a performance improvement of about 2-3x.

## How was this patch tested?

I added a unit test to `VersionsSuite` which tests that the Hive client's `getPartitionNames` method returns the correct number of partitions.