### PR TITLE
[SPARK-18653][SQL] Fix incorrect space padding for unicode character at Dataset.show

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -72,6 +72,7 @@ hk2-locator-2.4.0-b34.jar
 hk2-utils-2.4.0-b34.jar
 httpclient-4.5.2.jar
 httpcore-4.4.4.jar
+icu4j-58.1.jar
 ivy-2.4.0.jar
 jackson-annotations-2.6.5.jar
 jackson-core-2.6.5.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -74,6 +74,7 @@ hk2-locator-2.4.0-b34.jar
 hk2-utils-2.4.0-b34.jar
 httpclient-4.5.2.jar
 httpcore-4.4.4.jar
+icu4j-58.1.jar
 ivy-2.4.0.jar
 jackson-annotations-2.6.5.jar
 jackson-core-2.6.5.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -74,6 +74,7 @@ hk2-locator-2.4.0-b34.jar
 hk2-utils-2.4.0-b34.jar
 httpclient-4.5.2.jar
 httpcore-4.4.4.jar
+icu4j-58.1.jar
 ivy-2.4.0.jar
 jackson-annotations-2.6.5.jar
 jackson-core-2.6.5.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -80,6 +80,7 @@ hk2-utils-2.4.0-b34.jar
 htrace-core-3.0.4.jar
 httpclient-4.5.2.jar
 httpcore-4.4.4.jar
+icu4j-58.1.jar
 ivy-2.4.0.jar
 jackson-annotations-2.6.5.jar
 jackson-core-2.6.5.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -80,6 +80,7 @@ hk2-utils-2.4.0-b34.jar
 htrace-core-3.1.0-incubating.jar
 httpclient-4.5.2.jar
 httpcore-4.4.4.jar
+icu4j-58.1.jar
 ivy-2.4.0.jar
 jackson-annotations-2.6.5.jar
 jackson-core-2.6.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
     <paranamer.version>2.8</paranamer.version>
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.0.0</commons-crypto.version>
+    <ibm.icu.version>58.1</ibm.icu.version>
 
     <test.java.home>${java.home}</test.java.home>
     <test.exclude.tags></test.exclude.tags>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -92,6 +92,11 @@
       <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>${ibm.icu.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -238,7 +238,7 @@ class Dataset[T] private[sql](
       }
   }
 
