### PR TITLE
[SPARK-18956][SQL][PySpark] Reuse existing SparkSession while creating new SQLContext instances

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -73,7 +73,7 @@ class SQLContext(object):
         self._jsc = self._sc._jsc
         self._jvm = self._sc._jvm
         if sparkSession is None:
-            sparkSession = SparkSession(sparkContext)
+            sparkSession = SparkSession.builder.getOrCreate()
         if jsqlContext is None:
             jsqlContext = sparkSession._jwrapped
         self.sparkSession = sparkSession


### PR DESCRIPTION
## What changes were proposed in this pull request?

To reuse existing SparkSession while creating new SQLContext instances in PySpark.

## How was this patch tested?

N/A

Please review http://spark.apache.org/contributing.html before opening a pull request.
