### PR TITLE
[SPARK-14772][PYTHON][ML] Fixed Params.copy method to match Scala implementation

### DIFF
--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -385,6 +385,7 @@ class Params(Identifiable):
             extra = dict()
         that = copy.copy(self)
         that._paramMap = {}
+        that._defaultParamMap = {}
         return self._copyValues(that, extra)
 
     def _shouldOwn(self, param):
@@ -465,12 +466,16 @@ class Params(Identifiable):
         :param extra: extra params to be copied
         :return: the target instance with param values copied
         """
-        if extra is None:
-            extra = dict()
-        paramMap = self.extractParamMap(extra)
-        for p in self.params:
-            if p in paramMap and to.hasParam(p.name):
-                to._set(**{p.name: paramMap[p]})
+        paramMap = self._paramMap.copy()
+        if extra is not None:
+            paramMap.update(extra)
+        for param in self.params:
+            # copy default params
+            if param in self._defaultParamMap and to.hasParam(param.name):
+                to._defaultParamMap[to.getParam(param.name)] = self._defaultParamMap[param]
+            # copy explicitly set params
+            if param in paramMap and to.hasParam(param.name):
+                to._set(**{param.name: paramMap[param]})
         return to
 
     def _resetUid(self, newUid):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -390,7 +390,7 @@ class ParamTests(PySparkTestCase):
         self.assertEqual(model.getWindowSize(), 6)
 
     def test_copy_param_extras(self):
-        tp = TestParams()
+        tp = TestParams(seed=42)
         extra = {tp.getParam(TestParams.inputCol.name): "copy_input"}
         tp_copy = tp.copy(extra=extra)
         self.assertEqual(tp.uid, tp_copy.uid)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -389,6 +389,19 @@ class ParamTests(PySparkTestCase):
         # Check windowSize is set properly
         self.assertEqual(model.getWindowSize(), 6)
 
+    def test_copy_param_extras(self):
+        tp = TestParams()
+        extra = {tp.getParam(TestParams.inputCol.name): "copy_input"}
+        tp_copy = tp.copy(extra=extra)
+        self.assertEqual(tp.uid, tp_copy.uid)
+        self.assertEqual(tp.params, tp_copy.params)
+        for k, v in extra.iteritems():
+            self.assertTrue(tp_copy.isDefined(k))
+            self.assertEqual(tp_copy.getOrDefault(k), v)
+        self.assertEqual(tp._paramMap,
+                         {k: tp_copy._paramMap[k] for k in tp_copy._paramMap if k not in extra})
+        self.assertEqual(tp._defaultParamMap, tp_copy._defaultParamMap)
+
 
 class EvaluatorTests(SparkSessionTestCase):
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -395,11 +395,14 @@ class ParamTests(PySparkTestCase):
         tp_copy = tp.copy(extra=extra)
         self.assertEqual(tp.uid, tp_copy.uid)
         self.assertEqual(tp.params, tp_copy.params)
-        for k, v in extra.iteritems():
+        for k, v in extra.items():
             self.assertTrue(tp_copy.isDefined(k))
             self.assertEqual(tp_copy.getOrDefault(k), v)
-        self.assertEqual(tp._paramMap,
-                         {k: tp_copy._paramMap[k] for k in tp_copy._paramMap if k not in extra})
+        copied_no_extra = {}
+        for k, v in tp_copy._paramMap.items():
+            if k not in extra:
+                copied_no_extra[k] = v
+        self.assertEqual(tp._paramMap, copied_no_extra)
         self.assertEqual(tp._defaultParamMap, tp_copy._defaultParamMap)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed the PySpark Params.copy method to behave like the Scala implementation.  The main issue was that it did not account for the _defaultParamMap and merged it into the explicitly created param map.

## How was this patch tested?
Added new unit test to verify the copy method behaves correctly for copying uid, explicitly created params, and default params.
