### PR TITLE
[SPARK-17967][SPARK-17878][SQL][PYTHON] Support for array as an option for datasources and for multiple values in nullValue in CSV

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -142,7 +142,7 @@ class DataFrameReader(OptionUtils):
             self.option(k, options[k])
         return self
 
-    @since(2.2)
+    @since(2.3)
     def unsetOption(self, key):
         """Un-sets the option given to the key for the underlying data source.
         """
@@ -583,7 +583,7 @@ class DataFrameWriter(OptionUtils):
             self.option(k, options[k])
         return self
 
-    @since(2.2)
+    @since(2.3)
     def unsetOption(self, key):
         """Un-sets the option given to the key for the underlying data source.
         """

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -121,7 +121,12 @@ class DataFrameReader(OptionUtils):
                 in the JSON/CSV datasources or partition values.
                 If it isn't set, it uses the default value, session local timezone.
         """
-        self._jreader = self._jreader.option(key, to_str(value))
+        if isinstance(value, (list, tuple)):
+            gateway = self._spark._sc._gateway
+            jvalues = utils.toJArray(gateway, gateway.jvm.java.lang.String, value)
+            self._jreader = self._jreader.option(key, jvalues)
+        else:
+            self._jreader = self._jreader.option(key, to_str(value))
         return self
 
     @since(1.4)
@@ -134,7 +139,14 @@ class DataFrameReader(OptionUtils):
                 If it isn't set, it uses the default value, session local timezone.
         """
         for k in options:
-            self._jreader = self._jreader.option(k, to_str(options[k]))
+            self.option(k, options[k])
+        return self
+
+    @since(2.2)
+    def unsetOption(self, key):
+        """Un-sets the option given to the key for the underlying data source.
+        """
+        self._jreader = self._jreader.unsetOption(key)
         return self
 
     @since(1.4)
@@ -322,6 +334,7 @@ class DataFrameReader(OptionUtils):
             paths = [paths]
         return self._df(self._jreader.text(self._spark._sc._jvm.PythonUtils.toSeq(paths)))
 
