### PR TITLE
[SPARK-18698][ML] Adding public constructor that takes uid for IndexToString

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -255,7 +255,7 @@ object StringIndexerModel extends MLReadable[StringIndexerModel] {
  * @see `StringIndexer` for converting strings into indices
  */
 @Since("1.5.0")
-class IndexToString private[ml] (@Since("1.5.0") override val uid: String)
+class IndexToString @Since("2.2.0") (@Since("1.5.0") override val uid: String)
   extends Transformer with HasInputCol with HasOutputCol with DefaultParamsWritable {
 
   @Since("1.5.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
 import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
+import org.apache.spark.ml.util.{DefaultReadWriteTest, Identifiable, MLTestingUtils}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
@@ -217,6 +217,16 @@ class StringIndexerSuite
       .setOutputCol("myOutputCol")
       .setLabels(Array("a", "b", "c"))
     testDefaultReadWrite(t)
+  }
+
+  test("SPARK 18698: construct IndexToString with custom uid") {
+    val uid = Identifiable.randomUID("customuid")
+    val t = new IndexToString(uid)
+      .setInputCol("myInputCol")
+      .setOutputCol("myOutputCol")
+      .setLabels(Array("label"))
+    testDefaultReadWrite(t)
+    assert(t.uid == uid)
   }
 
   test("StringIndexer metadata") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -220,12 +220,8 @@ class StringIndexerSuite
   }
 
   test("SPARK 18698: construct IndexToString with custom uid") {
-    val uid = Identifiable.randomUID("customuid")
+    val uid = "customUID"
     val t = new IndexToString(uid)
-      .setInputCol("myInputCol")
-      .setOutputCol("myOutputCol")
-      .setLabels(Array("label"))
-    testDefaultReadWrite(t)
     assert(t.uid == uid)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Based on SPARK-18698, this adds a public constructor that takes a UID for IndexToString.  Other transforms have similar constructors.

## How was this patch tested?

A unit test was added to verify the new functionality.