### PR TITLE
[SPARK-18599] Add Spectral LDA algorithm

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -113,6 +113,11 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.nativelibs4java</groupId>
+      <artifactId>scalaxy-loops_${scala.binary.version}</artifactId>
+      <version>0.3.4</version>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.uci.eecs.spectralLDA.algorithm
 
 /**

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -1,0 +1,126 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+/**
+* Tensor Decomposition Algorithms.
+* Alternating Least Square algorithm is implemented.
+* Created by Furong Huang on 11/2/15.
+*/
+
+import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, TensorOps}
+import breeze.linalg.{*, DenseMatrix, DenseVector, diag, inv, max, min, norm, qr}
+import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
+
+/** Tensor decomposition by Alternating Least Square (ALS)
+  *
+  * Suppose dimK-by-dimK-by-dimK symmetric tensor T can be decomposed as sum of rank-1 tensors
+  *
+  * $$ T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i $$
+  *
+  * If we pool all \lambda_i in the vector \Lambda, all the column vectors \lambda_i a_i in A,
+  * b_i in B, c_i in C, then
+  *
+  * $$ T^{1} = A \diag(\Lambda)(C \khatri-rao product B)^{\top} $$
+  *
+  * where T^{1} is a dimK-by-(dimK^2) matrix for the unfolded T.
+  *
+  * @param dimK               tensor T is of shape dimK-by-dimK-by-dimK
+  * @param thirdOrderMoments  dimK-by-(dimK*dimK) matrix for the unfolded 3rd-order moments
+  *                           $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
+  * @param maxIterations      max iterations for the ALS algorithm
+  * @param tol                tolerance. the dot product threshold is 1-tol
+  * @param restarts           number of restarts of the ALS loop
+  */
+class ALS(dimK: Int,
+          thirdOrderMoments: DenseMatrix[Double],
+          maxIterations: Int = 500,
+          tol: Double = 1e-6,
+          restarts: Int = 5)
+  extends Serializable {
+  assert(dimK > 0, "The number of topics dimK must be positive.")
+  assert(thirdOrderMoments.rows == dimK && thirdOrderMoments.cols == dimK * dimK,
+    "The thirdOrderMoments must be dimK-by-(dimK * dimK) unfolded matrix")
+
+  assert(maxIterations > 0, "Max iterations must be positive.")
+  assert(tol > 0.0, "tol must be positive and probably close to 0.")
+  assert(restarts > 0, "Number of restarts for ALS must be positive.")
+
+  /** Run Alternating Least Squares (ALS)
+    *
+    * Compute the best approximating rank-$k$ tensor $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
+    *
+    * @param randBasis   default random seed
+    * @return            three dimK-by-dimK matrices with all the $beta_i$ as columns,
+    *                    length-dimK vector for all the eigenvalues
+    */
+  def run(implicit randBasis: RandBasis = Rand)
+     : (DenseMatrix[Double], DenseMatrix[Double],
+        DenseMatrix[Double], DenseVector[Double])={
+    val gaussian = Gaussian(mu = 0.0, sigma = 1.0)
+
+    var optimalA = DenseMatrix.zeros[Double](dimK, dimK)
+    var optimalB = DenseMatrix.zeros[Double](dimK, dimK)
+    var optimalC = DenseMatrix.zeros[Double](dimK, dimK)
+    var optimalLambda = DenseVector.zeros[Double](dimK)
+
+    var reconstructedLoss: Double = 0.0
+    var optimalReconstructedLoss: Double = Double.PositiveInfinity
+
+    for (s <- 0 until restarts) {
+      val qr.QR(a0, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
+      val qr.QR(b0, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
+      val qr.QR(c0, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
+
+      var A = a0
+      var B = b0
+      var C = c0
+
+      var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
+      var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)
+
+      println("Start ALS iterations...")
+      var iter: Int = 0
+      while ((iter == 0) || (iter < maxIterations &&
+        !AlgebraUtil.isConverged(A_prev, A, dotProductThreshold = 1 - tol))) {
+        A_prev = A.copy
+
+        val (updatedA, updatedLambda1) = updateALSIteration(thirdOrderMoments, B, C)
+        A = updatedA
+        lambda = updatedLambda1
+
+        val (updatedB, updatedLambda2) = updateALSIteration(thirdOrderMoments, C, A)
+        B = updatedB
+        lambda = updatedLambda2
+
+        val (updatedC, updatedLambda3) = updateALSIteration(thirdOrderMoments, A, B)
+        C = updatedC
+        lambda = updatedLambda3
+
+        println(s"iter $iter\tlambda: max ${max(lambda)}, min ${min(lambda)}")
+
+        iter += 1
+      }
+      println("Finished ALS iterations.")
+
+      reconstructedLoss = TensorOps.dmatrixNorm(thirdOrderMoments - A * diag(lambda) * TensorOps.krprod(C, B).t)
+      println(s"Reconstructed loss: $reconstructedLoss\tOptimal reconstructed loss: $optimalReconstructedLoss")
+
+      if (reconstructedLoss < optimalReconstructedLoss) {
+        optimalA = A
+        optimalB = B
+        optimalC = C
+        optimalLambda = lambda
+        optimalReconstructedLoss = reconstructedLoss
+      }
+    }
+
+    (optimalA, optimalB, optimalC, optimalLambda)
+  }
+
+  private def updateALSIteration(unfoldedM3: DenseMatrix[Double],
+                                 B: DenseMatrix[Double],
+                                 C: DenseMatrix[Double]): (DenseMatrix[Double], DenseVector[Double]) = {
+    val updatedA = unfoldedM3 * TensorOps.krprod(C, B) * TensorOps.to_invert(C, B)
+    val lambda = norm(updatedA(::, *)).toDenseVector
+    (AlgebraUtil.matrixNormalization(updatedA), lambda)
+  }
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -56,6 +56,8 @@ class TensorLDA(dimK: Int,
                 numIterationsKrylovMethod: Int = 1) extends Serializable {
   assert(dimK > 0, "The number of topics dimK must be positive.")
   assert(alpha0 > 0, "The topic concentration alpha0 must be positive.")
+  assert(numIterationsKrylovMethod >= 0,
+    "No of iterations for the Krylov method must be non-negative.")
   assert(maxIterations > 0, "The number of iterations for ALS must be positive.")
   assert(tol > 0.0, "tol must be positive and probably close to 0.")
 

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.uci.eecs.spectralLDA.algorithm
 
 /**

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -22,26 +22,30 @@ package edu.uci.eecs.spectralLDA.algorithm
  * Alternating Least Square algorithm is implemented.
  * Created by Furong Huang on 11/2/15.
  */
-import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
-import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, argtopk, diag, max, min}
+
+import breeze.linalg.{argtopk, diag, max, min, DenseMatrix, DenseVector, SparseVector}
 import breeze.numerics._
 import breeze.stats.distributions.{Rand, RandBasis}
+import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
 import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
+
 import org.apache.spark.rdd.RDD
 
 
 /** Spectral LDA model
-  *
-  * @param dimK                 number of topics k
-  * @param alpha0               sum of alpha for the Dirichlet prior for topic distribution
-  * @param maxIterations        max number of iterations for the ALS algorithm for CP decomposition
-  * @param tol                  tolerance. the dot product threshold in ALS is 1-tol
-  * @param idfLowerBound        lower bound of Inverse Document Frequency (IDF) for the words to be taken into account
-  * @param m2ConditionNumberUB  upper bound of Condition Number for the shifted M2 matrix, if the empirical
-  *                             Condition Number exceeds the uppper bound the code quits with error before computing
-  *                             the M3. It allows to quickly check if there're any predominant topics
-  * @param randomisedSVD        uses randomised SVD on M2, true by default
-  */
+ *
+ * @param dimK                 number of topics k
+ * @param alpha0               sum of alpha for the Dirichlet prior for topic distribution
+ * @param maxIterations        max number of iterations for the ALS algorithm for CP decomposition
+ * @param tol                  tolerance. the dot product threshold in ALS is 1-tol
+ * @param idfLowerBound        lower bound of Inverse Document Frequency (IDF) for the words
+ *                             to be taken into account
+ * @param m2ConditionNumberUB  upper bound of Condition Number for the shifted M2 matrix,
+ *                             if the empirical Condition Number exceeds the uppper bound
+ *                             the code quits with error before computing the M3. It allows
+ *                             to quickly check if there're any predominant topics
+ * @param randomisedSVD        uses randomised SVD on M2, true by default
+ */
 class TensorLDA(dimK: Int,
                 alpha0: Double,
                 maxIterations: Int = 500,
@@ -98,11 +102,6 @@ class TensorLDA(dimK: Int,
     // It could be due to some very frequent (low IDF) words or that we specified dimK
     // larger than the rank of the shifted M2.
     val m2ConditionNumber = max(cumulant.eigenValuesM2) / min(cumulant.eigenValuesM2)
-    println(s"Shifted M2 top $dimK eigenvalues: ${cumulant.eigenValuesM2}")
-    println(s"Shifted M2 condition number: $m2ConditionNumber")
-    println("If the condition number is too large (e.g. >10), the algorithm may not be able to " +
-      "output reasonable results. It could be due to the existence of very frequent words " +
-      "across the documents or that the specified k is larger than the true number of topics.")
 
     (NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix), alpha,
       cumulant.eigenVectorsM2, cumulant.eigenValuesM2, cumulant.firstOrderMoments)

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -23,7 +23,7 @@ package edu.uci.eecs.spectralLDA.algorithm
  * Created by Furong Huang on 11/2/15.
  */
 
-import breeze.linalg.{argtopk, diag, max, min, DenseMatrix, DenseVector, SparseVector}
+import breeze.linalg.{argsort, diag, max, min, DenseMatrix, DenseVector, SparseVector}
 import breeze.numerics._
 import breeze.stats.distributions.{Rand, RandBasis}
 import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
@@ -87,11 +87,11 @@ class TensorLDA(dimK: Int,
     // unwhitening matrix: $(W^T)^{-1}=U\Sigma^{1/2}$
     val unwhiteningMatrix = cumulant.eigenVectorsM2 * diag(sqrt(cumulant.eigenValuesM2))
 
-    val alphaUnordered: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2))
+    val alphaUnordered: DenseVector[Double] = pow(lambda, -2)
     val topicWordMatrixUnordered: DenseMatrix[Double] = unwhiteningMatrix * nu * diag(lambda)
 
     // re-arrange alpha and topicWordMatrix in descending order of alpha
-    val idx = argtopk(alphaUnordered, dimK)
+    val idx = argsort(alphaUnordered).reverse
     val alpha = alphaUnordered(idx).toDenseVector
     val topicWordMatrix = topicWordMatrixUnordered(::, idx).toDenseMatrix
 

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -1,0 +1,94 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+/**
+ * Tensor Decomposition Algorithms.
+ * Alternating Least Square algorithm is implemented.
+ * Created by Furong Huang on 11/2/15.
+ */
+import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, argtopk, diag, max, min}
+import breeze.numerics._
+import breeze.stats.distributions.{Rand, RandBasis}
+import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
+import org.apache.spark.rdd.RDD
+
+
+/** Spectral LDA model
+  *
+  * @param dimK                 number of topics k
+  * @param alpha0               sum of alpha for the Dirichlet prior for topic distribution
+  * @param maxIterations        max number of iterations for the ALS algorithm for CP decomposition
+  * @param tol                  tolerance. the dot product threshold in ALS is 1-tol
+  * @param idfLowerBound        lower bound of Inverse Document Frequency (IDF) for the words to be taken into account
+  * @param m2ConditionNumberUB  upper bound of Condition Number for the shifted M2 matrix, if the empirical
+  *                             Condition Number exceeds the uppper bound the code quits with error before computing
+  *                             the M3. It allows to quickly check if there're any predominant topics
+  * @param randomisedSVD        uses randomised SVD on M2, true by default
+  */
+class TensorLDA(dimK: Int,
+                alpha0: Double,
+                maxIterations: Int = 500,
+                tol: Double = 1e-6,
+                idfLowerBound: Double = 1.0,
+                m2ConditionNumberUB: Double = Double.PositiveInfinity,
+                randomisedSVD: Boolean = true,
+                numIterationsKrylovMethod: Int = 1) extends Serializable {
+  assert(dimK > 0, "The number of topics dimK must be positive.")
+  assert(alpha0 > 0, "The topic concentration alpha0 must be positive.")
+  assert(maxIterations > 0, "The number of iterations for ALS must be positive.")
+  assert(tol > 0.0, "tol must be positive and probably close to 0.")
+
+  def fit(documents: RDD[(Long, SparseVector[Double])])
+         (implicit randBasis: RandBasis = Rand)
+          : (DenseMatrix[Double], DenseVector[Double],
+             DenseMatrix[Double], DenseVector[Double],
+             DenseVector[Double]) = {
+    val cumulant: DataCumulant = DataCumulant.getDataCumulant(
+      dimK,
+      alpha0,
+      documents,
+      idfLowerBound = idfLowerBound,
+      m2ConditionNumberUB = m2ConditionNumberUB,
+      randomisedSVD = randomisedSVD,
+      numIterationsKrylovMethod = numIterationsKrylovMethod
+    )
+
+    val myALS: ALS = new ALS(
+      dimK,
+      cumulant.thirdOrderMoments,
+      maxIterations = maxIterations,
+      tol = tol
+    )
+
+    val (nu: DenseMatrix[Double], _, _, lambda: DenseVector[Double]) = myALS.run
+
+    // unwhiten the results
+    // unwhitening matrix: $(W^T)^{-1}=U\Sigma^{1/2}$
+    val unwhiteningMatrix = cumulant.eigenVectorsM2 * diag(sqrt(cumulant.eigenValuesM2))
+
+    val alphaUnordered: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2))
+    val topicWordMatrixUnordered: DenseMatrix[Double] = unwhiteningMatrix * nu * diag(lambda)
+
+    // re-arrange alpha and topicWordMatrix in descending order of alpha
+    val idx = argtopk(alphaUnordered, dimK)
+    val alpha = alphaUnordered(idx).toDenseVector
+    val topicWordMatrix = topicWordMatrixUnordered(::, idx).toDenseMatrix
+
+    // Diagnostic information: the ratio of the maximum to the minimum of the
+    // top k eigenvalues of shifted M2
+    //
+    // If it's too large (>10), the algorithm may not be able to output reasonable results.
+    // It could be due to some very frequent (low IDF) words or that we specified dimK
+    // larger than the rank of the shifted M2.
+    val m2ConditionNumber = max(cumulant.eigenValuesM2) / min(cumulant.eigenValuesM2)
+    println(s"Shifted M2 top $dimK eigenvalues: ${cumulant.eigenValuesM2}")
+    println(s"Shifted M2 condition number: $m2ConditionNumber")
+    println("If the condition number is too large (e.g. >10), the algorithm may not be able to " +
+      "output reasonable results. It could be due to the existence of very frequent words " +
+      "across the documents or that the specified k is larger than the true number of topics.")
+
+    (NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix), alpha,
+      cumulant.eigenVectorsM2, cumulant.eigenValuesM2, cumulant.firstOrderMoments)
+  }
+
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.uci.eecs.spectralLDA.datamoments
 
 /**

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -1,0 +1,308 @@
+package edu.uci.eecs.spectralLDA.datamoments
+
+/**
+ * Data Cumulants Calculation.
+ * Created by Furong Huang on 11/2/15.
+ */
+
+import edu.uci.eecs.spectralLDA.utils.{RandNLA, TensorOps}
+import breeze.linalg._
+import breeze.numerics._
+import breeze.stats.distributions.{Rand, RandBasis}
+import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+
+
+/** Data cumulant
+  *
+  * Let the truncated eigendecomposition of the shifted M2 be
+  *
+  * $$M2 = U\Sigma U^T,$$
+  *
+  * where $M2\in\mathsf{R}^{V\times V}$, $U\in\mathsf{R}^{V\times k}$,
+  * $\Sigma\in\mathsf{R}^{k\times k}$, $V$ is the vocabulary size,
+  * $k$ is the number of topics, $k<V$.
+  *
+  * If we denote $W=U\Sigma^{-1/2}$, then $W^T M2 W\approx I$. We call $W$ the whitening matrix.
+  *
+  * $W$ could be used to whiten the shifted M3,
+  *
+  * $$ \frac{\alpha_0(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)
+  *       = \sum_{i=1}^k\alpha_i(W^T\mu_i)^{\otimes 3}
+  *       = \sum_{i=1}^k\alpha_i^{-1/2}(W^T\alpha_i^{1/2}\mu_i)^{\otimes 3} $$
+  *
+  * Note $W^T\alpha_i^{1/2}\mu_i$ are orthonormal, for all $1\le i\le k$.
+  *
+  * @param thirdOrderMoments Scaled whitened M3, precisely,
+  *                            $\frac{\alpha_0(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)$
+  * @param eigenVectorsM2   V-by-k top eigenvectors of shifted M2, stored column-wise
+  * @param eigenValuesM2    length-k top eigenvalues of shifted M2
+  * @param firstOrderMoments  average of term count frequencies M1
+  *
+  * REFERENCES
+  * [Wang2015] Wang Y et al, Fast and Guaranteed Tensor Decomposition via Sketching, 2015,
+  *            http://arxiv.org/abs/1506.04448
+  *
+  */
+case class DataCumulant(thirdOrderMoments: DenseMatrix[Double],
+                        eigenVectorsM2: DenseMatrix[Double],
+                        eigenValuesM2: DenseVector[Double],
+                        firstOrderMoments: DenseVector[Double])
+  extends Serializable
+
+
+object DataCumulant {
+  def getDataCumulant(dimK: Int,
+                      alpha0: Double,
+                      documents: RDD[(Long, SparseVector[Double])],
+                      idfLowerBound: Double = 1.0,
+                      m2ConditionNumberUB: Double = Double.PositiveInfinity,
+                      randomisedSVD: Boolean = true,
+                      numIterationsKrylovMethod: Int = 1)
+                     (implicit randBasis: RandBasis = Rand)
+        : DataCumulant = {
+    assert(dimK > 0, "The number of topics dimK must be positive.")
+    assert(alpha0 > 0, "The topic concentration alpha0 must be positive.")
+
+    val sc: SparkContext = documents.sparkContext
+
+    val idf: DenseVector[Double] = TextProcessor.inverseDocumentFrequency(documents)
+    val termsLowIDF: Seq[Int] = idf.findAll(_ <= idfLowerBound - 1e-12)
+
+    val validDocuments = documents
+      .map {
+        case (id, wc) => (id, sum(wc), wc)
+      }
+      .filter {
+        case (_, len, _) => len >= 3
+      }
+    validDocuments.cache()
+
+    val dimVocab = validDocuments.map(_._3.length).take(1)(0)
+    val numDocs = validDocuments.count()
+
+    println("Start calculating first order moments...")
+    val (m1Index: Array[Int], m1Value: Array[Double]) = validDocuments
+      .flatMap {
+        case (_, length, vec) =>
+          val termDistribution: SparseVector[Double] = vec / length.toDouble
+          termDistribution.activeIterator.toSeq
+      }
+      .reduceByKey(_ + _)
+      .mapValues(_ / numDocs.toDouble)
+      .collect
+      .sorted
+      .unzip
+    val firstOrderMoments = new SparseVector[Double](m1Index, m1Value, dimVocab).toDenseVector
+
+    // Zero out the terms with low IDF
+    firstOrderMoments(termsLowIDF) := 0.0
+    println("Finished calculating first order moments.")
+
+    println("Start calculating second order moments...")
+    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) =
+      if (randomisedSVD) {
+        RandNLA.whiten2(
+          alpha0,
+          dimVocab,
+          dimK,
+          numDocs,
+          firstOrderMoments,
+          validDocuments,
+          termsLowIDF,
+          nIter = numIterationsKrylovMethod
+        )
+      }
+      else {
+        val E_x1_x2: DenseMatrix[Double] = validDocuments
+          .map { case (_, len, vec) =>
+            (TensorOps.spVectorTensorProd2d(vec) - diag(vec)) / (len * (len - 1))
+          }
+          .reduce(_ + _)
+          .map(_ / numDocs.toDouble).toDenseMatrix
+        val M2: DenseMatrix[Double] = E_x1_x2 - alpha0 / (alpha0 + 1) * (firstOrderMoments * firstOrderMoments.t)
+        M2(termsLowIDF, ::) := 0.0
+        M2(::, termsLowIDF) := 0.0
+
+        val eigSym.EigSym(sigma, u) = eigSym(alpha0 * (alpha0 + 1) * M2)
+        val i = argsort(sigma)
+        (u(::, i.slice(dimVocab - dimK, dimVocab)).copy, sigma(i.slice(dimVocab - dimK, dimVocab)).copy)
+      }
+    println("Finished calculating second order moments and whitening matrix.")
+
+    val m2ConditionNumber: Double = max(eigenValues) / min(eigenValues)
+    if (m2ConditionNumber > m2ConditionNumberUB) {
+      println(s"ERROR: Shifted M2 top $dimK eigenvalues: $eigenValues")
+      println(s"ERROR: Shifted M2 condition number: $m2ConditionNumber > UB $m2ConditionNumberUB")
+      sys.exit(2)
+    }
+
+    println("Start whitening data with dimensionality reduction...")
+    val W: DenseMatrix[Double] = eigenVectors * diag(eigenValues map { x => 1 / (sqrt(x) + 1e-9) })
+    println("Finished whitening data.")
+
+    // We computing separately the first order, second order, 3rd order terms in Eq (25) (26)
+    // in [Wang2015]. For the 2nd order, 3rd order terms, We'd achieve maximum performance with
+    // reduceByKey() of w_i, 1\le i\le V, the rows of the whitening matrix W.
+    println("Start calculating third order moments...")
+    val firstOrderMoments_whitened = W.t * firstOrderMoments
+    val broadcasted_W = sc.broadcast[DenseMatrix[Double]](W)
+
+    // First order terms: p^{\otimes 3}, p\otimes p\otimes q, p\otimes q\otimes p,
+    // q\otimes p\otimes p
+    val m3FirstOrderPart = validDocuments
+      .map {
+        case (_, len, vec) => whitenedM3FirstOrderTerms(
+          alpha0,
+          broadcasted_W.value,
+          firstOrderMoments_whitened,
+          vec, len
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    // Second order terms: all terms as w_i\otimes w_i\otimes p, w_i\otimes w_i\otimes q,
+    // 1\le i\le V and their permutations
+    val m3SecondOrderPart = validDocuments
+      .flatMap {
+        case (_, len, vec) => whitenedM3SecondOrderTerms(
+          alpha0,
+          broadcasted_W.value,
+          firstOrderMoments_whitened,
+          vec, len
+        )
+      }
+      .reduceByKey(_ + _)
+      .map {
+        case (i: Int, x: DenseVector[Double]) => computeSecondOrderTerms(
+          i, x,
+          broadcasted_W.value
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    // Third order terms: all terms w_i^{\otimes 3}, 1\le i\le V
+    val m3ThirdOrderPart = validDocuments
+      .flatMap {
+        case (_, len, vec) => whitenedM3ThirdOrderTerms(
+          alpha0,
+          vec, len
+        )
+      }
+      .reduceByKey(_ + _)
+      .map {
+        case (i: Int, p: Double) => computeThirdOrderTerms(
+          i, p,
+          broadcasted_W.value
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    // sketch of q=W^T M1
+    val q_otimes_3 = 2 * alpha0 * alpha0 / ((alpha0 + 1) * (alpha0 + 2)) * TensorOps.makeRankOneTensor3d(
+      firstOrderMoments_whitened, firstOrderMoments_whitened, firstOrderMoments_whitened
+    )
+
+    broadcasted_W.unpersist()
+
+    val whitenedM3 = m3FirstOrderPart + m3SecondOrderPart + m3ThirdOrderPart + q_otimes_3
+    println("Finished calculating third order moments.")
+
+    // val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
+
+    new DataCumulant(
+      whitenedM3 * alpha0 * (alpha0 + 1) * (alpha0 + 2) / 2.0,
+      eigenVectors,
+      eigenValues,
+      firstOrderMoments
+    )
+  }
+
+  private def whitenedM3FirstOrderTerms(alpha0: Double,
+                                        W: DenseMatrix[Double],
+                                        q: DenseVector[Double],
+                                        n: SparseVector[Double],
+                                        len: Double)
+  : DenseMatrix[Double] = {
+    // $p=W^T n$, where n is the original word count vector
+    val p: DenseVector[Double] = W.t * n
+
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
+
+    val s1 = TensorOps.makeRankOneTensor3d(p, p, p)
+    val s2 = TensorOps.makeRankOneTensor3d(p, p, q)
+    val s3 = TensorOps.makeRankOneTensor3d(p, q, p)
+    val s4 = TensorOps.makeRankOneTensor3d(q, p, p)
+
+    coeff1 * s1 - coeff2 * h1 * (s2 + s3 + s4)
+  }
+
+  private def whitenedM3SecondOrderTerms(alpha0: Double,
+                                         W: DenseMatrix[Double],
+                                         q: DenseVector[Double],
+                                         n: SparseVector[Double],
+                                         len: Double)
+  : Seq[(Int, DenseVector[Double])] = {
+    val p: DenseVector[Double] = W.t * n
+
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
+
+    var seqTerms = Seq[(Int, DenseVector[Double])]()
+    for ((wc_index, wc_value) <- n.activeIterator) {
+      seqTerms ++= Seq(
+        (wc_index, -coeff1 * wc_value * p),
+        (wc_index, coeff2 * h1 * wc_value * q)
+      )
+    }
+
+    seqTerms
+  }
+
+  private def whitenedM3ThirdOrderTerms(alpha0: Double,
+                                        n: SparseVector[Double],
+                                        len: Double)
+  : Seq[(Int, Double)] = {
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
+
+    var seqTerms = Seq[(Int, Double)]()
+    for ((wc_index, wc_value) <- n.activeIterator) {
+      seqTerms :+= (wc_index, 2 * coeff1 * wc_value)
+    }
+
+    seqTerms
+  }
+
+  private def computeSecondOrderTerms(i: Int,
+                                      x: DenseVector[Double],
+                                      W: DenseMatrix[Double])
+      : DenseMatrix[Double] = {
+    val w: DenseVector[Double] = W(i, ::).t
+
+    val prod1 = TensorOps.makeRankOneTensor3d(w, w, x)
+    val prod2 = TensorOps.makeRankOneTensor3d(w, x, w)
+    val prod3 = TensorOps.makeRankOneTensor3d(x, w, w)
+
+    prod1 + prod2 + prod3
+  }
+
+  private def computeThirdOrderTerms(i: Int,
+                                     p: Double,
+                                     W: DenseMatrix[Double])
+      : DenseMatrix[Double] = {
+    val w: DenseVector[Double] = W(i, ::).t
+
+    val z = TensorOps.makeRankOneTensor3d(w, w, w)
+
+    z * p
+  }
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
@@ -18,164 +18,24 @@
 
 package edu.uci.eecs.spectralLDA.textprocessing
 
-import breeze.linalg.{DenseVector, SparseVector, min}
-import org.apache.spark.SparkContext
+import breeze.linalg.{DenseVector, SparseVector}
+
 import org.apache.spark.rdd.RDD
-import org.apache.spark.storage.StorageLevel
-
-import scala.collection.mutable
-
 
 object TextProcessor {
-  /** Process input text files under specified paths into word count vectors, and vocabulary array
-    *
-    */
-  def processDocuments(sc: SparkContext,
-                       path: String,
-                       stopwordFile: String,
-                       vocabSize: Int)
-      : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) = {
-    val textRDD: RDD[(String, String)] = sc.wholeTextFiles(path)
-
-    processDocumentsRDD(textRDD, stopwordFile, vocabSize)
-  }
-
-  /** Process text files into word count vectors, and vocabulary array
-    *
-    * The input text files are in RDD[(String, String)], each row being (filename, content)
-    */
-  def processDocumentsRDD(textRDD: RDD[(String, String)],
-                          stopwordFile: String,
-                          vocabSize: Int)
-      : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) = {
-    val sc = textRDD.sparkContext
-
-    // Split text into words
-    val tokenizer: SimpleTokenizer = new SimpleTokenizer(sc, stopwordFile)
-
-    val tokenized: RDD[(Long, IndexedSeq[String])] = textRDD.zipWithIndex()
-      .map {
-        case ((filename, text), id) => id -> tokenizer.getWords(text)
-      }
-
-    // Counts words: RDD[(word, wordCount)]
-    val wordCounts: RDD[(String, Long)] = tokenized.flatMap{ case (_, tokens) => tokens.map(_ -> 1L) }.reduceByKey(_ + _)
-    wordCounts.cache()
-    val fullVocabSize: Long = wordCounts.count()
-    println(s"Full vocabulary size $fullVocabSize")
-
-    // Select vocab
-    val (vocab: Map[String, Int], selectedTokenCount: Long) = {
-      val tmpSortedWC: Array[(String, Long)] = if (vocabSize == -1 || fullVocabSize <= vocabSize) {
-        // Use all terms
-        wordCounts.collect().sortBy(-_._2)
-      } else {
-        // Sort terms to select vocab
-        wordCounts.sortBy(_._2, ascending = false).take(vocabSize)
-      }
-      (tmpSortedWC.map(_._1).zipWithIndex.toMap, tmpSortedWC.map(_._2).sum)
-    }
-    println("selectedTokenCount: " + selectedTokenCount.toString)
-    println("vocab.size: " + vocab.size.toString)
-
-    val mydocuments: RDD[(Long, breeze.linalg.SparseVector[Double])] = tokenized.map { case (id, tokens) =>
-      // Filter tokens by vocabulary, and create word count vector representation of document.
-      val wc: mutable.HashMap[Int, Int] = new mutable.HashMap[Int, Int]()
-      tokens.foreach { term =>
-        if (vocab.contains(term)) {
-          val termIndex: Int = vocab(term)
-          wc(termIndex) = wc.getOrElse(termIndex, 0) + 1
-        }
-      }
-      val indices: Array[Int] = wc.keys.toArray.sorted
-      val values: Array[Double] = indices.map(i => wc(i).toDouble)
-      val sb: breeze.linalg.SparseVector[Double] = {
-        new breeze.linalg.SparseVector[Double](indices, values, vocab.size)
-      }
-      (id, sb)
-    }
-    println("successfully got the documents.")
-    val vocabarray: Array[String] = new Array[String](vocab.size)
-    vocab.foreach { case (term, i) => vocabarray(i) = term }
-
-    (mydocuments, vocabarray)
-  }
-
-  def processDocuments_libsvm(sc: SparkContext, path: String, vocabSize: Int)
-  : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) ={
-    println(path)
-    val mydocuments: RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path)
-    val vocabsize = mydocuments.map(_._2.length).take(1)(0)
-    val vocabarray: Array[String] = (0 until vocabsize).toArray.map(x => x.toString)
-    (mydocuments, vocabarray)
-  }
-
-  private def loadLibSVMFile2sparseVector(
-                                           sc: SparkContext,
-                                           path: String,
-                                           numFeatures: Int,
-                                           minPartitions: Int)
-        : RDD[(Long, breeze.linalg.SparseVector[Double])] = {
-    val parsed = sc.textFile(path, minPartitions)
-      .map(_.trim)
-      .filter(line => !(line.isEmpty || line.startsWith("#")))
-      .map { line =>
-        val items = line.split(' ')
-        val label = items.head.toDouble.toLong
-        val (indices, values) = items.tail.filter(_.nonEmpty).map { item =>
-          val indexAndValue = item.split(':')
-          val index = indexAndValue(0).toInt - 1 // Convert 1-based indices to 0-based.
-        val value = indexAndValue(1).toDouble
-          (index, value)
-        }.unzip
-
-
-        (label, indices.toArray, values.toArray)
-      }
-
-    // Determine number of features.
-    val d = if (numFeatures > 0) {
-      numFeatures
-    } else {
-      parsed.persist(StorageLevel.MEMORY_ONLY)
-      parsed.map { case (label, indices, values) =>
-        indices.lastOption.getOrElse(0)
-      }.reduce(math.max) + 1
-    }
-
-    parsed.map { case (label, indices, values) =>
-      // LabeledPoint(label, Vectors.sparse(d, indices, values))
-      val myDoubleZero:Double = 0.0
-      val mySparseArray:breeze.collection.mutable.SparseArray[Double] =new  breeze.collection.mutable.SparseArray[Double](indices,values,indices.size,d,myDoubleZero)
-      (label, new breeze.linalg.SparseVector[Double](indices, values, d))
-    }
-  }
-
-  private def loadLibSVMFile2sparseVector(
-                                           sc: SparkContext,
-                                           path: String,
-                                           multiclass: Boolean,
-                                           numFeatures: Int,
-                                           minPartitions: Int): RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path, numFeatures, minPartitions)
-
-  private def loadLibSVMFile2sparseVector(
-                                           sc: SparkContext,
-                                           path: String,
-                                           numFeatures: Int): RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path, numFeatures, sc.defaultMinPartitions)
-
-  private def loadLibSVMFile2sparseVector(sc: SparkContext, path: String): RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path, -1)
 
   /** Returns the Inverse Document Frequency
-    *
-    * @param docs the documents RDD
-    * @return     the IDF vector
-    */
+   * @param docs the documents RDD
+   * @return     the IDF vector
+   */
   def inverseDocumentFrequency(docs: RDD[(Long, SparseVector[Double])], approxCount: Boolean = true)
       : DenseVector[Double] = {
-    val numDocs: Double = if (approxCount)
+    val numDocs: Double = if (approxCount) {
       docs.countApprox(30000L).getFinalValue.mean
-    else
+    }
+    else {
       docs.count.toDouble
+    }
 
     val vocabSize: Int = docs.map(_._2.length).take(1)(0)
     val documentFrequency: DenseVector[Double] = DenseVector.zeros[Double](vocabSize)
@@ -196,16 +56,15 @@ object TextProcessor {
   }
 
   /** Filter out terms whose IDF is lower than the given bound
-    *
-    * @param docs           the documents RDD
-    * @param idfLowerBound  lower bound for the IDF
-    */
+   *
+   * @param docs           the documents RDD
+   * @param idfLowerBound  lower bound for the IDF
+   */
   def filterIDF(docs: RDD[(Long, SparseVector[Double])], idfLowerBound: Double)
       : RDD[(Long, SparseVector[Double])] = {
     if (idfLowerBound > 1.0 + 1e-12) {
       val idf = inverseDocumentFrequency(docs)
       val invalidTermIndices = (idf :< idfLowerBound).toVector
-      println(s"Ignoring term IDs $invalidTermIndices")
 
       docs.map {
         case (id: Long, w: SparseVector[Double]) =>
@@ -213,7 +72,8 @@ object TextProcessor {
           (id, w)
       }
     }
-    else
+    else {
       docs
+    }
   }
 }

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
@@ -1,0 +1,201 @@
+package edu.uci.eecs.spectralLDA.textprocessing
+
+import breeze.linalg.{DenseVector, SparseVector, min}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+
+import scala.collection.mutable
+
+
+object TextProcessor {
+  /** Process input text files under specified paths into word count vectors, and vocabulary array
+    *
+    */
+  def processDocuments(sc: SparkContext,
+                       path: String,
+                       stopwordFile: String,
+                       vocabSize: Int)
+      : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) = {
+    val textRDD: RDD[(String, String)] = sc.wholeTextFiles(path)
+
+    processDocumentsRDD(textRDD, stopwordFile, vocabSize)
+  }
+
+  /** Process text files into word count vectors, and vocabulary array
+    *
+    * The input text files are in RDD[(String, String)], each row being (filename, content)
+    */
+  def processDocumentsRDD(textRDD: RDD[(String, String)],
+                          stopwordFile: String,
+                          vocabSize: Int)
+      : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) = {
+    val sc = textRDD.sparkContext
+
+    // Split text into words
+    val tokenizer: SimpleTokenizer = new SimpleTokenizer(sc, stopwordFile)
+
+    val tokenized: RDD[(Long, IndexedSeq[String])] = textRDD.zipWithIndex()
+      .map {
+        case ((filename, text), id) => id -> tokenizer.getWords(text)
+      }
+
+    // Counts words: RDD[(word, wordCount)]
+    val wordCounts: RDD[(String, Long)] = tokenized.flatMap{ case (_, tokens) => tokens.map(_ -> 1L) }.reduceByKey(_ + _)
+    wordCounts.cache()
+    val fullVocabSize: Long = wordCounts.count()
+    println(s"Full vocabulary size $fullVocabSize")
+
+    // Select vocab
+    val (vocab: Map[String, Int], selectedTokenCount: Long) = {
+      val tmpSortedWC: Array[(String, Long)] = if (vocabSize == -1 || fullVocabSize <= vocabSize) {
+        // Use all terms
+        wordCounts.collect().sortBy(-_._2)
+      } else {
+        // Sort terms to select vocab
+        wordCounts.sortBy(_._2, ascending = false).take(vocabSize)
+      }
+      (tmpSortedWC.map(_._1).zipWithIndex.toMap, tmpSortedWC.map(_._2).sum)
+    }
+    println("selectedTokenCount: " + selectedTokenCount.toString)
+    println("vocab.size: " + vocab.size.toString)
+
+    val mydocuments: RDD[(Long, breeze.linalg.SparseVector[Double])] = tokenized.map { case (id, tokens) =>
+      // Filter tokens by vocabulary, and create word count vector representation of document.
+      val wc: mutable.HashMap[Int, Int] = new mutable.HashMap[Int, Int]()
+      tokens.foreach { term =>
+        if (vocab.contains(term)) {
+          val termIndex: Int = vocab(term)
+          wc(termIndex) = wc.getOrElse(termIndex, 0) + 1
+        }
+      }
+      val indices: Array[Int] = wc.keys.toArray.sorted
+      val values: Array[Double] = indices.map(i => wc(i).toDouble)
+      val sb: breeze.linalg.SparseVector[Double] = {
+        new breeze.linalg.SparseVector[Double](indices, values, vocab.size)
+      }
+      (id, sb)
+    }
+    println("successfully got the documents.")
+    val vocabarray: Array[String] = new Array[String](vocab.size)
+    vocab.foreach { case (term, i) => vocabarray(i) = term }
+
+    (mydocuments, vocabarray)
+  }
+
+  def processDocuments_libsvm(sc: SparkContext, path: String, vocabSize: Int)
+  : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) ={
+    println(path)
+    val mydocuments: RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path)
+    val vocabsize = mydocuments.map(_._2.length).take(1)(0)
+    val vocabarray: Array[String] = (0 until vocabsize).toArray.map(x => x.toString)
+    (mydocuments, vocabarray)
+  }
+
+  private def loadLibSVMFile2sparseVector(
+                                           sc: SparkContext,
+                                           path: String,
+                                           numFeatures: Int,
+                                           minPartitions: Int)
+        : RDD[(Long, breeze.linalg.SparseVector[Double])] = {
+    val parsed = sc.textFile(path, minPartitions)
+      .map(_.trim)
+      .filter(line => !(line.isEmpty || line.startsWith("#")))
+      .map { line =>
+        val items = line.split(' ')
+        val label = items.head.toDouble.toLong
+        val (indices, values) = items.tail.filter(_.nonEmpty).map { item =>
+          val indexAndValue = item.split(':')
+          val index = indexAndValue(0).toInt - 1 // Convert 1-based indices to 0-based.
+        val value = indexAndValue(1).toDouble
+          (index, value)
+        }.unzip
+
+
+        (label, indices.toArray, values.toArray)
+      }
+
+    // Determine number of features.
+    val d = if (numFeatures > 0) {
+      numFeatures
+    } else {
+      parsed.persist(StorageLevel.MEMORY_ONLY)
+      parsed.map { case (label, indices, values) =>
+        indices.lastOption.getOrElse(0)
+      }.reduce(math.max) + 1
+    }
+
+    parsed.map { case (label, indices, values) =>
+      // LabeledPoint(label, Vectors.sparse(d, indices, values))
+      val myDoubleZero:Double = 0.0
+      val mySparseArray:breeze.collection.mutable.SparseArray[Double] =new  breeze.collection.mutable.SparseArray[Double](indices,values,indices.size,d,myDoubleZero)
+      (label, new breeze.linalg.SparseVector[Double](indices, values, d))
+    }
+  }
+
+  private def loadLibSVMFile2sparseVector(
+                                           sc: SparkContext,
+                                           path: String,
+                                           multiclass: Boolean,
+                                           numFeatures: Int,
+                                           minPartitions: Int): RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path, numFeatures, minPartitions)
+
+  private def loadLibSVMFile2sparseVector(
+                                           sc: SparkContext,
+                                           path: String,
+                                           numFeatures: Int): RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path, numFeatures, sc.defaultMinPartitions)
+
+  private def loadLibSVMFile2sparseVector(sc: SparkContext, path: String): RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path, -1)
+
+  /** Returns the Inverse Document Frequency
+    *
+    * @param docs the documents RDD
+    * @return     the IDF vector
+    */
+  def inverseDocumentFrequency(docs: RDD[(Long, SparseVector[Double])], approxCount: Boolean = true)
+      : DenseVector[Double] = {
+    val numDocs: Double = if (approxCount)
+      docs.countApprox(30000L).getFinalValue.mean
+    else
+      docs.count.toDouble
+
+    val vocabSize: Int = docs.map(_._2.length).take(1)(0)
+    val documentFrequency: DenseVector[Double] = DenseVector.zeros[Double](vocabSize)
+
+    docs
+      .flatMap[(Int, Double)] {
+        case (_, w: SparseVector[Double]) =>
+          for ((token, count) <- w.activeIterator)
+            yield (token, if (count > 0.0) 1.0 else 0.0)
+      }
+      .reduceByKey(_ + _)
+      .collect
+      .foreach {
+        case (token, df) => documentFrequency(token) = df
+      }
+
+    numDocs / documentFrequency
+  }
+
+  /** Filter out terms whose IDF is lower than the given bound
+    *
+    * @param docs           the documents RDD
+    * @param idfLowerBound  lower bound for the IDF
+    */
+  def filterIDF(docs: RDD[(Long, SparseVector[Double])], idfLowerBound: Double)
+      : RDD[(Long, SparseVector[Double])] = {
+    if (idfLowerBound > 1.0 + 1e-12) {
+      val idf = inverseDocumentFrequency(docs)
+      val invalidTermIndices = (idf :< idfLowerBound).toVector
+      println(s"Ignoring term IDs $invalidTermIndices")
+
+      docs.map {
+        case (id: Long, w: SparseVector[Double]) =>
+          w(invalidTermIndices) := 0.0
+          (id, w)
+      }
+    }
+    else
+      docs
+  }
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package edu.uci.eecs.spectralLDA.textprocessing
 
 import breeze.linalg.{DenseVector, SparseVector, min}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -1,0 +1,41 @@
