### PR TITLE
[SPARK-17629][ML] methods to return synonyms directly

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -226,8 +226,9 @@ class Word2VecModel private[ml] (
 
   /**
    * Find "num" number of words closest in similarity to the given word, not
-   * including the word itself. Returns a dataframe with the words and the
-   * cosine similarities between the synonyms and the given word.
+   * including the word itself.
+   * @return a dataframe with columns "word" and "similarity" of the word and the cosine
+   * similarities between the synonyms and the given word vector.
    */
   @Since("1.5.0")
   def findSynonyms(word: String, num: Int): DataFrame = {
@@ -238,7 +239,8 @@ class Word2VecModel private[ml] (
   /**
    * Find "num" number of words whose vector representation is most similar to the supplied vector.
    * If the supplied vector is the vector representation of a word in the model's vocabulary,
-   * that word will be in the results.  Returns a dataframe with the words and the cosine
+   * that word will be in the results.
+   * @return a dataframe with columns "word" and "similarity" of the word and the cosine
    * similarities between the synonyms and the given word vector.
    */
   @Since("2.0.0")
@@ -250,8 +252,9 @@ class Word2VecModel private[ml] (
   /**
    * Find "num" number of words whose vector representation is most similar to the supplied vector.
    * If the supplied vector is the vector representation of a word in the model's vocabulary,
-   * that word will be in the results. Returns an array of the words and the cosine
-   * similarities between the synonyms and the given word vector.
+   * that word will be in the results.
+   * @return an array of the words and the cosine similarities between the synonyms given
+   * word vector.
    */
   @Since("2.2.0")
   def findSynonymsLocal(vec: Vector, num: Int): Array[(String, Double)] = {
@@ -260,8 +263,9 @@ class Word2VecModel private[ml] (
 
   /**
    * Find "num" number of words closest in similarity to the given word, not
-   * including the word itself. Returns a dataframe with the words and the
-   * cosine similarities between the synonyms and the given word.
+   * including the word itself.
+   * @return an array of the words and the cosine similarities between the synonyms given
+   * word vector.
    */
   @Since("2.2.0")
   def findSynonymsLocal(word: String, num: Int): Array[(String, Double)] = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -232,11 +232,11 @@ class Word2VecModel private[ml] (
   @Since("1.5.0")
   def findSynonyms(word: String, num: Int): DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
-    spark.createDataFrame(wordVectors.findSynonyms(word, num)).toDF("word", "similarity")
+    spark.createDataFrame(findSynonymsLocal(word, num)).toDF("word", "similarity")
   }
 
   /**
-   * Find "num" number of words whose vector representation most similar to the supplied vector.
+   * Find "num" number of words whose vector representation is most similar to the supplied vector.
    * If the supplied vector is the vector representation of a word in the model's vocabulary,
    * that word will be in the results.  Returns a dataframe with the words and the cosine
    * similarities between the synonyms and the given word vector.
@@ -244,7 +244,28 @@ class Word2VecModel private[ml] (
   @Since("2.0.0")
   def findSynonyms(vec: Vector, num: Int): DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
-    spark.createDataFrame(wordVectors.findSynonyms(vec, num)).toDF("word", "similarity")
+    spark.createDataFrame(findSynonymsLocal(vec, num)).toDF("word", "similarity")
+  }
+
+  /**
+   * Find "num" number of words whose vector representation is most similar to the supplied vector.
+   * If the supplied vector is the vector representation of a word in the model's vocabulary,
+   * that word will be in the results. Returns an array of the words and the cosine
+   * similarities between the synonyms and the given word vector.
+   */
+  @Since("2.2.0")
+  def findSynonymsLocal(vec: Vector, num: Int): Array[(String, Double)] = {
+    wordVectors.findSynonyms(vec, num)
+  }
+
+  /**
+   * Find "num" number of words closest in similarity to the given word, not
+   * including the word itself. Returns a dataframe with the words and the
+   * cosine similarities between the synonyms and the given word.
+   */
+  @Since("2.2.0")
+  def findSynonymsLocal(word: String, num: Int): Array[(String, Double)] = {
+    wordVectors.findSynonyms(word, num)
   }
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -233,7 +233,7 @@ class Word2VecModel private[ml] (
   @Since("1.5.0")
   def findSynonyms(word: String, num: Int): DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
-    spark.createDataFrame(findSynonymsLocal(word, num)).toDF("word", "similarity")
+    spark.createDataFrame(findSynonymsArray(word, num)).toDF("word", "similarity")
   }
 
   /**
@@ -246,7 +246,7 @@ class Word2VecModel private[ml] (
   @Since("2.0.0")
   def findSynonyms(vec: Vector, num: Int): DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
-    spark.createDataFrame(findSynonymsLocal(vec, num)).toDF("word", "similarity")
+    spark.createDataFrame(findSynonymsArray(vec, num)).toDF("word", "similarity")
   }
 
   /**
@@ -257,7 +257,7 @@ class Word2VecModel private[ml] (
    * word vector.
    */
   @Since("2.2.0")
-  def findSynonymsLocal(vec: Vector, num: Int): Array[(String, Double)] = {
+  def findSynonymsArray(vec: Vector, num: Int): Array[(String, Double)] = {
     wordVectors.findSynonyms(vec, num)
   }
 
@@ -268,7 +268,7 @@ class Word2VecModel private[ml] (
    * word vector.
    */
   @Since("2.2.0")
-  def findSynonymsLocal(word: String, num: Int): Array[(String, Double)] = {
+  def findSynonymsArray(word: String, num: Int): Array[(String, Double)] = {
     wordVectors.findSynonyms(word, num)
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -141,15 +141,13 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
 
     assert(synonyms === Array("b", "c"))
     expectedSimilarity.zip(similarity).foreach {
-      case (expected, actual) => assert(math.abs((expected - actual) / expected) < 1E-5)
+      case (expected, actual) => assert(expected ~== actual absTol 1E-5)
     }
 
     result.zip(model.findSynonymsArray("a", 2)).foreach {
       case (expectedSynonymAndSimilarity, actualSynonymAndSimilarity) =>
         assert(expectedSynonymAndSimilarity._1 === actualSynonymAndSimilarity._1)
-        assert(
-          math.abs((expectedSynonymAndSimilarity._2 - actualSynonymAndSimilarity._2)
-            / expectedSynonymAndSimilarity._2) < 1E-5)
+        assert(expectedSynonymAndSimilarity._2 ~== actualSynonymAndSimilarity._2 absTol 1E-5)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -133,21 +133,22 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
       .setSeed(42L)
       .fit(docDF)
 
-    val expectedSimilarity = Array(0.2608488929093532, -0.8271274846926078)
-    val result = model.findSynonyms("a", 2).rdd.map {
+    val expected = Map(("b", 0.2608488929093532), ("c", -0.8271274846926078))
+    val findSynonymsResult = model.findSynonyms("a", 2).rdd.map {
       case Row(w: String, sim: Double) => (w, sim)
-    }.collect()
-    val (synonyms, similarity) = result.unzip
+    }.collectAsMap()
 
-    assert(synonyms === Array("b", "c"))
-    expectedSimilarity.zip(similarity).foreach {
-      case (expected, actual) => assert(expected ~== actual absTol 1E-5)
+    expected.foreach {
+      case (expectedSynonym, expectedSimilarity) =>
+        assert(findSynonymsResult.contains(expectedSynonym))
+        assert(expectedSimilarity ~== findSynonymsResult.get(expectedSynonym).get absTol 1E-5)
     }
 
-    result.zip(model.findSynonymsArray("a", 2)).foreach {
-      case ((expectedSynonym, expectedSimilarity), (actualSynonym, actualSimilarity)) =>
-        assert(expectedSynonym === actualSynonym)
-        assert(expectedSimilarity ~== actualSimilarity absTol 1E-5)
+    val findSynonymsArrayResult = model.findSynonymsArray("a", 2).toMap
+    findSynonymsResult.foreach {
+      case (expectedSynonym, expectedSimilarity) =>
+        assert(findSynonymsArrayResult.contains(expectedSynonym))
+        assert(expectedSimilarity ~== findSynonymsArrayResult.get(expectedSynonym).get absTol 1E-5)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -134,38 +134,22 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
       .fit(docDF)
 
     val expectedSimilarity = Array(0.2608488929093532, -0.8271274846926078)
-    val (synonyms, similarity) = model.findSynonyms("a", 2).rdd.map {
+    val result = model.findSynonyms("a", 2).rdd.map {
       case Row(w: String, sim: Double) => (w, sim)
-    }.collect().unzip
+    }.collect()
+    val (synonyms, similarity) = result.unzip
 
     assert(synonyms === Array("b", "c"))
     expectedSimilarity.zip(similarity).foreach {
       case (expected, actual) => assert(math.abs((expected - actual) / expected) < 1E-5)
     }
-  }
 
-  test("findSynonymsArray") {
-
-    val spark = this.spark
-    import spark.implicits._
-
-    val sentence = "a b " * 100 + "a c " * 10
-    val doc = sc.parallelize(Seq(sentence, sentence)).map(line => line.split(" "))
-    val docDF = doc.zip(doc).toDF("text", "alsotext")
-
-    val model = new Word2Vec()
-      .setVectorSize(3)
-      .setInputCol("text")
-      .setOutputCol("result")
-      .setSeed(42L)
-      .fit(docDF)
-
-    val expectedSimilarity = Array(0.2608488929093532, -0.8271274846926078)
-    val (synonyms, similarity) = model.findSynonymsArray("a", 2).unzip
-
-    assert(synonyms === Array("b", "c"))
-    expectedSimilarity.zip(similarity).foreach {
-      case (expected, actual) => assert(math.abs((expected - actual) / expected) < 1E-5)
+    result.zip(model.findSynonymsArray("a", 2)).foreach {
+      case (expectedSynonymAndSimilarity, actualSynonymAndSimilarity) =>
+        assert(expectedSynonymAndSimilarity._1 === actualSynonymAndSimilarity._1)
+        assert(
+          math.abs((expectedSynonymAndSimilarity._2 - actualSynonymAndSimilarity._2)
+            / expectedSynonymAndSimilarity._2) < 1E-5)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -145,9 +145,9 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     }
 
     result.zip(model.findSynonymsArray("a", 2)).foreach {
-      case (expectedSynonymAndSimilarity, actualSynonymAndSimilarity) =>
-        assert(expectedSynonymAndSimilarity._1 === actualSynonymAndSimilarity._1)
-        assert(expectedSynonymAndSimilarity._2 ~== actualSynonymAndSimilarity._2 absTol 1E-5)
+      case ((expectedSynonym, expectedSimilarity), (actualSynonym, actualSimilarity)) =>
+        assert(expectedSynonym === actualSynonym)
+        assert(expectedSimilarity ~== actualSimilarity absTol 1E-5)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
provide methods to return synonyms directly, without wrapping them in a dataframe

In performance sensitive applications (such as user facing apis) the roundtrip to and from dataframes is costly and unnecessary

The methods are named ``findSynonymsArray`` to make the return type clear, which also implies a local datastructure
## How was this patch tested?
updated word2vec tests
