### PR TITLE
[SPARK-18816] [Web UI] Executors Logs column only ran visibility check on initial table load

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -412,10 +412,6 @@ $(document).ready(function () {
                     ],
                     "columnDefs": [
                         {
-                            "targets": [ 15 ],
-                            "visible": logsExist(response)
-                        },
-                        {
                             "targets": [ 16 ],
                             "visible": getThreadDumpEnabled()
                         }
@@ -423,7 +419,8 @@ $(document).ready(function () {
                     "order": [[0, "asc"]]
                 };
     
-                $(selector).DataTable(conf);
+                var dt = $(selector).DataTable(conf);
+                dt.column(15).visible(logsExist(response));
                 $('#active-executors [data-toggle="tooltip"]').tooltip();
     
                 var sumSelector = "#summary-execs-table";


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I added a visibility check for the logs column on the executors page in #14382 the method I used only ran the check on the initial DataTable creation and not subsequent page loads. I moved the check out of the table definition and instead it runs on each page load. The jQuery DataTable functionality used is the same.

## How was this patch tested?

Tested Manually

No visible UI changes to screenshot.