### PR TITLE
[SPARK-8425][Scheduler][HOTFIX] fix scala 2.10 compile error

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -296,13 +296,13 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     val mockAmClient = mock(classOf[AMRMClient[ContainerRequest]])
     val handler = createAllocator(4, mockAmClient)
     handler.requestTotalExecutorsWithPreferredLocalities(1, 0, Map(), Set("hostA"))
-    verify(mockAmClient).updateBlacklist(Seq("hostA").asJava, Seq().asJava)
+    verify(mockAmClient).updateBlacklist(Seq("hostA").asJava, Seq[String]().asJava)
 
     handler.requestTotalExecutorsWithPreferredLocalities(2, 0, Map(), Set("hostA", "hostB"))
-    verify(mockAmClient).updateBlacklist(Seq("hostB").asJava, Seq().asJava)
+    verify(mockAmClient).updateBlacklist(Seq("hostB").asJava, Seq[String]().asJava)
 
     handler.requestTotalExecutorsWithPreferredLocalities(3, 0, Map(), Set())
-    verify(mockAmClient).updateBlacklist(Seq().asJava, Seq("hostA", "hostB").asJava)
+    verify(mockAmClient).updateBlacklist(Seq[String]().asJava, Seq("hostA", "hostB").asJava)
   }
 
   test("memory exceeded diagnostic regexes") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/spark/commit/93cdb8a7d0f124b4db069fd8242207c82e263c52 Introduced a compile error under scala 2.10, this fixes that error.

## How was this patch tested?

locally ran
```
dev/change-version-to-2.10.sh
build/sbt -Pyarn -Phadoop-2.4 -Dhadoop.version=2.6.0 -Dscala-2.10 "project yarn" "test-only *YarnAllocatorSuite"
```
(which failed at test compilation before this change)