### PR TITLE
[SPARK-18959] the new leader will lost the statistics of the driver's resource on the worker When the leader master has changed.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -360,13 +360,14 @@ private[deploy] class Master(
             val execInfo = app.addExecutor(worker, exec.cores, Some(exec.execId))
             worker.addExecutor(execInfo)
             execInfo.copyState(exec)
+            app.state = ApplicationState.RUNNING
           }
 
           for (driverId <- driverIds) {
             drivers.find(_.id == driverId).foreach { driver =>
               driver.worker = Some(worker)
               driver.state = DriverState.RUNNING
-              worker.drivers(driverId) = driver
+              worker.addDriver(driver)
             }
           }
         case None =>


### PR DESCRIPTION
I deploy the standalone cluster with two masters. and utilize zooKeeper to provide leader election. Firstly, I submit the application with cluster mode. Then I kill the leader master, and the standby master will be the leader. But the new leader will lost the statistics of the driver's resource. Then I stop the application, we will see the negative used resource at the worker from masterPage.  Like that:

```
Workers

Worker Id	Address	State	Cores	Memory
worker-20161220162751-10.125.6.222-59295	10.125.6.222:59295	ALIVE	4 (-1 Used)	6.8 GB (-1073741824.0 B Used)
worker-20161220164233-10.218.135.80-10944	10.218.135.80:10944	ALIVE	4 (0 Used)	6.8 GB (0.0 B Used)
```

Because  the new leader  forget calculate the driver‘ resource  when the master receive the "WorkerLatestState" message. At the same time we can  set RUNNING state for the app after the master receive the message， otherwise the app' state will still be WAITTING.