### PR TITLE
[SPARK-18826][SS]Add 'latestFirst' option to FileStreamSource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
@@ -53,4 +53,15 @@ class FileStreamOptions(parameters: CaseInsensitiveMap) extends Logging {
   /** Options as specified by the user, in a case-insensitive map, without "path" set. */
   val optionMapWithoutPath: Map[String, String] =
     parameters.filterKeys(_ != "path")
+
+  /** Whether to scan new files first. */
+  val newestFirst: Boolean = parameters.get("newestFirst").map { str =>
+    try {
+      str.toBoolean
+    } catch {
+      case _: IllegalArgumentException =>
+        throw new IllegalArgumentException(
+          s"Invalid value '$str' for option 'newestFirst', must be 'true' or 'false'")
+    }
+  }.getOrElse(false)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
@@ -54,14 +54,17 @@ class FileStreamOptions(parameters: CaseInsensitiveMap) extends Logging {
   val optionMapWithoutPath: Map[String, String] =
     parameters.filterKeys(_ != "path")
 
-  /** Whether to scan new files first. */
-  val newestFirst: Boolean = parameters.get("newestFirst").map { str =>
+  /**
+   * Whether to scan latest files first. If it's true, when the source finds unprocessed files in a
+   * trigger, it will first process the latest files.
+   */
+  val latestFirst: Boolean = parameters.get("latestFirst").map { str =>
     try {
       str.toBoolean
     } catch {
       case _: IllegalArgumentException =>
         throw new IllegalArgumentException(
-          s"Invalid value '$str' for option 'newestFirst', must be 'true' or 'false'")
+          s"Invalid value '$str' for option 'latestFirst', must be 'true' or 'false'")
     }
   }.getOrElse(false)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -62,6 +62,15 @@ class FileStreamSource(
   /** Maximum number of new files to be considered in each batch */
   private val maxFilesPerBatch = sourceOptions.maxFilesPerTrigger
 
+  private val fileSortOrder = if (sourceOptions.newestFirst) {
+      logWarning(
+        """'newestFirst' is true. New files will be processed first.
+          |It may affect the watermark value""".stripMargin)
+      implicitly[Ordering[Long]].reverse
+    } else {
+      implicitly[Ordering[Long]]
+    }
+
   /** A mapping from a file that we have processed to some timestamp it was last modified. */
   // Visible for testing and debugging in production.
   val seenFiles = new SeenFilesMap(sourceOptions.maxFileAgeMs)
@@ -155,7 +164,7 @@ class FileStreamSource(
     val startTime = System.nanoTime
     val globbedPaths = SparkHadoopUtil.get.globPathIfNecessary(qualifiedBasePath)
     val catalog = new InMemoryFileIndex(sparkSession, globbedPaths, options, Some(new StructType))
-    val files = catalog.allFiles().sortBy(_.getModificationTime).map { status =>
+    val files = catalog.allFiles().sortBy(_.getModificationTime)(fileSortOrder).map { status =>
       (status.getPath.toUri.toString, status.getModificationTime)
     }
     val endTime = System.nanoTime

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -62,9 +62,9 @@ class FileStreamSource(
   /** Maximum number of new files to be considered in each batch */
   private val maxFilesPerBatch = sourceOptions.maxFilesPerTrigger
 
-  private val fileSortOrder = if (sourceOptions.newestFirst) {
+  private val fileSortOrder = if (sourceOptions.latestFirst) {
       logWarning(
-        """'newestFirst' is true. New files will be processed first.
+        """'latestFirst' is true. New files will be processed first.
           |It may affect the watermark value""".stripMargin)
       implicitly[Ordering[Long]].reverse
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.streaming
 import java.io.File
 
 import org.scalatest.PrivateMethodTester
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql._
@@ -1058,6 +1059,72 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     import scala.io.Source
     val str = Source.fromFile(getClass.getResource(s"/structured-streaming/$file").toURI).mkString
     SerializedOffset(str.trim)
+  }
+
+  test("FileStreamSource - newestFirst") {
+    withTempDir { src =>
+      // Prepare two files: 1.txt, 2.txt, and make sure they have different modified time.
+      val f1 = stringToFile(new File(src, "1.txt"), "1")
+      val f2 = stringToFile(new File(src, "2.txt"), "2")
+      eventually(timeout(streamingTimeout)) {
+        f2.setLastModified(System.currentTimeMillis())
+        assert(f1.lastModified < f2.lastModified)
+      }
+
+      // Read oldest first, so the first batch is "1", and the second batch is "2".
+      val fileStream = createFileStream(
+        "text",
+        src.getCanonicalPath,
+        options = Map("newestFirst" -> "false", "maxFilesPerTrigger" -> "1"))
+      val clock = new StreamManualClock()
+      testStream(fileStream)(
+        StartStream(trigger = ProcessingTime(10), triggerClock = clock),
+        AssertOnQuery { _ =>
+          // Block until the first batch finishes.
+          eventually(timeout(streamingTimeout)) {
+            assert(clock.isStreamWaitingAt(0))
+          }
+          true
+        },
+        CheckLastBatch("1"),
+        AdvanceManualClock(10),
+        AssertOnQuery { _ =>
+          // Block until the second batch finishes.
+          eventually(timeout(streamingTimeout)) {
+            assert(clock.isStreamWaitingAt(10))
+          }
+          true
+        },
+        CheckLastBatch("2")
+      )
+
+      // Read newest first, so the first batch is "2", and the second batch is "1".
+      val fileStream2 = createFileStream(
+        "text",
+        src.getCanonicalPath,
+        options = Map("newestFirst" -> "true", "maxFilesPerTrigger" -> "1"))
+      val clock2 = new StreamManualClock()
+      testStream(fileStream2)(
+        StartStream(trigger = ProcessingTime(10), triggerClock = clock2),
+        AssertOnQuery { _ =>
+          // Block until the first batch finishes.
+          eventually(timeout(streamingTimeout)) {
+            assert(clock2.isStreamWaitingAt(0))
+          }
+          true
+        },
+        CheckLastBatch("2"),
+        AdvanceManualClock(10),
+        AssertOnQuery { _ =>
+          // Block until the second batch finishes.
+          eventually(timeout(streamingTimeout)) {
+            assert(clock2.isStreamWaitingAt(10))
+          }
+          true
+        },
+        CheckLastBatch("1")
+      )
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1061,7 +1061,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     SerializedOffset(str.trim)
   }
 
-  test("FileStreamSource - newestFirst") {
+  test("FileStreamSource - latestFirst") {
     withTempDir { src =>
       // Prepare two files: 1.txt, 2.txt, and make sure they have different modified time.
       val f1 = stringToFile(new File(src, "1.txt"), "1")
@@ -1071,11 +1071,11 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         assert(f1.lastModified < f2.lastModified)
       }
 
-      // Read oldest first, so the first batch is "1", and the second batch is "2".
+      // Read oldest files first, so the first batch is "1", and the second batch is "2".
       val fileStream = createFileStream(
         "text",
         src.getCanonicalPath,
-        options = Map("newestFirst" -> "false", "maxFilesPerTrigger" -> "1"))
+        options = Map("latestFirst" -> "false", "maxFilesPerTrigger" -> "1"))
       val clock = new StreamManualClock()
       testStream(fileStream)(
         StartStream(trigger = ProcessingTime(10), triggerClock = clock),
@@ -1098,11 +1098,11 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         CheckLastBatch("2")
       )
 
-      // Read newest first, so the first batch is "2", and the second batch is "1".
+      // Read latest files first, so the first batch is "2", and the second batch is "1".
       val fileStream2 = createFileStream(
         "text",
         src.getCanonicalPath,
-        options = Map("newestFirst" -> "true", "maxFilesPerTrigger" -> "1"))
+        options = Map("latestFirst" -> "true", "maxFilesPerTrigger" -> "1"))
       val clock2 = new StreamManualClock()
       testStream(fileStream2)(
         StartStream(trigger = ProcessingTime(10), triggerClock = clock2),


### PR DESCRIPTION
## What changes were proposed in this pull request?

When starting a stream with a lot of backfill and maxFilesPerTrigger, the user could often want to start with most recent files first. This would let you keep low latency for recent data and slowly backfill historical data.

This PR adds a new option `latestFirst` to control this behavior. When it's true, `FileStreamSource` will sort the files by the modified time from latest to oldest, and take the first `maxFilesPerTrigger` files as a new batch.

## How was this patch tested?

The added test.