### PR TITLE
[SPARK-19163][PYTHON][SQL] Delay _judf initialization to the __call__

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1833,6 +1833,10 @@ class UserDefinedFunction(object):
 
     @property
     def _judf(self):
+        # It is possible that concurrent access, to newly created UDF,
+        # will initialize multiple UserDefinedPythonFunctions.
+        # This is unlikely, doesn't affect correctness,
+        # and should have a minimal performance impact.
         if self._judf_placeholder is None:
             self._judf_placeholder = self._create_judf()
         return self._judf_placeholder

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1854,9 +1854,9 @@ class UserDefinedFunction(object):
         return judf
 
     def __call__(self, *cols):
-        sc = SparkContext.getOrCreate()
-        jc = self._judf.apply(_to_seq(sc, cols, _to_java_column))
-        return Column(jc)
+        judf = self._judf
+        sc = SparkContext._active_spark_context
+        return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))
 
 
 @since(1.3)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1826,7 +1826,14 @@ class UserDefinedFunction(object):
     def __init__(self, func, returnType, name=None):
         self.func = func
         self.returnType = returnType
-        self._judf = self._create_judf(name)
+        self._judf_placeholder = None
+        self._name = name
+
+    @property
+    def _judf(self):
+        if self._judf_placeholder is None:
+            self._judf_placeholder = self._create_judf(self._name)
+        return self._judf_placeholder
 
     def _create_judf(self, name):
         from pyspark.sql import SparkSession

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1850,7 +1850,7 @@ class UserDefinedFunction(object):
         return judf
 
     def __call__(self, *cols):
-        sc = SparkContext._active_spark_context
+        sc = SparkContext.getOrCreate()
         jc = self._judf.apply(_to_seq(sc, cols, _to_java_column))
         return Column(jc)
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1845,8 +1845,8 @@ class UserDefinedFunction(object):
     def _create_judf(self):
         from pyspark.sql import SparkSession
 
-        sc = SparkContext.getOrCreate()
         spark = SparkSession.builder.getOrCreate()
+        sc = spark.sparkContext
 
         wrapped_func = _wrap_function(sc, self.func, self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1826,6 +1826,7 @@ class UserDefinedFunction(object):
     def __init__(self, func, returnType, name=None):
         self.func = func
         self.returnType = returnType
+        # Stores UserDefinedPythonFunctions jobj, once initialized
         self._judf_placeholder = None
         self._name = name or (
             func.__name__ if hasattr(func, '__name__')

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -478,7 +478,7 @@ class SQLTests(ReusedPySparkTestCase):
             "judf should not be initialized before the first call."
         )
 
-        self.assertTrue(isinstance(f("foo"), Column), "UDF call should return a Column.")
+        self.assertIsInstance(f("foo"), Column, "UDF call should return a Column.")
 
         self.assertIsNotNone(
             f._judf_placeholder,

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -469,6 +469,10 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertTrue(row2[0].find("people.json") != -1)
 
     def test_udf_defers_judf_initalization(self):
+        # This is separate of  UDFInitializationTests
+        # to avoid context initialization
+        # when udf is called
+
         from pyspark.sql.functions import UserDefinedFunction
 
         f = UserDefinedFunction(lambda x: x, StringType())
@@ -1962,6 +1966,29 @@ class SQLTests2(ReusedPySparkTestCase):
         spark = SparkSession.builder.getOrCreate()
         df = spark.createDataFrame([(1, 2)], ["c", "c"])
         df.collect()
+
+
+class UDFInitializationTests(unittest.TestCase):
+    def tearDown(self):
+        if SparkSession._instantiatedSession is not None:
+            SparkSession._instantiatedSession.stop()
+
+        if SparkContext._active_spark_context is not None:
+            SparkContext._active_spark_contex.stop()
+
+    def test_udf_init_shouldnt_initalize_context(self):
+        from pyspark.sql.functions import UserDefinedFunction
+
+        UserDefinedFunction(lambda x: x, StringType())
+
+        self.assertIsNone(
+            SparkContext._active_spark_context,
+            "SparkContext shouldn't be initialized when UserDefinedFunction is created."
+        )
+        self.assertIsNone(
+            SparkSession._instantiatedSession,
+            "SparkSession shouldn't be initialized when UserDefinedFunction is created."
+        )
 
 
 class HiveContextSQLTests(ReusedPySparkTestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Defer `UserDefinedFunction._judf` initialization to the first call. This prevents unintended `SparkSession` initialization.  This allows users to define and import UDF without creating a context / session as a side effect.

[SPARK-19163](https://issues.apache.org/jira/browse/SPARK-19163)

## How was this patch tested?

Unit tests.