### PR TITLE
[SPARK-18539][SQL]: tolerate pushed-down filter on non-existing parquet columns

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -107,7 +107,13 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
       footer = readFooter(configuration, file, range(split.getStart(), split.getEnd()));
       MessageType fileSchema = footer.getFileMetaData().getSchema();
       FilterCompat.Filter filter = getFilter(configuration);
-      blocks = filterRowGroups(filter, footer.getBlocks(), fileSchema);
+      try {
+        blocks = filterRowGroups(filter, footer.getBlocks(), fileSchema);
+      } catch (IllegalArgumentException e) {
+        // In the case where a particular parquet files does not contain
+        // the column(s) in the filter, we don't do filtering at this level
+        blocks = footer.getBlocks();
+      }
     } else {
       // otherwise we find the row groups that were selected on the client
       footer = readFooter(configuration, file, NO_FILTER);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -112,6 +112,9 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
       } catch (IllegalArgumentException e) {
         // In the case where a particular parquet files does not contain
         // the column(s) in the filter, we don't do filtering at this level
+        // PARQUET-389 will resolve this issue in Parquet 1.9, which may be used
+        // by future Spark versions. This is a workaround for current Spark version.
+        // Also the assumption here is that the predicates will be applied later
         blocks = footer.getBlocks();
       }
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -634,6 +634,8 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
 
           checkAnswer(readDf2.filter("c is null and a < 2"),
             Row(1, "abc", null) :: Nil)
+
+          readDf2.filter("c is null and a < 2").explain(true)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -578,4 +578,64 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
       // scalastyle:on nonascii
     }
   }
+
+  test("SPARK-18539 - filtered by non-existing parquet column") {
+    Seq("parquet").foreach { format =>
+      withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
+        withTempPath { path =>
+          import testImplicits._
+          Seq((1, "abc"), (2, "hello")).toDF("a", "b").write.format(format).save(path.toString)
+
+          // user-specified schema contains nonexistent columns
+          val schema = StructType(
+            Seq(StructField("a", IntegerType),
+              StructField("b", StringType),
+              StructField("c", IntegerType)))
+          val readDf1 = spark.read.schema(schema).format(format).load(path.toString)
+
+          // Read the table without any filter
+          checkAnswer(readDf1, Row(1, "abc", null) :: Row(2, "hello", null) :: Nil)
+          // Read the table with a filter on existing columns
+          checkAnswer(readDf1.filter("a < 2"), Row(1, "abc", null) :: Nil)
+
+          // Read the table with a filter on nonexistent columns
+          checkAnswer(readDf1.filter("c < 2"), Nil)
+          checkAnswer(readDf1.filter("c is not null"), Nil)
+
+          checkAnswer(readDf1.filter("c is null"),
+            Row(1, "abc", null) :: Row(2, "hello", null) :: Nil)
+
+          checkAnswer(readDf1.filter("c is null and a < 2"),
+            Row(1, "abc", null) :: Nil)
+
+          // With another parquet file that contains the column "c"
+          Seq((2, "abc", 3), (3, "hello", 4)).toDF("a", "b", "c")
+            .write.format(format).mode(SaveMode.Append).save(path.toString)
+
+          // Right now, there are 2 parquet files. one with the column "c",
+          // the other does not have it.
+          val readDf2 = spark.read.schema(schema).format(format).load(path.toString)
+          // Read the table without any filter
+          checkAnswer(readDf2,
+            Row(1, "abc", null) :: Row(2, "hello", null) ::
+            Row(2, "abc", 3) :: Row(3, "hello", 4) :: Nil)
+
+          // Read the table with a filter on existing columns
+          checkAnswer(readDf2.filter("a < 2"), Row(1, "abc", null) :: Nil)
+
+          // column "c" is in one parquet file, not in the other parquet file
+          checkAnswer(readDf2.filter("c < 4"),
+            Row(2, "abc", 3) :: Nil)
+          checkAnswer(readDf2.filter("c is not null"),
+            Row(2, "abc", 3) :: Row(3, "hello", 4) :: Nil)
+
+          checkAnswer(readDf2.filter("c is null"),
+            Row(1, "abc", null) :: Row(2, "hello", null) :: Nil)
+
+          checkAnswer(readDf2.filter("c is null and a < 2"),
+            Row(1, "abc", null) :: Nil)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `spark.sql.parquet.filterPushdown` is on, SparkSQL's Parquet reader pushes down filters to Parquet file when creating reader, in order to start with filtered blocks. However, when the parquet file does not have the predicate column(s), Parquet-mr throw exceptions complaining the filter column does not existing. This issue will be fixed in parquet-mr 1.9. But Spark 2.1 is still on parquet 1.8. 

This PR is to tolerate such exception thrown by Parquet-mr and just return all the blocks from the current parquet file to the created SparkSQL parquet reader. Filters will be applied again anyway in later physical plan operation. According to following example physical plan:

```
== Physical Plan ==
*Project [a#2805, b#2806, c#2807]
+- *Filter ((isnotnull(a#2805) && isnull(c#2807)) && (a#2805 < 2))
  +- *FileScan parquet [a#2805,b#2806,c#2807] Batched: true, Format: ParquetFormat, Location: InMemoryFileIndex[file:/Users/xinwu/spark/target/tmp/spark-ed6f0c12-6494-4ac5-b485-5b986ef475cc], PartitionFilters: [], PushedFilters: [IsNotNull(a), IsNull(c), LessThan(a,2)], ReadSchema: struct<a:int,b:string,c:int>
```

## How was this patch tested?
A unit test case is added. 