### PR TITLE
[SPARK-19464][BUILD][HOTFIX][test-hadoop2.6] Add back mockito test dep in YARN module, as it ends up being required in a Maven build

### DIFF
--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -132,6 +132,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
      <!--
        Jersey 1 dependencies only required for YARN integration testing. Creating a YARN cluster
        in the JVM requires starting a Jersey 1-based web application.


### PR DESCRIPTION
Add back mockito test dep in YARN module, as it ends up being required in a Maven build

## How was this patch tested?

PR builder again, but also a local `mvn` run using the command that the broken Jenkins job uses