### PR TITLE
[SPARK-16929] Improve performance when check speculatable tasks.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -172,7 +172,7 @@ private[spark] class TaskSchedulerImpl private[scheduler](
 
     if (!isLocal && conf.getBoolean("spark.speculation", false)) {
       logInfo("Starting speculative execution thread")
-      speculationScheduler.scheduleAtFixedRate(new Runnable {
+      speculationScheduler.scheduleWithFixedDelay(new Runnable {
         override def run(): Unit = Utils.tryOrStopSparkContext(sc) {
           checkSpeculatableTasks()
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -172,7 +172,7 @@ private[spark] class TaskSchedulerImpl private[scheduler](
 
     if (!isLocal && conf.getBoolean("spark.speculation", false)) {
       logInfo("Starting speculative execution thread")
-      speculationScheduler.scheduleWithFixedDelay(new Runnable {
+      speculationScheduler.scheduleAtFixedRate(new Runnable {
         override def run(): Unit = Utils.tryOrStopSparkContext(sc) {
           checkSpeculatableTasks()
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -917,10 +917,8 @@ private[spark] class TaskSetManager(
    *
    */
   override def checkSpeculatableTasks(minTimeToSpeculation: Int): Boolean = {
-
     // Can't speculate if we only have one task, and no need to speculate if the task set is a
     // zombie.
-
     if (isZombie || numTasks == 1 || !speculationEnabled) {
       return false
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -19,11 +19,10 @@ package org.apache.spark.scheduler
 
 import java.io.NotSerializableException
 import java.nio.ByteBuffer
-import java.util.Arrays
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
-import scala.math.{max, min}
+import scala.math.max
 import scala.util.control.NonFatal
 
 import org.apache.spark._
@@ -31,6 +30,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.util.{AccumulatorV2, Clock, SystemClock, Utils}
+import org.apache.spark.util.collection.MedianHeap
 
 /**
  * Schedules the tasks within a single TaskSet in the TaskSchedulerImpl. This class keeps track of
@@ -62,6 +62,8 @@ private[spark] class TaskSetManager(
 
   // Limit of bytes for total size of results (default is 1GB)
   val maxResultSize = Utils.getMaxResultSize(conf)
+
+  val speculationEnabled = conf.getBoolean("spark.speculation", false)
 
   // Serializer for closures and tasks.
   val env = SparkEnv.get
@@ -140,6 +142,9 @@ private[spark] class TaskSetManager(
 
   // Task index, start and finish time for each task attempt (indexed by task ID)
   val taskInfos = new HashMap[Long, TaskInfo]
+
+  // Use a MedianHeap to record durations of successful tasks when speculation is enabled.
+  val successfulTaskDurations = new MedianHeap()
 
   // How frequently to reprint duplicate exceptions in full, in milliseconds
   val EXCEPTION_PRINT_INTERVAL =
@@ -696,6 +701,9 @@ private[spark] class TaskSetManager(
     val info = taskInfos(tid)
     val index = info.index
     info.markFinished(TaskState.FINISHED, clock.getTimeMillis())
+    if (speculationEnabled) {
+      successfulTaskDurations.insert(info.duration)
+    }
     removeRunningTask(tid)
     // This method is called by "TaskSchedulerImpl.handleSuccessfulTask" which holds the
     // "TaskSchedulerImpl" lock until exiting. To avoid the SPARK-7655 issue, we should not
@@ -909,19 +917,20 @@ private[spark] class TaskSetManager(
    *
    */
   override def checkSpeculatableTasks(minTimeToSpeculation: Int): Boolean = {
+
     // Can't speculate if we only have one task, and no need to speculate if the task set is a
     // zombie.
-    if (isZombie || numTasks == 1) {
+
+    if (isZombie || numTasks == 1 || !speculationEnabled) {
       return false
     }
     var foundTasks = false
     val minFinishedForSpeculation = (SPECULATION_QUANTILE * numTasks).floor.toInt
     logDebug("Checking for speculative tasks: minFinished = " + minFinishedForSpeculation)
+
     if (tasksSuccessful >= minFinishedForSpeculation && tasksSuccessful > 0) {
       val time = clock.getTimeMillis()
-      val durations = taskInfos.values.filter(_.successful).map(_.duration).toArray
-      Arrays.sort(durations)
-      val medianDuration = durations(min((0.5 * tasksSuccessful).round.toInt, durations.length - 1))
+      var medianDuration = successfulTaskDurations.findMedian()
       val threshold = max(SPECULATION_MULTIPLIER * medianDuration, minTimeToSpeculation)
       // TODO: Threshold should also look at standard deviation of task durations and have a lower
       // bound based on that.

--- a/core/src/main/scala/org/apache/spark/util/collection/MedianHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/MedianHeap.scala
@@ -31,28 +31,28 @@ import scala.collection.mutable.PriorityQueue
  * return the average of the two top values of heaps. Otherwise we return the top of the
  * heap which has one more element.
  */
-
 private[spark] class MedianHeap(implicit val ord: Ordering[Double]) {
 
-  // Stores all the numbers less than the current median in a smallerHalf,
-  // i.e median is the maximum, at the root
+  /**
+   * Stores all the numbers less than the current median in a smallerHalf,
+   * i.e median is the maximum, at the root.
+   */
   private[this] var smallerHalf = PriorityQueue.empty[Double](ord)
 
-  // Stores all the numbers greater than the current median in a largerHalf,
-  // i.e median is the minimum, at the root
+  /**
+   * Stores all the numbers greater than the current median in a largerHalf,
+   * i.e median is the minimum, at the root.
+   */
   private[this] var largerHalf = PriorityQueue.empty[Double](ord.reverse)
 
-  // Returns if there is no element in MedianHeap.
   def isEmpty(): Boolean = {
     smallerHalf.isEmpty && largerHalf.isEmpty
   }
 
-  // Size of MedianHeap.
   def size(): Int = {
     smallerHalf.size + largerHalf.size
   }
 
-  // Insert a new number into MedianHeap.
   def insert(x: Double): Unit = {
     // If both heaps are empty, we arbitrarily insert it into a heap, let's say, the largerHalf.
     if (isEmpty) {
@@ -69,7 +69,6 @@ private[spark] class MedianHeap(implicit val ord: Ordering[Double]) {
     rebalance()
   }
 
-  // Re-balance the heaps.
   private[this] def rebalance(): Unit = {
     if (largerHalf.size - smallerHalf.size > 1) {
       smallerHalf.enqueue(largerHalf.dequeue())
@@ -79,7 +78,6 @@ private[spark] class MedianHeap(implicit val ord: Ordering[Double]) {
     }
   }
 
-  // Returns the median of the numbers.
   def median: Double = {
     if (isEmpty) {
       throw new NoSuchElementException("MedianHeap is empty.")

--- a/core/src/main/scala/org/apache/spark/util/collection/MedianHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/MedianHeap.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection
+
+import scala.collection.mutable
+
+/**
+ * MedianHeap stores numbers and returns the median by O(1) time complexity.
+ * The basic idea is to maintain two heaps: a maxHeap and a minHeap. The maxHeap stores
+ * the smaller half of all numbers while the minHeap stores the larger half.  The sizes
+ * of two heaps need to be balanced each time when a new number is inserted so that their
+ * sizes will not be different by more than 1. Therefore each time when findMedian() is
+ * called we check if two heaps have the same size. If they do, we should return the
+ * average of the two top values of heaps. Otherwise we return the top of the heap which
+ * has one more element.
+ */
+
+private[spark]
+class MedianHeap(implicit val ord: Ordering[Double]) {
+
+  // Stores all the numbers less than the current median in a maxHeap,
+  // i.e median is the maximum, at the root
+  private[this] var maxHeap = mutable.PriorityQueue.empty[Double](implicitly[Ordering[Double]])
+
+  // Stores all the numbers greater than the current median in a minHeap,
+  // i.e median is the minimum, at the root
+  private[this] var minHeap = mutable.PriorityQueue.empty[Double](
+    implicitly[Ordering[Double]].reverse)
+
+  // Returns if there is no element in MedianHeap.
+  def isEmpty(): Boolean = {
+    maxHeap.isEmpty && minHeap.isEmpty
+  }
+
+  // Size of MedianHeap.
+  def size(): Int = {
+    maxHeap.size + minHeap.size
+  }
+
+  // Insert a new number into MedianHeap.
+  def insert(x: Double): Unit = {
+    // If both heaps are empty, we arbitrarily insert it into a heap, let's say, the minHeap.
+    if (isEmpty) {
+      minHeap.enqueue(x)
+    } else {
+      // If the number is larger than current median, it should be inserted into minHeap,
+      // otherwise maxHeap.
+      if (x > findMedian) {
+        minHeap.enqueue(x)
+      } else {
+        maxHeap.enqueue(x)
+      }
+    }
+    rebalance()
+  }
+
+  // Remove an number from MedianHeap, return if the number exists.
+  def remove(x: Double): Boolean = {
+    if (maxHeap.size != 0 && minHeap.size == 0 ||
+      maxHeap.size != 0 && minHeap.size != 0 && maxHeap.head >= x) {
+      var dropped = false
+      maxHeap = maxHeap.filterNot {
+        case num =>
+          if (!dropped && num == x) {
+            dropped = true
+            true
+          } else {
+            false
+          }
+      }
+      rebalance()
+      dropped
+    } else if (maxHeap.size == 0 && minHeap.size != 0 ||
+      maxHeap.size != 0 && minHeap.size != 0 && minHeap.head <= x) {
+      var dropped = false
+      minHeap = minHeap.filterNot {
+        case num =>
+          if (!dropped && num == x) {
+            dropped = true
+            true
+          } else {
+            false
+          }
+      }
+      rebalance()
+      dropped
+    } else {
+      false
+    }
+  }
+
+  // Re-balance the heaps.
+  private[this] def rebalance(): Unit = {
+    if (minHeap.size - maxHeap.size > 1) {
+      maxHeap.enqueue(minHeap.dequeue())
+    }
+    if (maxHeap.size - minHeap.size > 1) {
+      minHeap.enqueue(maxHeap.dequeue)
+    }
+  }
+
+  // Returns the median of the numbers.
+  def findMedian(): Double = {
+    if (isEmpty) {
+      throw new NoSuchElementException("MedianHeap is empty.")
+    }
+    if (minHeap.size == maxHeap.size) {
+      (minHeap.head + maxHeap.head) / 2.0
+    } else if (minHeap.size > maxHeap.size) {
+      minHeap.head
+    } else {
+      maxHeap.head
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/collection/MedianHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/MedianHeap.scala
@@ -20,7 +20,7 @@ package org.apache.spark.util.collection
 import scala.collection.mutable
 
 /**
- * MedianHeap stores numbers and returns the median by O(1) time complexity.
+ * MedianHeap inserts number by O(log n) and returns the median by O(1) time complexity.
  * The basic idea is to maintain two heaps: a maxHeap and a minHeap. The maxHeap stores
  * the smaller half of all numbers while the minHeap stores the larger half.  The sizes
  * of two heaps need to be balanced each time when a new number is inserted so that their
@@ -30,17 +30,15 @@ import scala.collection.mutable
  * has one more element.
  */
 
-private[spark]
-class MedianHeap(implicit val ord: Ordering[Double]) {
+private[spark] class MedianHeap(implicit val ord: Ordering[Double]) {
 
   // Stores all the numbers less than the current median in a maxHeap,
   // i.e median is the maximum, at the root
-  private[this] var maxHeap = mutable.PriorityQueue.empty[Double](implicitly[Ordering[Double]])
+  private[this] var maxHeap = mutable.PriorityQueue.empty[Double](ord)
 
   // Stores all the numbers greater than the current median in a minHeap,
   // i.e median is the minimum, at the root
-  private[this] var minHeap = mutable.PriorityQueue.empty[Double](
-    implicitly[Ordering[Double]].reverse)
+  private[this] var minHeap = mutable.PriorityQueue.empty[Double](ord.reverse)
 
   // Returns if there is no element in MedianHeap.
   def isEmpty(): Boolean = {
@@ -67,41 +65,6 @@ class MedianHeap(implicit val ord: Ordering[Double]) {
       }
     }
     rebalance()
-  }
-
-  // Remove an number from MedianHeap, return if the number exists.
-  def remove(x: Double): Boolean = {
-    if (maxHeap.size != 0 && minHeap.size == 0 ||
-      maxHeap.size != 0 && minHeap.size != 0 && maxHeap.head >= x) {
-      var dropped = false
-      maxHeap = maxHeap.filterNot {
-        case num =>
-          if (!dropped && num == x) {
-            dropped = true
-            true
-          } else {
-            false
-          }
-      }
-      rebalance()
-      dropped
-    } else if (maxHeap.size == 0 && minHeap.size != 0 ||
-      maxHeap.size != 0 && minHeap.size != 0 && minHeap.head <= x) {
-      var dropped = false
-      minHeap = minHeap.filterNot {
-        case num =>
-          if (!dropped && num == x) {
-            dropped = true
-            true
-          } else {
-            false
-          }
-      }
-      rebalance()
-      dropped
-    } else {
-      false
-    }
   }
 
   // Re-balance the heaps.

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -893,6 +893,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     val taskSet = FakeTask.createTaskSet(4)
     // Set the speculation multiplier to be 0 so speculative tasks are launched immediately
     sc.conf.set("spark.speculation.multiplier", "0.0")
+    sc.conf.set("spark.speculation", "true")
     val clock = new ManualClock()
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
     val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>
@@ -948,6 +949,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // Set the speculation multiplier to be 0 so speculative tasks are launched immediately
     sc.conf.set("spark.speculation.multiplier", "0.0")
     sc.conf.set("spark.speculation.quantile", "0.6")
+    sc.conf.set("spark.speculation", "true")
     val clock = new ManualClock()
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
     val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>

--- a/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
@@ -79,25 +79,4 @@ class MedianHeapSuite extends SparkFunSuite {
     assert(medianHeap.size === 1000)
     assert(medianHeap.findMedian() === ((array(499) + array(500)) / 2.0))
   }
-
-  test("Remove a number from MedianHeap.") {
-    val random = new Random()
-    val medianHeap = new MedianHeap()
-    val array = new Array[Int](99)
-    var lastNumber = 0
-    (0 until 100).foreach {
-      case i =>
-        val randomNumber = random.nextInt(100)
-        medianHeap.insert(randomNumber)
-        if (i != 99) {
-          array(i) += randomNumber
-        } else {
-          lastNumber = randomNumber
-        }
-    }
-    util.Arrays.sort(array)
-    assert(medianHeap.remove(lastNumber) === true)
-    assert(medianHeap.findMedian() === array(49))
-
-  }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util.collection
 
-import java.util
+import java.util.Arrays
 import java.util.NoSuchElementException
 
 import scala.collection.mutable.ArrayBuffer
@@ -31,7 +31,7 @@ class MedianHeapSuite extends SparkFunSuite {
     val medianHeap = new MedianHeap()
     var valid = false
     try {
-      medianHeap.findMedian()
+      medianHeap.median
     } catch {
       case e: NoSuchElementException =>
         valid = true
@@ -40,43 +40,28 @@ class MedianHeapSuite extends SparkFunSuite {
     assert(valid)
   }
 
-  test("Median should be correct when size of MedianHeap is even or odd") {
-    val random = new Random()
-    val medianHeap1 = new MedianHeap()
-    val array1 = new Array[Int](100)
-    (0 until 100).foreach {
-      case i =>
-        val randomNumber = random.nextInt(1000)
-        medianHeap1.insert(randomNumber)
-        array1(i) += randomNumber
-    }
-    util.Arrays.sort(array1)
-    assert(medianHeap1.findMedian() === ((array1(49) + array1(50)) / 2.0))
+  test("Median should be correct when size of MedianHeap is even") {
+    val array = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    val medianHeap = new MedianHeap()
+    array.foreach(medianHeap.insert(_))
+    assert(medianHeap.size() === 10)
+    assert(medianHeap.median === ((array(4) + array(5)) / 2.0))
+  }
 
-    val medianHeap2 = new MedianHeap()
-    val array2 = new Array[Int](101)
-    (0 until 101).foreach {
-      case i =>
-        val randomNumber = random.nextInt(1000)
-        medianHeap2.insert(randomNumber)
-        array2(i) += randomNumber
-    }
-    util.Arrays.sort(array2)
-    assert(medianHeap2.findMedian() === array2(50))
+  test("Median should be correct when size of MedianHeap is odd") {
+    val array = Array(0, 1, 2, 3, 4, 5, 6, 7, 8)
+    val medianHeap = new MedianHeap()
+    array.foreach(medianHeap.insert(_))
+    assert(medianHeap.size() === 9)
+    assert(medianHeap.median === (array(4)))
   }
 
   test("Size of Median should be correct though there are duplicated numbers inside.") {
-    val random = new Random()
+    val array = Array(0, 0, 1, 1, 2, 2, 3, 3, 4, 4)
     val medianHeap = new MedianHeap()
-    val array = new Array[Int](1000)
-    (0 until 1000).foreach {
-      case i =>
-        val randomNumber = random.nextInt(100)
-        medianHeap.insert(randomNumber)
-        array(i) += randomNumber
-    }
-    util.Arrays.sort(array)
-    assert(medianHeap.size === 1000)
-    assert(medianHeap.findMedian() === ((array(499) + array(500)) / 2.0))
+    array.foreach(medianHeap.insert(_))
+    Arrays.sort(array)
+    assert(medianHeap.size === 10)
+    assert(medianHeap.median === ((array(4) + array(5)) / 2.0))
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
@@ -54,7 +54,6 @@ class MedianHeapSuite extends SparkFunSuite {
     val array = Array(0, 0, 1, 1, 2, 2, 3, 3, 4, 4)
     val medianHeap = new MedianHeap()
     array.foreach(medianHeap.insert(_))
-    Arrays.sort(array)
     assert(medianHeap.size === 10)
     assert(medianHeap.median === ((array(4) + array(5)) / 2.0))
   }

--- a/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
@@ -17,11 +17,7 @@
 
 package org.apache.spark.util.collection
 
-import java.util.Arrays
 import java.util.NoSuchElementException
-
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Random
 
 import org.apache.spark.SparkFunSuite
 
@@ -39,7 +35,7 @@ class MedianHeapSuite extends SparkFunSuite {
     val medianHeap = new MedianHeap()
     array.foreach(medianHeap.insert(_))
     assert(medianHeap.size() === 10)
-    assert(medianHeap.median === ((array(4) + array(5)) / 2.0))
+    assert(medianHeap.median === 4.5)
   }
 
   test("Median should be correct when size of MedianHeap is odd") {
@@ -47,18 +43,18 @@ class MedianHeapSuite extends SparkFunSuite {
     val medianHeap = new MedianHeap()
     array.foreach(medianHeap.insert(_))
     assert(medianHeap.size() === 9)
-    assert(medianHeap.median === (array(4)))
+    assert(medianHeap.median === 4)
   }
 
   test("Median should be correct though there are duplicated numbers inside.") {
-    val array = Array(0, 0, 1, 1, 2, 2, 3, 3, 4, 4)
+    val array = Array(0, 0, 1, 1, 2, 3, 4)
     val medianHeap = new MedianHeap()
     array.foreach(medianHeap.insert(_))
-    assert(medianHeap.size === 10)
-    assert(medianHeap.median === ((array(4) + array(5)) / 2.0))
+    assert(medianHeap.size === 7)
+    assert(medianHeap.median === 1)
   }
 
-  test("Median should be correct when skew situations.") {
+  test("Median should be correct when input data is skewed.") {
     val medianHeap = new MedianHeap()
     (0 until 10).foreach(_ => medianHeap.insert(5))
     assert(medianHeap.median === 5)

--- a/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection
+
+import java.util
+import java.util.NoSuchElementException
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
+
+import org.apache.spark.SparkFunSuite
+
+class MedianHeapSuite extends SparkFunSuite {
+
+  test("If no numbers in MedianHeap, NoSuchElementException is thrown.") {
+    val medianHeap = new MedianHeap()
+    var valid = false
+    try {
+      medianHeap.findMedian()
+    } catch {
+      case e: NoSuchElementException =>
+        valid = true
+    }
+
+    assert(valid)
+  }
+
+  test("Median should be correct when size of MedianHeap is even or odd") {
+    val random = new Random()
+    val medianHeap1 = new MedianHeap()
+    val array1 = new Array[Int](100)
+    (0 until 100).foreach {
+      case i =>
+        val randomNumber = random.nextInt(1000)
+        medianHeap1.insert(randomNumber)
+        array1(i) += randomNumber
+    }
+    util.Arrays.sort(array1)
+    assert(medianHeap1.findMedian() === ((array1(49) + array1(50)) / 2.0))
+
+    val medianHeap2 = new MedianHeap()
+    val array2 = new Array[Int](101)
+    (0 until 101).foreach {
+      case i =>
+        val randomNumber = random.nextInt(1000)
+        medianHeap2.insert(randomNumber)
+        array2(i) += randomNumber
+    }
+    util.Arrays.sort(array2)
+    assert(medianHeap2.findMedian() === array2(50))
+  }
+
+  test("Size of Median should be correct though there are duplicated numbers inside.") {
+    val random = new Random()
+    val medianHeap = new MedianHeap()
+    val array = new Array[Int](1000)
+    (0 until 1000).foreach {
+      case i =>
+        val randomNumber = random.nextInt(100)
+        medianHeap.insert(randomNumber)
+        array(i) += randomNumber
+    }
+    util.Arrays.sort(array)
+    assert(medianHeap.size === 1000)
+    assert(medianHeap.findMedian() === ((array(499) + array(500)) / 2.0))
+  }
+
+  test("Remove a number from MedianHeap.") {
+    val random = new Random()
+    val medianHeap = new MedianHeap()
+    val array = new Array[Int](99)
+    var lastNumber = 0
+    (0 until 100).foreach {
+      case i =>
+        val randomNumber = random.nextInt(100)
+        medianHeap.insert(randomNumber)
+        if (i != 99) {
+          array(i) += randomNumber
+        } else {
+          lastNumber = randomNumber
+        }
+    }
+    util.Arrays.sort(array)
+    assert(medianHeap.remove(lastNumber) === true)
+    assert(medianHeap.findMedian() === array(49))
+
+  }
+}

--- a/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/MedianHeapSuite.scala
@@ -29,15 +29,9 @@ class MedianHeapSuite extends SparkFunSuite {
 
   test("If no numbers in MedianHeap, NoSuchElementException is thrown.") {
     val medianHeap = new MedianHeap()
-    var valid = false
-    try {
+    intercept[NoSuchElementException] {
       medianHeap.median
-    } catch {
-      case e: NoSuchElementException =>
-        valid = true
     }
-
-    assert(valid)
   }
 
   test("Median should be correct when size of MedianHeap is even") {
@@ -56,12 +50,22 @@ class MedianHeapSuite extends SparkFunSuite {
     assert(medianHeap.median === (array(4)))
   }
 
-  test("Size of Median should be correct though there are duplicated numbers inside.") {
+  test("Median should be correct though there are duplicated numbers inside.") {
     val array = Array(0, 0, 1, 1, 2, 2, 3, 3, 4, 4)
     val medianHeap = new MedianHeap()
     array.foreach(medianHeap.insert(_))
     Arrays.sort(array)
     assert(medianHeap.size === 10)
     assert(medianHeap.median === ((array(4) + array(5)) / 2.0))
+  }
+
+  test("Median should be correct when skew situations.") {
+    val medianHeap = new MedianHeap()
+    (0 until 10).foreach(_ => medianHeap.insert(5))
+    assert(medianHeap.median === 5)
+    (0 until 100).foreach(_ => medianHeap.insert(10))
+    assert(medianHeap.median === 10)
+    (0 until 1000).foreach(_ => medianHeap.insert(0))
+    assert(medianHeap.median === 0)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Use a MedianHeap to record durations of successful tasks.  When check speculatable tasks, we can get the median duration with O(1) time complexity.

2. `checkSpeculatableTasks` will synchronize `TaskSchedulerImpl`. If `checkSpeculatableTasks` doesn't finish with 100ms, then the possibility exists for that thread to release and then immediately re-acquire the lock. Change `scheduleAtFixedRate` to be `scheduleWithFixedDelay` when call method of `checkSpeculatableTasks`.
## How was this patch tested?
Added MedianHeapSuite.