+    @ignore_unicode_prefix
     @since(2.0)
     def csv(self, path, schema=None, sep=None, encoding=None, quote=None, escape=None,
             comment=None, header=None, inferSchema=None, ignoreLeadingWhiteSpace=None,
@@ -362,7 +375,8 @@ class DataFrameReader(OptionUtils):
                                          uses the default value, ``false``.
         :param nullValue: sets the string representation of a null value. If None is set, it uses
                           the default value, empty string. Since 2.0.1, this ``nullValue`` param
-                          applies to all supported types including the string type.
+                          applies to all supported types including the string type. A list or tuple
+                          of strings to represent null values can be set for this option.
         :param nanValue: sets the string representation of a non-number value. If None is set, it
                          uses the default value, ``NaN``.
         :param positiveInf: sets the string representation of a positive infinity value. If None
@@ -408,6 +422,10 @@ class DataFrameReader(OptionUtils):
         >>> df = spark.read.csv('python/test_support/sql/ages.csv')
         >>> df.dtypes
         [('_c0', 'string'), ('_c1', 'string')]
+
+        >>> df = spark.read.csv('python/test_support/sql/ages.csv', nullValue=['Tom', 'Joe'])
+        >>> df.collect()
+        [Row(_c0=None, _c1=u'20'), Row(_c0=None, _c1=u'30'), Row(_c0=u'Hyukjin', _c1=u'25')]
         """
         self._set_opts(
             schema=schema, sep=sep, encoding=encoding, quote=quote, escape=escape, comment=comment,
@@ -544,7 +562,12 @@ class DataFrameWriter(OptionUtils):
                 timestamps in the JSON/CSV datasources or partition values.
                 If it isn't set, it uses the default value, session local timezone.
         """
-        self._jwrite = self._jwrite.option(key, to_str(value))
+        if isinstance(value, (list, tuple)):
+            gateway = self._spark._sc._gateway
+            jvalues = utils.toJArray(gateway, gateway.jvm.java.lang.String, value)
+            self._jwrite = self._jwrite.option(key, jvalues)
+        else:
+            self._jwrite = self._jwrite.option(key, to_str(value))
         return self
 
     @since(1.4)
@@ -557,7 +580,14 @@ class DataFrameWriter(OptionUtils):
                 If it isn't set, it uses the default value, session local timezone.
         """
         for k in options:
-            self._jwrite = self._jwrite.option(k, to_str(options[k]))
+            self.option(k, options[k])
+        return self
+
+    @since(2.2)
+    def unsetOption(self, key):
+        """Un-sets the option given to the key for the underlying data source.
+        """
+        self._jwrite = self._jwrite.unsetOption(key)
         return self
 
     @since(1.4)

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -374,11 +374,11 @@ class DataStreamReader(OptionUtils):
             self.option(k, options[k])
         return self
 
-    @since(2.2)
+    @since(2.3)
     def unsetOption(self, key):
         """Un-sets the option given to the key for the underlying data source.
 
-        .. note:: Experimental.
+        .. note:: Evolving.
         """
         self._jreader = self._jreader.unsetOption(key)
         return self
@@ -748,11 +748,11 @@ class DataStreamWriter(object):
             self.option(k, options[k])
         return self
 
-    @since(2.2)
+    @since(2.3)
     def unsetOption(self, key):
         """Un-sets the option given to the key for the underlying data source.
 
-        .. note:: Experimental.
+        .. note:: Evolving.
         """
         self._jwrite = self._jwrite.unsetOption(key)
         return self

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -349,7 +349,12 @@ class DataStreamReader(OptionUtils):
 
         >>> s = spark.readStream.option("x", 1)
         """
-        self._jreader = self._jreader.option(key, to_str(value))
+        if isinstance(value, (list, tuple)):
+            gateway = self._spark._sc._gateway
+            jvalues = utils.toJArray(gateway, gateway.jvm.java.lang.String, value)
+            self._jreader = self._jreader.option(key, jvalues)
+        else:
+            self._jreader = self._jreader.option(key, to_str(value))
         return self
 
     @since(2.0)
@@ -366,7 +371,16 @@ class DataStreamReader(OptionUtils):
         >>> s = spark.readStream.options(x="1", y=2)
         """
         for k in options:
-            self._jreader = self._jreader.option(k, to_str(options[k]))
+            self.option(k, options[k])
+        return self
+
+    @since(2.2)
+    def unsetOption(self, key):
+        """Un-sets the option given to the key for the underlying data source.
+
+        .. note:: Experimental.
+        """
+        self._jreader = self._jreader.unsetOption(key)
         return self
 
     @since(2.0)
@@ -579,7 +593,8 @@ class DataStreamReader(OptionUtils):
                                          uses the default value, ``false``.
         :param nullValue: sets the string representation of a null value. If None is set, it uses
                           the default value, empty string. Since 2.0.1, this ``nullValue`` param
-                          applies to all supported types including the string type.
+                          applies to all supported types including the string type. A list or tuple
+                          of strings to represent null values can be set for this option.
         :param nanValue: sets the string representation of a non-number value. If None is set, it
                          uses the default value, ``NaN``.
         :param positiveInf: sets the string representation of a positive infinity value. If None
@@ -710,7 +725,12 @@ class DataStreamWriter(object):
 
         .. note:: Evolving.
         """
-        self._jwrite = self._jwrite.option(key, to_str(value))
+        if isinstance(value, (list, tuple)):
+            gateway = self._spark._sc._gateway
+            jvalues = utils.toJArray(gateway, gateway.jvm.java.lang.String, value)
+            self._jwrite = self._jwrite.option(key, jvalues)
+        else:
+            self._jwrite = self._jwrite.option(key, to_str(value))
         return self
 
     @since(2.0)
@@ -725,7 +745,16 @@ class DataStreamWriter(object):
        .. note:: Evolving.
         """
         for k in options:
-            self._jwrite = self._jwrite.option(k, to_str(options[k]))
+            self.option(k, options[k])
+        return self
+
+    @since(2.2)
+    def unsetOption(self, key):
+        """Un-sets the option given to the key for the underlying data source.
+
+        .. note:: Experimental.
+        """
+        self._jwrite = self._jwrite.unsetOption(key)
         return self
 
     @since(2.0)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1369,7 +1369,7 @@ class SQLTests(ReusedPySparkTestCase):
         self.spark.sql("SET spark.sql.sources.default=" + defaultDataSourceName)
 
         csvpath = os.path.join(tempfile.mkdtemp(), 'data')
-        df.write.option('quote', None).format('csv').save(csvpath)
+        df.write.unsetOption('quote').format('csv').save(csvpath)
 
         shutil.rmtree(tmpPath)
 

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -297,10 +297,19 @@ tablePropertyKey
     ;
 
 tablePropertyValue
+    : propertyValue
+    | propertyArrayValue
+    ;
+
+propertyValue
     : INTEGER_VALUE
     | DECIMAL_VALUE
     | booleanValue
     | STRING
+    ;
+
+propertyArrayValue
+    : '[' propertyValue (',' propertyValue)* ']'
     ;
 
 constantList

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -21,6 +21,9 @@ import java.util.{Locale, Properties}
 
 import scala.collection.JavaConverters._
 
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, render}
+
 import org.apache.spark.Partition
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.api.java.JavaRDD
@@ -117,6 +120,22 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
   def option(key: String, value: Double): DataFrameReader = option(key, value.toString)
 
   /**
+   * (Scala-specific) Adds an input option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Seq[String]): DataFrameReader = {
+    option(key, compact(render(value)))
+  }
+
+  /**
+   * Adds an input option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Array[String]): DataFrameReader = option(key, value.toSeq)
+
+  /**
    * (Scala-specific) Adds input options for the underlying data source.
    *
    * You can set the following option(s):
@@ -145,6 +164,16 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    */
   def options(options: java.util.Map[String, String]): DataFrameReader = {
     this.options(options.asScala)
+    this
+  }
+
+  /**
+   * Un-sets an input option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def unsetOption(key: String): DataFrameReader = {
+    this.extraOptions.remove(key)
     this
   }
 
@@ -502,7 +531,9 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * <li>`ignoreTrailingWhiteSpace` (default `false`): a flag indicating whether or not trailing
    * whitespaces from values being read should be skipped.</li>
    * <li>`nullValue` (default empty string): sets the string representation of a null value. Since
-   * 2.0.1, this applies to all supported types including the string type.</li>
+   * 2.0.1, this applies to all supported types including the string type.
+   * An array of strings to represent null values can be set for this option. For example,
+   * `spark.read.format("csv").option("nullValue", Seq("", "null"))`.</li>
    * <li>`nanValue` (default `NaN`): sets the string representation of a non-number" value.</li>
    * <li>`positiveInf` (default `Inf`): sets the string representation of a positive infinity
    * value.</li>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -122,7 +122,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
   /**
    * (Scala-specific) Adds an input option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Seq[String]): DataFrameReader = {
     option(key, compact(render(value)))
@@ -131,7 +131,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
   /**
    * Adds an input option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Array[String]): DataFrameReader = option(key, value.toSeq)
 
@@ -170,7 +170,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
   /**
    * Un-sets an input option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def unsetOption(key: String): DataFrameReader = {
     this.extraOptions.remove(key)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -131,7 +131,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
   /**
    * (Scala-specific) Adds an output option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Seq[String]): DataFrameWriter[T] = {
     option(key, compact(render(value)))
@@ -140,7 +140,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
   /**
    * Adds an output option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Array[String]): DataFrameWriter[T] = option(key, value.toSeq)
 
@@ -179,7 +179,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
   /**
    * Un-sets an output option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def unsetOption(key: String): DataFrameWriter[T] = {
     this.extraOptions.remove(key)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -21,6 +21,9 @@ import java.util.{Locale, Properties}
 
 import scala.collection.JavaConverters._
 
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, render}
+
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedRelation}
@@ -126,6 +129,22 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
   def option(key: String, value: Double): DataFrameWriter[T] = option(key, value.toString)
 
   /**
+   * (Scala-specific) Adds an output option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Seq[String]): DataFrameWriter[T] = {
+    option(key, compact(render(value)))
+  }
+
+  /**
+   * Adds an output option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Array[String]): DataFrameWriter[T] = option(key, value.toSeq)
+
+  /**
    * (Scala-specific) Adds output options for the underlying data source.
    *
    * You can set the following option(s):
@@ -154,6 +173,16 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    */
   def options(options: java.util.Map[String, String]): DataFrameWriter[T] = {
     this.options(options.asScala)
+    this
+  }
+
+  /**
+   * Un-sets an output option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def unsetOption(key: String): DataFrameWriter[T] = {
+    this.extraOptions.remove(key)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVInferSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVInferSchema.scala
@@ -79,7 +79,7 @@ private[csv] object CSVInferSchema {
    * point checking if it is an Int, as the final type must be Double or higher.
    */
   def inferField(typeSoFar: DataType, field: String, options: CSVOptions): DataType = {
-    if (field == null || field.isEmpty || field == options.nullValue) {
+    if (field == null || field.isEmpty || options.nullValue.contains(field)) {
       typeSoFar
     } else {
       typeSoFar match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityGenerator.scala
@@ -65,7 +65,7 @@ private[csv] class UnivocityGenerator(
       if (!row.isNullAt(i)) {
         values(i) = valueConverters(i).apply(row, i)
       } else {
-        values(i) = options.nullValue
+        values(i) = options.nullValue(0)
       }
       i += 1
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
@@ -170,7 +170,7 @@ class UnivocityParser(
        name: String,
        nullable: Boolean,
        options: CSVOptions)(converter: ValueConverter): Any = {
-    if (datum == options.nullValue || datum == null) {
+    if (options.nullValue.contains(datum) || datum == null) {
       if (!nullable) {
         throw new RuntimeException(s"null value found but field $name is not nullable.")
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -71,7 +71,8 @@ trait RelationProvider {
    * Returns a new base relation with the given parameters.
    *
    * @note The parameters' keywords are case insensitive and this insensitivity is enforced
-   * by the Map that is passed to the function.
+   * by the Map that is passed to the function. Also, the value of the Map can be a JSON
+   * array string if users set an array via option APIs.
    */
   def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation
 }
@@ -102,7 +103,8 @@ trait SchemaRelationProvider {
    * Returns a new base relation with the given parameters and user defined schema.
    *
    * @note The parameters' keywords are case insensitive and this insensitivity is enforced
-   * by the Map that is passed to the function.
+   * by the Map that is passed to the function. Also, the value of the Map can be a JSON
+   * array string if users set an array via option APIs.
    */
   def createRelation(
       sqlContext: SQLContext,
@@ -122,7 +124,12 @@ trait StreamSourceProvider {
 
   /**
    * Returns the name and schema of the source that can be used to continually read data.
+   *
    * @since 2.0.0
+   *
+   * @note The parameters' keywords are case insensitive and this insensitivity is enforced
+   * by the Map that is passed to the function. Also, the value of the Map can be a JSON
+   * array string if users set an array via option APIs.
    */
   def sourceSchema(
       sqlContext: SQLContext,
@@ -131,7 +138,13 @@ trait StreamSourceProvider {
       parameters: Map[String, String]): (String, StructType)
 
   /**
+   * Returns a source that can be used to continually read data.
+   *
    * @since 2.0.0
+   *
+   * @note The parameters' keywords are case insensitive and this insensitivity is enforced
+   * by the Map that is passed to the function. Also, the value of the Map can be a JSON
+   * array string if users set an array via option APIs.
    */
   def createSource(
       sqlContext: SQLContext,
@@ -150,6 +163,13 @@ trait StreamSourceProvider {
 @Experimental
 @InterfaceStability.Unstable
 trait StreamSinkProvider {
+  /**
+   * Returns a sink that can be used to continually write data.
+   *
+   * @note The parameters' keywords are case insensitive and this insensitivity is enforced
+   * by the Map that is passed to the function. Also, the value of the Map can be a JSON
+   * array string if users set an array via option APIs.
+   */
   def createSink(
       sqlContext: SQLContext,
       parameters: Map[String, String],
@@ -172,6 +192,10 @@ trait CreatableRelationProvider {
    * @return Relation with a known schema
    *
    * @since 1.3.0
+   *
+   * @note The parameters' keywords are case insensitive and this insensitivity is enforced
+   * by the Map that is passed to the function. Also, the value of the Map can be a JSON
+   * array string if users set an array via option APIs.
    */
   def createRelation(
       sqlContext: SQLContext,

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -114,7 +114,7 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
   /**
    * (Scala-specific) Adds an input option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Seq[String]): DataStreamReader = {
     option(key, compact(render(value)))
@@ -123,7 +123,7 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
   /**
    * Adds an input option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Array[String]): DataStreamReader = option(key, value.toSeq)
 
@@ -162,7 +162,7 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
   /**
    * Un-sets an input option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def unsetOption(key: String): DataStreamReader = {
     this.extraOptions.remove(key)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -21,6 +21,9 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, render}
+
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SparkSession}
@@ -109,6 +112,22 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
   def option(key: String, value: Double): DataStreamReader = option(key, value.toString)
 
   /**
+   * (Scala-specific) Adds an input option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Seq[String]): DataStreamReader = {
+    option(key, compact(render(value)))
+  }
+
+  /**
+   * Adds an input option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Array[String]): DataStreamReader = option(key, value.toSeq)
+
+  /**
    * (Scala-specific) Adds input options for the underlying data source.
    *
    * You can set the following option(s):
@@ -140,6 +159,15 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
     this
   }
 
+  /**
+   * Un-sets an input option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def unsetOption(key: String): DataStreamReader = {
+    this.extraOptions.remove(key)
+    this
+  }
 
   /**
    * Loads input data stream in as a `DataFrame`, for data streams that don't require a path
@@ -259,7 +287,9 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * <li>`ignoreTrailingWhiteSpace` (default `false`): a flag indicating whether or not trailing
    * whitespaces from values being read should be skipped.</li>
    * <li>`nullValue` (default empty string): sets the string representation of a null value. Since
-   * 2.0.1, this applies to all supported types including the string type.</li>
+   * 2.0.1, this applies to all supported types including the string type.
+   * An array of strings to represent null values can be set for this option. For example,
+   * `spark.readStream.format("csv").option("nullValue", Seq("", "null"))`.</li>
    * <li>`nanValue` (default `NaN`): sets the string representation of a non-number" value.</li>
    * <li>`positiveInf` (default `Inf`): sets the string representation of a positive infinity
    * value.</li>

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -186,7 +186,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   /**
    * (Scala-specific) Adds an output option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Seq[String]): DataStreamWriter[T] = {
     option(key, compact(render(value)))
@@ -195,7 +195,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   /**
    * Adds an output option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def option(key: String, value: Array[String]): DataStreamWriter[T] = option(key, value.toSeq)
 
@@ -234,7 +234,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   /**
    * Un-sets an option option for the underlying data source.
    *
-   * @since 2.2.0
+   * @since 2.3.0
    */
   def unsetOption(key: String): DataStreamWriter[T] = {
     this.extraOptions.remove(key)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -21,6 +21,9 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, render}
+
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.sql.{AnalysisException, Dataset, ForeachWriter}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
@@ -179,6 +182,23 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
    */
   def option(key: String, value: Double): DataStreamWriter[T] = option(key, value.toString)
 
+
+  /**
+   * (Scala-specific) Adds an output option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Seq[String]): DataStreamWriter[T] = {
+    option(key, compact(render(value)))
+  }
+
+  /**
+   * Adds an output option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def option(key: String, value: Array[String]): DataStreamWriter[T] = option(key, value.toSeq)
+
   /**
    * (Scala-specific) Adds output options for the underlying data source.
    *
@@ -208,6 +228,16 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
    */
   def options(options: java.util.Map[String, String]): DataStreamWriter[T] = {
     this.options(options.asScala)
+    this
+  }
+
+  /**
+   * Un-sets an option option for the underlying data source.
+   *
+   * @since 2.2.0
+   */
+  def unsetOption(key: String): DataStreamWriter[T] = {
+    this.extraOptions.remove(key)
     this
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
@@ -70,6 +70,7 @@ public class JavaDataFrameReaderWriterSuite {
         .option("b", 1)
         .option("c", 1.0)
         .option("d", true)
+        .option("e", new String[]{"1", "2"})
         .options(map)
         .text()
         .write()
@@ -77,6 +78,7 @@ public class JavaDataFrameReaderWriterSuite {
         .option("b", 1)
         .option("c", 1.0)
         .option("d", true)
+        .option("e", new String[]{"1", "2"})
         .options(map)
         .format("org.apache.spark.sql.test")
         .save();

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -22,6 +22,9 @@ import java.util.Locale
 
 import scala.reflect.{classTag, ClassTag}
 
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, render}
+
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -1030,15 +1033,16 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
       """
         |CREATE DATABASE database_name
         |LOCATION '/home/user/db'
-        |WITH DBPROPERTIES ('a'=1, 'b'=0.1, 'c'=TRUE)
+        |WITH DBPROPERTIES ('a'=1, 'b'=0.1, 'c'=TRUE, 'd'=[1, 0.1, TRUE, "e"])
       """.stripMargin
     val parsed = parser.parsePlan(sql)
+    val dValue = compact(render(Seq(1.toString, 0.1.toString, true.toString, "e")))
     val expected = CreateDatabaseCommand(
       "database_name",
       ifNotExists = false,
       Some("/home/user/db"),
       None,
-      Map("a" -> "1", "b" -> "0.1", "c" -> "true"))
+      Map("a" -> "1", "b" -> "0.1", "c" -> "true", "d" -> dValue))
 
     comparePlans(parsed, expected)
   }
@@ -1047,12 +1051,13 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
     val sql =
       """
         |ALTER TABLE table_name
-        |SET TBLPROPERTIES ('a' = 1, 'b' = 0.1, 'c' = TRUE)
+        |SET TBLPROPERTIES ('a' = 1, 'b' = 0.1, 'c' = TRUE, 'd'=[1,0.1,TRUE,"e"])
       """.stripMargin
     val parsed = parser.parsePlan(sql)
+    val dValue = compact(render(Seq(1.toString, 0.1.toString, true.toString, "e")))
     val expected = AlterTableSetPropertiesCommand(
       TableIdentifier("table_name"),
-      Map("a" -> "1", "b" -> "0.1", "c" -> "true"),
+      Map("a" -> "1", "b" -> "0.1", "c" -> "true", "d" -> dValue),
       isView = false)
 
     comparePlans(parsed, expected)
@@ -1062,14 +1067,15 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
     val sql =
       """
         |CREATE TABLE table_name USING json
-        |OPTIONS (a 1, b 0.1, c TRUE)
+        |OPTIONS (a 1, b 0.1, c TRUE, d [1,  0.1,TRUE, "e"])
       """.stripMargin
 
+    val dValue = compact(render(Seq(1.toString, 0.1.toString, true.toString, "e")))
     val expectedTableDesc = CatalogTable(
       identifier = TableIdentifier("table_name"),
       tableType = CatalogTableType.MANAGED,
       storage = CatalogStorageFormat.empty.copy(
-        properties = Map("a" -> "1", "b" -> "0.1", "c" -> "true")
+        properties = Map("a" -> "1", "b" -> "0.1", "c" -> "true", "d" -> dValue)
       ),
       schema = new StructType,
       provider = Some("json")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
@@ -66,10 +66,11 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
   test("test hadoop conf option propagation") {
     withTempPath { file =>
       // Test write side
+      val nullVal: String = null
       val df = spark.range(10).selectExpr("cast(id as string)")
       df.write
         .option("some-random-write-option", "hahah-WRITE")
-        .option("some-null-value-option", null)  // test null robustness
+        .option("some-null-value-option", nullVal) // test null robustness
         .option("dataSchema", df.schema.json)
         .format(dataSourceName).save(file.getAbsolutePath)
       assert(SimpleTextRelation.lastHadoopConf.get.get("some-random-write-option") == "hahah-WRITE")
@@ -77,7 +78,7 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
       // Test read side
       val df1 = spark.read
         .option("some-random-read-option", "hahah-READ")
-        .option("some-null-value-option", null)  // test null robustness
+        .option("some-null-value-option", nullVal) // test null robustness
         .option("dataSchema", df.schema.json)
         .format(dataSourceName)
         .load(file.getAbsolutePath)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/SimpleTextHadoopFsRelationSuite.scala
@@ -65,8 +65,9 @@ class SimpleTextHadoopFsRelationSuite extends HadoopFsRelationTest with Predicat
 
   test("test hadoop conf option propagation") {
     withTempPath { file =>
-      // Test write side
       val nullVal: String = null
+
+      // Test write side
       val df = spark.range(10).selectExpr("cast(id as string)")
       df.write
         .option("some-random-write-option", "hahah-WRITE")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes two types of APIs as below:

### Array as an option value in readers/writers

As an concrete implementation to use it, multiple values for `nullValue` is dealt with here together (SPARK-17878).

**Python** - `list`/`tuple` of any object that can be converted into string

```python
spark.read.format('csv') \
    .option("nullValue", ['Tom', 'Joe']) \
    ...
```

**Scala** - `Seq[String]`

```scala
spark.read.format("csv")
  .option("nullValue", Seq("2012", "Tesla", "null"))
  ...
```

**Java** - `String[]`

```java
spark.read().format("csv")
  .option("nullValue", new String[]{"", "null", "NA"})
  ...
```

**SQL** - Python's list-like form of integer, decimal, string and boolean 

```sql
CREATE TEMPORARY TABLE tableA USING csv
OPTIONS (nullValue [2012, 1.1, 'null'], ...)
```

### Unsets an option in readers/writers

**Scala**

```scala
spark.read.unsetOption("optionKey")
  ...
```

**Java**

```java
spark.read().unsetOption("optionKey")
  ...
```

**Python**

```java
spark.read.unsetOption("optionKey")
  ...
```

In case of R, there seems requiring a quite bit of more changes. It will be a follow-up.

## How was this patch tested?

Unit tests in each suite and manually.