### PR TITLE
[SPARK-19158][SPARKR][EXAMPLES] Fix ml.R example fails due to lack of e1071 package.

### DIFF
--- a/examples/src/main/r/ml/ml.R
+++ b/examples/src/main/r/ml/ml.R
@@ -49,17 +49,16 @@ unlink(modelPath)
 
 ############################ fit models with spark.lapply #####################################
 # Perform distributed training of multiple models with spark.lapply
-costs <- exp(seq(from = log(1), to = log(1000), length.out = 5))
-train <- function(cost) {
-  stopifnot(requireNamespace("e1071", quietly = TRUE))
-  model <- e1071::svm(Species ~ ., data = iris, cost = cost)
-  summary(model)
+algorithms <- c("Hartigan-Wong", "Lloyd", "MacQueen")
+train <- function(algorithm) {
+  model <- kmeans(x = iris[1:4], centers = 3, algorithm = algorithm)
+  model$withinss
 }
 
-model.summaries <- spark.lapply(costs, train)
+model.withinss <- spark.lapply(algorithms, train)
 
-# Print the summary of each model
-print(model.summaries)
+# Print the within-cluster sum of squares for each model
+print(model.withinss)
 
 # Stop the SparkSession now
 sparkR.session.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?
```ml.R``` example depends on ```e1071``` package, if it's not available in users' environment, it will fail. I think the example should not depends on third-party packages, so I update it to remove the dependency.

## How was this patch tested?
Manual test.