### PR TITLE
[SPARK-19349][DStreams]improve resource ready check to avoid multiple receivers to be scheduled on the same node.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -422,6 +422,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   def sufficientResourcesRegistered(): Boolean = true
 
+  def allResourcesRegistered(): Boolean = true
+
   override def isReady(): Boolean = {
     if (sufficientResourcesRegistered) {
       logInfo("SchedulerBackend is ready for scheduling beginning after " +

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -164,6 +164,10 @@ private[spark] class StandaloneSchedulerBackend(
     totalCoreCount.get() >= totalExpectedCores * minRegisteredRatio
   }
 
+  override def allResourcesRegistered(): Boolean = {
+    totalCoreCount.get() == totalExpectedCores
+  }
+
   override def applicationId(): String =
     Option(appId).getOrElse {
       logWarning("Application ID is not initialized yet.")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -149,6 +149,10 @@ private[spark] abstract class YarnSchedulerBackend(
     totalRegisteredExecutors.get() >= totalExpectedExecutors * minRegisteredRatio
   }
 
+  override def allResourcesRegistered(): Boolean = {
+    totalRegisteredExecutors.get() == totalExpectedExecutors
+  }
+
   /**
    * Add filters to the SparkUI.
    */

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -810,7 +810,8 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
   test("SPARK-18560 Receiver data should be deserialized properly.") {
     // Start a two nodes cluster, so receiver will use one node, and Spark jobs will use the
     // other one. Then Spark jobs need to fetch remote blocks and it will trigger SPARK-18560.
-    val conf = new SparkConf().setMaster("local-cluster[2,1,1024]").setAppName(appName)
+    val conf = new SparkConf().setMaster("local-cluster[2,1,1024]")
+        .set("spark.cores.max", "2").setAppName(appName)
     ssc = new StreamingContext(conf, Milliseconds(100))
     val input = ssc.receiverStream(new TestReceiver)
     val latch = new CountDownLatch(1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove related TODO

Currently, we can only ensure registered resource satisfy the "spark.scheduler.minRegisteredResourcesRatio". But if "spark.scheduler.minRegisteredResourcesRatio" is set too small, receivers may still be scheduled to few nodes. In fact, we can give once more chance to wait for sufficient resource to schedule receiver evenly.

## How was this patch tested?

update ut
