### PR TITLE
[SPARK-18836][MINOR] remove obsolete param doc for metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -46,7 +46,6 @@ import org.apache.spark.util._
  * @param stageId id of the stage this task belongs to
  * @param stageAttemptId attempt id of the stage this task belongs to
  * @param partitionId index of the number in the RDD
- * @param metrics a `TaskMetrics` that is created at driver side and sent to executor side.
  * @param localProperties copy of thread-local properties set by the user on the driver side.
  * @param serializedTaskMetrics a `TaskMetrics` that is created and serialized on the driver side
  *                              and sent to executor side.


### PR DESCRIPTION
## What changes were proposed in this pull request?

4cb49412d1d7d10ffcc738475928c7de2bc59fd4 removed the `metrics` parameter from Task, but left it in the docs -- this removes it from the docs as well.  (The original commit removed it from the docs for ResultTask and ShuffleMapTask, but not the parent Task.)

## How was this patch tested?

jenkins