### PR TITLE
[SPARK-8855][MLlib][PySpark] Python API for Association Rules

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/FPGrowthModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/FPGrowthModelWrapper.scala
@@ -29,4 +29,9 @@ private[python] class FPGrowthModelWrapper(model: FPGrowthModel[Any])
   def getFreqItemsets: RDD[Array[Any]] = {
     SerDe.fromTuple2RDD(model.freqItemsets.map(x => (x.javaItems, x.freq)))
   }
+
+  def getGenerateAssociationRules(confidence: Double): RDD[Array[Any]] = {
+    model.generateAssociationRules(confidence)
+      .map(x => Array(x.javaAntecedent, x.javaConsequent, x.confidence))
+  }
 }

--- a/python/pyspark/mllib/fpm.py
+++ b/python/pyspark/mllib/fpm.py
@@ -55,6 +55,7 @@ class FPGrowthModel(JavaModelWrapper, JavaSaveable, JavaLoader):
         """
         return self.call("getFreqItemsets").map(lambda x: (FPGrowth.FreqItemset(x[0], x[1])))
 
+    @ignore_unicode_prefix
     @since("2.2.0")
     def generateAssociationRules(self, confidence):
         """

--- a/python/pyspark/mllib/fpm.py
+++ b/python/pyspark/mllib/fpm.py
@@ -55,6 +55,21 @@ class FPGrowthModel(JavaModelWrapper, JavaSaveable, JavaLoader):
         """
         return self.call("getFreqItemsets").map(lambda x: (FPGrowth.FreqItemset(x[0], x[1])))
 
+    @since("2.2.0")
+    def generateAssociationRules(self, confidence):
+        """
+        Generates association rules for the items in freqItemsets.
+        >>> data = [["a", "b", "c"], ["a", "b", "d", "e"], ["a", "c", "e"], ["a", "c", "f"]]
+        >>> rdd = sc.parallelize(data, 2)
+        >>> model = FPGrowth.train(rdd, 0.6, 2)
+        >>> model.generateAssociationRules(0.9).collect()
+        [Rule(antecedent=[u'c'], consequent=[u'a'], confidence=1.0)]
+
+        :param confidence: minimal confidence of the rules produced
+        """
+        return self.call("getGenerateAssociationRules", confidence)\
+            .map(lambda x: AssociationRules.Rule(x[0], x[1], x[2]))
+
     @classmethod
     @since("2.0.0")
     def load(cls, sc, path):
@@ -97,6 +112,15 @@ class FPGrowth(object):
         Represents an (items, freq) tuple.
 
         .. versionadded:: 1.4.0
+        """
+
+
+class AssociationRules(object):
+    class Rule(namedtuple("Rule", ["antecedent", "consequent", "confidence"])):
+        """
+        Represents an (antecedent, consequent, confidence) tuple.
+
+        .. versionadded:: 2.2.0
         """
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds a `generateAssociationRules(confidence)` method to `FPGrowthModel` for feature parity with the Scala and Java API.

I will do a follow up for website documentation.

## How was this patch tested?

Doctest
