### PR TITLE
[SPARK-16441][YARN] Set maxNumExecutor depends on yarn cluster resources.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -90,7 +90,8 @@ private[spark] class ExecutorAllocationManager(
 
   // Lower and upper bounds on the number of executors.
   private val minNumExecutors = conf.get(DYN_ALLOCATION_MIN_EXECUTORS)
-  private val maxNumExecutors = conf.get(DYN_ALLOCATION_MAX_EXECUTORS)
+  // Upper bounds is dynamic for Spark on YARN
+  private var maxNumExecutors = conf.get(DYN_ALLOCATION_MAX_EXECUTORS)
   private val initialNumExecutors = Utils.getDynamicAllocationInitialExecutors(conf)
 
   // How long there must be backlogged tasks for before an addition is triggered (seconds)
@@ -348,6 +349,7 @@ private[spark] class ExecutorAllocationManager(
    * @return the number of additional executors actually requested.
    */
   private def addExecutors(maxNumExecutorsNeeded: Int): Int = {
+    maxNumExecutors = conf.get(DYN_ALLOCATION_MAX_EXECUTORS)
     // Do not request more executors if it would put our target over the upper bound
     if (numExecutorsTarget >= maxNumExecutors) {
       logDebug(s"Not adding executors because our current target total " +

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1541,7 +1541,8 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.dynamicAllocation.maxExecutors</code></td>
-  <td>infinity</td>
+  <td>Depends on yarn cluster VCores Total for YARN;
+      infinity for standalone mode and Mesos mode</td>
   <td>
     Upper bound for the number of executors if dynamic allocation is enabled.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1541,7 +1541,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.dynamicAllocation.maxExecutors</code></td>
-  <td>Depends on yarn cluster VCores Total for YARN;
+  <td>Depends on queue's max resources for YARN;
       infinity for standalone mode and Mesos mode</td>
   <td>
     Upper bound for the number of executors if dynamic allocation is enabled.

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -151,6 +151,8 @@ private[spark] class Client(
       yarnClient.init(yarnConf)
       yarnClient.start()
 
+      setMaxNumExecutors()
+
       logInfo("Requesting a new application from cluster with %d NodeManagers"
         .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
 
@@ -1191,6 +1193,26 @@ private[spark] class Client(
           s"$py4jFile not found; cannot run pyspark application in YARN mode.")
         Seq(pyArchivesFile.getAbsolutePath(), py4jFile.getAbsolutePath())
       }
+  }
+
+  /**
+   * If using dynamic allocation and user doesn't set spark.dynamicAllocation.maxExecutors
+   * then set the max number of executors depends on yarn cluster VCores Total.
+   * If not using dynamic allocation don't set it.
+   */
+  def setMaxNumExecutors(): Unit = {
+    if (Utils.isDynamicAllocationEnabled(sparkConf)) {
+
+      val defaultMaxNumExecutors = DYN_ALLOCATION_MAX_EXECUTORS.defaultValue.get
+      if (defaultMaxNumExecutors == sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS)) {
+        val executorCores = sparkConf.getInt("spark.executor.cores", 1)
+        val maxNumExecutors = yarnClient.getNodeReports().asScala.
+          filter(_.getNodeState == NodeState.RUNNING).
+          map(_.getCapability.getVirtualCores / executorCores).sum
+
+        sparkConf.set(DYN_ALLOCATION_MAX_EXECUTORS, maxNumExecutors)
+      }
+    }
   }
 
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -144,8 +144,12 @@ private[spark] class Client(
   def submitApplication(): ApplicationId = {
     var appId: ApplicationId = null
     try {
-
-      init()
+      launcherBackend.connect()
+      // Setup the credentials before doing anything else,
+      // so we have don't have issues at any point.
+      setupCredentials()
+      yarnClient.init(yarnConf)
+      yarnClient.start()
 
       logInfo("Requesting a new application from cluster with %d NodeManagers"
         .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
@@ -1187,60 +1191,6 @@ private[spark] class Client(
           s"$py4jFile not found; cannot run pyspark application in YARN mode.")
         Seq(pyArchivesFile.getAbsolutePath(), py4jFile.getAbsolutePath())
       }
-  }
-
-  def init(): Unit = {
-    launcherBackend.connect()
-    // Setup the credentials before doing anything else,
-    // so we have don't have issues at any point.
-    setupCredentials()
-    yarnClient.init(yarnConf)
-    yarnClient.start()
-
-    setMaxNumExecutors()
-  }
-
-  /**
-   * If using dynamic allocation and user doesn't set spark.dynamicAllocation.maxExecutors
-   * then set the max number of executors depends on yarn cluster VCores Total.
-   * If not using dynamic allocation don't set it.
-   */
-  private def setMaxNumExecutors(): Unit = {
-    if (Utils.isDynamicAllocationEnabled(sparkConf)) {
-
-      val defaultMaxNumExecutors = DYN_ALLOCATION_MAX_EXECUTORS.defaultValue.get
-      if (defaultMaxNumExecutors == sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS)) {
-        val executorCores = sparkConf.get(EXECUTOR_CORES)
-        val runningNodes = yarnClient.getNodeReports().asScala.
-          filter(_.getNodeState == NodeState.RUNNING)
-        val absMaxCapacity = getAbsMaxCapacity(yarnClient, sparkConf.get(QUEUE_NAME))
-
-        val maxNumExecutors = runningNodes.map(_.getCapability.getVirtualCores).
-          sum * absMaxCapacity / executorCores
-        sparkConf.set(DYN_ALLOCATION_MAX_EXECUTORS, maxNumExecutors.toInt)
-      }
-    }
-  }
-
-  /**
-   * Get the absolute max capacity for a given queue.
-   */
-  private def getAbsMaxCapacity(yarnClient: YarnClient, queueName: String): Float = {
-    var maxCapacity = 1F
-    for (queue <- yarnClient.getRootQueueInfos.asScala) {
-      getQueueInfo(queue, queue.getMaximumCapacity)
-    }
-
-    def getQueueInfo(queueInfo: QueueInfo, capacity: Float): Unit = {
-      if (queueInfo.getQueueName.equals(queueName)) {
-        maxCapacity = capacity
-      } else {
-        for (child <- queueInfo.getChildQueues.asScala) {
-          getQueueInfo(child, child.getMaximumCapacity * capacity)
-        }
-      }
-    }
-    maxCapacity
   }
 
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -144,14 +144,8 @@ private[spark] class Client(
   def submitApplication(): ApplicationId = {
     var appId: ApplicationId = null
     try {
-      launcherBackend.connect()
-      // Setup the credentials before doing anything else,
-      // so we have don't have issues at any point.
-      setupCredentials()
-      yarnClient.init(yarnConf)
-      yarnClient.start()
 
-      setMaxNumExecutors()
+      init()
 
       logInfo("Requesting a new application from cluster with %d NodeManagers"
         .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
@@ -1195,12 +1189,23 @@ private[spark] class Client(
       }
   }
 
+  def init(): Unit = {
+    launcherBackend.connect()
+    // Setup the credentials before doing anything else,
+    // so we have don't have issues at any point.
+    setupCredentials()
+    yarnClient.init(yarnConf)
+    yarnClient.start()
+
+    setMaxNumExecutors()
+  }
+
   /**
    * If using dynamic allocation and user doesn't set spark.dynamicAllocation.maxExecutors
    * then set the max number of executors depends on yarn cluster VCores Total.
    * If not using dynamic allocation don't set it.
    */
-  def setMaxNumExecutors(): Unit = {
+  private def setMaxNumExecutors(): Unit = {
     if (Utils.isDynamicAllocationEnabled(sparkConf)) {
 
       val defaultMaxNumExecutors = DYN_ALLOCATION_MAX_EXECUTORS.defaultValue.get

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -61,6 +61,7 @@ abstract class BaseYarnClusterSuite
   private var fakeSparkJar: File = _
   protected var hadoopConfDir: File = _
   private var logConfDir: File = _
+  protected var numNodeManagers: Int = 1
 
   var oldSystemProperties: Properties = null
 
@@ -84,7 +85,7 @@ abstract class BaseYarnClusterSuite
     yarnConf.set("yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage",
       "100.0")
 
-    yarnCluster = new MiniYARNCluster(getClass().getName(), 1, 1, 1)
+    yarnCluster = new MiniYARNCluster(getClass().getName(), numNodeManagers, 1, 1)
     yarnCluster.init(yarnConf)
     yarnCluster.start()
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -28,6 +28,7 @@ import scala.language.postfixOps
 
 import com.google.common.io.Files
 import org.apache.commons.lang3.SerializationUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.server.MiniYARNCluster
 import org.scalatest.{BeforeAndAfterAll, Matchers}
@@ -65,7 +66,7 @@ abstract class BaseYarnClusterSuite
 
   var oldSystemProperties: Properties = null
 
-  def newYarnConfig(): YarnConfiguration
+  def newYarnConfig(): Configuration
 
   override def beforeAll() {
     super.beforeAll()

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -286,7 +286,7 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
     clientA.stop()
 
     // a1's cores: 80 * 0.6 * 0.7 = 33
-    val a1CoreTotal = (coresTotal * (aMaximumCapacity / 100) * (a1MaximumCapacity/ 100)).toInt
+    val a1CoreTotal = (coresTotal * (aMaximumCapacity / 100) * (a1MaximumCapacity / 100)).toInt
     val sparkConfA1 = new SparkConf()
       .set("spark.dynamicAllocation.enabled", "true")
       .set(QUEUE_NAME, "a1")
@@ -347,10 +347,10 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
       .set(QUEUE_NAME, "b")
     val clientEnabledSetCores = new Client(args, yarnCluster.getConfig, sparkConfSetCores)
 
-    assert(Int.MaxValue == clientEnabledSetCores.sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS))
+    assert(Int.MaxValue === clientEnabledSetCores.sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS))
     clientEnabledSetCores.init()
     assert(bExecutorTotal === 26)
-    assert(26 ===  clientEnabledSetCores.sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS))
+    assert(26 === clientEnabledSetCores.sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS))
     clientEnabledSetCores.stop()
 
     // dynamicAllocation disabled

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/DynamicSetMaxExecutorsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/DynamicSetMaxExecutorsSuite.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+import scala.language.postfixOps
+
+import com.google.common.io.Files
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration
+import org.scalatest.Matchers
+
+import org.apache.spark._
+import org.apache.spark.deploy.yarn.config._
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.tags.ExtendedYarnTest
+
+/**
+ * Integration test for the dynamic set spark.dynamicAllocation.maxExecutors
+ * depends on queue's maxResources use a mini Yarn cluster.
+ */
+@ExtendedYarnTest
+class DynamicSetMaxExecutorsSuite extends BaseYarnClusterSuite {
+
+  numNodeManagers = 10
+  val cpuCores = 8
+  // coresTotal = cpuCores * numNodeManagers = 80
+
+  val queueNameRA = "ra"
+  val queueNameRB = "rb"
+  val queueNameA1 = "a1"
+  val queueNameA2 = "a2"
+  val ra = CapacitySchedulerConfiguration.ROOT + "." + queueNameRA
+  val rb = CapacitySchedulerConfiguration.ROOT + "." + queueNameRB
+  val a1 = ra + "." + queueNameA1
+  val a2 = ra + "." + queueNameA2
+
+  val aCapacity = 40F
+  val aMaximumCapacity = 60F
+  val bCapacity = 60F
+  val bMaximumCapacity = 100F
+  val a1Capacity = 30F
+  val a1MaximumCapacity = 70F
+  val a2Capacity = 70F
+  val isDynamicAllocation = true
+
+  override def newYarnConfig(): CapacitySchedulerConfiguration = {
+
+    val yarnConf = new CapacitySchedulerConfiguration()
+
+    // Define top-level queues
+    yarnConf.setQueues(CapacitySchedulerConfiguration.ROOT, Array(queueNameRA, queueNameRB))
+    yarnConf.setMaximumCapacity(CapacitySchedulerConfiguration.ROOT, 100)
+    yarnConf.setCapacity(ra, aCapacity)
+    yarnConf.setMaximumCapacity(ra, aMaximumCapacity)
+    yarnConf.setCapacity(rb, bCapacity)
+    yarnConf.setMaximumCapacity(rb, bMaximumCapacity)
+
+    // Define 2nd-level queues
+    yarnConf.setQueues(ra, Array(queueNameA1, queueNameA2))
+    yarnConf.setCapacity(a1, a1Capacity)
+    yarnConf.setMaximumCapacity(a1, a1MaximumCapacity)
+    yarnConf.setCapacity(a2, a2Capacity)
+    yarnConf.set("yarn.nodemanager.resource.cpu-vcores", cpuCores.toString)
+    yarnConf
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation enabled and ${ queueNameA1 } queue") {
+    // a1's executors: 80 * 0.6 * 0.7 = 33
+    setMaxExecutors(33, queueNameA1,
+      s"spark.dynamicAllocation.enabled=${ isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ isDynamicAllocation }")
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation enabled and ${ queueNameA2 } queue") {
+    // a2's executors: 80 * 0.6 * 1 = 48
+    setMaxExecutors(48, queueNameA2,
+      s"spark.dynamicAllocation.enabled=${ isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ isDynamicAllocation }")
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation enabled and ${ queueNameRB } queue") {
+    // b's executors: 80 * 1 = 80
+    setMaxExecutors(80, queueNameRB,
+      s"spark.dynamicAllocation.enabled=${ isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ isDynamicAllocation }")
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation enabled and ${ queueNameA1 } queue and " +
+    s"user set maxExecutors") {
+    val executors = 12
+    setMaxExecutors(executors, queueNameA1,
+      s"spark.dynamicAllocation.enabled=${ isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ isDynamicAllocation }" +
+        s",${DYN_ALLOCATION_MAX_EXECUTORS.key}=${ executors }")
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation disabled and ${ queueNameA1 } queue") {
+    setMaxExecutors(Int.MaxValue, queueNameA1,
+      s"spark.dynamicAllocation.enabled=${ !isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ !isDynamicAllocation }")
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation disabled and ${ queueNameA1 } queue and " +
+    s"user set maxExecutors") {
+    val executors = 12
+    setMaxExecutors(executors, queueNameA1,
+      s"spark.dynamicAllocation.enabled=${ isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ isDynamicAllocation }" +
+        s",${DYN_ALLOCATION_MAX_EXECUTORS.key}=${ executors }")
+  }
+
+  test(s"run Spark on YARN with dynamicAllocation enabled and ${ queueNameRB } queue and " +
+    s"user set spark.executor.cores") {
+    // b's executors = 80 * 1 / 3 = 26
+    setMaxExecutors(26, queueNameRB,
+      s"spark.dynamicAllocation.enabled=${ isDynamicAllocation }" +
+        s",spark.shuffle.service.enabled=${ isDynamicAllocation }" +
+        s",${EXECUTOR_CORES.key}=3")
+  }
+
+  private def setMaxExecutors(expectedExecutors: Int,
+                              queueName: String,
+                              extArgMaps: String): Unit = {
+    val result = File.createTempFile("result", null, tempDir)
+    val finalState = runSpark(true,
+      mainClassName(SetMaxExecutors.getClass),
+      appArgs = Seq(result.getAbsolutePath, queueName, extArgMaps))
+    checkResult(finalState, result, expectedExecutors.toString)
+  }
+
+}
+
+private object SetMaxExecutors extends Logging with Matchers {
+  def main(args: Array[String]): Unit = {
+
+    var result = Int.MaxValue.toString
+    val status = new File(args(0))
+    val queueName = args(1)
+    val extArgMaps = args(2)
+
+    var sc: SparkContext = null
+    try {
+      val conf = new SparkConf()
+        .setAppName(s"DynamicSetMaxExecutors-${ queueName }-${ extArgMaps }")
+        .set(QUEUE_NAME, queueName)
+
+      extArgMaps.split(",").foreach{ kv =>
+        val confKVs = kv.split("=")
+        conf.set(confKVs(0), confKVs(1))
+      }
+
+      sc = new SparkContext(conf)
+
+      result = sc.getConf.get(DYN_ALLOCATION_MAX_EXECUTORS).toString
+    } finally {
+      Files.write(result, status, StandardCharsets.UTF_8)
+      sc.stop()
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dynamic set `spark.dynamicAllocation.maxExecutors` by cluster resources.

## How was this patch tested?

manual test and unit test
