### PR TITLE
[SPARK-19359][SQL]clear useless path after rename a partition with upper-case by HiveExternalCatalog

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -121,7 +121,7 @@ object ExternalCatalogUtils {
     }
   }
 
-  def getUselessHivePartPathAfterRename(
+  def getExtraPartPathCreatedByHive(
                              lowerCaseSpec: TablePartitionSpec,
                              partitionColumnNames: Seq[String],
                              tablePath: Path): Path = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -120,6 +120,17 @@ object ExternalCatalogUtils {
       new Path(totalPath, nextPartPath)
     }
   }
+
+  def getUselessHivePartPathAfterRename(
+                             lowerCaseSpec: TablePartitionSpec,
+                             partitionColumnNames: Seq[String],
+                             tablePath: Path): Path = {
+    val partColumnNames = partitionColumnNames
+      .take(partitionColumnNames.indexWhere(col => col.toLowerCase != col) + 1)
+      .map(_.toLowerCase)
+
+    generatePartitionPath(lowerCaseSpec, partColumnNames, tablePath)
+  }
 }
 
 object CatalogUtils {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -120,24 +120,6 @@ object ExternalCatalogUtils {
       new Path(totalPath, nextPartPath)
     }
   }
-
-  /**
-   * partition path created by Hive is lower-case, while Spark SQL will
-   * rename it with the partition name in partitionColumnNames, and this function
-   * return the extra lower-case path created by Hive, and then we can delete it.
-   * e.g. /path/A=1/B=2/C=3 rename to /path/A=4/B=5/C=6, the extra path returned is
-   * /path/a=4, which also include all its' child path, such as /path/a=4/b=2
-   */
-  def getExtraPartPathCreatedByHive(
-      lowerCaseSpec: TablePartitionSpec,
-       partitionColumnNames: Seq[String],
-       tablePath: Path): Path = {
-    val partColumnNames = partitionColumnNames
-      .take(partitionColumnNames.indexWhere(col => col.toLowerCase != col) + 1)
-      .map(_.toLowerCase)
-
-    generatePartitionPath(lowerCaseSpec, partColumnNames, tablePath)
-  }
 }
 
 object CatalogUtils {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -121,10 +121,17 @@ object ExternalCatalogUtils {
     }
   }
 
