### PR TITLE
[SPARK-18116][DStream] Report stream input information after recover from checkpoint

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -309,16 +309,31 @@ private[spark] class DirectKafkaInputDStream[K, V](
 
     override def restore(): Unit = {
       batchForTime.toSeq.sortBy(_._1)(Time.ordering).foreach { case (t, b) =>
-         logInfo(s"Restoring KafkaRDD for time $t ${b.mkString("[", ", ", "]")}")
-         generatedRDDs += t -> new KafkaRDD[K, V](
-           context.sparkContext,
-           executorKafkaParams,
-           b.map(OffsetRange(_)),
-           getPreferredHosts,
-           // during restore, it's possible same partition will be consumed from multiple
-           // threads, so dont use cache
-           false
-         )
+        logInfo(s"Restoring KafkaRDD for time $t ${b.mkString("[", ", ", "]")}")
+        val offsetRanges = b.map(OffsetRange(_))
+        val rdd = new KafkaRDD[K, V](
+          context.sparkContext,
+          executorKafkaParams,
+          offsetRanges,
+          getPreferredHosts,
+          // during restore, it's possible same partition will be consumed from multiple
+          // threads, so do not use cache
+          false
+        )
+        // Re-report the record number and metadata of this batch interval to InputInfoTracker.
+        // Then, we can get StreamInputInfo after recover from checkpoint.
+        val description = offsetRanges.filter { offsetRange =>
+          offsetRange.fromOffset != offsetRange.untilOffset
+        }.map { offsetRange =>
+          s"topic: ${offsetRange.topic}\tpartition: ${offsetRange.partition}\t" +
+            s"offsets: ${offsetRange.fromOffset} to ${offsetRange.untilOffset}"
+        }.mkString("\n")
+        val metadata = Map(
+          "offsets" -> offsetRanges.toList,
+          StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
+        val inputInfo = StreamInputInfo(id, rdd.count(), metadata)
+        context.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
+        generatedRDDs += t -> rdd
       }
     }
   }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -21,14 +21,12 @@ import java.{ util => ju }
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.kafka.clients.consumer._
-import org.apache.kafka.common.{ PartitionInfo, TopicPartition }
+import org.apache.kafka.common.TopicPartition
 
-import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{StreamingContext, Time}
@@ -332,7 +330,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
           "offsets" -> offsetRanges.toList,
           StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
         val inputInfo = StreamInputInfo(id, rdd.count(), metadata)
-        context.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
+        recoveredReports += t -> inputInfo
         generatedRDDs += t -> rdd
       }
     }

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
@@ -210,9 +210,24 @@ class DirectKafkaInputDStream[
       val leaders = KafkaCluster.checkErrors(kc.findLeaders(topics))
 
       batchForTime.toSeq.sortBy(_._1)(Time.ordering).foreach { case (t, b) =>
-         logInfo(s"Restoring KafkaRDD for time $t ${b.mkString("[", ", ", "]")}")
-         generatedRDDs += t -> new KafkaRDD[K, V, U, T, R](
-           context.sparkContext, kafkaParams, b.map(OffsetRange(_)), leaders, messageHandler)
+        logInfo(s"Restoring KafkaRDD for time $t ${b.mkString("[", ", ", "]")}")
+        val offsetRanges = b.map(OffsetRange(_))
+        val rdd = new KafkaRDD[K, V, U, T, R](
+          context.sparkContext, kafkaParams, offsetRanges, leaders, messageHandler)
+        // Re-report the record number and metadata of this batch interval to InputInfoTracker.
+        // Then, we can get StreamInputInfo after recover from checkpoint.
+        val description = offsetRanges.filter { offsetRange =>
+          offsetRange.fromOffset != offsetRange.untilOffset
+        }.map { offsetRange =>
+          s"topic: ${offsetRange.topic}\tpartition: ${offsetRange.partition}\t" +
+            s"offsets: ${offsetRange.fromOffset} to ${offsetRange.untilOffset}"
+        }.mkString("\n")
+        val metadata = Map(
+          "offsets" -> offsetRanges.toList,
+          StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
+        val inputInfo = StreamInputInfo(id, rdd.count(), metadata)
+        context.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
+        generatedRDDs += t -> rdd
       }
     }
   }

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
@@ -226,7 +226,7 @@ class DirectKafkaInputDStream[
           "offsets" -> offsetRanges.toList,
           StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
         val inputInfo = StreamInputInfo(id, rdd.count(), metadata)
-        context.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
+        recoveredReports += t -> inputInfo
         generatedRDDs += t -> rdd
       }
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -32,7 +32,7 @@ import org.apache.spark.rdd.{BlockRDD, RDD, RDDOperationScope}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.StreamingContext.rddToFileName
-import org.apache.spark.streaming.scheduler.Job
+import org.apache.spark.streaming.scheduler.{Job, StreamInputInfo}
 import org.apache.spark.streaming.ui.UIUtils
 import org.apache.spark.util.{CallSite, Utils}
 
