### PR TITLE
[SPARK-16554][CORE] Automatically Kill Executors and Nodes when they are Blacklisted

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -63,7 +63,7 @@ private[spark] trait ExecutorAllocationClient {
    * and maybe replace them.
    * @return whether the request is acknowledged by the cluster manager.
    */
-  def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Seq[String]
+  def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Unit
 
   /**
    * Request that the cluster manager kill every executor on the specified host.

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -59,9 +59,16 @@ private[spark] trait ExecutorAllocationClient {
   def killExecutors(executorIds: Seq[String]): Seq[String]
 
   /**
-   * Request that the cluster manager try harder to kill the specified executors,
-   * and maybe replace them.
-   * @return whether the request is acknowledged by the cluster manager.
+   * Request that the cluster manager kill the specified executors.
+   *
+   * When asking the executor to be replaced, the executor loss is considered a failure, and
+   * killed tasks that are running on the executor will count towards the failure limits. If no
+   * replacement is being requested, then the tasks will not count towards the limit.
+   *
+   * @param executorIds identifiers of executors to kill
+   * @param replace whether to replace the killed executors with new ones
+   * @param force whether to force kill busy executors
+   * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
   def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Seq[String]
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -71,6 +71,8 @@ private[spark] trait ExecutorAllocationClient {
 
   /**
    * Request that the cluster manager kill every executor on the specified host.
+   * Results in a call to killExecutors for each executor on the host, with the replace
+   * and force arguments set to true.
    * @return whether the request is acknowledged by the cluster manager.
    */
   def killExecutorsOnHost(host: String): Boolean

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -76,7 +76,7 @@ private[spark] trait ExecutorAllocationClient {
    * Request that the cluster manager kill every executor on the specified host.
    * @return whether the request is acknowledged by the cluster manager.
    */
-  def killExecutorsOnHost(host: String, replace: Boolean): Boolean
+  def killExecutorsOnHost(host: String): Boolean
 
     /**
    * Request that the cluster manager kill the specified executor.

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -58,6 +58,17 @@ private[spark] trait ExecutorAllocationClient {
    */
   def killExecutors(executorIds: Seq[String]): Seq[String]
 
+  /**
+   * Request that the cluster manager try harder to kill the specified executors,
+   * and maybe replace them.
+   * @return whether the request is acknowledged by the cluster manager.
+   */
+  def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Seq[String]
+
+  /**
+   * Request that the cluster manager kill every executor on the specified host.
+   * @return the ids of the executors acknowledged by the cluster manager to be removed
+   */
   def killExecutorsOnHost(host: String): Seq[String]
 
     /**

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -54,23 +54,20 @@ private[spark] trait ExecutorAllocationClient {
 
   /**
    * Request that the cluster manager kill the specified executors.
-   * @return the ids of the executors acknowledged by the cluster manager to be removed.
-   */
-  def killExecutors(executorIds: Seq[String]): Seq[String]
-
-  /**
-   * Request that the cluster manager kill the specified executors.
    *
    * When asking the executor to be replaced, the executor loss is considered a failure, and
    * killed tasks that are running on the executor will count towards the failure limits. If no
    * replacement is being requested, then the tasks will not count towards the limit.
    *
    * @param executorIds identifiers of executors to kill
-   * @param replace whether to replace the killed executors with new ones
-   * @param force whether to force kill busy executors
+   * @param replace whether to replace the killed executors with new ones, default false
+   * @param force whether to force kill busy executors, default false
    * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
-  def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Seq[String]
+  def killExecutors(
+    executorIds: Seq[String],
+    replace: Boolean = false,
+    force: Boolean = false): Seq[String]
 
   /**
    * Request that the cluster manager kill every executor on the specified host.

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -58,7 +58,9 @@ private[spark] trait ExecutorAllocationClient {
    */
   def killExecutors(executorIds: Seq[String]): Seq[String]
 
-  /**
+  def killExecutorsOnHost(host: String): Seq[String]
+
+    /**
    * Request that the cluster manager kill the specified executor.
    * @return whether the request is acknowledged by the cluster manager.
    */

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -69,7 +69,7 @@ private[spark] trait ExecutorAllocationClient {
    * Request that the cluster manager kill every executor on the specified host.
    * @return whether the request is acknowledged by the cluster manager.
    */
-  def killExecutorsOnHost(host: String): Boolean
+  def killExecutorsOnHost(host: String, replace: Boolean): Boolean
 
     /**
    * Request that the cluster manager kill the specified executor.

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -63,13 +63,13 @@ private[spark] trait ExecutorAllocationClient {
    * and maybe replace them.
    * @return whether the request is acknowledged by the cluster manager.
    */
-  def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Unit
+  def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean): Seq[String]
 
   /**
    * Request that the cluster manager kill every executor on the specified host.
-   * @return the ids of the executors acknowledged by the cluster manager to be removed
+   * @return whether the request is acknowledged by the cluster manager.
    */
-  def killExecutorsOnHost(host: String): Seq[String]
+  def killExecutorsOnHost(host: String): Boolean
 
     /**
    * Request that the cluster manager kill the specified executor.

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1672,13 +1672,8 @@ class SparkContext(config: SparkConf) extends Logging {
   def killExecutor(executorId: String): Boolean = killExecutors(Seq(executorId))
 
   /**
-   * :: DeveloperApo ::
+   * :: DeveloperApi ::
    * Request that the cluster manager kill all executors on the specified host.
-   *
-   * Note: This is an indication to the cluster manager that the application wishes to adjust
-   * its resource usage downwards. If the application wishes to replace the executor it kills
-   * through this method with a new one, it should follow up explicitly with a call to
-   * {{SparkContext#requestExecutors}}.
    *
    * @return whether the request is received.
    */

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1672,23 +1672,6 @@ class SparkContext(config: SparkConf) extends Logging {
   def killExecutor(executorId: String): Boolean = killExecutors(Seq(executorId))
 
   /**
-   * :: DeveloperApi ::
-   * Request that the cluster manager kill all executors on the specified host.
-   *
-   * @return whether the request is received.
-   */
-  @DeveloperApi
-  def killExecutorsOnHost(host: String): Boolean = {
-    schedulerBackend match {
-      case b: CoarseGrainedSchedulerBackend =>
-        b.killExecutorsOnHost(host).nonEmpty
-      case _ =>
-        logWarning("Killing executors is only supported in coarse-grained mode")
-        false
-    }
-  }
-
-  /**
    * Request that the cluster manager kill the specified executor without adjusting the
    * application resource requirements.
    *

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1672,6 +1672,28 @@ class SparkContext(config: SparkConf) extends Logging {
   def killExecutor(executorId: String): Boolean = killExecutors(Seq(executorId))
 
   /**
+   * :: DeveloperApo ::
+   * Request that the cluster manager kill all executors on the specified host.
+   *
+   * Note: This is an indication to the cluster manager that the application wishes to adjust
+   * its resource usage downwards. If the application wishes to replace the executor it kills
+   * through this method with a new one, it should follow up explicitly with a call to
+   * {{SparkContext#requestExecutors}}.
+   *
+   * @return whether the request is received.
+   */
+  @DeveloperApi
+  def killExecutorsOnHost(host: String): Boolean = {
+    schedulerBackend match {
+      case b: CoarseGrainedSchedulerBackend =>
+        b.killExecutorsOnHost(host).nonEmpty
+      case _ =>
+        logWarning("Killing executors is only supported in coarse-grained mode")
+        false
+    }
+  }
+
+  /**
    * Request that the cluster manager kill the specified executor without adjusting the
    * application resource requirements.
    *

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -139,6 +139,11 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
+  private[spark] val BLACKLIST_KILL_ENABLED =
+    ConfigBuilder("spark.blacklist.kill")
+    .booleanConf
+    .createOptional
+
   private[spark] val BLACKLIST_LEGACY_TIMEOUT_CONF =
     ConfigBuilder("spark.scheduler.executorTaskBlacklistTime")
       .internal()

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -141,8 +141,8 @@ package object config {
 
   private[spark] val BLACKLIST_KILL_ENABLED =
     ConfigBuilder("spark.blacklist.killBlacklistedExecutors")
-    .booleanConf
-    .createWithDefault(false)
+      .booleanConf
+      .createWithDefault(false)
 
   private[spark] val BLACKLIST_LEGACY_TIMEOUT_CONF =
     ConfigBuilder("spark.scheduler.executorTaskBlacklistTime")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -142,7 +142,7 @@ package object config {
   private[spark] val BLACKLIST_KILL_ENABLED =
     ConfigBuilder("spark.blacklist.kill")
     .booleanConf
-    .createOptional
+    .createWithDefault(false)
 
   private[spark] val BLACKLIST_LEGACY_TIMEOUT_CONF =
     ConfigBuilder("spark.scheduler.executorTaskBlacklistTime")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -140,7 +140,7 @@ package object config {
       .createOptional
 
   private[spark] val BLACKLIST_KILL_ENABLED =
-    ConfigBuilder("spark.blacklist.kill")
+    ConfigBuilder("spark.blacklist.killBlacklistedExecutors")
     .booleanConf
     .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -203,7 +203,9 @@ private[scheduler] class BlacklistTracker (
               case Some(allocationClient) =>
                 logInfo(s"Killing all executors on blacklisted host $node " +
                   s"since spark.blacklist.kill is set.")
-                allocationClient.killExecutorsOnHost(node)
+                if(allocationClient.killExecutorsOnHost(node) == false) {
+                  logError(s"Killing executors on node $node failed.")
+                }
               case None =>
                 logWarning(s"Not attempting to kill executors on blacklisted host $node " +
                   s"since allocation client is not defined.")

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -54,7 +54,7 @@ private[scheduler] class BlacklistTracker (
     clock: Clock = new SystemClock()) extends Logging {
 
   def this(sc: SparkContext, allocationClient: Option[ExecutorAllocationClient]) = {
-    this(sc.listenerBus, sc.getConf, allocationClient)
+    this(sc.listenerBus, sc.conf, allocationClient)
   }
 
   BlacklistTracker.validateBlacklistConfs(conf)
@@ -174,9 +174,6 @@ private[scheduler] class BlacklistTracker (
         listenerBus.post(SparkListenerExecutorBlacklisted(now, exec, newTotal))
         executorIdToFailureList.remove(exec)
         updateNextExpiryTime()
-        // Add executor to blacklist before attempting to kill it. This allows a scheduler backend
-        // to immediately fail to allocate resources on this executor, since killing could be
-        // asynchronous.
         if (conf.get(config.BLACKLIST_KILL_ENABLED)) {
           allocationClient match {
             case Some(allocationClient) =>

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -176,6 +176,9 @@ private[scheduler] class BlacklistTracker (
                 case Some(scheduler) =>
                   logInfo(s"Killing blacklisted executor id: $exec" +
                           s"since spark.blacklist.kill is set.")
+                  // TODO Do this killing in the driver via an RPC message?
+                  // TODO Update the coarseGrainedSchedulerBackend's list of executors and hosts
+                  // TODO to fail fast and not attempt to allocate this executor?
                   scheduler.killExecutors(Seq(exec), true, true)
                 case None =>
                   logWarning(s"Not attempting to kill blacklisted executor id $exec" +
@@ -200,7 +203,6 @@ private[scheduler] class BlacklistTracker (
             !nodeIdToBlacklistExpiryTime.contains(node)) {
           logInfo(s"Blacklisting node $node because it has ${blacklistedExecsOnNode.size} " +
             s"executors blacklisted: ${blacklistedExecsOnNode}")
-          // TODO Prevent the scheduler from offering executors on this host.
           conf.get(config.BLACKLIST_ENABLED) match {
             case Some(enabled) =>
               if (enabled) {
@@ -208,6 +210,7 @@ private[scheduler] class BlacklistTracker (
                   case Some(scheduler) =>
                     logInfo(s"Killing blacklisted executor id: $exec" +
                       s"since spark.blacklist.kill is set.")
+                    // TODO Same as above.
                     scheduler.killExecutorsOnHost(node)
                   case None =>
                     logWarning(s"Not attempting to kill blacklisted executor id $exec" +

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -203,6 +203,14 @@ private[scheduler] class BlacklistTracker (
             !nodeIdToBlacklistExpiryTime.contains(node)) {
           logInfo(s"Blacklisting node $node because it has ${blacklistedExecsOnNode.size} " +
             s"executors blacklisted: ${blacklistedExecsOnNode}")
+          // TODO:
+          // As soon as this decision has been made, a couple of things need to happen.
+          // First, as quickly as possible, we need to tell the scheduler backend to:
+          // not create any additional executors on this host
+          // (attempt to) fail to create any executors being created.
+          // not schedule any additional tasks on the executors on this host.
+          //
+          // Then, we kill and re-create all the executors on this host.
           conf.get(config.BLACKLIST_ENABLED) match {
             case Some(enabled) =>
               if (enabled) {

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -50,10 +50,10 @@ import org.apache.spark.util.{Clock, SystemClock, Utils}
 private[scheduler] class BlacklistTracker (
     private val listenerBus: LiveListenerBus,
     conf: SparkConf,
-    scheduler: ExecutorAllocationClient,
+    scheduler: Option[ExecutorAllocationClient],
     clock: Clock = new SystemClock()) extends Logging {
 
-  def this(sc: SparkContext, scheduler: ExecutorAllocationClient) = {
+  def this(sc: SparkContext, scheduler: Option[ExecutorAllocationClient]) = {
     this(sc.listenerBus, sc.getConf, scheduler)
   }
 
@@ -169,6 +169,21 @@ private[scheduler] class BlacklistTracker (
       if (newTotal >= MAX_FAILURES_PER_EXEC && !executorIdToBlacklistStatus.contains(exec)) {
         logInfo(s"Blacklisting executor id: $exec because it has $newTotal" +
           s" task failures in successful task sets")
+        conf.get(config.BLACKLIST_ENABLED) match {
+          case Some(enabled) =>
+            if (enabled) {
+              scheduler match {
+                case Some(scheduler) =>
+                  logInfo(s"Killing blacklisted executor id: $exec" +
+                          s"since spark.blacklist.kill is set.")
+                  scheduler.killExecutors(Seq(exec), true, true)
+                case None =>
+                  logWarning(s"Not attempting to kill blacklisted executor id $exec" +
+                             s"since scheduler is not defined.")
+              }
+            }
+          case None =>
+        }
         val node = failuresInTaskSet.node
         executorIdToBlacklistStatus.put(exec, BlacklistedExecutor(node, expiryTimeForNewBlacklists))
         listenerBus.post(SparkListenerExecutorBlacklisted(now, exec, newTotal))
@@ -185,9 +200,23 @@ private[scheduler] class BlacklistTracker (
             !nodeIdToBlacklistExpiryTime.contains(node)) {
           logInfo(s"Blacklisting node $node because it has ${blacklistedExecsOnNode.size} " +
             s"executors blacklisted: ${blacklistedExecsOnNode}")
+          // TODO Prevent the scheduler from offering executors on this host.
+          conf.get(config.BLACKLIST_ENABLED) match {
+            case Some(enabled) =>
+              if (enabled) {
+                scheduler match {
+                  case Some(scheduler) =>
+                    logInfo(s"Killing blacklisted executor id: $exec" +
+                      s"since spark.blacklist.kill is set.")
+                    scheduler.killExecutorsOnHost(node)
+                  case None =>
+                    logWarning(s"Not attempting to kill blacklisted executor id $exec" +
+                      s"since scheduler is not defined.")
+                }
+              }
+            case None =>
+          }
           nodeIdToBlacklistExpiryTime.put(node, expiryTimeForNewBlacklists)
-          // TODO Only do this if a config value is set.
-          scheduler.killExecutorsOnHost(node)
           listenerBus.post(SparkListenerNodeBlacklisted(now, node, blacklistedExecsOnNode.size))
           _nodeBlacklist.set(nodeIdToBlacklistExpiryTime.keySet.toSet)
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -50,6 +50,7 @@ import org.apache.spark.util.{Clock, SystemClock, Utils}
 private[scheduler] class BlacklistTracker (
     private val listenerBus: LiveListenerBus,
     conf: SparkConf,
+    sc: Option[SparkContext],
     clock: Clock = new SystemClock()) extends Logging {
 
   def this(sc: SparkContext) = {
@@ -185,6 +186,8 @@ private[scheduler] class BlacklistTracker (
           logInfo(s"Blacklisting node $node because it has ${blacklistedExecsOnNode.size} " +
             s"executors blacklisted: ${blacklistedExecsOnNode}")
           nodeIdToBlacklistExpiryTime.put(node, expiryTimeForNewBlacklists)
+          // TODO Only do this if a config value is set.
+          sc.foreach(context => context.killExecutorsOnHost(node))
           listenerBus.post(SparkListenerNodeBlacklisted(now, node, blacklistedExecsOnNode.size))
           _nodeBlacklist.set(nodeIdToBlacklistExpiryTime.keySet.toSet)
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -214,7 +214,7 @@ private[scheduler] class BlacklistTracker (
                   case Some(allocationClient) =>
                     logInfo(s"Killing all executors on blacklisted host $node" +
                       s"since spark.blacklist.kill is set.")
-                    allocationClient.killExecutorsOnHost(node)
+                    allocationClient.killExecutorsOnHost(node, true)
                   case None =>
                     logWarning(s"Not attempting to kill executors on blacklisted host $node" +
                       s"since allocation client is not defined.")

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -207,7 +207,7 @@ private[scheduler] class BlacklistTracker (
               case Some(allocationClient) =>
                 logInfo(s"Killing all executors on blacklisted host $node" +
                   s"since spark.blacklist.kill is set.")
-                allocationClient.killExecutorsOnHost(node, true)
+                allocationClient.killExecutorsOnHost(node)
               case None =>
                 logWarning(s"Not attempting to kill executors on blacklisted host $node" +
                   s"since allocation client is not defined.")

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -177,7 +177,8 @@ private[scheduler] class BlacklistTracker (
         if (conf.get(config.BLACKLIST_KILL_ENABLED)) {
           allocationClient match {
             case Some(allocationClient) =>
-              logInfo(s"Killing blacklisted executor id $exec since spark.blacklist.kill is set.")
+              logInfo(s"Killing blacklisted executor id $exec " +
+                s"since spark.blacklist.killBlacklistedExecutors is set.")
               allocationClient.killExecutors(Seq(exec), true, true)
             case None =>
               logWarning(s"Not attempting to kill blacklisted executor id $exec " +
@@ -202,8 +203,8 @@ private[scheduler] class BlacklistTracker (
             allocationClient match {
               case Some(allocationClient) =>
                 logInfo(s"Killing all executors on blacklisted host $node " +
-                  s"since spark.blacklist.kill is set.")
-                if(allocationClient.killExecutorsOnHost(node) == false) {
+                  s"since spark.blacklist.killBlacklistedExecutors is set.")
+                if (allocationClient.killExecutorsOnHost(node) == false) {
                   logError(s"Killing executors on node $node failed.")
                 }
               case None =>

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -177,11 +177,10 @@ private[scheduler] class BlacklistTracker (
         if (conf.get(config.BLACKLIST_KILL_ENABLED)) {
           allocationClient match {
             case Some(allocationClient) =>
-              logInfo(s"Killing blacklisted executor id $exec" +
-                s"since spark.blacklist.kill is set.")
+              logInfo(s"Killing blacklisted executor id $exec since spark.blacklist.kill is set.")
               allocationClient.killExecutors(Seq(exec), true, true)
             case None =>
-              logWarning(s"Not attempting to kill blacklisted executor id $exec" +
+              logWarning(s"Not attempting to kill blacklisted executor id $exec " +
                 s"since allocation client is not defined.")
           }
         }
@@ -202,11 +201,11 @@ private[scheduler] class BlacklistTracker (
           if (conf.get(config.BLACKLIST_KILL_ENABLED)) {
             allocationClient match {
               case Some(allocationClient) =>
-                logInfo(s"Killing all executors on blacklisted host $node" +
+                logInfo(s"Killing all executors on blacklisted host $node " +
                   s"since spark.blacklist.kill is set.")
                 allocationClient.killExecutorsOnHost(node)
               case None =>
-                logWarning(s"Not attempting to kill executors on blacklisted host $node" +
+                logWarning(s"Not attempting to kill executors on blacklisted host $node " +
                   s"since allocation client is not defined.")
             }
           }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -720,7 +720,7 @@ private[spark] object TaskSchedulerImpl {
   private def maybeCreateBlacklistTracker(sc: SparkContext): Option[BlacklistTracker] = {
     if (BlacklistTracker.isBlacklistEnabled(sc.conf)) {
       val executorAllocClient: Option[ExecutorAllocationClient] = sc.schedulerBackend match {
-        case b: ExecutorAllocationClient => Some(b.asInstanceOf[ExecutorAllocationClient])
+        case b: ExecutorAllocationClient => Some(b)
         case _ => None
       }
       Some(new BlacklistTracker(sc, executorAllocClient))

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -719,7 +719,7 @@ private[spark] object TaskSchedulerImpl {
 
   private def maybeCreateBlacklistTracker(sc: SparkContext): Option[BlacklistTracker] = {
     if (BlacklistTracker.isBlacklistEnabled(sc.conf)) {
-      Some(new BlacklistTracker(sc))
+      Some(new BlacklistTracker(sc, scheduler))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -719,7 +719,11 @@ private[spark] object TaskSchedulerImpl {
 
   private def maybeCreateBlacklistTracker(sc: SparkContext): Option[BlacklistTracker] = {
     if (BlacklistTracker.isBlacklistEnabled(sc.conf)) {
-      Some(new BlacklistTracker(sc, scheduler))
+      val executorAllocClient: Option[ExecutorAllocationClient] = sc.schedulerBackend match {
+        case b: ExecutorAllocationClient => Some(b.asInstanceOf[ExecutorAllocationClient])
+        case _ => None
+      }
+      Some(new BlacklistTracker(sc, executorAllocClient))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -43,7 +43,8 @@ private[spark] object CoarseGrainedClusterMessages {
   case class KillTask(taskId: Long, executor: String, interruptThread: Boolean)
     extends CoarseGrainedClusterMessage
 
-  case class KillExecutorsOnHost(host: String) extends CoarseGrainedClusterMessage
+  case class KillExecutorsOnHost(host: String, replace: Boolean)
+    extends CoarseGrainedClusterMessage
 
   sealed trait RegisterExecutorResponse
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -43,7 +43,7 @@ private[spark] object CoarseGrainedClusterMessages {
   case class KillTask(taskId: Long, executor: String, interruptThread: Boolean)
     extends CoarseGrainedClusterMessage
 
-  case class KillExecutorsOnHost(host: String, replace: Boolean)
+  case class KillExecutorsOnHost(host: String)
     extends CoarseGrainedClusterMessage
 
   sealed trait RegisterExecutorResponse

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -43,6 +43,8 @@ private[spark] object CoarseGrainedClusterMessages {
   case class KillTask(taskId: Long, executor: String, interruptThread: Boolean)
     extends CoarseGrainedClusterMessage
 
+  case class KillExecutorsOnHost(host: String) extends CoarseGrainedClusterMessage
+
   sealed trait RegisterExecutorResponse
 
   case object RegisteredExecutor extends CoarseGrainedClusterMessage with RegisterExecutorResponse

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -600,6 +600,15 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    */
   protected def doKillExecutors(executorIds: Seq[String]): Future[Boolean] =
     Future.successful(false)
+
+  /**
+   * Request that the cluster manager kill all executors on a given host.
+   * @return whether the kill request is acknowledged
+   */
+  final override def killExecutorsOnHost(host: String): Seq[String] = {
+    logInfo(s"Requesting to kill any and all executors on host ${host}")
+    killExecutors(scheduler.getExecutorsAliveOnHost(host).get.toSeq, replace = true, force = true)
+  }
 }
 
 private[spark] object CoarseGrainedSchedulerBackend {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -544,7 +544,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * @return whether the kill request is acknowledged. If list to kill is empty, it will return
    *         false.
    */
-  final def killExecutors(
+  final override def killExecutors(
       executorIds: Seq[String],
       replace: Boolean,
       force: Boolean): Seq[String] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -142,9 +142,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         }
 
       case KillExecutorsOnHost(host) =>
-        scheduler.getExecutorsAliveOnHost(host).foreach(exec =>
+        scheduler.getExecutorsAliveOnHost(host).foreach { exec =>
           killExecutors(exec.toSeq, replace = true, force = true)
-        )
+        }
     }
 
     override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
@@ -154,7 +154,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           executorRef.send(RegisterExecutorFailed("Duplicate executor ID: " + executorId))
           context.reply(true)
         } else if (scheduler.nodeBlacklist != null &&
-          scheduler.nodeBlacklist.contains(executorId)) {
+          scheduler.nodeBlacklist.contains(hostname)) {
           // If the cluster manager gives us an executor on a blacklisted node (because it
           // already started allocating those resources before we informed it of our blacklist,
           // or if it ignored our blacklist), then we reject that executor immediately.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -537,23 +537,14 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   /**
    * Request that the cluster manager kill the specified executors.
-   * @return whether the kill request is acknowledged. If list to kill is empty, it will return
-   *         false.
-   */
-  final override def killExecutors(executorIds: Seq[String]): Seq[String] = {
-    killExecutors(executorIds, replace = false, force = false)
-  }
-
-  /**
-   * Request that the cluster manager kill the specified executors.
    *
    * When asking the executor to be replaced, the executor loss is considered a failure, and
    * killed tasks that are running on the executor will count towards the failure limits. If no
    * replacement is being requested, then the tasks will not count towards the limit.
    *
    * @param executorIds identifiers of executors to kill
-   * @param replace whether to replace the killed executors with new ones
-   * @param force whether to force kill busy executors
+   * @param replace whether to replace the killed executors with new ones, default false
+   * @param force whether to force kill busy executors, default false
    * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
   final override def killExecutors(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -607,7 +607,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    */
   final override def killExecutorsOnHost(host: String): Seq[String] = {
     logInfo(s"Requesting to kill any and all executors on host ${host}")
-    killExecutors(scheduler.getExecutorsAliveOnHost(host).get.toSeq, replace = true, force = true)
+    scheduler.getExecutorsAliveOnHost(host).foreach(exec =>
+      killExecutors(exec.toSeq, replace = true, force = true)
+    )
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -141,9 +141,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             logWarning(s"Attempted to kill task $taskId for unknown executor $executorId.")
         }
 
-      case KillExecutorsOnHost(host, replace) =>
+      case KillExecutorsOnHost(host) =>
         scheduler.getExecutorsAliveOnHost(host).foreach(exec =>
-          killExecutors(exec.toSeq, replace, force = true)
+          killExecutors(exec.toSeq, replace = true, force = true)
         )
     }
 
@@ -617,9 +617,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * Request that the cluster manager kill all executors on a given host.
    * @return whether the kill request is acknowledged.
    */
-  final override def killExecutorsOnHost(host: String, replace: Boolean): Boolean = {
+  final override def killExecutorsOnHost(host: String): Boolean = {
     logInfo(s"Requesting to kill any and all executors on host ${host}")
-    driverEndpoint.send(KillExecutorsOnHost(host, replace))
+    driverEndpoint.send(KillExecutorsOnHost(host))
     true
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -159,7 +159,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // already started allocating those resources before we informed it of our blacklist,
           // or if it ignored our blacklist), then we reject that executor immediately.
           logInfo(s"Rejecting $executorId as it has been blacklisted.")
-          executorRef.send(RegisterExecutorFailed("Executor is blacklisted: " + executorId))
+          executorRef.send(RegisterExecutorFailed(s"Executor is blacklisted: $executorId"))
           context.reply(true)
         } else {
           // If the executor's rpc env is not listening for incoming connections, `hostPort`

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -608,11 +608,12 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   /**
    * Request that the cluster manager kill all executors on a given host.
-   * @return whether the kill request is acknowledged
+   * @return whether the kill request is acknowledged.
    */
-  final override def killExecutorsOnHost(host: String): Unit = {
+  final override def killExecutorsOnHost(host: String): Boolean = {
     logInfo(s"Requesting to kill any and all executors on host ${host}")
     driverEndpoint.send(KillExecutorsOnHost(host))
+    true
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -153,6 +153,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         if (executorDataMap.contains(executorId)) {
           executorRef.send(RegisterExecutorFailed("Duplicate executor ID: " + executorId))
           context.reply(true)
+        } else if (scheduler.nodeBlacklist.contains(executorId)) {
+          // Handle a race where the cluster manager finishes creating an executor, just after
+          // the executor is blacklisted and just before it is possibly killed.
+          executorRef.send(RegisterExecutorFailed("Executor is blacklisted: " + executorId))
+          context.reply(true)
         } else {
           // If the executor's rpc env is not listening for incoming connections, `hostPort`
           // will be null, and the client connection should be used to contact the executor.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -605,7 +605,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * Request that the cluster manager kill all executors on a given host.
    * @return whether the kill request is acknowledged
    */
-  final override def killExecutorsOnHost(host: String): Seq[String] = {
+  final override def killExecutorsOnHost(host: String): Unit = {
     logInfo(s"Requesting to kill any and all executors on host ${host}")
     scheduler.getExecutorsAliveOnHost(host).foreach(exec =>
       killExecutors(exec.toSeq, replace = true, force = true)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -153,7 +153,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         if (executorDataMap.contains(executorId)) {
           executorRef.send(RegisterExecutorFailed("Duplicate executor ID: " + executorId))
           context.reply(true)
-        } else if (scheduler.nodeBlacklist.contains(executorId)) {
+        } else if (scheduler.nodeBlacklist != null &&
+                   scheduler.nodeBlacklist.contains(executorId)) {
           // Handle a race where the cluster manager finishes creating an executor, just after
           // the executor is blacklisted and just before it is possibly killed.
           executorRef.send(RegisterExecutorFailed("Executor is blacklisted: " + executorId))

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -141,9 +141,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             logWarning(s"Attempted to kill task $taskId for unknown executor $executorId.")
         }
 
-      case KillExecutorsOnHost(host) =>
+      case KillExecutorsOnHost(host, replace) =>
         scheduler.getExecutorsAliveOnHost(host).foreach(exec =>
-          killExecutors(exec.toSeq, replace = true, force = true)
+          killExecutors(exec.toSeq, replace, force = true)
         )
     }
 
@@ -616,9 +616,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * Request that the cluster manager kill all executors on a given host.
    * @return whether the kill request is acknowledged.
    */
-  final override def killExecutorsOnHost(host: String): Boolean = {
+  final override def killExecutorsOnHost(host: String, replace: Boolean): Boolean = {
     logInfo(s"Requesting to kill any and all executors on host ${host}")
-    driverEndpoint.send(KillExecutorsOnHost(host))
+    driverEndpoint.send(KillExecutorsOnHost(host, replace))
     true
   }
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1160,5 +1160,5 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
 
   // Unused.
   override def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean)
-  : Seq[String] = { Seq.empty[String] }
+  : Unit = {}
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1147,8 +1147,6 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
     }
   }
 
-  override def killExecutorsOnHost(host: String): Seq[String] = { Seq.empty[String] }
-
   override def start(): Unit = sb.start()
 
   override def stop(): Unit = sb.stop()
@@ -1156,4 +1154,11 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
   override def reviveOffers(): Unit = sb.reviveOffers()
 
   override def defaultParallelism(): Int = sb.defaultParallelism()
+
+  // Unused.
+  override def killExecutorsOnHost(host: String): Seq[String] = { Seq.empty[String] }
+
+  // Unused.
+  override def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean)
+  : Seq[String] = { Seq.empty[String] }
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1147,6 +1147,8 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
     }
   }
 
+  override def killExecutorsOnHost(host: String): Seq[String] = { Seq.empty[String] }
+
   override def start(): Unit = sb.start()
 
   override def stop(): Unit = sb.stop()

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1156,9 +1156,9 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
   override def defaultParallelism(): Int = sb.defaultParallelism()
 
   // Unused.
-  override def killExecutorsOnHost(host: String): Seq[String] = { Seq.empty[String] }
+  override def killExecutorsOnHost(host: String): Boolean = false
 
   // Unused.
   override def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean)
-  : Unit = {}
+  : Seq[String] = Seq.empty[String]
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1156,7 +1156,9 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
   override def defaultParallelism(): Int = sb.defaultParallelism()
 
   // Unused.
-  override def killExecutorsOnHost(host: String): Boolean = false
+  override def killExecutorsOnHost(host: String, replace: Boolean): Boolean = {
+    false
+  }
 
   // Unused.
   override def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean)

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1158,7 +1158,6 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
 
   override def defaultParallelism(): Int = sb.defaultParallelism()
 
-  // Unused.
   override def killExecutorsOnHost(host: String): Boolean = {
     false
   }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1138,7 +1138,10 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
   override def requestExecutors(numAdditionalExecutors: Int): Boolean =
     sc.requestExecutors(numAdditionalExecutors)
 
-  override def killExecutors(executorIds: Seq[String]): Seq[String] = {
+  override def killExecutors(
+      executorIds: Seq[String],
+      replace: Boolean,
+      force: Boolean): Seq[String] = {
     val response = sc.killExecutors(executorIds)
     if (response) {
       executorIds
@@ -1159,8 +1162,4 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
   override def killExecutorsOnHost(host: String): Boolean = {
     false
   }
-
-  // Unused.
-  override def killExecutors(executorIds: Seq[String], replace: Boolean, force: Boolean)
-  : Seq[String] = Seq.empty[String]
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1156,7 +1156,7 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
   override def defaultParallelism(): Int = sb.defaultParallelism()
 
   // Unused.
-  override def killExecutorsOnHost(host: String, replace: Boolean): Boolean = {
+  override def killExecutorsOnHost(host: String): Boolean = {
     false
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -478,7 +478,7 @@ class StandaloneDynamicAllocationSuite
       assert(apps.head.getExecutorLimit === Int.MaxValue)
     }
     // kill all executors
-    assert(killExecutorsOnHost(sc, "localhost").size == 2)
+    assert(killExecutorsOnHost(sc, "localhost").equals(true))
     var apps = getApplications()
     assert(apps.head.executors.size === 0)
     assert(apps.head.getExecutorLimit === 0)
@@ -546,7 +546,7 @@ class StandaloneDynamicAllocationSuite
   }
 
   /** Kill the executors on a given host. */
-  private def killExecutorsOnHost(sc: SparkContext, host: String): Seq[String] = {
+  private def killExecutorsOnHost(sc: SparkContext, host: String): Unit = {
     syncExecutors(sc)
     sc.schedulerBackend match {
       case b: CoarseGrainedSchedulerBackend =>

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -477,13 +477,15 @@ class StandaloneDynamicAllocationSuite
       assert(apps.head.executors.size === 2)
       assert(apps.head.getExecutorLimit === Int.MaxValue)
     }
+    val beforeList = getApplications().head.executors.keys.toSet
     // kill all executors without replacement
     assert(killExecutorsOnHost(sc, "localhost").equals(true))
 
+    syncExecutors(sc)
+    val afterList = getApplications().head.executors.keys.toSet
+
     eventually(timeout(10.seconds), interval(100.millis)) {
-      val apps = getApplications()
-      assert(apps.head.executors.size === 0)
-      assert(apps.head.getExecutorLimit === 0)
+      assert(beforeList.intersect(afterList).size == 0)
     }
   }
 
@@ -553,7 +555,7 @@ class StandaloneDynamicAllocationSuite
     syncExecutors(sc)
     sc.schedulerBackend match {
       case b: CoarseGrainedSchedulerBackend =>
-        b.killExecutorsOnHost(host, false)
+        b.killExecutorsOnHost(host, true)
       case _ => fail("expected coarse grained scheduler")
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -555,7 +555,7 @@ class StandaloneDynamicAllocationSuite
     syncExecutors(sc)
     sc.schedulerBackend match {
       case b: CoarseGrainedSchedulerBackend =>
-        b.killExecutorsOnHost(host, true)
+        b.killExecutorsOnHost(host)
       case _ => fail("expected coarse grained scheduler")
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -506,7 +506,7 @@ class StandaloneDynamicAllocationSuite
     // Create a fresh scheduler backend to blacklist "localhost".
     sc.schedulerBackend.stop()
     val backend =
-     new StandaloneSchedulerBackend(taskScheduler, sc, Array(masterRpcEnv.address.toSparkURL))
+      new StandaloneSchedulerBackend(taskScheduler, sc, Array(masterRpcEnv.address.toSparkURL))
     backend.start()
 
     backend.driverEndpoint.ask[Boolean](message)

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.scheduler
 
-import org.mockito.Matchers._
-import org.mockito.Mockito.{times, verify, when}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
 
@@ -477,7 +477,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     }
     blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist0.execToFailures)
 
-    verify(allocationClientMock, times(0)).killExecutor(any())
+    verify(allocationClientMock, never).killExecutor(any())
 
     val taskSetBlacklist1 = createTaskSetBlacklist(stageId = 1)
     // Fail 4 tasks in one task set on executor 2, so that executor gets blacklisted for the whole
@@ -487,8 +487,8 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
       taskSetBlacklist1.updateBlacklistForFailedTask("hostA", exec = "2", index = partition)
     }
 
-    verify(allocationClientMock, times(0)).killExecutors(any(), any(), any())
-    verify(allocationClientMock, times(0)).killExecutorsOnHost(any())
+    verify(allocationClientMock, never).killExecutors(any(), any(), any())
+    verify(allocationClientMock, never).killExecutorsOnHost(any())
 
     // Enable auto-kill. Blacklist an executor and make sure killExecutors is called.
     conf.set(config.BLACKLIST_KILL_ENABLED, true)

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.scheduler
 
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Matchers._
+import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
 
@@ -272,12 +273,14 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     // if task failures are spaced out by more than the timeout period, the first failure is timed
     // out, and the executor isn't blacklisted.
     var stageId = 0
+
     def failOneTaskInTaskSet(exec: String): Unit = {
       val taskSetBlacklist = createTaskSetBlacklist(stageId = stageId)
       taskSetBlacklist.updateBlacklistForFailedTask("host-" + exec, exec, 0)
       blacklist.updateBlacklistForSuccessfulTaskSet(stageId, 0, taskSetBlacklist.execToFailures)
       stageId += 1
     }
+
     failOneTaskInTaskSet(exec = "1")
     // We have one sporadic failure on exec 2, but that's it.  Later checks ensure that we never
     // blacklist executor 2 despite this one failure.
@@ -411,7 +414,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     // if you explicitly set the legacy conf to 0, that also would disable blacklisting
     conf.set(config.BLACKLIST_LEGACY_TIMEOUT_CONF, 0L)
     assert(!BlacklistTracker.isBlacklistEnabled(conf))
-    // but again, the new conf takes precendence
+    // but again, the new conf takes precedence
     conf.set(config.BLACKLIST_ENABLED, true)
     assert(BlacklistTracker.isBlacklistEnabled(conf))
     assert(1000 === BlacklistTracker.getBlacklistTimeout(conf))
@@ -455,5 +458,62 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
       assert(excMsg.contains(s"${config.key} was 0, but must be > 0."))
       conf.remove(config)
     }
+  }
+
+  test("blacklisting kills executors, configured by BLACKLIST_KILL_ENABLED") {
+    val allocationClientMock = mock[ExecutorAllocationClient]
+    when(allocationClientMock.killExecutors(any(), any(), any())).thenReturn(Seq("called"))
+    when(allocationClientMock.killExecutorsOnHost(any(), any())).thenReturn(true)
+    blacklist = new BlacklistTracker(listenerBusMock, conf, Some(allocationClientMock), clock)
+
+    // Disable auto-kill. Blacklist an executor and make sure killExecutors is not called.
+    conf.set(config.BLACKLIST_KILL_ENABLED, false)
+
+    val taskSetBlacklist0 = createTaskSetBlacklist(stageId = 0)
+    // Fail 4 tasks in one task set on executor 1, so that executor gets blacklisted for the whole
+    // application.
+    (0 until 4).foreach { partition =>
+      taskSetBlacklist0.updateBlacklistForFailedTask("hostA", exec = "1", index = partition)
+    }
+    blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist0.execToFailures)
+
+    verify(allocationClientMock, times(0)).killExecutor(any())
+
+    val taskSetBlacklist1 = createTaskSetBlacklist(stageId = 1)
+    // Fail 4 tasks in one task set on executor 2, so that executor gets blacklisted for the whole
+    // application.  Since that's the second executor that is blacklisted on the same node, we also
+    // blacklist that node.
+    (0 until 4).foreach { partition =>
+      taskSetBlacklist1.updateBlacklistForFailedTask("hostA", exec = "2", index = partition)
+    }
+
+    verify(allocationClientMock, times(0)).killExecutors(any(), any(), any())
+    verify(allocationClientMock, times(0)).killExecutorsOnHost(any(), any())
+
+    // Enable auto-kill. Blacklist an executor and make sure killExecutors is called.
+    conf.set(config.BLACKLIST_KILL_ENABLED, true)
+    blacklist = new BlacklistTracker(listenerBusMock, conf, Some(allocationClientMock), clock)
+
+    val taskSetBlacklist2 = createTaskSetBlacklist(stageId = 0)
+    // Fail 4 tasks in one task set on executor 1, so that executor gets blacklisted for the whole
+    // application.
+    (0 until 4).foreach { partition =>
+      taskSetBlacklist2.updateBlacklistForFailedTask("hostA", exec = "1", index = partition)
+    }
+    blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist2.execToFailures)
+
+    verify(allocationClientMock).killExecutors(Seq("1"), true, true)
+
+    val taskSetBlacklist3 = createTaskSetBlacklist(stageId = 1)
+    // Fail 4 tasks in one task set on executor 2, so that executor gets blacklisted for the whole
+    // application.  Since that's the second executor that is blacklisted on the same node, we also
+    // blacklist that node.
+    (0 until 4).foreach { partition =>
+      taskSetBlacklist3.updateBlacklistForFailedTask("hostA", exec = "2", index = partition)
+    }
+    blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist3.execToFailures)
+
+    verify(allocationClientMock).killExecutors(Seq("2"), true, true)
+    verify(allocationClientMock).killExecutorsOnHost("hostA", true)
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -463,7 +463,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
   test("blacklisting kills executors, configured by BLACKLIST_KILL_ENABLED") {
     val allocationClientMock = mock[ExecutorAllocationClient]
     when(allocationClientMock.killExecutors(any(), any(), any())).thenReturn(Seq("called"))
-    when(allocationClientMock.killExecutorsOnHost(any(), any())).thenReturn(true)
+    when(allocationClientMock.killExecutorsOnHost(any())).thenReturn(true)
     blacklist = new BlacklistTracker(listenerBusMock, conf, Some(allocationClientMock), clock)
 
     // Disable auto-kill. Blacklist an executor and make sure killExecutors is not called.
@@ -488,7 +488,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     }
 
     verify(allocationClientMock, times(0)).killExecutors(any(), any(), any())
