### PR TITLE
[SPARK-18741][STREAMING] Reuse or clean-up SparkContext in streaming tests

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2350,6 +2350,16 @@ object SparkContext extends Logging {
     }
   }
 
+  private[spark] def getActiveContext(): Option[SparkContext] = {
+    SPARK_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+      Option(activeContext.get())
+    }
+  }
+
+  private[spark] def stopActiveContext(): Unit = {
+    getActiveContext().foreach(_.stop())
+  }
+
   /**
    * Called at the end of the SparkContext constructor to ensure that no other SparkContext has
    * raced with this constructor and started.

--- a/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
@@ -18,6 +18,7 @@
 package org.apache.spark.streaming;
 
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext$;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import org.junit.After;
 import org.junit.Before;
@@ -28,6 +29,7 @@ public abstract class LocalJavaStreamingContext {
 
     @Before
     public void setUp() {
+        SparkContext$.MODULE$.stopActiveContext();
         SparkConf conf = new SparkConf()
             .setMaster("local[2]")
             .setAppName("test")

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -211,6 +211,8 @@ trait DStreamCheckpointTester { self: SparkFunSuite =>
 class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
   with ResetSystemProperties {
 
+  override val reuseContext: Boolean = false
+
   var ssc: StreamingContext = null
 
   override def batchDuration: Duration = Milliseconds(500)
@@ -237,8 +239,6 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
   test("basic rdd checkpoints + dstream graph checkpoint recovery") {
 
     assert(batchDuration === Milliseconds(500), "batchDuration for this test must be 1 second")
-
-    conf.set("spark.streaming.clock", "org.apache.spark.util.ManualClock")
 
     val stateStreamCheckpointInterval = Seconds(1)
     val fs = FileSystem.getLocal(new Configuration())
@@ -571,7 +571,7 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
   }
 
   test("recovery maintains rate controller") {
-    ssc = new StreamingContext(conf, batchDuration)
+    ssc = new StreamingContext(sc, batchDuration)
     ssc.checkpoint(checkpointDir)
 
     val dstream = new RateTestInputDStream(ssc) {
@@ -635,7 +635,7 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
     try {
       // This is a var because it's re-assigned when we restart from a checkpoint
       var clock: ManualClock = null
-      withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+      withStreamingContext(batchDuration) { ssc =>
         ssc.checkpoint(checkpointDir)
         clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
         val batchCounter = new BatchCounter(ssc)
@@ -760,7 +760,7 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
   }
 
   test("DStreamCheckpointData.restore invoking times") {
-    withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+    withStreamingContext { ssc =>
       ssc.checkpoint(checkpointDir)
       val inputDStream = new CheckpointInputDStream(ssc)
       val checkpointData = inputDStream.checkpointData
@@ -822,7 +822,7 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
     val jobGenerator = mock(classOf[JobGenerator])
     val checkpointDir = Utils.createTempDir().toString
     val checkpointWriter =
-      new CheckpointWriter(jobGenerator, conf, checkpointDir, new Configuration())
+      new CheckpointWriter(jobGenerator, sc.conf, checkpointDir, new Configuration())
     val bytes1 = Array.fill[Byte](10)(1)
     new checkpointWriter.CheckpointWriteHandler(
       Time(2000), bytes1, clearCheckpointDataLater = false).run()
@@ -869,6 +869,7 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
     // Therefore SPARK-6847 introduces "spark.checkpoint.checkpointAllMarked" to force checkpointing
     // all marked RDDs in the DAG to resolve this issue. (For the previous example, it will break
     // connections between layer 2 and layer 3)
+    stopActiveContext()
     ssc = new StreamingContext(master, framework, batchDuration)
     val batchCounter = new BatchCounter(ssc)
     ssc.checkpoint(checkpointDir)

--- a/streaming/src/test/scala/org/apache/spark/streaming/DStreamClosureSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/DStreamClosureSuite.scala
@@ -19,9 +19,7 @@ package org.apache.spark.streaming
 
 import java.io.NotSerializableException
 
-import org.scalatest.BeforeAndAfterAll
-
-import org.apache.spark.{HashPartitioner, SparkContext, SparkException, SparkFunSuite}
+import org.apache.spark.{HashPartitioner, SparkException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.util.ReturnStatementInClosureException
@@ -29,18 +27,17 @@ import org.apache.spark.util.ReturnStatementInClosureException
 /**
  * Test that closures passed to DStream operations are actually cleaned.
  */
