### PR TITLE
[SPARK-19342][SPARKR] bug fixed in collect method for collecting timestamp column

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1138,6 +1138,7 @@ setMethod("collect",
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
                     vec <- do.call(c, col)
                     stopifnot(class(vec) != "list")
+                    class(vec) <- PRIMITIVE_TYPES[[colType]]
                     df[[colIndex]] <- vec
                   } else {
                     df[[colIndex]] <- col

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1136,9 +1136,17 @@ setMethod("collect",
 
                   # Note that "binary" columns behave like complex types.
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
-                    vec <- do.call(c, col)
+                    valueIndex <- which(!is.na(col))
+                    if (length(valueIndex) > 0 && valueIndex[1] > 1) {
+                      colTail <- col[-(1 : (valueIndex[1] - 1))]
+                      vec <- do.call(c, colTail)
+                      classVal <- class(vec)
+                      vec <- c(rep(NA, valueIndex[1] - 1), vec)
+                      class(vec) <- classVal
+                    } else {
+                      vec <- do.call(c, col)
+                    }
                     stopifnot(class(vec) != "list")
-                    class(vec) <- PRIMITIVE_TYPES[[colType]]
                     df[[colIndex]] <- vec
                   } else {
                     df[[colIndex]] <- col

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1136,17 +1136,11 @@ setMethod("collect",
 
                   # Note that "binary" columns behave like complex types.
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
-                    valueIndex <- which(!is.na(col))
-                    if (length(valueIndex) > 0 && valueIndex[1] > 1) {
-                      colTail <- col[-(1 : (valueIndex[1] - 1))]
-                      vec <- do.call(c, colTail)
-                      classVal <- class(vec)
-                      vec <- c(rep(NA, valueIndex[1] - 1), vec)
-                      class(vec) <- classVal
-                    } else {
-                      vec <- do.call(c, col)
-                    }
+                    vec <- do.call(c, col)
                     stopifnot(class(vec) != "list")
+                    # If vec is an vector with only NAs, the type is logical
+                    if (length(vec[!is.na(vec)]) > 0)
+                      class(vec) <- PRIMITIVE_TYPES[[colType]]
                     df[[colIndex]] <- vec
                   } else {
                     df[[colIndex]] <- col

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1138,11 +1138,7 @@ setMethod("collect",
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
                     vec <- do.call(c, col)
                     stopifnot(class(vec) != "list")
-                    class(vec) <-
-                      if (colType == "timestamp")
-                        c("POSIXct", "POSIXt")
-                      else
-                        PRIMITIVE_TYPES[[colType]]
+                    class(vec) <- PRIMITIVE_TYPES[[colType]]
                     df[[colIndex]] <- vec
                   } else {
                     df[[colIndex]] <- col

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -417,7 +417,7 @@ setMethod("coltypes",
                   type <- PRIMITIVE_TYPES[[specialtype]]
                 }
               }
-              type
+              type[[1]]
             })
 
             # Find which types don't have mapping to R

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1138,7 +1138,6 @@ setMethod("collect",
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
                     vec <- do.call(c, col)
                     stopifnot(class(vec) != "list")
-                    # NOTE: If vec is an vector with only NAs, the type will be cast to PRIMITIVE_TYPE
                     class(vec) <-
                       if (colType == "timestamp")
                         c("POSIXct", "POSIXt")

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1138,9 +1138,18 @@ setMethod("collect",
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
                     vec <- do.call(c, col)
                     stopifnot(class(vec) != "list")
-                    # If vec is an vector with only NAs, the type is logical
                     if (length(vec[!is.na(vec)]) > 0)
-                      class(vec) <- PRIMITIVE_TYPES[[colType]]
+                    {
+                      class(vec) <- class(vec[!is.na(vec)])
+                    }
+                    else {
+                      # If vec is an vector with only NAs, the type will be cast to PRIMITIVE_TYPE
+                      class(vec) <-
+                        if (colType == "timestamp")
+                          c("POSIXct", "POSIXt")
+                        else
+                          PRIMITIVE_TYPES[[colType]]
+                    }
                     df[[colIndex]] <- vec
                   } else {
                     df[[colIndex]] <- col

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1138,18 +1138,12 @@ setMethod("collect",
                   if (!is.null(PRIMITIVE_TYPES[[colType]]) && colType != "binary") {
                     vec <- do.call(c, col)
                     stopifnot(class(vec) != "list")
-                    if (length(vec[!is.na(vec)]) > 0)
-                    {
-                      class(vec) <- class(vec[!is.na(vec)])
-                    }
-                    else {
-                      # If vec is an vector with only NAs, the type will be cast to PRIMITIVE_TYPE
-                      class(vec) <-
-                        if (colType == "timestamp")
-                          c("POSIXct", "POSIXt")
-                        else
-                          PRIMITIVE_TYPES[[colType]]
-                    }
+                    # NOTE: If vec is an vector with only NAs, the type will be cast to PRIMITIVE_TYPE
+                    class(vec) <-
+                      if (colType == "timestamp")
+                        c("POSIXct", "POSIXt")
+                      else
+                        PRIMITIVE_TYPES[[colType]]
                     df[[colIndex]] <- vec
                   } else {
                     df[[colIndex]] <- col

--- a/R/pkg/R/types.R
+++ b/R/pkg/R/types.R
@@ -29,7 +29,7 @@ PRIMITIVE_TYPES <- as.environment(list(
   "string" = "character",
   "binary" = "raw",
   "boolean" = "logical",
-  "timestamp" = "POSIXct",
+  "timestamp" = c("POSIXct", "POSIXt"),
   "date" = "Date",
   # following types are not SQL types returned by dtypes(). They are listed here for usage
   # by checkType() in schema.R.

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1277,9 +1277,9 @@ test_that("column functions", {
 
   # Test first(), last()
   df <- read.json(jsonPath)
-  expect_equal(collect(select(df, first(df$age)))[[1]], NA)
+  expect_equal(collect(select(df, first(df$age)))[[1]], NA_real_)
   expect_equal(collect(select(df, first(df$age, TRUE)))[[1]], 30)
-  expect_equal(collect(select(df, first("age")))[[1]], NA)
+  expect_equal(collect(select(df, first("age")))[[1]], NA_real_)
   expect_equal(collect(select(df, first("age", TRUE)))[[1]], 30)
   expect_equal(collect(select(df, last(df$age)))[[1]], 19)
   expect_equal(collect(select(df, last(df$age, TRUE)))[[1]], 19)
@@ -2752,18 +2752,38 @@ test_that("Collect on DataFrame when NAs exists at the top of a timestamp column
   ldf <- data.frame(col1 = c(0, 1, 2),
                    col2 = c(as.POSIXct("2017-01-01 00:00:01"),
                             NA,
-                            as.POSIXct("2017-01-01 12:00:01")))
+                            as.POSIXct("2017-01-01 12:00:01")),
+                   col3 = c(as.POSIXlt("2016-01-01 00:59:59"),
+                            NA,
+                            as.POSIXlt("2016-01-01 12:01:01")))
   sdf1 <- createDataFrame(ldf)
   ldf1 <- collect(sdf1)
-  expect_equal(dtypes(sdf1), list(c("col1", "double"), c("col2", "timestamp")))
+  expect_equal(dtypes(sdf1), list(c("col1", "double"),
+                                  c("col2", "timestamp"),
+                                  c("col3", "timestamp")))
   expect_equal(class(ldf1$col1), "numeric")
-  expect_equal(class(ldf1$col2), "POSIXct")
+  expect_equal(class(ldf1$col2), c("POSIXct", "POSIXt"))
+  expect_equal(class(ldf1$col3), c("POSIXct", "POSIXt"))
   
-  sdf2 <- filter(sdf1, "col1 > 0")
+  # Columns with NAs at the top
+  sdf2 <- filter(sdf1, "col1 > 1")
   ldf2 <- collect(sdf2)
-  expect_equal(dtypes(sdf2), list(c("col1", "double"), c("col2", "timestamp")))
+  expect_equal(dtypes(sdf2), list(c("col1", "double"),
+                                  c("col2", "timestamp"),
+                                  c("col3", "timestamp")))
   expect_equal(class(ldf2$col1), "numeric")
-  expect_equal(class(ldf2$col2), "POSIXct")
+  expect_equal(class(ldf2$col2), c("POSIXct", "POSIXt"))
+  expect_equal(class(ldf2$col3), c("POSIXct", "POSIXt"))
+  
+  # Columns with only NAs, the type will also be cast to PRIMITIVE_TYPE
+  sdf3 <- filter(sdf1, "col1 == 0")
+  ldf3 <- collect(sdf3)
+  expect_equal(dtypes(sdf3), list(c("col1", "double"),
+                                  c("col2", "timestamp"),
+                                  c("col3", "timestamp")))
+  expect_equal(class(ldf3$col1), "numeric")
+  expect_equal(class(ldf3$col2), c("POSIXct", "POSIXt"))
+  expect_equal(class(ldf3$col3), c("POSIXct", "POSIXt"))
 })
 
 unlink(parquetPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2748,7 +2748,7 @@ test_that("Call DataFrameWriter.load() API in Java without path and check argume
                  "Unnamed arguments ignored: 2, 3, a.")
 })
 
-test_that("Collect on DataFrame when NAs exists at the top of a timestamp column") {
+test_that("Collect on DataFrame when NAs exists at the top of a timestamp column", {
   ldf <- data.frame(col1 = c(0, 1, 2),
                    col2 = c(as.POSIXct("2017-01-01 00:00:01"),
                             NA,
@@ -2764,7 +2764,7 @@ test_that("Collect on DataFrame when NAs exists at the top of a timestamp column
   expect_equal(dtypes(sdf2), list(c("col1", "double"), c("col2", "timestamp")))
   expect_equal(class(ldf2$col1), "numeric")
   expect_equal(class(ldf2$col2), "POSIXct")
-}
+})
 
 unlink(parquetPath)
 unlink(orcPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2748,6 +2748,24 @@ test_that("Call DataFrameWriter.load() API in Java without path and check argume
                  "Unnamed arguments ignored: 2, 3, a.")
 })
 
+test_that("Collect on DataFrame when NAs exists at the top of a timestamp column") {
+  ldf <- data.frame(col1 = c(0, 1, 2),
+                   col2 = c(as.POSIXct("2017-01-01 00:00:01"),
+                            NA,
+                            as.POSIXct("2017-01-01 12:00:01")))
+  sdf1 <- createDataFrame(ldf)
+  ldf1 <- collect(sdf1)
+  expect_equal(dtypes(sdf1), list(c("col1", "double"), c("col2", "timestamp")))
+  expect_equal(class(ldf1$col1), "numeric")
+  expect_equal(class(ldf1$col2), "POSIXct")
+  
+  sdf2 <- filter(sdf1, "col1 > 0")
+  ldf2 <- collect(sdf2)
+  expect_equal(dtypes(sdf2), list(c("col1", "double"), c("col2", "timestamp")))
+  expect_equal(class(ldf2$col1), "numeric")
+  expect_equal(class(ldf2$col2), "POSIXct")
+}
+
 unlink(parquetPath)
 unlink(orcPath)
 unlink(jsonPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2764,7 +2764,7 @@ test_that("Collect on DataFrame when NAs exists at the top of a timestamp column
   expect_equal(class(ldf1$col1), "numeric")
   expect_equal(class(ldf1$col2), c("POSIXct", "POSIXt"))
   expect_equal(class(ldf1$col3), c("POSIXct", "POSIXt"))
-  
+
   # Columns with NAs at the top
   sdf2 <- filter(sdf1, "col1 > 1")
   ldf2 <- collect(sdf2)
@@ -2774,7 +2774,7 @@ test_that("Collect on DataFrame when NAs exists at the top of a timestamp column
   expect_equal(class(ldf2$col1), "numeric")
   expect_equal(class(ldf2$col2), c("POSIXct", "POSIXt"))
   expect_equal(class(ldf2$col3), c("POSIXct", "POSIXt"))
-  
+
   # Columns with only NAs, the type will also be cast to PRIMITIVE_TYPE
   sdf3 <- filter(sdf1, "col1 == 0")
   ldf3 <- collect(sdf3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a bug in collect method for collecting timestamp column, the bug can be reproduced as shown in the following codes and outputs:

```
library(SparkR)
sparkR.session(master = "local")
df <- data.frame(col1 = c(0, 1, 2), 
                 col2 = c(as.POSIXct("2017-01-01 00:00:01"), NA, as.POSIXct("2017-01-01 12:00:01")))

sdf1 <- createDataFrame(df)
print(dtypes(sdf1))
df1 <- collect(sdf1)
print(lapply(df1, class))

sdf2 <- filter(sdf1, "col1 > 0")
print(dtypes(sdf2))
df2 <- collect(sdf2)
print(lapply(df2, class))
```

As we can see from the printed output, the column type of col2 in df2 is converted to numeric unexpectedly, when NA exists at the top of the column. 

This is caused by method `do.call(c, list)`, if we convert a list, i.e. `do.call(c, list(NA, as.POSIXct("2017-01-01 12:00:01"))`, the class of the result is numeric instead of POSIXct. 

Therefore, we need to cast the data type of the vector explicitly. 



## How was this patch tested?

The patch can be tested manually with the same code above.