-    verify(allocationClientMock, times(0)).killExecutorsOnHost(any(), any())
+    verify(allocationClientMock, times(0)).killExecutorsOnHost(any())
 
     // Enable auto-kill. Blacklist an executor and make sure killExecutors is called.
     conf.set(config.BLACKLIST_KILL_ENABLED, true)
@@ -514,6 +514,6 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist3.execToFailures)
 
     verify(allocationClientMock).killExecutors(Seq("2"), true, true)
-    verify(allocationClientMock).killExecutorsOnHost("hostA", true)
+    verify(allocationClientMock).killExecutorsOnHost("hostA")
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -466,6 +466,9 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     val allocationClientMock = mock[ExecutorAllocationClient]
     when(allocationClientMock.killExecutors(any(), any(), any())).thenReturn(Seq("called"))
     when(allocationClientMock.killExecutorsOnHost("hostA")).thenAnswer(new Answer[Boolean] {
+      // To avoid a race between blacklisting and killing, it is important that the nodeBlacklist
+      // is updated before we ask the executor allocation client to kill all the executors
+      // on a particular host.
       override def answer(invocation: InvocationOnMock): Boolean = {
         if (blacklist.nodeBlacklist.contains("hostA") == false) {
           throw new IllegalStateException("hostA should be on the blacklist")

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -43,7 +43,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     clock.setTime(0)
 
     listenerBusMock = mock[LiveListenerBus]
-    blacklist = new BlacklistTracker(listenerBusMock, conf, clock)
+    blacklist = new BlacklistTracker(null, conf, None, clock)
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -43,7 +43,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     clock.setTime(0)
 
     listenerBusMock = mock[LiveListenerBus]
-    blacklist = new BlacklistTracker(null, conf, None, clock)
+    blacklist = new BlacklistTracker(listenerBusMock, conf, None, clock)
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -495,6 +495,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     (0 until 4).foreach { partition =>
       taskSetBlacklist1.updateBlacklistForFailedTask("hostA", exec = "2", index = partition)
     }
+    blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist1.execToFailures)
 
     verify(allocationClientMock, never).killExecutors(any(), any(), any())
     verify(allocationClientMock, never).killExecutorsOnHost(any())
@@ -524,32 +525,5 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
 
     verify(allocationClientMock).killExecutors(Seq("2"), true, true)
     verify(allocationClientMock).killExecutorsOnHost("hostA")
-  }
-
-  /*
-  Also it would be nice to have a test for CoarseGrainedSchedulerBackend, that it rejects executors
-  that are registered on a blacklisted node -- that one will be a bit more work to setup, but
-  I think it should be possible.
-
-  These tests won't really be stressing this implementation, but they'll help prevent regressions
-  with future changes.
-   */
-
-  test("reject executors on a node scheduled for killing") {
-    val allocationClientMock = mock[ExecutorAllocationClient]
-    when(allocationClientMock.killExecutors(any(), any(), any())).thenReturn(Seq("called"))
-    // when(allocationClientMock.killExecutorsOnHost(any())).thenReturn(true)
-    when(allocationClientMock.killExecutorsOnHost("hostA")).
-      thenReturn(blacklist.nodeBlacklist.contains("hostA"))
-    blacklist = new BlacklistTracker(listenerBusMock, conf, Some(allocationClientMock), clock)
-
-    // Disable auto-kill. Blacklist an executor and make sure killExecutors is not called.
-    conf.set(config.BLACKLIST_KILL_ENABLED, false)
-
-    // Construct an environment with a node and three executors.
-    // Blacklist the first executor.
-    // Blacklist the second executor. This should trigger node killing.
-    // Try to allocate a resource on the third executor and verify that you are unable.
-
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -429,7 +429,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // We don't directly use the application blacklist, but its presence triggers blacklisting
     // within the taskset.
     val mockListenerBus = mock(classOf[LiveListenerBus])
-    val blacklistTrackerOpt = Some(new BlacklistTracker(mockListenerBus, conf, clock))
+    val blacklistTrackerOpt = Some(new BlacklistTracker(null, conf, None, clock))
     val manager = new TaskSetManager(sched, taskSet, 4, blacklistTrackerOpt, clock)
 
     {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -429,7 +429,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // We don't directly use the application blacklist, but its presence triggers blacklisting
     // within the taskset.
     val mockListenerBus = mock(classOf[LiveListenerBus])
-    val blacklistTrackerOpt = Some(new BlacklistTracker(null, conf, None, clock))
+    val blacklistTrackerOpt = Some(new BlacklistTracker(mockListenerBus, conf, None, clock))
     val manager = new TaskSetManager(sched, taskSet, 4, blacklistTrackerOpt, clock)
 
     {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1402,7 +1402,7 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.blacklist.kill</code></td>
+  <td><code>spark.blacklist.killBlacklistedExecutors</code></td>
   <td>false</td>
   <td>
     (Experimental) If set to "true", allow Spark to automatically kill, and attempt to re-create,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1402,6 +1402,15 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.blacklist.kill</code></td>
+  <td>false</td>
+  <td>
+    (Experimental) If set to "true", allow Spark to automatically kill, and attempt to re-create,
+    executors when they are blacklisted.  Note that, when an entire node is added to the blacklist,
+    all of the executors on that node will be killed.
+  </td>
+</tr>
+<tr>
   <td><code>spark.speculation</code></td>
   <td>false</td>
   <td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SPARK-8425, we introduced a mechanism for blacklisting executors and nodes (hosts). After a certain number of failures, these resources would be "blacklisted" and no further work would be assigned to them for some period of time.

In some scenarios, it is better to fail fast, and to simply kill these unreliable resources. This changes proposes to do so by having the BlacklistTracker kill unreliable resources when they would otherwise be "blacklisted".

In order to be thread safe, this code depends on the CoarseGrainedSchedulerBackend sending a message to the driver backend in order to do the actual killing. This also helps to prevent a race which would permit work to begin on a resource (executor or node), between the time the resource is marked for killing and the time at which it is finally killed.

## How was this patch tested?

./dev/run-tests
Ran https://github.com/jsoltren/jose-utils/blob/master/blacklist/test-blacklist.sh, and checked logs to see executors and nodes being killed.

Testing can likely be improved here; suggestions welcome.