### PR TITLE
[MINOR][ML] Fix wrong @since version in KMeans

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -310,7 +310,7 @@ class KMeans @Since("1.5.0") (
     fit(dataset, handlePersistence)
   }
 
-  @Since("2.2.0")
+  @Since("2.1.0")
   protected def fit(dataset: Dataset[_], handlePersistence: Boolean): KMeansModel = {
     transformSchema(dataset.schema, logging = true)
     val instances: RDD[OldVector] = dataset.select(col($(featuresCol))).rdd.map {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -99,8 +99,6 @@ private[regression] trait GeneralizedLinearRegressionBase extends PredictorParam
     isDefined(linkPredictionCol) && $(linkPredictionCol).nonEmpty
   }
 
-  import GeneralizedLinearRegression._
-
   @Since("2.0.0")
   override def validateAndTransformSchema(
       schema: StructType,


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix wrong version in `KMeans.fit`
there were two `import GeneralizedLinearRegression._` in trait GLR.GeneralizedLinearRegressionBase
## How was this patch tested?
existing tests
