### PR TITLE
[SPARK-19151][SQL]DataFrameWriter.saveAsTable support hive overwrite

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -384,7 +384,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         val srcRelations = df.logicalPlan.collect {
           case LogicalRelation(src: BaseRelation, _, _) => src
           case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable) =>
-            relation.catalogTable.qualifiedName
+            relation.catalogTable.identifier
         }
         EliminateSubqueryAliases(catalog.lookupRelation(tableIdentWithDB)) match {
           // Only do the check if the table is a data source table (the relation is a BaseRelation).
@@ -394,7 +394,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
               s"Cannot overwrite table $tableName that is also being read from")
           // check hive table relation when overwrite mode
           case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable)
-            && srcRelations.contains(relation.catalogTable.qualifiedName) =>
+            && srcRelations.contains(relation.catalogTable.identifier) =>
             throw new AnalysisException(
               s"Cannot overwrite table $tableName that is also being read from")
           case _ => // OK

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -383,7 +383,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         // Get all input data source relations of the query.
         val srcRelations = df.logicalPlan.collect {
           case LogicalRelation(src: BaseRelation, _, _) => src
-          case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable) => relation
+          case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable) =>
+            relation.catalogTable.qualifiedName
         }
         EliminateSubqueryAliases(catalog.lookupRelation(tableIdentWithDB)) match {
           // Only do the check if the table is a data source table (the relation is a BaseRelation).
@@ -393,7 +394,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
               s"Cannot overwrite table $tableName that is also being read from")
           // check hive table relation when overwrite mode
           case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable)
-            && srcRelations.contains(relation) =>
+            && srcRelations.contains(relation.catalogTable.qualifiedName) =>
             throw new AnalysisException(
               s"Cannot overwrite table $tableName that is also being read from")
           case _ => // OK

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -393,12 +393,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
               s"Cannot overwrite table $tableName that is also being read from")
           // check hive table relation when overwrite mode
           case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable)
-            && srcRelations.filter(_.isInstanceOf[CatalogRelation]).exists {
-                case r: CatalogRelation =>
-                  // here src/dest MetaStoreRelation equal according to database&qualifiedName
-                  r.catalogTable.database == relation.catalogTable.database &&
-                    r.catalogTable.qualifiedName == relation.catalogTable.qualifiedName
-              } =>
+            && srcRelations.contains(relation) =>
             throw new AnalysisException(
               s"Cannot overwrite table $tableName that is also being read from")
           case _ => // OK

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -385,7 +385,6 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           case LogicalRelation(src: BaseRelation, _, _) => src
           case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable) => relation
         }
-
         EliminateSubqueryAliases(catalog.lookupRelation(tableIdentWithDB)) match {
           // Only do the check if the table is a data source table (the relation is a BaseRelation).
           // for creating hive tables.

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogRelation, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.plans.logical.InsertIntoTable
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, LogicalRelation}
@@ -383,12 +383,23 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         // Get all input data source relations of the query.
         val srcRelations = df.logicalPlan.collect {
           case LogicalRelation(src: BaseRelation, _, _) => src
+          case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable) => relation
         }
