### PR TITLE
[SPARK-18036][ML][MLLIB] Fixing decision trees handling edge cases

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
@@ -113,6 +113,8 @@ private[spark] object DecisionTreeMetadata extends Logging {
       throw new IllegalArgumentException(s"DecisionTree requires size of input RDD > 0, " +
         s"but was given by empty one.")
     }
+    require(numFeatures > 0, s"DecisionTree requires number of features > 0, " +
+      s"but was given an empty features vector")
     val numExamples = input.count()
     val numClasses = strategy.algo match {
       case Classification => strategy.numClasses

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -839,11 +839,11 @@ private[spark] object RandomForest extends Logging {
         val parentImpurityCalculator = binAggregates.getImpurityCalculator(
           binAggregates.getFeatureOffset(dummyFeatureIndex), 0)
         if (binAggregates.metadata.isContinuous(dummyFeatureIndex)) {
-          return (new ContinuousSplit(dummyFeatureIndex, 0),
+          (new ContinuousSplit(dummyFeatureIndex, 0),
             ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))
         } else {
           val numCategories = binAggregates.metadata.numBins(dummyFeatureIndex)
-          return (new CategoricalSplit(dummyFeatureIndex, Array(), numCategories),
+          (new CategoricalSplit(dummyFeatureIndex, Array(), numCategories),
             ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))
         }
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -842,7 +842,7 @@ private[spark] object RandomForest extends Logging {
           (new ContinuousSplit(dummyFeatureIndex, 0),
             ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))
         } else {
-          val numCategories = binAggregates.metadata.numBins(dummyFeatureIndex)
+          val numCategories = binAggregates.metadata.featureArity(dummyFeatureIndex)
           (new CategoricalSplit(dummyFeatureIndex, Array(), numCategories),
             ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))
         }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -714,7 +714,7 @@ private[spark] object RandomForest extends Logging {
       }
 
     // For each (feature, split), calculate the gain, and select the best (feature, split).
-    val (bestSplit, bestSplitStats) =
+    val splitsAndImpurityInfo =
       validFeatureSplits.map { case (featureIndexIdx, featureIndex) =>
         val numSplits = binAggregates.metadata.numSplits(featureIndex)
         if (binAggregates.metadata.isContinuous(featureIndex)) {
@@ -828,8 +828,27 @@ private[spark] object RandomForest extends Logging {
             new CategoricalSplit(featureIndex, categoriesForSplit.toArray, numCategories)
           (bestFeatureSplit, bestFeatureGainStats)
         }
-      }.maxBy(_._2.gain)
+      }
 
+    val (bestSplit, bestSplitStats) =
+      if (splitsAndImpurityInfo.isEmpty) {
+        // If no valid splits for features, then this split is invalid,
+        // return invalid information gain stats.  Take any split and continue.
+        // Splits is empty, so arbitrarily choose to split on any threshold
+        val dummyFeatureIndex = featuresForNode.map(_.head).getOrElse(0)
+        val parentImpurityCalculator = binAggregates.getImpurityCalculator(
+          binAggregates.getFeatureOffset(dummyFeatureIndex), 0)
+        if (binAggregates.metadata.isContinuous(dummyFeatureIndex)) {
+          return (new ContinuousSplit(dummyFeatureIndex, 0),
+            ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))
+        } else {
+          val numCategories = binAggregates.metadata.numBins(dummyFeatureIndex)
+          return (new CategoricalSplit(dummyFeatureIndex, Array(), numCategories),
+            ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))
+        }
+      } else {
+        splitsAndImpurityInfo.maxBy(_._2.gain)
+      }
     (bestSplit, bestSplitStats)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -836,8 +836,7 @@ private[spark] object RandomForest extends Logging {
         // return invalid information gain stats.  Take any split and continue.
         // Splits is empty, so arbitrarily choose to split on any threshold
         val dummyFeatureIndex = featuresForNode.map(_.head).getOrElse(0)
-        val parentImpurityCalculator = binAggregates.getImpurityCalculator(
-          binAggregates.getFeatureOffset(dummyFeatureIndex), 0)
+        val parentImpurityCalculator = binAggregates.getParentImpurityCalculator()
         if (binAggregates.metadata.isContinuous(dummyFeatureIndex)) {
           (new ContinuousSplit(dummyFeatureIndex, 0),
             ImpurityStats.getInvalidImpurityStats(parentImpurityCalculator))

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -167,9 +167,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     val rdd = sc.parallelize(data)
 
     val strategy = new OldStrategy(OldAlgo.Regression, Gini, maxDepth = 2,
-      maxBins = 100)
+      maxBins = 5)
     intercept[IllegalArgumentException] {
-      DecisionTreeMetadata.buildMetadata(rdd, strategy)
+      RandomForest.run(rdd, strategy, 1, "all", 42L, instr = None)
     }
   }
 
