### PR TITLE
[SPARK-18917][SQL] Add Skip Partition Check Flag to avoid list all leaf files in append mode

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -446,7 +446,7 @@ case class DataSource(
         // If we are appending to a table that already exists, make sure the partitioning matches
         // up.  If we fail to load the table for whatever reason, ignore the check.
 
-        // SPARK-18917 Skip Partition Check to skip reading all leaf files
+        // SPARK-18917 Add Skip Partition Check Flag to avoid list all leaf files in append mode
         val skipPartitionCheckOnAppend = sparkSession.sessionState.conf.skipPartitionCheckOnAppend
         if (skipPartitionCheckOnAppend) {
           logInfo("Skipping Partition Check on Append Mode")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -445,21 +445,28 @@ case class DataSource(
 
         // If we are appending to a table that already exists, make sure the partitioning matches
         // up.  If we fail to load the table for whatever reason, ignore the check.
-        if (mode == SaveMode.Append) {
-          val existingPartitionColumns = Try {
-            getOrInferFileFormatSchema(format, justPartitioning = true)._2.fieldNames.toList
-          }.getOrElse(Seq.empty[String])
-          // TODO: Case sensitivity.
-          val sameColumns =
-            existingPartitionColumns.map(_.toLowerCase()) == partitionColumns.map(_.toLowerCase())
-          if (existingPartitionColumns.nonEmpty && !sameColumns) {
-            throw new AnalysisException(
-              s"""Requested partitioning does not match existing partitioning.
-                 |Existing partitioning columns:
-                 |  ${existingPartitionColumns.mkString(", ")}
-                 |Requested partitioning columns:
-                 |  ${partitionColumns.mkString(", ")}
-                 |""".stripMargin)
+
+        // SPARK-18917 Skip Partition Check to skip reading all leaf files
+        val skipPartitionCheckOnAppend = sparkSession.sessionState.conf.skipPartitionCheckOnAppend
+        if (skipPartitionCheckOnAppend) {
+          logInfo("Skipping Partition Check on Append Mode")
+        } else {
+          if (mode == SaveMode.Append) {
+            val existingPartitionColumns = Try {
+              getOrInferFileFormatSchema(format, justPartitioning = true)._2.fieldNames.toList
+            }.getOrElse(Seq.empty[String])
+            // TODO: Case sensitivity.
+            val sameColumns =
+              existingPartitionColumns.map(_.toLowerCase()) == partitionColumns.map(_.toLowerCase())
+            if (existingPartitionColumns.nonEmpty && !sameColumns) {
+              throw new AnalysisException(
+                s"""Requested partitioning does not match existing partitioning.
+                   |Existing partitioning columns:
+                   |  ${existingPartitionColumns.mkString(", ")}
+                   |Requested partitioning columns:
+                   |  ${partitionColumns.mkString(", ")}
+                   |""".stripMargin)
+            }
           }
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -546,6 +546,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val SKIP_PARTITION_CHECK_ON_APPEND =
+    SQLConfigBuilder("spark.sql.execution.skipPartitionCheckOnAppend")
+    .internal()
+    .doc("Decides if we need to skip Partition Check on Append Mode. +" +
+      "Enable this is when writing to Object Stores to avoid time out issues")
+    .booleanConf
+    .createWithDefault(false)
+
   val FILE_SINK_LOG_DELETION = SQLConfigBuilder("spark.sql.streaming.fileSink.log.deletion")
     .internal()
     .doc("Whether to delete the expired log files in file stream sink.")
@@ -812,6 +820,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def enableTwoLevelAggMap: Boolean = getConf(ENABLE_TWOLEVEL_AGG_MAP)
 
   def useObjectHashAggregation: Boolean = getConf(USE_OBJECT_HASH_AGG)
+
+  def skipPartitionCheckOnAppend: Boolean = getConf(SKIP_PARTITION_CHECK_ON_APPEND)
 
   def objectAggSortBasedFallbackThreshold: Int = getConf(OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently saving a dataframe in append mode lists all leaf files in save directory. When the directory is in object stores object stores (S3 / Google Storage) and has many subfolders due to partitioning, the writes are taking a long time to write or they result in read time out.
This pull request introduces a skip flag that is false by default and can be enabled by users to skip partition checking.

## How was this patch tested?
This patch was tested using manual tests and regression tests.

