### PR TITLE
[SPARK-18715][ML]Fix AIC calculations in Binomial GLM

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -215,6 +215,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
    * Default is not set, so all instances have weight one.
+   * In the Binomial model, weights correspond to number of trials.
    *
    * @group setParam
    */
@@ -468,11 +469,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     override def variance(mu: Double): Double = mu * (1.0 - mu)
 
     private def ylogy(y: Double, mu: Double): Double = {
-      if (y == 0) {
-        0.0
-      } else {
-        y * math.log(y / mu)
-      }
+      if (y == 0) 0.0 else y * math.log(y / mu)
     }
 
     override def deviance(y: Double, mu: Double, weight: Double): Double = {
@@ -485,6 +482,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
         numInstances: Double,
         weightSum: Double): Double = {
       -2.0 * predictions.map { case (y: Double, mu: Double, weight: Double) =>
+        // weights for Binomial distribution correspond to number of trials
         val wt = math.round(weight).toInt
         if (wt == 0) {
           0.0

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -468,9 +468,14 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
     override def variance(mu: Double): Double = mu * (1.0 - mu)
 
     override def deviance(y: Double, mu: Double, weight: Double): Double = {
-      val my = 1.0 - y
-      2.0 * weight * (y * math.log(math.max(y, 1.0) / mu) +
-        my * math.log(math.max(my, 1.0) / (1.0 - mu)))
+      val y_logy = (y: Double, mu: Double) => {
+        if (y == 0) {
+          0.0
+        } else {
+          y * math.log(y / mu)
+        }
+      }
+      2.0 * weight * (y_logy(y, mu) + y_logy(1.0 - y, 1.0 - mu))
     }
 
     override def aic(

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -215,7 +215,8 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
    * Default is not set, so all instances have weight one.
-   * In the Binomial model, weights correspond to number of trials.
+   * In the Binomial family, weights correspond to number of trials and should be integer.
+   * Non-integer weights are rounded to integer in AIC calculation.
    *
    * @group setParam
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -467,15 +467,16 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     override def variance(mu: Double): Double = mu * (1.0 - mu)
 
-    override def deviance(y: Double, mu: Double, weight: Double): Double = {
-      val y_logy = (y: Double, mu: Double) => {
-        if (y == 0) {
-          0.0
-        } else {
-          y * math.log(y / mu)
-        }
+    private def ylogy(y: Double, mu: Double): Double = {
+      if (y == 0) {
+        0.0
+      } else {
+        y * math.log(y / mu)
       }
-      2.0 * weight * (y_logy(y, mu) + y_logy(1.0 - y, 1.0 - mu))
+    }
+
+    override def deviance(y: Double, mu: Double, weight: Double): Double = {
+      2.0 * weight * (ylogy(y, mu) + ylogy(1.0 - y, 1.0 - mu))
     }
 
     override def aic(

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -479,7 +479,12 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
         numInstances: Double,
         weightSum: Double): Double = {
       -2.0 * predictions.map { case (y: Double, mu: Double, weight: Double) =>
-        weight * dist.Binomial(1, mu).logProbabilityOf(math.round(y).toInt)
+        val wt = math.round(weight).toInt
+        if (wt == 0) {
+          0.0
+        } else {
+          dist.Binomial(wt, mu).logProbabilityOf(math.round(y * weight).toInt)
+        }
       }.sum()
     }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -715,7 +715,7 @@ class GeneralizedLinearRegressionSuite
     val datasetWithWeight = Seq(
       Instance(1.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
       Instance(0.5, 2.0, Vectors.dense(1.0, 2.0)),
-      Instance(1.0, 3.0, Vectors.dense(2.0, 1.0)),
+      Instance(1.0, 0.3, Vectors.dense(2.0, 1.0)),
       Instance(0.0, 4.0, Vectors.dense(3.0, 3.0))
     ).toDF()
 
@@ -726,31 +726,33 @@ class GeneralizedLinearRegressionSuite
        summary(model)
 
        Deviance Residuals:
-              1         2         3         4
-        0.96447   0.09609   2.48431  -1.77960
-
+              1        2        3        4
+         0.2509   0.1755   1.2578  -0.6835
+        
        Coefficients:
-          Estimate Std. Error z value Pr(>|z|)
-       V1  -0.3455     0.4598  -0.751    0.452
-       V2   0.1048     0.3791   0.276    0.782
-
+           Estimate Std. Error z value Pr(>|z|)
+       x1  -1.6256     1.2575  -1.293    0.196
+       x2   0.6886     0.9201   0.748    0.454
+        
        (Dispersion parameter for binomial family taken to be 1)
-
-           Null deviance: 11.090  on 4  degrees of freedom
-       Residual deviance: 10.278  on 2  degrees of freedom
-       AIC: 15.665
+        
+           Null deviance: 7.3474  on 4  degrees of freedom
+       Residual deviance: 2.1431  on 2  degrees of freedom
+       AIC: 5.9472
+        
+       Number of Fisher Scoring iterations: 5
 
        residuals(model, type="pearson")
               1         2         3         4
-       0.76953169  0.09620122  2.32201281 -1.39381800
+       0.1788113  0.1761654  1.9726225 -0.4904407
 
        residuals(model, type="working")
               1         2         3         4
-       1.5921790  0.1363635  2.7972478 -1.4856822
+       1.031973  0.251061 13.970798 -1.060133
 
        residuals(model, type="response")
                1          2          3          4
-       0.37192992  0.03393385  0.64250576 -0.32690852
+       0.03098285  0.06180621  0.92842213 -0.05672214
     */
     val trainer = new GeneralizedLinearRegression()
       .setFamily("binomial")
@@ -759,21 +761,21 @@ class GeneralizedLinearRegressionSuite
 
     val model = trainer.fit(datasetWithWeight)
 
-    val coefficientsR = Vectors.dense(Array(-0.3455229, 0.1047893))
+    val coefficientsR = Vectors.dense(Array(-1.6256351, 0.6885697))
     val interceptR = 0.0
-    val devianceResidualsR = Array(0.96447, 0.09609, 2.48431, -1.77960)
-    val pearsonResidualsR = Array(0.76953169, 0.09620122, 2.32201281, -1.39381800)
-    val workingResidualsR = Array(1.5921790, 0.1363635, 2.7972478, -1.4856822)
-    val responseResidualsR = Array(0.37192992, 0.03393385, 0.64250576, -0.32690852)
-    val seCoefR = Array(0.45983, 0.3791)
-    val tValsR = Array(-0.75141, 0.27641)
-    val pValsR = Array(0.45241, 0.78223)
+    val devianceResidualsR = Array(0.2509, 0.1755, 1.2578, -0.6835)
+    val pearsonResidualsR = Array(0.1788113, 0.1761654, 1.9726225, -0.4904407)
+    val workingResidualsR = Array(1.031973, 0.251061, 13.970798, -1.060133)
+    val responseResidualsR = Array(0.03098285, 0.06180621, 0.92842213, -0.05672214)
+    val seCoefR = Array(1.257499, 0.920116)
+    val tValsR = Array(-1.292752, 0.748351)
+    val pValsR = Array(0.196097, 0.454248)
     val dispersionR = 1.0
-    val nullDevianceR = 11.090
-    val residualDevianceR = 10.278
+    val nullDevianceR = 7.3474
+    val residualDevianceR = 2.1431
     val residualDegreeOfFreedomNullR = 4
     val residualDegreeOfFreedomR = 2
-    val aicR = 15.665
+    val aicR = 5.9472
 
     val summary = model.summary
     val devianceResiduals = summary.residuals()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -709,14 +709,14 @@ class GeneralizedLinearRegressionSuite
 
        A <- matrix(c(0, 1, 2, 3, 5, 2, 1, 3), 4, 2)
        b <- c(1, 0.5, 1, 0)
-       w <- c(1, 2, 3, 4)
+       w <- c(1, 2.0, 0.3, 4.7)
        df <- as.data.frame(cbind(A, b))
      */
     val datasetWithWeight = Seq(
       Instance(1.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
       Instance(0.5, 2.0, Vectors.dense(1.0, 2.0)),
       Instance(1.0, 0.3, Vectors.dense(2.0, 1.0)),
-      Instance(0.0, 4.0, Vectors.dense(3.0, 3.0))
+      Instance(0.0, 4.7, Vectors.dense(3.0, 3.0))
     ).toDF()
 
     /*
@@ -726,33 +726,33 @@ class GeneralizedLinearRegressionSuite
        summary(model)
 
        Deviance Residuals:
-              1        2        3        4
-         0.2509   0.1755   1.2578  -0.6835
-        
+             1        2        3        4
+        0.2404   0.1965   1.2824  -0.6916
+
        Coefficients:
-           Estimate Std. Error z value Pr(>|z|)
-       x1  -1.6256     1.2575  -1.293    0.196
-       x2   0.6886     0.9201   0.748    0.454
-        
+          Estimate Std. Error z value Pr(>|z|)
+       x1  -1.6901     1.2764  -1.324    0.185
+       x2   0.7059     0.9449   0.747    0.455
+
        (Dispersion parameter for binomial family taken to be 1)
-        
-           Null deviance: 7.3474  on 4  degrees of freedom
-       Residual deviance: 2.1431  on 2  degrees of freedom
-       AIC: 5.9472
-        
+
+           Null deviance: 8.3178  on 4  degrees of freedom
+       Residual deviance: 2.2193  on 2  degrees of freedom
+       AIC: 5.9915
+
        Number of Fisher Scoring iterations: 5
 
        residuals(model, type="pearson")
               1         2         3         4
-       0.1788113  0.1761654  1.9726225 -0.4904407
+       0.171217  0.197406  2.085864 -0.495332
 
        residuals(model, type="working")
               1         2         3         4
-       1.031973  0.251061 13.970798 -1.060133
+       1.029315  0.281881 15.502768 -1.052203
 
        residuals(model, type="response")
-               1          2          3          4
-       0.03098285  0.06180621  0.92842213 -0.05672214
+              1          2          3          4
+       0.028480  0.069123  0.935495 -0.049613
     */
     val trainer = new GeneralizedLinearRegression()
       .setFamily("binomial")
@@ -761,21 +761,21 @@ class GeneralizedLinearRegressionSuite
 
     val model = trainer.fit(datasetWithWeight)
 
-    val coefficientsR = Vectors.dense(Array(-1.6256351, 0.6885697))
+    val coefficientsR = Vectors.dense(Array(-1.690134, 0.705929))
     val interceptR = 0.0
-    val devianceResidualsR = Array(0.2509, 0.1755, 1.2578, -0.6835)
-    val pearsonResidualsR = Array(0.1788113, 0.1761654, 1.9726225, -0.4904407)
-    val workingResidualsR = Array(1.031973, 0.251061, 13.970798, -1.060133)
-    val responseResidualsR = Array(0.03098285, 0.06180621, 0.92842213, -0.05672214)
-    val seCoefR = Array(1.257499, 0.920116)
-    val tValsR = Array(-1.292752, 0.748351)
-    val pValsR = Array(0.196097, 0.454248)
+    val devianceResidualsR = Array(0.2404, 0.1965, 1.2824, -0.6916)
+    val pearsonResidualsR = Array(0.171217, 0.197406, 2.085864, -0.495332)
+    val workingResidualsR = Array(1.029315, 0.281881, 15.502768, -1.052203)
+    val responseResidualsR = Array(0.02848, 0.069123, 0.935495, -0.049613)
+    val seCoefR = Array(1.276417, 0.944934)
+    val tValsR = Array(-1.324124, 0.747068)
+    val pValsR = Array(0.185462, 0.455023)
     val dispersionR = 1.0
-    val nullDevianceR = 7.3474
-    val residualDevianceR = 2.1431
+    val nullDevianceR = 8.3178
+    val residualDevianceR = 2.2193
     val residualDegreeOfFreedomNullR = 4
     val residualDegreeOfFreedomR = 2
-    val aicR = 5.9472
+    val aicR = 5.991537
 
     val summary = model.summary
     val devianceResiduals = summary.residuals()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -708,16 +708,17 @@ class GeneralizedLinearRegressionSuite
        R code:
 
        A <- matrix(c(0, 1, 2, 3, 5, 2, 1, 3), 4, 2)
-       b <- c(1, 0, 1, 0)
+       b <- c(1, 0.5, 1, 0)
        w <- c(1, 2, 3, 4)
        df <- as.data.frame(cbind(A, b))
      */
     val datasetWithWeight = Seq(
       Instance(1.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
-      Instance(0.0, 2.0, Vectors.dense(1.0, 2.0)),
+      Instance(0.5, 2.0, Vectors.dense(1.0, 2.0)),
       Instance(1.0, 3.0, Vectors.dense(2.0, 1.0)),
       Instance(0.0, 4.0, Vectors.dense(3.0, 3.0))
     ).toDF()
+
     /*
        R code:
 
@@ -725,34 +726,32 @@ class GeneralizedLinearRegressionSuite
        summary(model)
 
        Deviance Residuals:
-           1       2       3       4
-       1.273  -1.437   2.533  -1.556
+              1         2         3         4
+        0.96447   0.09609   2.48431  -1.77960
 
        Coefficients:
           Estimate Std. Error z value Pr(>|z|)
-       V1 -0.30217    0.46242  -0.653    0.513
-       V2 -0.04452    0.37124  -0.120    0.905
+       V1  -0.3455     0.4598  -0.751    0.452
+       V2   0.1048     0.3791   0.276    0.782
 
        (Dispersion parameter for binomial family taken to be 1)
 
-           Null deviance: 13.863  on 4  degrees of freedom
-       Residual deviance: 12.524  on 2  degrees of freedom
-       AIC: 16.524
-
-       Number of Fisher Scoring iterations: 5
+           Null deviance: 11.090  on 4  degrees of freedom
+       Residual deviance: 10.278  on 2  degrees of freedom
+       AIC: 15.665
 
        residuals(model, type="pearson")
               1         2         3         4
-       1.117731 -1.162962  2.395838 -1.189005
+       0.76953169  0.09620122  2.32201281 -1.39381800
 
        residuals(model, type="working")
               1         2         3         4
-       2.249324 -1.676240  2.913346 -1.353433
+       1.5921790  0.1363635  2.7972478 -1.4856822
 
        residuals(model, type="response")
                1          2          3          4
-       0.5554219 -0.4034267  0.6567520 -0.2611382
-     */
+       0.37192992  0.03393385  0.64250576 -0.32690852
+    */
     val trainer = new GeneralizedLinearRegression()
       .setFamily("binomial")
       .setWeightCol("weight")
@@ -760,21 +759,21 @@ class GeneralizedLinearRegressionSuite
 
     val model = trainer.fit(datasetWithWeight)
 
-    val coefficientsR = Vectors.dense(Array(-0.30217, -0.04452))
+    val coefficientsR = Vectors.dense(Array(-0.3455229, 0.1047893))
     val interceptR = 0.0
-    val devianceResidualsR = Array(1.273, -1.437, 2.533, -1.556)
-    val pearsonResidualsR = Array(1.117731, -1.162962, 2.395838, -1.189005)
-    val workingResidualsR = Array(2.249324, -1.676240, 2.913346, -1.353433)
-    val responseResidualsR = Array(0.5554219, -0.4034267, 0.6567520, -0.2611382)
-    val seCoefR = Array(0.46242, 0.37124)
-    val tValsR = Array(-0.653, -0.120)
-    val pValsR = Array(0.513, 0.905)
+    val devianceResidualsR = Array(0.96447, 0.09609, 2.48431, -1.77960)
+    val pearsonResidualsR = Array(0.76953169, 0.09620122, 2.32201281, -1.39381800)
+    val workingResidualsR = Array(1.5921790, 0.1363635, 2.7972478, -1.4856822)
+    val responseResidualsR = Array(0.37192992, 0.03393385, 0.64250576, -0.32690852)
+    val seCoefR = Array(0.45983, 0.3791)
+    val tValsR = Array(-0.75141, 0.27641)
+    val pValsR = Array(0.45241, 0.78223)
     val dispersionR = 1.0
-    val nullDevianceR = 13.863
-    val residualDevianceR = 12.524
+    val nullDevianceR = 11.090
+    val residualDevianceR = 10.278
     val residualDegreeOfFreedomNullR = 4
     val residualDegreeOfFreedomR = 2
-    val aicR = 16.524
+    val aicR = 15.665
 
     val summary = model.summary
     val devianceResiduals = summary.residuals()


### PR DESCRIPTION
The AIC calculation in Binomial GLM seems to be off when the response or weight is non-integer: the result is different from that in R. This issue arises when one models rates, i.e, num of successes normalized over num of trials, and uses num of trials as weights. In this case, the effective likelihood is  weight * label ~ binomial(weight, mu), where weight = number of trials, and weight * label = number of successes and mu = is the success rate.  

@srowen @sethah @yanboliang @HyukjinKwon @zhengruifeng 

## What changes were proposed in this pull request?
I suggest changing the current aic calculation for the Binomial family from 
```
-2.0 * predictions.map { case (y: Double, mu: Double, weight: Double) =>
        weight * dist.Binomial(1, mu).logProbabilityOf(math.round(y).toInt)
      }.sum()
```
to the following which generalizes to the case of real-valued response and weights. 
```
      -2.0 * predictions.map { case (y: Double, mu: Double, weight: Double) =>
        val wt = math.round(weight).toInt
        if (wt == 0){
          0.0
        } else {
          dist.Binomial(wt, mu).logProbabilityOf(math.round(y * weight).toInt)
        }
      }.sum()
``` 
## How was this patch tested?
I will write the unit test once the community wants to include the proposed change. For now, the following modifies existing tests in weighted Binomial GLM to illustrate the issue. The second label is changed from 0 to 0.5. 

```
val datasetWithWeight = Seq(
    (1.0, 1.0, 0.0, 5.0),
    (0.5, 2.0, 1.0, 2.0),
    (1.0, 3.0, 2.0, 1.0),
    (0.0, 4.0, 3.0, 3.0)
  ).toDF("y", "w", "x1", "x2")

val formula = (new RFormula()
  .setFormula("y ~ x1 + x2")
  .setFeaturesCol("features")
  .setLabelCol("label"))
val output = formula.fit(datasetWithWeight).transform(datasetWithWeight).select("features", "label", "w")

val glr = new GeneralizedLinearRegression()
    .setFamily("binomial")
    .setWeightCol("w")
    .setFitIntercept(false)
    .setRegParam(0)

val model = glr.fit(output)
model.summary.aic
```
The AIC from Spark is 17.3227, and the AIC from R is 15.66454. 