### PR TITLE
[SPARK-19307][pyspark] Make sure user conf is propagated to SparkContext.

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -132,6 +132,9 @@ class SparkContext(object):
             self._conf = conf
         else:
             self._conf = SparkConf(_jvm=SparkContext._jvm)
+            if conf is not None:
+                for k, v in conf.getAll():
+                    self._conf.set(k, v)
 
         self._batchSize = batchSize  # -1 represents an unlimited batch size
         self._unbatched_serializer = serializer

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2036,24 +2036,25 @@ class SparkSubmitTests(unittest.TestCase):
         self.assertIn("[2, 4, 6]", out.decode('utf-8'))
 
     def test_user_configuration(self):
-      """Make sure user configuration is respected (SPARK-19307)"""
-      script = self.createTempFile("test.py", """
-          |from pyspark import SparkConf, SparkContext
-          |
-          |conf = SparkConf().set("spark.test_config", "1")
-          |sc = SparkContext(conf = conf)
-          |try:
-          |    if sc._conf.get("spark.test_config") != "1":
-          |        raise Exception("Cannot find spark.test_config in SparkContext's conf.")
-          |finally:
-          |    sc.stop()
-          """)
-      try:
-          subprocess.check_output([self.sparkSubmit, "--master", "local", script],
-              stderr=subprocess.STDOUT)
-      except subprocess.CalledProcessError as e:
-          # This gives us a better error message for debugging.
-          self.fail("Test exited with {0}, output:\n{1}".format(e.returncode, e.output))
+        """Make sure user configuration is respected (SPARK-19307)"""
+        script = self.createTempFile("test.py", """
+            |from pyspark import SparkConf, SparkContext
+            |
+            |conf = SparkConf().set("spark.test_config", "1")
+            |sc = SparkContext(conf = conf)
+            |try:
+            |    if sc._conf.get("spark.test_config") != "1":
+            |        raise Exception("Cannot find spark.test_config in SparkContext's conf.")
+            |finally:
+            |    sc.stop()
+            """)
+        try:
+            subprocess.check_output(
+                [self.sparkSubmit, "--master", "local", script],
+                stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            # This gives us a better error message for debugging.
+            self.fail("Test exited with {0}, output:\n{1}".format(e.returncode, e.output))
 
 
 class ContextTests(unittest.TestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2035,6 +2035,26 @@ class SparkSubmitTests(unittest.TestCase):
         self.assertEqual(0, proc.returncode)
         self.assertIn("[2, 4, 6]", out.decode('utf-8'))
 
+    def test_user_configuration(self):
+      """Make sure user configuration is respected (SPARK-19307)"""
+      script = self.createTempFile("test.py", """
+          |from pyspark import SparkConf, SparkContext
+          |
+          |conf = SparkConf().set("spark.test_config", "1")
+          |sc = SparkContext(conf = conf)
+          |try:
+          |    if sc._conf.get("spark.test_config") != "1":
+          |        raise Exception("Cannot find spark.test_config in SparkContext's conf.")
+          |finally:
+          |    sc.stop()
+          """)
+      try:
+          subprocess.check_output([self.sparkSubmit, "--master", "local", script],
+              stderr=subprocess.STDOUT)
+      except subprocess.CalledProcessError as e:
+          # This gives us a better error message for debugging.
+          self.fail("Test exited with {0}, output:\n{1}".format(e.returncode, e.output))
+
 
 class ContextTests(unittest.TestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2048,13 +2048,12 @@ class SparkSubmitTests(unittest.TestCase):
             |finally:
             |    sc.stop()
             """)
-        try:
-            subprocess.check_output(
-                [self.sparkSubmit, "--master", "local", script],
-                stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            # This gives us a better error message for debugging.
-            self.fail("Test exited with {0}, output:\n{1}".format(e.returncode, e.output))
+        proc = subprocess.Popen(
+            [self.sparkSubmit, "--master", "local", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        out, err = proc.communicate()
+        self.assertEqual(0, proc.returncode, msg="Process failed with error:\n {0}".format(out))
 
 
 class ContextTests(unittest.TestCase):


### PR DESCRIPTION
The code was failing to propagate the user conf in the case where the
JVM was already initialized, which happens when a user submits a
python script via spark-submit.

Tested with new unit test and by running a python script in a real cluster.