### PR TITLE
Update Spark documentation to provide information on how to create External Table

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -526,7 +526,10 @@ By default `saveAsTable` will create a "managed table", meaning that the locatio
 be controlled by the metastore. Managed tables will also have their data deleted automatically
 when a table is dropped.
 
-hello this should work
+Currently, `saveAsTable` does not expose an API supporting the creation of an "External table" from a `DataFrame`, 
+however, this functionality can be achieved by providing a `path` option to the `DataFrameWriter` with `path` as the key 
+and location of the external table as its value (String) when saving the table with `saveAsTable`. When an External table 
+is dropped only its metadata is removed.
 
 ## Parquet Files
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -526,6 +526,8 @@ By default `saveAsTable` will create a "managed table", meaning that the locatio
 be controlled by the metastore. Managed tables will also have their data deleted automatically
 when a table is dropped.
 
+hello this should work
+
 ## Parquet Files
 
 [Parquet](http://parquet.io) is a columnar format that is supported by many other data processing systems.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Although, currently, the saveAsTable does not provide an API to save the table as an external table from a DataFrame, we can achieve this functionality by using options on DataFrameWriter where the key for the map is the String: "path" and the value is another String which is the location of the external table itself. This can be provided before the call to saveAsTable is performed.

## How was this patch tested?
Documentation was reviewed for formatting and content after the push was performed on the branch.
![updated documentation](https://cloud.githubusercontent.com/assets/15376052/20953147/4cfcf308-bc57-11e6-807c-e21fb774a760.PNG)