+
         EliminateSubqueryAliases(catalog.lookupRelation(tableIdentWithDB)) match {
           // Only do the check if the table is a data source table (the relation is a BaseRelation).
-          // TODO(cloud-fan): also check hive table relation here when we support overwrite mode
           // for creating hive tables.
           case LogicalRelation(dest: BaseRelation, _, _) if srcRelations.contains(dest) =>
+            throw new AnalysisException(
+              s"Cannot overwrite table $tableName that is also being read from")
+          // check hive table relation when overwrite mode
+          case relation: CatalogRelation if DDLUtils.isHiveTable(relation.catalogTable)
+            && srcRelations.filter(_.isInstanceOf[CatalogRelation]).exists {
+                case r: CatalogRelation =>
+                  // here src/dest MetaStoreRelation equal according to database&qualifiedName
+                  r.catalogTable.database == relation.catalogTable.database &&
+                    r.catalogTable.qualifiedName == relation.catalogTable.qualifiedName
+              } =>
             throw new AnalysisException(
               s"Cannot overwrite table $tableName that is also being read from")
           case _ => // OK

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -114,7 +114,7 @@ private[hive] trait HiveStrategies {
         // tables yet.
         if (mode == SaveMode.Append) {
           throw new AnalysisException(
-            "CTAS for hive serde tables does not support overwrite semantics.")
+            "CTAS for hive serde tables does not support append semantics.")
         }
 
         val dbName = tableDesc.identifier.database.getOrElse(sparkSession.catalog.currentDatabase)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -112,9 +112,9 @@ private[hive] trait HiveStrategies {
         // Currently we will never hit this branch, as SQL string API can only use `Ignore` or
         // `ErrorIfExists` mode, and `DataFrameWriter.saveAsTable` doesn't support hive serde
         // tables yet.
-        if (mode == SaveMode.Append || mode == SaveMode.Overwrite) {
+        if (mode == SaveMode.Append) {
           throw new AnalysisException(
-            "CTAS for hive serde tables does not support append or overwrite semantics.")
+            "CTAS for hive serde tables does not support overwrite semantics.")
         }
 
         val dbName = tableDesc.identifier.database.getOrElse(sparkSession.catalog.currentDatabase)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -109,9 +109,8 @@ private[hive] trait HiveStrategies {
           table, partition, planLater(child), overwrite, ifNotExists) :: Nil
 
       case CreateTable(tableDesc, mode, Some(query)) if DDLUtils.isHiveTable(tableDesc) =>
-        // Currently we will never hit this branch, as SQL string API can only use `Ignore` or
-        // `ErrorIfExists` mode, and `DataFrameWriter.saveAsTable` doesn't support hive serde
-        // tables yet.
+        // Currently `DataFrameWriter.saveAsTable` doesn't support
+        // the Append mode of hive serde tables yet.
         if (mode == SaveMode.Append) {
           throw new AnalysisException(
             "CTAS for hive serde tables does not support append semantics.")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
@@ -49,8 +49,7 @@ private[hive] case class MetastoreRelation(
   override def equals(other: Any): Boolean = other match {
     case relation: MetastoreRelation =>
       databaseName == relation.databaseName &&
-        tableName == relation.tableName &&
-        output == relation.output
+        tableName == relation.tableName
     case _ => false
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
@@ -49,7 +49,8 @@ private[hive] case class MetastoreRelation(
   override def equals(other: Any): Boolean = other match {
     case relation: MetastoreRelation =>
       databaseName == relation.databaseName &&
-        tableName == relation.tableName
+        tableName == relation.tableName &&
+        output == relation.output
     case _ => false
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1314,6 +1314,10 @@ class HiveDDLSuite
         .write.format("hive").option("fileFormat", "avro").saveAsTable("t")
       checkAnswer(spark.table("t"), Row(1, "a"))
 
+      Seq(9 -> "x").toDF("i", "j")
+        .write.format("hive").mode(SaveMode.Overwrite).option("fileFormat", "avro").saveAsTable("t")
+      checkAnswer(spark.table("t"), Row(9, "x"))
+
       val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))
       assert(DDLUtils.isHiveTable(table))
       assert(table.storage.inputFormat ==
@@ -1324,7 +1328,7 @@ class HiveDDLSuite
         Some("org.apache.hadoop.hive.serde2.avro.AvroSerDe"))
 
       sql("INSERT INTO t SELECT 2, 'b'")
-      checkAnswer(spark.table("t"), Row(1, "a") :: Row(2, "b") :: Nil)
+      checkAnswer(spark.table("t"), Row(9, "x") :: Row(2, "b") :: Nil)
 
       val e = intercept[AnalysisException] {
         Seq(1 -> "a").toDF("i", "j").write.format("hive").partitionBy("i").saveAsTable("t2")
@@ -1338,10 +1342,12 @@ class HiveDDLSuite
       assert(e2.message.contains("Creating bucketed Hive serde table is not supported yet"))
 
       val e3 = intercept[AnalysisException] {
-        spark.table("t").write.format("hive").mode("overwrite").saveAsTable("t")
+        spark.table("t").write.format("hive").mode("append").saveAsTable("t")
       }
       assert(e3.message.contains(
-        "CTAS for hive serde tables does not support append or overwrite semantics"))
+        "Saving data in the Hive serde table")
+        && e3.message.contains(
+        "is not supported yet. Please use the insertInto() API as an alternative."))
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1314,8 +1314,8 @@ class HiveDDLSuite
         .write.format("hive").option("fileFormat", "avro").saveAsTable("t")
       checkAnswer(spark.table("t"), Row(1, "a"))
 
-      Seq("c" -> 1).toDF("i", "j")
-        .write.format("hive").mode(SaveMode.Overwrite).option("fileFormat", "parquet").saveAsTable("t")
+      Seq("c" -> 1).toDF("i", "j").write.format("hive")
+        .mode(SaveMode.Overwrite).option("fileFormat", "parquet").saveAsTable("t")
       checkAnswer(spark.table("t"), Row("c", 1))
 
       var table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1314,6 +1314,10 @@ class HiveDDLSuite
         .write.format("hive").option("fileFormat", "avro").saveAsTable("t")
       checkAnswer(spark.table("t"), Row(1, "a"))
 
+      Seq("c" -> 1).toDF("i", "j")
+        .write.format("hive").mode(SaveMode.Overwrite).option("fileFormat", "avro").saveAsTable("t")
+      checkAnswer(spark.table("t"), Row("c", 1))
+
       Seq(9 -> "x").toDF("i", "j")
         .write.format("hive").mode(SaveMode.Overwrite).option("fileFormat", "avro").saveAsTable("t")
       checkAnswer(spark.table("t"), Row(9, "x"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1342,12 +1342,10 @@ class HiveDDLSuite
       assert(e2.message.contains("Creating bucketed Hive serde table is not supported yet"))
 
       val e3 = intercept[AnalysisException] {
-        spark.table("t").write.format("hive").mode("append").saveAsTable("t")
+        spark.table("t").write.format("hive").mode("overwrite").saveAsTable("t")
       }
-      assert(e3.message.contains(
-        "Saving data in the Hive serde table")
-        && e3.message.contains(
-        "is not supported yet. Please use the insertInto() API as an alternative."))
+      assert(e3.message.contains("Cannot overwrite table")
+        && e3.message.contains("that is also being read from"))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After [SPARK-19107](https://issues.apache.org/jira/browse/SPARK-19107), we now can treat hive as a data source and create hive tables with DataFrameWriter and Catalog. However, the support is not completed, there are still some cases we do not support.

This PR implement:
DataFrameWriter.saveAsTable work with hive format with overwrite mode

## How was this patch tested?
unit test added