### PR TITLE
[SPARK-16282][SQL] Follow-up: remove "percentile" from temp function detection after implementing it natively

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -939,10 +939,7 @@ class SessionCatalog(
    */
   def isTemporaryFunction(name: FunctionIdentifier): Boolean = {
     // copied from HiveSessionCatalog
-    val hiveFunctions = Seq(
-      "hash",
-      "histogram_numeric",
-      "percentile")
+    val hiveFunctions = Seq("histogram_numeric")
 
     // A temporary function is a function that has been registered in functionRegistry
     // without a database name, and is neither a built-in function nor a Hive function

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -981,7 +981,6 @@ class SessionCatalogSuite extends SparkFunSuite {
     assert(FunctionRegistry.builtin.functionExists("sum"))
     assert(!sessionCatalog.isTemporaryFunction(FunctionIdentifier("sum")))
     assert(!sessionCatalog.isTemporaryFunction(FunctionIdentifier("histogram_numeric")))
-    assert(!sessionCatalog.isTemporaryFunction(FunctionIdentifier("percentile")))
   }
 
   test("drop function") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In #15764 we added a mechanism to detect if a function is temporary or not. Hive functions are treated as non-temporary. Of the three hive functions, now "percentile" has been implemented natively, and "hash" has been removed. So we should update the list.

## How was this patch tested?

Unit tests.