### PR TITLE
[SPARK-19026]SPARK_LOCAL_DIRS(multiple directories on different disks) cannot be deleted 

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -453,11 +453,11 @@ private[deploy] class Worker(
                 Some(appDir.getAbsolutePath())
               } catch {
                 case e: IOException =>
-                  logError(s"${e.getMessage}. Ignoring this directory.")
+                  logWarning(s"${e.getMessage}. Ignoring this directory.")
                   None
               }
             }.toSeq
-            if (dirs.length <= 0) {
+            if (dirs.isEmpty) {
               throw new IOException("None subfolder can be created in " +
                 s"${Utils.getOrCreateLocalRootDirs(conf).mkString(",")}.")
             }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -446,7 +446,8 @@ private[deploy] class Worker(
           // SPARK_EXECUTOR_DIRS environment variable, and deleted by the Worker when the
           // application finishes.
           val appLocalDirs = appDirectories.getOrElse(appId, {
-            val dirs = Utils.getOrCreateLocalRootDirs(conf).flatMap { dir =>
+            val localRootDirs = Utils.getOrCreateLocalRootDirs(conf)
+            val dirs = localRootDirs.flatMap { dir =>
               try {
                 val appDir = Utils.createDirectory(dir, namePrefix = "executor")
                 Utils.chmod700(appDir)
@@ -458,8 +459,8 @@ private[deploy] class Worker(
               }
             }.toSeq
             if (dirs.isEmpty) {
-              throw new IOException("None subfolder can be created in " +
-                s"${Utils.getOrCreateLocalRootDirs(conf).mkString(",")}.")
+              throw new IOException("No subfolder can be created in " +
+                s"${localRootDirs.mkString(",")}.")
             }
             dirs
           })


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-19026

SPARK_LOCAL_DIRS (Standalone) can  be a comma-separated list of multiple directories on different disks, e.g. SPARK_LOCAL_DIRS=/dir1,/dir2,/dir3, if there is a IOExecption when create sub directory on dir3 , the sub directory which have been created successfully on dir1 and dir2 cannot be deleted anymore when the application finishes. 
So we should catch the IOExecption at Utils.createDirectory  , otherwise the variable "appDirectories(appId)" which the function maybeCleanupApplication calls will not be set then dir1 and dir2 will not be cleaned up .