### PR TITLE
[SPARK-19385][SQL] During canonicalization, `NOT(...(l, r))` should not expect such cases that l.hashcode > r.hashcode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
@@ -78,18 +78,12 @@ object Canonicalize extends {
     case GreaterThanOrEqual(l, r) if l.hashCode() > r.hashCode() => LessThanOrEqual(r, l)
     case LessThanOrEqual(l, r) if l.hashCode() > r.hashCode() => GreaterThanOrEqual(r, l)
 
-    case Not(GreaterThan(l, r)) =>
-      assert(l.hashCode() <= r.hashCode())
-      LessThanOrEqual(l, r)
-    case Not(LessThan(l, r)) =>
-      assert(l.hashCode() <= r.hashCode())
-      GreaterThanOrEqual(l, r)
-    case Not(GreaterThanOrEqual(l, r)) =>
-      assert(l.hashCode() <= r.hashCode())
-      LessThan(l, r)
-    case Not(LessThanOrEqual(l, r)) =>
-      assert(l.hashCode() <= r.hashCode())
-      GreaterThan(l, r)
+    // Note in the following `NOT` cases, `l.hashCode() <= r.hashCode()` holds. The reason is that
+    // canonicalization is conducted bottom-up -- see [[Expression.canonicalized]].
+    case Not(GreaterThan(l, r)) => LessThanOrEqual(l, r)
+    case Not(LessThan(l, r)) => GreaterThanOrEqual(l, r)
+    case Not(GreaterThanOrEqual(l, r)) => LessThan(l, r)
+    case Not(LessThanOrEqual(l, r)) => GreaterThan(l, r)
 
     case _ => e
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -39,14 +39,14 @@ class ExpressionSetSuite extends SparkFunSuite {
       AttributeReference("maxHash", IntegerType)(exprId =
         new ExprId(4, NamedExpression.jvmId) {
           // maxHash's hashcode is calculated based on this exprId's hashcode, so we set this
-          // exprId's hashCode to this specific value to make sure maxHash's hashcode is almost
+          // exprId's hashCode to this specific value to make sure maxHash's hashcode is
           // `Int.MaxValue`
-          override def hashCode: Int = 826929706
+          override def hashCode: Int = -1030353449
           // We are implementing this equals() only because the style-checking rule "you should
           // implement equals and hashCode together" requires us to
           override def equals(obj: Any): Boolean = super.equals(obj)
         })).asInstanceOf[AttributeReference]
-  assert(maxHash.hashCode() == Int.MaxValue - 1)
+  assert(maxHash.hashCode() == Int.MaxValue)
 
   // An [AttributeReference] with almost the minimum hashcode, to make testing canonicalize rules
   // like `case GreaterThan(l, r) if l.hashcode > r.hashcode => GreaterThan(r, l)` easier
@@ -55,14 +55,14 @@ class ExpressionSetSuite extends SparkFunSuite {
       AttributeReference("minHash", IntegerType)(exprId =
         new ExprId(5, NamedExpression.jvmId) {
           // minHash's hashcode is calculated based on this exprId's hashcode, so we set this
-          // exprId's hashCode to this specific value to make sure minHash's hashcode is almost
+          // exprId's hashCode to this specific value to make sure minHash's hashcode is
           // `Int.MinValue`
-          override def hashCode: Int = 826929707
+          override def hashCode: Int = 1407330692
           // We are implementing this equals() only because the style-checking rule "you should
           // implement equals and hashCode together" requires us to
           override def equals(obj: Any): Boolean = super.equals(obj)
         })).asInstanceOf[AttributeReference]
-  assert(minHash.hashCode() == Int.MinValue + 35)
+  assert(minHash.hashCode() == Int.MinValue)
 
   def setTest(size: Int, exprs: Expression*): Unit = {
     test(s"expect $size: ${exprs.mkString(", ")}") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -42,6 +42,9 @@ class ExpressionSetSuite extends SparkFunSuite {
           // exprId's hashCode to this specific value to make sure maxHash's hashcode is almost
           // `Int.MaxValue`
           override def hashCode: Int = 826929706
+          // We are implementing this equals() only because the style-checking rule "you should
+          // implement equals and hashCode together" requires us to
+          override def equals(obj: Any): Boolean = super.equals(obj)
         })).asInstanceOf[AttributeReference]
   assert(maxHash.hashCode() == Int.MaxValue - 1)
 
@@ -55,6 +58,9 @@ class ExpressionSetSuite extends SparkFunSuite {
           // exprId's hashCode to this specific value to make sure minHash's hashcode is almost
           // `Int.MinValue`
           override def hashCode: Int = 826929707
+          // We are implementing this equals() only because the style-checking rule "you should
+          // implement equals and hashCode together" requires us to
+          override def equals(obj: Any): Boolean = super.equals(obj)
         })).asInstanceOf[AttributeReference]
   assert(minHash.hashCode() == Int.MinValue + 35)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During canonicalization, `NOT(...(l, r))` should not expect such cases that `l.hashcode > r.hashcode`.

Take the rule `case NOT(GreaterThan(l, r)) if l.hashcode > r.hashcode` for example, it should never be matched since `GreaterThan(l, r)` itself would be re-written as `GreaterThan(r, l)` given `l.hashcode > r.hashcode` after canonicalization.

This patch consolidates rules like `case NOT(GreaterThan(l, r)) if l.hashcode > r.hashcode` and `case NOT(GreaterThan(l, r))`.

## How was this patch tested?

This patch expanded the `NOT` test case to cover both cases where:
- `l.hashcode > r.hashcode`
- `l.hashcode < r.hashcode`