### PR TITLE
[SPARK-17807][core] Demote scalatest to "provided" in spark-tags.

### DIFF
--- a/common/tags/pom.xml
+++ b/common/tags/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This avoids exposing scalatest as a transitive dependencies to projects
that depend on spark-core, but don't declare a direct dependency on
scalatest in test scope.

Tested by checking "mvn dependency:tree" with a small pom file that just
declared a dependency on spark-core; scalatest would show up as "compile"
before the change, now it doesn't show at all.