### PR TITLE
[SPARK-18908][SS] Creating StreamingQueryException should check if logicalPlan is created

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -309,7 +309,7 @@ class StreamExecution(
         updateStatusMessage("Stopped")
       case e: Throwable =>
         streamDeathCause = new StreamingQueryException(
-          this,
+          this.toDebugString,
           s"Query $prettyIdString terminated with exception: ${e.getMessage}",
           e,
           prettyCommittedOffsets,
@@ -655,10 +655,7 @@ class StreamExecution(
     s"Streaming Query $prettyIdString [state = $state]"
   }
 
-  def toDebugString: String = {
-    val deathCauseStr = if (streamDeathCause != null) {
-      "Error:\n" + stackTraceToString(streamDeathCause.cause)
-    } else ""
+  private def toDebugString: String = {
     s"""
        |=== Streaming Query ===
        |Identifier: $prettyIdString
@@ -670,8 +667,6 @@ class StreamExecution(
        |
        |Logical Plan:
        |${if (_logicalPlan == null) null else _logicalPlan}
-       |
-       |$deathCauseStr
      """.stripMargin
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, CurrentBatchTimestamp, CurrentDate, CurrentTimestamp}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
-import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.ExplainCommand
 import org.apache.spark.sql.streaming._
@@ -554,9 +553,7 @@ class StreamExecution(
       microBatchThread.interrupt()
       microBatchThread.join()
     }
-    if (isLogicalPlanGenerated) {
-      uniqueSources.foreach(_.stop())
-    }
+    uniqueSources.foreach(_.stop())
     logInfo(s"Query $prettyIdString was stopped")
   }
 
@@ -665,7 +662,7 @@ class StreamExecution(
        |Thread State: ${microBatchThread.getState}
        |
        |Logical Plan:
-       |${if (isLogicalPlanGenerated) logicalPlan else null}
+       |${if (isLogicalPlanGenerated) logicalPlan else "N/A"}
      """.stripMargin
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -582,11 +582,13 @@ class StreamExecution(
 
   /**
    * Assert that the await APIs should not be called in the stream thread. Otherwise, it may cause
-   * dead-lock.
+   * dead-lock, e.g., calling any await APIs in `StreamingQueryListener.onQueryStarted` will block
+   * the stream thread forever.
    */
   private def assertAwaitThread(): Unit = {
     if (microBatchThread eq Thread.currentThread) {
-      throw new IllegalStateException("Cannot wait inside a stream thread")
+      throw new IllegalStateException(
+        "Cannot wait for a query state from the same thread that is running the query")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -118,7 +118,34 @@ class StreamExecution(
   private val prettyIdString =
     Option(name).map(_ + " ").getOrElse("") + s"[id = $id, runId = $runId]"
 
-  override lazy val logicalPlan: LogicalPlan = {
+  private val localPlanLock = new Object
+
+  @volatile private var _logicalPlan: LogicalPlan = null
+
+  override def logicalPlan: LogicalPlan = {
+    if (_logicalPlan == null) {
+      localPlanLock.synchronized {
+        if (_logicalPlan == null) {
+          _logicalPlan = createLogicalPlan
+        }
+      }
+    }
+    _logicalPlan
+  }
+
+  private def prettyCommittedOffsets: String = {
+    Option(_logicalPlan).map { _ =>
+      committedOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString
+    }.getOrElse("[-]")
+  }
+
+  private def prettyAvailableOffsets: String = {
+    Option(_logicalPlan).map { _ =>
+      availableOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString
+    }.getOrElse("[-]")
+  }
+
+  private def createLogicalPlan: LogicalPlan = {
     var nextSourceId = 0L
     analyzedPlan.transform {
       case StreamingRelation(dataSource, _, output) =>
@@ -285,8 +312,8 @@ class StreamExecution(
           this,
           s"Query $prettyIdString terminated with exception: ${e.getMessage}",
           e,
-          committedOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString,
-          availableOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString)
+          prettyCommittedOffsets,
+          prettyAvailableOffsets)
         logError(s"Query $prettyIdString terminated with error", e)
         updateStatusMessage(s"Terminated with exception: ${e.getMessage}")
         // Rethrow the fatal errors to allow the user using `Thread.UncaughtExceptionHandler` to
@@ -528,7 +555,9 @@ class StreamExecution(
       microBatchThread.interrupt()
       microBatchThread.join()
     }
-    uniqueSources.foreach(_.stop())
+    if (_logicalPlan != null) {
+      uniqueSources.foreach(_.stop())
+    }
     logInfo(s"Query $prettyIdString was stopped")
   }
 
@@ -560,6 +589,9 @@ class StreamExecution(
   @volatile private var noNewData = false
 
   override def processAllAvailable(): Unit = {
+    if (streamDeathCause != null) {
+      throw streamDeathCause
+    }
     awaitBatchLock.lock()
     try {
       noNewData = false
@@ -630,13 +662,14 @@ class StreamExecution(
     s"""
        |=== Streaming Query ===
        |Identifier: $prettyIdString
-       |Current Offsets: $committedOffsets
+       |Current Committed Offsets: $prettyCommittedOffsets
+       |Current Available Offsets: $prettyAvailableOffsets
        |
        |Current State: $state
        |Thread State: ${microBatchThread.getState}
        |
        |Logical Plan:
-       |$logicalPlan
+       |${if (_logicalPlan == null) null else _logicalPlan}
        |
        |$deathCauseStr
      """.stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -43,6 +43,5 @@ class StreamingQueryException private[sql](
 
   override def toString(): String =
     s"""${classOf[StreamingQueryException].getName}: ${cause.getMessage}
-       |$queryDebugString
-       |""".stripMargin
+       |$queryDebugString""".stripMargin
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.streaming
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.sql.execution.streaming.{Offset, OffsetSeq, StreamExecution}
 
 /**
  * :: Experimental ::
@@ -31,35 +30,19 @@ import org.apache.spark.sql.execution.streaming.{Offset, OffsetSeq, StreamExecut
  * @since 2.0.0
  */
 @Experimental
-class StreamingQueryException private(
-    causeString: String,
+class StreamingQueryException private[sql](
+    private val queryDebugString: String,
     val message: String,
     val cause: Throwable,
     val startOffset: String,
     val endOffset: String)
   extends Exception(message, cause) {
 
-  private[sql] def this(
-      query: StreamingQuery,
-      message: String,
-      cause: Throwable,
-      startOffset: String,
-      endOffset: String) {
-    this(
-      // scalastyle:off
-      s"""${classOf[StreamingQueryException].getName}: ${cause.getMessage} ${cause.getStackTrace.take(10).mkString("", "\n|\t", "\n")}
-         |
-         |${query.asInstanceOf[StreamExecution].toDebugString}
-         """.stripMargin,
-      // scalastyle:on
-      message,
-      cause,
-      startOffset,
-      endOffset)
-  }
-
   /** Time when the exception occurred */
   val time: Long = System.currentTimeMillis
 
-  override def toString(): String = causeString
+  override def toString(): String =
+    s"""${classOf[StreamingQueryException].getName}: ${cause.getMessage}
+       |$queryDebugString
+       |""".stripMargin
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -820,7 +820,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       withTempDir { case src =>
         def testMaxFilePerTriggerValue(value: String): Unit = {
           val df = spark.readStream.option("maxFilesPerTrigger", value).text(src.getCanonicalPath)
-          val e = intercept[IllegalArgumentException] {
+          val e = intercept[StreamingQueryException] {
             // Note: `maxFilesPerTrigger` is checked in the stream thread when creating the source
             val q = df.writeStream.format("memory").queryName(testTable).start()
             try {
@@ -829,6 +829,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
               q.stop()
             }
           }
+          assert(e.getCause.isInstanceOf[IllegalArgumentException])
           Seq("maxFilesPerTrigger", value, "positive integer").foreach { s =>
             assert(e.getMessage.contains(s))
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -927,6 +927,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         expectedCompactInterval: Int): Boolean = {
       import CompactibleFileStreamLog._
 
+      // Make sure `logicalPlan` is created
+      execution.logicalPlan
       val fileSource = (execution invokePrivate _sources()).head.asInstanceOf[FileStreamSource]
       val metadataLog = fileSource invokePrivate _metadataLog()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1212,7 +1212,8 @@ class FileStreamSourceStressTestSuite extends FileStreamSourceTest {
   }
 }
 
-/** Fake FileSystem to test whether the method `fs.exists` is called during
+/**
+ * Fake FileSystem to test whether the method `fs.exists` is called during
  * `DataSource.resolveRelation`.
  */
 class ExistsThrowsExceptionFileSystem extends RawLocalFileSystem {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -815,21 +815,30 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
   }
 
   test("max files per trigger - incorrect values") {
-    withTempDir { case src =>
-      def testMaxFilePerTriggerValue(value: String): Unit = {
-        val df = spark.readStream.option("maxFilesPerTrigger", value).text(src.getCanonicalPath)
-        val e = intercept[IllegalArgumentException] {
-          testStream(df)()
+    val testTable = "maxFilesPerTrigger_test"
+    withTable(testTable) {
+      withTempDir { case src =>
+        def testMaxFilePerTriggerValue(value: String): Unit = {
+          val df = spark.readStream.option("maxFilesPerTrigger", value).text(src.getCanonicalPath)
+          val e = intercept[IllegalArgumentException] {
+            // Note: `maxFilesPerTrigger` is checked in the stream thread when creating the source
+            val q = df.writeStream.format("memory").queryName(testTable).start()
+            try {
+              q.processAllAvailable()
+            } finally {
+              q.stop()
+            }
+          }
+          Seq("maxFilesPerTrigger", value, "positive integer").foreach { s =>
+            assert(e.getMessage.contains(s))
+          }
         }
-        Seq("maxFilesPerTrigger", value, "positive integer").foreach { s =>
-          assert(e.getMessage.contains(s))
-        }
-      }
 
-      testMaxFilePerTriggerValue("not-a-integer")
-      testMaxFilePerTriggerValue("-1")
-      testMaxFilePerTriggerValue("0")
-      testMaxFilePerTriggerValue("10.1")
+        testMaxFilePerTriggerValue("not-a-integer")
+        testMaxFilePerTriggerValue("-1")
+        testMaxFilePerTriggerValue("0")
+        testMaxFilePerTriggerValue("10.1")
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -927,8 +927,6 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         expectedCompactInterval: Int): Boolean = {
       import CompactibleFileStreamLog._
 
-      // Make sure `logicalPlan` is created
-      execution.logicalPlan
       val fileSource = (execution invokePrivate _sources()).head.asInstanceOf[FileStreamSource]
       val metadataLog = fileSource invokePrivate _metadataLog()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -259,8 +259,8 @@ class StreamSuite extends StreamTest {
       }
       val df = Dataset[Int](sqlContext.sparkSession, StreamingExecutionRelation(source))
       // These error are fatal errors and should be ignored in `testStream` to not fail the test.
-      testStream(df, ignoreThreadDeathCause = true)(
-        ExpectFailure()(ClassTag(e.getClass))
+      testStream(df)(
+        ExpectFailure(isFatalError = true)(ClassTag(e.getClass))
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -258,7 +258,8 @@ class StreamSuite extends StreamTest {
         override def stop(): Unit = {}
       }
       val df = Dataset[Int](sqlContext.sparkSession, StreamingExecutionRelation(source))
-      testStream(df)(
+      // These error are fatal errors and should be ignored in `testStream` to not fail the test.
+      testStream(df, ignoreThreadDeathCause = true)(
         ExpectFailure()(ClassTag(e.getClass))
       )
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -364,6 +364,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with Timeouts {
                   streamThreadDeathCause = e
                 }
               })
+            currentStream.awaitInitialization(streamingTimeout.toMillis)
 
           case AdvanceManualClock(timeToAdd) =>
             verify(currentStream != null,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -111,7 +111,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
         StartStream(ProcessingTime(100), triggerClock = clock),
         AddData(inputData, 0),
         AdvanceManualClock(100),
-        ExpectFailure[SparkException],
+        ExpectFailure[SparkException](),
         AssertOnQuery { query =>
           eventually(Timeout(streamingTimeout)) {
             assert(listener.terminationEvent !== null)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -142,7 +142,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging {
       StartStream(),
       AssertOnQuery(_.isActive === true),
       AddData(inputData, 0),
-      ExpectFailure[SparkException],
+      ExpectFailure[SparkException](),
       AssertOnQuery(_.isActive === false),
       TestAwaitTermination(ExpectException[SparkException]),
       TestAwaitTermination(ExpectException[SparkException], timeoutMs = 2000),
@@ -306,7 +306,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging {
       StartStream(ProcessingTime(100), triggerClock = clock),
       AddData(inputData, 0),
       AdvanceManualClock(100),
-      ExpectFailure[SparkException],
+      ExpectFailure[SparkException](),
       AssertOnQuery(_.status.isDataAvailable === false),
       AssertOnQuery(_.status.isTriggerActive === false),
       AssertOnQuery(_.status.message.startsWith("Terminated with exception"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR audits places using `logicalPlan` in StreamExecution and ensures they all handles the case that `logicalPlan` cannot be created.

In addition, this PR also fixes the following issues in `StreamingQueryException`:
- `StreamingQueryException` and `StreamExecution` are cycle-dependent because in the `StreamingQueryException`'s constructor, it calls `StreamExecution`'s `toDebugString` which uses `StreamingQueryException`. Hence it will output `null` value in the error message.
- Duplicated stack trace when calling Throwable.printStackTrace because StreamingQueryException's toString contains the stack trace.

## How was this patch tested?

The updated `test("max files per trigger - incorrect values")`. I found this issue when I switched from `testStream` to the real codes to verify the failure in this test.
