### PR TITLE
[SPARK-19392][SQL] Fix the bug that throws an exception when using numeric types in Oracle JDBC

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -95,7 +95,8 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
       StructField("string_type", StringType, true),
       StructField("binary_type", BinaryType, true),
       StructField("date_type", DateType, true),
-      StructField("timestamp_type", TimestampType, true)
+      StructField("timestamp_type", TimestampType, true),
+      StructField("decimal_type", DecimalType(31, 20), true)
     ))
 
     val tableName = "test_oracle_general_types"
@@ -110,11 +111,12 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
     val binaryVal = Array[Byte](6, 7, 8)
     val dateVal = Date.valueOf("2016-07-26")
     val timestampVal = Timestamp.valueOf("2016-07-26 11:49:45")
+    val decimalVal = new java.math.BigDecimal("123456745.56789012345000000000")
 
     val data = spark.sparkContext.parallelize(Seq(
       Row(
         booleanVal, integerVal, longVal, floatVal, doubleVal, byteVal, shortVal, stringVal,
-        binaryVal, dateVal, timestampVal
+        binaryVal, dateVal, timestampVal, decimalVal
       )))
 
     val dfWrite = spark.createDataFrame(data, schema)
@@ -135,6 +137,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
     assert(types(8).equals("class [B"))
     assert(types(9).equals("class java.sql.Date"))
     assert(types(10).equals("class java.sql.Timestamp"))
+    assert(types(11).equals("class java.math.BigDecimal"))
     // verify the value is the inserted correct or not
     val values = rows(0)
     assert(values.getBoolean(0).equals(booleanVal))
@@ -148,5 +151,6 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
     assert(values.getAs[Array[Byte]](8).mkString.equals("678"))
     assert(values.getDate(9).equals(dateVal))
     assert(values.getTimestamp(10).equals(timestampVal))
+    assert(values.getDecimal(11).equals(decimalVal))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -29,7 +29,12 @@ private case object OracleDialect extends JdbcDialect {
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
     if (sqlType == Types.NUMERIC) {
-      val scale = if (null != md) md.build().getLong("scale") else 0L
+      val scale = if (null != md) {
+        val metadata = md.build()
+        if (metadata.contains("scale")) metadata.getLong("scale") else 0L
+      } else {
+        0L
+      }
       size match {
         // Handle NUMBER fields that have no precision/scale in special way
         // because JDBC ResultSetMetaData converts this to 0 precision and -127 scale

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -726,10 +726,13 @@ class JDBCSuite extends SparkFunSuite
 
   test("OracleDialect jdbc type mapping") {
     val oracleDialect = JdbcDialects.get("jdbc:oracle")
-    val metadata = new MetadataBuilder().putString("name", "test_column").putLong("scale", -127)
-    assert(oracleDialect.getCatalystType(java.sql.Types.NUMERIC, "float", 1, metadata) ==
-      Some(DecimalType(DecimalType.MAX_PRECISION, 10)))
     assert(oracleDialect.getCatalystType(java.sql.Types.NUMERIC, "numeric", 0, null) ==
+      Some(DecimalType(DecimalType.MAX_PRECISION, 10)))
+    val metadata1 = new MetadataBuilder()
+    assert(oracleDialect.getCatalystType(java.sql.Types.NUMERIC, "numeric", 0, metadata1) ==
+      Some(DecimalType(DecimalType.MAX_PRECISION, 10)))
+    val metadata2 = new MetadataBuilder().putString("name", "test_column").putLong("scale", -127)
+    assert(oracleDialect.getCatalystType(java.sql.Types.NUMERIC, "float", 1, metadata2) ==
       Some(DecimalType(DecimalType.MAX_PRECISION, 10)))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In OracleDialect, if you use Numeric types in Oracle JDBC, this throws an exception below;
```
  java.util.NoSuchElementException: key not found: scale  at scala.collection.MapLike$class.default(MapLike.scala:228)
  at scala.collection.AbstractMap.default(Map.scala:59)  at scala.collection.MapLike$class.apply(MapLike.scala:141)
```
This ticket comes from https://www.mail-archive.com/user@spark.apache.org/msg61280.html.

## How was this patch tested?
Added a test in `JDBCSuite`.
