### PR TITLE
[SPARK-19482][CORE] Fail it if 'spark.master' is set with different value

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -783,25 +783,24 @@ private[spark] object SparkConf extends Logging {
   /**
    * check if the given config key-value is valid.
    */
-  private def checkValidSetting(key: String, value: String, conf: SparkConf): Unit = {
-    key match {
-      case "spark.master" =>
-        // First, there is no need to set 'spark.master' multi-times with different values.
-        // Second, It is possible for users to set the different 'spark.master' in code with
-        // `spark-submit` command, and will confuse users.
-        // So, we should do once check if the 'spark.master' already exists in settings and if
-        // the previous value is the same with current value. Throw a IllegalArgumentException when
-        // previous value is different with current value.
-        val previousOne = try {
-          Some(conf.get(key))
-        } catch {
-          case e: NoSuchElementException =>
-            None
-        }
-        if (previousOne.isDefined && !previousOne.get.equals(value)) {
-          throw new IllegalArgumentException(s"'spark.master' should not be set with different " +
-            s"value, previous value is ${previousOne.get} and current value is $value")
-        }
+  def checkValidSetting(key: String, value: String, conf: SparkConf): Unit = {
+    if (key.equals("spark.master")) {
+      // First, there is no need to set 'spark.master' multi-times with different values.
+      // Second, It is possible for users to set the different 'spark.master' in code with
+      // `spark-submit` command, and will confuse users.
+      // So, we should do once check if the 'spark.master' already exists in settings and if
+      // the previous value is the same with current value. Throw a IllegalArgumentException when
+      // previous value is different with current value.
+      val previousOne = try {
+        Some(conf.get(key))
+      } catch {
+        case e: NoSuchElementException =>
+          None
+      }
+      if (previousOne.isDefined && !previousOne.get.equals(value)) {
+        throw new IllegalArgumentException(s"'spark.master' should not be set with different " +
+          s"value, previous value is ${previousOne.get} and current value is $value")
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -799,7 +799,8 @@ private[spark] object SparkConf extends Logging {
             None
         }
         if (previousOne.isDefined && !previousOne.get.equals(value)) {
-          throw new IllegalArgumentException("'spark.master' should not be ")
+          throw new IllegalArgumentException(s"'spark.master' should not be set with different " +
+            s"value, previous value is ${previousOne.get} and current value is $value")
         }
     }
   }

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -799,7 +799,7 @@ private[spark] object SparkConf extends Logging {
       }
       if (previousOne.isDefined && !previousOne.get.equals(value)) {
         throw new IllegalArgumentException(s"'spark.master' should not be set with different " +
-          s"value, previous value is ${previousOne.get} and current value is $value")
+          s"values, previous value is ${previousOne.get} and current value is $value.")
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark
 
+import java.util.NoSuchElementException
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
@@ -91,6 +92,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     if (!silent) {
       logDeprecationWarning(key)
     }
+    checkValidSetting(key, value, this)
     settings.put(key, value)
     this
   }
@@ -775,6 +777,30 @@ private[spark] object SparkConf extends Logging {
       logWarning(
         s"The configuration key $key is not supported any more " +
           s"because Spark doesn't use Akka since 2.0")
+    }
+  }
+
+  /**
+   * check if the given config key-value is valid.
+   */
+  private def checkValidSetting(key: String, value: String, conf: SparkConf): Unit = {
+    key match {
+      case "spark.master" =>
+        // First, there is no need to set 'spark.master' multi-times with different values.
+        // Second, It is possible for users to set the different 'spark.master' in code with
+        // `spark-submit` command, and will confuse users.
+        // So, we should do once check if the 'spark.master' already exists in settings and if
+        // the previous value is the same with current value. Throw a IllegalArgumentException when
+        // previous value is different with current value.
+        val previousOne = try {
+          Some(conf.get(key))
+        } catch {
+          case e: NoSuchElementException =>
+            None
+        }
+        if (previousOne.isDefined && !previousOne.get.equals(value)) {
+          throw new IllegalArgumentException("'spark.master' should not be ")
+        }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -131,9 +131,8 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
   }
 
   test("SparkContext property overriding") {
-    val conf = new SparkConf(false).setMaster("local").setAppName("My app")
+    val conf = new SparkConf(false).setAppName("My app")
     sc = new SparkContext("local[2]", "My other app", conf)
-    assert(sc.master === "local[2]")
     assert(sc.appName === "My other app")
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -322,6 +322,26 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
     conf.validateSettings()
   }
 
+  test("set 'spark.master' with different value") {
+    val conf = new SparkConf()
+    conf.setMaster("local[4]")
+    try {
+      conf.setMaster("yarn-client")
+      assert(false, "previous: local[4], current: yarn-client")
+    } catch {
+      case e: IllegalArgumentException =>
+      // expected
+    }
+
+    try {
+      conf.set("spark.master", "yarn-cluster")
+      assert(false, "previous: local[4], current: yarn-cluster")
+    } catch {
+      case e: IllegalArgumentException =>
+      // expected
+    }
+  }
+
 }
 
 class Class1 {}

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -440,7 +440,6 @@ class StandaloneRestSubmitSuite extends SparkFunSuite with BeforeAndAfterEach {
     val mainJar = "dummy-jar-not-used.jar"
     val commandLineArgs = Array(
       "--deploy-mode", "cluster",
-      "--master", masterUrl,
       "--name", mainClass,
       "--class", mainClass,
       mainJar) ++ appArgs

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -845,6 +845,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       conf.set("spark.executor.instances", "1")) === true)
     assert(Utils.isDynamicAllocationEnabled(
       conf.set("spark.executor.instances", "0")) === true)
+    conf.remove("spark.master")
     assert(Utils.isDynamicAllocationEnabled(conf.set("spark.master", "local")) === false)
     assert(Utils.isDynamicAllocationEnabled(conf.set("spark.dynamicAllocation.testing", "true")))
   }

