### PR TITLE
[SPARK-19270][ML] Add summary table to GLM summary

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -115,10 +115,10 @@ private[r] object GeneralizedLinearRegressionWrapper
     }
 
     val rCoefficients: Array[Double] = if (summary.isNormalSolver) {
-      summary.coefficientMatrix.map(_._2) ++
-        summary.coefficientMatrix.map(_._3) ++
-        summary.coefficientMatrix.map(_._4) ++
-        summary.coefficientMatrix.map(_._5)
+      summary.coefficientCollection.map(_._2) ++
+        summary.coefficientCollection.map(_._3) ++
+        summary.coefficientCollection.map(_._4) ++
+        summary.coefficientCollection.map(_._5)
     } else {
       if (glm.getFitIntercept) {
         Array(glm.intercept) ++ glm.coefficients.toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -115,10 +115,10 @@ private[r] object GeneralizedLinearRegressionWrapper
     }
 
     val rCoefficients: Array[Double] = if (summary.isNormalSolver) {
-      summary.coefficientCollection.map(_._2) ++
-        summary.coefficientCollection.map(_._3) ++
-        summary.coefficientCollection.map(_._4) ++
-        summary.coefficientCollection.map(_._5)
+      summary.coefficientsWithStatistics.map(_._2) ++
+        summary.coefficientsWithStatistics.map(_._3) ++
+        summary.coefficientsWithStatistics.map(_._4) ++
+        summary.coefficientsWithStatistics.map(_._5)
     } else {
       if (glm.getFitIntercept) {
         Array(glm.intercept) ++ glm.coefficients.toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -115,17 +115,10 @@ private[r] object GeneralizedLinearRegressionWrapper
     }
 
     val rCoefficients: Array[Double] = if (summary.isNormalSolver) {
-      val rCoefficientStandardErrors =
-        summary.summaryTable.select("StdError").collect.map(_.getDouble(0))
-
-      val rTValues =
-        summary.summaryTable.select("TValue").collect.map(_.getDouble(0))
-
-      val rPValues =
-        summary.summaryTable.select("PValue").collect.map(_.getDouble(0))
-
-      summary.summaryTable.select("Coefficient").collect.map(_.getDouble(0)) ++
-        rCoefficientStandardErrors ++ rTValues ++ rPValues
+      summary.coefficientMatrix.map(_._2) ++
+        summary.coefficientMatrix.map(_._3) ++
+        summary.coefficientMatrix.map(_._4) ++
+        summary.coefficientMatrix.map(_._5)
     } else {
       if (glm.getFitIntercept) {
         Array(glm.intercept) ++ glm.coefficients.toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1477,11 +1477,10 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
   }
 
   /**
-   * Coefficient matrix with feature name, coefficient, standard error,
+   * Collection of feature name, coefficient, standard error,
    * tValue and pValue.
    */
-  @Since("2.3.0")
-  lazy val coefficientMatrix: Array[(String, Double, Double, Double, Double)] = {
+  private[ml] lazy val coefficientCollection: Array[(String, Double, Double, Double, Double)] = {
     if (isNormalSolver) {
       var featureNamesLocal = featureNames
       var coefficients = model.coefficients.toArray
@@ -1498,7 +1497,7 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
       result
     } else {
       throw new UnsupportedOperationException(
-        "No summary table available for this GeneralizedLinearRegressionModel")
+        "No summary available for this GeneralizedLinearRegressionModel")
     }
   }
 
@@ -1509,8 +1508,8 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
   private[regression] def showString(_numRows: Int, truncate: Int = 20,
                                      numDigits: Int = 3): String = {
     val numRows = _numRows.max(1)
-    val data = coefficientMatrix.take(numRows)
-    val hasMoreData = coefficientMatrix.size > numRows
+    val data = coefficientCollection.take(numRows)
+    val hasMoreData = coefficientCollection.size > numRows
 
     val colNames = Array("Feature", "Estimate", "StdError", "TValue", "PValue")
     val numCols = colNames.size
@@ -1599,43 +1598,16 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
   }
 
   /**
-   * Displays the summary of a GeneralizedLinearModel fit.
-   *
-   * @since 2.3.0
-   */
-  def show(): Unit = {
-    val numRows = coefficientMatrix.size
-    show(numRows, true, 3)
-  }
-
-  /**
-   * Displays the top numRows rows of the summary of a GeneralizedLinearModel fit.
-   *
-   * @param numRows Number of rows to show
-   *
-   * @since 2.3.0
-   */
-  @Since("2.3.0")
-  def show(numRows: Int): Unit = {
-    show(numRows, true, 3)
-  }
-
-  /**
    * Displays the summary of a GeneralizedLinearModel fit. Strings more than 20 characters
-   * will be truncated, and all cells will be aligned right.
-   *
-   * @param numRows Number of rows to show
-   * @param truncate Whether truncate long strings. If true, strings more than 20 characters will
-   *              be truncated and all cells will be aligned right
-   * @param numDigits Number of decimal places used to round numerical values.
+   * will be truncated, and all cells will be aligned right. Numbers are rounded to three
+   * decimal places.
    *
    * @since 2.3.0
    */
   // scalastyle:off println
-  def show(numRows: Int, truncate: Boolean, numDigits: Int): Unit = if (truncate) {
-    println(showString(numRows, truncate = 20, numDigits))
-  } else {
-    println(showString(numRows, truncate = 0, numDigits))
+  def show(): Unit = {
+    println(showString(coefficientCollection.size, truncate = 20, 3))
   }
   // scalastyle:on println
+
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -34,11 +34,9 @@ import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
-import org.apache.spark.sql.SparkSession
-
 
 /**
  * Params for Generalized Linear Regression.

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -471,7 +471,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
   private[regression] val epsilon: Double = 1E-16
 
-  private[regression] val Intercept: String = "Intercept"
+  private[regression] val Intercept: String = "(Intercept)"
 
   /**
    * Wrapper of family and link combination used in the model.

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1478,10 +1478,9 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
   }
 
   /**
-    * Summary table with feature name, coefficient, standard error,
-    * tValue and pValue.
-    *
-    */
+   * Summary table with feature name, coefficient, standard error,
+   * tValue and pValue.
+   */
   @Since("2.2.0")
   lazy val summaryTable: DataFrame = {
     if (isNormalSolver) {
@@ -1491,7 +1490,7 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
       if (model.getFitIntercept) {
         featureNames = featureNames :+ "Intercept"
         coefficients = coefficients :+ model.intercept
-        // reorder so that intercept comes first
+        // Reorder so that intercept comes first
         idx = (coefficients.length - 1) +: idx
       }
       val result = for (i <- idx.toSeq) yield

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -20,9 +20,7 @@ package org.apache.spark.ml.regression
 import java.util.Locale
 
 import breeze.stats.{distributions => dist}
-
 import org.apache.commons.lang3.StringUtils
-
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkException

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -327,7 +327,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * </blockquote>
    * Default is 0.0.
    *
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -1478,7 +1477,7 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
   }
 
   /**
-   * coefficients with statistics: feature name, coefficients, standard error, tValue and pValue.
+   * Coefficients with statistics: feature name, coefficients, standard error, tValue and pValue.
    */
   private[ml] lazy val coefficientsWithStatistics: Array[
     (String, Double, Double, Double, Double)] = {
@@ -1501,7 +1500,7 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
     if (isNormalSolver) {
 
       def round(x: Double): String = {
-        BigDecimal(x).setScale(5, BigDecimal.RoundingMode.HALF_UP).toString
+        BigDecimal(x).setScale(4, BigDecimal.RoundingMode.HALF_UP).toString
       }
 
       val colNames = Array("Feature", "Estimate", "Std Error", "T Value", "P Value")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -470,8 +470,6 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
   private[regression] val epsilon: Double = 1E-16
 
-  private[regression] val Intercept: String = "(Intercept)"
-
   /**
    * Wrapper of family and link combination used in the model.
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -21,21 +21,22 @@ import java.util.Locale
 
 import breeze.stats.{distributions => dist}
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.PredictorParams
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.feature.{Instance, OffsetInstance}
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors}
 import org.apache.spark.ml.optim._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
-import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{DataType, DoubleType, StringType, StructType, StructField}
+import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 import org.apache.spark.sql.SparkSession
 
 
@@ -1504,5 +1505,4 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
         "No summary table available for this GeneralizedLinearRegressionModel")
     }
   }
-
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1505,7 +1505,8 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
     BigDecimal(x).setScale(digit, BigDecimal.RoundingMode.HALF_UP).toString()
   }
 
-  private[regression] def showString(_numRows: Int, truncate: Int = 20,
+  private[regression] def showString(_numRows: Int,
+                                     truncate: Int = 20,
                                      numDigits: Int = 3): String = {
     val numRows = _numRows.max(1)
     val data = coefficientCollection.take(numRows)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1208,7 +1208,7 @@ class GeneralizedLinearRegressionSummary private[regression] (
 
   /**
    * Name of features. If the name cannot be retrieved from attributes,
-   * use default names "V1", "V2", ...
+   * set default names to "V1", "V2", and so on.
    */
   @Since("2.2.0")
   lazy val featureName: Array[String] = {
@@ -1504,6 +1504,5 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
         "No summary table available for this GeneralizedLinearRegressionModel")
     }
   }
-
 
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1546,12 +1546,12 @@ class GeneralizedLinearRegressionSuite
     val formula = new RFormula().setFormula("y ~ x1 + x2")
     val dataset2 = formula.fit(datasetTmp).transform(datasetTmp)
 
-    val expectedFeature = Seq(Array("V1", "V2"), Array("x1", "x2"))
+    val expectedFeature = Seq(Array("features_0", "features_1"), Array("x1", "x2"))
 
     var idx = 0
     for (dataset <- Seq(dataset1, dataset2)) {
       val model = new GeneralizedLinearRegression().fit(dataset)
-      model.summary.featureName.zip(expectedFeature(idx))
+      model.summary.featureNames.zip(expectedFeature(idx))
         .foreach{ x => assert(x._1 === x._2) }
       idx += 1
     }
@@ -1566,8 +1566,8 @@ class GeneralizedLinearRegressionSuite
       Instance(2.0, 5.0, Vectors.dense(2.0, 3.0))
     ).toDF()
 
-    val expectedFeature = Seq(Array("V1", "V2"),
-      Array("Intercept", "V1", "V2"))
+    val expectedFeature = Seq(Array("features_0", "features_1"),
+      Array("Intercept", "features_0", "features_1"))
     val expectedEstimate = Seq(Vectors.dense(0.2884, 0.538),
       Vectors.dense(0.7903, 0.2258, 0.4677))
     val expectedStdError = Seq(Vectors.dense(1.724, 0.3787),
@@ -1585,17 +1585,17 @@ class GeneralizedLinearRegressionSuite
       val model = trainer.fit(dataset)
       val summaryTable = model.summary.summaryTable
 
-      summaryTable.select("Feature").rdd.collect.map(_.getString(0))
+      summaryTable.select("Feature").collect.map(_.getString(0))
         .zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
         "Feature name mismatch in summaryTable") }
-      assert(Vectors.dense(summaryTable.select("Estimate").rdd.collect.map(_.getDouble(0)))
-        ~= expectedEstimate(idx) absTol 1E-3, "Coefficient mismatch in summaryTable")
+      assert(Vectors.dense(summaryTable.select("Coefficient").rdd.collect.map(_.getDouble(0)))
+        ~== expectedEstimate(idx) absTol 1E-3, "Coefficient mismatch in summaryTable")
       assert(Vectors.dense(summaryTable.select("StdError").rdd.collect.map(_.getDouble(0)))
-        ~= expectedStdError(idx) absTol 1E-3, "Standard error mismatch in summaryTable")
+        ~== expectedStdError(idx) absTol 1E-3, "Standard error mismatch in summaryTable")
       assert(Vectors.dense(summaryTable.select("TValue").rdd.collect.map(_.getDouble(0)))
-        ~= expectedTValue(idx) absTol 1E-3, "TValue mismatch in summaryTable")
+        ~== expectedTValue(idx) absTol 1E-3, "TValue mismatch in summaryTable")
       assert(Vectors.dense(summaryTable.select("PValue").rdd.collect.map(_.getDouble(0)))
-        ~= expectedPValue(idx) absTol 1E-3, "PValue mismatch in summaryTable")
+        ~== expectedPValue(idx) absTol 1E-3, "PValue mismatch in summaryTable")
 
       idx += 1
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1567,7 +1567,7 @@ class GeneralizedLinearRegressionSuite
     ).toDF()
 
     val expectedFeature = Seq(Array("features_0", "features_1"),
-      Array("Intercept", "features_0", "features_1"))
+      Array("(Intercept)", "features_0", "features_1"))
     val expectedEstimate = Seq(Vectors.dense(0.2884, 0.538),
       Vectors.dense(0.7903, 0.2258, 0.4677))
     val expectedStdError = Seq(Vectors.dense(1.724, 0.3787),

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml.regression
 
 import scala.util.Random
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.classification.LogisticRegressionSuite._
 import org.apache.spark.ml.feature.{Instance, OffsetInstance}
@@ -1527,7 +1528,7 @@ class GeneralizedLinearRegressionSuite
   test("glm summary: feature name") {
     // dataset1 with no attribute
     val dataset1 = Seq(
-      Instance(2.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
+      Instance(2.0, 1.0, Vectors.dense(0.0, 5.0)),
       Instance(8.0, 2.0, Vectors.dense(1.0, 7.0)),
       Instance(3.0, 3.0, Vectors.dense(2.0, 11.0)),
       Instance(9.0, 4.0, Vectors.dense(3.0, 13.0)),
@@ -1547,20 +1548,18 @@ class GeneralizedLinearRegressionSuite
 
     val expectedFeature = Seq(Array("V1", "V2"), Array("x1", "x2"))
 
-    val trainer = new GeneralizedLinearRegression()
     var idx = 0
     for (dataset <- Seq(dataset1, dataset2)) {
-      val model = trainer.fit(dataset)
-      model.summary.featureName
-        .zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
-        "Feature name mismatch in glm summary") }
+      val model = new GeneralizedLinearRegression().fit(dataset)
+      model.summary.featureName.zip(expectedFeature(idx))
+        .foreach{ x => assert(x._1 === x._2) }
       idx += 1
     }
   }
 
   test("glm summary: summaryTable") {
     val dataset = Seq(
-      Instance(2.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
+      Instance(2.0, 1.0, Vectors.dense(0.0, 5.0)),
       Instance(8.0, 2.0, Vectors.dense(1.0, 7.0)),
       Instance(3.0, 3.0, Vectors.dense(2.0, 11.0)),
       Instance(9.0, 4.0, Vectors.dense(3.0, 13.0)),

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1593,13 +1593,13 @@ class GeneralizedLinearRegressionSuite
         .setFamily("gaussian")
         .setFitIntercept(fitIntercept)
       val model = trainer.fit(dataset)
-      val coefficientMatrix = model.summary.coefficientMatrix
+      val coefficients = model.summary.coefficientCollection
 
-      coefficientMatrix.map(_._1).zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
+      coefficients.map(_._1).zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
         "Feature name mismatch in summaryTable") }
-      assert(Vectors.dense(coefficientMatrix.map(_._2))
+      assert(Vectors.dense(coefficients.map(_._2))
         ~== expectedEstimate(idx) absTol 1E-3, "Coefficient mismatch in summaryTable")
-      assert(Vectors.dense(coefficientMatrix.map(_._3))
+      assert(Vectors.dense(coefficients.map(_._3))
         ~== expectedStdError(idx) absTol 1E-3, "Standard error mismatch in summaryTable")
       idx += 1
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1558,6 +1558,21 @@ class GeneralizedLinearRegressionSuite
   }
 
   test("glm summary: summaryTable") {
+    /*
+      R code:
+
+      A <- matrix(c(0, 1, 2, 3, 2, 5, 7, 11, 13, 3), 5, 2)
+      b <- c(2, 8, 3, 9, 2)
+      df <- as.data.frame(cbind(A, b))
+      model <- glm(formula = "b ~ .",  data = df)
+      summary(model)
+
+      Coefficients:
+                  Estimate Std. Error t value Pr(>|t|)
+      (Intercept)   0.7903     4.0129   0.197    0.862
+      V1            0.2258     2.1153   0.107    0.925
+      V2            0.4677     0.5815   0.804    0.506
+    */
     val dataset = Seq(
       Instance(2.0, 1.0, Vectors.dense(0.0, 5.0)),
       Instance(8.0, 2.0, Vectors.dense(1.0, 7.0)),
@@ -1588,13 +1603,13 @@ class GeneralizedLinearRegressionSuite
       summaryTable.select("Feature").collect.map(_.getString(0))
         .zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
         "Feature name mismatch in summaryTable") }
-      assert(Vectors.dense(summaryTable.select("Coefficient").rdd.collect.map(_.getDouble(0)))
+      assert(Vectors.dense(summaryTable.select("Coefficient").collect.map(_.getDouble(0)))
         ~== expectedEstimate(idx) absTol 1E-3, "Coefficient mismatch in summaryTable")
-      assert(Vectors.dense(summaryTable.select("StdError").rdd.collect.map(_.getDouble(0)))
+      assert(Vectors.dense(summaryTable.select("StdError").collect.map(_.getDouble(0)))
         ~== expectedStdError(idx) absTol 1E-3, "Standard error mismatch in summaryTable")
-      assert(Vectors.dense(summaryTable.select("TValue").rdd.collect.map(_.getDouble(0)))
+      assert(Vectors.dense(summaryTable.select("TValue").collect.map(_.getDouble(0)))
         ~== expectedTValue(idx) absTol 1E-3, "TValue mismatch in summaryTable")
-      assert(Vectors.dense(summaryTable.select("PValue").rdd.collect.map(_.getDouble(0)))
+      assert(Vectors.dense(summaryTable.select("PValue").collect.map(_.getDouble(0)))
         ~== expectedPValue(idx) absTol 1E-3, "PValue mismatch in summaryTable")
 
       idx += 1

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1525,7 +1525,7 @@ class GeneralizedLinearRegressionSuite
 
 
   test("glm summary: feature name") {
-    // dataset with no attribute
+    // dataset1 with no attribute
     val dataset1 = Seq(
       Instance(2.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
       Instance(8.0, 2.0, Vectors.dense(1.0, 7.0)),
@@ -1534,7 +1534,7 @@ class GeneralizedLinearRegressionSuite
       Instance(2.0, 5.0, Vectors.dense(2.0, 3.0))
     ).toDF()
 
-    // dataset with attribute
+    // dataset2 with attribute
     val datasetTmp = Seq(
       (2.0, 1.0, 0.0, 5.0),
       (8.0, 2.0, 1.0, 7.0),

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1524,7 +1524,6 @@ class GeneralizedLinearRegressionSuite
       .fit(datasetGaussianIdentity.as[LabeledPoint])
   }
 
-
   test("glm summary: feature name") {
     // dataset1 with no attribute
     val dataset1 = Seq(
@@ -1557,7 +1556,7 @@ class GeneralizedLinearRegressionSuite
     }
   }
 
-  test("glm summary: summaryTable") {
+  test("glm summary: coefficient matrix") {
     /*
       R code:
 
@@ -1587,10 +1586,6 @@ class GeneralizedLinearRegressionSuite
       Vectors.dense(0.7903, 0.2258, 0.4677))
     val expectedStdError = Seq(Vectors.dense(1.724, 0.3787),
       Vectors.dense(4.0129, 2.1153, 0.5815))
-    val expectedTValue = Seq(Vectors.dense(0.1673, 1.4205),
-      Vectors.dense(0.1969, 0.1067, 0.8043))
-    val expectedPValue = Seq(Vectors.dense(0.8778, 0.2506),
-      Vectors.dense(0.8621, 0.9247, 0.5056))
 
     var idx = 0
     for (fitIntercept <- Seq(false, true)) {
@@ -1598,20 +1593,14 @@ class GeneralizedLinearRegressionSuite
         .setFamily("gaussian")
         .setFitIntercept(fitIntercept)
       val model = trainer.fit(dataset)
-      val summaryTable = model.summary.summaryTable
+      val coefficientMatrix = model.summary.coefficientMatrix
 
-      summaryTable.select("Feature").collect.map(_.getString(0))
-        .zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
+      coefficientMatrix.map(_._1).zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
         "Feature name mismatch in summaryTable") }
-      assert(Vectors.dense(summaryTable.select("Coefficient").collect.map(_.getDouble(0)))
+      assert(Vectors.dense(coefficientMatrix.map(_._2))
         ~== expectedEstimate(idx) absTol 1E-3, "Coefficient mismatch in summaryTable")
-      assert(Vectors.dense(summaryTable.select("StdError").collect.map(_.getDouble(0)))
+      assert(Vectors.dense(coefficientMatrix.map(_._3))
         ~== expectedStdError(idx) absTol 1E-3, "Standard error mismatch in summaryTable")
-      assert(Vectors.dense(summaryTable.select("TValue").collect.map(_.getDouble(0)))
-        ~== expectedTValue(idx) absTol 1E-3, "TValue mismatch in summaryTable")
-      assert(Vectors.dense(summaryTable.select("PValue").collect.map(_.getDouble(0)))
-        ~== expectedPValue(idx) absTol 1E-3, "PValue mismatch in summaryTable")
-
       idx += 1
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1556,7 +1556,7 @@ class GeneralizedLinearRegressionSuite
     }
   }
 
-  test("glm summary: coefficient matrix") {
+  test("glm summary: coefficient with statistics") {
     /*
       R code:
 
@@ -1593,14 +1593,14 @@ class GeneralizedLinearRegressionSuite
         .setFamily("gaussian")
         .setFitIntercept(fitIntercept)
       val model = trainer.fit(dataset)
-      val coefficients = model.summary.coefficientCollection
+      val coefficientsWithStatistics = model.summary.coefficientsWithStatistics
 
-      coefficients.map(_._1).zip(expectedFeature(idx)).foreach{ x => assert(x._1 === x._2,
-        "Feature name mismatch in summaryTable") }
-      assert(Vectors.dense(coefficients.map(_._2))
-        ~== expectedEstimate(idx) absTol 1E-3, "Coefficient mismatch in summaryTable")
-      assert(Vectors.dense(coefficients.map(_._3))
-        ~== expectedStdError(idx) absTol 1E-3, "Standard error mismatch in summaryTable")
+      coefficientsWithStatistics.map(_._1).zip(expectedFeature(idx)).foreach { x =>
+        assert(x._1 === x._2, "Feature name mismatch in coefficientsWithStatistics") }
+      assert(Vectors.dense(coefficientsWithStatistics.map(_._2)) ~= expectedEstimate(idx)
+        absTol 1E-3, "Coefficients mismatch in coefficientsWithStatistics")
+      assert(Vectors.dense(coefficientsWithStatistics.map(_._3)) ~= expectedStdError(idx)
+        absTol 1E-3, "Standard error mismatch in coefficientsWithStatistics")
       idx += 1
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1350,6 +1350,9 @@ class GeneralizedLinearRegressionSuite
     assert(summary.residualDegreeOfFreedomNull === residualDegreeOfFreedomNullR)
     assert(summary.aic ~== aicR absTol 1E-3)
     assert(summary.solver === "irls")
+    println(summary.featureName)
+    println(summary.summaryTable(0))
+    println(summary.summaryTable(1))
   }
 
   test("glm summary: tweedie family with weight and offset") {
@@ -1492,7 +1495,7 @@ class GeneralizedLinearRegressionSuite
     }
   }
 
-  test("read/write") {
+  ignore("read/write") {
     def checkModelData(
         model: GeneralizedLinearRegressionModel,
         model2: GeneralizedLinearRegressionModel): Unit = {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1350,9 +1350,6 @@ class GeneralizedLinearRegressionSuite
     assert(summary.residualDegreeOfFreedomNull === residualDegreeOfFreedomNullR)
     assert(summary.aic ~== aicR absTol 1E-3)
     assert(summary.solver === "irls")
-    println(summary.featureName)
-    println(summary.summaryTable(0))
-    println(summary.summaryTable(1))
   }
 
   test("glm summary: tweedie family with weight and offset") {
@@ -1495,7 +1492,7 @@ class GeneralizedLinearRegressionSuite
     }
   }
 
-  ignore("read/write") {
+  test("read/write") {
     def checkModelData(
         model: GeneralizedLinearRegressionModel,
         model2: GeneralizedLinearRegressionModel): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add R-like summary table to GLM summary, which includes feature name (if exist), parameter estimate, standard error, t-stat and p-value. This allows scala users to easily gather these commonly used inference results.

@srowen @yanboliang  @felixcheung 

## How was this patch tested?
New tests. One for testing feature Name, and one for testing the summary Table. 
