### PR TITLE
[SPARK-19343][DStreams] Do once optimistic checkpoint before stop

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -349,7 +349,8 @@ abstract class DStream[T: ClassTag] (
             newRDD.persist(storageLevel)
             logDebug(s"Persisting RDD ${newRDD.id} for time $time to $storageLevel")
           }
-          if (checkpointDuration != null && (time - zeroTime).isMultipleOf(checkpointDuration)) {
+          if (checkpointDuration != null && ((time - zeroTime).isMultipleOf(checkpointDuration)
+              || ssc.scheduler.jobGenerator.stopTime == time.milliseconds)) {
             newRDD.checkpoint()
             logInfo(s"Marking RDD ${newRDD.id} for time $time for checkpointing")
           }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -52,7 +52,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
   private val numConcurrentJobs = ssc.conf.getInt("spark.streaming.concurrentJobs", 1)
   private val jobExecutor =
     ThreadUtils.newDaemonFixedThreadPool(numConcurrentJobs, "streaming-job-executor")
-  private val jobGenerator = new JobGenerator(this)
+  private[streaming] val jobGenerator = new JobGenerator(this)
   val clock = jobGenerator.clock
   val listenerBus = new StreamingListenerBus(ssc.sparkContext.listenerBus)
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.Queue
 
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
 import org.scalatest.{Assertions, BeforeAndAfter, PrivateMethodTester}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.Timeouts
@@ -32,6 +33,7 @@ import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark._
+import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.metrics.source.Source
@@ -835,6 +837,29 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     // SparkContext. Note: the stop codes in `after` will just do nothing if `ssc.stop` in this test
     // is running.
     assert(latch.await(60, TimeUnit.SECONDS))
+  }
+
+  test("SPARK-19343 Do once optimistic checkpoint before stop") {
+    val testDirectory = Utils.createTempDir().getAbsolutePath()
+    val checkpointDirectory = Utils.createTempDir().getAbsolutePath()
+    ssc = new StreamingContext(conf.clone.set("someKey", "someValue"), batchDuration)
+    ssc.checkpoint(checkpointDirectory)
+    val stream = ssc.textFileStream(testDirectory).checkpoint(batchDuration * 11)
+    stream.foreachRDD { rdd => rdd.count() }
+    ssc.start()
+    try {
+      Thread.sleep(batchDuration.milliseconds * 13)
+      ssc.stop(true, true)
+      val path = new Path(ssc.sparkContext.checkpointDir.get)
+      val fs = path.getFileSystem(SparkHadoopUtil.get.conf)
+      val statuses = fs.listStatus(path)
+      assert(statuses.count(_.getPath.toString.contains("rdd-")) == 2)
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        ssc.stop()
+        assert(false)
+    }
   }
 
   def addInputStream(s: StreamingContext): DStream[Int] = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Streaming job restarts from checkpoint, and it will rebuild several batch until finding latest checkpointed RDD. So we can do once optimistic checkpoint just before stop, so that reducing unnecessary recomputation.

## How was this patch tested?

add new unit test
