### PR TITLE
[SPARK-18950][SQL] Report conflicting fields when merging two StructTypes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -477,7 +477,7 @@ object StructType extends AbstractDataType {
                       dataType = dataType,
                       nullable = leftNullable || rightNullable)
                   case Failure(e) =>
-                    throw new SparkException(s"Failed to merge field $leftName: " + e.getMessage)
+                    throw new SparkException(s"Failed to merge field '$leftName': " + e.getMessage)
                 }
               }
               .orElse {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -476,7 +476,8 @@ object StructType extends AbstractDataType {
                     nullable = leftNullable || rightNullable)
                 } catch {
                   case NonFatal(e) =>
-                    throw new SparkException(s"Failed to merge fields '$leftName' and '$rightName'. " + e.getMessage)
+                    throw new SparkException(s"Failed to merge fields '$leftName' and " +
+                      s"'$rightName'. " + e.getMessage)
                 }
               }
               .orElse {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -184,14 +184,17 @@ class DataTypeSuite extends SparkFunSuite {
   test("merge where right contains type conflict") {
     val left = StructType(
       StructField("a", LongType) ::
-      StructField("b", FloatType) :: Nil)
+      StructField("conflictColumn", FloatType) :: Nil)
 
     val right = StructType(
-      StructField("b", LongType) :: Nil)
+      StructField("conflictColumn", LongType) :: Nil)
 
-    intercept[SparkException] {
+    val message = intercept[SparkException] {
       left.merge(right)
-    }
+    }.getMessage
+    assert(message.contains("conflictColumn"))
+    assert(message.contains(FloatType.toString))
+    assert(message.contains(LongType.toString))
   }
 
   test("existsRecursively") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -184,17 +184,16 @@ class DataTypeSuite extends SparkFunSuite {
   test("merge where right contains type conflict") {
     val left = StructType(
       StructField("a", LongType) ::
-      StructField("conflictColumn", FloatType) :: Nil)
+      StructField("b", FloatType) :: Nil)
 
     val right = StructType(
-      StructField("conflictColumn", LongType) :: Nil)
+      StructField("b", LongType) :: Nil)
 
     val message = intercept[SparkException] {
       left.merge(right)
     }.getMessage
-    assert(message.contains("conflictColumn"))
-    assert(message.contains(FloatType.toString))
-    assert(message.contains(LongType.toString))
+    assert(message.equals("Failed to merge fields 'b' and 'b'. " +
+      "Failed to merge incompatible data types FloatType and LongType"))
   }
 
   test("existsRecursively") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, StructType.merge() only reports data types of conflicting fields when merging two incompatible schemas. It would be nice to also report the field names for easier debugging.

## How was this patch tested?

Unit test in DataTypeSuite.
Print exception message when conflict is triggered.
