### PR TITLE
[spark-18806] [core] the processors DriverWrapper  and CoarseGrainedExecutorBackend should be exit when worker exit

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/WorkerWatcher.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/WorkerWatcher.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.deploy.worker
 
 import java.net.InetAddress
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc._
 

--- a/core/src/main/scala/org/apache/spark/deploy/worker/WorkerWatcher.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/WorkerWatcher.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.deploy.worker
 
+import java.net.InetAddress
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc._
 
@@ -43,7 +45,9 @@ private[spark] class WorkerWatcher(
 
   // Lets filter events only from the worker's rpc system
   private val expectedAddress = RpcAddress.fromURIString(workerUrl)
-  private def isWorker(address: RpcAddress) = expectedAddress == address
+  private def isWorker(address: RpcAddress) = expectedAddress == address ||
+    (expectedAddress.port == address.port &&
+      expectedAddress.host == InetAddress.getByName(address.host).getHostAddress)
 
   private def exitNonZero() = if (isTesting) isShutDown = true else System.exit(-1)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

modify the method `isWorker` by adding hostname equals 

## How was this patch tested?

test by manual