### PR TITLE
SPARK-9487][Tests] Begin the work of robustifying unit tests , start with ContextCleanerSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -44,7 +44,7 @@ abstract class ContextCleanerSuiteBase(val shuffleManager: Class[_] = classOf[So
 {
   implicit val defaultTimeout = timeout(10000 millis)
   val conf = new SparkConf()
-    .setMaster("local[2]")
+    .setMaster("local[4]")
     .setAppName("ContextCleanerSuite")
     .set("spark.cleaner.referenceTracking.blocking", "true")
     .set("spark.cleaner.referenceTracking.blocking.shuffle", "true")


### PR DESCRIPTION
…tests

## What changes were proposed in this pull request?
This is a work in progress pull request whose goal will be to robustify the unit tests, to kick this off I will focus on one module at a time, for now I will focus on robustifying all unit tests around ContextCleanerSuite
(Please fill in changes proposed in this fix)
Changed ContextCleanerSuite to use local[4] instead of local[2]
## How was this patch tested?
I ran unit tests locally for this suite and everything passed locally, of course this doesnt mean anything till we see how Jenkins deals with these changes
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
