### PR TITLE
[SPARK-4502][SQL] Parquet nested column pruning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdown.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdown.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
+
+/**
+ * Pushes down aliases to [[expressions.GetStructField]] expressions in an aggregate's grouping and
+ * aggregate expressions into a projection over its children. The original
+ * [[expressions.GetStructField]] expressions are replaced with references to the pushed down
+ * aliases.
+ */
+object AggregateFieldExtractionPushdown extends FieldExtractionPushdown {
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan transformDown {
+      case agg @ Aggregate(groupingExpressions, aggregateExpressions, child) =>
+        val expressions = groupingExpressions ++ aggregateExpressions
+        val attributes = AttributeSet(expressions.collect { case att: Attribute => att })
+        val childAttributes = AttributeSet(child.expressions)
+        val fieldExtractors0 =
+          expressions
+            .flatMap(getFieldExtractors)
+            .distinct
+        val fieldExtractors1 =
+          fieldExtractors0
+            .filter(_.collectFirst { case att: Attribute => att }
+              .filter(attributes.contains).isEmpty)
+        val fieldExtractors =
+          fieldExtractors1
+            .filter(_.collectFirst { case att: Attribute => att }
+              .filter(childAttributes.contains).nonEmpty)
+
+        if (fieldExtractors.nonEmpty) {
+          val (aliases, substituteAttributes) = constructAliasesAndSubstitutions(fieldExtractors)
+
+          // Construct the new grouping and aggregate expressions by substituting
+          // each GetStructField expression with a reference to its alias
+          val newAggregateExpressions =
+            aggregateExpressions.map(substituteAttributes)
+              .collect { case named: NamedExpression => named }
+          val newGroupingExpressions = groupingExpressions.map(substituteAttributes)
+
+          // We need to push down the aliases we've created. We do this with a new projection over
+          // this aggregate's child consisting of the aliases and original child's output sans
+          // attributes referenced by the aliases
+
+          // None of these attributes are required by this aggregate because we filtered out the
+          // GetStructField instances which referred to attributes that were required
+          val unnecessaryAttributes = aliases.map(_.child.references).reduce(_ ++ _)
+          // The output we require from this aggregate is the child's output minus the unnecessary
+          // attributes
+          val requiredChildOutput = child.output.filterNot(unnecessaryAttributes.contains)
+          val projects = requiredChildOutput ++ aliases
+          val newProject = Project(projects, child)
+
+          Aggregate(newGroupingExpressions, newAggregateExpressions, newProject)
+        } else {
+          agg
+        }
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdown.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdown.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Proj
  * format for aggregation queries involving only nested fields.
  */
 object AggregateFieldExtractionPushdown extends FieldExtractionPushdown {
-  override def apply(plan: LogicalPlan): LogicalPlan =
+  override protected def apply0(plan: LogicalPlan): LogicalPlan =
     plan transformDown {
       case agg @ Aggregate(groupingExpressions, aggregateExpressions, child) =>
         val expressions = groupingExpressions ++ aggregateExpressions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/FieldExtractionPushdown.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/FieldExtractionPushdown.scala
@@ -21,8 +21,18 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, GetStructFi
 import org.apache.spark.sql.catalyst.planning.SelectedField
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.internal.SQLConf
 
 abstract class FieldExtractionPushdown extends Rule[LogicalPlan] {
+  final override def apply(plan: LogicalPlan): LogicalPlan =
+    if (SQLConf.get.nestedSchemaPruningEnabled) {
+      apply0(plan)
+    } else {
+      plan
+    }
+
+  protected def apply0(plan: LogicalPlan): LogicalPlan
+
   // Gets the top-level GetStructField expressions from the given expression
   // and its children. This does not return children of a GetStructField.
   protected final def getFieldExtractors(expr: Expression): Seq[GetStructField] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/FieldExtractionPushdown.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/FieldExtractionPushdown.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, GetStructField}
+import org.apache.spark.sql.catalyst.planning.SelectedField
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+abstract class FieldExtractionPushdown extends Rule[LogicalPlan] {
+  // Gets the top-level GetStructField expressions from the given expression
+  // and its children. This does not return children of a GetStructField.
+  protected final def getFieldExtractors(expr: Expression): Seq[GetStructField] =
+    expr match {
+      // Check that getField matches SelectedField(_) to ensure that getField defines a chain of
+      // extractors down to an attribute.
+      case getField: GetStructField if SelectedField.unapply(getField).isDefined =>
+        getField :: Nil
+      case _ =>
+        expr.children.flatMap(getFieldExtractors)
+    }
+
+  // Constructs aliases and a substitution function for the given sequence of
+  // GetStructField expressions.
+  protected final def constructAliasesAndSubstitutions(fieldExtractors: Seq[GetStructField]) = {
+    val aliases =
+      fieldExtractors.map(extractor =>
+        Alias(extractor, extractor.childSchema(extractor.ordinal).name)())
+
+    val attributes = aliases.map(alias => (alias.child, alias.toAttribute)).toMap
+
+    val substituteAttributes: Expression => Expression = _.transformDown {
+      case expr: GetStructField => attributes.getOrElse(expr, expr)
+    }
+
+    (aliases, substituteAttributes)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdown.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdown.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, NamedExpression}
+import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
+
+/**
+ * Pushes down aliases to [[expressions.GetStructField]] expressions in a projection over a join
+ * and its join condition. The original [[expressions.GetStructField]] expressions are replaced
+ * with references to the pushed down aliases.
+ */
+object JoinFieldExtractionPushdown extends FieldExtractionPushdown {
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan transformDown {
+      case op @ PhysicalOperation(projects, Seq(),
+          join @ Join(left, right, joinType, Some(joinCondition))) =>
+        val fieldExtractors = (projects :+ joinCondition).flatMap(getFieldExtractors).distinct
+
+        if (fieldExtractors.nonEmpty) {
+          val (aliases, substituteAttributes) = constructAliasesAndSubstitutions(fieldExtractors)
+
+          // Construct the new projections and join condition by substituting each GetStructField
+          // expression with a reference to its alias
+          val newProjects =
+            projects.map(substituteAttributes).collect { case named: NamedExpression => named }
+          val newJoinCondition = substituteAttributes(joinCondition)
+
+          // Prune left and right output attributes according to whether they're needed by the
+          // new projections or join conditions
+          val aliasAttributes = AttributeSet(aliases.map(_.toAttribute))
+          val neededAttributes = AttributeSet((newProjects :+ newJoinCondition)
+            .flatMap(_.collect { case att: Attribute => att })) -- aliasAttributes
+          val leftAtts = left.output.filter(neededAttributes.contains)
+          val rightAtts = right.output.filter(neededAttributes.contains)
+
+          // Construct the left and right side aliases by partitioning the aliases according to
+          // whether they reference attributes in the left side or the right side
+          val (leftAliases, rightAliases) =
+            aliases.partition(_.references.intersect(left.outputSet).nonEmpty)
+
+          val newLeft = Project(leftAtts.toSeq ++ leftAliases, left)
+          val newRight = Project(rightAtts.toSeq ++ rightAliases, right)
+
+          Project(newProjects, Join(newLeft, newRight, joinType, Some(newJoinCondition)))
+        } else {
+          op
+        }
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdown.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdown.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
  * read from a column-oriented file format for joins involving only nested fields.
  */
 object JoinFieldExtractionPushdown extends FieldExtractionPushdown {
-  override def apply(plan: LogicalPlan): LogicalPlan =
+  override protected def apply0(plan: LogicalPlan): LogicalPlan =
     plan transformDown {
       case op @ PhysicalOperation(projects, Seq(),
           join @ Join(left, right, joinType, Some(joinCondition))) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -151,6 +151,9 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
     // The following batch should be executed after batch "Join Reorder" and "LocalRelation".
     Batch("Check Cartesian Products", Once,
       CheckCartesianProducts) :+
+    Batch("Field Extraction Pushdown", fixedPoint,
+      AggregateFieldExtractionPushdown,
+      JoinFieldExtractionPushdown) :+
     Batch("RewriteSubquery", Once,
       RewritePredicateSubquery,
       ColumnPruning,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/GetStructField2.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/GetStructField2.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.planning
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, GetStructField}
+import org.apache.spark.sql.types.StructField
+
+/**
+ * A Scala extractor that extracts the child expression and struct field from a [[GetStructField]].
+ * This is in contrast to the [[GetStructField]] case class extractor which returns the field
+ * ordinal instead of the field itself.
+ */
+private[planning] object GetStructField2 {
+  def unapply(getStructField: GetStructField): Option[(Expression, StructField)] =
+    Some((
+      getStructField.child,
+      getStructField.childSchema(getStructField.ordinal)))
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/GetStructFieldObject.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/GetStructFieldObject.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.StructField
  * This is in contrast to the [[GetStructField]] case class extractor which returns the field
  * ordinal instead of the field itself.
  */
-private[planning] object GetStructField2 {
+private[planning] object GetStructFieldObject {
   def unapply(getStructField: GetStructField): Option[(Expression, StructField)] =
     Some((
       getStructField.child,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/ProjectionOverSchema.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.planning
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types._
+
+/**
+ * A Scala extractor that projects an expression over a given schema. Data types,
+ * field indexes and array lengths of complex type extractors and attributes
+ * are adjusted to fit the schema. All other expressions are left as-is.
+ */
+case class ProjectionOverSchema(schema: StructType) {
+  private val fieldNames = schema.fieldNames.toSet
+
+  def unapply(expr: Expression): Option[Expression] = getProjection(expr)
+
+  private def getProjection(expr: Expression): Option[Expression] =
+    expr match {
+      case a @ AttributeReference(name, _, _, _) if (fieldNames.contains(name)) =>
+        Some(a.copy(dataType = schema(name).dataType)(a.exprId, a.qualifier))
+      case GetArrayItem(child, arrayItemOrdinal) =>
+        getProjection(child).map {
+          case projection =>
+            GetArrayItem(projection, arrayItemOrdinal)
+        }
+      case GetArrayStructFields(child, StructField(name, _, _, _), _, numFields, containsNull) =>
+        getProjection(child).map(p => (p, p.dataType)).map {
+          case (projection, ArrayType(projSchema @ StructType(_), _)) =>
+            GetArrayStructFields(projection,
+              projSchema(name), projSchema.fieldIndex(name), projSchema.size, containsNull)
+        }
+      case GetMapValue(child, key) =>
+        getProjection(child).map {
+          case projection =>
+            GetMapValue(projection, key)
+        }
+      case GetStructField2(child, StructField(name, _, _, _)) =>
+        getProjection(child).map(p => (p, p.dataType)).map {
+          case (projection, projSchema @ StructType(_)) =>
+            GetStructField(projection, projSchema.fieldIndex(name))
+        }
+      case _ =>
+        None
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/ProjectionOverSchema.scala
@@ -50,7 +50,7 @@ case class ProjectionOverSchema(schema: StructType) {
           case projection =>
             GetMapValue(projection, key)
         }
-      case GetStructField2(child, StructField(name, _, _, _)) =>
+      case GetStructFieldObject(child, StructField(name, _, _, _)) =>
         getProjection(child).map(p => (p, p.dataType)).map {
           case (projection, projSchema @ StructType(_)) =>
             GetStructField(projection, projSchema.fieldIndex(name))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/ProjectionOverSchema.scala
@@ -22,8 +22,9 @@ import org.apache.spark.sql.types._
 
 /**
  * A Scala extractor that projects an expression over a given schema. Data types,
- * field indexes and array lengths of complex type extractors and attributes
- * are adjusted to fit the schema. All other expressions are left as-is.
+ * field indexes and field counts of complex type extractors and attributes
+ * are adjusted to fit the schema. All other expressions are left as-is. This
+ * class is motivated by columnar nested schema pruning.
  */
 case class ProjectionOverSchema(schema: StructType) {
   private val fieldNames = schema.fieldNames.toSet

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/SelectedField.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.planning
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types._
+
+/**
+ * A Scala extractor that builds a [[StructField]] from a Catalyst complex type
+ * extractor. This is like the opposite of [[ExtractValue#apply]].
+ */
+object SelectedField {
+  def unapply(expr: Expression): Option[StructField] = {
+    // If this expression is an alias, work on its child instead
+    val unaliased = expr match {
+      case Alias(child, _) => child
+      case expr => expr
+    }
+    selectField(unaliased, None)
+  }
+
+  /**
+   * Converts some chain of complex type extractors into a [[StructField]].
+   *
+   * @param expr the top-level complex type extractor
+   * @param fieldOpt the subfield of [[expr]], where relevent
+   */
+  private def selectField(expr: Expression, fieldOpt: Option[StructField]): Option[StructField] =
+    expr match {
+      case AttributeReference(name, _, nullable, _) =>
+        fieldOpt.map(field => StructField(name, StructType(Array(field)), nullable))
+      case GetArrayItem(GetStructField2(child, field @ StructField(name,
+          ArrayType(_, arrayNullable), fieldNullable, _)), _) =>
+        val childField = fieldOpt.map(field => StructField(name, ArrayType(
+          StructType(Array(field)), arrayNullable), fieldNullable)).getOrElse(field)
+        selectField(child, Some(childField))
+      case GetArrayStructFields(child,
+          field @ StructField(name, _, nullable, _), _, _, containsNull) =>
+        val childField =
+          fieldOpt.map(field => StructField(name, StructType(Array(field)), nullable))
+            .getOrElse(field)
+        selectField(child, Some(childField)).map {
+          case StructField(name,
+              StructType(Array(StructField(name2, dataType, nullable2, _))), nullable, _) =>
+            StructField(name,
+              StructType(Array(StructField(name2,
+                ArrayType(dataType, containsNull), nullable2))), nullable)
+        }
+      case GetMapValue(GetStructField2(child, field @ StructField(name,
+          MapType(keyType, _, keyNullable), fieldNullable, _)), _) =>
+        val childField = fieldOpt.map(field => StructField(name, MapType(keyType,
+          StructType(Array(field)), keyNullable), fieldNullable)).getOrElse(field)
+        selectField(child, Some(childField))
+      case GetStructField2(child, field @ StructField(name, _, nullable, _)) =>
+        val childField = fieldOpt.map(field => StructField(name,
+          StructType(Array(field)), nullable)).getOrElse(field)
+        selectField(child, Some(childField))
+      case _ =>
+        None
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/SelectedField.scala
@@ -94,17 +94,7 @@ object SelectedField {
           fieldOpt.map(field => StructField(name,
             wrapStructType(dataType, field),
             nullable, metadata)).getOrElse(field)
-        selectField(child, Some(childField)).map {
-          case field @ StructField(name,
-              StructType(Array(StructField(name2,
-                elementType,
-                nullable2, metadata2))), nullable, metadata) =>
-            StructField(name,
-              StructType(Array(StructField(name2,
-                ArrayType(elementType, containsNull),
-                nullable2, metadata2))), nullable, metadata)
-          case field => field
-        }
+        selectField(child, Some(childField))
       // Handles case "expr0.field[key]", where "expr0" is of struct type and "expr0.field" is of
       // map type.
       case GetMapValue(x @ GetStructFieldObject(child, field @ StructField(name,
@@ -119,9 +109,9 @@ object SelectedField {
         selectField(child, fieldOpt)
       // Handles case "expr0.field", where expr0 is of struct type.
       case GetStructFieldObject(child,
-        field @ StructField(name, _, nullable, metadata)) =>
+        field @ StructField(name, dataType, nullable, metadata)) =>
         val childField = fieldOpt.map(field => StructField(name,
-          StructType(Array(field)),
+          wrapStructType(dataType, field),
           nullable, metadata)).getOrElse(field)
         selectField(child, Some(childField))
       case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/SelectedField.scala
@@ -64,44 +64,30 @@ object SelectedField {
     selectField(unaliased, None)
   }
 
-  // scalastyle:off
   private def selectField(expr: Expression, fieldOpt: Option[StructField]): Option[StructField] = {
-    val callNo = scala.util.Random.nextInt.toHexString
-    // println(s"$callNo: expr = $expr")
-    // println(s"$callNo: expr.dataType = ${expr.dataType}")
-    // println(s"$callNo: expr.getClass = ${expr.getClass.getSimpleName}")
-    // println(s"$callNo: requesting")
-    // println(fieldOpt.map(field => StructType(field :: Nil).treeString).getOrElse("None"))
-    val ret = expr match {
+    expr match {
       // No children. Returns a StructField with the attribute name or None if fieldOpt is None.
       case AttributeReference(name, dataType, nullable, metadata) =>
         fieldOpt.map(field =>
           StructField(name, wrapStructType(dataType, field), nullable, metadata))
-      // Handles case "col.field[n]", where "field" is an array type. Returns
-      // StructField("col",
-      //   StructType(Array(StructField("field", ArrayType(elementType, containsNull)))))
-      // where "elementType" is the element data type of "field".
-      case GetArrayItem(GetStructFieldObject(child, field @ StructField(name,
+      // Handles case "expr0.field[n]", where "expr0" is of struct type and "expr0.field" is of
+      // array type.
+      case GetArrayItem(x @ GetStructFieldObject(child, field @ StructField(name,
           dataType, nullable, metadata)), _) =>
         val childField = fieldOpt.map(field => StructField(name,
           wrapStructType(dataType, field), nullable, metadata)).getOrElse(field)
         selectField(child, Some(childField))
+      // Handles case "expr0.field[n]", where "expr0.field" is of array type.
       case GetArrayItem(child, _) =>
         selectField(child, fieldOpt)
-      // Handles case "col.field.subfield", where "field" and "subfield" are array types. Returns
-      // StructField("col", StructType(Array(
-      //   StructField("field", ArrayType(elementType, containsNull)))))
-      // where "elementType" is the element data type of "field".
+      // Handles case "expr0.field.subfield", where "expr0" and "expr0.field" are of array type.
       case GetArrayStructFields(child: GetArrayStructFields,
           field @ StructField(name, dataType, nullable, metadata), _, _, _) =>
         val childField = fieldOpt.map(field => StructField(name,
             wrapStructType(dataType, field),
             nullable, metadata)).getOrElse(field)
         selectField(child, Some(childField))
-      // Handles case "col.field", where "field" is an array type. Returns
-      // StructField("col", StructType(Array(
-      //   StructField("field", ArrayType(elementType, containsNull)))))
-      // where "elementType" is the element data type of "field".
+      // Handles case "expr0.field", where "expr0" is of array type.
       case GetArrayStructFields(child,
           field @ StructField(name, dataType, nullable, metadata), _, _, containsNull) =>
         val childField =
@@ -119,24 +105,19 @@ object SelectedField {
                 nullable2, metadata2))), nullable, metadata)
           case field => field
         }
-      // Handles case "col.field[key]", where "field" is a map type. Returns
-      // StructField("col",
-      //   StructType(Array(StructField("field", MapType(keyType, valueType, valueContainsNull)))))
-      // where "keyType" and "valueType" are the data types of keys and values of "field",
-      // respectively.
-      case GetMapValue(GetStructFieldObject(child, field @ StructField(name,
+      // Handles case "expr0.field[key]", where "expr0" is of struct type and "expr0.field" is of
+      // map type.
+      case GetMapValue(x @ GetStructFieldObject(child, field @ StructField(name,
           dataType,
           nullable, metadata)), _) =>
         val childField = fieldOpt.map(field => StructField(name,
           wrapStructType(dataType, field),
           nullable, metadata)).getOrElse(field)
         selectField(child, Some(childField))
+      // Handles case "expr0.field[key]", where "expr0.field" is of map type.
       case GetMapValue(child, _) =>
         selectField(child, fieldOpt)
-      // Handles case "col.field". Returns
-      // StructField("col", StructType(Array(
-      //   StructField("field", fieldType))))
-      // where "fieldType" is the data type of "field".
+      // Handles case "expr0.field", where expr0 is of struct type.
       case GetStructFieldObject(child,
         field @ StructField(name, _, nullable, metadata)) =>
         val childField = fieldOpt.map(field => StructField(name,
@@ -146,12 +127,11 @@ object SelectedField {
       case _ =>
         None
     }
-    // println(s"$callNo: returning")
-    // println(ret.map(field => StructType(field :: Nil).treeString).getOrElse("None"))
-    ret
   }
 
-  private def wrapStructType(dataType: DataType, field: StructField): DataType =
+  // Constructs a composition of complex types with a StructType(Array(field)) at its core. Returns
+  // a StructType for a StructType, an ArrayType for an ArrayType and a MapType for a MapType.
+  private def wrapStructType(dataType: DataType, field: StructField): DataType = {
     dataType match {
       case _: StructType =>
         StructType(Array(field))
@@ -160,4 +140,5 @@ object SelectedField {
       case MapType(keyType, valueType, valueContainsNull) =>
         MapType(keyType, wrapStructType(valueType, field), valueContainsNull)
     }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -106,20 +106,21 @@ trait ConstraintHelper {
     constraint match {
       // When the root is IsNotNull, we can push IsNotNull through the child null intolerant
       // expressions
-      case IsNotNull(expr) => scanNullIntolerantAttribute(expr).map(IsNotNull(_))
+      case IsNotNull(expr) => scanNullIntolerantField(expr).map(IsNotNull(_))
       // Constraints always return true for all the inputs. That means, null will never be returned.
       // Thus, we can infer `IsNotNull(constraint)`, and also push IsNotNull through the child
       // null intolerant expressions.
-      case _ => scanNullIntolerantAttribute(constraint).map(IsNotNull(_))
+      case _ => scanNullIntolerantField(constraint).map(IsNotNull(_))
     }
 
   /**
    * Recursively explores the expressions which are null intolerant and returns all attributes
    * in these expressions.
    */
-  private def scanNullIntolerantAttribute(expr: Expression): Seq[Attribute] = expr match {
+  private def scanNullIntolerantField(expr: Expression): Seq[Expression] = expr match {
+    case ev: ExtractValue => Seq(ev)
     case a: Attribute => Seq(a)
-    case _: NullIntolerant => expr.children.flatMap(scanNullIntolerantAttribute)
+    case _: NullIntolerant => expr.children.flatMap(scanNullIntolerantField)
     case _ => Seq.empty[Attribute]
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -81,8 +81,9 @@ trait ConstraintHelper {
 
   /**
    * Infers a set of `isNotNull` constraints from null intolerant expressions as well as
-   * non-nullable attributes. For e.g., if an expression is of the form (`a > 5`), this
-   * returns a constraint of the form `isNotNull(a)`
+   * non-nullable attributes and complex type extractors. For example, if an expression is of the
+   * form (`a > 5`), this returns a constraint of the form `isNotNull(a)`. For an expression of the
+   * form (`a.b > 5`), this returns the more precise constraint `isNotNull(a.b)`.
    */
   def constructIsNotNullConstraints(
       constraints: Set[Expression],
@@ -99,8 +100,8 @@ trait ConstraintHelper {
   }
 
   /**
-   * Infer the Attribute-specific IsNotNull constraints from the null intolerant child expressions
-   * of constraints.
+   * Infer the Attribute and ExtractValue-specific IsNotNull constraints from the null intolerant
+   * child expressions of constraints.
    */
   private def inferIsNotNullConstraints(constraint: Expression): Seq[Expression] =
     constraint match {
@@ -114,8 +115,8 @@ trait ConstraintHelper {
     }
 
   /**
-   * Recursively explores the expressions which are null intolerant and returns all attributes
-   * in these expressions.
+   * Recursively explores the expressions which are null intolerant and returns all attributes and
+   * complex type extractors in these expressions.
    */
   private def scanNullIntolerantField(expr: Expression): Seq[Expression] = expr match {
     case ev: ExtractValue => Seq(ev)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1243,9 +1243,10 @@ object SQLConf {
       .internal()
       .doc("Prune nested fields from a logical relation's output which are unnecessary in " +
         "satisfying a query. This optimization allows columnar file format readers to avoid " +
-        "reading unnecessary nested column data.")
+        "reading unnecessary nested column data. Currently Parquet is the only data source that " +
+        "implements this optimization.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1235,6 +1235,15 @@ object SQLConf {
         "issues. Turn on this config to insert a local sort before actually doing repartition " +
         "to generate consistent repartition results. The performance of repartition() may go " +
         "down since we insert extra local sort before it.")
+        .booleanConf
+        .createWithDefault(true)
+
+  val NESTED_SCHEMA_PRUNING_ENABLED =
+    buildConf("spark.sql.nestedSchemaPruning.enabled")
+      .internal()
+      .doc("Prune nested fields from a logical relation's output which are unnecessary in " +
+        "satisfying a query. This optimization allows columnar file format readers to avoid " +
+        "reading unnecessary nested column data.")
       .booleanConf
       .createWithDefault(true)
 
@@ -1602,6 +1611,8 @@ class SQLConf extends Serializable with Logging {
 
   def partitionOverwriteMode: PartitionOverwriteMode.Value =
     PartitionOverwriteMode.withName(getConf(PARTITION_OVERWRITE_MODE))
+
+  def nestedSchemaPruningEnabled: Boolean = getConf(NESTED_SCHEMA_PRUNING_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/SchemaPruningTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/SchemaPruningTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.internal.SQLConf.NESTED_SCHEMA_PRUNING_ENABLED
+
+/**
+ * A PlanTest that ensures that all tests in this suite are run with nested schema pruning enabled.
+ * Remove this trait once the default value of SQLConf.NESTED_SCHEMA_PRUNING_ENABLED is set to true.
+ */
+private[sql] trait SchemaPruningTest extends PlanTest with BeforeAndAfterAll {
+  private var originalConfSchemaPruningEnabled = false
+
+  override protected def beforeAll(): Unit = {
+    // Call `withSQLConf` eagerly because some subtypes of `PlanTest` (I'm looking at you,
+    // `SQLTestUtils`) override `withSQLConf` to reset the existing `SQLConf` with a new one without
+    // copying existing settings first. This here is an awful, ugly way to get around that behavior
+    // by initializing the "real" `SQLConf` with an noop call to `withSQLConf`. I don't want to risk
+    // "fixing" the downstream behavior, breaking everything else that's expecting these semantics.
+    // Oh well...
+    withSQLConf()(())
+    originalConfSchemaPruningEnabled = conf.nestedSchemaPruningEnabled
+    conf.setConf(NESTED_SCHEMA_PRUNING_ENABLED, true)
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      super.afterAll()
+    } finally {
+      conf.setConf(NESTED_SCHEMA_PRUNING_ENABLED, originalConfSchemaPruningEnabled)
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdownSuite.scala
@@ -17,15 +17,15 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.catalyst.SchemaPruningTest
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.aggregate.Count
-import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types._
 
-class AggregateFieldExtractionPushdownSuite extends PlanTest {
+class AggregateFieldExtractionPushdownSuite extends SchemaPruningTest {
   private val testRelation =
     LocalRelation(
       StructField("a", StructType(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdownSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.aggregate.Count
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types._
+
+class AggregateFieldExtractionPushdownSuite extends PlanTest {
+  private val testRelation =
+    LocalRelation(
+      StructField("a", StructType(
+        StructField("a1", IntegerType) :: Nil)),
+      StructField("b", IntegerType),
+      StructField("c", StructType(
+        StructField("c1", IntegerType) :: Nil)))
+
+  object Optimizer extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Aggregate Field Extraction Pushdown", Once,
+        AggregateFieldExtractionPushdown) :: Nil
+  }
+
+  test("basic aggregate field extraction pushdown") {
+    val originalQuery =
+      testRelation
+        .select('a)
+        .groupBy('a getField "a1")('a getField "a1" as 'a1, Count('*))
+        .analyze
+    val optimized = Optimizer.execute(originalQuery)
+    val correctAnswer =
+      testRelation
+        .select('a)
+        .select('a getField "a1" as 'a1)
+        .groupBy('a1)('a1 as 'a1, Count('*))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("do not push down a field extractor whose root child output is required by the aggregate") {
+    val originalQuery =
+      testRelation
+        .select('a, 'c)
+        .groupBy('a, 'a getField "a1", 'c getField "c1")(
+          'a, 'a getField "a1" as 'a1, 'c getField "c1" as 'c1, Count('*))
+        .analyze
+    val optimized = Optimizer.execute(originalQuery)
+    val correctAnswer =
+      testRelation
+        .select('a, 'c)
+        .select('a, 'c getField "c1" as 'c1)
+        .groupBy('a, 'a getField "a1", 'c1)('a, 'a getField "a1" as 'a1, 'c1 as 'c1, Count('*))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateFieldExtractionPushdownSuite.scala
@@ -44,14 +44,14 @@ class AggregateFieldExtractionPushdownSuite extends PlanTest {
     val originalQuery =
       testRelation
         .select('a)
-        .groupBy('a getField "a1")('a getField "a1" as 'a1, Count('*))
+        .groupBy('a getField "a1")('a getField "a1" as 'a1, Count("*"))
         .analyze
     val optimized = Optimizer.execute(originalQuery)
     val correctAnswer =
       testRelation
         .select('a)
         .select('a getField "a1" as 'a1)
-        .groupBy('a1)('a1 as 'a1, Count('*))
+        .groupBy('a1)('a1 as 'a1, Count("*"))
         .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -62,14 +62,14 @@ class AggregateFieldExtractionPushdownSuite extends PlanTest {
       testRelation
         .select('a, 'c)
         .groupBy('a, 'a getField "a1", 'c getField "c1")(
-          'a, 'a getField "a1" as 'a1, 'c getField "c1" as 'c1, Count('*))
+          'a, 'a getField "a1" as 'a1, 'c getField "c1" as 'c1, Count("*"))
         .analyze
     val optimized = Optimizer.execute(originalQuery)
     val correctAnswer =
       testRelation
         .select('a, 'c)
         .select('a, 'c getField "c1" as 'c1)
-        .groupBy('a, 'a getField "a1", 'c1)('a, 'a getField "a1" as 'a1, 'c1 as 'c1, Count('*))
+        .groupBy('a, 'a getField "a1", 'c1)('a, 'a getField "a1" as 'a1, 'c1 as 'c1, Count("*"))
         .analyze
 
     comparePlans(optimized, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdownSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.catalyst.SchemaPruningTest
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
@@ -25,7 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types._
 
-class JoinFieldExtractionPushdownSuite extends PlanTest {
+class JoinFieldExtractionPushdownSuite extends SchemaPruningTest {
   private val leftRelation =
     LocalRelation(
       StructField("la", StructType(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinFieldExtractionPushdownSuite.scala
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types._
+
+class JoinFieldExtractionPushdownSuite extends PlanTest {
+  private val leftRelation =
+    LocalRelation(
+      StructField("la", StructType(
+        StructField("la1", IntegerType) :: Nil)),
+      StructField("lb", IntegerType),
+      StructField("lc", StructType(
+        StructField("lc1", IntegerType) :: Nil)))
+
+  private val rightRelation =
+    LocalRelation(
+      StructField("ra", StructType(
+        StructField("ra1", IntegerType) :: Nil)),
+      StructField("rb", IntegerType),
+      StructField("rc", StructType(
+        StructField("rc1", IntegerType) :: Nil)))
+
+  private val joinTypes = Inner :: LeftOuter :: RightOuter :: FullOuter :: LeftSemi :: Nil
+
+  object Optimizer extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Join Field Extraction Pushdown", Once,
+        JoinFieldExtractionPushdown) :: Nil
+  }
+
+  test("don't modify simple joins") {
+    joinTypes.foreach { joinType =>
+      val originalQuery =
+        leftRelation.join(rightRelation, joinType, Some($"lb" === $"rb")).analyze
+      val optimized = Optimizer.execute(originalQuery)
+
+      comparePlans(optimized, originalQuery)
+    }
+  }
+
+  test("don't modify output of bare join") {
+    joinTypes.filterNot(_ == LeftSemi).foreach { joinType =>
+      val originalQuery =
+        leftRelation.join(rightRelation, joinType, Some($"la.la1" === $"rb")).analyze
+      val optimized = Optimizer.execute(originalQuery)
+      val correctAnswer =
+        leftRelation.select('la, 'lb, 'lc, $"la.la1" as 'la1)
+          .join(rightRelation.select('ra, 'rb, 'rc), joinType, Some('la1 === 'rb))
+          .select('la, 'lb, 'lc, 'ra, 'rb, 'rc)
+          .analyze
+
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+
+  test("push down left join condition path of degree 1") {
+    joinTypes.foreach { joinType =>
+      val originalQuery =
+        leftRelation.join(rightRelation, joinType, Some($"la.la1" === $"rb"))
+        .select($"la.la1")
+        .analyze
+      val optimized = Optimizer.execute(originalQuery)
+      val correctAnswer =
+        leftRelation.select($"la.la1" as 'la1)
+          .join(rightRelation.select('rb), joinType, Some('la1 === 'rb))
+          .select('la1 as 'la1)
+          .analyze
+
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+
+  test("push down right join condition path of degree 1") {
+    joinTypes.filterNot(_ == LeftSemi).foreach { joinType =>
+      val originalQuery =
+        leftRelation.join(rightRelation, joinType, Some($"lb" === $"ra.ra1"))
+        .select($"ra.ra1")
+        .analyze
+      val optimized = Optimizer.execute(originalQuery)
+      val correctAnswer =
+        leftRelation.select('lb)
+          .join(rightRelation.select($"ra.ra1" as 'ra1), joinType, Some('lb === 'ra1))
+          .select('ra1 as 'ra1)
+          .analyze
+
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+
+  test("push down both join condition paths of degree 1") {
+    def test1(
+        joinType: JoinType,
+        originalSelects: Seq[NamedExpression],
+        expectedSelects: Seq[NamedExpression]) {
+      val originalQuery =
+        leftRelation.join(rightRelation, joinType, Some($"la.la1" === $"ra.ra1"))
+        .select(originalSelects: _*)
+        .analyze
+      val optimized = Optimizer.execute(originalQuery)
+      val correctAnswer =
+        leftRelation.select($"la.la1" as 'la1)
+          .join(rightRelation.select($"ra.ra1" as 'ra1), joinType, Some('la1 === 'ra1))
+          .select(expectedSelects: _*)
+          .analyze
+
+      comparePlans(optimized, correctAnswer)
+    }
+
+    joinTypes.filterNot(_ == LeftSemi)
+      .foreach(joinType =>
+        test1(joinType, $"la.la1" :: $"ra.ra1" :: Nil, ('la1 as 'la1) :: ('ra1 as 'ra1) :: Nil))
+
+    test1(LeftSemi, $"la.la1" :: Nil, ('la1 as 'la1) :: Nil)
+  }
+
+  test("don't prune root of leaf when the root is in the projection") {
+    joinTypes.filterNot(_ == LeftSemi).foreach { joinType =>
+      val originalQuery =
+        leftRelation.join(rightRelation, joinType, Some($"la.la1" === $"ra.ra1"))
+        .select($"la.la1", 'ra)
+        .analyze
+      val optimized = Optimizer.execute(originalQuery)
+      val correctAnswer =
+        leftRelation.select($"la.la1" as 'la1)
+          .join(rightRelation.select('ra, $"ra.ra1" as 'ra1), joinType, Some('la1 === 'ra1))
+          .select('la1 as 'la1, 'ra)
+          .analyze
+
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.planning
 
+import org.scalatest.exceptions.TestFailedException
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
@@ -25,6 +27,39 @@ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.types._
 
 class SelectedFieldSuite extends SparkFunSuite {
+  // The test schema as a tree string, i.e. `schema.treeString`
+  // root
+  //  |-- col1: string (nullable = true)
+  //  |-- col2: struct (nullable = true)
+  //  |    |-- field1: integer (nullable = true)
+  //  |    |-- field2: array (nullable = true)
+  //  |    |    |-- element: integer (containsNull = false)
+  //  |    |-- field3: array (nullable = false)
+  //  |    |    |-- element: struct (containsNull = true)
+  //  |    |    |    |-- subfield1: integer (nullable = true)
+  //  |    |    |    |-- subfield2: integer (nullable = true)
+  //  |    |    |    |-- subfield3: array (nullable = true)
+  //  |    |    |    |    |-- element: integer (containsNull = true)
+  //  |    |-- field4: map (nullable = true)
+  //  |    |    |-- key: string
+  //  |    |    |-- value: struct (valueContainsNull = false)
+  //  |    |    |    |-- subfield1: integer (nullable = true)
+  //  |    |-- field5: array (nullable = true)
+  //  |    |    |-- element: struct (containsNull = false)
+  //  |    |    |    |-- subfield1: struct (nullable = true)
+  //  |    |    |    |    |-- subsubfield1: integer (nullable = true)
+  //  |    |    |    |    |-- subsubfield2: integer (nullable = true)
+  //  |    |    |    |-- subfield2: struct (nullable = true)
+  //  |    |    |    |    |-- subsubfield1: struct (nullable = true)
+  //  |    |    |    |    |    |-- subsubsubfield1: string (nullable = true)
+  //  |    |    |    |    |-- subsubfield2: integer (nullable = true)
+  //  |    |-- field6: struct (nullable = true)
+  //  |    |    |-- subfield1: string (nullable = true)
+  //  |    |    |-- subfield2: string (nullable = true)
+  //  |    |-- field7: struct (nullable = true)
+  //  |    |    |-- subfield1: struct (nullable = true)
+  //  |    |    |    |-- subsubfield1: integer (nullable = true)
+  //  |    |    |    |-- subsubfield2: integer (nullable = true)
   private val schema =
     StructType(
       StructField("col1", StringType) ::
@@ -33,9 +68,25 @@ class SelectedFieldSuite extends SparkFunSuite {
         StructField("field2", ArrayType(IntegerType, false)) ::
         StructField("field3", ArrayType(StructType(
           StructField("subfield1", IntegerType) ::
-          StructField("subfield2", IntegerType) :: Nil)), false) ::
+          StructField("subfield2", IntegerType) ::
+          StructField("subfield3", ArrayType(IntegerType)) :: Nil)), false) ::
         StructField("field4", MapType(StringType, StructType(
-          StructField("subfield1", IntegerType) :: Nil), false)) :: Nil)) :: Nil)
+          StructField("subfield1", IntegerType) :: Nil), false)) ::
+        StructField("field5", ArrayType(StructType(
+          StructField("subfield1", StructType(
+            StructField("subsubfield1", IntegerType) ::
+            StructField("subsubfield2", IntegerType) :: Nil)) ::
+          StructField("subfield2", StructType(
+            StructField("subsubfield1", StructType(
+              StructField("subsubsubfield1", StringType) :: Nil)) ::
+            StructField("subsubfield2", IntegerType) :: Nil)) :: Nil))) ::
+        StructField("field6", StructType(
+          StructField("subfield1", StringType) ::
+          StructField("subfield2", StringType) :: Nil)) ::
+        StructField("field7", StructType(
+          StructField("subfield1", StructType(
+            StructField("subsubfield1", IntegerType) ::
+            StructField("subsubfield2", IntegerType) :: Nil)) :: Nil)) :: Nil)) :: Nil)
 
   private val testRelation = LocalRelation(schema.toAttributes)
 
@@ -46,54 +97,186 @@ class SelectedFieldSuite extends SparkFunSuite {
   }
 
   test("should extract a field from a GetArrayItem") {
-    unapplySelect("col2.field2[0] as foo") match {
+    val expr1 = "col2.field2[0] as foo"
+    unapplySelect(expr1) match {
       case Some(field) =>
         assertResult(
           StructField("col2", StructType(
-            StructField("field2", ArrayType(IntegerType, false)) :: Nil)))(field)
+            StructField("field2", ArrayType(IntegerType, false)) :: Nil)))(field)(expr1)
       case None => fail
     }
 
-    unapplySelect("col2.field3[0] as foo") match {
-      case Some(field) =>
-        assertResult(
-          StructField("col2", StructType(
-              StructField("field3", ArrayType(StructType(
-                StructField("subfield1", IntegerType) ::
-                StructField("subfield2", IntegerType) :: Nil)), false) :: Nil)))(field)
-      case None => fail
-    }
-  }
-
-  test("should extract a field from a GetArrayStructFields") {
-    unapplySelect("col2.field3.subfield1") match {
+    val expr2 = "col2.field3[0] as foo"
+    unapplySelect(expr2) match {
       case Some(field) =>
         assertResult(
           StructField("col2", StructType(
             StructField("field3", ArrayType(StructType(
-              StructField("subfield1", IntegerType) :: Nil)), false) :: Nil)))(field)
+              StructField("subfield1", IntegerType) ::
+              StructField("subfield2", IntegerType) ::
+              StructField("subfield3", ArrayType(IntegerType)) ::
+              Nil)), false) :: Nil)))(field)(expr2)
+      case None => fail
+    }
+  }
+
+  test("should extract a field of atomic type from a GetArrayStructFields") {
+    val expr = "col2.field3.subfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        val expected =
+          StructField("col2", StructType(
+            StructField("field3", ArrayType(StructType(
+              StructField("subfield1", IntegerType) :: Nil)), false) :: Nil))
+        assertResult(expected)(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract a field of array type from a GetArrayStructFields") {
+    val expr = "col2.field3.subfield3"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        val expected =
+          StructField("col2", StructType(
+            StructField("field3", ArrayType(StructType(
+              StructField("subfield3", ArrayType(IntegerType)) :: Nil)), false) :: Nil))
+        assertResult(expected)(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract a field of struct type from a GetArrayStructFields") {
+    val expr = "col2.field5.subfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        val expected =
+          StructField("col2", StructType(
+            StructField("field5", ArrayType(StructType(
+              StructField("subfield1", StructType(
+                StructField("subsubfield1", IntegerType) ::
+                StructField("subsubfield2", IntegerType) :: Nil)) :: Nil))) :: Nil))
+        assertResult(expected)(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract a field from a field of a GetArrayStructFields") {
+    val expr = "col2.field5.subfield1.subsubfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        val expected =
+          StructField("col2", StructType(
+            StructField("field5", ArrayType(StructType(
+              StructField("subfield1", StructType(
+                StructField("subsubfield1", IntegerType) :: Nil)) :: Nil))) :: Nil))
+        assertResult(expected)(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract a field from a field from a field of a GetArrayStructFields") {
+    val expr = "col2.field5.subfield2.subsubfield1.subsubsubfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        val expected =
+          StructField("col2", StructType(
+            StructField("field5", ArrayType(StructType(
+              StructField("subfield2", StructType(
+                StructField("subsubfield1", StructType(
+                  StructField("subsubsubfield1", StringType) :: Nil)) :: Nil)) :: Nil))) ::
+            Nil))
+        assertResult(expected)(field)(expr)
       case None => fail
     }
   }
 
   test("should extract a field from a GetMapValue") {
-    unapplySelect("col2.field4['foo'] as foo") match {
+    val expr = "col2.field4['foo'] as foo"
+    unapplySelect(expr) match {
       case Some(field) =>
         assertResult(
           StructField("col2", StructType(
             StructField("field4", MapType(StringType, StructType(
-              StructField("subfield1", IntegerType) :: Nil), false)) :: Nil)))(field)
+              StructField("subfield1", IntegerType) :: Nil), false)) :: Nil)))(field)(expr)
       case None => fail
     }
   }
 
   test("should extract a field from a GetStructField") {
-    unapplySelect("col2.field1") match {
+    val expr = "col2.field1"
+    unapplySelect(expr) match {
       case Some(field) =>
         assertResult(
           StructField("col2", StructType(
-            StructField("field1", IntegerType) :: Nil)))(field)
+            StructField("field1", IntegerType) :: Nil)))(field)(expr)
       case None => fail
+    }
+  }
+
+  test("should extract a field of type StructType from a GetStructField") {
+    val expr = "col2.field6"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field6", StructType(
+              StructField("subfield1", StringType) ::
+              StructField("subfield2", StringType) :: Nil)) :: Nil)))(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract a subfield of type StructType from a field from a GetStructField") {
+    val expr = "col2.field7.subfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field7", StructType(
+              StructField("subfield1", StructType(
+                StructField("subsubfield1", IntegerType) ::
+                StructField("subsubfield2", IntegerType) :: Nil)) :: Nil)) :: Nil)))(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract a subfield from a field from a GetStructField") {
+    val expr = "col2.field6.subfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field6", StructType(
+              StructField("subfield1", StringType) :: Nil)) :: Nil)))(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("should extract an array field from a GetStructField") {
+    val expr = "col2.field2"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field2", ArrayType(IntegerType, false)) :: Nil)))(field)(expr)
+      case None => fail
+    }
+  }
+
+  def assertResult(expected: StructField)(actual: StructField)(expr: String): Unit = {
+    try {
+      super.assertResult(expected)(actual)
+    } catch {
+      case ex: TestFailedException =>
+        println("For " + expr)
+        println("Expected:")
+        println(StructType(expected :: Nil).treeString)
+        println("Actual:")
+        println(StructType(actual :: Nil).treeString)
+        println("expected.dataType.sameType(actual.dataType) = " +
+          expected.dataType.sameType(actual.dataType))
+        throw ex
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
@@ -178,14 +178,6 @@ class SelectedFieldSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   private val testRelation = LocalRelation(schema.toAttributes)
 
-  override def beforeAll() {
-    val indentedSchema = schema.treeString.split('\n').map(x => "  " + x).mkString("\n") + "\n"
-    // Print the test schema at the beginning of the test
-    // scalastyle:off println
-    println("Testing SelectedField extractor using the following schema:\n" + indentedSchema)
-    // scalastyle:on println
-  }
-
   test("should not match an attribute reference") {
     assertResult(None)(unapplySelect("col1"))
     assertResult(None)(unapplySelect("col1 as foo"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
@@ -180,7 +180,10 @@ class SelectedFieldSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   override def beforeAll() {
     val indentedSchema = schema.treeString.split('\n').map(x => "  " + x).mkString("\n") + "\n"
+    // Print the test schema at the beginning of the test
+    // scalastyle:off println
     println("Testing SelectedField extractor using the following schema:\n" + indentedSchema)
+    // scalastyle:on println
   }
 
   test("should not match an attribute reference") {
@@ -398,6 +401,8 @@ class SelectedFieldSuite extends SparkFunSuite with BeforeAndAfterAll {
       super.assertResult(expected)(actual)
     } catch {
       case ex: TestFailedException =>
+        // Print some helpful diagnostics in the case of failure
+        // scalastyle:off println
         println("For " + expr)
         println("Expected:")
         println(StructType(expected :: Nil).treeString)
@@ -405,6 +410,7 @@ class SelectedFieldSuite extends SparkFunSuite with BeforeAndAfterAll {
         println(StructType(actual :: Nil).treeString)
         println("expected.dataType.sameType(actual.dataType) = " +
           expected.dataType.sameType(actual.dataType))
+        // scalastyle:on println
         throw ex
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
@@ -45,7 +45,7 @@ class SelectedFieldSuite extends SparkFunSuite {
   //  |    |    |-- value: struct (valueContainsNull = false)
   //  |    |    |    |-- subfield1: integer (nullable = true)
   //  |    |-- field5: array (nullable = true)
-  //  |    |    |-- element: struct (containsNull = false)
+  //  |    |    |-- element: struct (containsNull = true)
   //  |    |    |    |-- subfield1: struct (nullable = true)
   //  |    |    |    |    |-- subsubfield1: integer (nullable = true)
   //  |    |    |    |    |-- subsubfield2: integer (nullable = true)
@@ -60,6 +60,11 @@ class SelectedFieldSuite extends SparkFunSuite {
   //  |    |    |-- subfield1: struct (nullable = true)
   //  |    |    |    |-- subsubfield1: integer (nullable = true)
   //  |    |    |    |-- subsubfield2: integer (nullable = true)
+  //  |-- col3: array (nullable = true)
+  //  |    |-- element: struct (containsNull = true)
+  //  |    |    |-- field1: struct (nullable = true)
+  //  |    |    |    |-- subfield1: integer (nullable = true)
+  //  |    |    |    |-- subfield2: integer (nullable = true)
   private val schema =
     StructType(
       StructField("col1", StringType) ::
@@ -86,7 +91,11 @@ class SelectedFieldSuite extends SparkFunSuite {
         StructField("field7", StructType(
           StructField("subfield1", StructType(
             StructField("subsubfield1", IntegerType) ::
-            StructField("subsubfield2", IntegerType) :: Nil)) :: Nil)) :: Nil)) :: Nil)
+            StructField("subsubfield2", IntegerType) :: Nil)) :: Nil)) :: Nil)) ::
+     StructField("col3", ArrayType(StructType(
+       StructField("field1", StructType(
+         StructField("subfield1", IntegerType) ::
+         StructField("subfield2", IntegerType) :: Nil)) :: Nil))) :: Nil)
 
   private val testRelation = LocalRelation(schema.toAttributes)
 
@@ -156,6 +165,19 @@ class SelectedFieldSuite extends SparkFunSuite {
               StructField("subfield1", StructType(
                 StructField("subsubfield1", IntegerType) ::
                 StructField("subsubfield2", IntegerType) :: Nil)) :: Nil))) :: Nil))
+        assertResult(expected)(field)(expr)
+      case None => fail
+    }
+  }
+
+  test("blah") {
+    val expr = "col3.field1.subfield1"
+    unapplySelect(expr) match {
+      case Some(field) =>
+        val expected =
+          StructField("col3", ArrayType(StructType(
+            StructField("field1", StructType(
+              StructField("subfield1", IntegerType) :: Nil)) :: Nil)))
         assertResult(expected)(field)(expr)
       case None => fail
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/SelectedFieldSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.planning
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.types._
+
+class SelectedFieldSuite extends SparkFunSuite {
+  private val schema =
+    StructType(
+      StructField("col1", StringType) ::
+      StructField("col2", StructType(
+        StructField("field1", IntegerType) ::
+        StructField("field2", ArrayType(IntegerType, false)) ::
+        StructField("field3", ArrayType(StructType(
+          StructField("subfield1", IntegerType) ::
+          StructField("subfield2", IntegerType) :: Nil)), false) ::
+        StructField("field4", MapType(StringType, StructType(
+          StructField("subfield1", IntegerType) :: Nil), false)) :: Nil)) :: Nil)
+
+  private val testRelation = LocalRelation(schema.toAttributes)
+
+  test("should not match an attribute reference") {
+    assertResult(None)(unapplySelect("col1"))
+    assertResult(None)(unapplySelect("col1 as foo"))
+    assertResult(None)(unapplySelect("col2"))
+  }
+
+  test("should extract a field from a GetArrayItem") {
+    unapplySelect("col2.field2[0] as foo") match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field2", ArrayType(IntegerType, false)) :: Nil)))(field)
+      case None => fail
+    }
+
+    unapplySelect("col2.field3[0] as foo") match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+              StructField("field3", ArrayType(StructType(
+                StructField("subfield1", IntegerType) ::
+                StructField("subfield2", IntegerType) :: Nil)), false) :: Nil)))(field)
+      case None => fail
+    }
+  }
+
+  test("should extract a field from a GetArrayStructFields") {
+    unapplySelect("col2.field3.subfield1") match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field3", ArrayType(StructType(
+              StructField("subfield1", IntegerType) :: Nil)), false) :: Nil)))(field)
+      case None => fail
+    }
+  }
+
+  test("should extract a field from a GetMapValue") {
+    unapplySelect("col2.field4['foo'] as foo") match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field4", MapType(StringType, StructType(
+              StructField("subfield1", IntegerType) :: Nil), false)) :: Nil)))(field)
+      case None => fail
+    }
+  }
+
+  test("should extract a field from a GetStructField") {
+    unapplySelect("col2.field1") match {
+      case Some(field) =>
+        assertResult(
+          StructField("col2", StructType(
+            StructField("field1", IntegerType) :: Nil)))(field)
+      case None => fail
+    }
+  }
+
+  private def unapplySelect(expr: String) = {
+    val parsedExpr =
+      CatalystSqlParser.parseExpression(expr) match {
+        case namedExpr: NamedExpression => namedExpr
+      }
+    val select = testRelation.select(parsedExpr)
+    val analyzed = select.analyze
+    SelectedField.unapply(analyzed.expressions.head)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.ExperimentalMethods
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
 import org.apache.spark.sql.execution.datasources.PruneFileSourcePartitions
+import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaPruning
 import org.apache.spark.sql.execution.datasources.v2.PushDownOperatorsToDataSource
 import org.apache.spark.sql.execution.python.ExtractPythonUDFFromAggregate
 
@@ -33,6 +34,7 @@ class SparkOptimizer(
     Batch("Optimize Metadata Only Query", Once, OptimizeMetadataOnlyQuery(catalog)) :+
     Batch("Extract Python UDF from Aggregate", Once, ExtractPythonUDFFromAggregate) :+
     Batch("Prune File Source Table Partitions", Once, PruneFileSourcePartitions) :+
+    Batch("Parquet Schema Pruning", Once, ParquetSchemaPruning) :+
     Batch("Push down operators to data source scan", Once, PushDownOperatorsToDataSource)) ++
     postHocOptimizationBatches :+
     Batch("User Provided Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -162,7 +162,9 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     val generatedIsNotNullChecks = new Array[Boolean](notNullPreds.length)
     val generated = otherPreds.map { c =>
       val nullChecks = c.references.map { r =>
-        val idx = notNullPreds.indexWhere { n => n.asInstanceOf[IsNotNull].child.semanticEquals(r)}
+        val idx = notNullPreds.indexWhere { n =>
+          n.asInstanceOf[IsNotNull].child.references.contains(r)
+        }
         if (idx != -1 && !generatedIsNotNullChecks(idx)) {
           generatedIsNotNullChecks(idx) = true
           // Use the child's output. The nullability is what the child produced.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
@@ -20,8 +20,13 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
 
-trait ColumnarFileFormat {
+/**
+ * An optional mix-in for columnar [[FileFormat]]s. This trait provides some helpful metadata when
+ * debugging a physical query plan.
+ */
+private[sql] trait ColumnarFileFormat {
   _: FileFormat =>
 
+  /** Returns the number of columns in this file format required to satisfy the given schema. */
   def columnCountForSchema(sparkSession: SparkSession, readSchema: StructType): Int
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
+
+trait ColumnarFileFormat {
+  _: FileFormat =>
+
+  def columnCountForSchema(sparkSession: SparkSession, readSchema: StructType): Int
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -55,6 +55,7 @@ import org.apache.spark.util.{SerializableConfiguration, ThreadUtils}
 
 class ParquetFileFormat
   extends FileFormat
+  with ColumnarFileFormat
   with DataSourceRegister
   with Logging
   with Serializable {
@@ -71,6 +72,14 @@ class ParquetFileFormat
   override def hashCode(): Int = getClass.hashCode()
 
   override def equals(other: Any): Boolean = other.isInstanceOf[ParquetFileFormat]
+
+  override def columnCountForSchema(sparkSession: SparkSession, readSchema: StructType): Int = {
+    val converter = new SparkToParquetSchemaConverter(
+          sparkSession.sessionState.conf.writeLegacyParquetFormat,
+          sparkSession.sessionState.conf.parquetOutputTimestampType)
+    val parquetSchema = converter.convert(readSchema)
+    parquetSchema.getPaths.size
+  }
 
   override def prepareWrite(
       sparkSession: SparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -414,11 +414,12 @@ class ParquetFileFormat
       } else {
         logDebug(s"Falling back to parquet-mr")
         // ParquetRecordReader returns UnsafeRow
+        val readSupport = new ParquetReadSupport(convertTz, true)
         val reader = if (pushed.isDefined && enableRecordFilter) {
           val parquetFilter = FilterCompat.get(pushed.get, null)
-          new ParquetRecordReader[UnsafeRow](new ParquetReadSupport(convertTz), parquetFilter)
+          new ParquetRecordReader[UnsafeRow](readSupport, parquetFilter)
         } else {
-          new ParquetRecordReader[UnsafeRow](new ParquetReadSupport(convertTz))
+          new ParquetRecordReader[UnsafeRow](readSupport)
         }
         val iter = new RecordReaderIterator(reader)
         // SPARK-23457 Register a task completion lister before `initialization`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -47,16 +47,25 @@ import org.apache.spark.sql.types._
  *
  * Due to this reason, we no longer rely on [[ReadContext]] to pass requested schema from [[init()]]
  * to [[prepareForRead()]], but use a private `var` for simplicity.
+ *
+ * @param parquetMrCompatibility support reading with parquet-mr or Spark's built-in Parquet reader
  */
-private[parquet] class ParquetReadSupport(val convertTz: Option[TimeZone])
+private[parquet] class ParquetReadSupport(val convertTz: Option[TimeZone],
+    parquetMrCompatibility: Boolean)
     extends ReadSupport[UnsafeRow] with Logging {
   private var catalystRequestedSchema: StructType = _
 
+  /**
+   * Construct a [[ParquetReadSupport]] with [[convertTz]] set to [[None]] and
+   * [[parquetMrCompatibility]] set to [[false]].
+   *
+   * We need a zero-arg constructor for SpecificParquetRecordReaderBase.  But that is only
+   * used in the vectorized reader, where we get the convertTz value directly, and the value here
+   * is ignored. Further, we set [[parquetMrCompatibility]] to [[false]] as this constructor is only
+   * called by the Spark reader.
+   */
   def this() {
-    // We need a zero-arg constructor for SpecificParquetRecordReaderBase.  But that is only
-    // used in the vectorized reader, where we get the convertTz value directly, and the value here
-    // is ignored.
-    this(None)
+    this(None, false)
   }
 
   /**
@@ -71,8 +80,21 @@ private[parquet] class ParquetReadSupport(val convertTz: Option[TimeZone])
       StructType.fromString(schemaString)
     }
 
-    val parquetRequestedSchema =
+    val clippedParquetSchema =
       ParquetReadSupport.clipParquetSchema(context.getFileSchema, catalystRequestedSchema)
+
+    val parquetRequestedSchema = if (parquetMrCompatibility) {
+      // Parquet-mr will throw an exception if we try to read a superset of the file's schema.
+      // Therefore, we intersect our clipped schema with the underlying file's schema
+      ParquetReadSupport.intersectParquetGroups(clippedParquetSchema, context.getFileSchema)
+        .map(intersectionGroup =>
+          new MessageType(intersectionGroup.getName, intersectionGroup.getFields))
+        .getOrElse(ParquetSchemaConverter.EMPTY_MESSAGE)
+    } else {
+      // Spark's built-in Parquet reader will throw an exception in some cases if the requested
+      // schema is not the same as the clipped schema
+      clippedParquetSchema
+    }
 
     new ReadContext(parquetRequestedSchema, Map.empty[String, String].asJava)
   }
@@ -96,7 +118,7 @@ private[parquet] class ParquetReadSupport(val convertTz: Option[TimeZone])
          |Parquet form:
          |$parquetRequestedSchema
          |Catalyst form:
-         |$catalystRequestedSchema
+         |${catalystRequestedSchema.prettyJson}
        """.stripMargin
     }
 
@@ -285,6 +307,27 @@ private[parquet] object ParquetReadSupport {
         .get(f.name)
         .map(clipParquetType(_, f.dataType))
         .getOrElse(toParquet.convertField(f))
+    }
+  }
+
+  /**
+   * Computes the structural intersection between two Parquet group types.
+   */
+  private def intersectParquetGroups(
+      groupType1: GroupType, groupType2: GroupType): Option[GroupType] = {
+    val fields =
+      groupType1.getFields.asScala
+        .filter(field => groupType2.containsField(field.getName))
+        .flatMap {
+          case field1: GroupType =>
+            intersectParquetGroups(field1, groupType2.getType(field1.getName).asGroupType)
+          case field1 => Some(field1)
+        }
+
+    if (fields.nonEmpty) {
+      Some(groupType1.withNewFields(fields.asJava))
+    } else {
+      None
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -130,8 +130,8 @@ private[parquet] class ParquetRowConverter(
   extends ParquetGroupConverter(updater) with Logging {
 
   assert(
-    parquetType.getFieldCount == catalystType.length,
-    s"""Field counts of the Parquet schema and the Catalyst schema don't match:
+    parquetType.getFieldCount <= catalystType.length,
+    s"""Field count of the Parquet schema is greater than the field count of the Catalyst schema:
        |
        |Parquet schema:
        |$parquetType
@@ -182,10 +182,12 @@ private[parquet] class ParquetRowConverter(
 
   // Converters for each field.
   private val fieldConverters: Array[Converter with HasParentContainerUpdater] = {
-    parquetType.getFields.asScala.zip(catalystType).zipWithIndex.map {
-      case ((parquetFieldType, catalystField), ordinal) =>
-        // Converted field value should be set to the `ordinal`-th cell of `currentRow`
-        newConverter(parquetFieldType, catalystField.dataType, new RowUpdater(currentRow, ordinal))
+    parquetType.getFields.asScala.map {
+      case parquetField =>
+        val fieldIndex = catalystType.fieldIndex(parquetField.getName)
+        val catalystField = catalystType(fieldIndex)
+        // Converted field value should be set to the `fieldIndex`-th cell of `currentRow`
+        newConverter(parquetField, catalystField.dataType, new RowUpdater(currentRow, fieldIndex))
     }.toArray
   }
 
@@ -193,7 +195,7 @@ private[parquet] class ParquetRowConverter(
 
   override def end(): Unit = {
     var i = 0
-    while (i < currentRow.numFields) {
+    while (i < fieldConverters.length) {
       fieldConverters(i).updater.end()
       i += 1
     }
@@ -202,8 +204,12 @@ private[parquet] class ParquetRowConverter(
 
   override def start(): Unit = {
     var i = 0
-    while (i < currentRow.numFields) {
+    while (i < fieldConverters.length) {
       fieldConverters(i).updater.start()
+      currentRow.setNullAt(i)
+      i += 1
+    }
+    while (i < currentRow.numFields) {
       currentRow.setNullAt(i)
       i += 1
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -35,7 +35,7 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
     plan transformDown {
       case op @ PhysicalOperation(projects, filters,
           l @ LogicalRelation(hadoopFsRelation @ HadoopFsRelation(_, partitionSchema,
-            dataSchema, _, parquetFormat: ParquetFileFormat, _), _, _, isStreaming)) =>
+            dataSchema, _, parquetFormat: ParquetFileFormat, _), _, _, _)) =>
         val projectionFields = projects.flatMap(getFields)
         val filterFields = filters.flatMap(getFields)
         val requestedFields = (projectionFields ++ filterFields).distinct
@@ -72,7 +72,8 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
                   case att => att
                 }
             val prunedRelation =
-              LogicalRelation(prunedParquetRelation, prunedRelationOutput, None, isStreaming)
+              l.copy(relation = prunedParquetRelation, output = prunedRelationOutput,
+                catalogTable = None)
 
             val projectionOverSchema = ProjectionOverSchema(prunedDataSchema)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -122,9 +122,9 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
    */
   private def getFields(expr: Expression): Seq[(StructField, Option[Attribute])] =
     expr match {
-      case SelectedField(field) => (field, None) :: Nil
       case att: Attribute =>
         (StructField(att.name, att.dataType, att.nullable), Some(att)) :: Nil
+      case SelectedField(field) => (field, None) :: Nil
       case _ =>
         expr.children.flatMap(getFields)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -80,8 +80,7 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
                   case att => att
                 }
             val prunedRelation =
-              l.copy(relation = prunedParquetRelation, output = prunedRelationOutput,
-                catalogTable = None)
+              l.copy(relation = prunedParquetRelation, output = prunedRelationOutput)
 
             val projectionOverSchema = ProjectionOverSchema(prunedDataSchema)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.planning.{PhysicalOperation, ProjectionOverSchema, SelectedField}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.types.{StructField, StructType}
+
+/**
+ * Prunes unnecessary Parquet columns given a [[PhysicalOperation]] over a
+ * [[ParquetRelation]]. By "Parquet column", we mean a column as defined in the
+ * Parquet format. In Spark SQL, a root-level Parquet column corresponds to a
+ * SQL column, and a nested Parquet column corresponds to a [[StructField]].
+ */
+private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan transformDown {
+      case op @ PhysicalOperation(projects, filters,
+          l @ LogicalRelation(hadoopFsRelation @ HadoopFsRelation(_, partitionSchema,
+            dataSchema, _, parquetFormat: ParquetFileFormat, _), _, _, isStreaming)) =>
+        val projectionFields = projects.flatMap(getFields)
+        val filterFields = filters.flatMap(getFields)
+        val requestedFields = (projectionFields ++ filterFields).distinct
+
+        // If [[requestedFields]] includes a proper field, continue. Otherwise,
+        // return [[op]]
+        if (requestedFields.exists { case (_, optAtt) => optAtt.isEmpty }) {
+          val prunedSchema = requestedFields
+            .map { case (field, _) => field }
+            .map(field => StructType(Array(field)))
+            .reduceLeft(_ merge _)
+          val parquetDataColumnNames = dataSchema.fieldNames
+          val prunedDataSchema =
+            StructType(prunedSchema.filter(f => parquetDataColumnNames.contains(f.name)))
+          val parquetDataFields = dataSchema.fields.toSet
+          val prunedDataFields = prunedDataSchema.fields.toSet
+
+          // If the original Parquet relation data fields are different from the
+          // pruned data fields, continue. Otherwise, return [[op]]
+          if (parquetDataFields != prunedDataFields) {
+            val dataSchemaFieldNames = hadoopFsRelation.dataSchema.fieldNames
+            val newDataSchema =
+              StructType(prunedSchema.filter(f => dataSchemaFieldNames.contains(f.name)))
+            val prunedParquetRelation =
+              hadoopFsRelation.copy(dataSchema = newDataSchema)(hadoopFsRelation.sparkSession)
+
+            // We need to replace the expression ids of the pruned relation output attributes
+            // with the expression ids of the original relation output attributes so that
+            // references to the original relation's output are not broken
+            val outputIdMap = l.output.map(att => (att.name, att.exprId)).toMap
+            val prunedRelationOutput =
+              prunedParquetRelation
+                .schema
+                .toAttributes
+                .map {
+                  case att if outputIdMap.contains(att.name) =>
+                    att.withExprId(outputIdMap(att.name))
+                  case att => att
+                }
+            val prunedRelation =
+              LogicalRelation(prunedParquetRelation, prunedRelationOutput, None, isStreaming)
+
+            val projectionOverSchema = ProjectionOverSchema(prunedDataSchema)
+
+            // Construct a new target for our projection by rewriting and
+            // including the original filters where available
+            val projectionChild =
+              if (filters.nonEmpty) {
+                val projectedFilters = filters.map(_.transformDown {
+                  case projectionOverSchema(expr) => expr
+                })
+                val newFilterCondition = projectedFilters.reduce(And)
+                Filter(newFilterCondition, prunedRelation)
+              } else {
+                prunedRelation
+              }
+
+            val nonDataPartitionColumnNames =
+              partitionSchema.filterNot(parquetDataFields.contains).map(_.name)
+
+            // Construct the new projections of our [[Project]] by
+            // rewriting the original projections
+            val newProjects = projects.map {
+              case project if (nonDataPartitionColumnNames.contains(project.name)) => project
+              case project =>
+                (project transformDown {
+                  case projectionOverSchema(expr) => expr
+                }).asInstanceOf[NamedExpression]
+            }
+
+            logDebug("New projects:\n" + newProjects.map(_.treeString).mkString("\n"))
+
+            require(prunedDataSchema == prunedParquetRelation.dataSchema,
+              s"""Pruned data schema != pruned parquet relation schema
+                 |Pruned data schema:
+                 |${prunedDataSchema.treeString}
+                 |
+                 |Pruned parquet relation schema:
+                 |${prunedParquetRelation.schema.treeString}""".stripMargin)
+
+            logDebug(s"Pruned data schema:\n${prunedDataSchema.treeString}")
+
+            Project(newProjects, projectionChild)
+          } else {
+            op
+          }
+        } else {
+          op
+        }
+    }
+
+  /**
+   * Gets the top-level (no-parent) [[StructField]]s for the given [[Expression]].
+   * When [[expr]] is an [[Attribute]], construct a field around it and return the
+   * attribute as the second component of the returned tuple.
+   */
+  private def getFields(expr: Expression): Seq[(StructField, Option[Attribute])] =
+    expr match {
+      case SelectedField(field) => (field, None) :: Nil
+      case att: Attribute =>
+        (StructField(att.name, att.dataType, att.nullable), Some(att)) :: Nil
+      case _ =>
+        expr.children.flatMap(getFields)
+    }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -42,7 +42,7 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
         val filterFields = filters.flatMap(getFields)
         val requestedFields = (projectionFields ++ filterFields).distinct
 
-        // If [[requestedFields]] includes a proper field, continue. Otherwise,
+        // If [[requestedFields]] includes a nested field, continue. Otherwise,
         // return [[op]]
         if (requestedFields.exists { case (_, optAtt) => optAtt.isEmpty }) {
           val prunedSchema = requestedFields

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2267,15 +2267,17 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-4502: Nested column pruning shouldn't fail filter") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-      val data =
-        """{"a":{"b":1,"c":2}}
-          |{}""".stripMargin
-      Seq(data).toDF().repartition(1).write.text(path)
-      checkAnswer(
-        spark.read.json(path).filter($"a.b" > 1).select($"a.b"),
-        Seq.empty)
+    withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        val data =
+          """{"a":{"b":1,"c":2}}
+            |{}""".stripMargin
+        Seq(data).toDF().repartition(1).write.text(path)
+        checkAnswer(
+          spark.read.json(path).filter($"a.b" > 1).select($"a.b"),
+          Seq.empty)
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/FileSchemaPruningTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/FileSchemaPruningTest.scala
@@ -21,10 +21,11 @@ import org.scalactic.Equality
 import org.scalatest.Assertions
 
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.SchemaPruningTest
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.types.StructType
 
-private[sql] trait FileSchemaPruningTest {
+private[sql] trait FileSchemaPruningTest extends SchemaPruningTest {
   _: Assertions =>
 
   private val schemaEquality = new Equality[StructType] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/FileSchemaPruningTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/FileSchemaPruningTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.scalactic.Equality
+import org.scalatest.Assertions
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.types.StructType
+
+private[sql] trait FileSchemaPruningTest {
+  _: Assertions =>
+
+  private val schemaEquality = new Equality[StructType] {
+    override def areEqual(a: StructType, b: Any) =
+      b match {
+        case otherType: StructType => a sameType otherType
+        case _ => false
+      }
+  }
+
+  protected def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      df.queryExecution.executedPlan.collect {
+        case scan: FileSourceScanExec => scan.requiredSchema
+      }
+    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected ${expectedSchemaCatalogStrings}")
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -108,7 +108,7 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
       val queryOutput = selfJoin.queryExecution.analyzed.output
 
       assertResult(4, "Field count mismatches")(queryOutput.size)
-      assertResult(2, "Duplicated expression ID in query plan:\n $selfJoin") {
+      assertResult(2, s"Duplicated expression ID in query plan:\n $selfJoin") {
         queryOutput.filter(_.name == "_1").map(_.exprId).size
       }
 
@@ -117,7 +117,7 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
   }
 
   test("nested data - struct with array field") {
-    val data = (1 to 10).map(i => Tuple1((i, Seq("val_$i"))))
+    val data = (1 to 10).map(i => Tuple1((i, Seq(s"val_$i"))))
     withParquetTable(data, "t") {
       checkAnswer(sql("SELECT _1._2[0] FROM t"), data.map {
         case Tuple1((_, Seq(string))) => Row(string)
@@ -126,7 +126,7 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
   }
 
   test("nested data - array of struct") {
-    val data = (1 to 10).map(i => Tuple1(Seq(i -> "val_$i")))
+    val data = (1 to 10).map(i => Tuple1(Seq(i -> s"val_$i")))
     withParquetTable(data, "t") {
       checkAnswer(sql("SELECT _1[0]._2 FROM t"), data.map {
         case Tuple1(Seq((_, string))) => Row(string)
@@ -877,6 +877,15 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
         val withShortField = new StructType().add("f", ShortType)
         checkAnswer(spark.read.schema(withShortField).parquet(path), Row(1: Short))
       }
+    }
+  }
+
+  test("select function over nested data") {
+    val data = (1 to 10).map(i => Tuple1((i, s"val_$i")))
+    withParquetTable(data, "t") {
+      checkAnswer(sql("SELECT isnotnull(_1._2) FROM t"), data.map {
+        case _ => Row(true)
+      })
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningJoinSuite.scala
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.FileSchemaPruningTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSQLContext
+
+class ParquetSchemaPruningJoinSuite
+    extends QueryTest
+    with ParquetTest
+    with FileSchemaPruningTest
+    with SharedSQLContext {
+  setupTestData()
+
+  private lazy val upperCaseStructData: DataFrame = {
+    val df = sql("select named_struct(\"N\", N, \"L\", L) as S from uppercasedata")
+    df.createOrReplaceTempView("upperCaseStruct")
+    df
+  }
+
+  private lazy val lowerCaseStructData: DataFrame = {
+    val df = sql("select named_struct(\"n\", n, \"l\", l) as s from lowercasedata")
+    df.createOrReplaceTempView("lowerCaseStruct")
+    df
+  }
+
+  override def loadTestData(): Unit = {
+    super.loadTestData
+    upperCaseStructData
+    lowerCaseStructData
+  }
+
+  testStandardAndLegacyModes("schema pruning join 1") {
+    asParquetTable(upperCaseStructData, "r1") {
+      asParquetTable(lowerCaseStructData, "r2") {
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          def join(joinType: String): DataFrame =
+            sql(s"select s.n from r1 $joinType join r2 on r1.S.N = r2.s.n")
+          val scanSchema1 = "struct<S:struct<N:int>>"
+          val scanSchema2 = "struct<s:struct<n:int>>"
+          checkScanSchemata(
+            join("inner"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("left outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("right outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("full outer"),
+            scanSchema1,
+            scanSchema2)
+        }
+      }
+    }
+  }
+
+  testStandardAndLegacyModes("schema pruning join 2") {
+    asParquetTable(upperCaseStructData, "r1") {
+      asParquetTable(lowerCaseStructData, "r2") {
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          def join(joinType: String): DataFrame =
+            sql(s"select s.l from r1 $joinType join r2 on r1.S.N = r2.s.n")
+          val scanSchema1 = "struct<S:struct<N:int>>"
+          val scanSchema2 = "struct<s:struct<l:string,n:int>>"
+          checkScanSchemata(
+            join("inner"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("left outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("right outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("full outer"),
+            scanSchema1,
+            scanSchema2)
+        }
+      }
+    }
+  }
+
+  testStandardAndLegacyModes("schema pruning join 3") {
+    asParquetTable(upperCaseStructData, "r1") {
+      asParquetTable(lowerCaseStructData, "r2") {
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          def join(joinType: String): DataFrame =
+            sql(s"select S.L from r1 $joinType join r2 on r1.S.N = r2.s.n")
+          val scanSchema1 = "struct<S:struct<L:string,N:int>>"
+          val scanSchema2 = "struct<s:struct<n:int>>"
+          checkScanSchemata(
+            join("inner"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("left outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("right outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("full outer"),
+            scanSchema1,
+            scanSchema2)
+        }
+      }
+    }
+  }
+
+  testStandardAndLegacyModes("schema pruning join 4") {
+    asParquetTable(upperCaseStructData, "r1") {
+      asParquetTable(lowerCaseStructData, "r2") {
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          def join(joinType: String): DataFrame =
+            sql(s"select count(s.n) from r1 $joinType join r2 on r1.S.N = r2.s.n")
+          val scanSchema1 = "struct<S:struct<N:int>>"
+          val scanSchema2 = "struct<s:struct<n:int>>"
+          checkScanSchemata(
+            join("inner"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("left outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("right outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("full outer"),
+            scanSchema1,
+            scanSchema2)
+        }
+      }
+    }
+  }
+
+  testStandardAndLegacyModes("schema pruning join 5") {
+    asParquetTable(upperCaseStructData, "r1") {
+      asParquetTable(lowerCaseStructData, "r2") {
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          def join(joinType: String): DataFrame =
+            sql(s"select count(1), s.n from r1 $joinType join r2 on r1.S.N = r2.s.n group by s.n")
+          val scanSchema1 = "struct<S:struct<N:int>>"
+          val scanSchema2 = "struct<s:struct<n:int>>"
+          checkScanSchemata(
+            join("inner"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("left outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("right outer"),
+            scanSchema1,
+            scanSchema2)
+          checkScanSchemata(
+            join("full outer"),
+            scanSchema1,
+            scanSchema2)
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningJoinSuite.scala
@@ -83,7 +83,7 @@ class ParquetSchemaPruningJoinSuite
           def join(joinType: String): DataFrame =
             sql(s"select s.l from r1 $joinType join r2 on r1.S.N = r2.s.n")
           val scanSchema1 = "struct<S:struct<N:int>>"
-          val scanSchema2 = "struct<s:struct<l:string,n:int>>"
+          val scanSchema2 = "struct<s:struct<n:int,l:string>>"
           checkScanSchemata(
             join("inner"),
             scanSchema1,
@@ -111,7 +111,7 @@ class ParquetSchemaPruningJoinSuite
         withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
           def join(joinType: String): DataFrame =
             sql(s"select S.L from r1 $joinType join r2 on r1.S.N = r2.s.n")
-          val scanSchema1 = "struct<S:struct<L:string,N:int>>"
+          val scanSchema1 = "struct<S:struct<N:int,L:string>>"
           val scanSchema2 = "struct<s:struct<n:int>>"
           checkScanSchemata(
             join("inner"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import java.io.File
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.FileSchemaPruningTest
+import org.apache.spark.sql.test.SharedSQLContext
+
+class ParquetSchemaPruningSuite
+    extends QueryTest
+    with ParquetTest
+    with FileSchemaPruningTest
+    with SharedSQLContext {
+  case class FullName(first: String, middle: String, last: String)
+  case class Contact(name: FullName, address: String, pets: Int)
+
+  val contacts =
+    Contact(FullName("Jane", "X.", "Doe"), "123 Main Street", 1) ::
+    Contact(FullName("John", "Y.", "Doe"), "321 Wall Street", 3) :: Nil
+
+  case class Name(first: String, last: String)
+  case class BriefContact(name: Name, address: String)
+
+  val briefContacts =
+    BriefContact(Name("sdfaf", "123"), "xyz") ::
+    BriefContact(Name("asdfaf", "xyz"), "abc") :: Nil
+
+  testStandardAndLegacyModes("partial schema intersection") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      makeParquetFile(contacts, new File(path + "/contacts/p=1"))
+      makeParquetFile(briefContacts, new File(path + "/contacts/p=2"))
+
+      spark.read.parquet(path + "/contacts").createOrReplaceTempView("contacts")
+
+      val query = sql("select name.middle, address from contacts where p=2")
+      checkScanSchemata(query, "struct<name:struct<middle:string>,address:string>")
+      checkAnswer(query,
+        Row(null, "xyz") ::
+        Row(null, "abc") :: Nil)
+    }
+  }
+
+  testStandardAndLegacyModes("empty schema intersection") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      makeParquetFile(contacts, new File(path + "/contacts/p=1"))
+      makeParquetFile(briefContacts, new File(path + "/contacts/p=2"))
+
+      spark.read.parquet(path + "/contacts").createOrReplaceTempView("contacts")
+
+      val query = sql("select name.middle from contacts where p=2")
+      checkScanSchemata(query, "struct<name:struct<middle:string>>")
+      checkAnswer(query,
+        Row(null) :: Row(null) :: Nil)
+    }
+  }
+
+  testStandardAndLegacyModes("aggregation over nested data") {
+    withParquetTable(contacts, "contacts") {
+      val query = sql("select count(distinct name.last), address from contacts group by address " +
+        "order by address")
+      checkScanSchemata(query, "struct<address:string,name:struct<last:string>>")
+      checkAnswer(query,
+        Row(1, "123 Main Street") ::
+        Row(1, "321 Wall Street") :: Nil)
+    }
+  }
+
+  testStandardAndLegacyModes("select function over nested data") {
+    withParquetTable(contacts, "contacts") {
+      val query = sql("select count(name.middle) from contacts")
+      checkScanSchemata(query, "struct<name:struct<middle:string>>")
+      checkAnswer(query,
+        Row(2) :: Nil)
+    }
+  }
+}


### PR DESCRIPTION
(Link to Jira: https://issues.apache.org/jira/browse/SPARK-4502)

## What changes were proposed in this pull request?

One of the hallmarks of a column-oriented data storage format is the ability to read data from a subset of columns, efficiently skipping reads from other columns. Spark has long had support for pruning unneeded top-level schema fields from the scan of a parquet file. For example, consider a table, `contacts`, backed by parquet with the following Spark SQL schema:

```
root
 |-- name: struct
 |    |-- first: string
 |    |-- last: string
 |-- address: string
```

Parquet stores this table's data in three physical columns: `name.first`, `name.last` and `address`. To answer the query

```SQL
select address from contacts
```

Spark will read only from the `address` column of parquet data. However, to answer the query

```SQL
select name.first from contacts
```

Spark will read `name.first` and `name.last` from parquet.

This PR modifies Spark SQL to support a finer-grain of schema pruning. With this patch, Spark reads only the `name.first` column to answer the previous query.

### Implementation

There are three main components of this patch. First, there is a `ParquetSchemaPruning` optimizer rule for gathering the required schema fields of a `PhysicalOperation` over a parquet file, constructing a new schema based on those required fields and rewriting the plan in terms of that pruned schema. The pruned schema fields are pushed down to the parquet requested read schema. `ParquetSchemaPruning` uses a new `ProjectionOverSchema` extractor for rewriting a catalyst expression in terms of a pruned schema.

Second, the `ParquetRowConverter` has been patched to ensure the ordinals of the parquet columns read are correct for the pruned schema. `ParquetReadSupport` has been patched to address a compatibility mismatch between Spark's built in vectorized reader and the parquet-mr library's reader.

Third, we introduce two new catalyst query transformations, `AggregateFieldExtractionPushdown` and `JoinFieldExtractionPushdown`, to support schema pruning in aggregation and join query plans. These rules extract field references in aggregations and joins respectively, push down aliases to those references and replace them with references to the pushed down aliases. They use a new `SelectedField` extractor that transforms a catalyst complex type extractor (the "selected field") into a corresponding `StructField`.

### Performance

The performance difference in executing queries with this patch compared to master is related to the depth of the table schema and the query itself. At VideoAmp, one of our biggest tables stores OpenRTB bid requests we receive from our exchange partners. Our bid request table's schema closely follows the OpenRTB bid request object schema. Additionally, when we bid we save our response along with the request in the same table. We store these two objects as two top-level fields in our table. Therefore, all bid request and response data are contained within nested fields.

For the purposes of measuring the performance impact of this patch, we ran some queries on our bid request table with the un-patched and patched master. We measured query execution time and the amount of data read from the underlying parquet files. I'll focus on a couple of benchmarks. (All benchmarks were run on an AWS EC2 cluster with four c3.8xl workers.) The first query I'll highlight is

```SQL
select count(request.device.ip) from event.bid_request where ds=20161128 and h=0
```

(Hopefully it's obvious what this query means.) On the un-patched master, this query ran in 2.7 minutes and read 34.3 GB of data. On the patched master, this query ran in 4 seconds and read 987.3 MB of data.

We also ran a reporting-oriented query benchmark. I won't reproduce the query here, but it reads a larger subset of the bid request fields and joins against another table with a deeply nested schema. In addition to a join, we perform several aggregations in this query. On the un-patched master, this query ran in 3.4 minutes and read 34.6 GB of data. On the patched master, this query ran in 59 seconds and read 2.6 GB of data.

### Limitation

Among the complex Spark SQL data types, this patch supports parquet column pruning of nested sequences of struct fields only.

## How was this patch tested?

Care has been taken to ensure correctness and prevent regressions. This patch introduces over two dozen new unit tests and has been running on a production Spark 1.5 cluster at VideoAmp for about a year. In that time, one bug was found and fixed early on, and we added a regression test for that bug.

We forward-ported this patch to Spark master in June 2016 and have been running this patch against Spark 2.0 and 2.1 branches on ad-hoc clusters since then.