### PR TITLE
[SPARK-18541][Python]Add metadata parameter to pyspark.sql.Column.alias()

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -299,19 +299,22 @@ class Column(object):
     isNotNull = _unary_op("isNotNull", "True if the current expression is not null.")
 
     @since(1.3)
-    def alias(self, *alias, metadata=None):
+    def alias(self, *alias, **kwargs):
         """
         Returns this column aliased with a new name or names (in the case of expressions that
         return more than one column, such as explode).
 
-        Optional ``metadata`` can be passed when aliasing a single column.  It will be stored
-        in the ``metadata`` attribute of the corresponding ``StructField``.
+        Optional ``metadata`` keyword argument can be passed when aliasing a single column.
+        Its contents will be stored in the ``metadata`` attribute of the matching ``StructField``.
 
         >>> df.select(df.age.alias("age2")).collect()
         [Row(age2=2), Row(age2=5)]
         >>> df.select(df.age.alias("age3", metadata={'max': 99})).schema['age3'].metadata['max']
         99
         """
+
+        metadata = kwargs.pop('metadata', None)
+        assert not kwargs, 'Unexpected kwargs where passed: %s' % kwargs
 
         sc = SparkContext._active_spark_context
         if len(alias) == 1:

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -307,6 +307,9 @@ class Column(object):
         Optional ``metadata`` keyword argument can be passed when aliasing a single column.
         Its contents will be stored in the ``metadata`` attribute of the matching ``StructField``.
 
+        .. versionchanged:: 2.2
+           Added optional metadata argument.
+
         >>> df.select(df.age.alias("age2")).collect()
         [Row(age2=2), Row(age2=5)]
         >>> df.select(df.age.alias("age3", metadata={'max': 99})).schema['age3'].metadata['max']

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -17,6 +17,7 @@
 
 import sys
 import warnings
+import json
 
 if sys.version >= '3':
     basestring = str
@@ -298,19 +299,31 @@ class Column(object):
     isNotNull = _unary_op("isNotNull", "True if the current expression is not null.")
 
     @since(1.3)
-    def alias(self, *alias):
+    def alias(self, *alias, metadata=None):
         """
         Returns this column aliased with a new name or names (in the case of expressions that
         return more than one column, such as explode).
 
+        Optional ``metadata`` can be passed when aliasing a single column.  It will be stored
+        in the ``metadata`` attribute of the corresponding ``StructField``.
+
         >>> df.select(df.age.alias("age2")).collect()
         [Row(age2=2), Row(age2=5)]
+        >>> df.select(df.age.alias("age3", metadata={'max': 99})).schema['age3'].metadata['max']
+        99
         """
 
+        sc = SparkContext._active_spark_context
         if len(alias) == 1:
-            return Column(getattr(self._jc, "as")(alias[0]))
+            if metadata:
+                jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(
+                    json.dumps(metadata))
+                return Column(getattr(self._jc, "as")(alias[0], jmeta))
+            else:
+                return Column(getattr(self._jc, "as")(alias[0]))
         else:
-            sc = SparkContext._active_spark_context
+            if metadata:
+                raise ValueError('metadata can only be provided for a single column')
             return Column(getattr(self._jc, "as")(_to_seq(sc, list(alias))))
 
     name = copy_func(alias, sinceversion=2.0, doc=":func:`name` is an alias for :func:`alias`.")

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -304,11 +304,12 @@ class Column(object):
         Returns this column aliased with a new name or names (in the case of expressions that
         return more than one column, such as explode).
 
-        Optional ``metadata`` keyword argument can be passed when aliasing a single column.
-        Its contents will be stored in the ``metadata`` attribute of the matching ``StructField``.
+        :param alias: strings of desired column names (collects all positional arguments passed)
+        :param metadata: a dict of information to be stored in ``metadata`` attribute of the
+            corresponding :class: `StructField` (optional, keyword only argument)
 
         .. versionchanged:: 2.2
