### PR TITLE
[SPARK-19105][YARN] Fix for misnamed keytab in app staging dir

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -479,7 +479,7 @@ private[spark] class Client(
           val localPath = getQualifiedLocalPath(localURI, hadoopConf)
           val linkname = targetDir.map(_ + "/").getOrElse("") +
             destName.orElse(Option(localURI.getFragment())).getOrElse(localPath.getName())
-          val destPath = copyFileToRemote(destDir, localPath, replication)
+          val destPath = copyFileToRemote(destDir, localPath, replication, destName = destName)
           val destFs = FileSystem.get(destPath.toUri(), hadoopConf)
           distCacheMgr.addResource(
             destFs, hadoopConf, destPath, localResources, resType, linkname, statCache,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bug fix to respect the generated YARN client keytab name when copying the local keytab file to the app staging dir. Without destName, the keytab gets copied to using the local filename which mis-matches the UUID suffixed filename generated and stored in spark.yarn.keytab. Then AMDelegationTokenRenewer fails to find the keytab file when it comes time to renew kerberos tickets.

Ref: https://issues.apache.org/jira/browse/SPARK-19105

## How was this patch tested?

existing tests