### PR TITLE
[SPARK-18701][ML] Fix Poisson GLM failure due to wrong initialization

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -505,7 +505,8 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     override def initialize(y: Double, weight: Double): Double = {
       require(y >= 0.0, "The response variable of Poisson family " +
         s"should be non-negative, but got $y")
-      y + 0.1
+      // Set lower bound for mean in the FIRST step in IWLS
+      math.max(y, 0.1)
     }
 
     override def variance(mu: Double): Double = mu

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -505,7 +505,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     override def initialize(y: Double, weight: Double): Double = {
       require(y >= 0.0, "The response variable of Poisson family " +
         s"should be non-negative, but got $y")
-      // Set lower bound for mean in the FIRST step in IWLS
+      // force Poisson mean > 0 to avoid numerical instability in IRLS
       math.max(y, 0.1)
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -505,7 +505,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     override def initialize(y: Double, weight: Double): Double = {
       require(y >= 0.0, "The response variable of Poisson family " +
         s"should be non-negative, but got $y")
-      y
+      y + 0.1
     }
 
     override def variance(mu: Double): Double = mu

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -505,7 +505,10 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     override def initialize(y: Double, weight: Double): Double = {
       require(y >= 0.0, "The response variable of Poisson family " +
         s"should be non-negative, but got $y")
-      // force Poisson mean > 0 to avoid numerical instability in IRLS
+      /*
+        Force Poisson mean > 0 to avoid numerical instability in IRLS.
+        R uses y + 0.1 for initialization. See poisson()$initialize.
+       */
       math.max(y, 0.1)
     }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -89,11 +89,23 @@ class GeneralizedLinearRegressionSuite
       xVariance = Array(0.7, 1.2), nPoints = 10000, seed, noiseLevel = 0.01,
       family = "poisson", link = "log").toDF()
 
