### PR TITLE
[SPARK-19239][PySpark] Check parameters whether equals None when specify the column in jdbc API

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -399,8 +399,8 @@ class DataFrameReader(OptionUtils):
         accessible via JDBC URL ``url`` and connection ``properties``.
 
         Partitions of the table will be retrieved in parallel if either ``column`` or
-        ``predicates`` is specified. ``lowerBound` and ``upperBound`` is needed when ``column``
-        is specified.
+        ``predicates`` is specified. ``lowerBound`, ``upperBound`` and ``numPartitions``
+        is needed when ``column`` is specified.
 
         If both ``column`` and ``predicates`` are specified, ``column`` will be used.
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -399,7 +399,8 @@ class DataFrameReader(OptionUtils):
         accessible via JDBC URL ``url`` and connection ``properties``.
 
         Partitions of the table will be retrieved in parallel if either ``column`` or
-        ``predicates`` is specified.
+        ``predicates`` is specified. ``lowerBound` and ``upperBound`` is needed when ``column``
+        is specified.
 
         If both ``column`` and ``predicates`` are specified, ``column`` will be used.
 
@@ -431,6 +432,8 @@ class DataFrameReader(OptionUtils):
         if column is not None:
             if numPartitions is None:
                 numPartitions = self._spark._sc.defaultParallelism
+            assert lowerBound != None, "lowerBound can not be None when ``column`` is specified"
+            assert upperBound != None, "upperBound can not be None when ``column`` is specified"
             return self._df(self._jreader.jdbc(url, table, column, int(lowerBound), int(upperBound),
                                                int(numPartitions), jprop))
         if predicates is not None:

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -432,8 +432,8 @@ class DataFrameReader(OptionUtils):
         if column is not None:
             assert lowerBound is not None, "lowerBound can not be None when ``column`` is specified"
             assert upperBound is not None, "upperBound can not be None when ``column`` is specified"
-            assert numPartitions is not None, "numPartitions can not be None " \
-                                              "when ``column`` is specified"
+            assert numPartitions is not None, \
+                "numPartitions can not be None when ``column`` is specified"
             return self._df(self._jreader.jdbc(url, table, column, int(lowerBound), int(upperBound),
                                                int(numPartitions), jprop))
         if predicates is not None:

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -430,10 +430,10 @@ class DataFrameReader(OptionUtils):
         for k in properties:
             jprop.setProperty(k, properties[k])
         if column is not None:
-            if numPartitions is None:
-                numPartitions = self._spark._sc.defaultParallelism
             assert lowerBound is not None, "lowerBound can not be None when ``column`` is specified"
             assert upperBound is not None, "upperBound can not be None when ``column`` is specified"
+            assert numPartitions is not None, "numPartitions can not be None " \
+                                              "when ``column`` is specified"
             return self._df(self._jreader.jdbc(url, table, column, int(lowerBound), int(upperBound),
                                                int(numPartitions), jprop))
         if predicates is not None:

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -432,8 +432,8 @@ class DataFrameReader(OptionUtils):
         if column is not None:
             if numPartitions is None:
                 numPartitions = self._spark._sc.defaultParallelism
-            assert lowerBound != None, "lowerBound can not be None when ``column`` is specified"
-            assert upperBound != None, "upperBound can not be None when ``column`` is specified"
+            assert lowerBound is not None, "lowerBound can not be None when ``column`` is specified"
+            assert upperBound is not None, "upperBound can not be None when ``column`` is specified"
             return self._df(self._jreader.jdbc(url, table, column, int(lowerBound), int(upperBound),
                                                int(numPartitions), jprop))
         if predicates is not None:


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `jdbc` API do not check the `lowerBound` and `upperBound` when we
specified the ``column``, and just throw the following exception:

>```int() argument must be a string or a number, not 'NoneType'```


If we check the parameter, we can give a more friendly suggestion.


## How was this patch tested?
Test using the pyspark shell, without the lowerBound and upperBound parameters.
