### PR TITLE
[SPARK-18609][SQL]Fix when CTE with Join between two table with same column name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -418,8 +418,8 @@ object ColumnPruning extends Rule[LogicalPlan] {
     case w: Window if w.windowExpressions.isEmpty => w.child
 
     // Eliminate no-op Projects
-    case p @ Project(_, child) if sameOutput(child.output, p.output) =>
-      if (child.isInstanceOf[CatalogRelation]) p else child
+    case p @ Project(_, child) if sameOutput(child.output, p.output) => child
+
     // Can't prune the columns on LeafNode
     case p @ Project(_, _: LeafNode) => p
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -200,7 +200,8 @@ object RemoveAliasOnlyProject extends Rule[LogicalPlan] {
         case plan: Project if plan eq proj => plan.child
         case plan => plan transformExpressions {
           case a: Attribute if attrMap.contains(a) => attrMap(a)
-          case b: Alias if (attrMap.exists(_._1.exprId == b.exprId)) => b.child
+          case b: Alias if attrMap.exists(_._1.exprId == b.exprId)
+            && b.child.isInstanceOf[NamedExpression] => b.child
         }
       }
     }.getOrElse(plan)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2011,6 +2011,22 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
+  test("test CTE with join between two table with the same column name ") {
+    sql("DROP TABLE IF EXISTS p1")
+    sql("DROP TABLE IF EXISTS p2")
+    sql("CREATE TABLE p1 (col String)" )
+    sql("CREATE TABLE p2 (col String)")
+
+    assert(
+      sql(
+        """
+          | WITH CTE AS
+          |  (SELECT s2.col as col FROM p1
+          |     CROSS JOIN (SELECT e.col as col FROM p2 E) s2)
+          | SELECT T1.col as c1,T2.col as c2 FROM CTE T1 CROSS JOIN CTE T2
+        """.stripMargin).collect.isEmpty)
+  }
+
   def testCommandAvailable(command: String): Boolean = {
     val attempt = Try(Process(command).run(ProcessLogger(_ => ())).exitValue())
     attempt.isSuccess && attempt.get == 0


### PR DESCRIPTION
## What changes were proposed in this pull request?
   After optimize the SQL with CTE and Join between two tables with the same column name,  there will throw a exception when the Physical Plan executed.
SQL:
```
>spark.sql("CREATE TABLE p1 (col STRING)"
>spark.sql("CREATE TABLE p2 (col STRING) "
>spark.sql("set spark.sql.crossJoin.enabled = true")
>spark.sql("WITH CTE AS (SELECT s2.col as col FROM p1 CROSS JOIN (SELECT e.col as col FROM p2 E) s2) SELECT T1.col as c1, T2.col as c2 FROM CTE T1 CROSS JOIN CTE T2")
```

before fixed the SQL explained:
```
== Physical Plan ==
*Project [col#123 AS c1#104, col#126 AS c2#105]
+- CartesianProduct
   :- CartesianProduct
   :  :- HiveTableScan MetastoreRelation default, p1
   :  +- HiveTableScan [col#123], MetastoreRelation default, p2, E
   +- *!Project [col#123 AS col#126]
      +- CartesianProduct
         :- HiveTableScan MetastoreRelation default, p1
         +- HiveTableScan MetastoreRelation default, p2, E
```
when execute the Physical Plan above, it will throw exception because of there is no attribute for col#123 to bind( the rules ColumnPruning/RemoveAliasOnlyProject are the root cause):
`
org.apache.spark.sql.catalyst.errors.package$TreeNodeException: Binding attribute, tree: col#123
	at org.apache.spark.sql.catalyst.errors.package$.attachTree(package.scala:56)
	at org.apache.spark.sql.catalyst.expressions.BindReferences$$anonfun$bindReference$1.applyOrElse(BoundAttribute.scala:88)
	at org.apache.spark.sql.catalyst.expressions.BindReferences$$anonfun$bindReference$1.applyOrElse(BoundAttribute.scala:87)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$3.apply(TreeNode.scala:286)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$3.apply(TreeNode.scala:286)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:69)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:285)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformDown$1.apply(TreeNode.scala:291)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformDown$1.apply(TreeNode.scala:291)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$5.apply(TreeNode.scala:328)
	at org.apache.spark.sql.catalyst.trees.TreeNode.mapProductIterator(TreeNode.scala:186)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformChildren(TreeNode.scala:326)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:291)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transform(TreeNode.scala:275)
	at org.apache.spark.sql.catalyst.expressions.BindReferences$.bindReference(BoundAttribute.scala:87)
	at org.apache.spark.sql.execution.ProjectExec$$anonfun$4.apply(basicPhysicalOperators.scala:61)
	at org.apache.spark.sql.execution.ProjectExec$$anonfun$4.apply(basicPhysicalOperators.scala:60)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
` 

after fixed the SQL explained:
```
== Physical Plan ==
*Project [col#12 AS c1#0, col#12 AS c2#1]
+- CartesianProduct
   :- CartesianProduct
   :  :- HiveTableScan MetastoreRelation default, p1
   :  +- HiveTableScan [col#12], MetastoreRelation default, p2
   +- CartesianProduct
      :- HiveTableScan MetastoreRelation default, p1
      +- HiveTableScan [col#12], MetastoreRelation default, p2
```
and the result is 
```
+---+---+
| c1| c2|
+---+---+
+---+---+
```



## How was this patch tested?
unit test added