### PR TITLE
[SPARK-19225][SQL]round decimal return normal value but not null

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Spark Spark Spark
+# Apache Spark Spark Spark Spark
 
 Spark is a fast and general cluster computing system for Big Data. It provides
 high-level APIs in Scala, Java, Python, and R, and an optimized engine that

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Spark Spark
+# Apache Spark Spark Spark
 
 Spark is a fast and general cluster computing system for Big Data. It provides
 high-level APIs in Scala, Java, Python, and R, and an optimized engine that

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Spark
+# Apache Spark Spark
 
 Spark is a fast and general cluster computing system for Big Data. It provides
 high-level APIs in Scala, Java, Python, and R, and an optimized engine that

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -41,7 +41,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
    * @tparam T Generic type for primitives
    */
   private def testLeaf[T](
-      e: () => Expression,  
+      e: () => Expression,       
       c: T): Unit = {
     checkEvaluation(e(), c, EmptyRow)
     checkEvaluation(e(), c, create_row(null))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -41,7 +41,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
    * @tparam T Generic type for primitives
    */
   private def testLeaf[T](
-      e: () => Expression,
+      e: () => Expression,  
       c: T): Unit = {
     checkEvaluation(e(), c, EmptyRow)
     checkEvaluation(e(), c, create_row(null))


### PR DESCRIPTION
## What changes were proposed in this pull request?

in https://issues.apache.org/jira/browse/SPARK-19225,
change the round decimal function. select round(4.4, 2) can return 4.4 , not return null when round scale is larger than decimal scale

## How was this patch tested?

Jeckins

Please review http://spark.apache.org/contributing.html before opening a pull request.
