### PR TITLE
[SPARK-19209] [WIP] JDBC: Fix "No suitable driver" on the first try 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc
 
-import java.sql.{Connection, DriverManager}
+import java.sql.Connection
 import java.util.Properties
 
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
@@ -73,17 +73,7 @@ class JDBCOptions(
   // ------------------------------------------------------------
   // Optional parameters
   // ------------------------------------------------------------
-  val driverClass = {
-    val userSpecifiedDriverClass = parameters.get(JDBC_DRIVER_CLASS)
-    userSpecifiedDriverClass.foreach(DriverRegistry.register)
-
-    // Performing this part of the logic on the driver guards against the corner-case where the
-    // driver returned for a URL is different on the driver and executors due to classpath
-    // differences.
-    userSpecifiedDriverClass.getOrElse {
-      DriverManager.getDriver(url).getClass.getCanonicalName
-    }
-  }
+  val driverClass = parameters.get(JDBC_DRIVER_CLASS)
 
   // the number of partitions
   val numPartitions = parameters.get(JDBC_NUM_PARTITIONS).map(_.toInt)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -46,7 +46,14 @@ object JdbcUtils extends Logging {
    * @param options - JDBC options that contains url, table and other information.
    */
   def createConnectionFactory(options: JDBCOptions): () => Connection = {
-    val driverClass: String = options.driverClass
+    val userSpecifiedDriverClass = options.driverClass
+    userSpecifiedDriverClass.foreach(DriverRegistry.register)
+    // Performing this part of the logic on the driver guards against the corner-case where the
+    // driver returned for a URL is different on the driver and executors due to classpath
+    // differences.
+    val driverClass: String = userSpecifiedDriverClass.getOrElse {
+      DriverManager.getDriver(options.url).getClass.getCanonicalName
+    }
     () => {
       DriverRegistry.register(driverClass)
       val driver: Driver = DriverManager.getDrivers.asScala.collectFirst {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is to revert some changes made in https://github.com/apache/spark/pull/15292

> @darabos  reported Spark 2.1.0 issued the `No suitable driver` exception at the first time when reading a JDBC data source but simply re-executing the same command a second time "fixes" the `No suitable driver` error. This only happens when the Hive support is enabled. 

Based on my understanding, the problem is `java.sql.DriverManager` class that can't access drivers loaded by Spark ClassLoader. The changes made in this PR does not sound a solution for the reported issue. It could be caused by the other code changes in 2.1 that change the current ClassLoader 

@darabos Could you please help us try it in your local environment? Thanks!

Below is the error @darabos got in his environement.

```
$ ~/spark-2.1.0/bin/spark-shell --jars org.xerial.sqlite-jdbc-3.8.11.2.jar --driver-class-path org.xerial.sqlite-jdbc-3.8.11.2.jar
[...]
scala> spark.read.format("jdbc").option("url", "jdbc:sqlite:").option("dbtable", "x").load
java.sql.SQLException: No suitable driver
  at java.sql.DriverManager.getDriver(DriverManager.java:315)
  at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions$$anonfun$7.apply(JDBCOptions.scala:84)
  at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions$$anonfun$7.apply(JDBCOptions.scala:84)
  at scala.Option.getOrElse(Option.scala:121)
  at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.<init>(JDBCOptions.scala:83)
  at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.<init>(JDBCOptions.scala:34)
  at org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider.createRelation(JdbcRelationProvider.scala:32)
  at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:330)
  at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:152)
  at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:125)
  ... 48 elided

scala> spark.read.format("jdbc").option("url", "jdbc:sqlite:").option("dbtable", "x").load
java.sql.SQLException: [SQLITE_ERROR] SQL error or missing database (no such table: x)
```

### How was this patch tested?
@darabos Could you make a manual test and see whether this changes can resolve your issue?