### PR TITLE
[SPARK-18793] [SPARK-18794] [R] add spark.randomForest/spark.gbt to vignettes

### DIFF
--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -451,6 +451,8 @@ SparkR supports the following machine learning models and algorithms.
 
 * Random Forest
 
+* Gradient-Boosted Trees (GBT)
+
 * Naive Bayes Model
 
 * $k$-means Clustering
@@ -531,7 +533,7 @@ head(select(gaussianFitted, "model", "prediction", "mpg", "wt", "hp"))
 #### Random Forest
 
 `spark.randomForest` fits a [random forest](https://en.wikipedia.org/wiki/Random_forest) classification or regression model on a `SparkDataFrame`.
-Users can use `summary` to get a summary of the fitted model, `predict` to make predictions on new data, and `write.ml`/`read.ml` to save/load fitted models.
+Users can call `summary` to get a summary of the fitted model, `predict` to make predictions, and `write.ml`/`read.ml` to save/load fitted models.
 
 In the following example, we use the `longley` dataset to train a random forest and make predictions:
 
@@ -540,6 +542,20 @@ df <- createDataFrame(longley)
 rfModel <- spark.randomForest(df, Employed ~ ., type = "regression", numTrees = 5)
 summary(rfModel)
 predictions <- predict(rfModel, df)
+```
+
+#### Gradient-Boosted Trees
+
+`spark.gbt` fits a [gradient-boosted tree](https://en.wikipedia.org/wiki/Gradient_boosting) classification or regression model on a `SparkDataFrame`.
+Users can call `summary` to get a summary of the fitted model, `predict` to make predictions, and `write.ml`/`read.ml` to save/load fitted models.
+
+Similar to the random forest example above, we use the `longley` dataset to train a gradient-boosted tree and make predictions:
+
+```{r}
+df <- createDataFrame(longley)
+gbtModel <- spark.gbt(df, Employed ~ ., type = "regression", maxIter = 5)
+summary(gbtModel)
+predictions <- predict(gbtModel, df)
 ```
 
 #### Naive Bayes Model

--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -537,7 +537,7 @@ Users can call `summary` to get a summary of the fitted model, `predict` to make
 
 In the following example, we use the `longley` dataset to train a random forest and make predictions:
 
-```{r}
+```{r, warning=FALSE}
 df <- createDataFrame(longley)
 rfModel <- spark.randomForest(df, Employed ~ ., type = "regression", maxDepth = 2, numTrees = 2)
 summary(rfModel)
@@ -551,7 +551,7 @@ Users can call `summary` to get a summary of the fitted model, `predict` to make
 
 Similar to the random forest example above, we use the `longley` dataset to train a gradient-boosted tree and make predictions:
 
-```{r}
+```{r, warning=FALSE}
 df <- createDataFrame(longley)
 gbtModel <- spark.gbt(df, Employed ~ ., type = "regression", maxDepth = 2, maxIter = 2)
 summary(gbtModel)

--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -449,6 +449,8 @@ SparkR supports the following machine learning models and algorithms.
 
 * Generalized Linear Model (GLM)
 
+* Random Forest
+
 * Naive Bayes Model
 
 * $k$-means Clustering
@@ -524,6 +526,20 @@ When doing prediction, a new column called `prediction` will be appended. Let's 
 ```{r}
 gaussianFitted <- predict(gaussianGLM, carsDF)
 head(select(gaussianFitted, "model", "prediction", "mpg", "wt", "hp"))
+```
+
+#### Random Forest
+
+`spark.randomForest` fits a [random forest](https://en.wikipedia.org/wiki/Random_forest) classification or regression model on a `SparkDataFrame`.
+Users can use `summary` to get a summary of the fitted model, `predict` to make predictions on new data, and `write.ml`/`read.ml` to save/load fitted models.
+
+In the following example, we use the `longley` dataset to train a random forest and make predictions:
+
+```{r}
+df <- createDataFrame(longley)
+rfModel <- spark.randomForest(df, Employed ~ ., type = "regression", numTrees = 5)
+summary(rfModel)
+predictions <- predict(rfModel, df)
 ```
 
 #### Naive Bayes Model

--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -539,7 +539,7 @@ In the following example, we use the `longley` dataset to train a random forest 
 
 ```{r}
 df <- createDataFrame(longley)
-rfModel <- spark.randomForest(df, Employed ~ ., type = "regression", numTrees = 5)
+rfModel <- spark.randomForest(df, Employed ~ ., type = "regression", maxDepth = 2, numTrees = 2)
 summary(rfModel)
 predictions <- predict(rfModel, df)
 ```
@@ -553,7 +553,7 @@ Similar to the random forest example above, we use the `longley` dataset to trai
 
 ```{r}
 df <- createDataFrame(longley)
-gbtModel <- spark.gbt(df, Employed ~ ., type = "regression", maxIter = 5)
+gbtModel <- spark.gbt(df, Employed ~ ., type = "regression", maxDepth = 2, maxIter = 2)
 summary(gbtModel)
 predictions <- predict(gbtModel, df)
 ```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mention `spark.randomForest` and `spark.gbt` in vignettes. Keep the content minimal since users can type `?spark.randomForest` to see the full doc.

cc: @jkbradley 