### PR TITLE
[SPARK-13619] [WEBUI] [CORE] Jobs page UI shows wrong number of failed tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -234,7 +234,6 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
     }
     for (stageId <- jobData.stageIds) {
       stageIdToActiveJobIds.get(stageId).foreach { jobsUsingStage =>
-        jobsUsingStage.remove(jobEnd.jobId)
         if (jobsUsingStage.isEmpty) {
           stageIdToActiveJobIds.remove(stageId)
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the Failed/Killed Task End events come after the Job End event then these task events are simply getting ignored without considering/updating into JobUIData. It is happening because jobId information is getting deleted from stageIdToActiveJobIds during the Job End event and Task End event is not able to find the Job information to update. 

## How was this patch tested?

### Current behaviour of Spark Jobs page for Running Application and History page,

#### Completed Jobs (1)

| Job Id | Description | Submitted | Duration | Stages: Succeeded/Total | Tasks (for all stages): Succeeded/Total | 
| --- | --- | --- | --- | --- | --- |
| 0	 | saveAsTextFile at JavaWordCountWithSlowTask.java:49  | 2017/01/25 09:03:14 |	1.4 min	 | 2/2	 | 400/400 (17 killed) | 


#### Completed Stages (2)

| Stage Id | Description | Submitted | Duration | Tasks: Succeeded/Total | Input | Output | Shuffle Read | Shuffle Write | 
| --- | --- | --- | --- | --- | --- | --- | --- | --- | 
| 1 | saveAsTextFile at JavaWordCountWithSlowTask.java:49 +details | 2017/01/25 09:04:34 | 5 s | 200/200 (2 failed) (1 killed) | |  6.8 KB | 2.3 MB | | 
| 0 | mapToPair at JavaWordCountWithSlowTask.java:33 +details  | 2017/01/25 09:03:15 | 1.3 min | 200/200 (16 killed) | 1915.5 MB | |  |  2.3 MB | 


### Behaviour of the Web Pages after applying the patch,

#### Completed Jobs (1)

| Job Id | Description | Submitted | Duration | Stages: Succeeded/Total | Tasks (for all stages): Succeeded/Total | 
| --- | --- | --- | --- | --- | --- |
| 0	 | saveAsTextFile at JavaWordCountWithSlowTask.java:49 | 2017/01/25 09:03:14 | 	1.4 min	 | 2/2	 | 400/400 (2 failed) (17 killed) | 


#### Completed Stages (2)

| Stage Id | Description | Submitted | Duration | Tasks: Succeeded/Total | Input | Output | Shuffle Read | Shuffle Write | 
| --- | --- | --- | --- | --- | --- | --- | --- | --- | 
| 1 | saveAsTextFile at JavaWordCountWithSlowTask.java:49 +details | 2017/01/25 09:04:34 | 5 s | 200/200 (2 failed) (1 killed) |  | 6.8 KB | 	2.3 MB	 | 
| 0 | mapToPair at JavaWordCountWithSlowTask.java:33 +details | 2017/01/25 09:03:15 | 1.3 min | 200/200 (16 killed) | 	1915.5 MB |  |  | 2.3 MB | 
