### PR TITLE
[SPARK-19238][GRAPHX] Ignore sorting the edges if edges are sorted when building edge partition

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/TimSort.java
+++ b/core/src/main/java/org/apache/spark/util/collection/TimSort.java
@@ -83,6 +83,27 @@ class TimSort<K, Buffer> {
     this.s = sortDataFormat;
   }
 
+
+  /**
+   * Check if the array is sorted
+   * @param a the array in which a range is to be sorted
+   * @param lo the index of the first element in the range to be sorted
+   * @param hi the index after the last element in the range to be sorted
+   * @param c comparator to used for the sort
+   */
+  public boolean isSorted(Buffer a, int lo, int hi, Comparator<? super K> c) {
+    assert lo < hi;
+    int runHi = lo + 1;
+
+    K key0 = s.newKey();
+    K key1 = s.newKey();
+
+    while (runHi < hi && c.compare(s.getKey(a, runHi, key0), s.getKey(a, runHi - 1, key1)) >= 0)
+      runHi++;
+
+    return runHi == hi;
+  }
+
   /**
    * A stable, adaptive, iterative mergesort that requires far fewer than
    * n lg(n) comparisons when running on partially sorted arrays, while

--- a/core/src/main/scala/org/apache/spark/util/collection/Sorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Sorter.scala
@@ -36,4 +36,11 @@ class Sorter[K, Buffer](private val s: SortDataFormat[K, Buffer]) {
   def sort(a: Buffer, lo: Int, hi: Int, c: Comparator[_ >: K]): Unit = {
     timSort.sort(a, lo, hi, c)
   }
+
+  /**
+    * Check of the input buffer is sorted within range [lo, hi).
+    */
+  def isSorted(a: Buffer, lo: Int, hi: Int, c: Comparator[_ >: K]): Boolean = {
+    timSort.isSorted(a, lo, hi, c)
+  }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -26,6 +26,15 @@ import org.apache.spark.util.random.XORShiftRandom
 
 class SorterSuite extends SparkFunSuite with Logging {
 
+  test("Check array is sorted") {
+    val rand = new XORShiftRandom(123)
+    val data0 = Array.tabulate[Int](10000) { i => i}
+    assert(new Sorter(new IntArraySortDataFormat).isSorted(data0, 0, data0.length, Ordering.Int))
+
+    val data1 = Array.tabulate[Int](10000) { i => rand.nextInt()}
+    assert(!new Sorter(new IntArraySortDataFormat).isSorted(data1, 0, data1.length, Ordering.Int))
+  }
+
   test("equivalent to Arrays.sort") {
     val rand = new XORShiftRandom(123)
     val data0 = Array.tabulate[Int](10000) { i => rand.nextInt() }

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
@@ -36,8 +36,10 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: Cla
 
   def toEdgePartition: EdgePartition[ED, VD] = {
     val edgeArray = edges.trim().array
-    new Sorter(Edge.edgeArraySortDataFormat[ED])
-      .sort(edgeArray, 0, edgeArray.length, Edge.lexicographicOrdering)
+    val sorter = new Sorter(Edge.edgeArraySortDataFormat[ED])
+    if (!sorter.isSorted(edgeArray, 0, edgeArray.length, Edge.lexicographicOrdering)) {
+      sorter.sort(edgeArray, 0, edgeArray.length, Edge.lexicographicOrdering)
+    }
     val localSrcIds = new Array[Int](edgeArray.length)
     val localDstIds = new Array[Int](edgeArray.length)
     val data = new Array[ED](edgeArray.length)
@@ -96,8 +98,10 @@ class ExistingEdgePartitionBuilder[
 
   def toEdgePartition: EdgePartition[ED, VD] = {
     val edgeArray = edges.trim().array
-    new Sorter(EdgeWithLocalIds.edgeArraySortDataFormat[ED])
-      .sort(edgeArray, 0, edgeArray.length, EdgeWithLocalIds.lexicographicOrdering)
+    val sorter = new Sorter(EdgeWithLocalIds.edgeArraySortDataFormat[ED])
+    if (!sorter.isSorted(edgeArray, 0, edgeArray.length, EdgeWithLocalIds.lexicographicOrdering)) {
+      sorter.sort(edgeArray, 0, edgeArray.length, EdgeWithLocalIds.lexicographicOrdering)
+    }
     val localSrcIds = new Array[Int](edgeArray.length)
     val localDstIds = new Array[Int](edgeArray.length)
     val data = new Array[ED](edgeArray.length)


### PR DESCRIPTION

## What changes were proposed in this pull request?
Ignore sorting the edges if edges are sorted when building edge partition

Usually the graph edges generated by upstream application and saved by other graphs are sorted. So the sorting is not necessary.

## How was this patch tested?
unit tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
