### PR TITLE
[Core][SPARK-18778]Fix the scala classpath under some environment

### DIFF
--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -50,11 +50,11 @@ function main() {
     # (see https://github.com/sbt/sbt/issues/562).
     stty -icanon min 1 -echo > /dev/null 2>&1
     export SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djline.terminal=unix"
-    "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.repl.Main --name "Spark shell" "$@"
+    "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.repl.Main -usejavacp --name "Spark shell" "$@"
     stty icanon echo > /dev/null 2>&1
   else
     export SPARK_SUBMIT_OPTS
-    "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.repl.Main --name "Spark shell" "$@"
+    "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.repl.Main -usejavacp --name "Spark shell" "$@"
   fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
under some environment, the Dscala.usejavacp=true option seems not work, pass the -usejavacp directly to the repl fix this.

## How was this patch tested?
we test in our cluster environment.