### PR TITLE
[SPARK-19368][MLlib] BlockMatrix.toIndexedRowMatrix() optimization for sparse matrices

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -17,15 +17,16 @@
 
 package org.apache.spark.mllib.linalg.distributed
 
-import breeze.linalg.{VectorBuilder, DenseMatrix => BDM, DenseVector => BDV, Matrix => BM, SparseVector => BSV, Vector => BV}
+import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV, Matrix => BM}
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{Partitioner, SparkException}
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.{Partitioner, SparkException}
 
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * A grid partitioner, which uses a regular grid to partition coordinates.

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -276,7 +276,7 @@ class BlockMatrix @Since("1.3.0") (
       mat.rowIter.zipWithIndex.filter(_._1.size > 0).map {
         case (vector, rowIdx) =>
           blockRowIdx * rowsPerBlock + rowIdx -> ((blockColIdx, vector))
-      }.filter(_._2._2.size > 0)
+      }
     }.groupByKey().map { case (rowIdx, vectors) =>
       val numberNonZero = vectors.map(_._2.numActives).sum
       val numberNonZeroPerRow = numberNonZero.toDouble / cols.toDouble

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -281,7 +281,7 @@ class BlockMatrix @Since("1.3.0") (
 
       val wholeVector =
         if (numberNonZeroPerRow <= 0.1) { // Sparse at 1/10th nnz
-        val wholeVectorBuf = VectorBuilder.zeros[Double](cols)
+          val wholeVectorBuf = VectorBuilder.zeros[Double](cols)
           vectors.foreach { case (blockColIdx: Int, vec: BV[Double]) =>
             val offset = colsPerBlock * blockColIdx
             vec.activeIterator.foreach {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimization [SPARK-12869] was made for dense matrices but caused great performance issue for sparse matrices because manipulating them is very inefficient. When manipulating sparse matrices in Breeze we better use VectorBuilder.

## How was this patch tested?

checked it against a use case that we have that after moving to Spark 2 took 6.5 hours instead of 20 mins. After the change it is back to 20 mins again.

