### PR TITLE
[WIP] Fix `SET -v` not to raise exceptions for configs with default value `null`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -89,7 +89,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       val runFunc = (sparkSession: SparkSession) => {
         sparkSession.sessionState.conf.getAllDefinedConfs.map { case (key, defaultValue, doc) =>
           Row(key, defaultValue, doc)
-        }
+        }.toArray.toSeq
       }
       val schema = StructType(
         StructField("key", StringType, nullable = false) ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -88,8 +88,8 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
     case Some(("-v", None)) =>
       val runFunc = (sparkSession: SparkSession) => {
         sparkSession.sessionState.conf.getAllDefinedConfs.map { case (key, defaultValue, doc) =>
-          Row(key, defaultValue, doc)
-        }.toArray.toSeq
+          Row(key, if (defaultValue == null) "null" else defaultValue, doc)
+        }
       }
       val schema = StructType(
         StructField("key", StringType, nullable = false) ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -948,9 +948,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
    * definition contains key, defaultValue and doc.
    */
   def getAllDefinedConfs: Seq[(String, String, String)] = sqlConfEntries.synchronized {
-    sqlConfEntries.asScala.toMap.values.filter(_.isPublic).map { entry =>
+    sqlConfEntries.values.asScala.filter(_.isPublic).map { entry =>
       (entry.key, getConfString(entry.key, entry.defaultValueString), entry.doc)
-    }.toArray.toSeq
+    }.toSeq
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -948,9 +948,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
    * definition contains key, defaultValue and doc.
    */
   def getAllDefinedConfs: Seq[(String, String, String)] = sqlConfEntries.synchronized {
-    sqlConfEntries.values.asScala.filter(_.isPublic).map { entry =>
+    sqlConfEntries.asScala.toMap.values.filter(_.isPublic).map { entry =>
       (entry.key, getConfString(entry.key, entry.defaultValueString), entry.doc)
-    }.toSeq
+    }.toArray.toSeq
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -993,10 +993,12 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   }
 
   test("`SET -v` show") {
+    sql("RESET")
     sql("SET -v").show(200, false)
   }
 
   test("`SET -v` collect") {
+    sql("RESET")
     sql("SET -v").collect()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -992,7 +992,11 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     spark.sessionState.conf.clear()
   }
 
-  test("`SET -v` collect test") {
+  test("`SET -v` show") {
+    sql("SET -v").show(200, false)
+  }
+
+  test("`SET -v` collect") {
     sql("SET -v").collect()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -992,13 +992,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     spark.sessionState.conf.clear()
   }
 
-  test("`SET -v` show") {
-    sql("RESET")
-    sql("SET -v").show(200, false)
-  }
-
   test("`SET -v` collect") {
-    sql("RESET")
     sql("SET -v").collect()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -992,6 +992,10 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     spark.sessionState.conf.clear()
   }
 
+  test("`SET -v` collect test") {
+    sql("SET -v").collect()
+  }
+
   test("apply schema") {
     val schema1 = StructType(
       StructField("f1", IntegerType, false) ::


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is to investigate the current `SET -v` behavior.

## How was this patch tested?

Add two test cases.