### PR TITLE
[SPARK-19400][ML] Allow GLM to handle intercept only model

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
@@ -86,9 +86,13 @@ private[ml] class IterativelyReweightedLeastSquares(
         standardizeFeatures = false, standardizeLabel = false).fit(newInstances)
 
       // Check convergence
-      val oldCoefficients = oldModel.coefficients.toArray :+ oldModel.intercept
-      val coefficients = model.coefficients.toArray :+ model.intercept
-      val maxTol = oldCoefficients.zip(coefficients).map(x => math.abs(x._1 - x._2)).max
+      val oldCoefficients = oldModel.coefficients
+      val coefficients = model.coefficients
+      BLAS.axpy(-1.0, coefficients, oldCoefficients)
+      val maxTolOfCoefficients = oldCoefficients.toArray.foldLeft(0.0) { (x, y) =>
+        math.max(math.abs(x), math.abs(y))
+      }
+      val maxTol = math.max(maxTolOfCoefficients, math.abs(oldModel.intercept - model.intercept))
 
       if (maxTol < tol) {
         converged = true

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
@@ -86,13 +86,11 @@ private[ml] class IterativelyReweightedLeastSquares(
         standardizeFeatures = false, standardizeLabel = false).fit(newInstances)
 
       // Check convergence
-      val oldCoefficients = oldModel.coefficients
-      val coefficients = model.coefficients
-      BLAS.axpy(-1.0, coefficients, oldCoefficients)
-      val maxTolOfCoefficients = oldCoefficients.toArray.reduce { (x, y) =>
-        math.max(math.abs(x), math.abs(y))
+      val oldCoefficients = oldModel.coefficients.toArray :+ oldModel.intercept
+      val coefficients = model.coefficients.toArray :+ model.intercept
+      val maxTol = oldCoefficients.zip(coefficients).map(x => x._1 - x._2).reduce {
+        (x, y) => math.max(math.abs(x), math.abs(y))
       }
-      val maxTol = math.max(maxTolOfCoefficients, math.abs(oldModel.intercept - model.intercept))
 
       if (maxTol < tol) {
         converged = true

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/IterativelyReweightedLeastSquares.scala
@@ -88,9 +88,7 @@ private[ml] class IterativelyReweightedLeastSquares(
       // Check convergence
       val oldCoefficients = oldModel.coefficients.toArray :+ oldModel.intercept
       val coefficients = model.coefficients.toArray :+ model.intercept
-      val maxTol = oldCoefficients.zip(coefficients).map(x => x._1 - x._2).reduce {
-        (x, y) => math.max(math.abs(x), math.abs(y))
-      }
+      val maxTol = oldCoefficients.zip(coefficients).map(x => math.abs(x._1 - x._2)).max
 
       if (maxTol < tol) {
         converged = true

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -336,7 +336,8 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
     }
 
     require(numFeatures > 0 || $(fitIntercept),
-      "Specified model is empty with neither intercept nor feature.")
+      "GeneralizedLinearRegression was given data with 0 features, and with Param fitIntercept " +
+        "set to false. To fit a model with 0 features, fitIntercept must be set to true." )
 
     val w = if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol))
     val instances: RDD[Instance] =

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -335,10 +335,8 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
       throw new SparkException(msg)
     }
 
-    if (numFeatures == 0 && !$(fitIntercept)) {
-      val msg = "Specified model is empty with neither intercept nor feature."
-      throw new SparkException(msg)
-    }
+    require(numFeatures > 0 || $(fitIntercept),
+      "Specified model is empty with neither intercept nor feature.")
 
     val w = if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol))
     val instances: RDD[Instance] =

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -335,6 +335,11 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
       throw new SparkException(msg)
     }
 
+    if (numFeatures == 0 && !$(fitIntercept)) {
+      val msg = "Specified model is empty with neither intercept nor feature."
+      throw new SparkException(msg)
+    }
+
     val w = if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol))
     val instances: RDD[Instance] =
       dataset.select(col($(labelCol)), w, col($(featuresCol))).rdd.map {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -774,6 +774,7 @@ class GeneralizedLinearRegressionSuite
       val actual = model.intercept
       assert(actual ~== expected(idx) absTol 1E-3, "Model mismatch: intercept only GLM with " +
         s"useWeight = $useWeight.")
+      assert(model.coefficients === new DenseVector(Array.empty[Double]))
 
       val familyLink = FamilyAndLink(trainer)
       model.transform(dataset).select("features", "prediction", "linkPrediction").collect()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.ml.regression
 
 import scala.util.Random
 
+import org.apache.spark.SparkException
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.classification.LogisticRegressionSuite._
 import org.apache.spark.ml.feature.Instance
@@ -768,7 +769,6 @@ class GeneralizedLinearRegressionSuite
     var idx = 0
     for (useWeight <- Seq(false, true)) {
       val trainer = new GeneralizedLinearRegression().setFamily("poisson")
-        .setLinkPredictionCol("linkPrediction")
       if (useWeight) trainer.setWeightCol("weight")
       val model = trainer.fit(dataset)
       val actual = model.intercept
@@ -777,6 +777,12 @@ class GeneralizedLinearRegressionSuite
       assert(model.coefficients === new DenseVector(Array.empty[Double]))
 
       idx += 1
+    }
+
+    // throw exception for empty model
+    val trainer = new GeneralizedLinearRegression().setFitIntercept(false)
+    intercept[SparkException] {
+      trainer.fit(dataset)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -781,8 +781,10 @@ class GeneralizedLinearRegressionSuite
 
     // throw exception for empty model
     val trainer = new GeneralizedLinearRegression().setFitIntercept(false)
-    intercept[SparkException] {
-      trainer.fit(dataset)
+    withClue("Specified model is empty with neither intercept nor feature") {
+      intercept[SparkException] {
+        trainer.fit(dataset)
+      }
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -776,18 +776,6 @@ class GeneralizedLinearRegressionSuite
         s"useWeight = $useWeight.")
       assert(model.coefficients === new DenseVector(Array.empty[Double]))
 
-      val familyLink = FamilyAndLink(trainer)
-      model.transform(dataset).select("features", "prediction", "linkPrediction").collect()
-        .foreach {
-          case Row(features: DenseVector, prediction1: Double, linkPrediction1: Double) =>
-            val eta = BLAS.dot(features, model.coefficients) + model.intercept
-            val prediction2 = familyLink.fitted(eta)
-            val linkPrediction2 = eta
-            assert(prediction1 ~== prediction2 relTol 1E-5, "Prediction mismatch: intercept only " +
-              s"GLM with useWeight = $useWeight.")
-            assert(linkPrediction1 ~== linkPrediction2 relTol 1E-5, "Link prediction mismatch: " +
-              s"intercept only GLM with useWeight = $useWeight.")
-        }
       idx += 1
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Intercept-only GLM is failing for non-Gaussian family because of reducing an empty array in IWLS. The following code `val maxTolOfCoefficients = oldCoefficients.toArray.reduce { (x, y) => math.max(math.abs(x), math.abs(y))` fails in the intercept-only model because `oldCoefficients` is empty. This PR fixes this issue. 

@yanboliang @srowen @imatiach-msft @zhengruifeng 

## How was this patch tested?
New test for intercept only model.
