### PR TITLE
[SPARK-19366][SQL] add getNumPartitions to Dataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2425,7 +2425,7 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 2.2.0
    */
-  def getNumPartitions: Int = rdd.getNumPartitions()
+  def getNumPartitions: Int = rdd.getNumPartitions
 
   /**
    * Returns a new Dataset that has exactly `numPartitions` partitions.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2421,6 +2421,13 @@ class Dataset[T] private[sql](
   }
 
   /**
+   * Returns the number of partitions of this Dataset.
+   * @group basic
+   * @since 2.2.0
+   */
+  def getNumPartitions: Int = rdd.getNumPartitions()
+
+  /**
    * Returns a new Dataset that has exactly `numPartitions` partitions.
    * Similar to coalesce defined on an `RDD`, this operation results in a narrow dependency, e.g.
    * if you go from 1000 partitions to 100 partitions, there will not be a shuffle, instead each of

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -269,6 +269,9 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       testData.select('key).repartition(10).select('key),
       testData.select('key).collect().toSeq)
+    checkAnswer(
+      testData.select('key).repartition(10).select('key).getNumPartitions(),
+      10)
   }
 
   test("coalesce") {
@@ -1301,12 +1304,14 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   test("distributeBy and localSort") {
     val original = testData.repartition(1)
     assert(original.rdd.partitions.length == 1)
+    assert(original.getNumPartitions() == 1)
     val df = original.repartition(5, $"key")
     assert(df.rdd.partitions.length == 5)
+    assert(df.getNumPartitions() == 5)
     checkAnswer(original.select(), df.select())
 
     val df2 = original.repartition(10, $"key")
-    assert(df2.rdd.partitions.length == 10)
+    assert(df2.getNumPartitions() == 10)
     checkAnswer(original.select(), df2.select())
 
     // Group by the column we are distributed by. This should generate a plan with no exchange

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -269,9 +269,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       testData.select('key).repartition(10).select('key),
       testData.select('key).collect().toSeq)
-    checkAnswer(
-      testData.select('key).repartition(10).select('key).getNumPartitions(),
-      10)
+    assert(testData.select('key).repartition(10).select('key).getNumPartitions == 10)
   }
 
   test("coalesce") {
@@ -1304,14 +1302,14 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   test("distributeBy and localSort") {
     val original = testData.repartition(1)
     assert(original.rdd.partitions.length == 1)
-    assert(original.getNumPartitions() == 1)
+    assert(original.getNumPartitions == 1)
     val df = original.repartition(5, $"key")
     assert(df.rdd.partitions.length == 5)
-    assert(df.getNumPartitions() == 5)
+    assert(df.getNumPartitions == 5)
     checkAnswer(original.select(), df.select())
 
     val df2 = original.repartition(10, $"key")
-    assert(df2.getNumPartitions() == 10)
+    assert(df2.getNumPartitions == 10)
     checkAnswer(original.select(), df2.select())
 
     // Group by the column we are distributed by. This should generate a plan with no exchange


### PR DESCRIPTION
## What changes were proposed in this pull request?

As suggested by @cloud-fan [here](https://github.com/apache/spark/pull/16668#discussion_r97254989), adding a simple wrapper in Scala can help avoid inefficiency with non-JVM cases

## How was this patch tested?

unit tests
