### PR TITLE
[SPARK-18681][SQL] Fix filtering to compatible with partition keys of type int

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -591,7 +591,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         logDebug(s"Hive metastore filter is '$filter'.")
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
         // We should get this config value from the metaStore. otherwise hit SPARK-18681.
-        // To be compatible with hive-0.12 and hive-0.13,In the future we can achieve this by:
+        // To be compatible with hive-0.12 and hive-0.13, In the future we can achieve this by:
         // val tryDirectSql = hive.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
         val tryDirectSql = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,
           tryDirectSqlConfVar.defaultBoolVal.toString).toBoolean

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -590,6 +590,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
+        // We should get this config value from the metaStore. otherwise hit SPARK-18681.
         // To be compatible with hive-0.12 and hive-0.13,In the future we can achieve this by:
         // val tryDirectSql = hive.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
         val tryDirectSql = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -590,7 +590,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
-        val tryDirectSql = hive.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
+        val tryDirectSql = hive.getMSC.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
         try {
           // Hive may throw an exception when calling this method in some circumstances, such as
           // when filtering on a non-string partition column when the hive config key

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -590,8 +590,10 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
+        // To be compatible with hive-0.12 and hive-0.13,In the future we can achieve this by:
+        // val tryDirectSql = hive.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
         val tryDirectSql = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,
-          tryDirectSqlConfVar.getDefaultValue).toBoolean
+          tryDirectSqlConfVar.defaultBoolVal.toString).toBoolean
         try {
           // Hive may throw an exception when calling this method in some circumstances, such as
           // when filtering on a non-string partition column when the hive config key

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -590,7 +590,8 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
-        val tryDirectSql = hive.getMSC.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
+        val tryDirectSql = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,
+          tryDirectSqlConfVar.getDefaultValue).toBoolean
         try {
           // Hive may throw an exception when calling this method in some circumstances, such as
           // when filtering on a non-string partition column when the hive config key

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -590,8 +590,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
-        val tryDirectSql =
-          hive.getConf.getBoolean(tryDirectSqlConfVar.varname, tryDirectSqlConfVar.defaultBoolVal)
+        val tryDirectSql = hive.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
         try {
           // Hive may throw an exception when calling this method in some circumstances, such as
           // when filtering on a non-string partition column when the hive config key
@@ -600,14 +599,11 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
             .asInstanceOf[JArrayList[Partition]]
         } catch {
           case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] &&
-              (!tryDirectSql || ex.getCause.getMessage.contains(
-                "Filtering is supported only on partition keys of type string")) =>
-            if (!tryDirectSql) {
-              logWarning("Caught Hive MetaException attempting to get partition metadata by " +
-                "filter from Hive. Falling back to fetching all partition metadata, which will " +
-                "degrade performance. Modifying your Hive metastore configuration to set " +
-                s"${tryDirectSqlConfVar.varname} to true may resolve this problem.", ex)
-            }
+              !tryDirectSql =>
+            logWarning("Caught Hive MetaException attempting to get partition metadata by " +
+              "filter from Hive. Falling back to fetching all partition metadata, which will " +
+              "degrade performance. Modifying your Hive metastore configuration to set " +
+              s"${tryDirectSqlConfVar.varname} to true may resolve this problem.", ex)
             // HiveShim clients are expected to handle a superset of the requested partitions
             getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
           case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] &&

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive.client
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.metadata.Hive
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.catalog._
@@ -29,9 +30,9 @@ import org.apache.spark.sql.types.IntegerType
 class HiveClientSuite extends SparkFunSuite {
   private val clientBuilder = new HiveClientBuilder
 
-  private val tryDirectSqlKey = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname
+  private val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
 
-  test(s"getPartitionsByFilter returns all partitions when $tryDirectSqlKey=false") {
+  test(s"getPartitionsByFilter returns all partitions when ${tryDirectSqlConfVar.varname}=false") {
     val testPartitionCount = 5
 
     val storageFormat = CatalogStorageFormat(
@@ -43,7 +44,7 @@ class HiveClientSuite extends SparkFunSuite {
       properties = Map.empty)
 
     val hadoopConf = new Configuration()
-    hadoopConf.setBoolean(tryDirectSqlKey, false)
+    hadoopConf.setBoolean(tryDirectSqlConfVar.varname, false)
     val client = clientBuilder.buildClient(HiveUtils.hiveExecutionVersion, hadoopConf)
     client.runSqlHive("CREATE TABLE test (value INT) PARTITIONED BY (part INT)")
 
@@ -57,5 +58,21 @@ class HiveClientSuite extends SparkFunSuite {
       Seq(EqualTo(AttributeReference("part", IntegerType)(), Literal(3))))
 
     assert(filteredPartitions.size == testPartitionCount)
+  }
+
+  test("Get configure value from the local and the metaStore may be not equality") {
+    // Only set the metaStore to false, local is default.
+    // The local should be true and the metaStore should be false.
+    val conf = new HiveConf()
+    val hive = Hive.get(conf)
+    hive.getMSC.setMetaConf(tryDirectSqlConfVar.varname, false.toString)
+    val clientSide = hive.getConf.getBoolean(tryDirectSqlConfVar.varname,
+      tryDirectSqlConfVar.defaultBoolVal)
+    val metaStoreSide = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,
+      tryDirectSqlConfVar.defaultBoolVal.toString).toBoolean
+    //  Hive may throw an exception (SPARK-18681) if get config value from the local.
+    assert(clientSide)
+    assert(!metaStoreSide)
+    assert(clientSide != metaStoreSide)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cloudera put `/var/run/cloudera-scm-agent/process/15000-hive-HIVEMETASTORE/hive-site.xml` as the configuration file for the Hive Metastore Server, where `hive.metastore.try.direct.sql=false`. But Spark isn't reading this configuration file and get default value `hive.metastore.try.direct.sql=true`. As @mallman said, we should use `getMetaConf` method to obtain the original configuration from Hive Metastore Server. I have tested this method few times and the return value is always consistent with Hive Metastore Server.

## How was this patch tested?

The existing tests.