### PR TITLE
[SPARK-18527][SQL] Convert decimal array to double array double for Hive UDAFPercentile

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DecimalType, DoubleType}
+import org.apache.spark.sql.types.{ArrayType, DecimalType, DoubleType}
 import org.apache.spark.util.Utils
 
 
@@ -166,8 +166,13 @@ private[sql] class HiveSessionCatalog(
     } catch {
       case NonFatal(_) =>
         // SPARK-16228 ExternalCatalog may recognize `double`-type only.
+        // SPARK-18527 Percentile needs explicit cast to array<double>
         val newChildren = children.map { child =>
-          if (child.dataType.isInstanceOf[DecimalType]) Cast(child, DoubleType) else child
+          child.dataType match {
+            case ArrayType(DecimalType(), nullable) => Cast(child, ArrayType(DoubleType, nullable))
+            case DecimalType() => Cast(child, DoubleType)
+            case _ => child
+          }
         }
         lookupFunction0(name, newChildren)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -149,6 +149,12 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
     sql("select percentile_approx(value, 0.5) from values 1.0,2.0,3.0 T(value)")
   }
 
+  test("SPARK-18527 Percentile needs explicit cast to array<double>") {
+    sql("select percentile(value, cast(array(0.1, 0.5) as array<double>))" +
+        "from values 1,2,3 T(value)")
+    sql("select percentile(value, array(0.1, 0.5)) from values 1,2,3 T(value)")
+  }
+
   test("Generic UDAF aggregates") {
 
     checkAnswer(sql(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Hive UDAFPercentile takes a double or an array of doubles as its second argument. Spark typically passes a decimal or an array of decimals. This will causes a failure during function lookup for the percentile function.

We added a stop-gap measure in https://github.com/apache/spark/pull/13930 for doubles, by retrying the lookup with all decimal arguments casted to doubles. This PR extends this approach by adding the same logic for arrays of decimals.

Note that this is a temporary measure until https://github.com/apache/spark/pull/14136 is merged.

## How was this patch tested?
Added a test to `HiveUDFSuite`