### PR TITLE
[SPARK-17975][MLLIB] Fix EMLDAOptimizer failing with ClassCastException

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.mllib.clustering
 import java.util.{ArrayList => JArrayList}
 
 import breeze.linalg.{argmax, argtopk, max, DenseMatrix => BDM}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.graphx.Edge
 import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix, Vector, Vectors}
@@ -564,38 +565,12 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(model.vocabSize === vocabSize)
   }
 
-  test("SPARK-17975: Repro EMLDA optimizer error") {
-    // read in the data
-    val corpus: RDD[String] = sc.textFile("/home/ilya/ReproSparkBUG.txt")
-    // Split each document into a sequence of terms (words)
-    val tokenized: RDD[Seq[String]] =
-    corpus.map(_.toLowerCase.split("\\s"))
-      .map(_.filter(_.length > 3)
-        .filter(_.forall(java.lang.Character.isLetter)))
-    // Choose the vocabulary.
-    //   termCounts: Sorted list of (term, termCount) pairs
-    val termCounts: Array[(String, Long)] =
-    tokenized.flatMap(_.map(_ -> 1L)).reduceByKey(_ + _).collect().sortBy(-_._2)
-    //   vocabArray: Chosen vocab (removing common terms)
-    val numStopwords = 20
-    val vocabArray: Array[String] =
-      termCounts.takeRight(termCounts.size - numStopwords).map(_._1)
-    //   vocab: Map term -> term index
-    val vocab: Map[String, Int] = vocabArray.zipWithIndex.toMap
-
-    // Convert documents into term count vectors
+  test("SPARK-17975: Verify EMLDA optimizer error does not occur on empty arrays") {
+    // Verifies we do not get the class cast exception "scala.Tuple2
+    // cannot be cast to org.apache.spark.graphx.Edge"
     val documents: RDD[(Long, Vector)] =
-    tokenized.zipWithIndex.map { case (tokens, id) =>
-      val counts = new scala.collection.mutable.HashMap[Int, Double]()
-      tokens.foreach { term =>
-        if (vocab.contains(term)) {
-          val idx = vocab(term)
-          counts(idx) = counts.getOrElse(idx, 0.0) + 1.0
-        }
-      }
-      (id, Vectors.sparse(vocab.size, counts.toSeq))
-    }
-
+    sc.parallelize(Seq((0L, Vectors.sparse(236, Array[Int](), Array[Double]())),
+      (1L, Vectors.sparse(236, Array[Int](), Array[Double]()))))
     val lda = new LDA
     val optimizer = new EMLDAOptimizer
     lda.setOptimizer(optimizer)

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
@@ -571,15 +571,8 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     val documents: RDD[(Long, Vector)] =
     sc.parallelize(Seq((0L, Vectors.sparse(236, Array[Int](), Array[Double]())),
       (1L, Vectors.sparse(236, Array[Int](), Array[Double]()))))
-    val lda = new LDA
-    val optimizer = new EMLDAOptimizer
-    lda.setOptimizer(optimizer)
-      .setK(10)
-      .setMaxIterations(400)
-      .setAlpha(-1)
-      .setBeta(-1)
-      .setCheckpointInterval(7)
-    val ldaModel = lda.run(documents)
+    val lda = new LDA().setOptimizer(new EMLDAOptimizer)
+    lda.run(documents)
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

LDA fails with a ClassCastException when run on a dataset with at least one row that contains an empty sparse vector.  The error occurs in method fromEdges where one of the edges may already be an EdgeRDDImpl and it does not need to be converted.

## How was this patch tested?

I first ran LDA on the dataset provided by the JIRA submitter and I was able to reproduce the issue.  I then fixed the issue based on the submitter's suggestion and simplified the test case so that we wouldn't need to read in a file.
