### PR TITLE
[SPARK-18915] [SQL] Automatic Table Repair when Creating a Partitioned Data Source Table with a Specified Path

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -106,6 +106,13 @@ case class CreateDataSourceTableCommand(table: CatalogTable, ignoreIfExists: Boo
     // we reach here, the table should not exist and we should set `ignoreIfExists` to false.
     sessionState.catalog.createTable(newTable, ignoreIfExists = false)
 
+    // Need to recover partitions into the metastore so the data in the path is visible.
+    if (partitionColumnNames.nonEmpty && pathOption.nonEmpty &&
+        sparkSession.sessionState.conf.manageFilesourcePartitions) {
+      sparkSession.sessionState.executePlan(
+        AlterTableRecoverPartitionsCommand(table.identifier)).toRdd
+    }
+
     Seq.empty[Row]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -271,7 +271,7 @@ object SQLConf {
   val HIVE_MANAGE_FILESOURCE_PARTITIONS =
     SQLConfigBuilder("spark.sql.hive.manageFilesourcePartitions")
       .doc("When true, enable metastore partition management for file source tables as well. " +
-           "This includes both datasource and converted Hive tables. When partition managment " +
+           "This includes both datasource and converted Hive tables. When partition management " +
            "is enabled, datasource tables store partition in the Hive metastore, and use the " +
            "metastore to prune partitions during query planning.")
       .booleanConf

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
@@ -108,7 +108,7 @@ class PartitionProviderCompatibilitySuite
     }
   }
 
-  test("when partition management is disabled, we preserve the old behavior even for new tables") {
+  test("When partition management is disabled, we preserve the old behavior even for new tables") {
     withTable("test") {
       withTempDir { dir =>
         withSQLConf(SQLConf.HIVE_MANAGE_FILESOURCE_PARTITIONS.key -> "true") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In Spark 2.1 (the default of `spark.sql.hive.manageFilesourcePartitions` is set to `true`), if we create a parititoned data source table given a specified path, it returns nothing when we try to query it. To get the data, we have to manually issue a DDL to repair the table. 

In Spark 2.0, it can return the data stored in the specified path, without repairing the table. In Spark 2.1, if we set `spark.sql.hive.manageFilesourcePartitions` to false, the behavior is the same as Spark 2.0. 

Below is the output of Spark 2.1. 
```Scala
scala> spark.range(5).selectExpr("id as fieldOne", "id as partCol").write.partitionBy("partCol").mode("overwrite").saveAsTable("test")
                                                                                
scala> spark.sql("desc formatted test").show(50, false)
+----------------------------+----------------------------------------------------------------------+-------+
|col_name                    |data_type                                                             |comment|
+----------------------------+----------------------------------------------------------------------+-------+
...
|Location:                   |file:/Users/xiaoli/IdeaProjects/sparkDelivery/bin/spark-warehouse/test|       |
|Table Type:                 |MANAGED                                                               |       |
...
|Partition Provider:         |Catalog                                                               |       |
+----------------------------+----------------------------------------------------------------------+-------+


scala> spark.sql(s"create table newTab (fieldOne long, partCol int) using parquet options (path 'file:/Users/xiaoli/IdeaProjects/sparkDelivery/bin/spark-warehouse/test') partitioned by (partCol)")
res3: org.apache.spark.sql.DataFrame = []

scala> spark.table("newTab").show()
+--------+-------+
|fieldOne|partCol|
+--------+-------+
+--------+-------+
```

This PR is to make it consistent with the behavior of Spark 2.0. no matter whether `spark.sql.hive.manageFilesourcePartitions` is `true` or `false`. It repairs the table when creating such a table. After the change, the behavior becomes consistent with what we did for CTAS of partitioned data source tables. 

### How was this patch tested?
Modified the existing test case.