### PR TITLE
[SPARK-18620][Streaming][Kinesis] Flatten input rates in timeline for streaming + kinesis

### DIFF
--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -221,6 +221,12 @@ private[kinesis] class KinesisReceiver[T](
     }
   }
 
+  /** Return the current rate limit defined in [[BlockGenerator]]. */
+  private[kinesis] def getCurrentLimit: Int = {
+    assert(blockGenerator != null)
+    math.min(blockGenerator.getCurrentLimit, Int.MaxValue).toInt
+  }
+
   /** Get the latest sequence number for the given shard that can be checkpointed through KCL */
   private[kinesis] def getLatestSeqNumToCheckpoint(shardId: String): Option[String] = {
     Option(shardIdToLatestStoredSeqNum.get(shardId))

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -77,8 +77,9 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
         for (start <- 0 until batch.size by maxRecords) {
           val miniBatch = batch.subList(start, math.min(start + maxRecords, batch.size))
           receiver.addRecords(shardId, miniBatch)
+          logDebug(s"Stored: Worker $workerId stored ${miniBatch.size} records " +
+            s"for shardId $shardId")
         }
-        logDebug(s"Stored: Worker $workerId stored ${batch.size} records for shardId $shardId")
         receiver.setCheckpointer(shardId, checkpointer)
       } catch {
         case NonFatal(e) =>

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -79,11 +79,11 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
       val rem = batch.size % maxRecords
       for (idx <- 0 until numIter) {
         val fromIdx = idx * maxRecords
-        val toIdx = fromIdx + maxRecords - 1
-        addRecords(batch.subList(fromIdx, toIdx), checkpointer)
+        val untilIdx = fromIdx + maxRecords
+        addRecords(batch.subList(fromIdx, untilIdx), checkpointer)
       }
       if (rem > 0) {
-        addRecords(batch.subList(numIter * maxRecords, batch.size - 1), checkpointer)
+        addRecords(batch.subList(numIter * maxRecords, batch.size), checkpointer)
       }
     }
   }

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -18,7 +18,7 @@ package org.apache.spark.streaming.kinesis
 
 import java.util.List
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.Random
 import scala.util.control.NonFatal
 
@@ -74,8 +74,8 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
         // in `KinesisClientLibConfiguration`. For example, if we set 10 to the number of max
         // records in a worker and a producer aggregates two records into one message, the worker
         // possibly 20 records every callback function called.