-  var EAST_ASIAN_LANGS = Seq("ja", "vi", "kr", "zh")
+  val EAST_ASIAN_LANGS = Seq("ja", "vi", "kr", "zh")
 
   private def unicodeWidth(str: String): Int = {
     val locale = Locale.getDefault()
@@ -249,24 +249,16 @@ class Dataset[T] private[sql](
     var len = 0
     for (i <- 0 until str.length) {
       val codePoint = str.codePointAt(i)
-      val value = UCharacter.getIntPropertyValue(codePoint, UProperty.EAST_ASIAN_WIDTH);
+      val value = UCharacter.getIntPropertyValue(codePoint, UProperty.EAST_ASIAN_WIDTH)
       len = len + (value match {
         case UCharacter.EastAsianWidth.NARROW | UCharacter.EastAsianWidth.NEUTRAL |
-              UCharacter.EastAsianWidth.HALFWIDTH => 1
+             UCharacter.EastAsianWidth.HALFWIDTH => 1
         case UCharacter.EastAsianWidth.FULLWIDTH | UCharacter.EastAsianWidth.WIDE => 2
         case UCharacter.EastAsianWidth.AMBIGUOUS => ambiguousLen
         case _ => 1
       })
     }
     len
-  }
-
-  private def repeatPadding(len: Int): StringBuilder = {
-    var str = new StringBuilder(len)
-    for (i <- 0 until len) {
-      str.append(' ')
-    }
-    str
   }
 
   /**
@@ -327,10 +319,11 @@ class Dataset[T] private[sql](
 
     // column names
     rows.head.zipWithIndex.map { case (cell, i) =>
+      val paddingLen = colMaxWidths(i) - colWidths(0)(i)
       if (truncate > 0) {
-        repeatPadding(colMaxWidths(i) - colWidths(0)(i)).append(cell)
+        new StringBuilder(cell.length, " " * paddingLen).append(cell)
       } else {
-        new StringBuffer(cell).append(repeatPadding(colMaxWidths(i) - colWidths(0)(i)))
+        new StringBuilder(paddingLen, cell).append(" " * paddingLen)
       }
     }.addString(sb, "|", "|", "|\n")
 
@@ -341,10 +334,11 @@ class Dataset[T] private[sql](
     rows.tail.map { row =>
       j = j + 1
       row.zipWithIndex.map { case (cell, i) =>
+        val paddingLen = colMaxWidths(i) - colWidths(j)(i)
         if (truncate > 0) {
-          repeatPadding(colMaxWidths(i) - colWidths(j)(i)).append(cell)
+          new StringBuilder(cell.length, " " * paddingLen).append(cell)
         } else {
-          new StringBuffer(cell).append(repeatPadding(colMaxWidths(i) - colWidths(j)(i)))
+          new StringBuilder(paddingLen, cell).append(" " * paddingLen)
         }
       }.addString(sb, "|", "|", "|\n")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -338,9 +338,9 @@ class Dataset[T] private[sql](
 
     // data
     j = 0
-    rows.tail.map {
+    rows.tail.map { row =>
       j = j + 1
-      _.zipWithIndex.map { case (cell, i) =>
+      row.zipWithIndex.map { case (cell, i) =>
         if (truncate > 0) {
           repeatPadding(colMaxWidths(i) - colWidths(j)(i)).append(cell)
         } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1074,7 +1074,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-18653: Dataset.show() should generate correct padding for Unicode Character") {
     // scalastyle:off
-    val ds = Seq(UnicodeCaseClass(1, 1.1, "文字列1")).toDS
+    val ds = Seq(UnicodeCaseClass(1, 1.1, "文字列1"), UnicodeCaseClass(-2, -2.2, "文字列")).toDS
     val leftPadding = ds.showString(1, 99)
     val rightPadding = ds.showString(1, -99)
     checkString(leftPadding,
@@ -1082,6 +1082,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
         ||整数|実数|      s|
         |+----+----+-------+
         ||   1| 1.1|文字列1|
+        ||  -2|-2.2| 文字列|
         |+----+----+-------+
         |""".stripMargin)
     checkString(rightPadding,
@@ -1089,6 +1090,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
         ||整数|実数|s      |
         |+----+----+-------+
         ||1   |1.1 |文字列1|
+        ||-2  |-2.2|文字列 |
         |+----+----+-------+
         |""".stripMargin)
     // scalastyle:on

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1060,6 +1060,39 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     }
     assert(e.getMessage.contains("Cannot create encoder for Option of Product type"))
   }
+
+  private def checkString[T](actual: String, expected: String): Unit = {
+    if (expected != actual) {
+      fail(
+        "Dataset.showString() gives wrong result:\n\n" + sideBySide(
+          "== Expected ==\n" + expected,
+          "== Actual ==\n" + actual
+        ).mkString("\n")
+      )
+    }
+  }
+
+  test("SPARK-18653: Dataset.show() should generate correct padding for Unicode Character") {
+    // scalastyle:off
+    val ds = Seq(UnicodeCaseClass(1, 1.1, "文字列1")).toDS
+    val leftPadding = ds.showString(1, 99)
+    val rightPadding = ds.showString(1, -99)
+    checkString(leftPadding,
+      """+----+----+-------+
+        ||整数|実数|      s|
+        |+----+----+-------+
+        ||   1| 1.1|文字列1|
+        |+----+----+-------+
+        |""".stripMargin)
+    checkString(rightPadding,
+      """+----+----+-------+
+        ||整数|実数|s      |
+        |+----+----+-------+
+        ||1   |1.1 |文字列1|
+        |+----+----+-------+
+        |""".stripMargin)
+    // scalastyle:on
+  }
 }
 
 case class Generic[T](id: T, value: Double)
@@ -1135,3 +1168,6 @@ object DatasetTransform {
 
 case class Route(src: String, dest: String, cost: Int)
 case class GroupedRoutes(src: String, dest: String, routes: Seq[Route])
+// scalastyle:off
+case class UnicodeCaseClass(整数: Int, 実数: Double, s: String)
+// scalastyle:on


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR put correct space padding for unicode character at `Dataset.show()`.
The reason of putting incorrect padding is to count string width by string.length. This PR counds string width by using [East Asian Width](http://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt).

Example program
````
case class UnicodeCaseClass(整数: Int, 実数: Double, s: String)
Seq(UnicodeCaseClass(1, 1.1, "文字列1")).toDS.show
````

Output without this PR
````
+---+---+----+
| 整数| 実数|   s|
+---+---+----+
|  1|1.1|文字列1|
+---+---+----+
````

Output with this PR
````
+----+----+-------+
|整数|実数|      s|
+----+----+-------+
|   1| 1.1|文字列1|
+----+----+-------+
````

## How was this patch tested?

Add a test suite