### PR TITLE
[ML] fix getThresholds logic error

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -150,11 +150,13 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
    */
   override def getThresholds: Array[Double] = {
     checkThresholdConsistency()
-    if (!isSet(thresholds) && isSet(threshold)) {
+    if (isSet(thresholds)) {
+      $(thresholds)
+    } else if (isSet(threshold)) {
       val t = $(threshold)
       Array(1-t, t)
     } else {
-      $(thresholds)
+      throw new SparkException("Get thresholds, but neigher thresholds nor threshold is set")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The logic of getThresholds in ML LogisticRegression is not right, and it doesn't match with the comments. 
The problem is fixed by this PR. 

## How was this patch tested?
The existing test.
