### PR TITLE
[SPARK-19292][SQL] filter with partition columns should be case-insensitive on Hive tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -62,7 +62,7 @@ object FileSourceStrategy extends Strategy with Logging {
       val filterSet = ExpressionSet(filters)
 
       // The attribute name of predicate could be different than the one in schema in case of
-      // case insensitive, we should change them to match the one in schema, so we donot need to
+      // case insensitive, we should change them to match the one in schema, so we do not need to
       // worry about case sensitivity anymore.
       val normalizedFilters = filters.map { e =>
         e transform {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2017,14 +2017,14 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
   test("SPARK-19292: filter with partition columns should be case-insensitive on Hive tables") {
     withTable("tbl") {
-      sql("CREATE TABLE tbl(i int, j int) USING hive PARTITIONED BY (j)")
-      sql("INSERT INTO tbl PARTITION(j=10) SELECT 1")
-      checkAnswer(spark.table("tbl"), Row(1, 10))
+      withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+        sql("CREATE TABLE tbl(i int, j int) USING hive PARTITIONED BY (j)")
+        sql("INSERT INTO tbl PARTITION(j=10) SELECT 1")
+        checkAnswer(spark.table("tbl"), Row(1, 10))
 
-      sql("SELECT i, j FROM tbl WHERE J=10").explain(true)
-
-      checkAnswer(sql("SELECT i, j FROM tbl WHERE J=10"), Row(1, 10))
-      checkAnswer(spark.table("tbl").filter($"J" === 10), Row(1, 10))
+        checkAnswer(sql("SELECT i, j FROM tbl WHERE J=10"), Row(1, 10))
+        checkAnswer(spark.table("tbl").filter($"J" === 10), Row(1, 10))
+      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2014,4 +2014,17 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       )
     }
   }
+
+  test("SPARK-19292: filter with partition columns should be case-insensitive on Hive tables") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(i int, j int) USING hive PARTITIONED BY (j)")
+      sql("INSERT INTO tbl PARTITION(j=10) SELECT 1")
+      checkAnswer(spark.table("tbl"), Row(1, 10))
+
+      sql("SELECT i, j FROM tbl WHERE J=10").explain(true)
+
+      checkAnswer(sql("SELECT i, j FROM tbl WHERE J=10"), Row(1, 10))
+      checkAnswer(spark.table("tbl").filter($"J" === 10), Row(1, 10))
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we query a table with a filter on partitioned columns, we will push the partition filter to the metastore to get matched partitions directly.

In `HiveExternalCatalog.listPartitionsByFilter`, we assume the column names in partition filter are already normalized and we don't need to consider case sensitivity. However, `HiveTableScanExec` doesn't follow this assumption. This PR fixes it.

## How was this patch tested?

new regression test