### PR TITLE
[SPARK-18800][SQL] Correct the assert in UnsafeKVExternalSorter which ensures array size

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
+import org.apache.spark.memory.MemoryConsumer;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.serializer.SerializerManager;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -33,6 +34,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.BlockManager;
 import org.apache.spark.unsafe.KVIterator;
 import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.array.LongArray;
 import org.apache.spark.unsafe.map.BytesToBytesMap;
 import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.util.collection.unsafe.sort.*;
@@ -96,13 +98,35 @@ public final class UnsafeKVExternalSorter {
         numElementsForSpillThreshold,
         canUseRadixSort);
     } else {
-      // The array will be used to do in-place sort, which require half of the space to be empty.
-      assert(map.numKeys() <= map.getArray().size() / 2);
+      // Becasue we insert the number of values in the map into `UnsafeInMemorySorter`, if
+      // the number of values is more than the number of keys, and the array in the map is
+      // not big enough to do in-place sort, we must acquire new array.
+      // To insert a record into `UnsafeInMemorySorter` will consume two spaces in the array.
+      // We must have half of the array as empty. There are totally `map.numValues()` records
+      // to be inserted.
+      LongArray sortArray = null;
+      boolean useAllocatedArray = false;
+      if (map.numValues() > map.numKeys() && map.numValues() * 2 > map.getArray().size() / 2) {
+        sortArray = map.allocateArray(map.numValues() * 2 * 2);
+        useAllocatedArray = true;
+      } else {
+        // The array will be used to do in-place sort, which require half of the space to be empty.
+        if (map.numKeys() * 2 <= map.getArray().size() / 2) {
+          sortArray = map.getArray();
+        } else {
+          sortArray = map.allocateArray(map.numKeys() * 2 * 2);
+          useAllocatedArray = true;
+        }
+      }
+
       // During spilling, the array in map will not be used, so we can borrow that and use it
       // as the underlying array for in-memory sorter (it's always large enough).
-      // Since we will not grow the array, it's fine to pass `null` as consumer.
+      // Although we will not grow the array, it's fine to pass `null` as consumer, however,
+      // if we have allocated array instead of using the map's array, we still need
+      // to pass the map as consumer in order to release the allocated array.
+      MemoryConsumer consumer = useAllocatedArray ? map : null;
       final UnsafeInMemorySorter inMemSorter = new UnsafeInMemorySorter(
-        null, taskMemoryManager, recordComparator, prefixComparator, map.getArray(),
+        consumer, taskMemoryManager, recordComparator, prefixComparator, sortArray,
         canUseRadixSort);
 
       // We cannot use the destructive iterator here because we are reusing the existing memory

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala
@@ -28,6 +28,8 @@ import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.{InterpretedOrdering, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter
 
 /**
@@ -204,4 +206,88 @@ class UnsafeKVExternalSorterSuite extends SparkFunSuite with SharedSQLContext {
       spill = true
     )
   }
+
+  test("SPARK-18800: pass BytesToBytesMap which contains numValues is more than numKeys") {
+    val PAGE_SIZE_BYTES = 1L << 26
+    val memoryManager =
+      new TestMemoryManager(new SparkConf().set("spark.memory.offHeap.enabled", "false"))
+    val taskMemMgr = new TaskMemoryManager(memoryManager, 0)
+    TaskContext.setTaskContext(new TaskContextImpl(
+      stageId = 0,
+      partitionId = 0,
+      taskAttemptId = 98456,
+      attemptNumber = 0,
+      taskMemoryManager = taskMemMgr,
+      localProperties = new Properties,
+      metricsSystem = null))
+
+    val schema = StructType(StructField("b", BinaryType) :: Nil)
+    val externalConverter = CatalystTypeConverters.createToCatalystConverter(schema)
+    val converter = UnsafeProjection.create(schema)
+
+    val rand = new Random()
+    val recordLengthInBytes = 80
+    val kBytes = new Array[Byte](recordLengthInBytes)
+    rand.nextBytes(kBytes)
+    val key = converter(externalConverter.apply(Row(kBytes)).asInstanceOf[InternalRow])
+      .asInstanceOf[InternalRow].copy()
+    val inputData = Seq.fill(1024) {
+      val vBytes = new Array[Byte](recordLengthInBytes)
+      rand.nextBytes(vBytes)
+      val v = converter(externalConverter.apply(Row(vBytes)).asInstanceOf[InternalRow])
+        .asInstanceOf[InternalRow].copy()
+      (key, v)
+    }
+
+    val map =
+      prepareMapFilledSameKey(recordLengthInBytes, PAGE_SIZE_BYTES, inputData, taskMemMgr)
+    val sorter = new UnsafeKVExternalSorter(
+      schema, schema, SparkEnv.get.blockManager, SparkEnv.get.serializerManager,
+      PAGE_SIZE_BYTES, UnsafeExternalSorter.DEFAULT_NUM_ELEMENTS_FOR_SPILL_THRESHOLD, map)
+
+    sorter.cleanupResources()
+   // Make sure there is no memory leak
+    assert(0 === taskMemMgr.cleanUpAllAllocatedMemory)
+    TaskContext.unset()
+  }
+
+  // A helper function used to insert kv pairs into BytesToBytesMap.
+  // Those kv pairs have the same key.
+  private def prepareMapFilledSameKey(
+      recordLengthInBytes: Int,
+      pageSize: Long,
+      inputData: Seq[(InternalRow, InternalRow)],
+      taskMemoryManager: TaskMemoryManager): BytesToBytesMap = {
+    val map = new BytesToBytesMap(taskMemoryManager, 64, pageSize)
+    var afterFirst = false
+    inputData.foreach { case (key, value) =>
+      val keyBytes = key.asInstanceOf[UnsafeRow].getBytes()
+      val valueBytes = value.asInstanceOf[UnsafeRow].getBytes()
+      val loc = map.lookup(keyBytes, Platform.BYTE_ARRAY_OFFSET, recordLengthInBytes)
+      if (!afterFirst) {
+        assert(!loc.isDefined())
+        afterFirst = true
+      } else {
+        assert(loc.isDefined())
+      }
+      val putResult = loc.append(
+        keyBytes,
+        Platform.BYTE_ARRAY_OFFSET,
+        recordLengthInBytes,
+        valueBytes,
+        Platform.BYTE_ARRAY_OFFSET,
+        recordLengthInBytes
+      )
+      assert(putResult)
+    }
+    var count = 0
+    val iter = map.iterator()
+    while (iter.hasNext()) {
+      iter.next()
+      count += 1
+    }
+    assert(count == inputData.size)
+    map
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`UnsafeKVExternalSorter` uses `UnsafeInMemorySorter` to sort the records of `BytesToBytesMap` if it is given a map.

Currently we use the number of keys in `BytesToBytesMap` to determine if the array used for sort is enough or not. We has an assert that ensures the size of the array is enough: `map.numKeys() <= map.getArray().size() / 2`.

However, each record in the map takes two entries in the array, one is record pointer, another is key prefix. So the correct assert should be `map.numKeys() * 2 <= map.getArray().size() / 2`.


## How was this patch tested?

N/A

Please review http://spark.apache.org/contributing.html before opening a pull request.

