### PR TITLE
[SPARK-18587][ML] Remove handleInvalid from QuantileDiscretizer

### DIFF
--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -979,6 +979,12 @@ Note that if you have no idea of the upper and lower bounds of the targeted colu
 
 Note also that the splits that you provided have to be in strictly increasing order, i.e. `s0 < s1 < s2 < ... < sn`.
 
+NaN values: Note also that `Bucketizer`
+will raise an error when it finds NaN values in the dataset by default, but the user can also choose to either
+keep or remove NaN values within the dataset by setting `handleInvalid`. If the user chooses to keep
+NaN values, they will be handled specially and placed into their own bucket, for example, if 4 buckets
+are used, then non-NaN data will be put into buckets[0-3], but NaNs will be counted in a special bucket[4].
+
 More details can be found in the API docs for [Bucketizer](api/scala/index.html#org.apache.spark.ml.feature.Bucketizer).
 
 **Examples**
@@ -1187,12 +1193,6 @@ for more details on the API.
 categorical features. The number of bins is set by the `numBuckets` parameter. It is possible
 that the number of buckets used will be smaller than this value, for example, if there are too few
 distinct values of the input to create enough distinct quantiles.
-
-NaN values: Note also that QuantileDiscretizer
-will raise an error when it finds NaN values in the dataset, but the user can also choose to either
-keep or remove NaN values within the dataset by setting `handleInvalid`. If the user chooses to keep
-NaN values, they will be handled specially and placed into their own bucket, for example, if 4 buckets
-are used, then non-NaN data will be put into buckets[0-3], but NaNs will be counted in a special bucket[4].
 
 Algorithm: The bin ranges are chosen using an approximate algorithm (see the documentation for
 [approxQuantile](api/scala/index.html#org.apache.spark.sql.DataFrameStatFunctions) for a

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -33,6 +33,13 @@ import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
 
 /**
  * `Bucketizer` maps a column of continuous features to a column of feature buckets.
+ *
+ * NaN handling:
+ * `Bucketizer` will raise an error when it finds NaN values in the dataset by default,
+ * but the user can also choose to either keep or remove NaN values within the dataset
+ * by setting `handleInvalid`. If the user chooses to keep NaN values, they will be handled
+ * specially and placed into their own bucket, for example, if 4 buckets are used, then
+ * non-NaN data will be put into buckets[0-3], but NaNs will be counted in a special bucket[4].
  */
 @Since("1.4.0")
 final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)


### PR DESCRIPTION
## What changes were proposed in this pull request?
HandleInvalid only happens when ```Bucketizer``` transforming a dataset which contains NaN, however, when the training dataset containing NaN, ```QuantileDiscretizer``` will always ignore them. So we should keep ```handleInvalid``` in ```Bucketizer``` and remove it from ```QuantileDiscretizer```.

For example, before this PR, the default behavior of ```QuantileDiscretizer``` to handle invalid value (i.e. NaN) is throwing error. So we expect errors if running against the following code.
```
val data = Array(-0.9, -0.5, -0.3, 0.0, 0.2, 0.5, 0.9, Double.NaN, Double.NaN, Double.NaN)
val df = data.toSeq.toDF("input")

val discretizer = new QuantileDiscretizer()
      .setInputCol("input")
      .setOutputCol("result")
      .setNumBuckets(3)

val model = discretizer.fit(df)
println(model.getSplits.mkString(","))
```
However, the above code can work well w/o any error thrown. This is because ```QuantileDiscretizer``` which use ```DataFrameStatFunctions.approxQuantile``` will always ignore NaN values when computing quantiles.

## How was this patch tested?
Existing tests.
