### PR TITLE
[Spark-18765] [CORE] Make values for spark.yarn.{am|driver|executor}.memoryOverhead have configurable units

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -213,21 +213,21 @@ If you need a reference to the proper location to put log files in the YARN so t
  <td><code>spark.yarn.executor.memoryOverhead</code></td>
   <td>executorMemory * 0.10, with minimum of 384 </td>
   <td>
-    The amount of off-heap memory (in megabytes) to be allocated per executor. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the executor size (typically 6-10%).
+    The amount of off-heap memory (in megabytes) to be allocated per executor. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the executor size (typically 6-10%). This works in the same format as JVM memory settings (e.g. 512m, 2g), but if no suffix is provided, the passed number is assumed to be in mebibytes.
   </td>
 </tr>
 <tr>
   <td><code>spark.yarn.driver.memoryOverhead</code></td>
   <td>driverMemory * 0.10, with minimum of 384 </td>
   <td>
-    The amount of off-heap memory (in megabytes) to be allocated per driver in cluster mode. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the container size (typically 6-10%).
+    The amount of off-heap memory (in megabytes) to be allocated per driver in cluster mode. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the container size (typically 6-10%). This works in the same format as JVM memory settings (e.g. 512m, 2g), but if no suffix is provided, the passed number is assumed to be in mebibytes.
   </td>
 </tr>
 <tr>
   <td><code>spark.yarn.am.memoryOverhead</code></td>
   <td>AM memory * 0.10, with minimum of 384 </td>
   <td>
-    Same as <code>spark.yarn.driver.memoryOverhead</code>, but for the YARN Application Master in client mode.
+    Same as <code>spark.yarn.driver.memoryOverhead</code>, but for the YARN Application Master in client mode. This works in the same format as JVM memory settings (e.g. 512m, 2g), but if no suffix is provided, the passed number is assumed to be in mebibytes.
   </td>
 </tr>
 <tr>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -61,12 +61,15 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
 
   // Additional memory to allocate to containers
   val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
-  val amMemoryOverhead = sparkConf
-    .getSizeAsMb(amMemoryOverheadConf,
-		 math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN).toString).toInt
-  val executorMemoryOverhead = sparkConf
-    .getSizeAsMb("spark.yarn.executor.memoryOverhead",
-		 math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN).toString).toInt
+  val amMemoryOverheadDefault = math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
+                                         MEMORY_OVERHEAD_MIN)
+  val amMemoryOverhead = sparkConf.getSizeAsMb(amMemoryOverheadConf,
+                                               amMemoryOverheadDefault.toString).toInt
+
+  val executorMemoryOverheadDefault = math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
+                                               MEMORY_OVERHEAD_MIN)
+  val executorMemoryOverhead = sparkConf.getSizeAsMb("spark.yarn.executor.memoryOverhead",
+                                                     executorMemoryOverheadDefault.toString).toInt
 
   /** Load any default arguments provided through environment variables and Spark properties. */
   private def loadEnvironmentArgs(): Unit = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -61,15 +61,19 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
 
   // Additional memory to allocate to containers
   val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
