### PR TITLE
[SPARK-19003][DOCS] Add Java example in Spark Streaming Guide, section Design Patterns for using foreachRDD

### DIFF
--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1246,6 +1246,21 @@ dstream.foreachRDD { rdd =>
 }
 {% endhighlight %}
 </div>
+<div data-lang="java" markdown="1">
+{% highlight java %}
+dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
+  @Override public void call(JavaRDD<String> rdd) throws Exception {
+    final Connection connection =  new Connection(connectionString); // executed at the driver
+    rdd.foreach(new VoidFunction<String>() {
+      @Override public void call(String record) throws Exception {
+        connection.send(record); // executed at the worker
+      }
+    });
+    connection.close();
+  }
+});
+{% endhighlight %}
+</div>
 <div data-lang="python" markdown="1">
 {% highlight python %}
 def sendRecord(rdd):
@@ -1279,6 +1294,21 @@ dstream.foreachRDD { rdd =>
 }
 {% endhighlight %}
 </div>
+<div data-lang="java" markdown="1">
+{% highlight java %}
+dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
+  @Override public void call(JavaRDD<String> rdd) throws Exception {
+    rdd.foreach(new VoidFunction<String>() {
+      @Override public void call(String record) throws Exception {
+        Connection connection = new Connection(connectionString);
+        connection.send(record);
+        connection.close();
+      }
+    });
+  }
+});
+{% endhighlight %}
+</div>
 <div data-lang="python" markdown="1">
 {% highlight python %}
 def sendRecord(record):
@@ -1307,6 +1337,23 @@ dstream.foreachRDD { rdd =>
     connection.close()
   }
 }
+{% endhighlight %}
+</div>
+<div data-lang="java" markdown="1">
+{% highlight java %}
+dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
+  @Override public void call(JavaRDD<String> rdd) throws Exception {
+    rdd.foreachPartition(new VoidFunction<Iterator<String>>() {
+      @Override public void call(Iterator<String> partitionOfRecords) throws Exception {
+        Connection connection = new Connection(connectionString);
+        while (partitionOfRecords.hasNext()) {
+          connection.send(partitionOfRecords.next());
+        }
+        connection.close();
+      }
+    });
+  }
+});
 {% endhighlight %}
 </div>
 <div data-lang="python" markdown="1">
@@ -1342,6 +1389,23 @@ dstream.foreachRDD { rdd =>
 {% endhighlight %}
 </div>
 
+<div data-lang="java" markdown="1">
+{% highlight java %}
+dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
+  @Override public void call(JavaRDD<String> rdd) throws Exception {
+    rdd.foreachPartition(new VoidFunction<Iterator<String>>() {
+      @Override public void call(Iterator<String> partitionOfRecords) throws Exception {
+        Connection connection = ConnectionPool.getConnection(connectionString);
+        while (partitionOfRecords.hasNext()) {
+          connection.send(partitionOfRecords.next());
+        }
+        ConnectionPool.releaseConnection(connection);
+      }
+    });
+  }
+});
+{% endhighlight %}
+</div>
 <div data-lang="python" markdown="1">
 {% highlight python %}
 def sendPartition(iter):

--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1249,14 +1249,15 @@ dstream.foreachRDD { rdd =>
 <div data-lang="java" markdown="1">
 {% highlight java %}
 dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
-  @Override public void call(JavaRDD<String> rdd) throws Exception {
-    final Connection connection =  new Connection(connectionString); // executed at the driver
+  @Override
+  public void call(JavaRDD<String> rdd) {
+    final Connection connection = createNewConnection(); // executed at the driver
     rdd.foreach(new VoidFunction<String>() {
-      @Override public void call(String record) throws Exception {
+      @Override
+      public void call(String record) {
         connection.send(record); // executed at the worker
       }
     });
-    connection.close();
   }
 });
 {% endhighlight %}
@@ -1297,10 +1298,12 @@ dstream.foreachRDD { rdd =>
 <div data-lang="java" markdown="1">
 {% highlight java %}
 dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
-  @Override public void call(JavaRDD<String> rdd) throws Exception {
+  @Override
+  public void call(JavaRDD<String> rdd) {
     rdd.foreach(new VoidFunction<String>() {
-      @Override public void call(String record) throws Exception {
-        Connection connection = new Connection(connectionString);
+      @Override
+      public void call(String record) {
+        Connection connection = createNewConnection();
         connection.send(record);
         connection.close();
       }
@@ -1342,10 +1345,12 @@ dstream.foreachRDD { rdd =>
 <div data-lang="java" markdown="1">
 {% highlight java %}
 dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
-  @Override public void call(JavaRDD<String> rdd) throws Exception {
+  @Override
+  public void call(JavaRDD<String> rdd) {
     rdd.foreachPartition(new VoidFunction<Iterator<String>>() {
-      @Override public void call(Iterator<String> partitionOfRecords) throws Exception {
-        Connection connection = new Connection(connectionString);
+      @Override
+      public void call(Iterator<String> partitionOfRecords) {
+        Connection connection = createNewConnection();
         while (partitionOfRecords.hasNext()) {
           connection.send(partitionOfRecords.next());
         }
@@ -1392,14 +1397,17 @@ dstream.foreachRDD { rdd =>
 <div data-lang="java" markdown="1">
 {% highlight java %}
 dstream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
-  @Override public void call(JavaRDD<String> rdd) throws Exception {
+  @Override
+  public void call(JavaRDD<String> rdd) {
     rdd.foreachPartition(new VoidFunction<Iterator<String>>() {
-      @Override public void call(Iterator<String> partitionOfRecords) throws Exception {
-        Connection connection = ConnectionPool.getConnection(connectionString);
+      @Override
+      public void call(Iterator<String> partitionOfRecords) {
+        // ConnectionPool is a static, lazily initialized pool of connections
+        Connection connection = ConnectionPool.getConnection();
         while (partitionOfRecords.hasNext()) {
           connection.send(partitionOfRecords.next());
         }
-        ConnectionPool.releaseConnection(connection);
+        ConnectionPool.returnConnection(connection); // return to the pool for future reuse
       }
     });
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added missing Java example under section "Design Patterns for using foreachRDD". Now this section has examples in all 3 languages, improving consistency of documentation.


## How was this patch tested?

Manual.
Generated docs using command "SKIP_API=1 jekyll build" and verified generated HTML page manually.

The syntax of example has been tested for correctness using sample code on Java1.7 and Spark 2.2.0-SNAPSHOT.

