### PR TITLE
[SPARK-19247][ML] Save large word2vec models

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml.feature
 
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.linalg.{BLAS, Vector, VectorUDT, Vectors}
@@ -311,9 +312,9 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
       DefaultParamsWriter.saveMetadata(instance, path, sc)
 
       val wordVectors = instance.wordVectors.getVectors
-      val dataArray = wordVectors.toSeq.map { case (word, vector) => Data(word, vector) }.toArray
+      val dataSeq = wordVectors.toSeq.map { case (word, vector) => Data(word, vector) }
       val dataPath = new Path(path, "data").toString
-      sparkSession.createDataFrame(dataArray)
+      sparkSession.createDataFrame(dataSeq)
         .repartition(calculateNumberOfPartitions)
         .write
         .parquet(dataPath)
@@ -348,7 +349,7 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
 
       val dataPath = new Path(path, "data").toString
 
-      val oldModel = if (major.toInt < 2 || (major.toInt == 2 && minor.toInt < 2)) {
+      val oldModel = if (major < 2 || (major == 2 && minor < 2)) {
         val data = spark.read.parquet(dataPath)
           .select("wordIndex", "wordVectors")
           .head()

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.linalg.{BLAS, Vector, VectorUDT, Vectors}
+import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -303,7 +303,7 @@ class Word2VecModel private[ml] (
 @Since("1.6.0")
 object Word2VecModel extends MLReadable[Word2VecModel] {
 
-  private case class Data(word: String, vector: Seq[Float])
+  private case class Data(word: String, vector: Array[Float])
 
   private[Word2VecModel]
   class Word2VecModelWriter(instance: Word2VecModel) extends MLWriter {
@@ -312,7 +312,7 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
       DefaultParamsWriter.saveMetadata(instance, path, sc)
 
       val wordVectors = instance.wordVectors.getVectors
-      val dataArray = wordVectors.toSeq.map { case (word, vector) => Data(word, vector) }
+      val dataArray = wordVectors.toSeq.map { case (word, vector) => Data(word, vector) }.toArray
       val dataPath = new Path(path, "data").toString
       sparkSession.createDataFrame(dataArray)
         .repartition(calculateNumberOfPartitions)
@@ -357,9 +357,9 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
         val wordVectors = data.getAs[Seq[Float]](1).toArray
         new feature.Word2VecModel(wordIndex, wordVectors)
       } else {
-        val wordVectorsMap: Map[String, Array[Float]] = rawData.as[Data]
+        val wordVectorsMap = rawData.as[Data]
           .collect()
-          .map(wordVector => (wordVector.word, wordVector.vector.toArray))
+          .map(wordVector => (wordVector.word, wordVector.vector))
           .toMap
         new feature.Word2VecModel(wordVectorsMap)
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -320,9 +320,9 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
         .parquet(dataPath)
     }
 
-    val FloatSize = 4
-    val AverageWordSize = 15
     def calculateNumberOfPartitions(): Int = {
+      val floatSize = 4
+      val averageWordSize = 15
       // [SPARK-11994] - We want to partition the model in partitions smaller than
       // spark.kryoserializer.buffer.max
       val bufferSizeInBytes = Utils.byteStringAsBytes(
@@ -331,7 +331,7 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
       // Assuming an average word size of 15 bytes, the formula is:
       // (floatSize * vectorSize + 15) * numWords
       val numWords = instance.wordVectors.wordIndex.size
-      val approximateSizeInBytes = (FloatSize * instance.getVectorSize + AverageWordSize) * numWords
+      val approximateSizeInBytes = (floatSize * instance.getVectorSize + averageWordSize) * numWords
       ((approximateSizeInBytes / bufferSizeInBytes) + 1).toInt
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

* save word2vec models as distributed files rather than as one large datum. Backwards compatibility with the previous save format is maintained by checking for the "wordIndex" column 
* migrate the fix for loading large models (SPARK-11994) to ml word2vec

## How was this patch tested?

Tested loading the new and old formats locally

@srowen @yanboliang @MLnick 