### PR TITLE
[SPARK-18817][SparkR] set default spark-warehouse path to tempdir()

### DIFF
--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -362,6 +362,10 @@ sparkR.session <- function(
   enableHiveSupport = TRUE,
   ...) {
 
+  if(length(sparkConfig[["spark.sql.warehouse.dir"]]) == 0) {
+    sparkConfig[["spark.sql.warehouse.dir"]] <- tempdir()
+  }
+  
   sparkConfigMap <- convertNamedListToEnv(sparkConfig)
   namedParams <- list(...)
   if (length(namedParams) > 0) {

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -362,10 +362,10 @@ sparkR.session <- function(
   enableHiveSupport = TRUE,
   ...) {
 
-  if(length(sparkConfig[["spark.sql.warehouse.dir"]]) == 0) {
+  if (length(sparkConfig[["spark.sql.warehouse.dir"]]) == 0) {
     sparkConfig[["spark.sql.warehouse.dir"]] <- tempdir()
   }
-  
+
   sparkConfigMap <- convertNamedListToEnv(sparkConfig)
   namedParams <- list(...)
   if (length(namedParams) > 0) {

--- a/R/pkg/inst/tests/testthat/test_sparkR.R
+++ b/R/pkg/inst/tests/testthat/test_sparkR.R
@@ -48,8 +48,13 @@ test_that("sparkCheckInstall", {
 test_that("sparkR.session", {
   # nothing should be written outside tempdir() without explicit user permission
   inital_working_directory_files <- list.files()
-  sparkR.session()
-  result <- sql("SELECT 1")
+  sparkR.session(enableHiveSupport = FALSE)
+  df <- data.frame("col1" = c(1, 2, 3, 4, 5, 6),
+                   "col2" = c(1, 0, 0, 1, 1, 0),
+                   "col3" = c(1, 0, 0, 2, 6, 2))
+  df <- as.DataFrame(df)
+  createOrReplaceTempView(df, "table")
+  result <- sql("SELECT * FROM `table`")
   sparkR.session.stop()
   expect_equal(inital_working_directory_files, list.files())
 })

--- a/R/pkg/inst/tests/testthat/test_sparkR.R
+++ b/R/pkg/inst/tests/testthat/test_sparkR.R
@@ -46,15 +46,10 @@ test_that("sparkCheckInstall", {
 })
 
 test_that("sparkR.session", {
-  # nothing should be written outside the tempdir() without explicit user premission
+  # nothing should be written outside tempdir() without explicit user permission
   inital_working_directory_files <- list.files()
   sparkR.session()
-  df <- data.frame("col1" = c(1, 2, 3, 4, 5, 6),
-                   "col2" = c(1, 0, 0, 1, 1, 0),
-                   "col3" = c(1, 0, 0, 2, 6, 2))
-  df <- as.DataFrame(df)
-  createOrReplaceTempView(df, "table")
-  result <- sql("SELECT * FROM `table`")
+  result <- sql("SELECT 1")
   sparkR.session.stop()
   expect_equal(inital_working_directory_files, list.files())
 })

--- a/R/pkg/inst/tests/testthat/test_sparkR.R
+++ b/R/pkg/inst/tests/testthat/test_sparkR.R
@@ -44,3 +44,11 @@ test_that("sparkCheckInstall", {
   deployMode <- "client"
   expect_error(sparkCheckInstall(sparkHome, master, deployMode))
 })
+
+test_that("sparkR.session", {
+  # nothing should be written outside the tempdir() without explicit user premission
+  inital_working_directory_files <- list.files()
+  sparkR.session()
+  expect_equal(inital_working_directory_files, list.files())
+
+})

--- a/R/pkg/inst/tests/testthat/test_sparkR.R
+++ b/R/pkg/inst/tests/testthat/test_sparkR.R
@@ -49,6 +49,12 @@ test_that("sparkR.session", {
   # nothing should be written outside the tempdir() without explicit user premission
   inital_working_directory_files <- list.files()
   sparkR.session()
+  df <- data.frame("col1" = c(1, 2, 3, 4, 5, 6),
+                   "col2" = c(1, 0, 0, 1, 1, 0),
+                   "col3" = c(1, 0, 0, 2, 6, 2))
+  df <- as.DataFrame(df)
+  createOrReplaceTempView(df, "table")
+  result <- sql("SELECT * FROM `table`")
+  sparkR.session.stop()
   expect_equal(inital_working_directory_files, list.files())
-
 })


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set the default location of `spark.sql.warehouse.dir` to be compliant with the CRAN policy (https://cran.r-project.org/web/packages/policies.html) regarding writing files outside of the tmp directory. Previously a folder named `spark-warehouse` was created in the working directory when `sparkR.session()` was called.

See SPARK-15799 for discussion.
cc @shivaram 


## How was this patch tested?

Added new test and manually verified nothing was created in my working directory after running the following code:
```R
sparkR.session(master = "local[*]",
               sparkConfig = list(spark.driver.memory = "2g"),
               enableHiveSupport = FALSE)
```


