### PR TITLE
[SPARK-18746][SQL] Add implicit encoder for BigDecimal, timestamp and date

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -74,6 +74,9 @@ abstract class SQLImplicits {
   /** @since 1.6.0 */
   implicit def newStringEncoder: Encoder[String] = Encoders.STRING
 
+  /** @since 2.2.0 */
+  implicit def newDecimalEncoder: Encoder[java.math.BigDecimal] = Encoders.DECIMAL
+
   // Boxed primitives
 
   /** @since 2.0.0 */

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -75,7 +75,17 @@ abstract class SQLImplicits {
   implicit def newStringEncoder: Encoder[String] = Encoders.STRING
 
   /** @since 2.2.0 */
-  implicit def newDecimalEncoder: Encoder[java.math.BigDecimal] = Encoders.DECIMAL
+  implicit def newJavaDecimalEncoder: Encoder[java.math.BigDecimal] = Encoders.DECIMAL
+
+  /** @since 2.2.0 */
+  implicit def newScalaDecimalEncoder: Encoder[scala.math.BigDecimal] = ExpressionEncoder()
+
+  /** @since 2.2.0 */
+  implicit def newDateEncoder: Encoder[java.sql.Date] = Encoders.DATE
+
+  /** @since 2.2.0 */
+  implicit def newTimeStampEncoder: Encoder[java.sql.Timestamp] = Encoders.TIMESTAMP
+
 
   // Boxed primitives
 
@@ -144,7 +154,7 @@ abstract class SQLImplicits {
   implicit def newFloatArrayEncoder: Encoder[Array[Float]] = ExpressionEncoder()
 
   /** @since 1.6.1 */
-  implicit def newByteArrayEncoder: Encoder[Array[Byte]] = ExpressionEncoder()
+  implicit def newByteArrayEncoder: Encoder[Array[Byte]] = Encoders.BINARY
 
   /** @since 1.6.1 */
   implicit def newShortArrayEncoder: Encoder[Array[Short]] = ExpressionEncoder()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -689,7 +689,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-14554: Dataset.map may generate wrong java code for wide table") {
-    val wideDF = spark.range(10).select(Seq.tabulate(1000) {i => ('id + i).as(s"c$i") }: _*)
+    val wideDF = spark.range(10).select(Seq.tabulate(1000) {i => ('id + i).as(s"c$i")} : _*)
     // Make sure the generated code for this plan can compile and execute.
     checkDataset(wideDF.map(_.getLong(0)), 0L until 10 : _*)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql
 
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
+import java.math
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
@@ -34,6 +35,7 @@ case class TestDataPoint(x: Int, y: Double, s: String, t: TestDataPoint2)
 case class TestDataPoint2(x: Int, s: String)
 
 class DatasetSuite extends QueryTest with SharedSQLContext {
+
   import testImplicits._
 
   private implicit val ordering = Ordering.by((c: ClassData) => c.a -> c.b)
@@ -67,11 +69,11 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("range") {
     assert(spark.range(10).map(_ + 1).reduce(_ + _) == 55)
-    assert(spark.range(10).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
+    assert(spark.range(10).map { case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
     assert(spark.range(0, 10).map(_ + 1).reduce(_ + _) == 55)
-    assert(spark.range(0, 10).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
+    assert(spark.range(0, 10).map { case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
     assert(spark.range(0, 10, 1, 2).map(_ + 1).reduce(_ + _) == 55)
-    assert(spark.range(0, 10, 1, 2).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
+    assert(spark.range(0, 10, 1, 2).map { case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
   }
 
   test("SPARK-12404: Datatype Helper Serializability") {
@@ -173,8 +175,8 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     // We inject a group by here to make sure this test case is future proof
     // when we implement better pipelining and local execution mode.
     val ds: Dataset[(ClassData, Long)] = Seq(ClassData("one", 1), ClassData("two", 2)).toDS()
-        .map(c => ClassData(c.a, c.b + 1))
-        .groupByKey(p => p).count()
+      .map(c => ClassData(c.a, c.b + 1))
+      .groupByKey(p => p).count()
 
     checkDatasetUnorderly(
       ds,
@@ -204,7 +206,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDataset(
       ds.select(
         expr("_1").as[String],
-        expr("_2").as[Int]) : Dataset[(String, Int)],
+        expr("_2").as[Int]): Dataset[(String, Int)],
       ("a", 1), ("b", 2), ("c", 3))
   }
 
@@ -271,7 +273,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("reduce") {
     val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
-    assert(ds.reduce((a, b) => ("sum", a._2 + b._2)) == ("sum", 6))
+    assert(ds.reduce((a, b) => ("sum", a._2 + b._2)) ==("sum", 6))
   }
 
   test("joinWith, flat schema") {
@@ -540,7 +542,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-14696: implicit encoders for boxed types") {
-    assert(spark.range(1).map { i => i : java.lang.Long }.head == 0L)
+    assert(spark.range(1).map { i => i: java.lang.Long }.head == 0L)
   }
 
   test("SPARK-11894: Incorrect results are returned when using null") {
@@ -690,9 +692,9 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-14554: Dataset.map may generate wrong java code for wide table") {
-    val wideDF = spark.range(10).select(Seq.tabulate(1000) {i => ('id + i).as(s"c$i")} : _*)
+    val wideDF = spark.range(10).select(Seq.tabulate(1000) { i => ('id + i).as(s"c$i") }: _*)
     // Make sure the generated code for this plan can compile and execute.
-    checkDataset(wideDF.map(_.getLong(0)), 0L until 10 : _*)
+    checkDataset(wideDF.map(_.getLong(0)), 0L until 10: _*)
   }
 
   test("SPARK-14838: estimating sizeInBytes in operators with ObjectProducer shouldn't fail") {
@@ -1010,7 +1012,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assert(df10.schema(0).dataType.asInstanceOf[MapType].valueContainsNull == true)
 
     val df11 = Seq(TestDataPoint(1, 2.2, "a", null),
-                   TestDataPoint(3, 4.4, "null", (TestDataPoint2(33, "b")))).toDF
+      TestDataPoint(3, 4.4, "null", (TestDataPoint2(33, "b")))).toDF
     assert(df11.schema(0).nullable == false)
     assert(df11.schema(1).nullable == false)
     assert(df11.schema(2).nullable == true)
@@ -1051,11 +1053,15 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       val dsPhysicalPlan = ds.queryExecution.executedPlan
       val cpPhysicalPlan = cp.queryExecution.executedPlan
 
-      assertResult(dsPhysicalPlan.outputPartitioning) { logicalRDD.outputPartitioning }
-      assertResult(dsPhysicalPlan.outputOrdering) { logicalRDD.outputOrdering }
+      assertResult(dsPhysicalPlan.outputPartitioning) {
+        logicalRDD.outputPartitioning }
+      assertResult(dsPhysicalPlan.outputOrdering) {
+        logicalRDD.outputOrdering }
 
-      assertResult(dsPhysicalPlan.outputPartitioning) { cpPhysicalPlan.outputPartitioning }
-      assertResult(dsPhysicalPlan.outputOrdering) { cpPhysicalPlan.outputOrdering }
+      assertResult(dsPhysicalPlan.outputPartitioning) {
+        cpPhysicalPlan.outputPartitioning }
+      assertResult(dsPhysicalPlan.outputOrdering) {
+        cpPhysicalPlan.outputOrdering }
 
       // For a lazy checkpoint() call, the first check also materializes the checkpoint.
       checkDataset(cp, (9L to 6L by -1L).map(java.lang.Long.valueOf): _*)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql
 
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
-import java.math
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
@@ -27,7 +26,6 @@ import org.apache.spark.sql.execution.{LogicalRDD, RDDScanExec, SortExec}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchange}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -33,7 +33,6 @@ case class TestDataPoint(x: Int, y: Double, s: String, t: TestDataPoint2)
 case class TestDataPoint2(x: Int, s: String)
 
 class DatasetSuite extends QueryTest with SharedSQLContext {
-
   import testImplicits._
 
   private implicit val ordering = Ordering.by((c: ClassData) => c.a -> c.b)
@@ -67,11 +66,11 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("range") {
     assert(spark.range(10).map(_ + 1).reduce(_ + _) == 55)
-    assert(spark.range(10).map { case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
+    assert(spark.range(10).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
     assert(spark.range(0, 10).map(_ + 1).reduce(_ + _) == 55)
-    assert(spark.range(0, 10).map { case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
+    assert(spark.range(0, 10).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
     assert(spark.range(0, 10, 1, 2).map(_ + 1).reduce(_ + _) == 55)
-    assert(spark.range(0, 10, 1, 2).map { case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
+    assert(spark.range(0, 10, 1, 2).map{ case i: java.lang.Long => i + 1 }.reduce(_ + _) == 55)
   }
 
   test("SPARK-12404: Datatype Helper Serializability") {
@@ -173,8 +172,8 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     // We inject a group by here to make sure this test case is future proof
     // when we implement better pipelining and local execution mode.
     val ds: Dataset[(ClassData, Long)] = Seq(ClassData("one", 1), ClassData("two", 2)).toDS()
-      .map(c => ClassData(c.a, c.b + 1))
-      .groupByKey(p => p).count()
+        .map(c => ClassData(c.a, c.b + 1))
+        .groupByKey(p => p).count()
 
     checkDatasetUnorderly(
       ds,
@@ -204,7 +203,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDataset(
       ds.select(
         expr("_1").as[String],
-        expr("_2").as[Int]): Dataset[(String, Int)],
+        expr("_2").as[Int]) : Dataset[(String, Int)],
       ("a", 1), ("b", 2), ("c", 3))
   }
 
@@ -271,7 +270,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("reduce") {
     val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
-    assert(ds.reduce((a, b) => ("sum", a._2 + b._2)) ==("sum", 6))
+    assert(ds.reduce((a, b) => ("sum", a._2 + b._2)) == ("sum", 6))
   }
 
   test("joinWith, flat schema") {
@@ -540,7 +539,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-14696: implicit encoders for boxed types") {
-    assert(spark.range(1).map { i => i: java.lang.Long }.head == 0L)
+    assert(spark.range(1).map { i => i : java.lang.Long }.head == 0L)
   }
 
   test("SPARK-11894: Incorrect results are returned when using null") {
@@ -690,9 +689,9 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-14554: Dataset.map may generate wrong java code for wide table") {
-    val wideDF = spark.range(10).select(Seq.tabulate(1000) { i => ('id + i).as(s"c$i") }: _*)
+    val wideDF = spark.range(10).select(Seq.tabulate(1000) {i => ('id + i).as(s"c$i") }: _*)
     // Make sure the generated code for this plan can compile and execute.
-    checkDataset(wideDF.map(_.getLong(0)), 0L until 10: _*)
+    checkDataset(wideDF.map(_.getLong(0)), 0L until 10 : _*)
   }
 
   test("SPARK-14838: estimating sizeInBytes in operators with ObjectProducer shouldn't fail") {
@@ -1010,7 +1009,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assert(df10.schema(0).dataType.asInstanceOf[MapType].valueContainsNull == true)
 
     val df11 = Seq(TestDataPoint(1, 2.2, "a", null),
-      TestDataPoint(3, 4.4, "null", (TestDataPoint2(33, "b")))).toDF
+                   TestDataPoint(3, 4.4, "null", (TestDataPoint2(33, "b")))).toDF
     assert(df11.schema(0).nullable == false)
     assert(df11.schema(1).nullable == false)
     assert(df11.schema(2).nullable == true)
@@ -1051,15 +1050,11 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       val dsPhysicalPlan = ds.queryExecution.executedPlan
       val cpPhysicalPlan = cp.queryExecution.executedPlan
 
-      assertResult(dsPhysicalPlan.outputPartitioning) {
-        logicalRDD.outputPartitioning }
-      assertResult(dsPhysicalPlan.outputOrdering) {
-        logicalRDD.outputOrdering }
+      assertResult(dsPhysicalPlan.outputPartitioning) { logicalRDD.outputPartitioning }
+      assertResult(dsPhysicalPlan.outputOrdering) { logicalRDD.outputOrdering }
 
-      assertResult(dsPhysicalPlan.outputPartitioning) {
-        cpPhysicalPlan.outputPartitioning }
-      assertResult(dsPhysicalPlan.outputOrdering) {
-        cpPhysicalPlan.outputOrdering }
+      assertResult(dsPhysicalPlan.outputPartitioning) { cpPhysicalPlan.outputPartitioning }
+      assertResult(dsPhysicalPlan.outputOrdering) { cpPhysicalPlan.outputOrdering }
 
       // For a lazy checkpoint() call, the first check also materializes the checkpoint.
       checkDataset(cp, (9L to 6L by -1L).map(java.lang.Long.valueOf): _*)
@@ -1132,6 +1127,21 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
     val ds2 = Seq(WithMap("hi", Map(42L -> "foo"))).toDS
     checkDataset(ds2.map(t => t), WithMap("hi", Map(42L -> "foo")))
+  }
+
+  test("SPARK-18746: add implicit encoder for BigDecimal, date, timestamp") {
+    // For this implicit encoder, 18 is the default scale
+    assert(spark.range(1).map { x => new java.math.BigDecimal(1) }.head ==
+      new java.math.BigDecimal(1).setScale(18))
+
+    assert(spark.range(1).map { x => scala.math.BigDecimal(1, 18) }.head ==
+      scala.math.BigDecimal(1, 18))
+
+    assert(spark.range(1).map { x => new java.sql.Date(2016, 12, 12) }.head ==
+      new java.sql.Date(2016, 12, 12))
+
+    assert(spark.range(1).map { x => new java.sql.Timestamp(100000) }.head ==
+      new java.sql.Timestamp(100000))
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add implicit encoders for BigDecimal, timestamp and date. 

## How was this patch tested?
Add an unit test.  Pass build, unit tests, and some tests below .
Before:
```
scala> spark.createDataset(Seq(new java.math.BigDecimal(10)))
<console>:24: error: Unable to find encoder for type stored in a Dataset.  Primitive types (Int, String, etc) and Product types (case classes) are supported by importing spark.implicits._  Support for serializing other types will be added in future releases.
       spark.createDataset(Seq(new java.math.BigDecimal(10)))
                          ^

scala>
```
After:
```
scala> spark.createDataset(Seq(new java.math.BigDecimal(10)))
res0: org.apache.spark.sql.Dataset[java.math.BigDecimal] = [value: decimal(38,18)]
```