### PR TITLE
[SPARK-19052] the restSubmissionServer  don't support multiple standby masters on standalone cluster

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -143,8 +143,8 @@ private[rest] class StandaloneSubmitRequestServlet(
 
     // Construct driver description
     val conf = new SparkConf(false)
-      .setAll(sparkProperties)
       .set("spark.master", masterUrl)
+      .setAll(sparkProperties)
     val extraClassPath = driverExtraClassPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraLibraryPath = driverExtraLibraryPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraJavaOpts = driverExtraJavaOptions.map(Utils.splitCommandString).getOrElse(Seq.empty)


### PR DESCRIPTION
The driver only know a master's address which come from StandaloneRestServer's masterUrl If submitting the job by rest api. Like that:
```
    // Construct driver description
    val conf = new SparkConf(false)
      .setAll(sparkProperties)
      .set("spark.master", masterUrl)
```

The masterUrl only is a master's address. So we should give priority to set "spark.master" by "sparkProperties".  Like that:

```
 val conf = new SparkConf(false)
        .set("spark.master", masterUrl)
       .setAll(sparkProperties)
```
Then we can set the  one or more masters at the "sparkProperties".