### PR TITLE
[SPARK-19491][SQL]add a config for table relation cache size

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystConf.scala
@@ -58,6 +58,11 @@ trait CatalystConf {
    * Enables CBO for estimation of plan statistics when set true.
    */
   def cboEnabled: Boolean
+
+  /**
+   * the size of tableRelationCache in SessionCatalog
+   */
+  def tableRelationCacheSize: Int = 1000
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -121,8 +121,8 @@ class SessionCatalog(
    * A cache of qualified table name to table relation plan.
    */
   val tableRelationCache: Cache[QualifiedTableName, LogicalPlan] = {
-    // TODO: create a config instead of hardcode 1000 here.
-    CacheBuilder.newBuilder().maximumSize(1000).build[QualifiedTableName, LogicalPlan]()
+    CacheBuilder.newBuilder().maximumSize(conf.tableRelationCacheSize)
+      .build[QualifiedTableName, LogicalPlan]()
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -666,6 +666,12 @@ object SQLConf {
       .stringConf
       .createWithDefault(TimeZone.getDefault().getID())
 
+  val SESSIONCATALOG_TABLE_RELATION_CACHE_SIZE =
+    SQLConfigBuilder("spark.sql.tableRelation.cache.size")
+      .doc("""The size of a cache of qualified table name to table relation plan.""")
+      .intConf
+      .createWithDefault(1000)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -865,6 +871,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   override def crossJoinEnabled: Boolean = getConf(SQLConf.CROSS_JOINS_ENABLED)
 
   override def sessionLocalTimeZone: String = getConf(SQLConf.SESSION_LOCAL_TIMEZONE)
+
+  override def tableRelationCacheSize: Int =
+    getConf(SQLConf.SESSIONCATALOG_TABLE_RELATION_CACHE_SIZE)
 
   def ndvMaxError: Double = getConf(NDV_MAX_ERROR)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -270,4 +270,13 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     val e2 = intercept[AnalysisException](spark.conf.unset(SCHEMA_STRING_LENGTH_THRESHOLD.key))
     assert(e2.message.contains("Cannot modify the value of a static config"))
   }
+
+  test("set the size of table relation cache size") {
+    withTable("t") {
+      withSQLConf(SQLConf.SESSIONCATALOG_TABLE_RELATION_CACHE_SIZE.key -> "25") {
+        assert(spark.sessionState.conf.getConf(SQLConf.
+          SESSIONCATALOG_TABLE_RELATION_CACHE_SIZE) == 25)
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

currently the table relation cache size is hardcode to 1000, it is better to add a config to set its size.

## How was this patch tested?
unit test added