### PR TITLE
[BUILD] make-distribution support alternate python to build pip package

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -116,6 +116,14 @@ if [ -z "$JAVA_HOME" ]; then
   exit -1
 fi
 
+if [ -z "$BUILD_PYTHON" ]; then
+  if [ `command -v python` ]; then
+    BUILD_PYTHON="$(which python)"
+  else
+    BUILD_PYTHON="python"
+  fi
+fi
+
 if [ $(command -v git) ]; then
     GITREV=$(git rev-parse --short HEAD 2>/dev/null || :)
     if [ ! -z "$GITREV" ]; then
@@ -220,7 +228,7 @@ cp -r "$SPARK_HOME/data" "$DISTDIR"
 if [ "$MAKE_PIP" == "true" ]; then
   echo "Building python distribution package"
   pushd "$SPARK_HOME/python" > /dev/null
-  python setup.py sdist
+  $BUILD_PYTHON setup.py sdist
   popd > /dev/null
 else
   echo "Skipping building python distribution package"


### PR DESCRIPTION
## What changes were proposed in this pull request?

make-distribution.sh to take an alternate python - this would allow build to use python3 or virtualenv.

Note that alias (doesn't pass to script) or PATH (can't change python to python3) or ln (can break system that expects python2) doesn't work.

## How was this patch tested?

Manually
