### PR TITLE
[SPARK-18910][SQL]Resolve faile to use UDF that jar file in hdfs.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -19,7 +19,7 @@ package org.apache.spark
 
 import java.io._
 import java.lang.reflect.Constructor
-import java.net.{URI}
+import java.net.{URI, URL}
 import java.util.{Arrays, Locale, Properties, ServiceLoader, UUID}
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
@@ -35,7 +35,7 @@ import scala.util.control.NonFatal
 import com.google.common.collect.MapMaker
 import org.apache.commons.lang3.SerializationUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.{FileSystem, FsUrlStreamHandlerFactory, Path}
 import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, NullWritable, Text, Writable}
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
@@ -2373,6 +2373,7 @@ class SparkContext(config: SparkConf) extends Logging {
  * various Spark features.
  */
 object SparkContext extends Logging {
+  URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory())
   private val VALID_LOG_LEVELS =
     Set("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I create a UDF that jar file in hdfs, I can't use the UDF. 

> spark-sql> create function trans_array as 'com.test.udf.TransArray'  using jar 'hdfs://host1:9000/spark/dev/share/libs/spark-proxy-server-biz-service-impl-1.0.0.jar';
> spark-sql> describe function trans_array;
> Function: test_db.trans_array
> Class: com.alipay.spark.proxy.server.biz.service.impl.udf.TransArray
> Usage: N/A.
> Time taken: 0.127 seconds, Fetched 3 row(s)
> spark-sql> select trans_array(1, '\\|', id, position) as (id0, position0) from test_spark limit 10;
> Error in query: Undefined function: 'trans_array'. This function is neither a registered temporary function nor a permanent function registered in the database 'test_db'.; line 1 pos 7
> 


The reason is when org.apache.spark.sql.internal.SessionState.FunctionResourceLoader.loadResource, the uri.toURL throw exception with " failed unknown protocol: hdfs"

> def addJar(path: String): Unit = {
>     sparkSession.sparkContext.addJar(path)
>     val uri = new Path(path).toUri
>     val jarURL = if (uri.getScheme == null) {
>       // `path` is a local file path without a URL scheme
>       new File(path).toURI.toURL
>     } else {
>       // `path` is a URL with a scheme
>       {color:red}uri.toURL{color}
>     }
>     jarClassLoader.addURL(jarURL)
>     Thread.currentThread().setContextClassLoader(jarClassLoader)
>   }


I think we should setURLStreamHandlerFactory method on URL with an instance of FsUrlStreamHandlerFactory, just like:
> static {
> 	URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory());
> }

## How was this patch tested?

I have test it in my cluster.

