### PR TITLE
[SPARK-18920][HISTORYSERVER]Update outdated date formatting

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -38,7 +38,7 @@ function makeIdNumeric(id) {
 }
 
 function formatDate(date) {
-  if (date <= 0) return "-";
+  if (date.substr(0, 2) == "19") return "-";
   else return date.split(".")[0].replace("T", " ");
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before we show "-" while the timestamp is less than 0, we should update it as now the date string is presented in format "yyyy-MM-dd ....."

## How was this patch tested?

**Before:**
![historyserver-before](https://cloud.githubusercontent.com/assets/5276001/21299300/1bd15ac6-c5d5-11e6-97c3-d51b19da9cd5.JPG)

**After:**
![history-after](https://cloud.githubusercontent.com/assets/5276001/21299304/24a34c68-c5d5-11e6-8282-974cf14f0089.JPG)
