### PR TITLE
[SPARK-19530][SQL] Use guava weigher for code cache eviction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-import com.google.common.cache.{CacheBuilder, CacheLoader}
+import com.google.common.cache.{CacheBuilder, CacheLoader, Weigher}
 import org.codehaus.janino.{ByteArrayClassLoader, ClassBodyEvaluator, SimpleCompiler}
 import org.codehaus.janino.util.ClassFile
 import scala.language.existentials
@@ -854,6 +854,17 @@ class CodeAndComment(val body: String, val comment: collection.Map[String, Strin
   }
 
   override def hashCode(): Int = body.hashCode
+
+  private var _classByteCodeSize = 0
+  private[codegen] def incByteCodeSize(size: Int): Unit = _classByteCodeSize += size
+  private[codegen] def getByteCodeSize: Int = _classByteCodeSize
+}
+
+/**
+ * A weigher used for determining the weight of generated classes in cache.
+ */
+class CodeAndCommentWeigher extends Weigher[CodeAndComment, GeneratedClass] {
+  override def weigh(key: CodeAndComment, value: GeneratedClass): Int = key.getByteCodeSize
 }
 
 /**
@@ -947,7 +958,7 @@ object CodeGenerator extends Logging {
 
     try {
       evaluator.cook("generated.java", code.body)
-      recordCompilationStats(evaluator)
+      recordCompilationStats(evaluator, code)
     } catch {
       case e: Exception =>
         val msg = s"failed to compile: $e\n$formatted"
@@ -960,7 +971,7 @@ object CodeGenerator extends Logging {
   /**
    * Records the generated class and method bytecode sizes by inspecting janino private fields.
    */
-  private def recordCompilationStats(evaluator: ClassBodyEvaluator): Unit = {
+  private def recordCompilationStats(evaluator: ClassBodyEvaluator, code: CodeAndComment): Unit = {
     // First retrieve the generated classes.
     val classes = {
       val resultField = classOf[SimpleCompiler].getDeclaredField("result")
@@ -977,6 +988,7 @@ object CodeGenerator extends Logging {
     codeAttrField.setAccessible(true)
     classes.foreach { case (_, classBytes) =>
       CodegenMetrics.METRIC_GENERATED_CLASS_BYTECODE_SIZE.update(classBytes.length)
+      code.incByteCodeSize(classBytes.length)
       try {
         val cf = new ClassFile(new ByteArrayInputStream(classBytes))
         cf.methodInfos.asScala.foreach { method =>
@@ -1004,7 +1016,8 @@ object CodeGenerator extends Logging {
    * weak keys/values and thus does not respond to memory pressure.
    */
   private val cache = CacheBuilder.newBuilder()
-    .maximumSize(100)
+    .maximumWeight(10 * 1024 * 1024)
+    .weigher(new CodeAndCommentWeigher)
     .build(
       new CacheLoader[CodeAndComment, GeneratedClass]() {
         override def load(code: CodeAndComment): GeneratedClass = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We use guava cache to cache compiled codes for codegen. Currently we use number of entries (100 as maximum now) in the cache to determine when to evict older entries.

However, the number of entries can't reflect well to actual memory usage of cache entries. As we heavily rely codegen now and the generated codes can be large, we shouldn't use maximum of entries.

This patch turns to use `Weigher` in guava. We use the size of bytecode as the weight of an entry.

## How was this patch tested?

Jenkins tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
