### PR TITLE
[SPARK-19215] Add necessary check for `RDD.checkpoint` to avoid potential mistakes

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1539,6 +1539,13 @@ abstract class RDD[T: ClassTag](
     // NOTE: we use a global lock here due to complexities downstream with ensuring
     // children RDD partitions point to the correct parent partitions. In the future
     // we should revisit this consideration.
+    if (doCheckpointCalled) {
+      throw new SparkException("Because job has been executed on this RDD, checkpoint won't work")
+    }
+    if (storageLevel == StorageLevel.NONE) {
+      logWarning("Call checkpoint on unpersisted RDD, it will cause RDD recomputation" +
+        " when saving checkpoint files.")
+    }
     if (context.checkpointDir.isEmpty) {
       throw new SparkException("Checkpoint directory has not been set in the SparkContext")
     } else if (checkpointData.isEmpty) {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1540,11 +1540,7 @@ abstract class RDD[T: ClassTag](
     // children RDD partitions point to the correct parent partitions. In the future
     // we should revisit this consideration.
     if (doCheckpointCalled) {
-      throw new SparkException("Because job has been executed on this RDD, checkpoint won't work")
-    }
-    if (storageLevel == StorageLevel.NONE) {
-      logWarning("Call checkpoint on unpersisted RDD, it will cause RDD recomputation" +
-        " when saving checkpoint files.")
+      logWarning(s"Because job has been executed on RDD ${id}, checkpoint won't work")
     }
     if (context.checkpointDir.isEmpty) {
       throw new SparkException("Checkpoint directory has not been set in the SparkContext")
@@ -1732,6 +1728,10 @@ abstract class RDD[T: ClassTag](
             // Checkpoint parents first because our lineage will be truncated after we
             // checkpoint ourselves
             dependencies.foreach(_.rdd.doCheckpoint())
+          }
+          if (storageLevel == StorageLevel.NONE) {
+            logInfo(s"do checkpoint on unpersisted RDD ${id}, it will cause RDD recomputation" +
+              " when saving checkpoint files.")
           }
           checkpointData.get.checkpoint()
         } else {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1539,7 +1539,7 @@ abstract class RDD[T: ClassTag](
     // NOTE: we use a global lock here due to complexities downstream with ensuring
     // children RDD partitions point to the correct parent partitions. In the future
     // we should revisit this consideration.
-    if (doCheckpointCalled) {
+    if (doCheckpointCalled && !isCheckpointed) {
       logWarning(s"Because job has been executed on RDD ${id}, checkpoint won't work")
     }
     if (context.checkpointDir.isEmpty) {
@@ -1730,8 +1730,7 @@ abstract class RDD[T: ClassTag](
             dependencies.foreach(_.rdd.doCheckpoint())
           }
           if (storageLevel == StorageLevel.NONE) {
-            logInfo(s"do checkpoint on unpersisted RDD ${id}, it will cause RDD recomputation" +
-              " when saving checkpoint files.")
+            logInfo(s"checkpoint on RDD ${this.toString} will result in recomputation.")
           }
           checkpointData.get.checkpoint()
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently RDD.checkpoint must be called before any job executed on this RDD, otherwise the `doCheckpoint` will never be called. This is a pitfall and this Patch print warning message for such case.
And, if RDD haven't been persisted, doing checkpoint will cause RDD recomputation, because current implementation will run separated job for checkpointing. In this case print RDD recomputation message, remind user to check whether he forgot persist the RDD.

## How was this patch tested?

Manual.

Test case 1:
```
val rdd1 =  sc.makeRDD(Array(1,2,3),3).map(_ + 10)
val rdd2 = rdd1.filter(...)
val rdd3 = rdd2.map(...)

rdd1.checkpoint() 
rdd3.count()

rdd2.checkpoint()
rdd3.count()
 // The latter `checkpoint` will not cause rdd2 to get checkpointed since the earlier checkpoint already marked `doCheckpointCalled = true`, this PR will printing some warning message for this case.
```
Test case 2:
```
val rdd = sc.makeRDD(Array(1,2,3),3).map(_ + 10)
rdd.checkpoint() // because `rdd` do not persisted, so that checkpoint will cause this RDD recomputation, this patch will print recomputation message here.
rdd.count() // trigger `doCheckpoint`
```

Test case 3:
```
val rdd = sc.makeRDD(Array(1,2,3),3).map(_ + 10)
rdd.persist()
rdd.checkpoint() // This is correct usage, won't print any warning in this patch.
rdd.count() // trigger `doCheckpoint`
```