@@ -181,7 +181,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       Gini,
       maxDepth = 2,
       numClasses = 2,
-      maxBins = 100)
+      maxBins = 5)
     val Array(tree) = RandomForest.run(rdd, strategy, 1, "all", 42L, instr = None)
     assert(tree.rootNode.impurity === -1.0)
     assert(tree.depth === 0)
@@ -197,8 +197,8 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
           Gini,
           maxDepth = 2,
           numClasses = 2,
-          maxBins = 100,
-          categoricalFeaturesInfo = Map(0 -> 1, 1 -> 5))
+          maxBins = 5,
+          categoricalFeaturesInfo = Map(0 -> 1))
     val Array(tree) = RandomForest.run(rdd, strategy, 1, "all", 42L, instr = None)
     assert(tree.rootNode.impurity === -1.0)
     assert(tree.depth === 0)
@@ -210,7 +210,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       Gini,
       maxDepth = 2,
       numClasses = 2,
-      maxBins = 100)
+      maxBins = 5)
     val Array(tree2) = RandomForest.run(rdd, strategy, 1, "all", 42L, instr = None)
     assert(tree2.rootNode.impurity === -1.0)
     assert(tree2.depth === 0)

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -18,14 +18,15 @@
 package org.apache.spark.ml.tree.impl
 
 import scala.collection.mutable
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.classification.DecisionTreeClassificationModel
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.tree._
 import org.apache.spark.ml.util.TestingUtils._
-import org.apache.spark.mllib.tree.{EnsembleTestHelper, DecisionTreeSuite => OldDTSuite}
-import org.apache.spark.mllib.tree.configuration.{QuantileStrategy, Algo => OldAlgo, Strategy => OldStrategy}
+import org.apache.spark.mllib.tree.{DecisionTreeSuite => OldDTSuite, EnsembleTestHelper}
+import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo, QuantileStrategy, Strategy => OldStrategy}
 import org.apache.spark.mllib.tree.impurity.{Entropy, Gini, GiniCalculator, Variance}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.util.collection.OpenHashMap

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -167,8 +167,11 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val strategy = new OldStrategy(OldAlgo.Regression, Gini, maxDepth = 2,
       maxBins = 5)
-    intercept[IllegalArgumentException] {
-      RandomForest.run(rdd, strategy, 1, "all", 42L, instr = None)
+    withClue("DecisionTree requires number of features > 0," +
+      " but was given an empty features vector") {
+      intercept[IllegalArgumentException] {
+        RandomForest.run(rdd, strategy, 1, "all", 42L, instr = None)
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Decision trees/GBT/RF do not handle edge cases such as constant features or empty features.
In the case of constant features we choose any arbitrary split instead of failing with a cryptic error message.
In the case of empty features we fail with a better error message stating:
DecisionTree requires number of features > 0, but was given an empty features vector
Instead of the cryptic error message:
java.lang.UnsupportedOperationException: empty.max

## How was this patch tested?

Unit tests are added in the patch for:
DecisionTreeRegressor
GBTRegressor
Random Forest Regressor