### PR TITLE
[MINOR] [README] Correct Markdown link inside readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ You can build Spark using more than one thread by using the -T option with Maven
 More detailed documentation is available from the project site, at
 ["Building Spark"](http://spark.apache.org/docs/latest/building-spark.html).
 
-For general development tips, including info on developing Spark using an IDE, see 
-[http://spark.apache.org/developer-tools.html](the Useful Developer Tools page).
+For general development tips, including info on developing Spark using an IDE, see ["Useful Developer Tools"](http://spark.apache.org/developer-tools.html).
 
 ## Interactive Scala Shell
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

"Useful Developer Tools" link inside [README.md](https://github.com/apache/spark/blob/master/README.md#building-spark) doesn't work on master branch. This pr corrects this Markdown link. 

## How was this patch tested?

[README.md](https://github.com/linbojin/spark/blob/fix-markdown-link-in-readme/README.md#building-spark) on this branch
![image](https://cloud.githubusercontent.com/assets/5894707/20864124/4c83499e-ba1e-11e6-9948-07b4627f516f.png)

@srowen 