### PR TITLE
[SPARK-18867] [SQL] Throw cause if IsolatedClientLoad can't create cl…

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -272,7 +272,7 @@ private[hive] class IsolatedClientLoader(
             "Please make sure that jars for your version of hive and hadoop are included in the " +
             s"paths passed to ${HiveUtils.HIVE_METASTORE_JARS.key}.", e)
         } else {
-          throw e
+          throw e.getCause()
         }
     } finally {
       Thread.currentThread.setContextClassLoader(origLoader)


### PR DESCRIPTION
## What changes were proposed in this pull request?
If IsolatedClientLoader can't instantiate a class object, it throws InvocationTargetException. But the caller doesn't need to know this exception. Instead, it should throw the exception that causes the InvocationTargetException, so that the caller may be able to handle it.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.

…ient