-class DStreamClosureSuite extends SparkFunSuite with BeforeAndAfterAll {
-  private var ssc: StreamingContext = null
+class DStreamClosureSuite extends ReuseableSparkContext {
+  private var ssc: StreamingContext = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val sc = new SparkContext("local", "test")
     ssc = new StreamingContext(sc, Seconds(1))
   }
 
   override def afterAll(): Unit = {
     try {
-      ssc.stop(stopSparkContext = true)
+      ssc.stop()
       ssc = null
     } finally {
       super.afterAll()

--- a/streaming/src/test/scala/org/apache/spark/streaming/DStreamScopeSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/DStreamScopeSuite.scala
@@ -30,20 +30,23 @@ import org.apache.spark.util.ManualClock
 /**
  * Tests whether scope information is passed from DStream operations to RDDs correctly.
  */
-class DStreamScopeSuite extends SparkFunSuite with BeforeAndAfter with BeforeAndAfterAll {
-  private var ssc: StreamingContext = null
-  private val batchDuration: Duration = Seconds(1)
+class DStreamScopeSuite extends ReuseableSparkContext {
+  private var ssc: StreamingContext = _
+
+  // Configurations to add to a new or existing spark context.
+  override def extraSparkConf: Map[String, String] = {
+    // Use a manual clock
+    super.extraSparkConf ++ Map("spark.streaming.clock" -> "org.apache.spark.util.ManualClock")
+  }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val conf = new SparkConf().setMaster("local").setAppName("test")
-    conf.set("spark.streaming.clock", classOf[ManualClock].getName())
-    ssc = new StreamingContext(new SparkContext(conf), batchDuration)
+    ssc = new StreamingContext(sc, Seconds(1))
   }
 
   override def afterAll(): Unit = {
     try {
-      ssc.stop(stopSparkContext = true)
+      ssc.stop()
     } finally {
       super.afterAll()
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/FailureSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/FailureSuite.scala
@@ -35,6 +35,11 @@ class FailureSuite extends SparkFunSuite with BeforeAndAfter with Logging {
   private val numBatches = 30
   private var directory: File = null
 
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    SparkContext.getActiveContext().foreach(_.stop())
+  }
+
   before {
     directory = Utils.createTempDir()
   }
@@ -46,7 +51,7 @@ class FailureSuite extends SparkFunSuite with BeforeAndAfter with Logging {
     StreamingContext.getActive().foreach { _.stop() }
 
     // Stop SparkContext if active
-    SparkContext.getOrCreate(new SparkConf().setMaster("local").setAppName("bla")).stop()
+    SparkContext.getActiveContext().foreach(_.stop())
   }
 
   test("multiple failures with map") {

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -49,7 +49,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       testServer.start()
 
       // Set up the streaming context and input streams
-      withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+      withStreamingContext { ssc =>
         ssc.addStreamingListener(ssc.progressListener)
 
         val input = Seq(1, 2, 3, 4, 5)
@@ -112,7 +112,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     withTestServer(new TestServer()) { testServer =>
       testServer.start()
 
-      withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+      withStreamingContext { ssc =>
         ssc.addStreamingListener(ssc.progressListener)
 
         val batchCounter = new BatchCounter(ssc)
@@ -149,7 +149,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       assert(existingFile.setLastModified(10000) && existingFile.lastModified === 10000)
 
       // Set up the streaming context and input streams
-      withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+      withStreamingContext(batchDuration) { ssc =>
         val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
         // This `setTime` call ensures that the clock is past the creation time of `existingFile`
         clock.setTime(existingFile.lastModified + batchDuration.milliseconds)
@@ -213,7 +213,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       val pathWithWildCard = testDir.toString + "/*/"
 
       // Set up the streaming context and input streams
-      withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+      withStreamingContext(batchDuration) { ssc =>
         val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
         clock.setTime(existingFile.lastModified + batchDuration.milliseconds)
         val batchCounter = new BatchCounter(ssc)
@@ -270,7 +270,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     def output: Iterable[Long] = outputQueue.asScala.flatMap(x => x)
 
     // set up the network stream using the test receiver
-    withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+    withStreamingContext { ssc =>
       val networkStream = ssc.receiverStream[Int](testReceiver)
       val countStream = networkStream.count
 
@@ -305,7 +305,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     def output: Iterable[Seq[String]] = outputQueue.asScala.filter(_.nonEmpty)
 
     // Set up the streaming context and input streams
-    withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+    withStreamingContext { ssc =>
       val queue = new mutable.Queue[RDD[String]]()
       val queueStream = ssc.queueStream(queue, oneAtATime = true)
       val outputStream = new TestOutputStream(queueStream, outputQueue)
@@ -350,7 +350,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     val expectedOutput = Seq(Seq("1", "2", "3"), Seq("4", "5"))
 
     // Set up the streaming context and input streams
-    withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+    withStreamingContext { ssc =>
       val queue = new mutable.Queue[RDD[String]]()
       val queueStream = ssc.queueStream(queue, oneAtATime = false)
       val outputStream = new TestOutputStream(queueStream, outputQueue)
@@ -396,7 +396,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
   }
 
   test("test track the number of input stream") {
-    withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+    withStreamingContext { ssc =>
 
       class TestInputDStream extends InputDStream[String](ssc) {
         def start() {}
@@ -434,7 +434,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       assert(existingFile.setLastModified(10000) && existingFile.lastModified === 10000)
 
       // Set up the streaming context and input streams
-      withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
+      withStreamingContext(batchDuration) { ssc =>
         val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
         // This `setTime` call ensures that the clock is past the creation time of `existingFile`
         clock.setTime(existingFile.lastModified + batchDuration.milliseconds)

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -75,6 +75,11 @@ class ReceivedBlockHandlerSuite
   var storageLevel: StorageLevel = null
   var tempDirectory: File = null
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    SparkContext.getActiveContext().foreach(_.stop())
+  }
+
   before {
     rpcEnv = RpcEnv.create("test", "localhost", 0, conf, securityMgr)
     conf.set("spark.driver.port", rpcEnv.address.port.toString)
@@ -106,6 +111,8 @@ class ReceivedBlockHandlerSuite
     rpcEnv.shutdown()
     rpcEnv.awaitTermination()
     rpcEnv = null
+
+    sc.stop()
 
     Utils.deleteRecursively(tempDirectory)
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
@@ -28,7 +28,7 @@ import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.Timeouts
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StreamBlockId
 import org.apache.spark.streaming.receiver._
@@ -194,6 +194,7 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
    * WALs should be cleaned later.
    */
   test("write ahead log - generating and cleaning") {
+    SparkContext.getActiveContext().foreach(_.stop())
     val sparkConf = new SparkConf()
       .setMaster("local[4]")  // must be at least 3 as we are going to start 2 receivers
       .setAppName(framework)

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -53,6 +53,10 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
   var sc: SparkContext = null
   var ssc: StreamingContext = null
 
+  before {
+    SparkContext.getActiveContext().foreach(_.stop())
+  }
+
   after {
     if (ssc != null) {
       ssc.stop()

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingListenerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingListenerSuite.scala
@@ -38,6 +38,8 @@ import org.apache.spark.streaming.scheduler._
 
 class StreamingListenerSuite extends TestSuiteBase with Matchers {
 
+  override val reuseContext: Boolean = false
+
   val input = (1 to 4).map(Seq(_)).toSeq
   val operation = (d: DStream[Int]) => d.map(x => x)
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
@@ -37,6 +37,8 @@ class UISeleniumSuite
 
   implicit var webDriver: WebDriver = _
 
+  override val reuseContext: Boolean = false
+
   override def beforeAll(): Unit = {
     super.beforeAll()
     webDriver = new HtmlUnitDriver {

--- a/streaming/src/test/scala/org/apache/spark/streaming/WindowOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/WindowOperationsSuite.scala
@@ -145,16 +145,16 @@ class WindowOperationsSuite extends TestSuiteBase {
   )
 
   test("window - persistence level") {
-    val input = Seq( Seq(0), Seq(1), Seq(2), Seq(3), Seq(4), Seq(5))
-    val ssc = new StreamingContext(conf, batchDuration)
-    val inputStream = new TestInputStream[Int](ssc, input, 1)
-    val windowStream1 = inputStream.window(batchDuration * 2)
-    assert(windowStream1.storageLevel === StorageLevel.NONE)
-    assert(inputStream.storageLevel === StorageLevel.MEMORY_ONLY_SER)
-    windowStream1.persist(StorageLevel.MEMORY_ONLY)
-    assert(windowStream1.storageLevel === StorageLevel.NONE)
-    assert(inputStream.storageLevel === StorageLevel.MEMORY_ONLY)
-    ssc.stop()
+    withStreamingContext { ssc =>
+      val input = Seq( Seq(0), Seq(1), Seq(2), Seq(3), Seq(4), Seq(5))
+      val inputStream = new TestInputStream[Int](ssc, input, 1)
+      val windowStream1 = inputStream.window(batchDuration * 2)
+      assert(windowStream1.storageLevel === StorageLevel.NONE)
+      assert(inputStream.storageLevel === StorageLevel.MEMORY_ONLY_SER)
+      windowStream1.persist(StorageLevel.MEMORY_ONLY)
+      assert(windowStream1.storageLevel === StorageLevel.NONE)
+      assert(inputStream.storageLevel === StorageLevel.MEMORY_ONLY)
+    }
   }
 
   // Testing naive reduceByKeyAndWindow (without invertible function)

--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/MapWithStateRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/MapWithStateRDDSuite.scala
@@ -22,32 +22,24 @@ import java.io.File
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
-import org.scalatest.BeforeAndAfterAll
-
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.{State, Time}
+import org.apache.spark.streaming.{ReuseableSparkContext, State, Time}
 import org.apache.spark.streaming.util.OpenHashMapBasedStateMap
 import org.apache.spark.util.Utils
 
-class MapWithStateRDDSuite extends SparkFunSuite with RDDCheckpointTester with BeforeAndAfterAll {
+class MapWithStateRDDSuite extends ReuseableSparkContext with RDDCheckpointTester {
 
-  private var sc: SparkContext = null
   private var checkpointDir: File = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    sc = new SparkContext(
-      new SparkConf().setMaster("local").setAppName("MapWithStateRDDSuite"))
     checkpointDir = Utils.createTempDir()
     sc.setCheckpointDir(checkpointDir.toString)
   }
 
   override def afterAll(): Unit = {
     try {
-      if (sc != null) {
-        sc.stop()
-      }
       Utils.deleteRecursively(checkpointDir)
     } finally {
       super.afterAll()

--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
@@ -58,6 +58,7 @@ class WriteAheadLogBackedBlockRDDSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    SparkContext.getActiveContext().foreach(_.stop())
     sparkContext = new SparkContext(conf)
     blockManager = sparkContext.env.blockManager
     serializerManager = sparkContext.env.serializerManager

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManagerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManagerSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.concurrent.Eventually.{eventually, timeout}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{ExecutorAllocationClient, SparkConf, SparkFunSuite}
+import org.apache.spark.{ExecutorAllocationClient, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.streaming.{DummyInputDStream, Seconds, StreamingContext}
 import org.apache.spark.util.{ManualClock, Utils}
 
@@ -41,6 +41,12 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite
   before {
     allocationClient = mock[ExecutorAllocationClient]
     clock = new ManualClock()
+    SparkContext.stopActiveContext()
+  }
+
+  protected override def afterAll(): Unit = {
+    SparkContext.stopActiveContext()
+    super.afterAll()
   }
 
   test("basic functionality") {

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/InputInfoTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/InputInfoTrackerSuite.scala
@@ -17,27 +17,21 @@
 
 package org.apache.spark.streaming.scheduler
 
-import org.scalatest.BeforeAndAfter
+import org.apache.spark.streaming._
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.streaming.{Duration, StreamingContext, Time}
-
-class InputInfoTrackerSuite extends SparkFunSuite with BeforeAndAfter {
+class InputInfoTrackerSuite extends ReuseableSparkContext {
 
   private var ssc: StreamingContext = _
 
   before {
-    val conf = new SparkConf().setMaster("local[2]").setAppName("DirectStreamTacker")
-    if (ssc == null) {
-      ssc = new StreamingContext(conf, Duration(1000))
-    }
+    assert(ssc == null)
+    ssc = new StreamingContext(sc, Duration(1000))
   }
 
   after {
-    if (ssc != null) {
-      ssc.stop()
-      ssc = null
-    }
+    assert(ssc != null)
+    ssc.stop()
+    ssc = null
   }
 
   test("test report and get InputInfo from InputInfoTracker") {

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/RateControllerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/RateControllerSuite.scala
@@ -25,13 +25,14 @@ import org.apache.spark.streaming.scheduler.rate.RateEstimator
 
 class RateControllerSuite extends TestSuiteBase {
 
-  override def useManualClock: Boolean = false
+  override def extraSparkConf: Map[String, String] = Map(
+    "spark.streaming.clock" -> "org.apache.spark.util.SystemClock",
+    "spark.streaming.stopSparkContextByDefault" -> "false")
 
   override def batchDuration: Duration = Milliseconds(50)
 
   test("RateController - rate controller publishes updates after batches complete") {
-    val ssc = new StreamingContext(conf, batchDuration)
-    withStreamingContext(ssc) { ssc =>
+    withStreamingContext { ssc =>
       val dstream = new RateTestInputDStream(ssc)
       dstream.register()
       ssc.start()
@@ -43,8 +44,7 @@ class RateControllerSuite extends TestSuiteBase {
   }
 
   test("ReceiverRateController - published rates reach receivers") {
-    val ssc = new StreamingContext(conf, batchDuration)
-    withStreamingContext(ssc) { ssc =>
+    withStreamingContext { ssc =>
       val estimator = new ConstantEstimator(100)
       val dstream = new RateTestInputDStream(ssc) {
         override val rateController =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Tests in Spark Streaming currently create a `SparkContext` for each test, and sometimes do not clean-up afterwards. This is resource intensive and it can lead to unneeded test failures (flakyness) when park.driver.allowMultipleContexts is disabled (this happens when the order of tests changes).

This PR makes most test re-use a `SparkContext`. For tests that have to create a new context (for instance `CheckpointSuite`) we make sure that no active `SparkContext` exists before the test, and that the created `SparkContext` is cleaned up afterwards. I have refactored the `TestSuiteBase` into two classes `TestSuiteBase` and a parent class `ReusableSparkContext`; this to make `SparkContext` management relatively straightforward for most tests.

I have done a simple very unscientific benchmark (n=1), and streaming tests with this patch took 212 seconds and streaming tests without this patch took 252 seconds.

## How was this patch tested?
The patch only covers test code.
