### PR TITLE
[SPARK-19242][SQL] SHOW CREATE TABLE should generate new syntax to create hive table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -761,6 +761,9 @@ case class AlterTableSetLocationCommand(
 
 object DDLUtils {
   val HIVE_PROVIDER = "hive"
+  val HIVE_SERDE_OPTION = "serde"
+  val HIVE_INPUT_FORMAT_OPTION = "inputFormat"
+  val HIVE_OUTPUT_FORMAT_OPTION = "outputFormat"
 
   def isHiveTable(table: CatalogTable): Boolean = {
     table.provider.isDefined && table.provider.get.toLowerCase == HIVE_PROVIDER

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveOptions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveOptions.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive.execution
 
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.execution.command.DDLUtils
 
 /**
  * Options for the Hive data source. Note that rule `DetermineHiveSerde` will extract Hive
@@ -87,9 +88,9 @@ object HiveOptions {
   }
 
   val FILE_FORMAT = newOption("fileFormat")
-  val INPUT_FORMAT = newOption("inputFormat")
-  val OUTPUT_FORMAT = newOption("outputFormat")
-  val SERDE = newOption("serde")
+  val INPUT_FORMAT = newOption(DDLUtils.HIVE_INPUT_FORMAT_OPTION)
+  val OUTPUT_FORMAT = newOption(DDLUtils.HIVE_OUTPUT_FORMAT_OPTION)
+  val SERDE = newOption(DDLUtils.HIVE_SERDE_OPTION)
 
   // A map from the public delimiter option keys to the underlying Hive serde property keys.
   val delimiterOptions = Map(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ShowCreateTableSuite.scala
@@ -338,9 +338,7 @@ class ShowCreateTableSuite extends QueryTest with SQLTestUtils with TestHiveSing
         "totalSize",
         "totalNumberFiles",
         "maxFileSize",
-        "minFileSize",
-        // EXTERNAL is not non-deterministic, but it is filtered out for external tables.
-        "EXTERNAL"
+        "minFileSize"
       )
 
       table.copy(


### PR DESCRIPTION
## What changes were proposed in this pull request?

after #16296 , we have a new unified CREATE TABLE syntax, `SHOW CREATE TABLE` should also generate SQL statement using the new syntax.

However, the new syntax doesn't support table properties, `SHOW CREATE TABLE` may still generate legacy hive syntax if table properties are not empty.

## How was this patch tested?

existing tests