### PR TITLE
[SPARK-19509][SQL]Fix a NPE problem in grouping sets when using an empty column

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -299,15 +299,8 @@ class Analyzer(
           case other => Alias(other, other.toString)()
         }
 
-        // The rightmost bit in the bitmasks corresponds to the last expression in groupByAliases
-        // with 0 indicating this expression is in the grouping set. The following line of code
-        // calculates the bitmask representing the expressions that absent in at least one grouping
-        // set (indicated by 1).
-        val nullBitmask = x.bitmasks.reduce(_ | _)
-
-        val attrLength = groupByAliases.length
-        val expandedAttributes = groupByAliases.zipWithIndex.map { case (a, idx) =>
-          a.toAttribute.withNullability(((nullBitmask >> (attrLength - idx - 1)) & 1) == 1)
+        val expandedAttributes = groupByAliases.map { case a =>
+          a.toAttribute.withNullability(true)
         }
 
         val expand = Expand(x.bitmasks, groupByAliases, expandedAttributes, gid, x.child)


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a column of a table is all null values, the follow SQL will throw an NPE: `select count(1) from test group by e grouping sets(e)`.

The reason is that when transformUp a `GroupingSets` in `ResolveGroupingAnalytics` it uses a `nullBitmask` to set an attribute with null ability, the nullable attribute may be modified.

This pr just set all attribute's null ability to `true` in group by  expressions to fix the problem.

The pr #15484 in master branch has fixed this problem. 

We also need to fix this problem in branch-2.1.

## How was this patch tested?

Test with Hive in my environment.