### PR TITLE
[SPARK-18637][SQL]Stateful UDF should be considered as nondeterministic

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -61,7 +61,7 @@ private[hive] case class HiveSimpleUDF(
   @transient
   private lazy val isUDFDeterministic = {
     val udfType = function.getClass.getAnnotation(classOf[HiveUDFType])
-    udfType != null && udfType.deterministic()
+    udfType != null && udfType.deterministic() && !udfType.stateful()
   }
 
   override def foldable: Boolean = isUDFDeterministic && children.forall(_.foldable)
@@ -144,7 +144,7 @@ private[hive] case class HiveGenericUDF(
   @transient
   private lazy val isUDFDeterministic = {
     val udfType = function.getClass.getAnnotation(classOf[HiveUDFType])
-    udfType != null && udfType.deterministic()
+    udfType != null && udfType.deterministic() && !udfType.stateful()
   }
 
   @transient

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -578,20 +578,18 @@ class PairUDF extends GenericUDF {
 
 @UDFType(stateful = true)
 class StatefulUDF extends UDF {
-  private val result = new LongWritable()
-  result.set(0)
+  private val result = new LongWritable(0)
 
-  def  evaluate(): LongWritable = {
+  def evaluate(): LongWritable = {
     result.set(result.get() + 1)
     result
   }
 }
 
 class StatelessUDF extends UDF {
-  private val result = new LongWritable()
-  result.set(0)
+  private val result = new LongWritable(0)
 
-  def  evaluate(): LongWritable = {
+  def evaluate(): LongWritable = {
     result.set(result.get() + 1)
     result
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -497,7 +497,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
         val testData = spark.sparkContext.parallelize(
           (0 until 10) map (x => IntegerCaseClass(1)), 2).toDF()
         testData.createOrReplaceTempView("inputTable")
-        // Distribute all row to one partition (all row has the same content),
+        // Distribute all rows to one partition (all rows have the same content),
         // and expected Max(s) is 10 as statefulUDF returns the sequence number starting from 1.
         checkAnswer(
           sql(
@@ -510,7 +510,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
           Row(10))
 
         // Expected Max(s) is 5, as there are 2 partitions with 5 rows each, and statefulUDF
-        // returns the sequence number of the row in the partition starting from 1.
+        // returns the sequence number of the rows in the partition starting from 1.
         checkAnswer(
           sql(
             """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make stateful udf as nondeterministic

## How was this patch tested?
Add new test cases with both Stateful and Stateless UDF.
Without the patch, the test cases will throw exception:

1 did not equal 10
ScalaTestFailureLocation: org.apache.spark.sql.hive.execution.HiveUDFSuite$$anonfun$21 at (HiveUDFSuite.scala:501)
org.scalatest.exceptions.TestFailedException: 1 did not equal 10
        at org.scalatest.Assertions$class.newAssertionFailedException(Assertions.scala:500)
        at org.scalatest.FunSuite.newAssertionFailedException(FunSuite.scala:1555)
        ...
