### PR TITLE
[SPARK-18209][SQL] More robust view canonicalization without full SQL expansion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CatalystConf, ScalaReflection, SimpleCatalystConf}
-import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.OuterScopes
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -509,32 +509,42 @@ class Analyzer(
    * Replaces [[UnresolvedRelation]]s with concrete relations from the catalog.
    */
   object ResolveRelations extends Rule[LogicalPlan] {
-    private def lookupTableFromCatalog(u: UnresolvedRelation): LogicalPlan = {
+    private def lookupTableFromCatalog(
+        u: UnresolvedRelation, db: Option[String] = None): LogicalPlan = {
       try {
-        catalog.lookupRelation(u.tableIdentifier, u.alias)
+        catalog.lookupRelation(u.tableIdentifier, u.alias, db)
       } catch {
         case _: NoSuchTableException =>
           u.failAnalysis(s"Table or view not found: ${u.tableName}")
       }
     }
 
-    def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-      case i @ InsertIntoTable(u: UnresolvedRelation, parts, child, _, _) if child.resolved =>
-        i.copy(table = EliminateSubqueryAliases(lookupTableFromCatalog(u)))
-      case u: UnresolvedRelation =>
-        val table = u.tableIdentifier
-        if (table.database.isDefined && conf.runSQLonFile && !catalog.isTemporaryTable(table) &&
+    def apply(plan: LogicalPlan): LogicalPlan = {
+      var currentDatabase = catalog.getCurrentDatabase
+      plan resolveOperators {
+        case i@InsertIntoTable(u: UnresolvedRelation, parts, child, _, _) if child.resolved =>
+          i.copy(table = EliminateSubqueryAliases(lookupTableFromCatalog(u)))
+        case u: UnresolvedRelation =>
+          val table = u.tableIdentifier
+          if (table.database.isDefined && conf.runSQLonFile && !catalog.isTemporaryTable(table) &&
             (!catalog.databaseExists(table.database.get) || !catalog.tableExists(table))) {
-          // If the database part is specified, and we support running SQL directly on files, and
-          // it's not a temporary view, and the table does not exist, then let's just return the
-          // original UnresolvedRelation. It is possible we are matching a query like "select *
-          // from parquet.`/path/to/query`". The plan will get resolved later.
-          // Note that we are testing (!db_exists || !table_exists) because the catalog throws
-          // an exception from tableExists if the database does not exist.
-          u
-        } else {
-          lookupTableFromCatalog(u)
-        }
+            // If the database part is specified, and we support running SQL directly on files, and
+            // it's not a temporary view, and the table does not exist, then let's just return the
+            // original UnresolvedRelation. It is possible we are matching a query like "select *
+            // from parquet.`/path/to/query`". The plan will get resolved later.
+            // Note that we are testing (!db_exists || !table_exists) because the catalog throws
+            // an exception from tableExists if the database does not exist.
+            u
+          } else {
+            val logicalPlan = lookupTableFromCatalog(u, Some(currentDatabase))
+            currentDatabase = logicalPlan.collectFirst {
+              case relation: CatalogRelation if relation.catalogTable.currentDatabase.isDefined =>
+                relation.catalogTable.currentDatabase.get
+            }.getOrElse(currentDatabase)
+
+            logicalPlan
+          }
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -557,9 +557,12 @@ class SessionCatalog(
    * If the relation is a view, the relation will be wrapped in a [[SubqueryAlias]] which will
    * track the name of the view.
    */
-  def lookupRelation(name: TableIdentifier, alias: Option[String] = None): LogicalPlan = {
+  def lookupRelation(
+      name: TableIdentifier,
+      alias: Option[String] = None,
+      databaseHint: Option[String] = None): LogicalPlan = {
     synchronized {
-      val db = formatDatabaseName(name.database.getOrElse(currentDb))
+      val db = formatDatabaseName(name.database.getOrElse(databaseHint.getOrElse(currentDb)))
       val table = formatTableName(name.table)
       val relationAlias = alias.getOrElse(table)
       if (db == globalTempViewManager.database) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -154,6 +154,7 @@ case class CatalogTable(
     tableType: CatalogTableType,
     storage: CatalogStorageFormat,
     schema: StructType,
+    originalSchema: Option[StructType] = None,
     provider: Option[String] = None,
     partitionColumnNames: Seq[String] = Seq.empty,
     bucketSpec: Option[BucketSpec] = None,
@@ -164,6 +165,7 @@ case class CatalogTable(
     stats: Option[Statistics] = None,
     viewOriginalText: Option[String] = None,
     viewText: Option[String] = None,
+    currentDatabase: Option[String] = None,
     comment: Option[String] = None,
     unsupportedFeatures: Seq[String] = Seq.empty,
     tracksPartitionsInCatalog: Boolean = false) {
@@ -221,11 +223,14 @@ case class CatalogTable(
         s"Last Access: ${new Date(lastAccessTime).toString}",
         s"Type: ${tableType.name}",
         if (schema.nonEmpty) s"Schema: ${schema.mkString("[", ", ", "]")}" else "",
+        if (originalSchema.isDefined) s"Original Schema: ${originalSchema.mkString("[", ", ", "]")}"
+        else "",
         if (provider.isDefined) s"Provider: ${provider.get}" else "",
         if (partitionColumnNames.nonEmpty) s"Partition Columns: $partitionColumns" else ""
       ) ++ bucketStrings ++ Seq(
         viewOriginalText.map("Original View: " + _).getOrElse(""),
         viewText.map("View: " + _).getOrElse(""),
+        currentDatabase.map("Database Hint: " + _).getOrElse(""),
         comment.map("Comment: " + _).getOrElse(""),
         if (properties.nonEmpty) s"Properties: $tableProperties" else "",
         if (stats.isDefined) s"Statistics: ${stats.get.simpleString}" else "",

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -17,12 +17,16 @@
 
 package org.apache.spark.sql.hive
 
+import scala.util.control.NonFatal
+
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
@@ -31,7 +35,6 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetOptions}
 import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.types._
-
 
 /**
  * Legacy catalog for interacting with the Hive metastore.
@@ -114,15 +117,81 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
       alias.map(a => SubqueryAlias(a, qualifiedTable, None)).getOrElse(qualifiedTable)
     } else if (table.tableType == CatalogTableType.VIEW) {
       val viewText = table.viewText.getOrElse(sys.error("Invalid view without text."))
+      val unresolvedPlan = sparkSession.sessionState.sqlParser.parsePlan(viewText).transform {
+        case u: UnresolvedRelation if u.tableIdentifier.database.isEmpty =>
+          u.copy(tableIdentifier = TableIdentifier(u.tableIdentifier.table, table.currentDatabase))
+      }
+      // Resolve the plan and check whether the analyzed plan is valid.
+      val resolvedPlan = try {
+        val resolvedPlan = sparkSession.sessionState.analyzer.execute(unresolvedPlan)
+        sparkSession.sessionState.analyzer.checkAnalysis(resolvedPlan)
+
+        resolvedPlan
+      } catch {
+        case NonFatal(e) =>
+          throw new RuntimeException(s"Failed to analyze the canonicalized SQL: $viewText", e)
+      }
+      val planWithProjection = table.originalSchema.map(withProjection(resolvedPlan, _))
+        .getOrElse(resolvedPlan)
+
       SubqueryAlias(
         alias.getOrElse(table.identifier.table),
-        sparkSession.sessionState.sqlParser.parsePlan(viewText),
+        aliasColumns(planWithProjection, table.schema.fields),
         Option(table.identifier))
     } else {
       val qualifiedTable =
         MetastoreRelation(
           qualifiedTableName.database, qualifiedTableName.name)(table, sparkSession)
       alias.map(a => SubqueryAlias(a, qualifiedTable, None)).getOrElse(qualifiedTable)
+    }
+  }
+
+  /**
+   * Apply Projection on unresolved logical plan to:
+   * 1. Omit the columns which are not referenced by the view;
+   * 2. Reorder the columns to keep the same order with the view;
+   */
+  private def withProjection(plan: LogicalPlan, schema: StructType): LogicalPlan = {
+    // All fields in schema should exist in plan.schema, or we should throw an AnalysisException
+    // to notify the underlying schema has been changed.
+    if (schema.fields.forall { field =>
+      plan.schema.fields.exists(other => compareStructField(field, other))}) {
+      val output = schema.fields.map { field =>
+        plan.output.find { expr =>
+          expr.name == field.name && expr.dataType == field.dataType}.getOrElse(
+            throw new AnalysisException("The underlying schema doesn't match the original " +
+              s"schema, expected ${schema.sql} but got ${plan.schema.sql}")
+          )}
+      Project(output, plan)
+    } else {
+      throw new AnalysisException("The underlying schema doesn't match the original schema, " +
+        s"expected ${schema.sql} but got ${plan.schema.sql}")
+    }
+  }
+
+  /**
+   * Compare the both [[StructField]] to verify whether they have the same name and dataType.
+   */
+  private def compareStructField(field: StructField, other: StructField): Boolean = {
+    field.name == other.name && field.dataType == other.dataType
+  }
+
+  /**
+   * Aliases the schema of the LogicalPlan to the view attribute names
+   */
+  private def aliasColumns(plan: LogicalPlan, fields: Seq[StructField]): LogicalPlan = {
+    val output = fields.map(field => (field.name, field.getComment))
+    if (plan.output.size != output.size) {
+      throw new AnalysisException("The output of plan does not have the same size with the " +
+        s"view schema, expected ${plan.output.size} but got ${output.mkString("[", ",", "]")}")
+    } else {
+      val aliasedOutput = plan.output.zip(output).map {
+        case (attr, (colName, None)) => Alias(attr, colName)()
+        case (attr, (colName, Some(colComment))) =>
+          val meta = new MetadataBuilder().putString("comment", colComment).build()
+          Alias(attr, colName)(explicitMetadata = Some(meta))
+      }
+      Project(aliasedOutput, plan)
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -395,6 +395,7 @@ private[hive] class HiveClientImpl(
             throw new AnalysisException("Hive index table is not supported.")
         },
         schema = schema,
+        originalSchema = Option(h.getProperty("originalSchema")).map(StructType.fromString(_)),
         partitionColumnNames = partCols.map(_.name),
         // We can not populate bucketing information for Hive tables as Spark SQL has a different
         // implementation of hash function from Hive.
@@ -417,6 +418,7 @@ private[hive] class HiveClientImpl(
         comment = properties.get("comment"),
         viewOriginalText = Option(h.getViewOriginalText),
         viewText = Option(h.getViewExpandedText),
+        currentDatabase = Option(h.getProperty("currentDatabase")),
         unsupportedFeatures = unsupportedFeatures)
     }
   }
@@ -837,6 +839,8 @@ private[hive] class HiveClientImpl(
     table.comment.foreach { c => hiveTable.setProperty("comment", c) }
     table.viewOriginalText.foreach { t => hiveTable.setViewOriginalText(t) }
     table.viewText.foreach { t => hiveTable.setViewExpandedText(t) }
+    table.currentDatabase.foreach {t => hiveTable.setProperty("currentDatabase", t)}
+    table.originalSchema.foreach {t => hiveTable.setProperty("originalSchema", t.json)}
     hiveTable
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -316,28 +316,32 @@ class HiveDDLSuite
       spark.range(10).write.saveAsTable(tabName)
       val viewName = "view1"
       withView(viewName) {
+        def checkProperties(properties: Map[String, String],
+                            expected: Map[String, String]): Boolean = {
+          properties.filterNot { case (key, value) =>
+            Seq("transient_lastDdlTime", "currentDatabase").contains(key)} == expected
+        }
+
         val catalog = spark.sessionState.catalog
         sql(s"CREATE VIEW $viewName AS SELECT * FROM $tabName")
 
-        assert(catalog.getTableMetadata(TableIdentifier(viewName))
-          .properties.filter(_._1 != "transient_lastDdlTime") == Map())
+        checkProperties(catalog.getTableMetadata(TableIdentifier(viewName)).properties, Map())
         sql(s"ALTER VIEW $viewName SET TBLPROPERTIES ('p' = 'an')")
-        assert(catalog.getTableMetadata(TableIdentifier(viewName))
-          .properties.filter(_._1 != "transient_lastDdlTime") == Map("p" -> "an"))
+        checkProperties(catalog.getTableMetadata(TableIdentifier(viewName)).properties,
+          Map("p" -> "an"))
 
         // no exception or message will be issued if we set it again
         sql(s"ALTER VIEW $viewName SET TBLPROPERTIES ('p' = 'an')")
-        assert(catalog.getTableMetadata(TableIdentifier(viewName))
-          .properties.filter(_._1 != "transient_lastDdlTime") == Map("p" -> "an"))
+        checkProperties(catalog.getTableMetadata(TableIdentifier(viewName)).properties,
+          Map("p" -> "an"))
 
         // the value will be updated if we set the same key to a different value
         sql(s"ALTER VIEW $viewName SET TBLPROPERTIES ('p' = 'b')")
-        assert(catalog.getTableMetadata(TableIdentifier(viewName))
-          .properties.filter(_._1 != "transient_lastDdlTime") == Map("p" -> "b"))
+        checkProperties(catalog.getTableMetadata(TableIdentifier(viewName)).properties,
+          Map("p" -> "b"))
 
         sql(s"ALTER VIEW $viewName UNSET TBLPROPERTIES ('p')")
-        assert(catalog.getTableMetadata(TableIdentifier(viewName))
-          .properties.filter(_._1 != "transient_lastDdlTime") == Map())
+        checkProperties(catalog.getTableMetadata(TableIdentifier(viewName)).properties, Map())
 
         val message = intercept[AnalysisException] {
           sql(s"ALTER VIEW $viewName UNSET TBLPROPERTIES ('p')")
@@ -590,10 +594,7 @@ class HiveDDLSuite
           Seq(
             Row("# View Information", "", ""),
             Row("View Original Text:", "SELECT * FROM tbl", ""),
-            Row("View Expanded Text:",
-              "SELECT `gen_attr_0` AS `a` FROM (SELECT `gen_attr_0` FROM " +
-              "(SELECT `a` AS `gen_attr_0` FROM `default`.`tbl`) AS gen_subquery_0) AS tbl",
-              "")
+            Row("View Expanded Text:", "SELECT * FROM tbl", "")
           )
         ))
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we canonicalize the view definition to provide the context for the database as well as star expansion, this is fragile for the following reasons:

1. It is non-trivial to guarantee that the generated SQL is correct without being extremely verbose, given the current set of operators.
2. We need extensive testing for all combination of operators.
3. Whenever we introduce a new logical plan operator, we need to be super careful because it might break SQL generation. 

We use a late binding approach to do view canonicalization, which resolve the dependent views every time the view is used. This PR is expected to achieve the following goals:

1. Views should reflect changes to the underlying tables and intermediate views. For example:
    ```
        CREATE TABLE T1(a int, b string)
        CREATE TABLE T2(a int, b string, c int)
        CREATE VIEW A AS SELECT * FROM T1
        CREATE VIEW B AS SELECT * FROM A
        ALTER VIEW A AS SELECT * FROM T2
        SELECT * FROM B
    ```
will return data from table T2 (Note that we still need to validate the schema).
2. Make views more robust by not using SQL generation to store the view’s logical plan.
3. The views generated by older versions of Spark or HIVE should still work or throw a meaningful error if the view definition is invalid.
4. A view should throw a meaningful error when the view in an invalid state due to an underlying change. Such errors should be thrown as early as possible.

The follow up works will be:

1. Remove the SQL generation (in particular the SQLBuilder class) for Spark SQL operators and the test suites(and also golden files) for them.
2. Disallow cyclic view reference(See [SPARK-18389](https://issues.apache.org/jira/browse/SPARK-18389)).
3. View dependency management similar to Postgres.
4. Underlying table schema change when star is used.
5. Support create permanent views on non-SQL DataFrames.

## How was this patch tested?
Add new test cases in `SQLViewSuite`.