### PR TITLE
[SPARK-19475][PYTHON][ML][MLLIB] Support (ml|mllib).linalg.Vector negation

### DIFF
--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -434,7 +434,7 @@ class DenseVector(Vector):
         return getattr(self.array, item)
 
     def _delegate(op):
-        unary_ops = {"__neg__"}
+        unary_ops = set(["__neg__"])
 
         def func(self, other=None):
             # Unary operator

--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -434,9 +434,11 @@ class DenseVector(Vector):
         return getattr(self.array, item)
 
     def _delegate(op):
+        unary_ops = {"__neg__"}
+
         def func(self, other=None):
             # Unary operator
-            if other is None:
+            if other is None and op in unary_ops:
                 return getattr(self.array, op)()
 
             # Binary operator

--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -434,10 +434,16 @@ class DenseVector(Vector):
         return getattr(self.array, item)
 
     def _delegate(op):
-        def func(self, other):
+        def func(self, other=None):
+            # Unary operator
+            if other is None:
+                return getattr(self.array, op)()
+
+            # Binary operator
             if isinstance(other, DenseVector):
                 other = other.array
             return DenseVector(getattr(self.array, op)(other))
+
         return func
 
     __neg__ = _delegate("__neg__")
@@ -741,6 +747,9 @@ class SparseVector(Vector):
                 nnz += 1
             i += 1
         return result
+
+    def __neg__(self):
+        return SparseVector(self.size, self.indices, -self.values)
 
 
 class Vectors(object):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1451,6 +1451,15 @@ class VectorTests(MLlibTestCase):
         self.assertListEqual(list(SparseVector(3, [], [])), [0.0, 0.0, 0.0])
         self.assertListEqual(list(SparseVector(5, [0, 3], [1.0, 2.0])), [1.0, 0.0, 0.0, 2.0, 0.0])
 
+    def test_negation(self):
+        self.assertListEqual(
+            list(-DenseVector([1.0, 2.0, 3.0])),
+            list(DenseVector([-1.0, -2.0, -3.0])))
+
+        self.assertListEqual(
+            list(-SparseVector(10, [0, 3, 5], [1.0, 2.0, 3.0])),
+            list(SparseVector(10, [0, 3, 5], [-1.0, -2.0, -3.0])))
+
     def test_matrix_indexing(self):
         mat = DenseMatrix(3, 2, [0, 1, 4, 6, 8, 10])
         expected = [[0, 6], [1, 8], [4, 10]]

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -478,9 +478,11 @@ class DenseVector(Vector):
         return getattr(self.array, item)
 
     def _delegate(op):
+        unary_ops = {"__neg__"}
+
         def func(self, other=None):
             # Unary operator
-            if other is None:
+            if other is None and op in unary_ops:
                 return getattr(self.array, op)()
 
             # Binary operator

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -478,7 +478,7 @@ class DenseVector(Vector):
         return getattr(self.array, item)
 
     def _delegate(op):
-        unary_ops = {"__neg__"}
+        unary_ops = set(["__neg__"])
 
         def func(self, other=None):
             # Unary operator

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -478,10 +478,16 @@ class DenseVector(Vector):
         return getattr(self.array, item)
 
     def _delegate(op):
-        def func(self, other):
+        def func(self, other=None):
+            # Unary operator
+            if other is None:
+                return getattr(self.array, op)()
+
+            # Binary operator
             if isinstance(other, DenseVector):
                 other = other.array
             return DenseVector(getattr(self.array, op)(other))
+
         return func
 
     __neg__ = _delegate("__neg__")
@@ -830,6 +836,9 @@ class SparseVector(Vector):
                 nnz += 1
             i += 1
         return result
+
+    def __neg__(self):
+        return SparseVector(self.size, self.indices, -self.values)
 
 
 class Vectors(object):

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -278,6 +278,15 @@ class VectorTests(MLlibTestCase):
         self.assertListEqual(list(SparseVector(3, [], [])), [0.0, 0.0, 0.0])
         self.assertListEqual(list(SparseVector(5, [0, 3], [1.0, 2.0])), [1.0, 0.0, 0.0, 2.0, 0.0])
 
+    def test_negation(self):
+        self.assertListEqual(
+            list(-DenseVector([1.0, 2.0, 3.0])),
+            list(DenseVector([-1.0, -2.0, -3.0])))
+
+        self.assertListEqual(
+            list(-SparseVector(10, [0, 3, 5], [1.0, 2.0, 3.0])),
+            list(SparseVector(10, [0, 3, 5], [-1.0, -2.0, -3.0])))
+
     def test_matrix_indexing(self):
         mat = DenseMatrix(3, 2, [0, 1, 4, 6, 8, 10])
         expected = [[0, 6], [1, 8], [4, 10]]


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Modify `DenseVector._delegate` to support unary operators, including `__neg__`.
- Implement  `SparseVector.__neg__`.
- Cover negation in unit tests.

## How was this patch tested?

Unit tests.