### PR TITLE
[SPARK-19165][PYTHON][SQL] UserDefinedFunction.__call__ should validate input types

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1949,6 +1949,14 @@ class UserDefinedFunction(object):
         return judf
 
     def __call__(self, *cols):
+        for c in cols:
+            if not isinstance(c, (Column, str)):
+                raise TypeError(
+                    "Invalid UDF argument, not a str or Column: "
+                    "{0} of type {1}. "
+                    "For Column literals use sql.functions "
+                    "lit, array, struct or create_map.".format(c, type(c)))
+
         judf = self._judf
         sc = SparkContext._active_spark_context
         return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -636,6 +636,11 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(f, f_.func)
         self.assertEqual(return_type, f_.returnType)
 
+    def test_udf_should_validate_input_args(self):
+        from pyspark.sql.functions import udf
+
+        self.assertRaises(TypeError, udf(lambda x: x), None)
+
     def test_basic_functions(self):
         rdd = self.sc.parallelize(['{"foo":"bar"}', '{"foo":"baz"}'])
         df = self.spark.read.json(rdd)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds basic input validation for `UserDefinedFunction.__call__` to avoid failing with cryptic `Py4J` errors.

## How was this patch tested?

Unit tests.