### PR TITLE
[SPARK-19354] [Core] Killed tasks are getting marked as FAILED

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -316,6 +316,12 @@ private[spark] class Executor(
             metricsSystem = env.metricsSystem)
           threwException = false
           res
+        } catch {
+          case t: Throwable =>
+            if (!task.killed) {
+              throw t
+            }
+            logWarning(s"Exception occured in $taskName (TID $taskId) during kill.", t)
         } finally {
           val releasedLocks = env.blockManager.releaseAllLocksForTask(taskId)
           val freedMemory = taskMemoryManager.cleanUpAllAllocatedMemory()

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -113,12 +113,14 @@ private[spark] abstract class Task[T](
       runTask(context)
     } catch {
       case e: Throwable =>
-        // Catch all errors; run task failure callbacks, and rethrow the exception.
-        try {
-          context.markTaskFailed(e)
-        } catch {
-          case t: Throwable =>
-            e.addSuppressed(t)
+        if (!_killed) {
+          // Catch all errors; run task failure callbacks, and rethrow the exception.
+          try {
+            context.markTaskFailed(e)
+          } catch {
+            case t: Throwable =>
+              e.addSuppressed(t)
+          }
         }
         throw e
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handling the exception which occurs during the kill and logging it instead of re-throwing the exception which causes to mark the task as FAILED.

## How was this patch tested?

I verified this manually by running multiple applications, with the patch changes when any exception occurs during kill, it logs the exception and continues with the kill process. It shows/considers the task as KILLED in Web UI sections of 'Details for Job' and 'Aggregated Metrics by Executor'.

