### PR TITLE
[SPARK-18719] Add spark.ui.showConsoleProgress to configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -700,6 +700,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.ui.showConsoleProgress</code></td>
+  <td>true</td>
+  <td>
+    Show the progress bar in the console.
+  </td>
+</tr>
+<tr>
   <td><code>spark.worker.ui.retainedExecutors</code></td>
   <td>1000</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -703,7 +703,9 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.ui.showConsoleProgress</code></td>
   <td>true</td>
   <td>
-    Show the progress bar in the console.
+    Show the progress bar in the console. The progress bar shows the progress of stages
+    that run for longer than 500ms. If multiple stages run at the same time, multiple
+    progress bars will be displayed on the same line.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR adds `spark.ui.showConsoleProgress` to the configuration docs.

I tested this PR by building the docs locally and confirming that this change shows up as expected.

Relates to #3029.