### PR TITLE
[SPARK-18598][SQL] Fixed inconsistent bean property inference

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -108,10 +108,7 @@ object JavaTypeInference {
         (MapType(keyDataType, valueDataType, nullable), true)
 
       case _ =>
-        // TODO: we should only collect properties that have getter and setter. However, some tests
-        // pass in scala case class as java bean class which doesn't have getter and setter.
-        val beanInfo = Introspector.getBeanInfo(typeToken.getRawType)
-        val properties = beanInfo.getPropertyDescriptors.filterNot(_.getName == "class")
+        val properties = getJavaBeanProperties(typeToken.getRawType)
         val fields = properties.map { property =>
           val returnType = typeToken.method(property.getReadMethod).getReturnType
           val (dataType, nullable) = inferDataType(returnType)

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/JavaTypeInferenceTestBean.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/JavaTypeInferenceTestBean.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst;
+
+public class JavaTypeInferenceTestBean {
+
+  private String name;
+
+  public JavaTypeInferenceTestBean(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getName2() {
+    return name;
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/JavaTypeInferenceSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/JavaTypeInferenceSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.StructType
+
+class JavaTypeInferenceSuite extends SparkFunSuite {
+  test("JavaTypeInferenceSuite serializerFor and inferDataType should agree on number of fields") {
+
+    val testClass = classOf[JavaTypeInferenceTestBean]
+
+    val dataType = JavaTypeInference.inferDataType(testClass)._1
+    val structType = dataType.asInstanceOf[StructType]
+
+    val serializer = JavaTypeInference.serializerFor(testClass).flatten
+
+    assert(structType.length == serializer.length)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`JavaTypeInference#inferDataType` used a different bean property filter from `serializerFor` and `deserializerFor`. While `inferDataType` required properties to simple not be named "class", the others require properties to have associated accessor and mutator. This caused an inconsistency in the `ExpressionEncoder`, resulting in an `AssertionError` when Datasets are operated on. (see https://issues.apache.org/jira/browse/SPARK-18598)

The PR patches `JavaTypeInference` to _always_ require properties to have an associated accessor and mutator.

## How was this patch tested?

Added a test case for the change. 

The larger, upstream issue (of AssertionError being thrown) has been tested with an integration test (as seen in the JIRA description) but I haven't submitted that.
