### PR TITLE
[SPARK-19318][SQL] Fix to send JDBC connection properties to the source as user-specified (case-sensitive)

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -75,7 +75,7 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
       s"""
         |CREATE OR REPLACE TEMPORARY VIEW PEOPLE1
         |USING org.apache.spark.sql.jdbc
-        |OPTIONS (url '$url1', dbtable 'TEST.PEOPLE1', user 'testUser', password 'testPass')
+        |OPTIONS (url '$url1', dbTable 'TEST.PEOPLE1', user 'testUser', password 'testPass')
       """.stripMargin.replaceAll("\n", " "))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The reason for test failure is that the  property “oracle.jdbc.mapDateToTimestamp” set by the test was getting converted into all lower case.  Oracle database expects this property in case-sensitive manner. 

This test was passing in previous releases because connection properties were sent as user specified for the test case scenario. Fixes to handle all option uniformly in case-insensitive manner, converted the JDBC connection properties also to lower case.

This PR makes changes to treat only JDBC options meant for spark sql in case-insensitive manner , and pass the connection properties to the JDBC  connection.as user specified.

Alternative approach PR https://github.com/apache/spark/pull/16891  is to enhance CaseInsensitiveMap to keep track case-sensitive keys and use them when creating connection properties.

## How was this patch tested?
Added new test cases to JdbcSuite , and OracleIntegrationSuite.  Ran docker integration tests passed on my laptop, all tests passed successfully.