-    datasetPoissonLogWithZero = generateGeneralizedLinearRegressionInput(
-      intercept = -1.5, coefficients = Array(0.22, 0.06), xMean = Array(2.9, 10.5),
-      xVariance = Array(0.7, 1.2), nPoints = 100, seed, noiseLevel = 0.01,
-      family = "poisson", link = "log")
-      .map{x => LabeledPoint(if (x.label < 0.7) 0.0 else x.label, x.features)}.toDF()
+    datasetPoissonLogWithZero = Seq(
+      LabeledPoint(0.0, Vectors.dense(18, 1.0)),
+      LabeledPoint(1.0, Vectors.dense(12, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(15, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(13, 2.0)),
+      LabeledPoint(0.0, Vectors.dense(15, 1.0)),
+      LabeledPoint(1.0, Vectors.dense(16, 1.0)),
+      LabeledPoint(0.0, Vectors.dense(10, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(15, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(12, 2.0)),
+      LabeledPoint(0.0, Vectors.dense(13, 0.0)),
+      LabeledPoint(1.0, Vectors.dense(15, 0.0)),
+      LabeledPoint(1.0, Vectors.dense(15, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(15, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(12, 2.0)),
+      LabeledPoint(1.0, Vectors.dense(12, 2.0))
+    ).toDF()
 
     datasetPoissonIdentity = generateGeneralizedLinearRegressionInput(
       intercept = 2.5, coefficients = Array(2.2, 0.6), xMean = Array(2.9, 10.5),
@@ -480,12 +492,12 @@ class GeneralizedLinearRegressionSuite
          model <- glm(formula, family="poisson", data=data)
          print(as.vector(coef(model)))
        }
-       [1]  0.4272661 -0.1565423
-       [1] -3.6911354  0.6214301  0.1295814
+       [1] -0.0666978 -0.2369600
+       [1] -1.2464752   0.0194581  -0.1853699
      */
     val expected = Seq(
-      Vectors.dense(0.0, 0.4272661, -0.1565423),
-      Vectors.dense(-3.6911354, 0.6214301, 0.1295814))
+      Vectors.dense(0.0, -0.0666978, -0.2369600),
+      Vectors.dense(-1.2464752, 0.0194581, -0.1853699))
 
     import GeneralizedLinearRegression._
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -500,7 +500,6 @@ class GeneralizedLinearRegressionSuite
         .setFitIntercept(fitIntercept).setLinkPredictionCol("linkPrediction")
       val model = trainer.fit(dataset)
       val actual = Vectors.dense(model.intercept, model.coefficients(0), model.coefficients(1))
-      println("coeff is " + actual)
       assert(actual ~= expected(idx) absTol 1e-4, "Model mismatch: GLM with poisson family, " +
         s"$link link and fitIntercept = $fitIntercept (with zero values).")
       idx += 1

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -95,16 +95,7 @@ class GeneralizedLinearRegressionSuite
       LabeledPoint(0.0, Vectors.dense(15, 0.0)),
       LabeledPoint(0.0, Vectors.dense(13, 2.0)),
       LabeledPoint(0.0, Vectors.dense(15, 1.0)),
-      LabeledPoint(1.0, Vectors.dense(16, 1.0)),
-      LabeledPoint(0.0, Vectors.dense(10, 0.0)),
-      LabeledPoint(0.0, Vectors.dense(15, 0.0)),
-      LabeledPoint(0.0, Vectors.dense(12, 2.0)),
-      LabeledPoint(0.0, Vectors.dense(13, 0.0)),
-      LabeledPoint(1.0, Vectors.dense(15, 0.0)),
-      LabeledPoint(1.0, Vectors.dense(15, 0.0)),
-      LabeledPoint(0.0, Vectors.dense(15, 0.0)),
-      LabeledPoint(0.0, Vectors.dense(12, 2.0)),
-      LabeledPoint(1.0, Vectors.dense(12, 2.0))
+      LabeledPoint(1.0, Vectors.dense(16, 1.0))
     ).toDF()
 
     datasetPoissonIdentity = generateGeneralizedLinearRegressionInput(
@@ -492,12 +483,12 @@ class GeneralizedLinearRegressionSuite
          model <- glm(formula, family="poisson", data=data)
          print(as.vector(coef(model)))
        }
-       [1] -0.0666978 -0.2369600
-       [1] -1.2464752   0.0194581  -0.1853699
+       [1] -0.0457441 -0.6833928
+       [1] 1.8121235  -0.1747493  -0.5815417
      */
     val expected = Seq(
-      Vectors.dense(0.0, -0.0666978, -0.2369600),
-      Vectors.dense(-1.2464752, 0.0194581, -0.1853699))
+      Vectors.dense(0.0, -0.0457441, -0.6833928),
+      Vectors.dense(1.8121235, -0.1747493, -0.5815417))
 
     import GeneralizedLinearRegression._
 
@@ -509,6 +500,7 @@ class GeneralizedLinearRegressionSuite
         .setFitIntercept(fitIntercept).setLinkPredictionCol("linkPrediction")
       val model = trainer.fit(dataset)
       val actual = Vectors.dense(model.intercept, model.coefficients(0), model.coefficients(1))
+      println("coeff is " + actual)
       assert(actual ~= expected(idx) absTol 1e-4, "Model mismatch: GLM with poisson family, " +
         s"$link link and fitIntercept = $fitIntercept (with zero values).")
       idx += 1


### PR DESCRIPTION
Poisson GLM fails for many standard data sets (see example in test or JIRA). The issue is incorrect initialization leading to almost zero probability and weights. Specifically, the mean is initialized as the response, which could be zero. Applying the log link results in very negative numbers (protected against -Inf), which again leads to close to zero probability and weights in the weighted least squares. Fix and test are included in the commits.

## What changes were proposed in this pull request?
Update initialization in Poisson GLM

## How was this patch tested?
Add test in GeneralizedLinearRegressionSuite

@srowen @sethah @yanboliang @HyukjinKwon @mengxr 
