### PR TITLE
SPARK-19138: Don't return SparkSession for stopped SparkContext.

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -161,7 +161,12 @@ class SparkSession(object):
             with self._lock:
                 from pyspark.context import SparkContext
                 from pyspark.conf import SparkConf
-                session = SparkSession._instantiatedContext
+                sc = SparkContext.get
+                if sc:
+                    session = SparkSession._instantiatedContext
+                    if session._sc != sc:
+                        SparkSession._instantiatedContext = None
+                        session = None
                 if session is None:
                     sparkConf = SparkConf()
                     for key, value in self._options.items():


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Update SparkSession to always return a session using the current SparkContext
* Add SparkContext#isStopped

## How was this patch tested?

Tested that sqlContext.sql works when created after closing a Spark context:

```python
sc.stop()
sc = SparkContext(conf=SparkConf())
sqlContext = HiveContext(sc)
```