--- a/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -50,7 +50,11 @@ class ReplSuite extends SparkFunSuite {
     val oldExecutorClasspath = System.getProperty(CONF_EXECUTOR_CLASSPATH)
     System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
     Main.sparkContext = null
-    Main.sparkSession = null // causes recreation of SparkContext for each test.
+    // causes recreation of SparkContext for each test.
+    Main.sparkSession = null
+    // (trick) avoid SPARK-19482.
+    // remove the previous 'spark.master' before set new one for each test.
+    Main.conf.remove("spark.master")
     Main.conf.set("spark.master", master)
     Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out)))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
@@ -181,7 +181,9 @@ class StateStoreRDDSuite extends SparkFunSuite with BeforeAndAfter with BeforeAn
 
       withSparkSession(
         SparkSession.builder
-          .config(sparkConf.setMaster("local-cluster[2, 1, 1024]"))
+          // (trick) avoid SPARK-19482.
+          // remove the previous 'spark.master' before set new one for each test.
+          .config(sparkConf.remove("spark.master").setMaster("local-cluster[2, 1, 1024]"))
           .getOrCreate()) { spark =>
         implicit val sqlContext = spark.sqlContext
         val path = Utils.createDirectory(tempDir, Random.nextString(10)).toString

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
@@ -157,6 +157,7 @@ class HiveSparkSubmitSuite
     val jarDir = getTestResourcePath("regression-test-SPARK-8489")
     val testJar = s"$jarDir/test-$version.jar"
     val args = Seq(
+      "--master", "local",
       "--conf", "spark.ui.enabled=false",
       "--conf", "spark.master.rest.enabled=false",
       "--driver-java-options", "-Dderby.system.durability=test",

--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -63,6 +63,8 @@ class Checkpoint(ssc: StreamingContext, val checkpointTime: Time)
     val newReloadConf = new SparkConf(loadDefaults = true)
     propertiesToReload.foreach { prop =>
       newReloadConf.getOption(prop).foreach { value =>
+        // (trick) avoid SPARK-19482.
+        newSparkConf.remove(prop)
         newSparkConf.set(prop, value)
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

First, there is no need to set 'spark.master' multi-times with different values. Second, It is possible for users to set the different 'spark.master' in code with
`spark-submit` command, and will confuse himself. So, we should do once check if the 'spark.master' already exists in settings and if the previous value is the same with current value. Throw a IllegalArgumentException when previous value is different with current value.

BTW, I have received many cases that users forgot to remove "local[*]" from code and submit it in command line. And many fresh users has no consciousness to check if job runs correctly in standalone mode or yarn mode. At last, the job will run on master node or gateway node all along.

## How was this patch tested?

add new unit test
