### PR TITLE
[SPARK-19208][ML][WIP] MaxAbsScaler and MinMaxScaler are very inefficient

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
@@ -21,13 +21,10 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.{ParamMap, Params}
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.util._
-import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors}
-import org.apache.spark.mllib.stat.Statistics
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -70,14 +67,27 @@ class MaxAbsScaler @Since("2.0.0") (@Since("2.0.0") override val uid: String)
   @Since("2.0.0")
   override def fit(dataset: Dataset[_]): MaxAbsScalerModel = {
     transformSchema(dataset.schema, logging = true)
-    val input: RDD[OldVector] = dataset.select($(inputCol)).rdd.map {
-      case Row(v: Vector) => OldVectors.fromML(v)
-    }
-    val summary = Statistics.colStats(input)
-    val minVals = summary.min.toArray
-    val maxVals = summary.max.toArray
-    val n = minVals.length
-    val maxAbs = Array.tabulate(n) { i => math.max(math.abs(minVals(i)), math.abs(maxVals(i))) }
+
+    val numFeatures = dataset.select($(inputCol)).first().getAs[Vector](0).size
+    val maxAbs = dataset.select($(inputCol)).rdd.map {
+      row => row.getAs[Vector](0)
+    }.treeAggregate[Array[Double]](Array.fill(numFeatures)(0.0))(
+      seqOp = {
+        case (max, vec) =>
+          vec.foreachActive {
+            case (i, v) =>
+              val abs = math.abs(v)
+              if (abs > max(i)) {
+                max(i) = abs
+              }
+          }
+          max
+      }, combOp = {
+        case (max1, max2) =>
+          max1.zip(max2).map {
+            case (m1, m2) => math.max(m1, m2)
+          }
+      })
 
     copyValues(new MaxAbsScalerModel(uid, Vectors.dense(maxAbs)).setParent(this))
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -125,7 +125,7 @@ class MinMaxScaler @Since("1.5.0") (@Since("1.5.0") override val uid: String)
           val max_ = Array.fill[Double](n)(Double.MinValue)
           val nnz_ = Array.fill[Long](n)(0L)
           vec.foreachActive {
-            case (i, v) if v != 0.0 =>
+            case (i, v) if v != 0.0 && !v.isNaN =>
               min_(i) = v
               max_(i) = v
               nnz_(i) = 1L
@@ -136,10 +136,11 @@ class MinMaxScaler @Since("1.5.0") (@Since("1.5.0") override val uid: String)
           require(min.length == vec.size,
             s"Dimensions mismatch when adding new sample: ${min.length} != ${vec.size}")
           vec.foreachActive {
-            case (i, v) if v != 0.0 =>
+            case (i, v) if v != 0.0 && !v.isNaN =>
               if (v < min(i)) {
                 min(i) = v
-              } else if (v > max(i)) {
+              }
+              if (v > max(i)) {
                 max(i) = v
               }
               nnz(i) += 1
@@ -168,7 +169,8 @@ class MinMaxScaler @Since("1.5.0") (@Since("1.5.0") override val uid: String)
       if (nnz(i) < cnt) {
         if (mins(i) > 0.0) {
           mins(i) = 0.0
-        } else if (maxs(i) < 0.0) {
+        }
+        if (maxs(i) < 0.0) {
           maxs(i) = 0.0
         }
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -125,9 +125,13 @@ class MinMaxScaler @Since("1.5.0") (@Since("1.5.0") override val uid: String)
           val max_ = Array.fill[Double](n)(Double.MinValue)
           val nnz_ = Array.fill[Long](n)(0L)
           vec.foreachActive {
-            case (i, v) if v != 0.0 && !v.isNaN =>
-              min_(i) = v
-              max_(i) = v
+            case (i, v) if v != 0.0 =>
+              if (v < min_(i)) {
+                min_(i) = v
+              }
+              if (v > max_(i)) {
+                max_(i) = v
+              }
               nnz_(i) = 1L
             case _ =>
           }
@@ -136,7 +140,7 @@ class MinMaxScaler @Since("1.5.0") (@Since("1.5.0") override val uid: String)
           require(min.length == vec.size,
             s"Dimensions mismatch when adding new sample: ${min.length} != ${vec.size}")
           vec.foreachActive {
-            case (i, v) if v != 0.0 && !v.isNaN =>
+            case (i, v) if v != 0.0 =>
               if (v < min(i)) {
                 min(i) = v
               }


### PR DESCRIPTION
## What changes were proposed in this pull request?
eliminate the usage of `MultivariateOnlineSummarizer`

## How was this patch tested?
existing tests, manual tests in spark-shell
