### PR TITLE
[SPARK-19063][ML]Speedup and optimize the GradientBoostedTrees

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -137,6 +137,10 @@ class GBTClassifier @Since("1.4.0") (
   @Since("1.4.0")
   override def setStepSize(value: Double): this.type = set(stepSize, value)
 
+  @Since("2.1.0")
+  override def setPeriodicRDDStorageLevel(value: String): this.type =
+    set(PeriodicRDDStorageLevel, value)
+    
   // Parameters from GBTClassifierParams:
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -134,6 +134,10 @@ class GBTRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   @Since("1.4.0")
   override def setStepSize(value: Double): this.type = set(stepSize, value)
 
+  @Since("2.1.0")
+  override def setPeriodicRDDStorageLevel(value: String): this.type =
+    set(PeriodicRDDStorageLevel, value)
+    
   // Parameters from GBTRegressorParams:
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -309,7 +309,7 @@ private[spark] object GradientBoostedTrees extends Logging {
 
     var m = 1
     var doneLearning = false
-    var pre_predError=predError
+    var previousPredError = predError
     while (m < numIterations && !doneLearning) {
       // Update data with pseudo-residuals
       val data = predError.zip(input).map { case ((pred, _), point) =>
@@ -330,10 +330,10 @@ private[spark] object GradientBoostedTrees extends Logging {
       //       However, the behavior should be reasonable, though not optimal.
       baseLearnerWeights(m) = learningRate
 
-      if (pre_predError.getStorageLevel != StorageLevel.NONE ){
-        pre_predError.unpersist()
+      if (previousPredError.getStorageLevel != StorageLevel.NONE) {
+        previousPredError.unpersist()
       }
-      pre_predError=predError
+      previousPredError = predError
 
       predError = updatePredictionError(
         input, predError, baseLearnerWeights(m), baseLearners(m), loss)
@@ -369,11 +369,11 @@ private[spark] object GradientBoostedTrees extends Logging {
     logInfo("Internal timing for DecisionTree:")
     logInfo(s"$timer")
 
-    if (predError.getStorageLevel != StorageLevel.NONE){
+    if (predError.getStorageLevel != StorageLevel.NONE) {
       predError.unpersist()
     }
-    if (pre_predError.getStorageLevel != StorageLevel.NONE) {
-      pre_predError.unpersist()
+    if (previousPredError.getStorageLevel != StorageLevel.NONE) {
+      previousPredError.unpersist()
     }
     
     predErrorCheckpointer.deleteAllCheckpoints()

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/GradientBoostedTrees.scala
@@ -295,7 +295,7 @@ private[spark] object GradientBoostedTrees extends Logging {
 
     var predError: RDD[(Double, Double)] =
       computeInitialPredictionAndError(input, firstTreeWeight, firstTreeModel, loss)
-    predErrorCheckpointer.update(predError)
+    predErrorCheckpointer.update(predError, boostingStrategy.PeriodicRDDStorageLevel)
     logDebug("error of gbt = " + predError.values.mean())
 
     // Note: A model of type regression is used since we require raw prediction
@@ -303,7 +303,8 @@ private[spark] object GradientBoostedTrees extends Logging {
 
     var validatePredError: RDD[(Double, Double)] =
       computeInitialPredictionAndError(validationInput, firstTreeWeight, firstTreeModel, loss)
-    if (validate) validatePredErrorCheckpointer.update(validatePredError)
+    if (validate) validatePredErrorCheckpointer
+      .update(validatePredError, boostingStrategy.PeriodicRDDStorageLevel)
     var bestValidateError = if (validate) validatePredError.values.mean() else 0.0
     var bestM = 1
 
@@ -331,7 +332,7 @@ private[spark] object GradientBoostedTrees extends Logging {
 
       predError = updatePredictionError(
         input, predError, baseLearnerWeights(m), baseLearners(m), loss)
-      predErrorCheckpointer.update(predError)
+      predErrorCheckpointer.update(predError, boostingStrategy.PeriodicRDDStorageLevel)
       logDebug("error of gbt = " + predError.values.mean())
 
       if (validate) {
@@ -342,7 +343,8 @@ private[spark] object GradientBoostedTrees extends Logging {
 
         validatePredError = updatePredictionError(
           validationInput, validatePredError, baseLearnerWeights(m), baseLearners(m), loss)
-        validatePredErrorCheckpointer.update(validatePredError)
+        validatePredErrorCheckpointer
+          .update(validatePredError, boostingStrategy.PeriodicRDDStorageLevel)
         val currentValidateError = validatePredError.values.mean()
         if (bestValidateError - currentValidateError < validationTol * Math.max(
           currentValidateError, 0.01)) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/impl/PeriodicCheckpointer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/impl/PeriodicCheckpointer.scala
@@ -78,8 +78,8 @@ private[mllib] abstract class PeriodicCheckpointer[T](
    *
    * @param newData  New Dataset created from previous Datasets in the lineage.
    */
-  def update(newData: T): Unit = {
-    persist(newData)
+  def update(newData: T, level: StorageLevel = StorageLevel.MEMORY_AND_DISK): Unit = {
+    persist(newData, level)
     persistedQueue.enqueue(newData)
     // We try to maintain 2 Datasets in persistedQueue to support the semantics of this class:
     // Users should call [[update()]] when a new Dataset has been created,
@@ -119,7 +119,7 @@ private[mllib] abstract class PeriodicCheckpointer[T](
    * Persist the Dataset.
    * Note: This should handle checking the current [[StorageLevel]] of the Dataset.
    */
-  protected def persist(data: T): Unit
+  protected def persist(data: T, level: StorageLevel): Unit
 
   /** Unpersist the Dataset */
   protected def unpersist(data: T): Unit

--- a/mllib/src/main/scala/org/apache/spark/mllib/impl/PeriodicRDDCheckpointer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/impl/PeriodicRDDCheckpointer.scala
@@ -85,7 +85,7 @@ private[spark] class PeriodicRDDCheckpointer[T](
 
   override protected def persist(data: RDD[T]): Unit = {
     if (data.getStorageLevel == StorageLevel.NONE) {
-      data.persist()
+      data.persist(StorageLevel.MEMORY_AND_DISK)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/impl/PeriodicRDDCheckpointer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/impl/PeriodicRDDCheckpointer.scala
@@ -83,9 +83,9 @@ private[spark] class PeriodicRDDCheckpointer[T](
 
   override protected def isCheckpointed(data: RDD[T]): Boolean = data.isCheckpointed
 
-  override protected def persist(data: RDD[T]): Unit = {
+  override protected def persist(data: RDD[T], level: StorageLevel): Unit = {
     if (data.getStorageLevel == StorageLevel.NONE) {
-      data.persist(StorageLevel.MEMORY_AND_DISK)
+      data.persist(level)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
@@ -53,7 +53,9 @@ case class BoostingStrategy @Since("1.4.0") (
     // Optional boosting parameters
     @Since("1.2.0") @BeanProperty var numIterations: Int = 100,
     @Since("1.2.0") @BeanProperty var learningRate: Double = 0.1,
-    @Since("1.4.0") @BeanProperty var validationTol: Double = 0.001) extends Serializable {
+    @Since("1.4.0") @BeanProperty var validationTol: Double = 0.001,
+    @Since("2.1.0") @BeanProperty var PeriodicRDDStorageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK)
+extends Serializable {
 
   /**
    * Check validity of parameters.


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-19007

Speedup and optimize the GradientBoostedTrees in the "data>memory" scene  by persist the RDD named predError.

Test data：80G CTR training data from criteolabs(http://criteolabs.wpengine.com/downloads/download-terabyte-click-logs/ ) ,I used 1 of the 24 days' data.Some features needed to be repalced by new generated continuous features，the way to generate the new features refers to the way mentioned in the xgboost's paper.

Recource allocated: spark on yarn, 20 executors, 8G memory and 2 cores per executor.
I tested the GradientBoostedTrees algorithm in mllib using 80G CTR data mentioned above.
It totally costs 1.5 hour, and i found many task failures after 6 or 7 GBT rounds later.Without these task failures and task retry it can be much faster ,which can save about half the time. I think it's caused by the RDD named predError in the while loop of the boost method at GradientBoostedTrees.scala,because the lineage of the RDD named predError is growing after every GBT round, and then it caused failures like this :

(ExecutorLostFailure (executor 6 exited caused by one of the running tasks) Reason: Container killed by YARN for exceeding memory limits. 10.2 GB of 10 GB physical memory used. Consider boosting spark.yarn.executor.memoryOverhead.).

I tried to boosting spark.yarn.executor.memoryOverhead but the meomry it needed is too much (even increase half the memory can't solve the problem) so i think it's not a proper method.

Although it can set the predCheckpoint Interval smaller to cut the line of the lineage but it increases IO cost a lot.

I tried another way to solve this problem.I persisted the RDD named predError every round and use pre_predError to record the previous RDD and unpersist it because it's useless anymore.
Finally it costs about 45 min after i tried my method and no task failure occured and no more memeory added.

So when the data is much larger than memory, my little improvement can speedup the GradientBoostedTrees 1~2 times.