+  /**
+   * partition path created by Hive is lower-case, while Spark SQL will
+   * rename it with the partition name in partitionColumnNames, and this function
+   * return the extra lower-case path created by Hive, and then we can delete it.
+   * e.g. /path/A=1/B=2/C=3 rename to /path/A=4/B=5/C=6, the extra path returned is
+   * /path/a=4, which also include all its' child path, such as /path/a=4/b=2
+   */
   def getExtraPartPathCreatedByHive(
-                             lowerCaseSpec: TablePartitionSpec,
-                             partitionColumnNames: Seq[String],
-                             tablePath: Path): Path = {
+      lowerCaseSpec: TablePartitionSpec,
+       partitionColumnNames: Seq[String],
+       tablePath: Path): Path = {
     val partColumnNames = partitionColumnNames
       .take(partitionColumnNames.indexWhere(col => col.toLowerCase != col) + 1)
       .map(_.toLowerCase)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -841,12 +841,12 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
 
   /**
-    * partition path created by Hive is lower-case, while Spark SQL will
-    * rename it with the partition name in partitionColumnNames, and this function
-    * return the extra lower-case path created by Hive, and then we can delete it.
-    * e.g. /path/A=1/B=2/C=3 rename to /path/A=4/B=5/C=6, the extra path returned is
-    * /path/a=4, which also include all its' child path, such as /path/a=4/b=2
-    */
+   * partition path created by Hive is lower-case, while Spark SQL will
+   * rename it with the partition name in partitionColumnNames, and this function
+   * return the extra lower-case path created by Hive, and then we can delete it.
+   * e.g. /path/A=1/B=2/C=3 rename to /path/A=4/B=5/C=6, the extra path returned is
+   * /path/a=4, which also include all its' child path, such as /path/a=4/b=2
+   */
   def getExtraPartPathCreatedByHive(
                                      lowerCaseSpec: TablePartitionSpec,
                                      partitionColumnNames: Seq[String],

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -906,7 +906,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
           // newSpec is 'A=1/B=2', after renamePartitions by Hive, the location path in FileSystem
           // changed to 'a=1/b=2', which is wrongPath, then we renamed to 'A=1/B=2', and 'a=1/b=2'
           // in FileSystem is deleted, while 'a=1' is already exists, which should also be deleted
-          val delHivePartPathAfterRename = ExternalCatalogUtils.getUselessHivePartPathAfterRename(
+          val delHivePartPathAfterRename = ExternalCatalogUtils.getExtraPartPathCreatedByHive(
             lowerCasePartitionSpec(spec),
             partitionColumnNames,
             tablePath)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
@@ -267,7 +267,7 @@ class PartitionProviderCompatibilitySuite
           // rename partition sanity check
           spark.sql(s"""
             |alter table test partition (A=5, B='%')
-            |rename to partition (a=100, b='%')""".stripMargin)
+            |rename to partition (A=100, B='%')""".stripMargin)
           assert(spark.sql("select * from test where a = 5 and b = '%'").count() == 0)
           assert(spark.sql("select * from test where a = 100 and b = '%'").count() == 1)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
@@ -486,14 +486,34 @@ class PartitionProviderCompatibilitySuite
   }
 
   test("partition path created by Hive should be deleted after renamePartitions with upper-case") {
-    withTable("t") {
+    withTable("t", "t1", "t2") {
       Seq((1, 2, 3)).toDF("id", "A", "B").write.partitionBy("A", "B").saveAsTable("t")
       spark.sql("alter table t partition(A=2, B=3) rename to partition(A=4, B=5)")
 
-      val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))
-      val uselessHivePath = new Path(table.location + "/a=4")
-      assert(!uselessHivePath.getFileSystem(spark.sessionState.newHadoopConf())
-        .exists(uselessHivePath), "partition path created by Hive should be deleted " +
+      var table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))
+      var extraHivePath = new Path(table.location + "/a=4")
+      assert(!extraHivePath.getFileSystem(spark.sessionState.newHadoopConf())
+        .exists(extraHivePath), "partition path created by Hive should be deleted " +
+        "after renamePartitions with upper-case")
+
+      Seq((1, 2, 3, 4)).toDF("id", "A", "B", "C").write.partitionBy("A", "B", "C").saveAsTable("t1")
+      spark.sql("alter table t1 partition(A=2, B=3, C=4) rename to partition(A=5, B=6, C=7)")
+      table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t1"))
+      extraHivePath = new Path(table.location + "/a=5")
+      assert(!extraHivePath.getFileSystem(spark.sessionState.newHadoopConf())
+        .exists(extraHivePath), "partition path created by Hive should be deleted " +
+        "after renamePartitions with upper-case")
+
+      Seq((1, 2, 3, 4)).toDF("id", "a", "B", "C").write.partitionBy("a", "B", "C").saveAsTable("t2")
+      spark.sql("alter table t2 partition(a=2, B=3, C=4) rename to partition(a=4, B=5, C=6)")
+      table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t2"))
+      val partPath = new Path(table.location + "/a=4")
+      assert(partPath.getFileSystem(spark.sessionState.newHadoopConf())
+        .exists(partPath), "partition path of lower-case partition name should not be deleted")
+
+      extraHivePath = new Path(table.location + "/a=4/b=5")
+      assert(!extraHivePath.getFileSystem(spark.sessionState.newHadoopConf())
+        .exists(extraHivePath), "partition path created by Hive should be deleted " +
         "after renamePartitions with upper-case")
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
@@ -488,7 +488,7 @@ class PartitionProviderCompatibilitySuite
   test("partition path created by Hive should be deleted after renamePartitions with upper-case") {
     withTable("t") {
       Seq((1, 2, 3)).toDF("id", "A", "B").write.partitionBy("A", "B").saveAsTable("t")
-      spark.sql("alter table t partition(a=2, B=3) rename to partition(a=4, B=5)")
+      spark.sql("alter table t partition(A=2, B=3) rename to partition(A=4, B=5)")
 
       val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))
       val uselessHivePath = new Path(table.location + "/a=4")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive metastore is not case preserving and keep partition columns with lower case names. 

If SparkSQL create a table with upper-case partion name use HiveExternalCatalog, when we rename partition, it first call the HiveClient to renamePartition, which will create a new lower case partition path, then SparkSql rename the lower case path to the upper-case.

while if the renamed partition contains more than one depth partition ,e.g. A=1/B=2, hive renamePartition change to a=1/b=2, then SparkSql rename it to A=1/B=2, but the a=1 still exists in the filesystem, we should also delete it.

## How was this patch tested?
unit test added
