### PR TITLE
[SPARK-18325][SPARKR] Add example for using native R package.

### DIFF
--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -489,6 +489,14 @@ print(model.summaries)
 {% endhighlight %}
 </div>
 
+##### spark.lapply with third-party packages
+Many of the SparkR jobs distributed by `spark.lapply` need supports from third-party packages. Rather than installing all necessary packages to all executors in advance,
+we could install them during the SparkR interactive session or script. Users can add a file or directory to be downloaded with this SparkR job on every node by `spark.addFile` firstly,
+download them to every executor node, and install them to be used.
+<div>
+{% include_example r/native-r-package.R %}
+</div>
+
 ## Running SQL Queries from SparkR
 A SparkDataFrame can also be registered as a temporary view in Spark SQL and that allows you to run SQL queries over its data.
 The `sql` function enables applications to run SQL queries programmatically and returns the result as a `SparkDataFrame`.

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -478,8 +478,8 @@ should fit in a single machine. If that is not the case they can do something li
 ##### spark.lapply with third-party packages
 
 Many of the SparkR jobs distributed by `spark.lapply` need supports from third-party packages. Rather than installing all necessary packages to all executors in advance,
-we could install them during the SparkR interactive session or script. Users can add package files or directories by `spark.addFile` firstly,
-download them to every executor node, and install them.
+we could install them during the SparkR interactive session or script. Users can add package files or directories by `spark.addFile` first,
+which automatically download them to every executor node, and then install them.
 
 <div data-lang="r"  markdown="1">
 {% include_example r/native-r-package.R %}

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -472,28 +472,16 @@ should fit in a single machine. If that is not the case they can do something li
 `dapply`
 
 <div data-lang="r"  markdown="1">
-{% highlight r %}
-# Perform distributed training of multiple models with spark.lapply. Here, we pass
-# a read-only list of arguments which specifies family the generalized linear model should be.
-families <- c("gaussian", "poisson")
-train <- function(family) {
-  model <- glm(Sepal.Length ~ Sepal.Width + Species, iris, family = family)
-  summary(model)
-}
-# Return a list of model's summaries
-model.summaries <- spark.lapply(families, train)
-
-# Print the summary of each model
-print(model.summaries)
-
-{% endhighlight %}
+{% include_example lapply r/ml/ml.R %}
 </div>
 
 ##### spark.lapply with third-party packages
+
 Many of the SparkR jobs distributed by `spark.lapply` need supports from third-party packages. Rather than installing all necessary packages to all executors in advance,
-we could install them during the SparkR interactive session or script. Users can add a file or directory to be downloaded with this SparkR job on every node by `spark.addFile` firstly,
-download them to every executor node, and install them to be used.
-<div>
+we could install them during the SparkR interactive session or script. Users can add package files or directories by `spark.addFile` firstly,
+download them to every executor node, and install them.
+
+<div data-lang="r"  markdown="1">
 {% include_example r/native-r-package.R %}
 </div>
 

--- a/examples/src/main/r/ml/ml.R
+++ b/examples/src/main/r/ml/ml.R
@@ -48,6 +48,7 @@ unlink(modelPath)
 # $example off:read_write$
 
 ############################ fit models with spark.lapply #####################################
