### PR TITLE
[SPARK-18341][ML] Eliminate use of SingularMatrixException in WeightedLeastSquares

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/NormalEquationSolver.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/NormalEquationSolver.scala
@@ -33,11 +33,16 @@ import org.apache.spark.mllib.linalg.CholeskyDecomposition
  *              format. None when an optimization program is used to solve the normal equations.
  * @param objectiveHistory Option containing the objective history when an optimization program is
  *                         used to solve the normal equations. None when an analytic solver is used.
+ * @param status Status of the solution. If the solution was produced by [[CholeskySolver]], status
+ *               value greater than 0 indicates singular matrix error; status value less than 0
+ *               indicates illegal input; status == 0 indicates success. If the solution was
+ *               produced by [[QuasiNewtonSolver]], status always return 0 which means success.
  */
 private[ml] class NormalEquationSolution(
     val coefficients: Array[Double],
     val aaInv: Option[Array[Double]],
-    val objectiveHistory: Option[Array[Double]])
+    val objectiveHistory: Option[Array[Double]],
+    val status: Int)
 
 /**
  * Interface for classes that solve the normal equations locally.
@@ -64,11 +69,17 @@ private[ml] class CholeskySolver extends NormalEquationSolver {
       abBar: DenseVector,
       aaBar: DenseVector,
       aBar: DenseVector): NormalEquationSolution = {
-    val k = abBar.size
-    val x = CholeskyDecomposition.solve(aaBar.values, abBar.values)
-    val aaInv = CholeskyDecomposition.inverse(aaBar.values, k)
 
-    new NormalEquationSolution(x, Some(aaInv), None)
+    val k = abBar.size
+    val (x, status1) = CholeskyDecomposition.solve(aaBar.values, abBar.values)
+    if (status1 != 0) {
+      return new NormalEquationSolution(Array(0), None, None, status1)
+    }
+    val (aaInv, status2) = CholeskyDecomposition.inverse(aaBar.values, k)
+    if (status2 != 0) {
+      return new NormalEquationSolution(Array(0), None, None, status2)
+    }
+    new NormalEquationSolution(x, Some(aaInv), None, 0)
   }
 }
 
@@ -110,7 +121,7 @@ private[ml] class QuasiNewtonSolver(
       arrayBuilder += state.adjustedValue
     }
     val x = state.x.toArray.clone()
-    new NormalEquationSolution(x, None, Some(arrayBuilder.result()))
+    new NormalEquationSolution(x, None, Some(arrayBuilder.result()), 0)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/NormalEquationSolver.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/NormalEquationSolver.scala
@@ -163,13 +163,3 @@ private[ml] class QuasiNewtonSolver(
     }
   }
 }
-
-/**
- * Exception thrown when solving a linear system Ax = b for which the matrix A is non-invertible
- * (singular).
- */
-private[spark] class SingularMatrixException(message: String, cause: Throwable)
-  extends IllegalArgumentException(message, cause) {
-
-  def this(message: String) = this(message, null)
-}

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -151,7 +151,7 @@ class WeightedLeastSquaresSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("two collinear features") {
     // Cholesky solver does not handle singular input
-    intercept[SingularMatrixException] {
+    intercept[IllegalArgumentException] {
       new WeightedLeastSquares(fitIntercept = false, regParam = 0.0, elasticNetParam = 0.0,
         standardizeFeatures = false, standardizeLabel = false,
         solverType = WeightedLeastSquares.Cholesky).fit(collinearInstances)
@@ -274,7 +274,7 @@ class WeightedLeastSquaresSuite extends SparkFunSuite with MLlibTestSparkContext
       val wls = new WeightedLeastSquares(fitIntercept, regParam = 0.0, elasticNetParam = 0.0,
         standardizeFeatures = standardization, standardizeLabel = standardization,
         solverType = WeightedLeastSquares.Cholesky)
-      intercept[SingularMatrixException] {
+      intercept[IllegalArgumentException] {
         wls.fit(constantFeaturesInstances)
       }
     }
@@ -283,7 +283,7 @@ class WeightedLeastSquaresSuite extends SparkFunSuite with MLlibTestSparkContext
     val wls = new WeightedLeastSquares(fitIntercept = true, regParam = 0.5, elasticNetParam = 0.0,
       standardizeFeatures = false, standardizeLabel = false,
       solverType = WeightedLeastSquares.Cholesky)
-    intercept[SingularMatrixException] {
+    intercept[IllegalArgumentException] {
       wls.fit(constantFeaturesInstances)
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
We should use error code or status code to indicate the normal equation solution status rather than exception. In this PR, I eliminated use of ```SingularMatrixException``` in ```WeightedLeastSquares```.

## How was this patch tested?
Existing tests.
