### PR TITLE
[SPARK-19099] correct the wrong time display in history server web UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/JacksonMessageWriter.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/JacksonMessageWriter.scala
@@ -21,7 +21,7 @@ import java.lang.annotation.Annotation
 import java.lang.reflect.Type
 import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
-import java.util.{Calendar, Locale, SimpleTimeZone}
+import java.util.{Calendar, SimpleTimeZone, TimeZone}
 import javax.ws.rs.Produces
 import javax.ws.rs.core.{MediaType, MultivaluedMap}
 import javax.ws.rs.ext.{MessageBodyWriter, Provider}
@@ -86,8 +86,9 @@ private[v1] class JacksonMessageWriter extends MessageBodyWriter[Object]{
 
 private[spark] object JacksonMessageWriter {
   def makeISODateFormat: SimpleDateFormat = {
-    val iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'GMT'", Locale.US)
-    val cal = Calendar.getInstance(new SimpleTimeZone(0, "GMT"))
+    val iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'GMT'")
+    val offset: Int = TimeZone.getDefault.getRawOffset
+    val cal = Calendar.getInstance(new SimpleTimeZone(offset, "GMT"))
     iso8601.setCalendar(cal)
     iso8601
   }


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-19099

Correct the wrong job start/end time display in spark history server web UI.
I am a user from China. The job time is 8 hour less than the actual time due to the hard coding of rawOffsetValue 0.
