### PR TITLE
[SPARK-19214][SQL] Typed aggregate count output field name should be "count"

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -315,7 +315,8 @@ class KeyValueGroupedDataset[K, V] private[sql](
    *
    * @since 1.6.0
    */
-  def count(): Dataset[(K, Long)] = agg(functions.count("*").as(ExpressionEncoder[Long]()))
+  def count(): Dataset[(K, Long)] =
+    agg(functions.count("*").as("count").as(ExpressionEncoder[Long]()))
 
   /**
    * (Scala-specific)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -369,6 +369,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       count,
       (Tuple1(3), 2L), (Tuple1(5), 1L)
     )
+    assert(count.schema(1).name == "count")
   }
 
   test("typed aggregation: expr") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes the output field name of typed aggregate counts to be `count` (instead of `count(1)`) for consistency with the dataframe api

## How was this patch tested?

unit test