### PR TITLE
[WIP] Add expression index and test cases

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.types._
 
 class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -104,5 +106,24 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
     checkEvaluation(ArrayContains(a3, Literal("")), null)
     checkEvaluation(ArrayContains(a3, Literal.create(null, StringType)), null)
+  }
+
+  test("index") {
+    val m0 = Literal.create(Map("a" -> 1, "b" -> 2), MapType(StringType, IntegerType))
+    val m1 = Literal.create(Map(), MapType(StringType, StringType))
+    val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
+    val a1 = Literal.create(Seq(), ArrayType(IntegerType))
+
+    checkEvaluation(Index(m0, Literal("a")), 1)
+    checkEvaluation(Index(m0, Literal("c")), null)
+    checkEvaluation(Index(m1, Literal("c")), null)
+    checkEvaluation(Index(m0, Literal(1)), null)
+    checkEvaluation(Index(m0, Literal.create(null, NullType)), null)
+
+    checkEvaluation(Index(a0, Literal(0)), 1)
+    checkEvaluation(Index(a0, Literal(3)), null)
+    checkEvaluation(Index(a1, Literal("c")), null)
+    checkEvaluation(Index(a0, Literal("3")), null)
+    checkEvaluation(Index(a0, Literal.create(null, NullType)), null)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expression Index returns the value of index n (right) of the array/map (left).
To be consistent with Hive, the left parameter should be of ArrayType or MapType, while the right parameter should be of AtomicType or NullType.
Except the rules above, Hive won't throw any exceptions, even if there's a type mismatch, it will output NULL to indicate not found. This implementation follows the rule.

There's one point this PR temporarily ignored, which is implicit cast for the right parameter, for example, in Hive:
`> SELECT index(array(1, 2, 3), '2'); 
3
`
While in this implementation, it returns NULL. I will continue working on this.

## How was this patch tested?

Test cases are also included in this PR.
