### PR TITLE
[SPARK-19496][SQL]to_date udf to return null when input date is invalid

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -566,7 +566,7 @@ abstract class UnixTime
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
   private lazy val formatter: DateFormat =
     try {
-      DateTimeUtils.newStrictDateFormat(constFormat.toString, timeZone)
+      DateTimeUtils.newDateFormat(constFormat.toString, timeZone, isLenient = false)
     } catch {
       case NonFatal(_) => null
     }
@@ -599,7 +599,7 @@ abstract class UnixTime
           } else {
             val formatString = f.asInstanceOf[UTF8String].toString
             try {
-              DateTimeUtils.newStrictDateFormat(formatString, timeZone).parse(
+              DateTimeUtils.newDateFormat(formatString, timeZone, isLenient = false).parse(
                 t.asInstanceOf[UTF8String].toString).getTime / 1000L
             } catch {
               case NonFatal(_) => null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -566,7 +566,7 @@ abstract class UnixTime
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
   private lazy val formatter: DateFormat =
     try {
-      DateTimeUtils.newDateFormat(constFormat.toString, timeZone)
+      DateTimeUtils.newStrictDateFormat(constFormat.toString, timeZone)
     } catch {
       case NonFatal(_) => null
     }
@@ -586,6 +586,7 @@ abstract class UnixTime
             null
           } else {
             try {
+              formatter.setLenient(false)
               formatter.parse(
                 t.asInstanceOf[UTF8String].toString).getTime / 1000L
             } catch {
@@ -599,7 +600,7 @@ abstract class UnixTime
           } else {
             val formatString = f.asInstanceOf[UTF8String].toString
             try {
-              DateTimeUtils.newDateFormat(formatString, timeZone).parse(
+              DateTimeUtils.newStrictDateFormat(formatString, timeZone).parse(
                 t.asInstanceOf[UTF8String].toString).getTime / 1000L
             } catch {
               case NonFatal(_) => null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -473,7 +473,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
     val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
     val tz = ctx.addReferenceMinorObj(timeZone)
     defineCodeGen(ctx, ev, (timestamp, format) => {
-      s"""UTF8String.fromString($dtu.newDateFormat($format.toString(), $tz, false)
+      s"""UTF8String.fromString($dtu.newDateFormat($format.toString(), $tz, true)
           .format(new java.util.Date($timestamp / 1000)))"""
     })
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -473,7 +473,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
     val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
     val tz = ctx.addReferenceMinorObj(timeZone)
     defineCodeGen(ctx, ev, (timestamp, format) => {
-      s"""UTF8String.fromString($dtu.newDateFormat($format.toString(), $tz)
+      s"""UTF8String.fromString($dtu.newDateFormat($format.toString(), $tz, false)
           .format(new java.util.Date($timestamp / 1000)))"""
     })
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -586,7 +586,6 @@ abstract class UnixTime
             null
           } else {
             try {
-              formatter.setLenient(false)
               formatter.parse(
                 t.asInstanceOf[UTF8String].toString).getTime / 1000L
             } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -465,7 +465,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
     copy(timeZoneId = Option(timeZoneId))
 
   override protected def nullSafeEval(timestamp: Any, format: Any): Any = {
-    val df = DateTimeUtils.newDateFormat(format.toString, timeZone)
+    val df = DateTimeUtils.newDateFormat(format.toString, timeZone, isLenient = true)
     UTF8String.fromString(df.format(new java.util.Date(timestamp.asInstanceOf[Long] / 1000)))
   }
 
@@ -707,7 +707,7 @@ case class FromUnixTime(sec: Expression, format: Expression, timeZoneId: Option[
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
   private lazy val formatter: DateFormat =
     try {
-      DateTimeUtils.newDateFormat(constFormat.toString, timeZone)
+      DateTimeUtils.newDateFormat(constFormat.toString, timeZone, isLenient = true)
     } catch {
       case NonFatal(_) => null
     }
@@ -734,8 +734,8 @@ case class FromUnixTime(sec: Expression, format: Expression, timeZoneId: Option[
           null
         } else {
           try {
-            UTF8String.fromString(DateTimeUtils.newDateFormat(f.toString, timeZone)
-              .format(new java.util.Date(time.asInstanceOf[Long] * 1000L)))
+            UTF8String.fromString(DateTimeUtils.newDateFormat(f.toString, timeZone,
+              isLenient = true).format(new java.util.Date(time.asInstanceOf[Long] * 1000L)))
           } catch {
             case NonFatal(_) => null
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -465,7 +465,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
     copy(timeZoneId = Option(timeZoneId))
 
   override protected def nullSafeEval(timestamp: Any, format: Any): Any = {
-    val df = DateTimeUtils.newDateFormat(format.toString, timeZone, isLenient = true)
+    val df = DateTimeUtils.newDateFormat(format.toString, timeZone)
     UTF8String.fromString(df.format(new java.util.Date(timestamp.asInstanceOf[Long] / 1000)))
   }
 
@@ -473,7 +473,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
     val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
     val tz = ctx.addReferenceMinorObj(timeZone)
     defineCodeGen(ctx, ev, (timestamp, format) => {
-      s"""UTF8String.fromString($dtu.newDateFormat($format.toString(), $tz, true)
+      s"""UTF8String.fromString($dtu.newDateFormat($format.toString(), $tz)
           .format(new java.util.Date($timestamp / 1000)))"""
     })
   }
@@ -566,7 +566,7 @@ abstract class UnixTime
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
   private lazy val formatter: DateFormat =
     try {
-      DateTimeUtils.newDateFormat(constFormat.toString, timeZone, isLenient = false)
+      DateTimeUtils.newDateFormat(constFormat.toString, timeZone)
     } catch {
       case NonFatal(_) => null
     }
@@ -599,7 +599,7 @@ abstract class UnixTime
           } else {
             val formatString = f.asInstanceOf[UTF8String].toString
             try {
-              DateTimeUtils.newDateFormat(formatString, timeZone, isLenient = false).parse(
+              DateTimeUtils.newDateFormat(formatString, timeZone).parse(
                 t.asInstanceOf[UTF8String].toString).getTime / 1000L
             } catch {
               case NonFatal(_) => null
@@ -707,7 +707,7 @@ case class FromUnixTime(sec: Expression, format: Expression, timeZoneId: Option[
   private lazy val constFormat: UTF8String = right.eval().asInstanceOf[UTF8String]
   private lazy val formatter: DateFormat =
     try {
-      DateTimeUtils.newDateFormat(constFormat.toString, timeZone, isLenient = true)
+      DateTimeUtils.newDateFormat(constFormat.toString, timeZone)
     } catch {
       case NonFatal(_) => null
     }
@@ -734,8 +734,8 @@ case class FromUnixTime(sec: Expression, format: Expression, timeZoneId: Option[
           null
         } else {
           try {
-            UTF8String.fromString(DateTimeUtils.newDateFormat(f.toString, timeZone,
-              isLenient = true).format(new java.util.Date(time.asInstanceOf[Long] * 1000L)))
+            UTF8String.fromString(DateTimeUtils.newDateFormat(f.toString, timeZone)
+              .format(new java.util.Date(time.asInstanceOf[Long] * 1000L)))
           } catch {
             case NonFatal(_) => null
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -95,9 +95,7 @@ object DateTimeUtils {
     sdf
   }
 
-  def newDateFormat(formatString: String,
-      timeZone: TimeZone,
-      isLenient: Boolean = true): DateFormat = {
+  def newDateFormat(formatString: String, timeZone: TimeZone, isLenient: Boolean): DateFormat = {
     val sdf = new SimpleDateFormat(formatString, Locale.US)
     sdf.setTimeZone(timeZone)
     sdf.setLenient(isLenient)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -100,6 +100,7 @@ object DateTimeUtils {
       isLenient: Boolean = true): DateFormat = {
     val sdf = new SimpleDateFormat(formatString, Locale.US)
     sdf.setTimeZone(timeZone)
+    sdf.setLenient(isLenient)
     sdf
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -103,17 +103,6 @@ object DateTimeUtils {
     sdf
   }
 
-  /*
-   * if the time is invalid it will throw an exception, e.g.
-   * to parse("2015-13-11", "yyyy-MM-dd") will throw an exception
-   */
-  def newStrictDateFormat(formatString: String, timeZone: TimeZone): DateFormat = {
-    val sdf = new SimpleDateFormat(formatString, Locale.US)
-    sdf.setTimeZone(timeZone)
-    sdf.setLenient(false)
-    sdf
-  }
-
   // we should use the exact day as Int, for example, (year, month, day) -> day
   def millisToDays(millisUtc: Long): SQLDate = {
     millisToDays(millisUtc, defaultTimeZone())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -95,7 +95,9 @@ object DateTimeUtils {
     sdf
   }
 
-  def newDateFormat(formatString: String, timeZone: TimeZone): DateFormat = {
+  def newDateFormat(formatString: String,
+      timeZone: TimeZone,
+      isLenient: Boolean = true): DateFormat = {
     val sdf = new SimpleDateFormat(formatString, Locale.US)
     sdf.setTimeZone(timeZone)
     sdf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -101,6 +101,17 @@ object DateTimeUtils {
     sdf
   }
 
+  /*
+   * if the time is invalid it will throw an exception, e.g.
+   * to parse("2015-13-11", "yyyy-MM-dd") will throw an exception
+   */
+  def newStrictDateFormat(formatString: String, timeZone: TimeZone): DateFormat = {
+    val sdf = new SimpleDateFormat(formatString, Locale.US)
+    sdf.setTimeZone(timeZone)
+    sdf.setLenient(false)
+    sdf
+  }
+
   // we should use the exact day as Int, for example, (year, month, day) -> day
   def millisToDays(millisUtc: Long): SQLDate = {
     millisToDays(millisUtc, defaultTimeZone())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -98,6 +98,9 @@ object DateTimeUtils {
   def newDateFormat(formatString: String, timeZone: TimeZone): DateFormat = {
     val sdf = new SimpleDateFormat(formatString, Locale.US)
     sdf.setTimeZone(timeZone)
+    // Enable strict parsing, if the input date/format is invalid, it will throw an exception.
+    // e.g. to parse invalid date '2016-13-12', or '2016-01-12' with  invalid format 'yyyy-aa-dd',
+    // an exception will be throwed.
     sdf.setLenient(false)
     sdf
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -95,10 +95,10 @@ object DateTimeUtils {
     sdf
   }
 
-  def newDateFormat(formatString: String, timeZone: TimeZone, isLenient: Boolean): DateFormat = {
+  def newDateFormat(formatString: String, timeZone: TimeZone): DateFormat = {
     val sdf = new SimpleDateFormat(formatString, Locale.US)
     sdf.setTimeZone(timeZone)
-    sdf.setLenient(isLenient)
+    sdf.setLenient(false)
     sdf
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -398,8 +398,7 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
         Row(Date.valueOf("2014-12-31"))))
     checkAnswer(
       df.select(to_date(col("s"), "yyyy-MM-dd")),
-      Seq(Row(Date.valueOf("2015-07-22")), Row(Date.valueOf("2014-12-31")),
-        Row(null)))
+      Seq(Row(Date.valueOf("2015-07-22")), Row(Date.valueOf("2014-12-31")), Row(null)))
 
     //  now switch format
     checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -475,7 +475,6 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.selectExpr(s"unix_timestamp(s, '$fmt')"), Seq(
       Row(ts1.getTime / 1000L), Row(ts2.getTime / 1000L)))
 
-
     val x1 = "2015-07-24 10:00:00"
     val x2 = "2015-25-07 02:02:02"
     val x3 = "2015-07-24 25:02:02"
@@ -489,9 +488,9 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df1.selectExpr("unix_timestamp(x)"), Seq(
       Row(ts1.getTime / 1000L), Row(null), Row(null), Row(null)))
     checkAnswer(df1.select(unix_timestamp(col("x"), "yyyy-dd-MM HH:mm:ss")), Seq(
-      Row(ts2.getTime / 1000L), Row(null), Row(null), Row(null)))
+      Row(null), Row(ts2.getTime / 1000L), Row(null), Row(null)))
     checkAnswer(df1.selectExpr(s"unix_timestamp(x, 'yyyy-MM-dd mm:HH:ss')"), Seq(
-      Row(ts3.getTime / 1000L), Row(ts4.getTime / 1000L), Row(null), Row(null)))
+      Row(ts4.getTime / 1000L), Row(null), Row(ts3.getTime / 1000L), Row(null)))
 
     val now = sql("select unix_timestamp()").collect().head.getLong(0)
     checkAnswer(sql(s"select cast ($now as timestamp)"), Row(new java.util.Date(now * 1000)))
@@ -517,7 +516,6 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.selectExpr(s"to_unix_timestamp(s, '$fmt')"), Seq(
       Row(ts1.getTime / 1000L), Row(ts2.getTime / 1000L)))
 
-
     val x1 = "2015-07-24 10:00:00"
     val x2 = "2015-25-07 02:02:02"
     val x3 = "2015-07-24 25:02:02"
@@ -529,7 +527,7 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df1.selectExpr("to_unix_timestamp(x)"), Seq(
       Row(ts1.getTime / 1000L), Row(null), Row(null), Row(null)))
     checkAnswer(df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd mm:HH:ss')"), Seq(
-      Row(ts3.getTime / 1000L), Row(ts4.getTime / 1000L), Row(null), Row(null)))
+      Row(ts4.getTime / 1000L), Row(null), Row(ts3.getTime / 1000L), Row(null)))
   }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -412,6 +412,13 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.select(to_date(col("s"), "yyyy-dd-aa")),
       Seq(Row(null), Row(null), Row(null)))
+
+    // february
+    val x1 = "2016-02-29"
+    val x2 = "2017-02-29"
+    val df1 = Seq(x1, x2).toDF("x")
+    checkAnswer(
+      df1.select(to_date(col("x"))), Row(Date.valueOf("2016-02-29")) :: Row(null) :: Nil)
   }
 
   test("function trunc") {
@@ -504,6 +511,14 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df1.selectExpr(s"unix_timestamp(x, 'yyyy-MM-dd aa:HH:ss')"), Seq(
       Row(null), Row(null), Row(null), Row(null)))
 
+    // february
+    val y1 = "2016-02-29"
+    val y2 = "2017-02-29"
+    val ts5 = Timestamp.valueOf("2016-02-29 00:00:00")
+    val df2 = Seq(y1, y2).toDF("y")
+    checkAnswer(df2.select(unix_timestamp(col("y"), "yyyy-MM-dd")), Seq(
+      Row(ts5.getTime / 1000L), Row(null)))
+
     val now = sql("select unix_timestamp()").collect().head.getLong(0)
     checkAnswer(sql(s"select cast ($now as timestamp)"), Row(new java.util.Date(now * 1000)))
   }
@@ -540,6 +555,14 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(ts1.getTime / 1000L), Row(null), Row(null), Row(null)))
     checkAnswer(df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd mm:HH:ss')"), Seq(
       Row(ts4.getTime / 1000L), Row(null), Row(ts3.getTime / 1000L), Row(null)))
+
+    // february
+    val y1 = "2016-02-29"
+    val y2 = "2017-02-29"
+    val ts5 = Timestamp.valueOf("2016-02-29 00:00:00")
+    val df2 = Seq(y1, y2).toDF("y")
+    checkAnswer(df2.select(unix_timestamp(col("y"), "yyyy-MM-dd")), Seq(
+      Row(ts5.getTime / 1000L), Row(null)))
 
     // invalid format
     checkAnswer(df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd bb:HH:ss')"), Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -404,6 +404,14 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.select(to_date(col("s"), "yyyy-dd-MM")),
       Seq(Row(null), Row(null), Row(Date.valueOf("2014-12-31"))))
+
+    // invalid format
+    checkAnswer(
+      df.select(to_date(col("s"), "yyyy-hh-MM")),
+      Seq(Row(null), Row(null), Row(null)))
+    checkAnswer(
+      df.select(to_date(col("s"), "yyyy-dd-aa")),
+      Seq(Row(null), Row(null), Row(null)))
   }
 
   test("function trunc") {
@@ -492,6 +500,10 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df1.selectExpr(s"unix_timestamp(x, 'yyyy-MM-dd mm:HH:ss')"), Seq(
       Row(ts4.getTime / 1000L), Row(null), Row(ts3.getTime / 1000L), Row(null)))
 
+    // invalid format
+    checkAnswer(df1.selectExpr(s"unix_timestamp(x, 'yyyy-MM-dd aa:HH:ss')"), Seq(
+      Row(null), Row(null), Row(null), Row(null)))
+
     val now = sql("select unix_timestamp()").collect().head.getLong(0)
     checkAnswer(sql(s"select cast ($now as timestamp)"), Row(new java.util.Date(now * 1000)))
   }
@@ -528,6 +540,10 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(ts1.getTime / 1000L), Row(null), Row(null), Row(null)))
     checkAnswer(df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd mm:HH:ss')"), Seq(
       Row(ts4.getTime / 1000L), Row(null), Row(ts3.getTime / 1000L), Row(null)))
+
+    // invalid format
+    checkAnswer(df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd bb:HH:ss')"), Seq(
+      Row(null), Row(null), Row(null), Row(null)))
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the udf  `to_date` has different return value with an invalid date input.

```
SELECT to_date('2015-07-22', 'yyyy-dd-MM') ->  return `2016-10-07`
SELECT to_date('2014-31-12')    -> return null
```

As discussed in JIRA [SPARK-19496](https://issues.apache.org/jira/browse/SPARK-19496), we should return null in both situations when the input date is invalid 

## How was this patch tested?
unit test added