### PR TITLE
Swamidass & Baldi Approximations

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
@@ -81,6 +81,11 @@ public abstract class BloomFilter {
   public abstract long bitSize();
 
   /**
+   * Swamidass & Baldi (2007) approximation for number of items in a Bloom filter
+   */
+  public abstract double approxItems();
+
+  /**
    * Puts an item into this {@code BloomFilter}. Ensures that subsequent invocations of
    * {@linkplain #mightContain(Object)} with the same item will always return {@code true}.
    *

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
@@ -153,6 +153,20 @@ public abstract class BloomFilter {
   public abstract boolean mightContainBinary(byte[] item);
 
   /**
+   * Returns a new Bloom filter of the union of two Bloom filters.
+   * Unlike mergeInplace, this will not cause a mutation.
+   * Callers must ensure the bloom filters are appropriately sized to avoid saturating them.
+   *
+   * @throws IncompatibleUnionException if either are null, different classes, or different size or number of hash functions
+   */
+  public abstract BloomFilterImpl createUnionBloomFilter(BloomFilter other) throws IncompatibleUnionException;
+
+  /**
+   * Swamidass & Baldi (2007) approximation for number of items in the intersection of two Bloom filters
+   */
+  public abstract double approxItemsInIntersection(BloomFilter that) throws IncompatibleUnionException;
+
+  /**
    * Writes out this {@link BloomFilter} to an output stream in binary format. It is the caller's
    * responsibility to close the stream.
    */

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
@@ -233,47 +233,42 @@ class BloomFilterImpl extends BloomFilter implements Serializable {
    *
    * @throws IncompatibleUnionException if either are null, different classes, or different size or number of hash functions
    */
-  public static BloomFilterImpl createUnionBloomFilter(BloomFilter bf1, BloomFilter bf2) throws IncompatibleUnionException {
+  public BloomFilterImpl createUnionBloomFilter(BloomFilter other) throws IncompatibleUnionException {
     // Duplicates the logic of `isCompatible` here to provide better error message.
-    if (bf1 == null || bf2 == null) {
+    if (other == null) {
       throw new IncompatibleUnionException("Cannot union null bloom filters");
     }
 
-    if (!(bf1 instanceof BloomFilterImpl)) {
+    if (!(other instanceof BloomFilterImpl)) {
       throw new IncompatibleUnionException(
-          "Cannot union bloom filter of class " + bf1.getClass().getName()
-      );
-    } else if (!(bf2 instanceof BloomFilterImpl)) {
-      throw new IncompatibleUnionException(
-          "Cannot union bloom filter of class " + bf2.getClass().getName()
+          "Cannot union bloom filter of class " + other.getClass().getName()
       );
     }
 
-    BloomFilterImpl bfImpl1 = (BloomFilterImpl) bf1;
-    BloomFilterImpl bfImpl2 = (BloomFilterImpl) bf2;
+    BloomFilterImpl that = (BloomFilterImpl) other;
 
-    if (bfImpl1.bitSize() != bfImpl2.bitSize()) {
+    if (this.bitSize() != that.bitSize()) {
       throw new IncompatibleUnionException("Cannot union bloom filters with different bit size");
     }
 
-    if (bfImpl1.numHashFunctions != bfImpl2.numHashFunctions) {
+    if (this.numHashFunctions != that.numHashFunctions) {
       throw new IncompatibleUnionException("Cannot union bloom filters with different number of hash functions");
     }
 
-    BloomFilterImpl bfUnion = (BloomFilterImpl)BloomFilter.create(bf1.bitSize());
+    BloomFilterImpl bfUnion = (BloomFilterImpl)BloomFilter.create(bitSize());
 
-    bfUnion.bits.putAll(bfImpl1.bits);
-    bfUnion.bits.putAll(bfImpl2.bits);
+    bfUnion.bits.putAll(this.bits);
+    bfUnion.bits.putAll(that.bits);
     return bfUnion;
   }
 
   /**
    * Swamidass & Baldi (2007) approximation for number of items in the intersection of two Bloom filters
    */
-  public static double approxItemsInIntersection(BloomFilterImpl bf1, BloomFilterImpl bf2) throws IncompatibleUnionException {
-    BloomFilterImpl union = createUnionBloomFilter(bf1, bf2);
+  public double approxItemsInIntersection(BloomFilter that) throws IncompatibleUnionException {
+    BloomFilterImpl union = createUnionBloomFilter(that);
 
-    return bf1.approxItems() + bf2.approxItems() - union.approxItems();
+    return this.approxItems() + that.approxItems() - union.approxItems();
   }
 
   @Override

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
@@ -221,6 +221,62 @@ class BloomFilterImpl extends BloomFilter implements Serializable {
   }
 
   @Override
+  public double approxItems() {
+    double m = bitSize();
+    return (m / numHashFunctions) * Math.log(1 - (bits.cardinality() / m));
+  }
+
+  /**
+   * Returns a new Bloom filter of the union of two Bloom filters.
+   * Unlike mergeInplace, this will not cause a mutation.
+   * Callers must ensure the bloom filters are appropriately sized to avoid saturating them.
+   *
+   * @throws IncompatibleUnionException if either are null, different classes, or different size or number of hash functions
+   */
+  public static BloomFilterImpl createUnionBloomFilter(BloomFilter bf1, BloomFilter bf2) throws IncompatibleUnionException {
+    // Duplicates the logic of `isCompatible` here to provide better error message.
+    if (bf1 == null || bf2 == null) {
+      throw new IncompatibleUnionException("Cannot union null bloom filters");
+    }
+
+    if (!(bf1 instanceof BloomFilterImpl)) {
+      throw new IncompatibleUnionException(
+          "Cannot union bloom filter of class " + bf1.getClass().getName()
+      );
+    } else if (!(bf2 instanceof BloomFilterImpl)) {
+      throw new IncompatibleUnionException(
+          "Cannot union bloom filter of class " + bf2.getClass().getName()
+      );
+    }
+
+    BloomFilterImpl bfImpl1 = (BloomFilterImpl) bf1;
+    BloomFilterImpl bfImpl2 = (BloomFilterImpl) bf2;
+
+    if (bfImpl1.bitSize() != bfImpl2.bitSize()) {
+      throw new IncompatibleUnionException("Cannot union bloom filters with different bit size");
+    }
+
+    if (bfImpl1.numHashFunctions != bfImpl2.numHashFunctions) {
+      throw new IncompatibleUnionException("Cannot union bloom filters with different number of hash functions");
+    }
+
+    BloomFilterImpl bfUnion = (BloomFilterImpl)BloomFilter.create(bf1.bitSize());
+
+    bfUnion.bits.putAll(bfImpl1.bits);
+    bfUnion.bits.putAll(bfImpl2.bits);
+    return bfUnion;
+  }
+
+  /**
+   * Swamidass & Baldi (2007) approximation for number of items in the intersection of two Bloom filters
+   */
+  public static double approxItemsInIntersection(BloomFilterImpl bf1, BloomFilterImpl bf2) throws IncompatibleUnionException {
+    BloomFilterImpl union = createUnionBloomFilter(bf1, bf2);
+
+    return bf1.approxItems() + bf2.approxItems() - union.approxItems();
+  }
+
+  @Override
   public void writeTo(OutputStream out) throws IOException {
     DataOutputStream dos = new DataOutputStream(out);
 

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
@@ -226,13 +226,7 @@ class BloomFilterImpl extends BloomFilter implements Serializable {
     return (m / numHashFunctions) * Math.log(1 - (bits.cardinality() / m));
   }
 
-  /**
-   * Returns a new Bloom filter of the union of two Bloom filters.
-   * Unlike mergeInplace, this will not cause a mutation.
-   * Callers must ensure the bloom filters are appropriately sized to avoid saturating them.
-   *
-   * @throws IncompatibleUnionException if either are null, different classes, or different size or number of hash functions
-   */
+  @Override
   public BloomFilterImpl createUnionBloomFilter(BloomFilter other) throws IncompatibleUnionException {
     // Duplicates the logic of `isCompatible` here to provide better error message.
     if (other == null) {
@@ -262,9 +256,7 @@ class BloomFilterImpl extends BloomFilter implements Serializable {
     return bfUnion;
   }
 
-  /**
-   * Swamidass & Baldi (2007) approximation for number of items in the intersection of two Bloom filters
-   */
+  @Override
   public double approxItemsInIntersection(BloomFilter that) throws IncompatibleUnionException {
     BloomFilterImpl union = createUnionBloomFilter(that);
 

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/IncompatibleUnionException.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/IncompatibleUnionException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.sketch;
+
+public class IncompatibleUnionException extends Exception {
+  public IncompatibleUnionException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added functions to get the Swamidass & Baldi (2007) approximation for number of items in a Bloom filter and the intersections of two filters. Added an exception type IncompatibleUnionException mimicing IncompatibleMergeException. As needed for the intersection approximation, there is a function that create the union of two Bloom filters (no mutations).

## How was this patch tested?

Manual Tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
