### PR TITLE
[SPARK-19409][BUILD][test-maven] Fix ParquetAvroCompatibilitySuite failure due to test dependency on avro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,6 @@
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>3.1.2</codahale.metrics.version>
     <avro.version>1.7.7</avro.version>
-    <avro.parquet.version>1.8.0</avro.parquet.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <jets3t.version>0.7.1</jets3t.version>
     <aws.kinesis.client.version>1.6.2</aws.kinesis.client.version>
@@ -869,12 +868,6 @@
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
         <scope>${hadoop.deps.scope}</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>${avro.parquet.version}</version>
-        <scope>${parquet.test.deps.scope}</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>3.1.2</codahale.metrics.version>
     <avro.version>1.7.7</avro.version>
+    <avro.parquet.version>1.8.0</avro.parquet.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <jets3t.version>0.7.1</jets3t.version>
     <aws.kinesis.client.version>1.6.2</aws.kinesis.client.version>
@@ -868,6 +869,12 @@
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
         <scope>${hadoop.deps.scope}</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.parquet.version}</version>
+        <scope>${parquet.test.deps.scope}</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>

--- a/resource-managers/mesos/pom.xml
+++ b/resource-managers/mesos/pom.xml
@@ -49,6 +49,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.mesos</groupId>
       <artifactId>mesos</artifactId>
       <version>${mesos.version}</version>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -130,6 +130,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.8.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -129,6 +129,13 @@
       <artifactId>parquet-avro</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--
+      This version of avro test-dep is different from the one defined
+      in the parent pom. The parent pom has avro 1.7.7 test-dep for Hadoop.
+      Here, ParquetAvroCompatibilitySuite uses parquet-avro's AvroParquetWriter
+      which uses avro 1.8.0+ specific API. In Maven 3, we need to have
+      this here to have different versions for the same artifact.
+    -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -130,12 +130,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>1.8.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.8.0</version>
+      <version>1.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After using Apache Parquet 1.8.2, `ParquetAvroCompatibilitySuite` fails on **Maven** test. It is because `org.apache.parquet.avro.AvroParquetWriter` in the test code used new `avro 1.8.0` specific class, `LogicalType`. This PR aims to fix the test dependency of `sql/core` module to use avro 1.8.0.

https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-maven-hadoop-2.7/2530/consoleFull

```
ParquetAvroCompatibilitySuite:
*** RUN ABORTED ***
  java.lang.NoClassDefFoundError: org/apache/avro/LogicalType
  at org.apache.parquet.avro.AvroParquetWriter.writeSupport(AvroParquetWriter.java:144)
```

## How was this patch tested?

Pass the existing test with **Maven**.

```
$ build/mvn -Pyarn -Phadoop-2.7 -Pkinesis-asl -Phive -Phive-thriftserver test
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:07 h
[INFO] Finished at: 2017-02-04T05:41:43+00:00
[INFO] Final Memory: 77M/987M
[INFO] ------------------------------------------------------------------------
```