### PR TITLE
[SPARK-14975][ML] Fixed GBTClassifier to predict probability per training instance and fixed interfaces

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -177,8 +177,6 @@ class DecisionTreeClassificationModel private[ml] (
   /**
    * Construct a decision tree classification model.
    * @param rootNode  Root node of tree, with other nodes attached.
-   * @param numFeatures The number of features.
-   * @param numClasses The number of classes to predict.
    */
   private[ml] def this(rootNode: Node, numFeatures: Int, numClasses: Int) =
     this(Identifiable.randomUID("dtc"), rootNode, numFeatures, numClasses)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -177,6 +177,8 @@ class DecisionTreeClassificationModel private[ml] (
   /**
    * Construct a decision tree classification model.
    * @param rootNode  Root node of tree, with other nodes attached.
+   * @param numFeatures The number of features.
+   * @param numClasses The number of classes to predict.
    */
   private[ml] def this(rootNode: Node, numFeatures: Int, numClasses: Int) =
     this(Identifiable.randomUID("dtc"), rootNode, numFeatures, numClasses)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -200,6 +200,8 @@ object GBTClassifier extends DefaultParamsReadable[GBTClassifier] {
  *
  * @param _trees  Decision trees in the ensemble.
  * @param _treeWeights  Weights for the decision trees in the ensemble.
+ * @param numFeatures  The number of features.
+ * @param numClasses  The number of classes.
  *
  * @note Multiclass labels are not currently supported.
  */
@@ -223,11 +225,23 @@ class GBTClassificationModel private[ml](
    *
    * @param _trees  Decision trees in the ensemble.
    * @param _treeWeights  Weights for the decision trees in the ensemble.
+   * @param numFeatures  The number of features.
+   */
+  @Since("1.6.0")
+  def this(uid: String, _trees: Array[DecisionTreeRegressionModel],
+           _treeWeights: Array[Double], numFeatures: Int) =
+    this(uid, _trees, _treeWeights, numFeatures, 2)
+
+  /**
+   * Construct a GBTClassificationModel
+   *
+   * @param _trees  Decision trees in the ensemble.
+   * @param _treeWeights  Weights for the decision trees in the ensemble.
    */
   @Since("1.6.0")
   def this(uid: String, _trees: Array[DecisionTreeRegressionModel],
            _treeWeights: Array[Double]) =
-    this(uid, _trees, _treeWeights, -1, 2)
+  this(uid, _trees, _treeWeights, -1, 2)
 
   @Since("1.4.0")
   override def trees: Array[DecisionTreeRegressionModel] = _trees

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -158,7 +158,7 @@ class GBTClassifier @Since("1.4.0") (
     val numFeatures = oldDataset.first().features.size
     val boostingStrategy = super.getOldBoostingStrategy(categoricalFeatures, OldAlgo.Classification)
 
-    val numClasses: Int = 2
+    val numClasses = 2
     if (isDefined(thresholds)) {
       require($(thresholds).length == numClasses, this.getClass.getSimpleName +
         ".train() called with non-matching numClasses and thresholds.length." +
@@ -201,8 +201,6 @@ object GBTClassifier extends DefaultParamsReadable[GBTClassifier] {
  *
  * @param _trees  Decision trees in the ensemble.
  * @param _treeWeights  Weights for the decision trees in the ensemble.
- * @param numFeatures  The number of features.
- * @param numClasses  The number of classes.
  *
  * @note Multiclass labels are not currently supported.
  */
@@ -329,6 +327,7 @@ class GBTClassificationModel private[ml](
     new OldGBTModel(OldAlgo.Classification, _trees.map(_.toOld), _treeWeights)
   }
 
+  // hard coded loss, which is not meant to be changed in the model
   private val loss = getOldLossType
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -318,6 +318,7 @@ class GBTClassificationModel private[ml](
   @Since("2.0.0")
   lazy val featureImportances: Vector = TreeEnsembleModel.featureImportances(trees, numFeatures)
 
+  /** Raw prediction for the positive class. */
   private def margin(features: Vector): Double = {
     val treePredictions = _trees.map(_.rootNode.predictImpl(features).prediction)
     blas.ddot(numTrees, treePredictions, 1, _treeWeights, 1)
@@ -328,11 +329,7 @@ class GBTClassificationModel private[ml](
     new OldGBTModel(OldAlgo.Classification, _trees.map(_.toOld), _treeWeights)
   }
 
-  /**
-   * Note: this is currently an optimization that should be removed when we have more loss
-   * functions available than only logistic.
-   */
-  private lazy val loss = getOldLossType
+  private val loss = getOldLossType
 
   @Since("2.0.0")
   override def write: MLWriter = new GBTClassificationModel.GBTClassificationModelWriter(this)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ml.classification
 import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import org.json4s.{DefaultFormats, JObject}
 import org.json4s.JsonDSL._
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.LabeledPoint
@@ -32,7 +33,6 @@ import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel => OldGBTModel}
-import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
@@ -280,14 +280,14 @@ class GBTClassificationModel private[ml](
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
     rawPrediction match {
       // The probability can be calculated for positive result:
-      // p+(x) = 1 / (1 + e^(-F(x)))
+      // p+(x) = 1 / (1 + e^(-2 * F(x)))
       // and negative result:
-      // p-(x) = 1 / (1 + e^(F(x)))
+      // p-(x) = 1 / (1 + e^(2 * F(x)))
       case dv: DenseVector =>
         var i = 0
         val size = dv.size
         while (i < size) {
-          dv.values(i) = 1 / (1 + math.exp(-dv.values(i)))
+          dv.values(i) = 1 / (1 + math.exp(-2 * dv.values(i)))
           i += 1
         }
         dv

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -228,7 +228,8 @@ class GBTClassificationModel private[ml](
    * @param _treeWeights  Weights for the decision trees in the ensemble.
    * @param numFeatures  The number of features.
    */
-  private[ml] def this(uid: String,
+  private[ml] def this(
+      uid: String,
       _trees: Array[DecisionTreeRegressionModel],
       _treeWeights: Array[Double],
       numFeatures: Int) =

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -280,14 +280,14 @@ class GBTClassificationModel private[ml](
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
     rawPrediction match {
       // The probability can be calculated for positive result:
-      // p+(x) = 1 / (1 + e^(-2*F(x)))
+      // p+(x) = 1 / (1 + e^(-F(x)))
       // and negative result:
-      // p-(x) = 1 / (1 + e^(2*F(x)))
+      // p-(x) = 1 / (1 + e^(F(x)))
       case dv: DenseVector =>
         var i = 0
         val size = dv.size
         while (i < size) {
-          dv.values(i) = 1 / MLUtils.log1pExp(-dv.values(i))
+          dv.values(i) = 1 / (1 + math.exp(-dv.values(i)))
           i += 1
         }
         dv

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -279,7 +279,7 @@ class GBTClassificationModel private[ml](
       // and negative result:
       // p-(x) = 1 / (1 + e^(2 * F(x)))
       case dv: DenseVector =>
-        dv.values(0) = classProbability(getLossType, dv.values(0))
+        dv.values(0) = getOldLossType.computeProbability(dv.values(0))
         dv.values(1) = 1.0 - dv.values(0)
         dv
       case sv: SparseVector =>
@@ -314,13 +314,6 @@ class GBTClassificationModel private[ml](
    */
   @Since("2.0.0")
   lazy val featureImportances: Vector = TreeEnsembleModel.featureImportances(trees, numFeatures)
-
-  private def classProbability(loss: String, rawPrediction: Double): Double = {
-    loss match {
-      case "logistic" => LogLoss.computeProbability(rawPrediction)
-      case _ => throw new Exception("Only logistic loss is supported ...")
-    }
-  }
 
   private def margin(features: Vector): Double = {
     val treePredictions = _trees.map(_.rootNode.predictImpl(features).prediction)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -225,6 +225,18 @@ class GBTClassificationModel private[ml](
    *
    * @param _trees  Decision trees in the ensemble.
    * @param _treeWeights  Weights for the decision trees in the ensemble.
+   * @param numFeatures  The number of features.
+   */
+  @Since("1.6.0")
+  private[ml] def this(uid: String, _trees: Array[DecisionTreeRegressionModel],
+    _treeWeights: Array[Double], numFeatures: Int) =
+  this(uid, _trees, _treeWeights, numFeatures, 2)
+
+  /**
+   * Construct a GBTClassificationModel
+   *
+   * @param _trees  Decision trees in the ensemble.
+   * @param _treeWeights  Weights for the decision trees in the ensemble.
    */
   @Since("1.6.0")
   def this(uid: String, _trees: Array[DecisionTreeRegressionModel], _treeWeights: Array[Double]) =

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ml.classification
 import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import org.json4s.{DefaultFormats, JObject}
 import org.json4s.JsonDSL._
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.LabeledPoint

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -228,7 +228,8 @@ class GBTClassificationModel private[ml](
    * @param _treeWeights  Weights for the decision trees in the ensemble.
    * @param numFeatures  The number of features.
    */
-  private[ml] def this(uid: String, _trees: Array[DecisionTreeRegressionModel],
+  private[ml] def this(uid: String,
+      _trees: Array[DecisionTreeRegressionModel],
       _treeWeights: Array[Double],
       numFeatures: Int) =
     this(uid, _trees, _treeWeights, numFeatures, 2)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -225,22 +225,9 @@ class GBTClassificationModel private[ml](
    *
    * @param _trees  Decision trees in the ensemble.
    * @param _treeWeights  Weights for the decision trees in the ensemble.
-   * @param numFeatures  The number of features.
    */
   @Since("1.6.0")
-  def this(uid: String, _trees: Array[DecisionTreeRegressionModel],
-           _treeWeights: Array[Double], numFeatures: Int) =
-    this(uid, _trees, _treeWeights, numFeatures, 2)
-
-  /**
-   * Construct a GBTClassificationModel
-   *
-   * @param _trees  Decision trees in the ensemble.
-   * @param _treeWeights  Weights for the decision trees in the ensemble.
-   */
-  @Since("1.6.0")
-  def this(uid: String, _trees: Array[DecisionTreeRegressionModel],
-           _treeWeights: Array[Double]) =
+  def this(uid: String, _trees: Array[DecisionTreeRegressionModel], _treeWeights: Array[Double]) =
   this(uid, _trees, _treeWeights, -1, 2)
 
   @Since("1.4.0")
@@ -287,7 +274,7 @@ class GBTClassificationModel private[ml](
         var i = 0
         val size = dv.size
         while (i < size) {
-          dv.values(i) = 1 / (1 + math.exp(-2 * dv.values(i)))
+          dv.values(i) = classProbability(getLossType, dv.values(i))
           i += 1
         }
         dv
@@ -323,6 +310,13 @@ class GBTClassificationModel private[ml](
    */
   @Since("2.0.0")
   lazy val featureImportances: Vector = TreeEnsembleModel.featureImportances(trees, numFeatures)
+
+  private def classProbability(loss: String, rawPrediction: Double): Double = {
+    loss match {
+      case "logistic" => 1 / (1 + math.exp(-2 * rawPrediction))
+      case _ => throw new Exception("Only logistic loss is supported ...")
+    }
+  }
 
   /** (private[ml]) Convert to a model in the old API */
   private[ml] def toOld: OldGBTModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -263,8 +263,13 @@ class GBTClassificationModel private[ml](
   }
 
   override protected def predict(features: Vector): Double = {
-    val prediction: Double = margin(features)
-    if (prediction > 0.0) 1.0 else 0.0
+    // If thresholds defined, use predictRaw to get probabilities, otherwise use optimization
+    if (isDefined(thresholds)) {
+      super.predict(features)
+    } else {
+      val prediction: Double = margin(features)
+      if (prediction > 0.0) 1.0 else 0.0
+    }
   }
 
   override protected def predictRaw(features: Vector): Vector = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ml.classification
 import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import org.json4s.{DefaultFormats, JObject}
 import org.json4s.JsonDSL._
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.LabeledPoint
@@ -31,7 +32,7 @@ import org.apache.spark.ml.tree.impl.GradientBoostedTrees
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
-import org.apache.spark.mllib.tree.loss.{ClassificationLoss, LogLoss}
+import org.apache.spark.mllib.tree.loss.LogLoss
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel => OldGBTModel}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row}

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -25,7 +25,7 @@ import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util.SchemaUtils
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo, BoostingStrategy => OldBoostingStrategy, Strategy => OldStrategy}
 import org.apache.spark.mllib.tree.impurity.{Entropy => OldEntropy, Gini => OldGini, Impurity => OldImpurity, Variance => OldVariance}
-import org.apache.spark.mllib.tree.loss.{AbsoluteError => OldAbsoluteError, LogLoss => OldLogLoss, Loss => OldLoss, SquaredError => OldSquaredError}
+import org.apache.spark.mllib.tree.loss.{AbsoluteError => OldAbsoluteError, ClassificationLoss => OldClassificationLoss, LogLoss => OldLogLoss, Loss => OldLoss, SquaredError => OldSquaredError}
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 
 /**
@@ -531,7 +531,7 @@ private[ml] trait GBTClassifierParams extends GBTParams with TreeClassifierParam
   def getLossType: String = $(lossType).toLowerCase
 
   /** (private[ml]) Convert new loss to old loss. */
-  override private[ml] def getOldLossType: OldLoss = {
+  override private[ml] def getOldLossType: OldClassificationLoss = {
     getLossType match {
       case "logistic" => OldLogLoss
       case _ =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
@@ -21,13 +21,6 @@ import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.mllib.util.MLUtils
 
 /**
- * Trait for adding probability function for the gradient boosting algorithm.
- */
-private[spark] trait ClassificationLoss extends Loss {
-  private[spark] def computeProbability(prediction: Double): Double
-}
-
-/**
  * :: DeveloperApi ::
  * Class for log loss calculation (for classification).
  * This uses twice the binomial negative log likelihood, called "deviance" in Friedman (1999).

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
@@ -52,9 +52,10 @@ object LogLoss extends ClassificationLoss {
     2.0 * MLUtils.log1pExp(-margin)
   }
 
-  override private[spark] def computeProbability(prediction: Double): Double = {
-    // The probability can be calculated as:
-    // p+(x) = 1 / (1 + e^(-2 * F(x)))
-    1.0 / (1.0 + math.exp(-2.0 * prediction))
+  /**
+   * Returns the estimated probability of a label of 1.0.
+   */
+  override private[spark] def computeProbability(margin: Double): Double = {
+    1.0 / (1.0 + math.exp(-2.0 * margin))
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
@@ -21,12 +21,9 @@ import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.mllib.util.MLUtils
 
 /**
- * :: DeveloperApi ::
- * Trait for adding "pluggable" probability function for the gradient boosting algorithm.
+ * Trait for adding probability function for the gradient boosting algorithm.
  */
-@Since("1.2.0")
-@DeveloperApi
-trait ClassificationLoss extends Loss {
+private[spark] trait ClassificationLoss extends Loss {
   private[spark] def computeProbability(prediction: Double): Double
 }
 
@@ -63,6 +60,8 @@ object LogLoss extends ClassificationLoss {
   }
 
   override private[spark] def computeProbability(prediction: Double): Double = {
-    1 / (1 + math.exp(-2 * prediction))
+    // The probability can be calculated as:
+    // p+(x) = 1 / (1 + e^(-2 * F(x)))
+    1.0 / (1.0 + math.exp(-2.0 * prediction))
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/LogLoss.scala
@@ -20,6 +20,15 @@ package org.apache.spark.mllib.tree.loss
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.mllib.util.MLUtils
 
+/**
+ * :: DeveloperApi ::
+ * Trait for adding "pluggable" probability function for the gradient boosting algorithm.
+ */
+@Since("1.2.0")
+@DeveloperApi
+trait ClassificationLoss extends Loss {
+  private[spark] def computeProbability(prediction: Double): Double
+}
 
 /**
  * :: DeveloperApi ::
@@ -32,7 +41,7 @@ import org.apache.spark.mllib.util.MLUtils
  */
 @Since("1.2.0")
 @DeveloperApi
-object LogLoss extends Loss {
+object LogLoss extends ClassificationLoss {
 
   /**
    * Method to calculate the loss gradients for the gradient boosting calculation for binary
@@ -51,5 +60,9 @@ object LogLoss extends Loss {
     val margin = 2.0 * label * prediction
     // The following is equivalent to 2.0 * log(1 + exp(-margin)) but more numerically stable.
     2.0 * MLUtils.log1pExp(-margin)
+  }
+
+  override private[spark] def computeProbability(prediction: Double): Double = {
+    1 / (1 + math.exp(-2 * prediction))
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/Loss.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/Loss.scala
@@ -70,8 +70,6 @@ trait Loss extends Serializable {
 private[spark] trait ClassificationLoss extends Loss {
   /**
    * Computes the class probability given the margin.
-   * @param prediction The margin.
-   * @return The class probability from the margin.
    */
-  private[spark] def computeProbability(prediction: Double): Double
+  private[spark] def computeProbability(margin: Double): Double
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/Loss.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/Loss.scala
@@ -22,7 +22,6 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.model.TreeEnsembleModel
 import org.apache.spark.rdd.RDD
 
-
 /**
  * :: DeveloperApi ::
  * Trait for adding "pluggable" loss functions for the gradient boosting algorithm.
@@ -66,4 +65,13 @@ trait Loss extends Serializable {
    * predicted values from previously fit trees.
    */
   private[spark] def computeError(prediction: Double, label: Double): Double
+}
+
+private[spark] trait ClassificationLoss extends Loss {
+  /**
+   * Computes the class probability given the margin.
+   * @param prediction The margin.
+   * @return The class probability from the margin.
+   */
+  private[spark] def computeProbability(prediction: Double): Double
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -18,10 +18,11 @@
 package org.apache.spark.ml.classification
 
 import com.github.fommil.netlib.BLAS
+
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
-import org.apache.spark.ml.param.{ParamMap, ParamsSuite}
+import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
 import org.apache.spark.ml.tree.LeafNode
 import org.apache.spark.ml.tree.impl.TreeTests

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -66,7 +66,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
     ParamsSuite.checkParams(new GBTClassifier)
     val model = new GBTClassificationModel("gbtc",
       Array(new DecisionTreeRegressionModel("dtr", new LeafNode(0.0, 0.0, null), 1)),
-      Array(1.0), 1)
+      Array(1.0), 1, 2)
     ParamsSuite.checkParams(model)
   }
 
@@ -246,7 +246,8 @@ private object GBTClassifierSuite extends SparkFunSuite {
     val newModel = gbt.fit(newData)
     // Use parent from newTree since this is not checked anyways.
     val oldModelAsNew = GBTClassificationModel.fromOld(
-      oldModel, newModel.parent.asInstanceOf[GBTClassifier], categoricalFeatures, numFeatures)
+      oldModel, newModel.parent.asInstanceOf[GBTClassifier], categoricalFeatures,
+      numFeatures, numClasses = 2)
     TreeTests.checkEqual(oldModelAsNew, newModel)
     assert(newModel.numFeatures === numFeatures)
     assert(oldModelAsNew.numFeatures === numFeatures)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.classification
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{DenseVector, Vector, Vectors}
+import org.apache.spark.ml.linalg.{DenseVector, Vectors}
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
 import org.apache.spark.ml.tree.LeafNode
@@ -28,7 +28,7 @@ import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, GradientBoostedTrees => OldGBT}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
-import org.apache.spark.mllib.util.{MLUtils, MLlibTestSparkContext}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.util.Utils
@@ -91,7 +91,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
     scoredData.select(rawPredictionCol, predictionCol).collect()
       .foreach(row => {
         val probabilities = Vectors.dense(row(0).asInstanceOf[DenseVector]
-          .values.map(value => 1 / (1 + math.exp(-value))))
+          .values.map(value => 1 / (1 + math.exp(-2 * value))))
         // Verify probabilities make sense
         assert(probabilities.toDense.values.forall(prob => prob <= 1 && prob >= 0))
         // Verify probabilities correspond to labels

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -115,7 +115,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
     val gbt2 = new GBTClassifier
     val threshold = Array(0.3, 0.7)
     gbt2.setThresholds(threshold)
-    assert(gbt2.getThresholds.zip(threshold).forall { case(t1, t2) => t1 === t2 })
+    assert(gbt2.getThresholds === threshold)
   }
 
   test("thresholds prediction") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -70,6 +70,23 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
     ParamsSuite.checkParams(model)
   }
 
+  test("Verify predicted probabilities correspond to labels") {
+    val rawPredictionCol = "MyRawPrediction"
+    val predictionCol = "MyPrediction"
+    val gbt = new GBTClassifier()
+      .setMaxDepth(2)
+      .setLossType("logistic")
+      .setMaxIter(5)
+      .setStepSize(0.1)
+      .setCheckpointInterval(2)
+      .setSeed(123)
+      .setRawPredictionCol(rawPredictionCol)
+      .setPredictionCol(predictionCol)
+    val gbtModel = gbt.fit(trainData.toDF())
+    val scoredData = gbtModel.transform(validationData.toDF())
+    scoredData.select(rawPredictionCol, predictionCol).foreach(row => print(row(0)))
+  }
+
   test("GBT parameter stepSize should be in interval (0, 1]") {
     withClue("GBT parameter stepSize should be in interval (0, 1]") {
       intercept[IllegalArgumentException] {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.classification
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.linalg.{DenseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
 import org.apache.spark.ml.tree.LeafNode
@@ -28,7 +28,7 @@ import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, GradientBoostedTrees => OldGBT}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
-import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.{MLUtils, MLlibTestSparkContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.util.Utils
@@ -70,9 +70,11 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
     ParamsSuite.checkParams(model)
   }
 
-  test("Verify predicted probabilities correspond to labels") {
+  test("Verify raw scores correspond to labels") {
     val rawPredictionCol = "MyRawPrediction"
     val predictionCol = "MyPrediction"
+    val labelCol = "label"
+    val featuresCol = "features"
     val gbt = new GBTClassifier()
       .setMaxDepth(2)
       .setLossType("logistic")
@@ -82,9 +84,19 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
       .setSeed(123)
       .setRawPredictionCol(rawPredictionCol)
       .setPredictionCol(predictionCol)
-    val gbtModel = gbt.fit(trainData.toDF())
-    val scoredData = gbtModel.transform(validationData.toDF())
-    scoredData.select(rawPredictionCol, predictionCol).foreach(row => print(row(0)))
+      .setLabelCol(labelCol)
+      .setFeaturesCol(featuresCol)
+    val gbtModel = gbt.fit(trainData.toDF(labelCol, featuresCol))
+    val scoredData = gbtModel.transform(validationData.toDF(labelCol, featuresCol))
+    scoredData.select(rawPredictionCol, predictionCol).collect()
+      .foreach(row => {
+        val probabilities = Vectors.dense(row(0).asInstanceOf[DenseVector]
+          .values.map(value => 1 / (1 + math.exp(-value))))
+        // Verify probabilities make sense
+        assert(probabilities.toDense.values.forall(prob => prob <= 1 && prob >= 0))
+        // Verify probabilities correspond to labels
+        assert(probabilities.argmax == row(1))
+      })
   }
 
   test("GBT parameter stepSize should be in interval (0, 1]") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -115,8 +115,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext
     val gbt2 = new GBTClassifier
     val threshold = Array(0.3, 0.7)
     gbt2.setThresholds(threshold)
-    assert(gbt2.getThresholds.zipWithIndex.forall(valueWithIndex =>
-      threshold(valueWithIndex._2) == valueWithIndex._1))
+    assert(gbt2.getThresholds.zip(threshold).forall { case(t1, t2) => t1 === t2 })
   }
 
   test("thresholds prediction") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For all of the classifiers in MLLib we can predict probabilities except for GBTClassifier.  
Also, all classifiers inherit from ProbabilisticClassifier but GBTClassifier strangely inherits from Predictor, which is a bug.
This change corrects the interface and adds the ability for the classifier to give a probabilities vector.

## How was this patch tested?

The basic ML tests were run after making the changes.  I've marked this as WIP as I need to add more tests.
