### PR TITLE
[SPARK-19210][DStream] Add log level info into checkpoint file 

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -368,6 +368,7 @@ class SparkContext(config: SparkConf) extends Logging {
     require(SparkContext.VALID_LOG_LEVELS.contains(upperCased),
       s"Supplied level $logLevel did not match one of:" +
         s" ${SparkContext.VALID_LOG_LEVELS.mkString(",")}")
+    _conf.set("spark.logLevel", logLevel)
     Utils.setLogLevel(org.apache.log4j.Level.toLevel(upperCased))
   }
 
@@ -394,6 +395,8 @@ class SparkContext(config: SparkConf) extends Logging {
     if (_conf.getBoolean("spark.logConf", false)) {
       logInfo("Spark configuration:\n" + _conf.toDebugString)
     }
+
+    setLogLevel(_conf.get("spark.logLevel", "INFO"))
 
     // Set Spark driver host and port system properties. This explicitly sets the configuration
     // instead of relying on the default value of the config constant.


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we set log level by using **SparkContext.setLogLevel()** and restart streaming job from checkpoint data, the log level info will be lost.

## How was this patch tested?

existing ut

cc @zsxwing 
