### PR TITLE
[SPARK-19237][SPARKR][CORE] On Windows spark-submit should handle when java is not installed

### DIFF
--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -35,6 +35,8 @@
 #' For \code{hadoopVersion = "without"}, [Hadoop version] in the filename is then
 #' \code{without-hadoop}.
 #'
+#' Note: Java should be in path or JAVA_HOME should be set for Spark to work.
+#'
 #' @param hadoopVersion Version of Hadoop to install. Default is \code{"2.7"}. It can take other
 #'                      version number in the format of "x.y" where x and y are integer.
 #'                      If \code{hadoopVersion = "without"}, "Hadoop free" build is installed.
@@ -103,6 +105,7 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir) && !overwrite) {
+    checkJava()
     if (releaseUrl != "") {
       message(paste(packageName, "found, setting SPARK_HOME to", packageLocalDir))
     } else {
@@ -289,7 +292,6 @@ sparkCachePath <- function() {
   normalizePath(path, mustWork = FALSE)
 }
 
-
 installInstruction <- function(mode) {
   if (mode == "remote") {
     paste0("Connecting to a remote Spark master. ",
@@ -304,5 +306,12 @@ installInstruction <- function(mode) {
            "contact the administrators of the cluster.")
   } else {
     stop(paste0("No instruction found for ", mode, " mode."))
+  }
+}
+
+checkJava <- function() {
+  java <- "java"
+  if (nchar(Sys.which(java)[[java]]) == 0 && nchar(Sys.getenv("JAVA_HOME")) == 0) {
+    stop("Java not found. Please make sure it is installed and in path or set JAVA_HOME.")
   }
 }

--- a/R/pkg/R/install.R
+++ b/R/pkg/R/install.R
@@ -35,8 +35,6 @@
 #' For \code{hadoopVersion = "without"}, [Hadoop version] in the filename is then
 #' \code{without-hadoop}.
 #'
-#' Note: Java should be in path or JAVA_HOME should be set for Spark to work.
-#'
 #' @param hadoopVersion Version of Hadoop to install. Default is \code{"2.7"}. It can take other
 #'                      version number in the format of "x.y" where x and y are integer.
 #'                      If \code{hadoopVersion = "without"}, "Hadoop free" build is installed.
@@ -105,7 +103,6 @@ install.spark <- function(hadoopVersion = "2.7", mirrorUrl = NULL,
 
   # can use dir.exists(packageLocalDir) under R 3.2.0 or later
   if (!is.na(file.info(packageLocalDir)$isdir) && !overwrite) {
-    checkJava()
     if (releaseUrl != "") {
       message(paste(packageName, "found, setting SPARK_HOME to", packageLocalDir))
     } else {
@@ -292,6 +289,7 @@ sparkCachePath <- function() {
   normalizePath(path, mustWork = FALSE)
 }
 
+
 installInstruction <- function(mode) {
   if (mode == "remote") {
     paste0("Connecting to a remote Spark master. ",
@@ -306,12 +304,5 @@ installInstruction <- function(mode) {
            "contact the administrators of the cluster.")
   } else {
     stop(paste0("No instruction found for ", mode, " mode."))
-  }
-}
-
-checkJava <- function() {
-  java <- "java"
-  if (nchar(Sys.which(java)[[java]]) == 0 && nchar(Sys.getenv("JAVA_HOME")) == 0) {
-    stop("Java not found. Please make sure it is installed and in path or set JAVA_HOME.")
   }
 }

--- a/R/pkg/inst/tests/testthat/test_Windows.R
+++ b/R/pkg/inst/tests/testthat/test_Windows.R
@@ -20,6 +20,7 @@ test_that("sparkJars tag in SparkContext", {
   if (.Platform$OS.type != "windows") {
     skip("This test is only for Windows, skipped")
   }
+
   testOutput <- launchScript("ECHO", "a/b/c", wait = TRUE)
   abcPath <- testOutput[1]
   expect_equal(abcPath, "a\\b\\c")

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -51,7 +51,7 @@ if not "x%SPARK_PREPEND_CLASSES%"=="x" (
 rem Figure out where java is.
 set RUNNER=java
 if not "x%JAVA_HOME%"=="x" (
-  set RUNNER=%JAVA_HOME%\bin\java
+  set RUNNER="%JAVA_HOME%\bin\java"
 ) else (
   where /q "%RUNNER%"
   if ERRORLEVEL 1 (

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -50,7 +50,13 @@ if not "x%SPARK_PREPEND_CLASSES%"=="x" (
 
 rem Figure out where java is.
 set RUNNER=java
-if not "x%JAVA_HOME%"=="x" set RUNNER=%JAVA_HOME%\bin\java
+if not "x%JAVA_HOME%"=="x" (
+  set RUNNER=%JAVA_HOME%\bin\java
+) else (
+  echo JAVA_HOME environment variable is not set.
+  echo Install Java and set JAVA_HOME to point to the Java installation directory.
+  exit /b 1
+)
 
 rem The launcher library prints the command to be executed in a single line suitable for being
 rem executed by the batch interpreter. So read all the output of the launcher into a variable.

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -53,9 +53,12 @@ set RUNNER=java
 if not "x%JAVA_HOME%"=="x" (
   set RUNNER=%JAVA_HOME%\bin\java
 ) else (
-  echo JAVA_HOME environment variable is not set.
-  echo Install Java and set JAVA_HOME to point to the Java installation directory.
-  exit /b 1
+  where /q "%RUNNER%"
+  if ERRORLEVEL 1 (
+    echo Java not found and JAVA_HOME environment variable is not set.
+    echo Install Java and set JAVA_HOME to point to the Java installation directory.
+    exit /b 1
+  )
 )
 
 rem The launcher library prints the command to be executed in a single line suitable for being


### PR DESCRIPTION
## What changes were proposed in this pull request?

When SparkR is installed as a R package there might not be any java runtime.
If it is not there SparkR's `sparkR.session()` will block waiting for the connection timeout, hanging the R IDE/shell, without any notification or message.


## How was this patch tested?

manually

- [x] need to test on Windows
