### PR TITLE
[SPARK] Config methods simplification at SparkSession#Builder

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -757,32 +757,7 @@ object SparkSession {
      *
      * @since 2.0.0
      */
-    def config(key: String, value: Long): Builder = synchronized {
-      options += key -> value.toString
-      this
-    }
-
-    /**
-     * Sets a config option. Options set using this method are automatically propagated to
-     * both `SparkConf` and SparkSession's own configuration.
-     *
-     * @since 2.0.0
-     */
-    def config(key: String, value: Double): Builder = synchronized {
-      options += key -> value.toString
-      this
-    }
-
-    /**
-     * Sets a config option. Options set using this method are automatically propagated to
-     * both `SparkConf` and SparkSession's own configuration.
-     *
-     * @since 2.0.0
-     */
-    def config(key: String, value: Boolean): Builder = synchronized {
-      options += key -> value.toString
-      this
-    }
+    def config(key: String, value: AnyVal): Builder = config(key, value.toString)
 
     /**
      * Sets a list of config options based on the given `SparkConf`.


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SparkSession`' companion object `Builder` inner class presents several implementations for config setter which are exact copies of the same method just varying the value input type.

There are setters for `Double`, `Long` and `Boolean`. And the three of them transform the input value into an string via the default `.toString` method.

These are basic types and, therefore, child classes of `AnyVal`. Why explicitly enumerating them in a set of methods replicating code?

The `config` implementation for `String` values can be invoke by a single method.

This PR tries to: 

- Reduce the amount of replicated code. That implies that further code updates will require modifying different methods with the dangers derived from possible oversights.
- Increase the code readability.
- Add all Scala basic types as possible inputs for the builder configuration pseudo-dsl implemented by `SparkSession#Builder`

## How was this patch tested?

This PRs changes the implementation of already tested, by the current test suites. Hence, no more testing has been added as no actual functionality is added.