### PR TITLE
[SPARK-19335] Introduce UPSERT feature to SPARK 

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -518,7 +518,8 @@ file directly with SQL.
 Save operations can optionally take a `SaveMode`, that specifies how to handle existing data if
 present. It is important to realize that these save modes do not utilize any locking and are not
 atomic. Additionally, when performing an `Overwrite`, the data will be deleted before writing out the
-new data.
+new data. When performing an `Append`, there is an option to enable the UPSERT feature for JDBC datasources, currently
+only MySQL and Postgres.  
 
 <table class="table">
 <tr><th>Scala/Java</th><th>Any Language</th><th>Meaning</th></tr>
@@ -1230,6 +1231,24 @@ the following case-insensitive options:
      The database column data types to use instead of the defaults, when creating the table. Data type information should be specified in the same format as CREATE TABLE columns syntax (e.g: <code>"name CHAR(64), comments VARCHAR(1024)")</code>. The specified types should be valid spark sql data types. This option applies only to writing.
     </td>
   </tr>  
+  
+  <tr>
+      <td><code>upsert, upsertConditionColumn, upsertUpdateColumn </code></td>
+      <td>
+        These options are JDBC writer related options. They describe how to
+        use UPSERT feature for different JDBC dialects. Right now, this feature implemented in MySQL, Postgres 
+        JDBC dialects. The upsert option is applicable only when <code>SaveMode.Append</code> is enabled,
+        in Overwrite mode, the existing table will be dropped or truncated first, including the unique constraints 
+        or primary key, before the insertion. So, UPSERT scenario is not applicable.
+        <code>upsertConditionColumn</code> are columns used to match existing rows. They are usually unique constraint/primary
+        key columns. This option is required by PostgreSQL datasource. This option is not applicable for MySQL datasource,
+        since the datasource will automatically use any existing unique constraint.
+        <code>upsertUpdateColumn</code> are columns updated with the input data set when existing rows are matched. It is required 
+        by MySQL datasource.
+        Be aware that if the input data set has duplicate rows, the upsert operation is
+        non-deterministic, it is documented at the [upsert(merge) wiki:](https://en.wikipedia.org/wiki/Merge_(SQL)).
+      </td>
+  </tr>
 </table>
 
 <div class="codetabs">

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -20,11 +20,13 @@ package org.apache.spark.sql.jdbc
 import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
+import org.apache.spark.sql.SaveMode
 
 import org.apache.spark.tags.DockerTest
 
 @DockerTest
 class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
+  import testImplicits._
   override val db = new DatabaseOnDocker {
     override val imageName = "mysql:5.7.9"
     override val env = Map(
@@ -61,6 +63,19 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     ).executeUpdate()
     conn.prepareStatement("INSERT INTO strings VALUES ('the', 'quick', 'brown', 'fox', " +
       "'jumps', 'over', 'the', 'lazy', 'dog')").executeUpdate()
+
+    conn.prepareStatement("CREATE TABLE upsertT0 (c1 INTEGER primary key, c2 INTEGER, c3 INTEGER)")
+      .executeUpdate()
+    conn.prepareStatement("INSERT INTO upsertT0 VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5)")
+      .executeUpdate()
+    conn.prepareStatement("CREATE TABLE upsertT1 (c1 INTEGER primary key, c2 INTEGER, c3 INTEGER)")
+      .executeUpdate()
+    conn.prepareStatement("INSERT INTO upsertT1 VALUES (1, 2, 3), (2, 3, 4)")
+      .executeUpdate()
+    conn.prepareStatement("CREATE TABLE upsertT2 (c1 INTEGER, c2 INTEGER, c3 INTEGER, " +
+      "primary key(c1, c2))").executeUpdate()
+    conn.prepareStatement("INSERT INTO upsertT2 VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5)")
+      .executeUpdate()
   }
 
   test("Basic test") {
@@ -151,5 +166,105 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     df1.write.jdbc(jdbcUrl, "numberscopy", new Properties)
     df2.write.jdbc(jdbcUrl, "datescopy", new Properties)
     df3.write.jdbc(jdbcUrl, "stringscopy", new Properties)
+  }
+
+  test("upsert with Append without existing table") {
+    val df1 = Seq((1, 3), (2, 5)).toDF("c1", "c2")
+    df1.write.mode(SaveMode.Append).option("upsert", true).option("upsertUpdateColumn", "c1")
+      .jdbc(jdbcUrl, "upsertT", new Properties)
+    val df2 = spark.read.jdbc(jdbcUrl, "upsertT", new Properties)
+    assert(df2.count() == 2)
+    assert(df2.filter("C1=1").collect.head.get(1) == 3)
+
+    // table upsertT create without primary key or unique constraints, it will do the insert
+    val df3 = Seq((1, 4)).toDF("c1", "c2")
+    df3.write.mode(SaveMode.Append).option("upsert", true).option("upsertUpdateColumn", "c1")
+      .jdbc(jdbcUrl, "upsertT", new Properties)
+    assert(spark.read.jdbc(jdbcUrl, "upsertT", new Properties).filter("c1=1").count() == 2)
+  }
+
+  test("Upsert and OverWrite mode") {
+    //existing table has these rows
+    //(1, 2, 3), (2, 3, 4), (3, 4, 5)
+    val df1 = spark.read.jdbc(jdbcUrl, "upsertT0", new Properties())
+    assert(df1.filter("c1=1").collect.head.getInt(1) == 2)
+    assert(df1.filter("c1=1").collect.head.getInt(2) == 3)
+    assert(df1.filter("c1=2").collect.head.getInt(1) == 3)
+    assert(df1.filter("c1=2").collect.head.getInt(2) == 4)
+    val df2 = Seq((1, 3, 6), (2, 5, 6)).toDF("c1", "c2", "c3")
+    // it will do the Overwrite, not upsert
+    df2.write.mode(SaveMode.Overwrite)
+      .option("upsert", true).option("upsertUpdateColumn", "c2, c3")
+      .jdbc(jdbcUrl, "upsertT0", new Properties)
+    val df3 = spark.read.jdbc(jdbcUrl, "upsertT0", new Properties())
+    assert(df3.filter("c1=1").collect.head.getInt(1) == 3)
+    assert(df3.filter("c1=1").collect.head.getInt(2) == 6)
+    assert(df3.filter("c1=2").collect.head.getInt(1) == 5)
+    assert(df3.filter("c1=2").collect.head.getInt(2) == 6)
+    assert(df3.filter("c1=3").collect.size == 0)
+  }
+
+  test("upsert with Append and negative option values") {
+    val df1 = Seq((1, 3, 6), (2, 5, 6)).toDF("c1", "c2", "c3")
+    val m = intercept[java.sql.SQLException] {
+    df1.write.mode(SaveMode.Append).option("upsert", true).option("upsertUpdateColumn", "C11")
+      .jdbc(jdbcUrl, "upsertT1", new Properties)
+    }.getMessage
+    assert(m.contains("column C11 not found"))
+
+    val n = intercept[java.sql.SQLException] {
+    df1.write.mode(SaveMode.Append).option("upsert", true).option("upsertUpdateColumn", "C11")
+      .jdbc(jdbcUrl, "upsertT1", new Properties)
+    }.getMessage
+    assert(n.contains("column C11 not found"))
+  }
+
+  test("Upsert and Append mode -- data matching one column") {
+    //existing table has these rows
+    //(1, 2, 3), (2, 3, 4)
+    val df1 = spark.read.jdbc(jdbcUrl, "upsertT1", new Properties())
+    assert(df1.count() == 2)
+    assert(df1.filter("c1=1").collect.head.getInt(1) == 2)
+    assert(df1.filter("c1=1").collect.head.getInt(2) == 3)
+    assert(df1.filter("c1=2").collect.head.getInt(1) == 3)
+    assert(df1.filter("c1=2").collect.head.getInt(2) == 4)
+    val df2 = Seq((1, 4, 7), (2, 6, 8)).toDF("c1", "c2", "c3")
+    df2.write.mode(SaveMode.Append)
+      .option("upsert", true).option("upsertUpdateColumn", "c2, c3")
+      .jdbc(jdbcUrl, "upsertT1", new Properties)
+    val df3 = spark.read.jdbc(jdbcUrl, "upsertT1", new Properties())
+    assert(df3.count() == 2)
+    assert(df3.filter("c1=1").collect.head.getInt(1) == 4)
+    assert(df3.filter("c1=1").collect.head.getInt(2) == 7)
+    assert(df3.filter("c1=2").collect.head.getInt(1) == 6)
+    assert(df3.filter("c1=2").collect.head.getInt(2) == 8)
+    // turn upsert off, it will do the insert the row with duplicate key, and it will get nullPointerException
+    val df4 = Seq((1, 5, 9)).toDF("c1", "c2", "c3")
+    val n = intercept[org.apache.spark.SparkException] {
+    df4.write.mode(SaveMode.Append).option("upsert", false).option("upsertUpdateColumn", "C11")
+      .jdbc(jdbcUrl, "upsertT1", new Properties)
+    }.getMessage
+    assert(n.contains("Duplicate entry '1' for key 'PRIMARY'"))
+  }
+
+  test("Upsert and Append mode -- data matching two columns") {
+    // table has these rows: (1, 2, 3), (2, 3, 4), (3, 4, 5)
+    // update Row(2, 3, 4) to Row(2, 3, 10) that matches 2 columns
+    val df1 = spark.read.jdbc(jdbcUrl, "upsertT2", new Properties())
+    assert(df1.count() == 3)
+    assert(df1.filter("c1=1").collect.head.getInt(1) == 2)
+    assert(df1.filter("c1=1").collect.head.getInt(2) == 3)
+    assert(df1.filter("c1=2").collect.head.getInt(1) == 3)
+    assert(df1.filter("c1=2").collect.head.getInt(2) == 4)
+
+    val df2 = Seq((2, 3, 10)).toDF("c1", "c2", "c3")
+    df2.write.mode(SaveMode.Append)
+      .option("upsert", true).option("upsertUpdateColumn", "c3")
+      .jdbc(jdbcUrl, "upsertT2", new Properties)
+
+    val df3 = spark.read.jdbc(jdbcUrl, "upsertT2", new Properties())
+    assert(df3.count() == 3)
+    assert(df3.filter("c1=2").collect.head.getInt(1) == 3)
+    assert(df3.filter("c1=2").collect.head.getInt(2) == 10)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -115,6 +115,20 @@ class JDBCOptions(
   // ------------------------------------------------------------
   // if to truncate the table from the JDBC database
   val isTruncate = parameters.getOrElse(JDBC_TRUNCATE, "false").toBoolean
+  // if to upsert the table from the JDBC database
+  val isUpsert = parameters.getOrElse(JDBC_UPSERT, "false").toBoolean
+  // the columns used to set condition columns for upsert feature
+  val upsertConditionColumn = parameters.getOrElse(JDBC_UPSERT_CONDITION_COLUMN, null) match {
+    case null => Array.empty[String]
+    case o => o.split(",").map(_.trim)
+  }
+  // the columns used to set columns to be updated for upsert feature
+  val upsertUpdateColumn = parameters.getOrElse(JDBC_UPSERT_UPDATE_COLUMN, null) match {
+    case null => Array.empty[String]
+    case o => o.split(",").map(_.trim)
+  }
+  // the jdbc table exist or not
+  val isJdbcTableExist = parameters.getOrElse(JDBC_TABLE_EXIST, "false").toBoolean
   // the create table option , which can be table_options or partition_options.
   // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
   // TODO: to reuse the existing partition parameters for those partition specific options
@@ -158,4 +172,8 @@ object JDBCOptions {
   val JDBC_CREATE_TABLE_COLUMN_TYPES = newOption("createTableColumnTypes")
   val JDBC_BATCH_INSERT_SIZE = newOption("batchsize")
   val JDBC_TXN_ISOLATION_LEVEL = newOption("isolationLevel")
+  val JDBC_UPSERT = newOption("upsert")
+  val JDBC_UPSERT_CONDITION_COLUMN = newOption("upsertConditionColumn")
+  val JDBC_UPSERT_UPDATE_COLUMN = newOption("upsertUpdateColumn")
+  val JDBC_TABLE_EXIST = newOption("jdbcTableExist")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -65,17 +65,17 @@ class JdbcRelationProvider extends CreatableRelationProvider
               // In this case, we should truncate table and then load.
               truncateTable(conn, options.table)
               val tableSchema = JdbcUtils.getSchemaOption(conn, options)
-              saveTable(df, tableSchema, isCaseSensitive, options)
+              saveTable(df, tableSchema, isCaseSensitive, mode, options)
             } else {
               // Otherwise, do not truncate the table, instead drop and recreate it
               dropTable(conn, options.table)
               createTable(conn, df, options)
-              saveTable(df, Some(df.schema), isCaseSensitive, options)
+              saveTable(df, Some(df.schema), isCaseSensitive, mode, options)
             }
 
           case SaveMode.Append =>
             val tableSchema = JdbcUtils.getSchemaOption(conn, options)
-            saveTable(df, tableSchema, isCaseSensitive, options)
+            saveTable(df, tableSchema, isCaseSensitive, mode, options)
 
           case SaveMode.ErrorIfExists =>
             throw new AnalysisException(
@@ -88,7 +88,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
         }
       } else {
         createTable(conn, df, options)
-        saveTable(df, Some(df.schema), isCaseSensitive, options)
+        saveTable(df, Some(df.schema), isCaseSensitive, mode, options, !tableExists)
       }
     } finally {
       conn.close()

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Connection
+import java.sql.{Connection, PreparedStatement}
 
 import org.apache.spark.annotation.{DeveloperApi, InterfaceStability, Since}
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types._
 
 /**
@@ -33,6 +34,18 @@ import org.apache.spark.sql.types._
 @DeveloperApi
 @InterfaceStability.Evolving
 case class JdbcType(databaseTypeDefinition : String, jdbcNullType : Int)
+
+/**
+ * :: DeveloperApi ::
+ * the duplicate key columns and update columns send to the database
+ * values to the database.
+ * @param upsertConditionColumns The duplicate key columns
+ * @param upsertUpdateColumns The columns to be updated
+ */
+@DeveloperApi
+@InterfaceStability.Evolving
+case class UpsertInfo(val upsertConditionColumns: Array[String],
+                      val upsertUpdateColumns: Array[String])
 
 /**
  * :: DeveloperApi ::
@@ -130,6 +143,23 @@ abstract class JdbcDialect extends Serializable {
    * None: The behavior of TRUNCATE TABLE is unknown (default).
    */
   def isCascadingTruncateTable(): Option[Boolean] = None
+
+  /**
+   * Generate a PreparedStatement that performs UPSERT operation
+   *
+   * @param conn The connection object
+   * @param table The target table
+   * @param rddSchema The schema for the table
+   * @param upsertParam The parameter contains upsert feature related information.
+   * @return PreparedStatement
+   */
+  def upsertStatement(
+      conn: Connection,
+      table: String,
+      rddSchema: StructType,
+      upsertParam: UpsertInfo = UpsertInfo(Array(), Array())): PreparedStatement = {
+    throw new UnsupportedOperationException("UPSERT operation is not implemented.")
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, Types}
+import java.sql.{Connection, PreparedStatement, Types}
 
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.types._
@@ -101,4 +101,49 @@ private object PostgresDialect extends JdbcDialect {
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(true)
+
+  /**
+   * Returns a PreparedStatement that does Insert/Update table
+   */
+  override def upsertStatement(
+      conn: Connection,
+      table: String,
+      rddSchema: StructType,
+      upsertParam: UpsertInfo =
+      UpsertInfo(Array.empty[String], Array.empty[String])): PreparedStatement = {
+    require(upsertParam.upsertConditionColumns.nonEmpty,
+      "Upsert option requires column names on which duplicate rows are identified. " +
+        "Please specify option(\"upsertConditionColumn\", \"c1, c2, ...\")")
+    require(conn.getMetaData.getDatabaseProductVersion.compareToIgnoreCase("9.5") > 0,
+      "INSERT INTO with ON CONFLICT clause only support by PostgreSQL 9.5 and up.")
+
+    val insertColumns = rddSchema.fields.map(_.name).mkString(", ")
+    val conflictTarget = upsertParam.upsertConditionColumns.mkString(", ")
+    val placeholders = rddSchema.fields.map(_ => "?").mkString(",")
+    val updateColumns = if (upsertParam.upsertUpdateColumns.nonEmpty)
+    { upsertParam.upsertUpdateColumns} else {rddSchema.fields.map(_.name)}
+    val updateClause = updateColumns
+      .filterNot(upsertParam.upsertConditionColumns.contains(_))
+      .map(x => s"$x = EXCLUDED.$x").mkString(", ")
+
+    // In the case where condition columns are the whole set of the rddSchema columns
+    // and rddSchema columns may be a subset of the target table schema.
+    // We need to do nothing for matched rows
+    val sql = if (updateClause != null && updateClause.nonEmpty) {
+      s"""
+         |INSERT INTO $table ($insertColumns)
+         |VALUES ( $placeholders )
+         |ON CONFLICT ($conflictTarget)
+         |DO UPDATE SET $updateClause
+      """.stripMargin
+    } else {
+      s"""
+         |INSERT INTO $table ($insertColumns)
+         |VALUES ( $placeholders )
+         |ON CONFLICT ($conflictTarget)
+         |DO NOTHING
+      """.stripMargin
+    }
+    conn.prepareStatement(sql)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Date, DriverManager, Timestamp}
+import java.sql.{Connection, DriverManager, PreparedStatement}
 import java.util.Properties
 
 import scala.collection.JavaConverters.propertiesAsScalaMapConverter
@@ -46,6 +46,30 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
   val testH2Dialect = new JdbcDialect {
     override def canHandle(url: String) : Boolean = url.startsWith("jdbc:h2")
     override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
+    override def upsertStatement(
+        conn: Connection,
+        table: String,
+        rddSchema: StructType,
+        upsertParam: UpsertInfo =
+        UpsertInfo(Array(), Array())): PreparedStatement = {
+      val columnNames = rddSchema.fields.map(_.name).mkString(", ")
+      val keyNames = upsertParam.upsertConditionColumns.mkString(", ")
+      val placeholders = rddSchema.fields.map(_ => "?").mkString(",")
+      val sql =
+      if (keyNames != null && !keyNames.isEmpty) {
+        s"""
+           |MERGE INTO $table ($columnNames)
+           |KEY($keyNames)
+           |VALUES($placeholders)
+        """.stripMargin
+      } else {
+        s"""
+           |MERGE INTO $table ($columnNames)
+           |VALUES($placeholders)
+        """.stripMargin
+      }
+      conn.prepareStatement(sql)
+    }
   }
 
   before {
@@ -63,6 +87,18 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     conn1.prepareStatement("drop table if exists test.people1").executeUpdate()
     conn1.prepareStatement(
       "create table test.people1 (name TEXT(32) NOT NULL, theid INTEGER NOT NULL)").executeUpdate()
+    conn1.prepareStatement(
+      "create table test.upsertT1(c1 INTEGER PRIMARY KEY, c2 INTEGER)").executeUpdate()
+    conn1.prepareStatement(
+      "insert into test.upsertT1 values (1, 10)").executeUpdate()
+    conn1.prepareStatement(
+      "insert into test.upsertT1 values (2, 12)").executeUpdate()
+    conn1.prepareStatement(
+      "create table test.upsertT2(c1 INTEGER PRIMARY KEY, c2 INTEGER)").executeUpdate()
+    conn1.prepareStatement(
+      "insert into test.upsertT2 values (1, 10)").executeUpdate()
+    conn1.prepareStatement(
+      "insert into test.upsertT2 values (2, 12)").executeUpdate()
     conn1.commit()
 
     sql(
@@ -100,6 +136,16 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
   private lazy val schema4 = StructType(
       StructField("NAME", StringType) ::
       StructField("ID", IntegerType) :: Nil)
+
+  private lazy val ary1x2 = Array[Row](Row.apply(1, 42))
+  private lazy val ary12x2 = Array[Row](Row.apply(2, 52))
+  private lazy val ary13x2 = Array[Row](Row.apply(1, 62))
+  private lazy val ary14x2 = Array[Row](Row.apply(1, 72))
+  private lazy val ary2x2 = Array[Row](Row.apply(1, 52), Row.apply(2, 222))
+  private lazy val ary3x2 = Array[Row](Row.apply(1, 10), Row.apply(2, 20), Row.apply(1, 30))
+  private lazy val schema5 = StructType(
+    StructField("C1", IntegerType) ::
+    StructField("C2", IntegerType) :: Nil)
 
   test("Basic CREATE") {
     val df = spark.createDataFrame(sparkContext.parallelize(arr2x2), schema2)
@@ -505,5 +551,150 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
       assert(msg.contains("createTableColumnTypes option column Name not found in " +
         "schema struct<name:string,id:int>"))
     }
+  }
+
+  test("upsert with Overwrite") {
+    JdbcDialects.registerDialect(testH2Dialect)
+    val df = spark.createDataFrame(sparkContext.parallelize(ary1x2), schema5)
+    val df1 = spark.createDataFrame(sparkContext.parallelize(ary2x2), schema5)
+
+    df.write.mode(SaveMode.Overwrite).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).count() == 1)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+
+    df1.write.mode(SaveMode.Overwrite).option("upsert", false).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).count() == 2)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).filter("C1=1")
+      .collect.head.get(1) == 52)
+    JdbcDialects.unregisterDialect(testH2Dialect)
+  }
+
+  test("upsert with Append and case insensitive") {
+    JdbcDialects.registerDialect(testH2Dialect)
+    val df = spark.createDataFrame(sparkContext.parallelize(ary1x2), schema5)
+    val df1 = spark.createDataFrame(sparkContext.parallelize(ary12x2), schema5)
+    val df2 = spark.createDataFrame(sparkContext.parallelize(ary13x2), schema5)
+
+    df.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT1", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).count() == 1)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+
+    df1.write.mode(SaveMode.Append).option("upsert", false).option("upsertConditionColumn", "c1")
+      .jdbc(url1, "TEST.UPSERT1", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).count() == 2)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+
+    df2.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "c1")
+      .jdbc(url1, "TEST.UPSERT1", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).count() == 2)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).filter("C1=1")
+      .collect.head.get(1) == 62)
+    JdbcDialects.unregisterDialect(testH2Dialect)
+  }
+
+  test("upsert with Append and case sensitive") {
+    JdbcDialects.registerDialect(testH2Dialect)
+    val df = spark.createDataFrame(sparkContext.parallelize(ary1x2), schema5)
+    val df1 = spark.createDataFrame(sparkContext.parallelize(ary12x2), schema5)
+    val df2 = spark.createDataFrame(sparkContext.parallelize(ary13x2), schema5)
+
+    spark.sql("set spark.sql.caseSensitive=true")
+    df.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT1", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).count() == 1)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+
+    df1.write.mode(SaveMode.Append).option("upsert", false).option("upsertConditionColumn", "c1")
+      .jdbc(url1, "TEST.UPSERT1", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).count() == 2)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT1", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+
+    val m = intercept[java.sql.SQLException] {
+    df2.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "c1")
+      .jdbc(url1, "TEST.UPSERT1", properties)
+    }.getMessage
+    assert(m.contains("column c1 not found"))
+    spark.sql("set spark.sql.caseSensitive=false")
+    JdbcDialects.unregisterDialect(testH2Dialect)
+  }
+
+  test("upsert with Append and negative option values") {
+    JdbcDialects.registerDialect(testH2Dialect)
+    val df = spark.createDataFrame(sparkContext.parallelize(ary1x2), schema5)
+    val df1 = spark.createDataFrame(sparkContext.parallelize(ary12x2), schema5)
+
+    val m = intercept[java.sql.SQLException] {
+    df.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "C11")
+      .jdbc(url1, "test.upsertT2", properties)
+    }.getMessage
+    assert(m.contains("column C11 not found"))
+
+    val n = intercept[java.sql.SQLException] {
+    df.write.mode(SaveMode.Append).option("upsert", true).option("upsertUpdateColumn", "c12")
+      .jdbc(url1, "test.upsertT2", properties)
+    }.getMessage
+    assert(n.contains("column c12 not found"))
+    JdbcDialects.unregisterDialect(testH2Dialect)
+  }
+
+  test("upsert with Append without existing table") {
+    JdbcDialects.registerDialect(testH2Dialect)
+    val df = spark.createDataFrame(sparkContext.parallelize(ary1x2), schema5)
+    val df1 = spark.createDataFrame(sparkContext.parallelize(ary12x2), schema5)
+    val df2 = spark.createDataFrame(sparkContext.parallelize(ary13x2), schema5)
+    val df3 = spark.createDataFrame(sparkContext.parallelize(ary14x2), schema5)
+
+    df.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).count() == 1)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+
+    df2.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).count() == 1)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).filter("C1=1")
+      .collect.head.get(1) == 62)
+
+    // turn it off, it will insert one more row
+    df3.write.mode(SaveMode.Append).option("upsert", false).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "TEST.UPSERT", properties)
+    assert(spark.read.jdbc(url1, "TEST.UPSERT", properties).count() == 2)
+    JdbcDialects.unregisterDialect(testH2Dialect)
+  }
+
+  test("upsert with Append with existing table") {
+    JdbcDialects.registerDialect(testH2Dialect)
+    val df = spark.createDataFrame(sparkContext.parallelize(ary1x2), schema5)
+    val df1 = spark.createDataFrame(sparkContext.parallelize(ary12x2), schema5)
+    val df2 = spark.createDataFrame(sparkContext.parallelize(ary13x2), schema5)
+    val df3 = spark.createDataFrame(sparkContext.parallelize(ary14x2), schema5)
+
+    assert(spark.read.jdbc(url1, "test.upsertT1", properties).count() == 2)
+    assert(spark.read.jdbc(url1, "test.upsertT1", properties).filter("C1=1")
+      .collect.head.get(1) == 10)
+    df.write.mode(SaveMode.Append).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "test.upsertT1", properties)
+    assert(spark.read.jdbc(url1, "test.upsertT1", properties).filter("C1=1")
+      .collect.head.get(1) == 42)
+    // Overwrite will drop the table, then insert the dataframe rows into the empty table
+    df2.write.mode(SaveMode.Overwrite).option("upsert", true).option("upsertConditionColumn", "C1")
+      .jdbc(url1, "test.upsertT1", properties)
+    assert(spark.read.jdbc(url1, "test.upsertT1", properties).filter("C1=1")
+      .collect.head.get(1) == 62)
+    // Append without upsert option, it will not insert the value into the table
+    df3.write.mode(SaveMode.Append).option("upsert", false).option("upsertConditionColumn", "c1")
+      .jdbc(url1, "test.upsertT1", properties)
+    assert(spark.read.jdbc(url1, "test.upsertT1", properties).filter("C1=1")
+      .collect.head.get(1) == 62)
+    JdbcDialects.unregisterDialect(testH2Dialect)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add the UPSERT feature support into SPARK through DataFrameWriter's JDBC data source options. 

For example:
If the mytable2 in mysql database have unique constraints on column c1, and the user wants to save the dataframe into the mysql database, it will fail with violation of unique constraints.

`val df = Seq((1,4)).toDF("c1","c2")`
`val url = "jdbc:mysql://9.30.167.220:3306/mydb"`
`df.write.mode(org.apache.spark.sql.SaveMode.Append)
.option("user","kevin").option("password","kevin").jdbc(url,"mytable2",new java.util.Properties())`

With this feature, the user can use this UPSERT options to write the dataframe into the mysql database table.

`df.write.mode(org.apache.spark.sql.SaveMode.Append)
.option(“upsert”,true).option(“upsertUpdateColumn”,”c1”).option("user","kevin").option("password","kevin").jdbc(url,"mytable2",new java.util.Properties())`

Here is the design doc.
[UPSERT DESIGN DOC](https://drive.google.com/open?id=1IoafDm78v7ATP-npKbTaw2_dTFiXplCd9NzEe8CBH6E)


## How was this patch tested?

Local test: run the test case from spark-shell and connect to MySQL and Postgresql database
Test case: add test cases in the existing test cases including docker integration suite
Please review http://spark.apache.org/contributing.html before opening a pull request.
