### PR TITLE
[SPARK-18841][SQL]fix PushProjectionThroughUnion throw exception when there are same column name 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -223,7 +223,7 @@ object RemoveAliasOnlyProject extends Rule[LogicalPlan] {
   // the attribute(col#14) of union exists in left child, it will be ok.
   //
   // so here we should not do RemoveAliasOnlyProject
-  // when the project is the left child of the Union,
+  // when the project is the right child of the Union,
   // this function is to check it.
   def isUnionRightProj(p: Project, plan: LogicalPlan): Boolean = {
     plan.collectFirst{

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -226,7 +226,7 @@ object RemoveAliasOnlyProject extends Rule[LogicalPlan] {
   // when the project is the right child of the Union,
   // this function is to check it.
   def isUnionRightProj(p: Project, plan: LogicalPlan): Boolean = {
-    plan.collectFirst{
+    plan.collectFirst {
       case u @ Union(children) if children.tail.exists(_ eq p)
         && children.head.isInstanceOf[Project]
         && p.projectList.exists(proj =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -186,9 +186,58 @@ object RemoveAliasOnlyProject extends Rule[LogicalPlan] {
     }
   }
 
+  // Project [1 AS cste#13, col#12]
+  // +- Union
+  //   :- Project [col#14 AS col#12]
+  //   :  +- Join LeftOuter
+  //   :     :- MetastoreRelation default, p1
+  //   :     +- MetastoreRelation default, p2
+  //   +- Project [col#16 AS col#12]
+  //      +- MetastoreRelation default, p3
+  //
+  // if we replace col#12 with col#16, Project [1 AS cste#13, col#12]
+  // change to Project [1 AS cste#13, col#16],
+  // Project [1 AS cste#13, col#16]
+  // +- Union
+  //   :- Project [col#14 AS col#12]
+  //   :  +- Join LeftOuter
+  //   :     :- MetastoreRelation default, p1
+  //   :     +- MetastoreRelation default, p2
+  //      +- MetastoreRelation default, p3
+  //
+  // after then apply PushProjectionThroughUnion, because the output attributes
+  // of a union are always equal to the left child's output,
+  // while col#16 does not exist in left child, it will throw a exception.
+  //
+  // if we replace col#12 with col#14, Project [1 AS cste#13, col#12]
+  // change to Project [1 AS cste#13, col#14],
+  // Project [1 AS cste#13, col#14]
+  // +- Union
+  //   :  +- Join LeftOuter
+  //   :     :- MetastoreRelation default, p1
+  //   :     +- MetastoreRelation default, p2
+  //   +- Project [col#16 AS col#12]
+  //      +- MetastoreRelation default, p3
+  //
+  // and then apply PushProjectionThroughUnion,
+  // the attribute(col#14) of union exists in left child, it will be ok.
+  //
+  // so here we should not do RemoveAliasOnlyProject
+  // when the project is the left child of the Union,
+  // this function is to check it.
+  def isUnionRightProj(p: Project, plan: LogicalPlan): Boolean = {
+    plan.collectFirst{
+      case u @ Union(children) if children.tail.exists(_ eq p)
+        && children.head.isInstanceOf[Project]
+        && p.projectList.exists(proj =>
+        children.head.asInstanceOf[Project].projectList.exists(_.exprId == proj.exprId)) => p
+    }.nonEmpty
+  }
+
   def apply(plan: LogicalPlan): LogicalPlan = {
     val aliasOnlyProject = plan.collectFirst {
-      case p @ Project(pList, child) if isAliasOnly(pList, child.output) => p
+      case p @ Project(pList, child) if isAliasOnly(pList, child.output)
+        && !isUnionRightProj(p, plan) => p
     }
 
     aliasOnlyProject.map { case proj =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
  a union SQL with the same column name, after apply the rule RemoveAliasOnlyProject&PushProjectionThroughUnion many times, it will throw a exception

The reason is that RemoveAliasOnlyProject rule remove the right project child(alias only project) of Union, and replace the attribute of Union & the left project child of Union, then apply PushProjectionThroughUnion rule ,as the output attributes of a union are always equal to the left child's output, so it will throw a exception that the left child do not contain an attribute of the Union(RemoveAliasOnlyProject has replace it with right column).

for example:
```
    >spark.sql("DROP TABLE IF EXISTS p1")
    >spark.sql("DROP TABLE IF EXISTS p2")
    >spark.sql("DROP TABLE IF EXISTS p3")
    >spark.sql("CREATE TABLE p1 (col int)" )
    >spark.sql("CREATE TABLE p2 (col int)")
    >spark.sql("CREATE TABLE p3 (col int)")
    >spark.sql("set spark.sql.crossJoin.enabled = true")
    >spark.sql("SELECT 1 as cste,col FROM (SELECT col as col FROM (SELECT p1.col as col FROM p1 LEFT JOIN p2 UNION ALL SELECT col FROM p3 ) T1) T2").show
```

exception:
```
key not found: col#16
java.util.NoSuchElementException: key not found: col#16
        at scala.collection.MapLike$class.default(MapLike.scala:228)
        at org.apache.spark.sql.catalyst.expressions.AttributeMap.default(AttributeMap.scala:31)
        at scala.collection.MapLike$class.apply(MapLike.scala:141)
        at org.apache.spark.sql.catalyst.expressions.AttributeMap.apply(AttributeMap.scala:31)
        at org.apache.spark.sql.catalyst.optimizer.PushProjectionThroughUnion$$anonfun$2.applyOrElse(Optimizer.scala:346)
        at org.apache.spark.sql.catalyst.optimizer.PushProjectionThroughUnion$$anonfun$2.applyOrElse(Optimizer.scala:345)
        at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$3.apply(TreeNode.scala:292)
        at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$3.apply(TreeNode.scala:292)
        at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:74)
        at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:291)
        at org.apache.spark.sql.catalyst.trees.TreeNode.transform(TreeNode.scala:281)
        at org.apache.spark.sql.catalyst.optimizer.PushProjectionThroughUnion$.org$apache$spark$sql$catalyst$optimizer$PushProjectionThroughUnion$$pushToRight(Optimizer.scala:345)
        at org.apache.spark.sql.catalyst.optimizer.PushProjectionThroughUnion$$anonfun$apply$4$$anonfun$8$$anonfun$apply$31.apply(Optimizer.scala:378)
        at org.apache.spark.sql.catalyst.optimizer.PushProjectionThroughUnion$$anonfun$apply$4$$anonfun$8$$anonfun$apply$31.apply(Optimizer.scala:378)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.immutable.List.foreach(List.scala:381)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
        at scala.collection.immutable.List.map(List.scala:285)
        at org.apache.spark.sql.catalyst.optimizer.PushProjectionThroughUnion$$anonfun$apply$4$$anonfun$8.apply(Optimizer.scala:378)
```

## How was this patch tested?
unit test added