### PR TITLE
[SPARK-18855][CORE] Add RDD flatten function

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -381,6 +381,14 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
+    *  Return a new RDD by flattening all elements from RDD with traversable elements
+    */
+  def flatten[U: ClassTag](implicit asTraversable: T => TraversableOnce[U]): RDD[U] = withScope {
+    val f = (x: T) => asTraversable(x)
+    flatMap(f)
+  }
+
+  /**
    * Return a new RDD containing only the elements that satisfy a predicate.
    */
   def filter(f: T => Boolean): RDD[T] = withScope {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -381,11 +381,14 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
-    *  Return a new RDD by flattening all elements from RDD with traversable elements
-    */
+   * Return a new RDD by flattening all elements from RDD with traversable elements
+   */
   def flatten[U: ClassTag](implicit asTraversable: T => TraversableOnce[U]): RDD[U] = withScope {
-    val f = (x: T) => asTraversable(x)
-    flatMap(f)
+    new MapPartitionsRDD[U, T](this, (context, pid, iter) => {
+      var newIter: Iterator[U] = Iterator.empty
+      for (x <- iter) newIter ++= asTraversable(x)
+      newIter
+    })
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -88,6 +88,13 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     }
   }
 
+  test("flatten") {
+    val nums = sc.makeRDD(Array(Array(1, 2, 3), Array(4, 5), Array(6)), 2)
+    assert(nums.flatten.collect().toList === List(1, 2, 3, 4, 5, 6))
+    val strs = sc.makeRDD(Array(Array("a", "b", "c"), Array("d", "e"), Array("f")), 2)
+    assert(strs.flatten.collect().toList === List("a", "b", "c", "d", "e", "f"))
+  }
+
   test("serialization") {
     val empty = new EmptyRDD[Int](sc)
     val serial = Utils.serialize(empty)

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -70,6 +70,10 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     assert(!nums.isEmpty())
     assert(nums.max() === 4)
     assert(nums.min() === 1)
+
+    val nestedNums = sc.makeRDD(Array(Array(1, 2, 3), Array(4, 5), Array(6)), 2)
+    assert(nestedNums.flatten.collect().toList === List(1, 2, 3, 4, 5, 6))
+
     val partitionSums = nums.mapPartitions(iter => Iterator(iter.sum))
     assert(partitionSums.collect().toList === List(3, 7))
 
@@ -86,13 +90,6 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     intercept[UnsupportedOperationException] {
       nums.filter(_ > 5).reduce(_ + _)
     }
-  }
-
-  test("flatten") {
-    val nums = sc.makeRDD(Array(Array(1, 2, 3), Array(4, 5), Array(6)), 2)
-    assert(nums.flatten.collect().toList === List(1, 2, 3, 4, 5, 6))
-    val strs = sc.makeRDD(Array(Array("a", "b", "c"), Array("d", "e"), Array("f")), 2)
-    assert(strs.flatten.collect().toList === List("a", "b", "c", "d", "e", "f"))
   }
 
   test("serialization") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new flatten function for RDD.

## How was this patch tested?

Unit tests inside RDDSuite and manually tests:
```
scala> val rdd = sc.makeRDD(List(List(1, 2, 3), List(4, 5), List(6)))
rdd: org.apache.spark.rdd.RDD[List[Int]] = ParallelCollectionRDD[0] at makeRDD at <console>:24

scala> rdd.flatten.collect
res0: Array[Int] = Array(1, 2, 3, 4, 5, 6)
```
