### PR TITLE
[SPARK-17119][Core]allow the history server to delete .inprogress files(configurable)

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -262,7 +262,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
     val provider = new FsHistoryProvider(
       createTestConf().set("spark.history.fs.cleaner.maxAge", s"${maxAge}ms")
         .set("spark.history.fs.cleaner.deleteInProgress.enabled", s"true")
-        .set("spark.history.fs.cleaner.noProgressMaxAge",s"${inProgressNoUpdateMaxAge}ms"), clock)
+        .set("spark.history.fs.cleaner.noProgressMaxAge", s"${inProgressNoUpdateMaxAge}ms"), clock)
     val log1 = newLogFile("app1", Some("attempt1"), inProgress = false)
     writeFile(log1, true, None,
       SparkListenerApplicationStart("app1", Some("app1"), 1L, "test", Some("attempt1")),
@@ -314,7 +314,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
       list.head.attempts.head.attemptId should be (Some("attempt3"))
     }
     assert(!log3.exists())
-    //Move the clock forward so log3 execeeds the inProgressNoUpdate Max Age
+    // Move the clock forward so log3 execeeds the inProgressNoUpdate Max Age
     clock.advance(inProgressNoUpdateMaxAge)
     updateAndCheck(provider) { list =>
       list.size should be (0)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -200,6 +200,23 @@ The history server can be configured as follows:
       Number of threads that will be used by history server to process event logs.
     </td>
   </tr>
+  <tr>
+    <td>spark.history.fs.cleaner.deleteInProgress.enabled</td>
+    <td>false</td>
+    <td>
+      In some cases, the spark job abort unexpectly and leaves the .inprogress event log files.
+      Specifies whether the History Server should periodically clean up those .inprogress files
+    </td>
+  </tr>
+  <tr>
+    <td>spark.history.fs.cleaner.noProgressMaxAg</td>
+    <td>30d</td>
+    <td>
+      Job history files stay untouch with .inprogress suffix , and older than this will be deleted
+      This also reuqires the filesystem history cleaner is enabled and deleteInProgress.enabled is
+      set to true.
+    </td>
+  </tr>
 </table>
 
 Note that in all of these UIs, the tables are sortable by clicking their headers,

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -209,7 +209,7 @@ The history server can be configured as follows:
     </td>
   </tr>
   <tr>
-    <td>spark.history.fs.cleaner.noProgressMaxAg</td>
+    <td>spark.history.fs.cleaner.noProgressMaxAge</td>
     <td>30d</td>
     <td>
       Job history files stay untouch with .inprogress suffix , and older than this will be deleted


### PR DESCRIPTION
## What changes were proposed in this pull request?
The History Server (HS) currently only considers completed applications when deleting event logs from spark.history.fs.logDirectory (since SPARK-6879). This means that over time, .inprogress files (from failed jobs, jobs where the SparkContext is not closed, spark-shell exits etc...) can accumulate and impact the HS.

Instead of having to manually delete these files,  this change add a configurable feature to let user decide if the .inprogress files should also be deleted after a period of time:
spark.history.fs.cleaner.deleteInProgress.enabled
spark.history.fs.cleaner.noProgressMaxAge

## How was this patch tested?

verified with manual tests
unit tests added in FsHistoryProviderSuite.scala but I am not able to run ./dev/run-tests for the whole project on my laptop, failed on SparkSinkSuite and network related tests uner org.apache.spark.network.* (all due to  java.io.IOException: Failed to connect to /<my_laptop_ip>:62343).
<code>
[info] SparkSinkSuite:
[info] - Success with ack *** FAILED *** (1 minute)
[info]   java.io.IOException: Error connecting to /0.0.0.0:62298
[info]   at org.apache.avro.ipc.NettyTransceiver.getChannel(NettyTransceiver.java:261)
</code>

## doc ##
monitoring.md is also updated