### PR TITLE
[SPARK-19421][ML][PySpark] Remove numClasses and numFeatures methods in LinearSVC

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -171,22 +171,6 @@ class LinearSVCModel(JavaModel, JavaClassificationModel, JavaMLWritable, JavaMLR
         """
         return self._call_java("intercept")
 
-    @property
-    @since("2.2.0")
-    def numClasses(self):
-        """
-        Number of classes.
-        """
-        return self._call_java("numClasses")
-
-    @property
-    @since("2.2.0")
-    def numFeatures(self):
-        """
-        Number of features.
-        """
-        return self._call_java("numFeatures")
-
 
 @inherit_doc
 class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasMaxIter,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Methods `numClasses` and `numFeatures` in LinearSVCModel are already usable by inheriting `JavaClassificationModel`
we should not explicitly add them.

## How was this patch tested?
existing tests