### PR TITLE
[SPARK-18580] [DStreams] [external/kafka-0-10] Use spark.streaming.backpressure.initialRate in DirectKafkaInputDStream

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -68,8 +68,8 @@ private[spark] class DirectKafkaInputDStream[K, V](
   }
 
   val backpressureInitialRate: Long =
-    _ssc.sparkContext.conf.getLong("spark.streaming.backpressure.initialRate",
-      _ssc.sparkContext.conf.getDouble("spark.streaming.backpressure.pid.minRate", 100).round)
+    ssc.sparkContext.conf.getLong("spark.streaming.backpressure.initialRate",
+      ssc.sparkContext.conf.getDouble("spark.streaming.backpressure.pid.minRate", 100).round)
 
   protected var currentOffsets = Map[TopicPartition, Long]()
 

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -153,7 +153,9 @@ private[spark] class DirectKafkaInputDStream[K, V](
             if (estimateRate > maxRateLimitPerPartition && maxRateLimitPerPartition > 0) {
               maxRateLimitPerPartition
             }
-            else estimateRate
+            else {
+              estimateRate
+            }
           tp -> backpressureRate
         }
       case None => offsets.map { case (tp, offset) => tp -> ppc.maxRatePerPartition(tp) }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -145,9 +145,10 @@ private[spark] class DirectKafkaInputDStream[K, V](
         }
         val totalLag = lagPerPartition.values.sum
 
+        val effectiveRate = if (rate >= 0) rate else backpressureInitialRate
+
         lagPerPartition.map { case (tp, lag) =>
           val maxRateLimitPerPartition = ppc.maxRatePerPartition(tp)
-          val effectiveRate = if (rate >= 0) rate else backpressureInitialRate
           val estimateRate = Math.round(lag / totalLag.toFloat * effectiveRate)
           val backpressureRate =
             if (estimateRate > maxRateLimitPerPartition && maxRateLimitPerPartition > 0) {

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -556,6 +556,76 @@ class DirectKafkaStreamSuite
       Map(new TopicPartition(topic, 0) -> 5L, new TopicPartition(topic, 1) -> 10L))
   }
 
+  test("use backpressure.initialRate with backpressure") {
+    val topic = "backpressureInitialRate"
+    val kafkaParams = getKafkaParams("auto.offset.reset" -> "earliest")
+    val sparkConf = new SparkConf()
+      // Safe, even with streaming, because we're using the direct API.
+      // Using 1 core is useful to make the test more predictable.
+      .setMaster("local[2]")
+      .setAppName(this.getClass.getSimpleName)
+      .set("spark.streaming.backpressure.enabled", "true")
+      .set("spark.streaming.kafka.maxRatePerPartition", "1000")
+      .set("spark.streaming.backpressure.initialRate", "500")
+
+    val messages = Map("foo" -> 5000)
+    kafkaTestUtils.sendMessages(topic, messages)
+
+    ssc = new StreamingContext(sparkConf, Milliseconds(500))
+
+    val kafkaStream = withClue("Error creating direct stream") {
+      new DirectKafkaInputDStream[String, String](
+        ssc,
+        preferredHosts,
+        ConsumerStrategies.Subscribe[String, String](List(topic), kafkaParams.asScala),
+        new DefaultPerPartitionConfig(sparkConf)
+      )
+    }
+    kafkaStream.start()
+
+    val input = Map(new TopicPartition(topic, 0) -> 1000L)
+
+    assert(kafkaStream.maxMessagesPerPartition(input).flatMap(_.headOption).contains(
+    new TopicPartition(topic, 0) -> 250)) // we run for half a second
+
+    kafkaStream.stop()
+  }
+
+  test("backpressure.initialRate should honor maxRatePerPartition") {
+    val topic = "backpressureInitialRate"
+    val kafkaParams = getKafkaParams("auto.offset.reset" -> "earliest")
+    val sparkConf = new SparkConf()
+      // Safe, even with streaming, because we're using the direct API.
+      // Using 1 core is useful to make the test more predictable.
+      .setMaster("local[1]")
+      .setAppName(this.getClass.getSimpleName)
+      .set("spark.streaming.backpressure.enabled", "true")
+      .set("spark.streaming.kafka.maxRatePerPartition", "300")
+      .set("spark.streaming.backpressure.initialRate", "1000")
+
+    val messages = Map("foo" -> 5000)
+    kafkaTestUtils.sendMessages(topic, messages)
+
+    ssc = new StreamingContext(sparkConf, Milliseconds(500))
+
+    val kafkaStream = withClue("Error creating direct stream") {
+      new DirectKafkaInputDStream[String, String](
+        ssc,
+        preferredHosts,
+        ConsumerStrategies.Subscribe[String, String](List(topic), kafkaParams.asScala),
+        new DefaultPerPartitionConfig(sparkConf)
+      )
+    }
+    kafkaStream.start()
+
+    val input = Map(new TopicPartition(topic, 0) -> 1000L)
+
+    assert(kafkaStream.maxMessagesPerPartition(input).flatMap(_.headOption).contains(
+      new TopicPartition(topic, 0) -> 150L)) // we run for half a second
+
+    kafkaStream.stop()
+  }
+
   test("using rate controller") {
     val topic = "backpressure"
     kafkaTestUtils.createTopic(topic, 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use spark.streaming.backpressure.initialRate in DirectKafkaInputDStream

## How was this patch tested?

- unit tests in `org.apache.spark.streaming.kafka010.DirectKafkaStreamSuite`
- tested on live system

This is intended as a PR for SPARK-18580