### PR TITLE
[SPARK-19213] DatasourceScanExec uses runtime sparksession

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -17,8 +17,11 @@
 
 package org.apache.spark.sql.execution
 
+import java.util.concurrent.{Callable, TimeUnit}
+
 import scala.collection.mutable.ArrayBuffer
 
+import com.google.common.cache.{Cache, CacheBuilder}
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
 
@@ -147,23 +150,26 @@ case class FileSourceScanExec(
     override val metastoreTableIdentifier: Option[TableIdentifier])
   extends DataSourceScanExec with ColumnarBatchScan  {
 
-  val supportsBatch: Boolean = relation.fileFormat.supportBatch(
-    relation.sparkSession, StructType.fromAttributes(output))
+  def supportsBatch: Boolean = relation.fileFormat.supportBatch(
+    sparkSession, StructType.fromAttributes(output))
 
-  val needsUnsafeRowConversion: Boolean = if (relation.fileFormat.isInstanceOf[ParquetSource]) {
-    SparkSession.getActiveSession.get.sessionState.conf.parquetVectorizedReaderEnabled
+  def needsUnsafeRowConversion: Boolean = if (relation.fileFormat.isInstanceOf[ParquetSource]) {
+    sparkSession.sessionState.conf.parquetVectorizedReaderEnabled
   } else {
     false
   }
 
+  def sparkSession: SparkSession = SparkSession.getActiveSession.get
+
+  private val readerCache: Cache[SparkSession, RDD[InternalRow]] =
+    CacheBuilder.newBuilder()
+      .expireAfterAccess(4, TimeUnit.HOURS)
+      .build()
+
   @transient private lazy val selectedPartitions = relation.location.listFiles(partitionFilters)
 
-  override val (outputPartitioning, outputOrdering): (Partitioning, Seq[SortOrder]) = {
-    val bucketSpec = if (relation.sparkSession.sessionState.conf.bucketingEnabled) {
-      relation.bucketSpec
-    } else {
-      None
-    }
+  private def partitioningAndOrder(
+      bucketSpec: Option[BucketSpec]): (Partitioning, Seq[SortOrder]) = {
     bucketSpec match {
       case Some(spec) =>
         // For bucketed columns:
@@ -225,6 +231,17 @@ case class FileSourceScanExec(
     }
   }
 
+  private def bucketSpec: Option[BucketSpec] =
+    if (sparkSession.sessionState.conf.bucketingEnabled) {
+      relation.bucketSpec
+    } else {
+      None
+    }
+
+  override def outputPartitioning: Partitioning = partitioningAndOrder(bucketSpec)._1
+
+  override def outputOrdering: Seq[SortOrder] = partitioningAndOrder(bucketSpec)._2
+
   // These metadata values make scan plans uniquely identifiable for equality checking.
   override val metadata: Map[String, String] = {
     def seqToString(seq: Seq[Any]) = seq.mkString("[", ", ", "]")
@@ -248,23 +265,29 @@ case class FileSourceScanExec(
     withOptPartitionCount
   }
 
-  private lazy val inputRDD: RDD[InternalRow] = {
-    val readFile: (PartitionedFile) => Iterator[InternalRow] =
-      relation.fileFormat.buildReaderWithPartitionValues(
-        sparkSession = relation.sparkSession,
-        dataSchema = relation.dataSchema,
-        partitionSchema = relation.partitionSchema,
-        requiredSchema = outputSchema,
-        filters = dataFilters,
-        options = relation.options,
-        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options))
+  private def inputRDDInternal(sparkSession: SparkSession): RDD[InternalRow] = {
+    val readFile = relation.fileFormat.buildReaderWithPartitionValues(
+      sparkSession = sparkSession,
+      dataSchema = relation.dataSchema,
+      partitionSchema = relation.partitionSchema,
+      requiredSchema = outputSchema,
+      filters = dataFilters,
+      options = relation.options,
+      hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(relation.options))
 
     relation.bucketSpec match {
-      case Some(bucketing) if relation.sparkSession.sessionState.conf.bucketingEnabled =>
+      case Some(bucketing) if sparkSession.sessionState.conf.bucketingEnabled =>
         createBucketedReadRDD(bucketing, readFile, selectedPartitions, relation)
       case _ =>
         createNonBucketedReadRDD(readFile, selectedPartitions, relation)
     }
+  }
+
+  private def inputRDD: RDD[InternalRow] = {
+    val sparkSession = sparkSession
+    readerCache.get(sparkSession, new Callable[RDD[InternalRow]] {
+      override def call(): RDD[InternalRow] = inputRDDInternal(sparkSession)
+    })
   }
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
@@ -370,7 +393,7 @@ case class FileSourceScanExec(
       FilePartition(bucketId, bucketed.getOrElse(bucketId, Nil))
     }
 
-    new FileScanRDD(fsRelation.sparkSession, readFile, filePartitions)
+    new FileScanRDD(sparkSession, readFile, filePartitions)
   }
 
   /**
@@ -385,10 +408,10 @@ case class FileSourceScanExec(
       readFile: (PartitionedFile) => Iterator[InternalRow],
       selectedPartitions: Seq[PartitionDirectory],
       fsRelation: HadoopFsRelation): RDD[InternalRow] = {
-    val defaultMaxSplitBytes =
-      fsRelation.sparkSession.sessionState.conf.filesMaxPartitionBytes
-    val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
-    val defaultParallelism = fsRelation.sparkSession.sparkContext.defaultParallelism
+    val session = sparkSession
+    val defaultMaxSplitBytes = session.sessionState.conf.filesMaxPartitionBytes
+    val openCostInBytes = session.sessionState.conf.filesOpenCostInBytes
+    val defaultParallelism = session.sparkContext.defaultParallelism
     val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
     val bytesPerCore = totalBytes / defaultParallelism
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -284,7 +284,6 @@ case class FileSourceScanExec(
   }
 
   private def inputRDD: RDD[InternalRow] = {
-    val sparkSession = sparkSession
     readerCache.get(sparkSession, new Callable[RDD[InternalRow]] {
       override def call(): RDD[InternalRow] = inputRDDInternal(sparkSession)
     })

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -176,8 +176,9 @@ case class DataSourceAnalysis(conf: CatalystConf) extends Rule[LogicalPlan] {
           "Cannot overwrite a path that is also being read from.")
       }
 
+      val sparkSession = SparkSession.getActiveSession.get
       val partitionSchema = actualQuery.resolve(
-        t.partitionSchema, t.sparkSession.sessionState.analyzer.resolver)
+        t.partitionSchema, sparkSession.sessionState.analyzer.resolver)
       val staticPartitions = parts.filter(_._2.nonEmpty).map { case (k, v) => k -> v.get }
 
       InsertIntoHadoopFsRelationCommand(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -71,16 +71,17 @@ object FileSourceStrategy extends Strategy with Logging {
         }
       }
 
+      val sparkSession = SparkSession.getActiveSession.get
       val partitionColumns =
         l.resolve(
-          fsRelation.partitionSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
+          fsRelation.partitionSchema, sparkSession.sessionState.analyzer.resolver)
       val partitionSet = AttributeSet(partitionColumns)
       val partitionKeyFilters =
         ExpressionSet(normalizedFilters.filter(_.references.subsetOf(partitionSet)))
       logInfo(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
 
       val dataColumns =
-        l.resolve(fsRelation.dataSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
+        l.resolve(fsRelation.dataSchema, sparkSession.sessionState.analyzer.resolver)
 
       // Partition keys are not available in the statistics of the files.
       val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
@@ -47,7 +48,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
         }
       }
 
-      val sparkSession = fsRelation.sparkSession
+      val sparkSession = SparkSession.getActiveSession.get
       val partitionColumns =
         logicalRelation.resolve(
           partitionSchema, sparkSession.sessionState.analyzer.resolver)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
@@ -28,7 +28,7 @@ import org.apache.parquet.hadoop.ParquetOutputCommitter
 
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql._
-import org.apache.spark.sql.execution.DataSourceScanExec
+import org.apache.spark.sql.execution.{DataSourceScanExec, FileSourceScanExec}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
@@ -895,6 +895,33 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
       }
       val readBack = reader.load(childDir)
       checkAnswer(df, readBack)
+    }
+  }
+
+  test("DataSourceScanExec uses active session upon execution") {
+    withTempPath { dir =>
+      val path = "file://" + dir.getCanonicalPath
+      spark.range(4).coalesce(1).write.format(dataSourceName).save(path)
+      val df = spark.read.format(dataSourceName).load(path)
+      val Some(scan1) = df.queryExecution.executedPlan.collectFirst {
+        case scan: FileSourceScanExec => scan
+      }
+
+      val newSession = spark.newSession()
+
+      val session1 = scan1.sparkSession
+      SparkSession.setActiveSession(newSession)
+      val Some(scan2) = df.queryExecution.executedPlan.collectFirst {
+        case scan: FileSourceScanExec => scan
+      }
+
+      val session2 = scan2.sparkSession
+
+      assert(scan1 == scan2)
+      assert(session1 == spark)
+      assert(session2 == newSession)
+
+      SparkSession.setActiveSession(spark)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Physical plan for hadoop fs relation uses active session at the moment of execution

## How was this patch tested?

Tests added to cover the behaviour