-  val amMemoryOverheadDefault = math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
-                                         MEMORY_OVERHEAD_MIN)
-  val amMemoryOverhead = sparkConf.getSizeAsMb(amMemoryOverheadConf,
-                                               amMemoryOverheadDefault.toString).toInt
+  val amMemoryOverheadDefault = math.max(
+    (MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
+    MEMORY_OVERHEAD_MIN)
+  val amMemoryOverhead = sparkConf.getSizeAsMb(
+    amMemoryOverheadConf,
+    amMemoryOverheadDefault.toString).toInt
 
-  val executorMemoryOverheadDefault = math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
-                                               MEMORY_OVERHEAD_MIN)
-  val executorMemoryOverhead = sparkConf.getSizeAsMb("spark.yarn.executor.memoryOverhead",
-                                                     executorMemoryOverheadDefault.toString).toInt
+  val executorMemoryOverheadDefault = math.max(
+    (MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
+    MEMORY_OVERHEAD_MIN)
+  val executorMemoryOverhead = sparkConf.getSizeAsMb(
+    "spark.yarn.executor.memoryOverhead",
+    executorMemoryOverheadDefault.toString).toInt
 
   /** Load any default arguments provided through environment variables and Spark properties. */
   private def loadEnvironmentArgs(): Unit = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -61,11 +61,12 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
 
   // Additional memory to allocate to containers
   val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
-  val amMemoryOverhead = sparkConf.getInt(amMemoryOverheadConf,
-    math.max((MEMORY_OVERHEAD_FACTOR * amMemory).toInt, MEMORY_OVERHEAD_MIN))
-
-  val executorMemoryOverhead = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN))
+  val amMemoryOverhead = sparkConf
+    .getSizeAsMb(amMemoryOverheadConf,
+		 math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN).toString).toInt
+  val executorMemoryOverhead = sparkConf
+    .getSizeAsMb("spark.yarn.executor.memoryOverhead",
+		 math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN).toString).toInt
 
   /** Load any default arguments provided through environment variables and Spark properties. */
   private def loadEnvironmentArgs(): Unit = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -108,9 +108,10 @@ private[yarn] class YarnAllocator(
   // Executor memory in MB.
   protected val executorMemory = args.executorMemory
   // Additional memory overhead.
-  protected val memoryOverhead: Int = sparkConf
-    .getSizeAsMb("spark.yarn.executor.memoryOverhead",
-		 math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN).toString).toInt
+  protected val memoryOverheadDefault: Int = math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
+                                                      MEMORY_OVERHEAD_MIN)
+  protected val memoryOverhead: Int = sparkConf.getSizeAsMb("spark.yarn.executor.memoryOverhead",
+                                                            memoryOverheadDefault.toString).toInt
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -108,8 +108,8 @@ private[yarn] class YarnAllocator(
   // Executor memory in MB.
   protected val executorMemory = args.executorMemory
   // Additional memory overhead.
-  protected val memoryOverheadDefault: Int = math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
-                                                      MEMORY_OVERHEAD_MIN)
+  protected val memoryOverheadDefault: Int =
+    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN)
   protected val memoryOverhead: Int = sparkConf.getSizeAsMb("spark.yarn.executor.memoryOverhead",
                                                             memoryOverheadDefault.toString).toInt
   // Number of cores per executor.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -108,10 +108,13 @@ private[yarn] class YarnAllocator(
   // Executor memory in MB.
   protected val executorMemory = args.executorMemory
   // Additional memory overhead.
-  protected val memoryOverheadDefault: Int =
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN)
-  protected val memoryOverhead: Int = sparkConf.getSizeAsMb("spark.yarn.executor.memoryOverhead",
-                                                            memoryOverheadDefault.toString).toInt
+  protected val memoryOverheadDefault: Int = math.max(
+    (MEMORY_OVERHEAD_FACTOR * executorMemory).toInt,
+    MEMORY_OVERHEAD_MIN)
+  protected val memoryOverhead: Int = sparkConf.getSizeAsMb(
+    "spark.yarn.executor.memoryOverhead",
+    memoryOverheadDefault.toString).toInt
+
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -108,8 +108,9 @@ private[yarn] class YarnAllocator(
   // Executor memory in MB.
   protected val executorMemory = args.executorMemory
   // Additional memory overhead.
-  protected val memoryOverhead: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN))
+  protected val memoryOverhead: Int = sparkConf
+    .getSizeAsMb("spark.yarn.executor.memoryOverhead",
+		 math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN).toString).toInt
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make values for spark.yarn.{am|driver|executor}.memoryOverhead have configurable units

## How was this patch tested?

Manual tests were done by running spark-shell and SparkPi.

Please review http://spark.apache.org/contributing.html before opening a pull request.
