### PR TITLE
[SPARK-19244][Core] Sort MemoryConsumers according to their memory usage when spilling

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -151,20 +151,16 @@ public class TaskMemoryManager {
         // Sort the consumers according their memory usage. So we avoid spilling the same consumer
         // which is just spilled in last few times and re-spilling on it will produce many small
         // spill files.
-        TreeMap<Long, List<MemoryConsumer>> sortedConsumers =
-          new TreeMap<Long, List<MemoryConsumer>>();
+        TreeMap<Long, List<MemoryConsumer>> sortedConsumers = new TreeMap<>();
         for (MemoryConsumer c: consumers) {
           if (c != consumer && c.getUsed() > 0 && c.getMode() == mode) {
             long key = c.getUsed();
-            List<MemoryConsumer> list = null;
-            if (sortedConsumers.containsKey(key)) {
-              list = sortedConsumers.get(key);
-              list.add(c);
-            } else {
-              list = new ArrayList<MemoryConsumer>(1);
-              list.add(c);
+            List<MemoryConsumer> list = sortedConsumers.get(key);
+            if (list == null) {
+              list = new ArrayList<>(1);
               sortedConsumers.put(key, list);
             }
+            list.add(c);
           }
         }
         while (!sortedConsumers.isEmpty()) {
@@ -178,7 +174,7 @@ public class TaskMemoryManager {
           }
           List<MemoryConsumer> cList = currentEntry.getValue();
           MemoryConsumer c = cList.remove(cList.size() - 1);
-          if (cList.size() == 0) {
+          if (cList.isEmpty()) {
             sortedConsumers.remove(currentEntry.getKey());
           }
           try {

--- a/core/src/test/java/org/apache/spark/memory/TaskMemoryManagerSuite.java
+++ b/core/src/test/java/org/apache/spark/memory/TaskMemoryManagerSuite.java
@@ -125,17 +125,22 @@ public class TaskMemoryManagerSuite {
     Assert.assertEquals(80, c2.getUsed());
     c3.use(80);
     Assert.assertEquals(20, c1.getUsed());  // c1: not spilled
-    Assert.assertEquals(0, c2.getUsed());   // c2: spilled as it uses more memory
+    Assert.assertEquals(0, c2.getUsed());   // c2: spilled as it has required size of memory
     Assert.assertEquals(80, c3.getUsed());
 
-    c2.use(50);
+    c2.use(80);
     Assert.assertEquals(20, c1.getUsed());  // c1: not spilled
-    Assert.assertEquals(0, c3.getUsed());   // c3: spilled as it uses more memory
-    Assert.assertEquals(50, c2.getUsed());
+    Assert.assertEquals(0, c3.getUsed());   // c3: spilled as it has required size of memory
+    Assert.assertEquals(80, c2.getUsed());
 
-    c1.free(20);
-    c2.free(50);
-    c3.free(0);
+    c3.use(10);
+    Assert.assertEquals(0, c1.getUsed());   // c1: spilled as it has required size of memory
+    Assert.assertEquals(80, c2.getUsed());  // c2: not spilled as spilling c1 already satisfies c3
+    Assert.assertEquals(10, c3.getUsed());
+
+    c1.free(0);
+    c2.free(80);
+    c3.free(10);
     Assert.assertEquals(0, manager.cleanUpAllAllocatedMemory());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `TaskMemoryManager `, when we acquire memory by calling `acquireExecutionMemory` and we can't acquire required memory, we will try to spill other memory consumers.

Currently, we simply iterates the memory consumers in a hash set. Normally each time the consumer will be iterated in the same order.

The first issue is that we might spill additional consumers. For example, if consumer 1 uses 10MB, consumer 2 uses 50MB, then consumer 3 acquires 100MB but we can only get 60MB and spilling is needed. We might spill both consumer 1 and consumer 2. But we actually just need to spill consumer 2 and get the required 100MB.

The second issue is that if we spill consumer 1 in first time spilling. After a while, consumer 1 now uses 5MB. Then consumer 4 may acquire some memory and spilling is needed again. Because we iterate the memory consumers in the same order, we will spill consumer 1 again. So for consumer 1, we will produce many small spilling files.

This patch modifies the way iterating the memory consumers. It sorts the memory consumers by their memory usage. So the consumer using more memory will spill first. Once it is spilled, even it acquires few memory again, in next time spilling happens it will not be the consumers to spill again if there are other consumers using more memory than it.

## How was this patch tested?

Jenkins tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
