### PR TITLE
[SPARK-19083]sbin/start-history-server.sh script use of $@ without quotes

### DIFF
--- a/sbin/start-history-server.sh
+++ b/sbin/start-history-server.sh
@@ -31,4 +31,4 @@ fi
 . "${SPARK_HOME}/sbin/spark-config.sh"
 . "${SPARK_HOME}/bin/load-spark-env.sh"
 
-exec "${SPARK_HOME}/sbin"/spark-daemon.sh start org.apache.spark.deploy.history.HistoryServer 1 $@
+exec "${SPARK_HOME}/sbin"/spark-daemon.sh start org.apache.spark.deploy.history.HistoryServer 1 "$@"


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-19083#

sbin/start-history-server.sh script use of $@ without quotes, this will affect the length of args which used in HistoryServerArguments::parse(args: List[String])

