### PR TITLE
[SPARK-8617] [WEBUI] HistoryServer: Include in-progress files during cleanup

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -461,7 +461,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           appListener.appAttemptId,
           appListener.startTime.getOrElse(-1L),
           appListener.endTime.getOrElse(-1L),
-          fileStatus.getModificationTime(),
+          clock.getTimeMillis(),
           appListener.sparkUser.getOrElse(NOT_STARTED),
           appCompleted,
           fileStatus.getLen()

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -446,8 +446,12 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       }
 
       val logPath = fileStatus.getPath()
-
       val appCompleted = isApplicationCompleted(fileStatus)
+
+      // Use loading time as lastUpdated since some filesystems don't update modifiedTime
+      // each time file is updated. However use modifiedTime for completed jobs so lastUpdated
+      // won't change whenever HistoryServer restarts and reloads the file.
+      val lastUpdated = if (appCompleted) fileStatus.getModificationTime else clock.getTimeMillis()
 
       val appListener = replay(fileStatus, appCompleted, new ReplayListenerBus(), eventsFilter)
 
@@ -461,7 +465,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           appListener.appAttemptId,
           appListener.startTime.getOrElse(-1L),
           appListener.endTime.getOrElse(-1L),
-          clock.getTimeMillis(),
+          lastUpdated,
           appListener.sparkUser.getOrElse(NOT_STARTED),
           appCompleted,
           fileStatus.getLen()

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -540,23 +540,13 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    */
   private[history] def cleanLogs(): Unit = {
     try {
-      val maxAge = conf.getTimeAsMs("spark.history.fs.cleaner.maxAge", "7d")
-
-      val cleanInProgressFiles =
-        conf.getBoolean("spark.history.fs.cleaner.inProgress.files", false)
-      val inProgressMaxAge =
-        conf.getTimeAsMs("spark.history.fs.cleaner.inProgress.maxAge", "28d")
+      val maxAge = conf.getTimeAsSeconds("spark.history.fs.cleaner.maxAge", "7d") * 1000
 
       val now = clock.getTimeMillis()
       val appsToRetain = new mutable.LinkedHashMap[String, FsApplicationHistoryInfo]()
 
       def shouldClean(attempt: FsApplicationAttemptInfo): Boolean = {
-        if (attempt.completed) {
-          now - attempt.lastUpdated > maxAge
-        } else {
-          cleanInProgressFiles &&
-            now - attempt.lastUpdated > inProgressMaxAge
-        }
+        now - attempt.lastUpdated > maxAge
       }
 
       // Scan all logs from the log directory.

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -540,13 +540,23 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    */
   private[history] def cleanLogs(): Unit = {
     try {
-      val maxAge = conf.getTimeAsSeconds("spark.history.fs.cleaner.maxAge", "7d") * 1000
+      val maxAge = conf.getTimeAsMs("spark.history.fs.cleaner.maxAge", "7d")
+
+      val cleanInProgressFiles =
+        conf.getBoolean("spark.history.fs.cleaner.inProgress.files", false)
+      val inProgressMaxAge =
+        conf.getTimeAsMs("spark.history.fs.cleaner.inProgress.maxAge", "28d")
 
       val now = clock.getTimeMillis()
       val appsToRetain = new mutable.LinkedHashMap[String, FsApplicationHistoryInfo]()
 
       def shouldClean(attempt: FsApplicationAttemptInfo): Boolean = {
-        now - attempt.lastUpdated > maxAge && attempt.completed
+        if (attempt.completed) {
+          now - attempt.lastUpdated > maxAge
+        } else {
+          cleanInProgressFiles &&
+            now - attempt.lastUpdated > inProgressMaxAge
+        }
       }
 
       // Scan all logs from the log directory.

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -299,6 +299,70 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
     assert(!log2.exists())
   }
 
+  test("log cleaner for inProgress files") {
+    val firstFileModifiedTime = TimeUnit.SECONDS.toMillis(10)
+    val secondFileModifiedTime = TimeUnit.SECONDS.toMillis(20)
+    val inProgressMaxAge = TimeUnit.SECONDS.toMillis(40)
+    val clock = new ManualClock(0)
+    val provider = new FsHistoryProvider(
+      createTestConf()
+        .set("spark.history.fs.cleaner.inProgress.files", "true")
+        .set("spark.history.fs.cleaner.inProgress.maxAge", s"${inProgressMaxAge}ms"),
+      clock)
+
+    val log1 = newLogFile("app1", None, inProgress = true)
+    writeFile(log1, true, None,
+      SparkListenerApplicationStart("app1", Some("app1"), 3L, "test", Some("attempt1"))
+    )
+    log1.setLastModified(firstFileModifiedTime)
+
+    val log2 = newLogFile("app2", None, inProgress = true)
+    writeFile(log2, true, None,
+      SparkListenerApplicationStart("app2", Some("app2"), 23L, "test2", Some("attempt2"))
+    )
+    log2.setLastModified(secondFileModifiedTime)
+
+    updateAndCheck(provider)(list => list.size should be (2))
+
+    // Move the clock forward little bit, this should not trigget any cleanup
+    clock.setTime(firstFileModifiedTime)
+    updateAndCheck(provider)(list => list.size should be (2))
+
+    // Should trigger cleanup for first file but not second one
+    clock.setTime(firstFileModifiedTime + inProgressMaxAge + 1)
+    updateAndCheck(provider) (list => list.size should be (1))
+    assert(!log1.exists())
+    assert(log2.exists())
+
+    // Should cleanup the second file as well.
+    clock.setTime(secondFileModifiedTime + inProgressMaxAge + 1)
+    updateAndCheck(provider)(list => list.size should be (0))
+    assert(!log1.exists())
+    assert(!log2.exists())
+  }
+
+  test("disable log cleaner for inProgress files") {
+    val fileModifiedTime = TimeUnit.SECONDS.toMillis(10)
+    val inProgressMaxAge = TimeUnit.SECONDS.toMillis(40)
+    val clock = new ManualClock(0)
+    val provider = new FsHistoryProvider(
+      createTestConf()
+        .set("spark.history.fs.cleaner.inProgress.files", "false")
+        .set("spark.history.fs.cleaner.inProgress.maxAge", s"${inProgressMaxAge}ms"),
+      clock)
+
+    val log1 = newLogFile("app1", None, inProgress = true)
+    writeFile(log1, true, None,
+      SparkListenerApplicationStart("app1", Some("app1"), 3L, "test", Some("attempt1"))
+    )
+    log1.setLastModified(fileModifiedTime)
+
+    // Should not trigget clean up
+    clock.setTime(fileModifiedTime + inProgressMaxAge + 1)
+    updateAndCheck(provider)(list => list.size should be (1))
+    assert(log1.exists())
+  }
+
   test("Event log copy") {
     val provider = new FsHistoryProvider(createTestConf())
     val logs = (1 to 2).map { i =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Removed the`attempt.completed ` filter so cleaner would include the orphan inprogress files.
- Use loading time for inprogress files as lastUpdated. Keep using the modTime for completed files. First one will prevent deletion of inprogress job files. Second one will ensure that lastUpdated time won't change for completed jobs in an event of HistoryServer reboot. 

## How was this patch tested?
Added new unittests and via existing tests.