-        batch.grouped(receiver.getCurrentLimit).foreach { batch =>
-          receiver.addRecords(shardId, batch)
+        batch.asScala.grouped(receiver.getCurrentLimit).foreach { batch =>
+          receiver.addRecords(shardId, batch.asJava)
           logDebug(s"Stored: Worker $workerId stored ${batch.size} records for shardId $shardId")
           receiver.setCheckpointer(shardId, checkpointer)
         }

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -72,12 +72,8 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
   private def processRecordsWithLimit(
       batch: List[Record], checkpointer: IRecordProcessorCheckpointer): Unit = {
     val maxRecords = receiver.getCurrentLimit
-    if (batch.size() <= maxRecords) {
-      addRecords(batch, checkpointer)
-    } else {
-      for (start <- 0 until batch.size by maxRecords) {
-        addRecords(batch.subList(start, math.min(start + maxRecords, batch.size)), checkpointer)
-      }
+    for (start <- 0 until batch.size by maxRecords) {
+      addRecords(batch.subList(start, math.min(start + maxRecords, batch.size)), checkpointer)
     }
   }
 

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -75,15 +75,8 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
     if (batch.size() <= maxRecords) {
       addRecords(batch, checkpointer)
     } else {
-      val numIter = batch.size / maxRecords
-      val rem = batch.size % maxRecords
-      for (idx <- 0 until numIter) {
-        val fromIdx = idx * maxRecords
-        val untilIdx = fromIdx + maxRecords
-        addRecords(batch.subList(fromIdx, untilIdx), checkpointer)
-      }
-      if (rem > 0) {
-        addRecords(batch.subList(numIter * maxRecords, batch.size), checkpointer)
+      for (start <- 0 until batch.size by maxRecords) {
+        addRecords(batch.subList(start, math.min(start + maxRecords, batch.size)), checkpointer)
       }
     }
   }

--- a/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisReceiverSuite.scala
+++ b/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisReceiverSuite.scala
@@ -91,7 +91,7 @@ class KinesisReceiverSuite extends TestSuiteBase with Matchers with BeforeAndAft
     verify(receiverMock, times(1)).isStopped()
     verify(receiverMock, times(1)).addRecords(shardId, batch.subList(0, 1))
     verify(receiverMock, times(1)).addRecords(shardId, batch.subList(1, 2))
-    verify(receiverMock, times(2)).setCheckpointer(shardId, checkpointerMock)
+    verify(receiverMock, times(1)).setCheckpointer(shardId, checkpointerMock)
   }
 
   test("shouldn't store and update checkpointer when receiver is stopped") {

--- a/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisReceiverSuite.scala
+++ b/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisReceiverSuite.scala
@@ -89,7 +89,8 @@ class KinesisReceiverSuite extends TestSuiteBase with Matchers with BeforeAndAft
     recordProcessor.processRecords(batch, checkpointerMock)
 
     verify(receiverMock, times(1)).isStopped()
-    verify(receiverMock, times(2)).addRecords(shardId, batch)
+    verify(receiverMock, times(1)).addRecords(shardId, batch.subList(0, 1))
+    verify(receiverMock, times(1)).addRecords(shardId, batch.subList(1, 2))
     verify(receiverMock, times(2)).setCheckpointer(shardId, checkpointerMock)
   }
 

--- a/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisReceiverSuite.scala
+++ b/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisReceiverSuite.scala
@@ -69,6 +69,7 @@ class KinesisReceiverSuite extends TestSuiteBase with Matchers with BeforeAndAft
 
   test("process records including store and set checkpointer") {
     when(receiverMock.isStopped()).thenReturn(false)
+    when(receiverMock.getCurrentLimit).thenReturn(Int.MaxValue)
 
     val recordProcessor = new KinesisRecordProcessor(receiverMock, workerId)
     recordProcessor.initialize(shardId)
@@ -79,8 +80,22 @@ class KinesisReceiverSuite extends TestSuiteBase with Matchers with BeforeAndAft
     verify(receiverMock, times(1)).setCheckpointer(shardId, checkpointerMock)
   }
 
+  test("split into multiple processes if a limitation is set") {
+    when(receiverMock.isStopped()).thenReturn(false)
+    when(receiverMock.getCurrentLimit).thenReturn(1)
+
+    val recordProcessor = new KinesisRecordProcessor(receiverMock, workerId)
+    recordProcessor.initialize(shardId)
+    recordProcessor.processRecords(batch, checkpointerMock)
+
+    verify(receiverMock, times(1)).isStopped()
+    verify(receiverMock, times(2)).addRecords(shardId, batch)
+    verify(receiverMock, times(2)).setCheckpointer(shardId, checkpointerMock)
+  }
+
   test("shouldn't store and update checkpointer when receiver is stopped") {
     when(receiverMock.isStopped()).thenReturn(true)
+    when(receiverMock.getCurrentLimit).thenReturn(Int.MaxValue)
 
     val recordProcessor = new KinesisRecordProcessor(receiverMock, workerId)
     recordProcessor.processRecords(batch, checkpointerMock)
@@ -92,6 +107,7 @@ class KinesisReceiverSuite extends TestSuiteBase with Matchers with BeforeAndAft
 
   test("shouldn't update checkpointer when exception occurs during store") {
     when(receiverMock.isStopped()).thenReturn(false)
+    when(receiverMock.getCurrentLimit).thenReturn(Int.MaxValue)
     when(
       receiverMock.addRecords(anyString, anyListOf(classOf[Record]))
     ).thenThrow(new RuntimeException())


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr is to make input rates in timeline more flat for spark streaming + kinesis.
Since kinesis workers fetch records and push them into block generators in bulk, timeline in web UI has many spikes when `maxRates` applied (See a Figure.1 below). This fix splits fetched input records into multiple `adRecords` calls.

Figure.1 Apply `maxRates=500` in vanilla Spark
<img width="1084" alt="apply_limit in_vanilla_spark" src="https://cloud.githubusercontent.com/assets/692303/20823861/4602f300-b89b-11e6-95f3-164a37061305.png">

Figure.2 Apply `maxRates=500` in Spark with my patch
<img width="1056" alt="apply_limit in_spark_with_my_patch" src="https://cloud.githubusercontent.com/assets/692303/20823882/6c46352c-b89b-11e6-81ab-afd8abfe0cfe.png">

## How was this patch tested?
Add tests to check to split input records into multiple `addRecords` calls.