### PR TITLE
[SPARK-19393][SQL] Add `approx_percentile` Dataset/DataFrame API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -617,6 +617,193 @@ object functions {
   def min(columnName: String): Column = min(Column(columnName))
 
   /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentiles of a column at the given
+   * percentages. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param col numeric column to compute approximate percentile values on
+   * @param percentages an array of double values representing the percentages requested; each
+   *                    percentage value must be between 0.0 and 1.0
+   * @param accuracy approximation accuracy at the cost of memory; higher value yields better
+   *                 accuracy, the default value is DEFAULT_PERCENTILE_ACCURACY
+   *
+   * @return the approximate percentile array of column `col` at the given percentage array
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(col: Column, percentages: Array[Double], accuracy: Int): Column =
+    withAggregateFunction {
+      new ApproximatePercentile(
+        col.expr, CreateArray(percentages.map(Literal(_))), Literal(accuracy))
+    }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentiles of a column at the given
+   * percentages. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param columnName numeric column to compute approximate percentile values on
+   * @param percentages an array of double values representing the percentages requested; each
+   *                    percentage value must be between 0.0 and 1.0
+   * @param accuracy approximation accuracy at the cost of memory; higher value yields better
+   *                 accuracy, the default value is DEFAULT_PERCENTILE_ACCURACY
+   *
+   * @return the approximate percentile array of column `col` at the given percentage array
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(columnName: String, percentages: Array[Double], accuracy: Int): Column = {
+    approx_percentile(Column(columnName), percentages, accuracy)
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentiles of a column at the given
+   * percentages. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param col numeric column to compute approximate percentile values on
+   * @param percentages an array of double values representing the percentages requested; each
+   *                    percentage value must be between 0.0 and 1.0
+   *
+   * @return the approximate percentile array of column `col` at the given percentage array
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(col: Column, percentages: Array[Double]): Column = withAggregateFunction {
+    new ApproximatePercentile(col.expr, CreateArray(percentages.map(v => Literal(v))))
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentiles of a column at the given
+   * percentages. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param columnName numeric column to compute approximate percentile values on
+   * @param percentages an array of double values representing the percentages requested; each
+   *                    percentage value must be between 0.0 and 1.0
+   *
+   * @return the approximate percentile array of column `col` at the given percentage array
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(columnName: String, percentages: Array[Double]): Column = {
+    approx_percentile(Column(columnName), percentages)
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentile of a column at the given
+   * percentage. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param col numeric column to compute approximate percentile value on
+   * @param percentage a double value representing the percentage requested; the percentage value
+   *                   must be between 0.0 and 1.0
+   * @param accuracy approximation accuracy at the cost of memory; higher value yields better
+   *                 accuracy, the default value is DEFAULT_PERCENTILE_ACCURACY
+   *
+   * @return the approximate percentile of column `col` at the given percentage
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(col: Column, percentage: Double, accuracy: Int): Column =
+    withAggregateFunction {
+      new ApproximatePercentile(col.expr, Literal(percentage), Literal(accuracy))
+    }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentile of a column at the given
+   * percentage. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param columnName numeric column to compute approximate percentile value on
+   * @param percentage a double value representing the percentage requested; the percentage value
+   *                   must be between 0.0 and 1.0
+   * @param accuracy approximation accuracy at the cost of memory; higher value yields better
+   *                 accuracy, the default value is DEFAULT_PERCENTILE_ACCURACY
+   *
+   * @return the approximate percentile of column `col` at the given percentage
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(columnName: String, percentage: Double, accuracy: Int): Column = {
+    approx_percentile(Column(columnName), percentage, accuracy)
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentile of a column at the given
+   * percentage. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param col numeric column to compute approximate percentile value on
+   * @param percentage a double value representing the percentage requested; the percentage value
+   *                   must be between 0.0 and 1.0
+   *
+   * @return the approximate percentile of column `col` at the given percentage
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(col: Column, percentage: Double): Column = withAggregateFunction {
+    new ApproximatePercentile(col.expr, Literal(percentage))
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Aggregate function: returns the approximate percentile of a column at the given
+   * percentage. A percentile is a watermark value below which a given percentage of the column
+   * values fall. For example, the percentile of column `col` at percentage 50% is the median of
+   * column `col`.
+   *
+   * @param columnName numeric column to compute approximate percentile value on
+   * @param percentage a double value representing the percentage requested; the percentage value
+   *                   must be between 0.0 and 1.0
+   *
+   * @return the approximate percentile of column `col` at the given percentage
+   *
+   * @group agg_funcs
+   * @since 2.2.0
+   */
+  @Experimental
+  def approx_percentile(columnName: String, percentage: Double): Column = {
+    approx_percentile(Column(columnName), percentage)
+  }
+
+  /**
    * Aggregate function: returns the skewness of the values in a group.
    *
    * @group agg_funcs

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -636,6 +636,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(col: Column, percentages: Array[Double], accuracy: Int): Column =
     withAggregateFunction {
       new ApproximatePercentile(
@@ -662,6 +663,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(columnName: String, percentages: Array[Double], accuracy: Int): Column = {
     approx_percentile(Column(columnName), percentages, accuracy)
   }
@@ -684,6 +686,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(col: Column, percentages: Array[Double]): Column = withAggregateFunction {
     new ApproximatePercentile(col.expr, CreateArray(percentages.map(v => Literal(v))))
   }
@@ -706,6 +709,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(columnName: String, percentages: Array[Double]): Column = {
     approx_percentile(Column(columnName), percentages)
   }
@@ -730,6 +734,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(col: Column, percentage: Double, accuracy: Int): Column =
     withAggregateFunction {
       new ApproximatePercentile(col.expr, Literal(percentage), Literal(accuracy))
@@ -755,6 +760,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(columnName: String, percentage: Double, accuracy: Int): Column = {
     approx_percentile(Column(columnName), percentage, accuracy)
   }
@@ -777,6 +783,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(col: Column, percentage: Double): Column = withAggregateFunction {
     new ApproximatePercentile(col.expr, Literal(percentage))
   }
@@ -799,6 +806,7 @@ object functions {
    * @since 2.2.0
    */
   @Experimental
+  @InterfaceStability.Evolving
   def approx_percentile(columnName: String, percentage: Double): Column = {
     approx_percentile(Column(columnName), percentage)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds `approx_percentile` API to Dataset/DataFrame. SQL equivalent: [FunctionRegistry.scala#L257-L258](https://github.com/apache/spark/blob/e7f982b20d8a1c0db711e0dcfe26b2f39f98dd64/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala#L257-L258).

Then people could migrate from [StatFunctions#multipleApproxQuantiles()](https://github.com/apache/spark/blob/51b1c1551d3a7147403b9e821fcc7c8f57b4824c/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala#L58) to this newly added api, as there were issues reported with StatFunctions#multipleApproxQuantiles():
- [SPARK-18656] StatFunctions#multipleApproxQuantiles requires too much memory in case of many columns
- [SPARK-19339] StatFunctions.multipleApproxQuantiles can give NoSuchElementException: next on empty iterator

## How was this patch tested?

New test cases