@@ -85,6 +85,9 @@ abstract class DStream[T: ClassTag] (
   // RDDs generated, marked as private[streaming] so that testsuites can access it
   @transient
   private[streaming] var generatedRDDs = new HashMap[Time, RDD[T]]()
+
+  @transient
+  private[streaming] var recoveredReports = new HashMap[Time, StreamInputInfo]()
 
   // Time zero for the DStream
   private[streaming] var zeroTime: Time = null
@@ -536,6 +539,7 @@ abstract class DStream[T: ClassTag] (
     logDebug(s"${this.getClass().getSimpleName}.readObject used")
     ois.defaultReadObject()
     generatedRDDs = new HashMap[Time, RDD[T]]()
+    recoveredReports = new HashMap[Time, StreamInputInfo]()
   }
 
   // =======================================================================

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -349,7 +349,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
             "files" -> f.toList,
             StreamInputInfo.METADATA_KEY_DESCRIPTION -> f.mkString("\n"))
           val inputInfo = StreamInputInfo(id, 0, metadata)
-          context.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
+          recoveredReports += t -> inputInfo
           generatedRDDs += ((t, filesToRDD(f)))
       }
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -345,6 +345,11 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
             f.mkString("[", ", ", "]") )
           batchTimeToSelectedFiles.synchronized { batchTimeToSelectedFiles += ((t, f)) }
           recentlySelectedFiles ++= f
+          val metadata = Map(
+            "files" -> f.toList,
+            StreamInputInfo.METADATA_KEY_DESCRIPTION -> f.mkString("\n"))
+          val inputInfo = StreamInputInfo(id, 0, metadata)
+          context.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
           generatedRDDs += ((t, filesToRDD(f)))
       }
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -231,7 +231,14 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
       // added but not allocated, are dangling in the queue after recovering, we have to allocate
       // those blocks to the next batch, which is the batch they were supposed to go.
       jobScheduler.receiverTracker.allocateBlocksToBatch(time) // allocate received blocks to batch
-      jobScheduler.submitJobSet(JobSet(time, graph.generateJobs(time)))
+      // SPARK-18116: submit job set with stream input information. These stream input information
+      // comes from two stage:
+      // 1. recover from checkpoint: like KafkaRDD contains the offset information.
+      // 2. get from inputInfoTracker: during downTimes and in `DStream.getOrCompute(time)`, the
+      // information can be reported.
+      val jobs = graph.generateJobs(time)
+      val streamIdToInputInfos = jobScheduler.inputInfoTracker.getInfo(time)
+      jobScheduler.submitJobSet(JobSet(time, jobs, streamIdToInputInfos))
     }
 
     // Restart the timer

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -226,6 +226,9 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
       .distinct.sorted(Time.ordering)
     logInfo("Batches to reschedule (" + timesToReschedule.length + " batches): " +
       timesToReschedule.mkString(", "))
+    graph.getInputStreams().foreach(is => {
+      is.recoveredReports.foreach(ts => jobScheduler.inputInfoTracker.reportInfo(ts._1, ts._2))
+    })
     timesToReschedule.foreach { time =>
       // Allocate the related blocks when recovering from failure, because some blocks that were
       // added but not allocated, are dangling in the queue after recovering, we have to allocate


### PR DESCRIPTION
## What changes were proposed in this pull request?

Run a streaming application which souce from kafka.There are many batchs queued in the job list before application stopped, and then stop the application, as follow starting it from checkpointed file, in the spark ui, the size of the queued batchs which stored in the checkpoint file are 0


## How was this patch tested?

update unit test
