### PR TITLE
[SPARK-19146][Core]Drop more elements when stageData.taskData.size > retainedTasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -409,8 +409,8 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
 
       // If Tasks is too large, remove and garbage collect old tasks
       if (stageData.taskData.size > retainedTasks) {
-        stageData.taskData = stageData.taskData.drop(
-          stageData.taskData.size - retainedTasks + (retainedTasks * 0.01).toInt)
+        val targetSize = (0.9 * retainedTasks).toInt
+        stageData.taskData = stageData.taskData.drop(stageData.taskData.size - targetSize)
       }
 
       for (

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -432,7 +432,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
   }
 
   def removedCount(dataSize: Int, retainedSize: Int): Int = {
-    dataSize - retainedSize + retainedSize / 10
+    math.max(retainedSize / 10, dataSize - retainedSize)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -142,7 +142,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
   /** If stages is too large, remove and garbage collect old stages */
   private def trimStagesIfNecessary(stages: ListBuffer[StageInfo]) = synchronized {
     if (stages.size > retainedStages) {
-      val toRemove = removedCount(stages.size, retainedStages)
+      val toRemove = calculateNumberToRemove(stages.size, retainedStages)
       stages.take(toRemove).foreach { s =>
         stageIdToData.remove((s.stageId, s.attemptId))
         stageIdToInfo.remove(s.stageId)
@@ -154,7 +154,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
   /** If jobs is too large, remove and garbage collect old jobs */
   private def trimJobsIfNecessary(jobs: ListBuffer[JobUIData]) = synchronized {
     if (jobs.size > retainedJobs) {
-      val toRemove = removedCount(jobs.size, retainedJobs)
+      val toRemove = calculateNumberToRemove(jobs.size, retainedJobs)
       jobs.take(toRemove).foreach { job =>
         // Remove the job's UI data, if it exists
         jobIdToData.remove(job.jobId).foreach { removedJob =>
@@ -410,7 +410,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       // If Tasks is too large, remove and garbage collect old tasks
       if (stageData.taskData.size > retainedTasks) {
         stageData.taskData = stageData.taskData.drop(
-          removedCount(stageData.taskData.size, retainedTasks))
+          calculateNumberToRemove(stageData.taskData.size, retainedTasks))
       }
 
       for (
@@ -434,7 +434,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
   /**
    * Remove at least (maxRetained / 10) items to reduce friction.
    */
-  def removedCount(dataSize: Int, retainedSize: Int): Int = {
+  private def calculateNumberToRemove(dataSize: Int, retainedSize: Int): Int = {
     math.max(retainedSize / 10, dataSize - retainedSize)
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -409,7 +409,8 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
 
       // If Tasks is too large, remove and garbage collect old tasks
       if (stageData.taskData.size > retainedTasks) {
-        stageData.taskData = stageData.taskData.drop(stageData.taskData.size - retainedTasks)
+        stageData.taskData = stageData.taskData.drop(
+          stageData.taskData.size - retainedTasks + (retainedTasks * 0.01).toInt)
       }
 
       for (

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -431,6 +431,9 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
     }
   }
 
+  /**
+   * Remove at least (maxRetained / 10) items to reduce friction.
+   */
   def removedCount(dataSize: Int, retainedSize: Int): Int = {
     math.max(retainedSize / 10, dataSize - retainedSize)
   }

--- a/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
@@ -426,8 +426,8 @@ class JobProgressListenerSuite extends SparkFunSuite with LocalSparkContext with
         SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
     }
 
-    // 101 - (101 - 100 + 100 * 0.01) = 99
-    assert(listener.stageIdToData((task.stageId, task.stageAttemptId)).taskData.size === 99)
+    // 101 - (101 - 100 * 0.9) = 90
+    assert(listener.stageIdToData((task.stageId, task.stageAttemptId)).taskData.size === 90)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
@@ -412,22 +412,30 @@ class JobProgressListenerSuite extends SparkFunSuite with LocalSparkContext with
   test("SPARK-19146 drop more elements when stageData.taskData.size > retainedTasks") {
     val conf = new SparkConf()
     conf.set("spark.ui.retainedTasks", "100")
-    val listener = new JobProgressListener(conf)
     val taskMetrics = TaskMetrics.empty
     taskMetrics.mergeShuffleReadMetrics()
-
     val task = new ShuffleMapTask(0)
     val taskType = Utils.getFormattedClassName(task)
 
+    val listener1 = new JobProgressListener(conf)
     for (t <- 1 to 101) {
       val taskInfo = new TaskInfo(t, 0, 1, 0L, "exe-1", "host1", TaskLocality.NODE_LOCAL, false)
       taskInfo.finishTime = 1
-      listener.onTaskEnd(
+      listener1.onTaskEnd(
         SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
     }
+    // 101 - math.max(100 / 10, 101 - 100) = 91
+    assert(listener1.stageIdToData((task.stageId, task.stageAttemptId)).taskData.size === 91)
 
-    // 101 - (101 - 100 + 100 / 10) = 90
-    assert(listener.stageIdToData((task.stageId, task.stageAttemptId)).taskData.size === 90)
+    val listener2 = new JobProgressListener(conf)
+    for (t <- 1 to 150) {
+      val taskInfo = new TaskInfo(t, 0, 1, 0L, "exe-1", "host1", TaskLocality.NODE_LOCAL, false)
+      taskInfo.finishTime = 1
+      listener2.onTaskEnd(
+        SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
+    }
+    // 150 - math.max(100 / 10, 150 - 100) = 100
+    assert(listener2.stageIdToData((task.stageId, task.stageAttemptId)).taskData.size === 100)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
@@ -426,7 +426,7 @@ class JobProgressListenerSuite extends SparkFunSuite with LocalSparkContext with
         SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
     }
 
-    // 101 - (101 - 100 * 0.9) = 90
+    // 101 - (101 - 100 + 100 / 10) = 90
     assert(listener.stageIdToData((task.stageId, task.stageAttemptId)).taskData.size === 90)
   }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -671,7 +671,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>1000</td>
   <td>
     How many jobs the Spark UI and status APIs remember before garbage collecting. 
-    This is a target maximum and that fewer elements may be retained in some circumstances.
+    This is a target maximum, and fewer elements may be retained in some circumstances.
   </td>
 </tr>
 <tr>
@@ -679,7 +679,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>1000</td>
   <td>
     How many stages the Spark UI and status APIs remember before garbage collecting. 
-    This is a target maximum and that fewer elements may be retained in some circumstances.
+    This is a target maximum, and fewer elements may be retained in some circumstances.
   </td>
 </tr>
 <tr>
@@ -687,7 +687,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>100000</td>
   <td>
     How many tasks the Spark UI and status APIs remember before garbage collecting. 
-    This is a target maximum and that fewer elements may be retained in some circumstances.
+    This is a target maximum, and fewer elements may be retained in some circumstances.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -670,24 +670,24 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.ui.retainedJobs</code></td>
   <td>1000</td>
   <td>
-    How many jobs the Spark UI and status APIs remember before garbage
-    collecting.
+    How many jobs the Spark UI and status APIs remember before garbage collecting. 
+    This is a target maximum and that fewer elements may be retained in some circumstances.
   </td>
 </tr>
 <tr>
   <td><code>spark.ui.retainedStages</code></td>
   <td>1000</td>
   <td>
-    How many stages the Spark UI and status APIs remember before garbage
-    collecting.
+    How many stages the Spark UI and status APIs remember before garbage collecting. 
+    This is a target maximum and that fewer elements may be retained in some circumstances.
   </td>
 </tr>
 <tr>
   <td><code>spark.ui.retainedTasks</code></td>
   <td>100000</td>
   <td>
-    How many tasks the Spark UI and status APIs remember before garbage
-    collecting.
+    How many tasks the Spark UI and status APIs remember before garbage collecting. 
+    This is a target maximum and that fewer elements may be retained in some circumstances.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Drop more elements when `stageData.taskData.size > retainedTasks` to reduce the number of times on call drop function.

## How was this patch tested?

Jenkins