+# $example on:lapply$
 # Perform distributed training of multiple models with spark.lapply
 costs <- exp(seq(from = log(1), to = log(1000), length.out = 5))
 train <- function(cost) {
@@ -60,6 +61,7 @@ model.summaries <- spark.lapply(costs, train)
 
 # Print the summary of each model
 print(model.summaries)
+# $example off:lapply$
 
 # Stop the SparkSession now
 sparkR.session.stop()

--- a/examples/src/main/r/ml/ml.R
+++ b/examples/src/main/r/ml/ml.R
@@ -49,7 +49,8 @@ unlink(modelPath)
 
 ############################ fit models with spark.lapply #####################################
 # $example on:lapply$
-# Perform distributed training of multiple models with spark.lapply
+# Perform distributed training of multiple models with spark.lapply. Here we pass a read-only
+# list of arguments which specifies cost values of the svm algorithm should be.
 costs <- exp(seq(from = log(1), to = log(1000), length.out = 5))
 train <- function(cost) {
   stopifnot(requireNamespace("e1071", quietly = TRUE))
@@ -57,6 +58,7 @@ train <- function(cost) {
   summary(model)
 }
 
+# Return a list of model's summaries
 model.summaries <- spark.lapply(costs, train)
 
 # Print the summary of each model

--- a/examples/src/main/r/native-r-package.R
+++ b/examples/src/main/r/native-r-package.R
@@ -52,7 +52,7 @@ path <- spark.getSparkFiles(filename)
 costs <- exp(seq(from = log(1), to = log(1000), length.out = 5))
 train <- function(cost) {
     if("e1071" %in% rownames(installed.packages(lib = libDir)) == FALSE) {
-        install.packages(path, repos = NULL, type = "source")
+        install.packages(path, lib = libDir, repos = NULL, type = "source")
     }
     library(e1071)
     model <- svm(Species ~ ., data = iris, cost = cost)

--- a/examples/src/main/r/native-r-package.R
+++ b/examples/src/main/r/native-r-package.R
@@ -16,14 +16,14 @@
 #
 
 # This example illustrates how to install third-party R packages to executors
-# in your SparkR jobs distributed by `spark.lapply`.
+# in your SparkR jobs distributed by "spark.lapply".
 #
 # Note: This example will install packages to a temporary directory on your machine.
 #       The directory will be removed automatically when the example exit.
 #       You environment should be connected to internet to run this example,
-#       otherwise, you should change `repos` to your private repository url.
+#       otherwise, you should change "repos" to your private repository url.
 #       And the environment need to have necessary tools such as gcc to compile
-#       and install the R package.
+#       and install R package "e1071".
 #
 # To run this example use
 # ./bin/spark-submit examples/src/main/r/native-r-package.R

--- a/examples/src/main/r/native-r-package.R
+++ b/examples/src/main/r/native-r-package.R
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This example illustrates how to use third-party R packages in your task
+# which is distributed by Spark. We support two scenarios:
+#  - Install packages from CRAN to executors directly.
+#  - Install packages from local file system to executors.
+#
+# To run this example use
+# ./bin/spark-submit examples/src/main/r/native-r-package.R
+
+# Load SparkR library into your R session
+library(SparkR)
+
+# Initialize SparkSession
+sparkR.session(appName = "SparkR-native-r-package-example")
+
+# Get the location of the default library
+libDir <- .libPaths()[1]
+
+# Install third-party R packages from CRAN to executors directly if it does not exist,
+# then the packages can be used by the corresponding task.
+
+# Perform distributed training of multiple models with spark.lapply
+costs <- exp(seq(from = log(1), to = log(1000), length.out = 5))
+train <- function(cost) {
+    if("e1071" %in% rownames(installed.packages(libDir)) == FALSE) {
+        install.packages("e1071", repos = "https://cran.r-project.org")
+    }
+    library(e1071)
+    model <- svm(Species ~ ., data = iris, cost = cost)
+    summary(model)
+}
+model.summaries <- spark.lapply(costs, train)
+
+# Print the summary of each model
+print(model.summaries)
+
+# Install third-party R packages from local file system to executors if it does not exist,
+# then the packages can be used by the corresponding task.
+
+# Downloaded e1071 package source code to a directory
+packagesDir <- paste0(tempdir(), "/", "packages")
+dir.create(packagesDir)
+download.packages("e1071", packagesDir, repos = "https://cran.r-project.org")
+filename <- list.files(packagesDir, "^e1071")
+packagesPath <- file.path(packagesDir, filename)
+# Add the third-party R package to be downloaded with this Spark job on every node.
+spark.addFile(packagesPath)
+
+path <- spark.getSparkFiles(filename)
+costs <- exp(seq(from = log(1), to = log(1000), length.out = 5))
+train <- function(cost) {
+    if("e1071" %in% rownames(installed.packages(libDir)) == FALSE) {
+        install.packages(path, repos=NULL, type="source")
+    }
+    library(e1071)
+    model <- svm(Species ~ ., data = iris, cost = cost)
+    summary(model)
+}
+model.summaries <- spark.lapply(costs, train)
+
+# Print the summary of each model
+print(model.summaries)
+
+unlink(packagesDir, recursive = TRUE)


### PR DESCRIPTION
## What changes were proposed in this pull request?
SparkR provides the ability to distribute the computations by ```spark.lapply```. In many cases, the distributed computation depends on third-party R packages, and we need to install corresponding packages to executor in advance which is tedious and unappeasable. Since SparkR is an interactive analytic tools and users may load lots of native R packages across the session, it's difficult to install all necessary packages before starting SparkR session, so I think it's helpful to provide an example to illustrate how to handle this scenario in an elegant way.

## How was this patch tested?
Offline test.