-           Added optional metadata argument.
+           Added optional ``metadata`` argument.
 
         >>> df.select(df.age.alias("age2")).collect()
         [Row(age2=2), Row(age2=5)]

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -776,6 +776,9 @@ class SQLTests(ReusedPySparkTestCase):
         df = self.df
         df_with_meta = df.select(df.key.alias('pk', metadata={'label': 'Primary Key'}))
         self.assertEqual(df_with_meta.schema['pk'].metadata['label'], 'Primary Key')
+        self.assertRaises(
+            AssertionError,
+            df.select(df.key.alias('pk', metdata={'label': 'Primary Key'})))
 
     def test_freqItems(self):
         vals = [Row(a=1, b=-2.0) if i % 2 == 0 else Row(a=i, b=i * 1.0) for i in range(100)]

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -260,9 +260,8 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(result[0][0], "a")
         self.assertEqual(result[0][1], "b")
 
-        self.assertRaises(
-            ValueError,
-            data.select(explode(data.mapfield).alias("a", "b", metadata={'max': 99})).count())
+        with self.assertRaises(ValueError):
+            data.select(explode(data.mapfield).alias("a", "b", metadata={'max': 99})).count()
 
     def test_and_in_expression(self):
         self.assertEqual(4, self.df.filter((self.df.key <= 10) & (self.df.value <= "2")).count())
@@ -776,9 +775,8 @@ class SQLTests(ReusedPySparkTestCase):
         df = self.df
         df_with_meta = df.select(df.key.alias('pk', metadata={'label': 'Primary Key'}))
         self.assertEqual(df_with_meta.schema['pk'].metadata['label'], 'Primary Key')
-        self.assertRaises(
-            AssertionError,
-            df.select(df.key.alias('pk', metdata={'label': 'Primary Key'})))
+        with self.assertRaises(AssertionError):
+            df.select(df.key.alias('pk', metdata={'label': 'Primary Key'}))
 
     def test_freqItems(self):
         vals = [Row(a=1, b=-2.0) if i % 2 == 0 else Row(a=i, b=i * 1.0) for i in range(100)]

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -260,6 +260,10 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(result[0][0], "a")
         self.assertEqual(result[0][1], "b")
 
+        self.assertRaises(
+            ValueError,
+            data.select(explode(data.mapfield).alias("a", "b", metadata={'max': 99})).count())
+
     def test_and_in_expression(self):
         self.assertEqual(4, self.df.filter((self.df.key <= 10) & (self.df.value <= "2")).count())
         self.assertRaises(ValueError, lambda: (self.df.key <= 10) and (self.df.value <= "2"))
@@ -767,6 +771,11 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(self.testData, df.select("*").collect())
         self.assertEqual(self.testData, df.select(df.key, df.value).collect())
         self.assertEqual([Row(value='1')], df.where(df.key == 1).select(df.value).collect())
+
+    def test_column_alias_metadata(self):
+        df = self.df
+        df_with_meta = df.select(df.key.alias('pk', metadata={'label': 'Primary Key'}))
+        self.assertEqual(df_with_meta.schema['pk'].metadata['label'], 'Primary Key')
 
     def test_freqItems(self):
         vals = [Row(a=1, b=-2.0) if i % 2 == 0 else Row(a=i, b=i * 1.0) for i in range(100)]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a `metadata` keyword parameter to `pyspark.sql.Column.alias()` to allow users to mix-in metadata while manipulating `DataFrame`s in `pyspark`.  Without this, I believe it was necessary to pass back through `SparkSession.createDataFrame` each time a user wanted to manipulate `StructField.metadata` in `pyspark`.  

This pull request also improves consistency between the Scala and Python APIs (i.e. I did not add any functionality that was not already in the Scala API).

Discussed ahead of time on JIRA with @marmbrus 

## How was this patch tested?

Added unit tests (and doc tests).  Ran the pertinent tests manually.
