### PR TITLE
Branch 2.0

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVInferSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVInferSchema.scala
@@ -237,9 +237,9 @@ private[csv] object CSVTypeCast {
     } else {
       castType match {
         case _: ByteType => datum.toByte
-        case _: ShortType => datum.toShort
-        case _: IntegerType => datum.toInt
-        case _: LongType => datum.toLong
+        case _: ShortType => Try(datum.toShort).getOrElse(null)
+        case _: IntegerType => Try(datum.toInt).getOrElse(null)
+        case _: LongType => Try(datum.toLong).getOrElse(null)
         case _: FloatType =>
           datum match {
             case options.nanValue => Float.NaN


### PR DESCRIPTION
## What changes were proposed in this pull request?

CSV parser changes allowing parsing of numeric fields to fail and return null in such case.
In conjunction with "nullValue" option that may be used elsewhere this allows handling of certain csv sources that may use empty string as indication of null in one column and another specific value indicating null in another.

Currently the option "nullValue" can only be provided once and we can't assume that a data source won't have a single "null" indicator.

This problem is very similar to the one discussed here: https://github.com/databricks/spark-csv/issues/239


## How was this patch tested?

The patch was tested using freshly compiled spark version 2.0.1 on a sample data source that has "null" values in 2 columns, one specified as "NA" and set using nullValue and another column with "" indicating no integer value.

Please review http://spark.apache.org/contributing.html before opening a pull request.