+package edu.uci.eecs.spectralLDA.utils
+
+/**
+ * Utils for algebric operations.
+ * Created by furongh on 11/2/15.
+ */
+
+import breeze.linalg._
+import scalaxy.loops._
+import scala.language.postfixOps
+
+object AlgebraUtil {
+
+  def matrixNormalization(B: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val A: DenseMatrix[Double] = B.copy
+    val colNorms: DenseVector[Double] = norm(A(::, *)).toDenseVector
+
+    for (i <- 0 until A.cols optimized) {
+      A(::, i) :/= colNorms(i)
+    }
+    A
+  }
+
+  def isConverged(oldA: DenseMatrix[Double],
+                  newA: DenseMatrix[Double],
+                  dotProductThreshold: Double = 0.99): Boolean = {
+    if (oldA == null || oldA.size == 0) {
+      return false
+    }
+
+    val dprod = diag(oldA.t * newA)
+    println(s"dot(oldA, newA): ${diag(oldA.t * newA)}")
+
+    all(dprod :> dotProductThreshold)
+  }
+
+  def Cumsum(xs: Array[Double]): Array[Double] = {
+    xs.scanLeft(0.0)(_ + _).tail
+  }
+  
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -23,14 +23,14 @@ package edu.uci.eecs.spectralLDA.utils
  */
 
 import breeze.linalg._
-import scalaxy.loops._
 import scala.language.postfixOps
+import scalaxy.loops._
+
 
 object AlgebraUtil {
-
   def matrixNormalization(B: DenseMatrix[Double]): DenseMatrix[Double] = {
     val A: DenseMatrix[Double] = B.copy
-    val colNorms: DenseVector[Double] = norm(A(::, *)).toDenseVector
+    val colNorms: DenseVector[Double] = norm(A(::, *)).t.toDenseVector
 
     for (i <- 0 until A.cols optimized) {
       A(::, i) :/= colNorms(i)
@@ -46,7 +46,6 @@ object AlgebraUtil {
     }
 
     val dprod = diag(oldA.t * newA)
-    println(s"dot(oldA, newA): ${diag(oldA.t * newA)}")
 
     all(dprod :> dotProductThreshold)
   }
@@ -54,5 +53,4 @@ object AlgebraUtil {
   def Cumsum(xs: Array[Double]): Array[Double] = {
     xs.scanLeft(0.0)(_ + _).tail
   }
-  
 }

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.uci.eecs.spectralLDA.utils
 
 /**

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.uci.eecs.spectralLDA.utils
 
 import breeze.linalg.{DenseMatrix, DenseVector, max, min}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
@@ -1,0 +1,76 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg.{DenseMatrix, DenseVector, max, min}
+
+import scala.util.control.Breaks._
+import scalaxy.loops._
+import scala.language.postfixOps
+
+object NonNegativeAdjustment {
+  /** Projection of one eigenvector matrix from the CP decomposition into l1-simplex
+    *
+    * Given an eigenvector w, we have to decide whether to return proj(w) or proj(-w) as
+    * the result.
+    *
+    * We notice that the Duchi algorithm produces the same result for any w with a
+    * parallel shift. We thus compute proj(w - min(w)) and proj((-w) - min(-w)) and compare
+    * the shift "theta" from the Duchi algorithm. We retain the one with smaller shift "theta".
+    *
+    * Ref:
+    * Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008
+    *
+    * @param M     One eigenvector matrix from the result of CP decomposition
+    * @return      {best of proj(w) or proj(-w), where w is each column of M}
+    */
+  def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
+    val M_onSimplex = DenseMatrix.zeros[Double](M.rows, M.cols)
+
+    for(i <- 0 until M.cols optimized){
+      val (projectedVector, theta) = simplexProj(M(::, i) - min(M(::, i)))
+      val (projectedVectorReversedSign, thetaReversedSign) = simplexProj(- M(::, i) - min(- M(::, i)))
+
+      if (theta < thetaReversedSign) {
+        M_onSimplex(::, i) := projectedVector
+      }
+      else {
+        M_onSimplex(::, i) := projectedVectorReversedSign
+      }
+    }
+
+    M_onSimplex
+  }
+
+  /** Projection of a vector onto a simplex
+    *
+    * Given a length-n vector V, find a vector W=(w_i)_{1\le i\le n} in the simplex that
+    * \sum_{i=1}^n w_i=1, w_i>0 \forall i, by minimising the Euclidean distance between V and W.
+    *
+    * Ref:
+    * Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008
+    *
+    * @param V  The input vector
+    * @return   Projected vector and the shift
+    */
+  def simplexProj(V: DenseVector[Double]): (DenseVector[Double], Double) = {
+    // val z:Double = 1.0
+    val len: Int = V.length
+    val U: DenseVector[Double] = DenseVector(V.copy.toArray.sortWith(_ > _))
+    val cums: DenseVector[Double] = DenseVector(AlgebraUtil.Cumsum(U.toArray).map(x => x-1))
+    val Index: DenseVector[Double] = DenseVector((1 to (len + 1)).toArray.map(x => 1.0/x.toDouble))
+    val InterVec: DenseVector[Double] = cums :* Index
+    val TobefindMax: DenseVector[Double] = U - InterVec
+    var maxIndex : Int = 0
+    // find maxIndex
+    breakable{
+      for (i <- 0 until len optimized){
+        if (TobefindMax(len - i - 1) > 0){
+          maxIndex = len - i - 1
+          break()
+        }
+      }
+    }
+    val theta: Double = InterVec(maxIndex)
+    val P_norm: DenseVector[Double] = max(V - theta, 0.0)
+    (P_norm, theta)
+  }
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
@@ -17,40 +17,39 @@
 
 package edu.uci.eecs.spectralLDA.utils
 
-import breeze.linalg.{DenseMatrix, DenseVector, max, min}
-
+import breeze.linalg.{max, min, DenseMatrix, DenseVector}
+import scala.language.postfixOps
 import scala.util.control.Breaks._
 import scalaxy.loops._
-import scala.language.postfixOps
 
 object NonNegativeAdjustment {
   /** Projection of one eigenvector matrix from the CP decomposition into l1-simplex
-    *
-    * Given an eigenvector w, we have to decide whether to return proj(w) or proj(-w) as
-    * the result.
-    *
-    * We notice that the Duchi algorithm produces the same result for any w with a
-    * parallel shift. We thus compute proj(w - min(w)) and proj((-w) - min(-w)) and compare
-    * the shift "theta" from the Duchi algorithm. We retain the one with smaller shift "theta".
-    *
-    * Ref:
-    * Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008
-    *
-    * @param M     One eigenvector matrix from the result of CP decomposition
-    * @return      {best of proj(w) or proj(-w), where w is each column of M}
-    */
-  def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
+   *
+   * Given an eigenvector w, we have to decide whether to return proj(w) or proj(-w) as
+   * the result.
+   *
+   * We notice that the Duchi algorithm produces the same result for any w with a
+   * parallel shift. We thus compute proj(w - min(w)) and proj((-w) - min(-w)) and compare
+   * the shift "theta" from the Duchi algorithm. We retain the one with smaller shift "theta".
+   *
+   * Ref:
+   * Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008
+   *
+   * @param M     One eigenvector matrix from the result of CP decomposition
+   * @return      {best of proj(w) or proj(-w), where w is each column of M}
+   */
+  def simplexProj_Matrix(M: DenseMatrix[Double]): DenseMatrix[Double] = {
     val M_onSimplex = DenseMatrix.zeros[Double](M.rows, M.cols)
 
-    for(i <- 0 until M.cols optimized){
+    for (i <- 0 until M.cols optimized) {
       val (projectedVector, theta) = simplexProj(M(::, i) - min(M(::, i)))
-      val (projectedVectorReversedSign, thetaReversedSign) = simplexProj(- M(::, i) - min(- M(::, i)))
+      val (projectedVectorRev, thetaRev) = simplexProj(- M(::, i) - min(- M(::, i)))
 
-      if (theta < thetaReversedSign) {
+      if (theta < thetaRev) {
         M_onSimplex(::, i) := projectedVector
       }
       else {
-        M_onSimplex(::, i) := projectedVectorReversedSign
+        M_onSimplex(::, i) := projectedVectorRev
       }
     }
 
@@ -58,16 +57,16 @@ object NonNegativeAdjustment {
   }
 
   /** Projection of a vector onto a simplex
-    *
-    * Given a length-n vector V, find a vector W=(w_i)_{1\le i\le n} in the simplex that
-    * \sum_{i=1}^n w_i=1, w_i>0 \forall i, by minimising the Euclidean distance between V and W.
-    *
-    * Ref:
-    * Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008
-    *
-    * @param V  The input vector
-    * @return   Projected vector and the shift
-    */
+   *
+   * Given a length-n vector V, find a vector W=(w_i)_{1\le i\le n} in the simplex that
+   * \sum_{i=1}^n w_i=1, w_i>0 \forall i, by minimising the Euclidean distance between V and W.
+   *
+   * Ref:
+   * Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008
+   *
+   * @param V  The input vector
+   * @return   Projected vector and the shift
+   */
   def simplexProj(V: DenseVector[Double]): (DenseVector[Double], Double) = {
     // val z:Double = 1.0
     val len: Int = V.length
@@ -79,8 +78,8 @@ object NonNegativeAdjustment {
     var maxIndex : Int = 0
     // find maxIndex
     breakable{
-      for (i <- 0 until len optimized){
-        if (TobefindMax(len - i - 1) > 0){
+      for (i <- 0 until len optimized) {
+        if (TobefindMax(len - i - 1) > 0) {
           maxIndex = len - i - 1
           break()
         }
@@ -91,3 +90,4 @@ object NonNegativeAdjustment {
     (P_norm, theta)
   }
 }
+

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package edu.uci.eecs.spectralLDA.utils
 
 import breeze.linalg.eigSym.EigSym

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -1,0 +1,183 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg.eigSym.EigSym
+import breeze.linalg.qr.QR
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, argtopk, cholesky, eigSym, inv, qr, svd}
+import breeze.numerics.{pow, sqrt}
+import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
+import org.apache.spark.rdd.RDD
+
+
+object RandNLA {
+  /** Randomised Power Iteration Method for SVD of shifted M2
+    *
+    * As the shifted M2 is of size V-by-V, where V is the vocabulary size, which could be
+    * very large, we carry out Randomised Power Iteration Method for computing the SVD of it
+    * following Musco & Musco 2016. The Nystrom decomposition is also implemented but it
+    * gives much worse empirical performance than Musco & Musco 2016.
+    *
+    * Ref:
+    * Halko, N, P.G. Martinsson, & J.A. Tropp, Finding Structure with Randomness:
+    * Probabilistic Algorithms for Constructing Approximate Matrix Decompositions, 2011
+    * Gu, Ming, Subspace Iteration Randomization and Singular Value Problems, 2014
+    * Musco, Cameron, & Christopher Musco, Randomized Block Krylov Methods for Stronger
+    * and Faster Approximate Singular Value Decomposition, 2016
+    *
+    * @param alpha0     sum of alpha, the Dirichlet prior vector
+    * @param vocabSize  V: the vocabulary size
+    * @param dimK       K: number of topics
+    * @param numDocs    number of documents
+    * @param firstOrderMoments   average of the word count vectors
+    * @param documents  RDD of the documents
+    * @param nIter      number of iterations for the Randomised Power Iteration method,
+    *                   denoted by q in the Algorithm 1 & 2 in the ref paper
+    * @param randBasis  the random seed
+    * @return           V-by-K eigenvector matrix and length-K eigenvalue vector
+    */
+  def whiten2(alpha0: Double,
+              vocabSize: Int,
+              dimK: Int,
+              numDocs: Long,
+              firstOrderMoments: DenseVector[Double],
+              documents: RDD[(Long, Double, SparseVector[Double])],
+              termsLowIDF: Seq[Int] = Seq[Int](),
+              nIter: Int = 1)
+            (implicit randBasis: RandBasis = Rand)
+  : (DenseMatrix[Double], DenseVector[Double]) = {
+    assert(vocabSize >= dimK)
+    assert(nIter >= 0)
+
+    val slackDimK = Math.min(vocabSize - dimK, dimK)
+
+    var q = DenseMatrix.rand[Double](vocabSize, dimK + slackDimK, Gaussian(mu = 0.0, sigma = 1.0))
+    var m2q: DenseMatrix[Double] = null
+
+    for (i <- 0 until 2 * nIter + 1) {
+      m2q = randomProjectM2(
+        alpha0,
+        vocabSize,
+        dimK,
+        slackDimK,
+        numDocs,
+        firstOrderMoments,
+        documents,
+        q,
+        termsLowIDF
+      )
+      val QR(nextq, _) = qr.reduced(m2q)
+      q = nextq
+    }
+
+    m2q = randomProjectM2(
+      alpha0,
+      vocabSize,
+      dimK,
+      slackDimK,
+      numDocs,
+      firstOrderMoments,
+      documents,
+      q,
+      termsLowIDF
+    )
+
+    // Randomised eigendecomposition of M2
+    val (s: DenseVector[Double], u: DenseMatrix[Double]) = decomp2(m2q, q)
+    val idx = argtopk(s, dimK)
+    val u_M2 = u(::, idx).toDenseMatrix
+    val s_M2 = s(idx).toDenseVector
+
+    (u_M2, s_M2)
+  }
+
+  /** Musco-Musco method for randomised eigendecomposition of Hermitian matrix
+    *
+    * We could first do the eigendecomposition (AQ)^* AQ=USU^*. If A=HKH^*; apparently
+    * K=S^{1/2}, H=QU.
+    *
+    * Empirically for the Spectral LDA model, this decomposition algorithm often
+    * gives better final results than the Nystrom method.
+    *
+    * Ref:
+    * Musco, Cameron, & Christopher Musco, Randomized Block Krylov Methods for Stronger
+    * and Faster Approximate Singular Value Decomposition, 2016
+    *
+    * @param aq product of the original n-by-n matrix A and a n-by-k test matrix
+    * @param q  the n-by-k test matrix
+    * @return   the top k eigenvalues, top k eigenvectors of the original matrix A
+    */
+  def decomp2(aq: DenseMatrix[Double],
+              q: DenseMatrix[Double])
+      : (DenseVector[Double], DenseMatrix[Double]) = {
+    val w = aq.t * aq
+    val EigSym(s: DenseVector[Double], u: DenseMatrix[Double]) = eigSym((w + w.t) / 2.0)
+
+    val sqrt_s = sqrt(s)
+
+    val h = q * u
+
+    (sqrt_s, h)
+  }
+
+  /** Given a test matrix q returns the product of shifted M2 and q */
+  private[utils] def randomProjectM2(alpha0: Double,
+                                     vocabSize: Int,
+                                     dimK: Int,
+                                     slackDimK: Int,
+                                     numDocs: Long,
+                                     firstOrderMoments: DenseVector[Double],
+                                     documents: RDD[(Long, Double, SparseVector[Double])],
+                                     q: DenseMatrix[Double],
+                                     termsLowIDF: Seq[Int] = Seq[Int]()
+                                    ): DenseMatrix[Double] = {
+    val para_main: Double = (alpha0 + 1.0) * alpha0
+    val para_shift: Double = alpha0 * alpha0
+
+    firstOrderMoments(termsLowIDF) := 0.0
+    q(termsLowIDF, ::) := 0.0
+
+    val qBroadcast = documents.sparkContext.broadcast[DenseMatrix[Double]](q)
+
+    val unshiftedM2 = DenseMatrix.zeros[Double](vocabSize, dimK + slackDimK)
+    documents
+      .flatMap {
+        doc => accumulate_M_mul_S(
+          qBroadcast.value, doc._3, doc._2
+        )
+      }
+      .reduceByKey(_ + _)
+      .collect
+      .foreach {
+        case (token, v) => unshiftedM2(token, ::) := v.t
+      }
+    unshiftedM2 /= numDocs.toDouble
+    unshiftedM2(termsLowIDF, ::) := 0.0
+
+    qBroadcast.unpersist
+
+    val m2 = unshiftedM2 * para_main - (firstOrderMoments * (firstOrderMoments.t * q)) * para_shift
+
+    m2
+  }
+
+
+  /** Return the contribution of a document to M2, multiplied by the test matrix
+    *
+    * @param S   n-by-k test matrix
+    * @param Wc  length-n word count vector
+    * @param len total word count
+    * @return    M2*S, i.e (Wc*Wc.t-diag(Wc))/(len*(len-1.0))*S
+    */
+  private[utils] def accumulate_M_mul_S(S: breeze.linalg.DenseMatrix[Double],
+                                        Wc: breeze.linalg.SparseVector[Double],
+                                        len: Double)
+        : Seq[(Int, DenseVector[Double])] = {
+    val len_calibrated: Double = math.max(len, 3.0)
+    val norm_length: Double = 1.0 / (len_calibrated * (len_calibrated - 1.0))
+
+    val data_mul_S: DenseVector[Double] = S.t * Wc
+
+    Wc.activeIterator.toSeq.map { case (token, count) =>
+      (token, (data_mul_S - S(token, ::).t) * count * norm_length)
+    }
+  }
+}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package edu.uci.eecs.spectralLDA.utils
 
 import breeze.linalg.{*, CSCMatrix, Counter, DenseMatrix, DenseVector, SparseVector, Tensor, norm}

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -18,22 +18,22 @@
 
 package edu.uci.eecs.spectralLDA.utils
 
-import breeze.linalg.{*, CSCMatrix, Counter, DenseMatrix, DenseVector, SparseVector, Tensor, norm}
+import breeze.linalg.{*, norm, CSCMatrix, DenseMatrix, DenseVector, SparseVector}
+import breeze.linalg.{Counter, Tensor}
 import breeze.math.{Complex, Semiring}
 import breeze.storage.Zero
-
 import scala.reflect.ClassTag
 
 
 object TensorOps {
   /** Complex matrix norm */
   def matrixNorm(m: DenseMatrix[Complex]): Double = {
-    norm(norm(m(::, *)).toDenseVector)
+    norm(norm(m(::, *)).t.toDenseVector)
   }
 
   /** Double matrix norm */
   def dmatrixNorm(m: DenseMatrix[Double]): Double = {
-    norm(norm(m(::, *)).toDenseVector)
+    norm(norm(m(::, *)).t.toDenseVector)
   }
 
   /** Unfold 3rd-order tensor */
@@ -108,3 +108,4 @@ object TensorOps {
     prod
   }
 }
+

--- a/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/mllib/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -1,0 +1,92 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg.{*, CSCMatrix, Counter, DenseMatrix, DenseVector, SparseVector, Tensor, norm}
+import breeze.math.{Complex, Semiring}
+import breeze.storage.Zero
+
+import scala.reflect.ClassTag
+
+
+object TensorOps {
+  /** Complex matrix norm */
+  def matrixNorm(m: DenseMatrix[Complex]): Double = {
+    norm(norm(m(::, *)).toDenseVector)
+  }
+
+  /** Double matrix norm */
+  def dmatrixNorm(m: DenseMatrix[Double]): Double = {
+    norm(norm(m(::, *)).toDenseVector)
+  }
+
+  /** Unfold 3rd-order tensor */
+  def unfoldTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+        (t: Tensor[Seq[Int], V], n: Seq[Int]): DenseMatrix[V] = {
+    assert(n.length == 3)
+    val m = DenseMatrix.zeros[V](n(0), n(1) * n(2))
+    for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
+      m(i, k * n(1) + j) = t(Seq(i, j, k))
+    }
+    m
+  }
+
+  /** Build 3rd-order tensor from the unfolded representation */
+  def tensor3dFromUnfolded[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+      (g: DenseMatrix[V], n: Seq[Int]): Tensor[Seq[Int], V] = {
+    assert(n.length == 3)
+    val t: Tensor[Seq[Int], V] = Counter[Seq[Int], V]
+    for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
+      t(Seq(i, j, k)) = g(i, k * n(1) + j)
+    }
+    t
+  }
+
+  /** makes 3rd-order rank-1 tensor $$x\otimes y\otimes z$$, returns the unfolded version */
+  def makeRankOneTensor3d(x: DenseVector[Double],
+                          y: DenseVector[Double],
+                          z: DenseVector[Double]
+                         ): DenseMatrix[Double] = {
+    // This is a non-templated version of the function
+    // It seems Spark 2.0.0 worker nodes don't work correctly
+    // with the templated version of the function
+    val p = y * z.t
+    x * p.toDenseVector.t
+  }
+
+  /** Khatri-Rao product */
+  def krprod[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+       (x: DenseVector[V], y: DenseVector[V]): DenseVector[V] = {
+    val ev = implicitly[Numeric[V]]
+    import ev._
+
+    val seq = for (i <- 0 until x.size; j <- 0 until y.size) yield x(i) * y(j)
+    DenseVector(seq: _*)
+  }
+
+  /** Khatri-Rao product */
+  def krprod[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+        (A: DenseMatrix[V], B: DenseMatrix[V]): DenseMatrix[V] = {
+    assert(A.cols == B.cols)
+    val result = DenseMatrix.zeros[V](A.rows * B.rows, A.cols)
+    for (i <- 0 until A.cols) {
+      result(::, i) := krprod[V](A(::, i), B(::, i))
+    }
+    result
+  }
+
+  /** Part of the ALS update formula */
+  def to_invert(c: DenseMatrix[Double], b: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val ctc: DenseMatrix[Double] = c.t * c
+    val btb: DenseMatrix[Double] = b.t * b
+    val to_be_inverted: DenseMatrix[Double] = ctc :* btb
+    breeze.linalg.pinv(to_be_inverted)
+  }
+
+  /** tensor product v * v.t given sparse vector v */
+  def spVectorTensorProd2d(v: SparseVector[Double]): CSCMatrix[Double] = {
+    val prod: CSCMatrix[Double] = CSCMatrix.zeros[Double](v.length, v.length)
+    for (i <- 0 until v.activeSize; j <- 0 until v.activeSize) {
+      prod(v.indexAt(i), v.indexAt(j)) = v.valueAt(i) * v.valueAt(j)
+    }
+    prod
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/TensorLDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/TensorLDA.scala
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
+import org.apache.commons.math3.random.MersenneTwister
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.internal.Logging
+import org.apache.spark.mllib.linalg.{Matrices, Matrix, Vector, Vectors}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.Utils
+
+
+/**
+ * Latent Dirichlet Allocation (LDA), a topic model designed for text documents.
+ *
+ * Terminology:
+ *  - "word" = "term": an element of the vocabulary
+ *  - "token": instance of a term appearing in a document
+ *  - "topic": multinomial distribution over words representing some concept
+ *
+ * References:
+ *  - Original LDA paper (journal version):
+ *    Blei, Ng, and Jordan.  "Latent Dirichlet Allocation."  JMLR, 2003.
+ *
+ * @see [[http://en.wikipedia.org/wiki/Latent_Dirichlet_allocation Latent Dirichlet allocation
+ *       (Wikipedia)]]
+ */
+@Since("2.0.2")
+class TensorLDA private (private var k: Int,
+                         private var alpha0: Double,
+                         private var q: Int,
+                         private var maxIterations: Int,
+                         private var tol: Double,
+                         private var seed: Long) extends Logging {
+  /**
+   * Constructs a LDA instance with default parameters.
+   */
+  @Since("2.0.2")
+  def this() = this(k = 10, alpha0 = 1.0,
+    q = 1, maxIterations = 500, tol = 1e-6,
+    seed = Utils.random.nextLong())
+
+  /**
+   * Number of topics to infer, i.e., the number of soft cluster centers.
+   */
+  @Since("2.0.2")
+  def getK(): Int = k
+
+  /**
+   * Set the number of topics to infer, i.e., the number of soft cluster centers.
+   * (default = 10)
+   */
+  @Since("2.0.2")
+  def setK(k: Int): this.type = {
+    require(k > 0, s"LDA k (number of clusters) must be > 0, but was set to $k")
+    this.k = k
+    this
+  }
+
+  /**
+   * Sum of the concentration parameter (commonly named "alpha") for the prior
+   * placed on documents' distributions over topics ("theta").
+   */
+  @Since("2.0.2")
+  def getAlpha0(): Double = alpha0
+
+  /**
+   * Sum of the concentration parameter (commonly named "alpha") for the prior
+   * placed on documents' distributions over topics ("theta").
+   */
+  @Since("2.0.2")
+  def setAlpha0(alpha0: Double): this.type = {
+    val alpha0Msg = ("alpha0 (sum of the concentration parameter "
+      + "for the Dirichlet prior)")
+    require(alpha0 > 0, s"LDA $alpha0Msg must be > 0, but was set to $alpha0")
+    this.alpha0 = alpha0
+    this
+  }
+
+  /**
+   * Number of iterations for the Kyrlov method when performing randomised SVD
+   */
+  @Since("2.0.2")
+  def getNumIterationsKrylovMethod(): Int = q
+
+  /**
+   * Number of iterations for the Kyrlov method when performing randomised SVD
+   */
+  @Since("2.0.2")
+  def setNumIterationsKrylovMethod(q: Int): this.type = {
+    require(q >= 0, s"q (no of iterations for the Krylov method) must be >= 0")
+    this.q = q
+    this
+  }
+
+  /**
+   * Max number of iterations for the tensor CP decomposition
+   */
+  @Since("2.0.2")
+  def getMaxIterations(): Int = maxIterations
+
+  /**
+   * Set max number of iterations for the tensor CP decomposition
+   */
+  @Since("2.0.2")
+  def setMaxIterations(maxIterations: Int): this.type = {
+    require(maxIterations > 0,
+      s"Max iterations for the tensor CP decomposition must be > 0")
+    this.maxIterations = maxIterations
+    this
+  }
+
+  /**
+   * Convergence tolerance for the tensor CP decomposition
+   */
+  @Since("2.0.2")
+  def getTol(): Double = tol
+
+  /**
+   * Set the convergence tolerance for the tensor CP decomposition
+   */
+  @Since("2.0.2")
+  def setTol(tol: Double): this.type = {
+    require(tol > 0.0,
+      s"Tol for the tensor CP decomposition must be > 0.0")
+    this.tol = tol
+    this
+  }
+
+  /**
+   * Random seed
+   */
+  @Since("2.0.2")
+  def getSeed(): Long = seed
+
+  /**
+   * Set random seed
+   */
+  @Since("2.0.2")
+  def setSeed(seed: Long): this.type = {
+    this.seed = seed
+    this
+  }
+
+  /**
+   * Learn an LDA model using the given dataset.
+   *
+   * @param documents  RDD of documents, which are term (word) count vectors paired with IDs.
+   *                   The term count vectors are "bags of words" with a fixed-size vocabulary
+   *                   (where the vocabulary size is the length of the vector).
+   *                   Document IDs must be unique and >= 0.
+   * @return           Fitted topic-word distributions beta,
+   *                   Fitted parameter alpha for the Dirichlet prior,
+   *                   Eigenvectors of M2 from empirical word counts,
+   *                   Eigenvalues of M2 from empirical word counts,
+   *                   The average word distribution M1 from empirical word counts
+   */
+  @Since("2.0.2")
+  def run(documents: RDD[(Long, Vector)]): (Matrix, Vector, Matrix, Vector, Vector) = {
+    val documentsBreeze = documents.map {
+      case (id, c) =>
+        val sp = c.toSparse
+        (id, new breeze.linalg.SparseVector[Double](sp.indices, sp.values, c.size))
+    }
+
+    implicit val randBasis = new RandBasis(new ThreadLocalRandomGenerator(
+      new MersenneTwister(seed)))
+
+    val tensorLDA = new edu.uci.eecs.spectralLDA.algorithm.TensorLDA(
+      dimK = k,
+      alpha0 = alpha0,
+      numIterationsKrylovMethod = q,
+      maxIterations = maxIterations,
+      tol = tol,
+      randomisedSVD = true
+    )
+
+    val (beta, alpha, eigvecM2, eigvalM2, m1) = tensorLDA.fit(documentsBreeze)
+
+    (Matrices.fromBreeze(beta), Vectors.fromBreeze(alpha),
+      Matrices.fromBreeze(eigvecM2), Vectors.fromBreeze(eigvalM2),
+      Vectors.fromBreeze(m1))
+  }
+}
+

--- a/mllib/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASuite.scala
+++ b/mllib/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASuite.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.eecs.spectralLDA.algorithm
+
+import breeze.linalg._
+import breeze.stats.distributions._
+import org.apache.commons.math3.random.MersenneTwister
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+
+class TensorLDASuite extends SparkFunSuite with MLlibTestSparkContext {
+  test("Simulated LDA with deterministic SVD on M2") {
+    val alpha: DenseVector[Double] = DenseVector[Double](20.0, 10.0, 5.0)
+    val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](6, 3,
+      Array[Double](0.4, 0.4, 0.05, 0.05, 0.05, 0.05,
+        0.05, 0.05, 0.4, 0.4, 0.05, 0.05,
+        0.05, 0.05, 0.05, 0.05, 0.4, 0.4))
+
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(57175437L)))
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 5000,
+      numTokensPerDocument = 100
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val tensorLDA = new TensorLDA(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      maxIterations = 200,
+      randomisedSVD = false
+    )
+
+    val (sorted_beta, sorted_alpha, _, _, _) = tensorLDA.fit(documentsRDD)
+
+    // if one vector is all negative, multiply it by -1 to turn it positive
+    for (j <- 0 until sorted_beta.cols) {
+      if (max(sorted_beta(::, j)) <= 0.0) {
+        sorted_beta(::, j) :*= -1.0
+      }
+    }
+
+    val diff_beta: DenseMatrix[Double] = sorted_beta - allTokenDistributions
+    val diff_alpha: DenseVector[Double] = sorted_alpha - alpha
+
+    val norm_diff_beta = norm(norm(diff_beta(::, *)).t.toDenseVector)
+    val norm_diff_alpha = norm(diff_alpha)
+
+    info(s"Expecting alpha: $alpha")
+    info(s"Obtained alpha: $sorted_alpha")
+    info(s"Norm of difference alpha: $norm_diff_alpha")
+
+    info(s"Expecting beta:\n$allTokenDistributions")
+    info(s"Obtained beta:\n$sorted_beta")
+    info(s"Norm of difference beta: $norm_diff_beta")
+
+    assert(norm_diff_beta <= 0.2)
+    assert(norm_diff_alpha <= 4.0)
+  }
+
+  test("Simulated LDA with Randomised SVD on M2") {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(23476541L)))
+
+    val alpha: DenseVector[Double] = DenseVector[Double](20.0, 10.0, 5.0)
+    val allTokenDistributions: DenseMatrix[Double] = DenseMatrix.rand(100, 3, Uniform(0.0, 1.0))
+    allTokenDistributions(0 until 10, 0) += 3.0
+    allTokenDistributions(10 until 20, 1) += 3.0
+    allTokenDistributions(20 until 30, 2) += 3.0
+
+
+    val s = sum(allTokenDistributions(::, *))
+    val normalisedAllTokenDistributions: DenseMatrix[Double] =
+      allTokenDistributions * diag(1.0 / s.t.toDenseVector)
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 5000,
+      numTokensPerDocument = 500
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val dimK = 3
+
+    val tensorLDA = new TensorLDA(
+      dimK = dimK,
+      alpha0 = sum(alpha(0 until dimK)),
+      maxIterations = 200,
+      randomisedSVD = true
+    )
+
+    val (sorted_beta, sorted_alpha, _, _, _) = tensorLDA.fit(documentsRDD)
+
+    val expected_alpha = alpha(0 until dimK)
+    val expected_beta = normalisedAllTokenDistributions(::, 0 until dimK)
+
+    val diff_beta: DenseMatrix[Double] = sorted_beta - expected_beta
+    val diff_alpha: DenseVector[Double] = sorted_alpha - expected_alpha
+
+    val norm_diff_beta = norm(norm(diff_beta(::, *)).t.toDenseVector)
+    val norm_diff_alpha = norm(diff_alpha)
+
+    info(s"Expecting alpha: $expected_alpha")
+    info(s"Obtained alpha: $sorted_alpha")
+    info(s"Norm of difference alpha: $norm_diff_alpha")
+
+    info(s"Expecting beta:\n$expected_beta")
+    info(s"Obtained beta:\n$sorted_beta")
+    info(s"Norm of difference beta: $norm_diff_beta")
+
+    assert(norm_diff_beta <= 0.025)
+    assert(norm_diff_alpha <= 3.5)
+  }
+
+  def simulateLDAData(alpha: DenseVector[Double],
+                      allTokenDistributions: DenseMatrix[Double],
+                      numDocuments: Int,
+                      numTokensPerDocument: Int)
+                     (implicit randBasis: RandBasis = Rand)
+  : Seq[(Long, SparseVector[Double])] = {
+    assert(alpha.size == allTokenDistributions.cols)
+    val k = alpha.size
+    val V = allTokenDistributions.rows
+
+    // Simulate the word histogram of each document
+    val dirichlet = Dirichlet(alpha)
+    val wordCounts: Seq[(Long, SparseVector[Double])] = for {
+      d <- 0 until numDocuments
+
+      topicDistribution: DenseVector[Double] = dirichlet.sample()
+      tokenDistribution: DenseVector[Double] = allTokenDistributions * topicDistribution
+      tokens = Multinomial(tokenDistribution) sample numTokensPerDocument
+
+      c = SparseVector.zeros[Double](V)
+      tokensCount = tokens foreach { t => c(t) += 1.0 }
+    } yield (d.toLong, c)
+
+    wordCounts
+  }
+}
+

--- a/mllib/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSuite.scala
+++ b/mllib/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSuite.scala
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.eecs.spectralLDA.datamoments
+
+import breeze.linalg._
+import breeze.numerics.sqrt
+import breeze.stats.distributions.{Dirichlet, Multinomial}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+
+class DataCumulantSuite extends SparkFunSuite with MLlibTestSparkContext {
+  def simulateLDAData(alpha: DenseVector[Double],
+                      allTokenDistributions: DenseMatrix[Double],
+                      numDocuments: Int,
+                      numTokensPerDocument: Int)
+  : Seq[(Long, SparseVector[Double])] = {
+    assert(alpha.size == allTokenDistributions.cols)
+    val k = alpha.size
+    val V = allTokenDistributions.rows
+
+    // Simulate the word histogram of each document
+    val dirichlet = Dirichlet(alpha)
+    val wordCounts: Seq[(Long, SparseVector[Double])] = for {
+      d <- 0 until numDocuments
+
+      topicDistribution: DenseVector[Double] = dirichlet.sample()
+      tokenDistribution: DenseVector[Double] = allTokenDistributions * topicDistribution
+      tokens = Multinomial(tokenDistribution) sample numTokensPerDocument
+
+      c = SparseVector.zeros[Double](V)
+      tokensCount = tokens foreach { t => c(t) += 1.0 }
+    } yield (d.toLong, c)
+
+    wordCounts
+  }
+
+  test("Whitened M3") {
+    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 10.0, 20.0)
+    val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](5, 3,
+      Array[Double](0.6, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.6, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.6))
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 100,
+      numTokensPerDocument = 100
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val cumulant = DataCumulant.getDataCumulant(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      documentsRDD,
+      randomisedSVD = false
+    )
+
+    val expectedM3: DenseMatrix[Double] = expected_whitened_M3(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      documents
+    )
+
+    val diffM3 = cumulant.thirdOrderMoments - expectedM3
+    assert(norm(norm(diffM3(::, *)).t.toDenseVector) <= 1e-6)
+  }
+
+  private def expected_whitened_M3(dimK: Int,
+                                   alpha0: Double,
+                                   documents: Seq[(Long, SparseVector[Double])])
+                                  (implicit tolerance: Double = 1e-9)
+  : DenseMatrix[Double] = {
+    val v = documents map { _._2.toDenseVector }
+    val numDocs = v.length
+    val V = v.head.length
+
+    // Compute unshifted M1, M2, M3
+    val M1: DenseVector[Double] = v
+      .map { x => x / sum(x) }
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    val E_x1_x2: DenseMatrix[Double] = v
+      .map { x => (x * x.t - diag(x)) / (sum(x) * (sum(x) - 1)) }
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    val seq_x1_x2_x3: Seq[DenseMatrix[Double]] = for {
+      c <- v
+      l = sum(c)
+
+      rawM3: DenseMatrix[Double] = DenseMatrix.zeros[Double](V, V * V)
+      fillM3 = for (i <- 0 until V; j <- 0 until V; k <- 0 until V) {
+        val j2 = k * V + j
+        rawM3(i, j2) = c(i) * c(j) * c(k)
+        if (i == j) {
+          rawM3(i, j2) -= c(i) * c(k)
+        }
+        if (i == k) {
+          rawM3(i, j2) -= c(i) * c(j)
+        }
+        if (j == k) {
+          rawM3(i, j2) -= c(i) * c(j)
+        }
+        if (i == j && j == k) {
+          rawM3(i, j2) += 2 * c(i)
+        }
+      }
+      m3 = rawM3 / (l * (l - 1) * (l - 2))
+    } yield m3
+
+    val E_x1_x2_x3 = seq_x1_x2_x3
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    // Compute shifted M2, M3
+    val (shiftedM2, shiftedM3) = shiftMoments(M1, E_x1_x2, E_x1_x2_x3, alpha0)
+    val scaledShiftedM2 = shiftedM2 * alpha0 * (alpha0 + 1)
+    val scaledShiftedM3 = shiftedM3 * (alpha0 * (alpha0 + 1) * (alpha0 + 2) / 2.0)
+
+    // Eigendecomposition of shiftedM2
+    val eigSym.EigSym(sigma, u) = eigSym(scaledShiftedM2)
+    val i = argsort(sigma)
+    val (truncated_u: DenseMatrix[Double], truncated_sigma: DenseVector[Double]) = (
+      u(::, i.slice(V - dimK, V)).copy, sigma(i.slice(V - dimK, V)).copy)
+
+    // Whitening matrix
+    val W: DenseMatrix[Double] = truncated_u * diag(
+      truncated_sigma map { x => 1 / (sqrt(x) + tolerance) }
+    )
+
+    // Whiten M3
+    val unfolded_whitenedM3: DenseMatrix[Double] = W.t * scaledShiftedM3 * kron(W.t, W.t).t
+
+    unfolded_whitenedM3
+  }
+
+
+  private def shiftMoments(M1: DenseVector[Double],
+                           M2: DenseMatrix[Double],
+                           M3: DenseMatrix[Double],
+                           alpha0: Double
+                          ): (DenseMatrix[Double], DenseMatrix[Double]) = {
+    val d: Int = M1.size
+    val kronM1: DenseMatrix[Double] = M1 * M1.t
+
+    // [Anand14] Theorem 3.5
+    val shiftedM2 = M2 - (alpha0 / (alpha0 + 1)) * kronM1
+
+    // We always unfold the 3rd-order tensors in matrix of size (d,d^2)
+    // G = E[x1 tensordot x2 tensordot M1] + E[x1 tensordot M1 tensordot x2]
+    // H = G + E[M1 tensordot x1 tensordot x2]
+    val G: Seq[DenseVector[Double]] = (0 until d) map { i =>
+      val kron = M1 * M2(i, ::)
+      (kron + kron.t).toDenseVector
+    }
+    val G2 = DenseMatrix.zeros[Double](d, d * M2.cols)
+    for (i <- 0 until d) {
+      G2(i, ::) := G(i).t
+    }
+    val H = G2 + M1 * M2.toDenseVector.t
+
+    // K = M1 tensordot M1 tensordot M1
+    val K = M1 * kronM1.toDenseVector.t
+
+    // [Anand14] Theorem 3.5
+    val shiftedM3 = M3 -
+      (alpha0 / (alpha0 + 2)) * H +
+      (2 * alpha0 * alpha0 / (alpha0 + 2) / (alpha0 + 1)) * K
+
+    (shiftedM2, shiftedM3)
+  }
+}
+

--- a/mllib/src/test/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessorSuite.scala
+++ b/mllib/src/test/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessorSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.eecs.spectralLDA.textprocessing
+
+import breeze.linalg._
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+
+class TextProcessorSuite extends SparkFunSuite with MLlibTestSparkContext {
+  test("Inverse Document Frequency") {
+    val docs = Seq[(Long, SparseVector[Double])](
+      (1000L, SparseVector[Double](0.0, 0.0, 7.0)),
+      (1001L, SparseVector[Double](0.0, 3.0, 5.0)),
+      (1002L, SparseVector[Double](1.0, 3.0, 0.5))
+    )
+    val docsRDD = sc.parallelize[(Long, SparseVector[Double])](docs)
+
+    val idf = TextProcessor.inverseDocumentFrequency(docsRDD)
+
+    assert(norm(idf - DenseVector[Double](3.0, 1.5, 1.0)) <= 1e-8)
+  }
+}
+

--- a/mllib/src/test/scala/edu/uci/eecs/spectralLDA/utils/SpectralLDAUtilsSuite.scala
+++ b/mllib/src/test/scala/edu/uci/eecs/spectralLDA/utils/SpectralLDAUtilsSuite.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.eecs.spectralLDA.utils
+
+import scala.language.postfixOps
+
+import breeze.linalg._
+import breeze.linalg.qr.QR
+import breeze.stats.distributions.{Gaussian, RandBasis, ThreadLocalRandomGenerator, Uniform}
+import org.apache.commons.math3.random.MersenneTwister
+import scalaxy.loops._
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+
+class SpectralLDAUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
+  def expectedRankOneTensor3d(x: DenseVector[Double],
+                              y: DenseVector[Double],
+                              z: DenseVector[Double]
+                             ): DenseMatrix[Double] = {
+    val d1 = x.length
+    val d2 = y.length
+    val d3 = z.length
+
+    val result = DenseMatrix.zeros[Double](d1, d2 * d3)
+
+    for (i <- 0 until d1 optimized) {
+      for (j <- 0 until d2 optimized) {
+        for (k <- 0 until d3 optimized) {
+          result(i, k * d2 + j) = x(i) * y(j) * z(k)
+        }
+      }
+    }
+
+    result
+  }
+
+  test("3rd-order vector outer product") {
+    val x = DenseVector.rand[Double](50)
+    val y = DenseVector.rand[Double](50)
+    val z = DenseVector.rand[Double](50)
+
+    val tensor = TensorOps.makeRankOneTensor3d(x, y, z)
+    val expected = expectedRankOneTensor3d(x, y, z)
+
+    val diff = tensor - expected
+    assert(norm(norm(diff(::, *)).t.toDenseVector) <= 1e-8)
+  }
+
+  test("M2 multiplied by random Gaussian matrix") {
+    val a1 = SparseVector(DenseVector.rand[Double](100).toArray)
+    val a2 = SparseVector(DenseVector.rand[Double](100).toArray)
+    val a3 = SparseVector(DenseVector.rand[Double](100).toArray)
+
+    val docs = Seq((1000L, a1), (1001L, a2), (1002L, a3))
+    val docsRDD = sc.parallelize(docs)
+
+    // Random Gaussian matrix
+    val g = DenseMatrix.rand[Double](100, 50, Gaussian(mu = 0.0, sigma = 1.0))
+
+    val result = DenseMatrix.zeros[Double](100, 50)
+    docsRDD
+      .flatMap {
+        case (id: Long, w: SparseVector[Double]) => RandNLA.accumulate_M_mul_S(g, w, sum(w))
+      }
+      .reduceByKey(_ + _)
+      .collect
+      .foreach {
+        case (r: Int, a: DenseVector[Double]) => result(r, ::) := a.t
+      }
+
+    val m2 = docsRDD
+      .map {
+        case (id: Long, w: SparseVector[Double]) =>
+          val l = sum(w)
+          (w * w.t - diag(w)) / (l * (l - 1.0))
+      }
+      .reduce(_ + _)
+    val expectedResult = m2 * g
+
+    val diff: DenseMatrix[Double] = result - expectedResult
+    val normDiff: Double = norm(norm(diff(::, *)).t.toDenseVector)
+    assert(normDiff <= 1e-8)
+  }
+
+  test("Randomised SVD") {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(234787)))
+
+    val n = 100
+    val k = 5
+
+    val alpha: DenseVector[Double] = DenseVector[Double](25.0, 20.0, 15.0, 10.0, 5.0)
+    val beta: DenseMatrix[Double] = DenseMatrix.rand(n, k, Uniform(0.0, 1.0))
+
+    val norms = norm(beta(::, *)).t.toDenseVector
+    for (j <- 0 until k) {
+      beta(::, j) /= norms(j)
+    }
+
+    val a: DenseMatrix[Double] = beta * diag(alpha) * beta.t
+    val sigma: DenseMatrix[Double] = DenseMatrix.rand(n, k, Gaussian(mu = 0.0, sigma = 1.0))
+    val y = a * sigma
+    val QR(q: DenseMatrix[Double], _) = qr.reduced(y)
+
+    val (s: DenseVector[Double], u: DenseMatrix[Double]) = RandNLA.decomp2(a * q, q)
+
+    val diff_a = u * diag(s) * u.t - a
+    val norm_diff_a = norm(norm(diff_a(::, *)).t.toDenseVector)
+
+    assert(norm_diff_a <= 1e-8)
+  }
+
+  test("Simple non-negative adjustment to vectors") {
+    val inputVectors = Seq(
+      DenseVector[Double](0.5, 0.5, 0.5),
+      DenseVector[Double](0.5, 0.5, -0.5),
+      DenseVector[Double](0.3, 0.3, -0.3, -0.3, 0.1, 0.1),
+      DenseVector[Double](0.3, 0.3, 0.3, 0.3, -0.3, -0.3, -0.3, -0.3, 0.1, 0.1, 0.1, 0.1),
+      DenseVector[Double](0.1, 0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, -0.3, -0.3, -0.3, -0.3),
+      DenseVector[Double](10, 10, 10, 10, 30, 30, 30, 30, -30, -30, -30, -30)
+    )
+
+    val expectedAdjustedVectors = Seq(
+      DenseVector(0.33333333333333337, 0.33333333333333337, 0.33333333333333337),
+      DenseVector(0.5, 0.5, 0.0),
+      DenseVector(0.35, 0.35, 0.0, 0.0, 0.15000000000000002, 0.15000000000000002),
+      DenseVector(0.22499999999999995, 0.22499999999999995,
+        0.22499999999999995, 0.22499999999999995, 0.0, 0.0, 0.0, 0.0,
+        0.024999999999999967, 0.024999999999999967,
+        0.024999999999999967, 0.024999999999999967),
+      DenseVector(0.024999999999999967, 0.024999999999999967,
+        0.024999999999999967, 0.024999999999999967,
+        0.22499999999999995, 0.22499999999999995,
+        0.22499999999999995, 0.22499999999999995,
+        0.0, 0.0, 0.0, 0.0),
+      DenseVector(0.0, 0.0, 0.0, 0.0, 0.25, 0.25, 0.25, 0.25, 0.0, 0.0, 0.0, 0.0)
+    )
+
+    for ((v1, v2) <- inputVectors.zip(expectedAdjustedVectors)) {
+      assert(norm(NonNegativeAdjustment.simplexProj(v1)._1 - v2) <= 1e-8)
+    }
+  }
+}
+


### PR DESCRIPTION
The Spectral LDA algorithm transforms the LDA problem to an orthogonal tensor decomposition problem. [[Anandkumar 2012]] establishes theoretical guarantee for the convergence of orthogonal tensor decomposition.

This algorithm first builds 2nd-order, 3rd-order moments from the empirical word counts, orthogonalize them and finally perform the tensor decomposition on the empirical data moments. The whole procedure is purely linear and could leverage machine native BLAS/LAPACK libraries (the Spark needs to be compiled with `-Pnetlib-lgpl` option).

It achieves competitive log-perplexity vs Online Variational Inference in the shortest time. It also has clean memory usage – as of v2.0.0 we've experienced crash due to memory problem with the built-in Gibbs Sampler or Online Variational Inference, but never with the Spectral LDA algorithm. This algorithm is linearly scalable.

The official repo is at https://github.com/FurongHuang/SpectralLDA-TensorSpark. We refactored for the Spark coding style and interfaces when porting over for the PR. We wrote a report describing the algorithm in detail and listing test results at https://www.overleaf.com/read/wscdvwrjmtmw. It's going to enter our official repo soon.

REFERENCES
Anandkumar, Anima, et al., Tensor decompositions for learning latent variable models, 2012, https://arxiv.org/abs/1210.7559.