### PR TITLE
[SPARK-19390][SQL] Replace the unnecessary usages of hiveQlTable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -195,6 +195,9 @@ case class CatalogTable(
     StructType(partitionFields)
   }
 
+  /** Returns whether the table is partitioned. */
+  def isPartitioned: Boolean = partitionColumnNames.nonEmpty
+
   /**
    * schema of this table's data columns
    */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -51,7 +51,7 @@ case class HiveTableScanExec(
     @transient private val sparkSession: SparkSession)
   extends LeafExecNode {
 
-  require(partitionPruningPred.isEmpty || relation.hiveQlTable.isPartitioned,
+  require(partitionPruningPred.isEmpty || relation.catalogTable.isPartitioned,
     "Partition pruning predicates only supported for partitioned tables.")
 
   override lazy val metrics = Map(
@@ -141,9 +141,9 @@ case class HiveTableScanExec(
   protected override def doExecute(): RDD[InternalRow] = {
     // Using dummyCallSite, as getCallSite can turn out to be expensive with
     // with multiple partitions.
-    val rdd = if (!relation.hiveQlTable.isPartitioned) {
+    val rdd = if (!relation.catalogTable.isPartitioned) {
       Utils.withDummyCallSite(sqlContext.sparkContext) {
-        hadoopReader.makeRDDForTable(relation.hiveQlTable)
+        hadoopReader.makeRDDForTable(relation.catalogTable)
       }
     } else {
       // The attribute name of predicate could be different than the one in schema in case of

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -221,7 +221,7 @@ case class InsertIntoHiveTable(
     // Have to pass the TableDesc object to RDD.mapPartitions and then instantiate new serializer
     // instances within the closure, since Serializer is not serializable while TableDesc is.
     val tableDesc = table.tableDesc
-    val tableLocation = table.hiveQlTable.getDataLocation
+    val tableLocation = new Path(table.catalogTable.location)
     val tmpLocation =
       getExternalTmpPath(tableLocation, hiveVersion, hadoopConf, stagingDir, scratchDir)
     val fileSinkConf = new FileSinkDesc(tmpLocation.toString, tableDesc, false)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
@@ -144,38 +144,4 @@ class HiveTableScanSuite extends HiveComparisonTest with SQLTestUtils with TestH
       }
     }
   }
-
-  test("SPARK-16926: number of table and partition columns match for new partitioned table") {
-    val view = "src"
-    withTempView(view) {
-      spark.range(1, 5).createOrReplaceTempView(view)
-      val table = "table_with_partition"
-      withTable(table) {
-        sql(
-          s"""
-             |CREATE TABLE $table(id string)
-             |PARTITIONED BY (p1 string,p2 string,p3 string,p4 string,p5 string)
-           """.stripMargin)
-        sql(
-          s"""
-             |FROM $view v
-             |INSERT INTO TABLE $table
-             |PARTITION (p1='a',p2='b',p3='c',p4='d',p5='e')
-             |SELECT v.id
-             |INSERT INTO TABLE $table
-             |PARTITION (p1='a',p2='c',p3='c',p4='d',p5='e')
-             |SELECT v.id
-           """.stripMargin)
-        val plan = sql(
-          s"""
-             |SELECT * FROM $table
-           """.stripMargin).queryExecution.sparkPlan
-        val relation = plan.collectFirst {
-          case p: HiveTableScanExec => p.relation
-        }.get
-        val tableCols = relation.hiveQlTable.getCols
-        relation.getHiveQlPartitions().foreach(p => assert(p.getCols.size == tableCols.size))
-      }
-    }
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`catalogTable` is the native table metadata structure for Spark SQL. Thus, we should avoid using Hive's table metadata structure `Table` in our code base. This PR is to replace it. 

### How was this patch tested?
The existing test cases.