### PR TITLE
[SPARK-19137][SQL] Fix `withSQLConf` to reset `OptionalConfigEntry` correctly

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -601,11 +601,9 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter with Pr
         StructField("part", IntegerType), // inferred partitionColumn dataType
         StructField("id", StringType))) // used user provided partitionColumn dataType
 
-      val checkpointLoc = newMetadataDir
       val sq = sdf.writeStream
         .queryName("corruption_test")
         .format("memory")
-        .option("checkpointLocation", checkpointLoc)
         .start()
       sq.processAllAvailable()
       checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -601,9 +601,11 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter with Pr
         StructField("part", IntegerType), // inferred partitionColumn dataType
         StructField("id", StringType))) // used user provided partitionColumn dataType
 
+      val checkpointLoc = newMetadataDir
       val sq = sdf.writeStream
         .queryName("corruption_test")
         .format("memory")
+        .option("checkpointLocation", checkpointLoc)
         .start()
       sq.processAllAvailable()
       checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -96,7 +96,7 @@ private[sql] trait SQLTestUtils
     val (keys, values) = pairs.unzip
     val currentValues = keys.map { key =>
       if (spark.conf.contains(key)) {
-        Try(spark.conf.get(key)).toOption
+        Some(spark.conf.get(key))
       } else {
         None
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -94,7 +94,13 @@ private[sql] trait SQLTestUtils
    */
   protected def withSQLConf(pairs: (String, String)*)(f: => Unit): Unit = {
     val (keys, values) = pairs.unzip
-    val currentValues = keys.map(key => Try(spark.conf.get(key)).toOption)
+    val currentValues = keys.map { key =>
+      if (spark.conf.contains(key)) {
+        Try(spark.conf.get(key)).toOption
+      } else {
+        None
+      }
+    }
     (keys, values).zipped.foreach(spark.conf.set)
     try f finally {
       keys.zip(currentValues).foreach {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DataStreamReaderWriterSuite` makes test files in source folder like the followings. Interestingly, the root cause is `withSQLConf` fails to reset `OptionalConfigEntry` correctly. In other words, it resets the config into `Some(undefined)`.

```bash
$ git status
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        sql/core/%253Cundefined%253E/
        sql/core/%3Cundefined%3E/
```

## How was this patch tested?

Manual.
```
build/sbt "project sql" test
git status
```