### PR TITLE
[SPARK][EXAMPLE] Added missing semicolon in quick-start-guide example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -330,7 +330,7 @@ public class SimpleApp {
 
     System.out.println("Lines with a: " + numAs + ", lines with b: " + numBs);
     
-    sc.stop()
+    sc.stop();
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added missing semicolon in quick-start-guide java example code which wasn't compiling before. 

## How was this patch tested?
Locally by running and generating site for docs. You can see the last line contains ";" in the below snapshot.
![image](https://cloud.githubusercontent.com/assets/10628224/20751760/9a7e0402-b723-11e6-9aa8-3b6ca2d92ebf.png)
