### PR TITLE
[SPARK-19001] [Deploy]don't submit sendHeartbeat task again if has registered…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -103,6 +103,7 @@ private[deploy] class Worker(
   private[worker] var activeMasterWebUiUrl : String = ""
   private val workerUri = rpcEnv.uriOf(systemName, rpcEnv.address, endpointName)
   private var registered = false
+  private var hasRegisteredBefore = false
   private var connected = false
   private val workerId = generateWorkerId()
   private val sparkHome =
@@ -358,6 +359,10 @@ private[deploy] class Worker(
         logInfo("Successfully registered with master " + masterRef.address.toSparkURL)
         registered = true
         changeMaster(masterRef, masterWebUiUrl)
+        if (hasRegisteredBefore) {
+          return
+        }
+        hasRegisteredBefore = true
         forwordMessageScheduler.scheduleAtFixedRate(new Runnable {
           override def run(): Unit = Utils.tryLogNonFatalError {
             self.send(SendHeartbeat)


### PR DESCRIPTION

## What changes were proposed in this pull request?

when first successfully registered response received, set the flag `hasRegisteredBefore` as `true`, and when it register next time, it will not submit the `SendHeartbeat` task again  
