### PR TITLE
[SPARK-19541][SQL] High Availability support for ThriftServer

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/HiveServer2.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/HiveServer2.java
@@ -18,7 +18,13 @@
 
 package org.apache.hive.service.server;
 
-import java.util.Properties;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -28,16 +34,32 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.hadoop.hive.common.LogUtils;
 import org.apache.hadoop.hive.common.LogUtils.LogInitializationException;
+import org.apache.hadoop.hive.common.ServerUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.util.ZooKeeperHiveHelper;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.hive.shims.Utils;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.common.util.HiveStringUtils;
 import org.apache.hive.service.CompositeService;
 import org.apache.hive.service.cli.CLIService;
 import org.apache.hive.service.cli.thrift.ThriftBinaryCLIService;
 import org.apache.hive.service.cli.thrift.ThriftCLIService;
 import org.apache.hive.service.cli.thrift.ThriftHttpCLIService;
+import org.apache.zookeeper.*;
+import com.google.common.base.Joiner;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.zookeeper.data.ACL;
 
 /**
  * HiveServer2.
@@ -45,9 +67,14 @@ import org.apache.hive.service.cli.thrift.ThriftHttpCLIService;
  */
 public class HiveServer2 extends CompositeService {
   private static final Log LOG = LogFactory.getLog(HiveServer2.class);
+  private static CountDownLatch deleteSignal;
 
   private CLIService cliService;
   private ThriftCLIService thriftCLIService;
+  private PersistentEphemeralNode znode;
+  private String znodePath;
+  private CuratorFramework zooKeeperClient;
+  private boolean registeredWithZooKeeper = false;
 
   public HiveServer2() {
     super(HiveServer2.class.getSimpleName());
@@ -81,15 +108,216 @@ public class HiveServer2 extends CompositeService {
     if (transportMode == null) {
       transportMode = hiveConf.getVar(HiveConf.ConfVars.HIVE_SERVER2_TRANSPORT_MODE);
     }
-    if (transportMode != null && (transportMode.equalsIgnoreCase("http"))) {
-      return true;
+    return transportMode != null && (transportMode.equalsIgnoreCase("http"));
+  }
+
+  private void addServerInstanceToZooKeeper(HiveConf hiveConf) throws Exception {
+    String zooKeeperEnsemble = ZooKeeperHiveHelper.getQuorumServers(hiveConf);
+    LOG.error("registe on zookeeper: "+zooKeeperEnsemble);
+    String rootNamespace = hiveConf.getVar(HiveConf.ConfVars.HIVE_SERVER2_ZOOKEEPER_NAMESPACE);
+    String instanceURI = getServerInstanceURI();
+    setUpZooKeeperAuth(hiveConf);
+    Map<String, String> confsToPublish = new HashMap<>();
+    addConfsToPublish(hiveConf, confsToPublish);
+   int sessionTimeout =
+        (int) hiveConf.getTimeVar(HiveConf.ConfVars.HIVE_ZOOKEEPER_SESSION_TIMEOUT,
+            TimeUnit.MILLISECONDS);
+    int baseSleepTime =
+        (int) hiveConf.getTimeVar(HiveConf.ConfVars.HIVE_ZOOKEEPER_CONNECTION_BASESLEEPTIME,
+            TimeUnit.MILLISECONDS);
+    int maxRetries = hiveConf.getIntVar(HiveConf.ConfVars.HIVE_ZOOKEEPER_CONNECTION_MAX_RETRIES);
+    // Create a CuratorFramework instance to be used as the ZooKeeper client
+    // Use the zooKeeperAclProvider to create appropriate ACLs
+    zooKeeperClient =
+        CuratorFrameworkFactory.builder().connectString(zooKeeperEnsemble)
+            .sessionTimeoutMs(sessionTimeout).aclProvider(zooKeeperAclProvider)
+            .retryPolicy(new ExponentialBackoffRetry(baseSleepTime, maxRetries)).build();
+    LOG.info("hive server: start thrift server");
+    zooKeeperClient.start();
+    // Create the parent znodes recursively; ignore if the parent already exists.
+    try {
+      zooKeeperClient.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT)
+          .forPath(ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + rootNamespace);
+      LOG.info("Created the root name space: " + rootNamespace + " on ZooKeeper for HiveServer2");
+    } catch (KeeperException e) {
+      if (e.code() != KeeperException.Code.NODEEXISTS) {
+        LOG.fatal("Unable to create HiveServer2 namespace: " + rootNamespace + " on ZooKeeper", e);
+        throw e;
+      }
     }
-    return false;
+
+    // Create a znode under the rootNamespace parent for this instance of the server
+    // Znode name: serverUri=host:port;version=versionInfo;sequence=sequenceNumber
+    try {
+      String pathPrefix =
+          ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + rootNamespace
+              + ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + "serverUri=" + instanceURI + ";"
+              + "version=" + ";" + "sequence=";
+      String znodeData;
+      // Publish configs for this instance as the data on the node
+      znodeData = Joiner.on(';').withKeyValueSeparator("=").join(confsToPublish);
+      byte[] znodeDataUTF8 = znodeData.getBytes(Charset.forName("UTF-8"));
+      znode =
+          new PersistentEphemeralNode(zooKeeperClient,
+              PersistentEphemeralNode.Mode.EPHEMERAL_SEQUENTIAL, pathPrefix, znodeDataUTF8);
+      znode.start();
+      // We'll wait for 120s for node creation
+      long znodeCreationTimeout = 120;
+      if (!znode.waitForInitialCreate(znodeCreationTimeout, TimeUnit.SECONDS)) {
+        throw new Exception("Max znode creation wait time: " + znodeCreationTimeout + "s exhausted");
+      }
+      setRegisteredWithZooKeeper(true);
+      znodePath = znode.getActualPath();
+      // Set a watch on the znode
+      if (zooKeeperClient.checkExists().usingWatcher(new DeRegisterWatcher()).forPath(znodePath) == null) {
+        // No node exists, throw exception
+        throw new Exception("Unable to create znode for this HiveServer2 instance on ZooKeeper.");
+      }
+      LOG.info("Created a znode on ZooKeeper for HiveServer2 uri: " + instanceURI);
+    } catch (Exception e) {
+      LOG.fatal("Unable to create a znode for this server instance", e);
+      if (znode != null) {
+        znode.close();
+      }
+      throw (e);
+    }
+  }
+
+  /**
+   * ACLProvider for providing appropriate ACLs to CuratorFrameworkFactory
+   */
+  private final ACLProvider zooKeeperAclProvider = new ACLProvider() {
+    List<ACL> nodeAcls = new ArrayList<ACL>();
+
+    @Override
+    public List<ACL> getDefaultAcl() {
+      if (UserGroupInformation.isSecurityEnabled()) {
+        // Read all to the world
+        nodeAcls.addAll(ZooDefs.Ids.READ_ACL_UNSAFE);
+        // Create/Delete/Write/Admin to the authenticated user
+        nodeAcls.add(new ACL(ZooDefs.Perms.ALL, ZooDefs.Ids.AUTH_IDS));
+      } else {
+        // ACLs for znodes on a non-kerberized cluster
+        // Create/Read/Delete/Write/Admin to the world
+        nodeAcls.addAll(ZooDefs.Ids.OPEN_ACL_UNSAFE);
+      }
+      return nodeAcls;
+    }
+
+    @Override
+    public List<ACL> getAclForPath(String path) {
+      return getDefaultAcl();
+    }
+  };
+
+  private void setUpZooKeeperAuth(HiveConf hiveConf) throws Exception {
+    if (UserGroupInformation.isSecurityEnabled()) {
+      String principal = hiveConf.getVar(ConfVars.HIVE_SERVER2_KERBEROS_PRINCIPAL);
+      if (principal.isEmpty()) {
+        throw new IOException("HiveServer2 Kerberos principal is empty");
+      }
+      String keyTabFile = hiveConf.getVar(ConfVars.HIVE_SERVER2_KERBEROS_KEYTAB);
+      if (keyTabFile.isEmpty()) {
+        throw new IOException("HiveServer2 Kerberos keytab is empty");
+      }
+      // Install the JAAS Configuration for the runtime
+      Utils.setZookeeperClientKerberosJaasConfig(principal, keyTabFile);
+    }
+  }
+
+  private void addConfsToPublish(HiveConf hiveConf, Map<String, String> confsToPublish)
+      throws UnknownHostException {
+    // Hostname
+    confsToPublish.put(ConfVars.HIVE_SERVER2_THRIFT_BIND_HOST.varname,
+        InetAddress.getLocalHost().getCanonicalHostName());
+    // Transport mode
+    confsToPublish.put(ConfVars.HIVE_SERVER2_TRANSPORT_MODE.varname,
+        hiveConf.getVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE));
+    // Transport specific confs
+    if (isHTTPTransportMode(hiveConf)) {
+      confsToPublish.put(ConfVars.HIVE_SERVER2_THRIFT_HTTP_PORT.varname,
+          hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_HTTP_PORT));
+      confsToPublish.put(ConfVars.HIVE_SERVER2_THRIFT_HTTP_PATH.varname,
+          hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_HTTP_PATH));
+    } else {
+      confsToPublish.put(ConfVars.HIVE_SERVER2_THRIFT_PORT.varname,
+          hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_PORT));
+      confsToPublish.put(ConfVars.HIVE_SERVER2_THRIFT_SASL_QOP.varname,
+          hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_SASL_QOP));
+    }
+    // Auth specific confs
+    confsToPublish.put(ConfVars.HIVE_SERVER2_AUTHENTICATION.varname,
+        hiveConf.getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION));
+    confsToPublish.put(ConfVars.HIVE_SERVER2_USE_SSL.varname,
+        hiveConf.getVar(ConfVars.HIVE_SERVER2_USE_SSL));
+  }
+  private class DeRegisterWatcher implements Watcher {
+    @Override
+    public void process(WatchedEvent event) {
+      if (event.getType().equals(Watcher.Event.EventType.NodeDeleted)) {
+        if (znode != null) {
+          try {
+            znode.close();
+            LOG.warn("This HiveServer2 instance is now de-registered from ZooKeeper. "
+                + "The server will be shut down after the last client sesssion completes.");
+          } catch (IOException e) {
+            LOG.error("Failed to close the persistent ephemeral znode", e);
+          } finally {
+            HiveServer2.this.setRegisteredWithZooKeeper(false);
+            // If there are no more active client sessions, stop the server
+            if (cliService.getSessionManager().getOpenSessionCount() == 0) {
+              LOG.warn("This instance of HiveServer2 has been removed from the list of server "
+                  + "instances available for dynamic service discovery. "
+                  + "The last client session has ended - will shutdown now.");
+              HiveServer2.this.stop();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private void removeServerInstanceFromZooKeeper() throws Exception {
+    setRegisteredWithZooKeeper(false);
+    if (znode != null) {
+      znode.close();
+    }
+    zooKeeperClient.close();
+    LOG.info("Server instance removed from ZooKeeper.");
+  }
+
+  public boolean isRegisteredWithZooKeeper() {
+    return registeredWithZooKeeper;
+  }
+
+  private void setRegisteredWithZooKeeper(boolean registeredWithZooKeeper) {
+    this.registeredWithZooKeeper = registeredWithZooKeeper;
+  }
+
+  private String getServerInstanceURI() throws Exception {
+    if ((thriftCLIService == null) || (thriftCLIService.getServerIPAddress() == null)) {
+      throw new Exception("Unable to get the server address; it hasn't been initialized yet.");
+    }
+    return thriftCLIService.getServerIPAddress().getHostName() + ":"
+        + thriftCLIService.getPortNumber();
   }
 
   @Override
   public synchronized void start() {
     super.start();
+    HiveConf hiveConf = new HiveConf();
+    String zooKeeperEnsemble = ZooKeeperHiveHelper.getQuorumServers(hiveConf);
+    LOG.error("hive server: "+zooKeeperEnsemble);
+    LOG.info("hive config: "+hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY));
+    if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
+      try
+      {
+        this.addServerInstanceToZooKeeper(hiveConf);
+      } catch (Exception e)
+      {
+        LOG.error(e.getMessage(),e);
+      }
+    }
   }
 
   @Override
@@ -97,6 +325,13 @@ public class HiveServer2 extends CompositeService {
     LOG.info("Shutting down HiveServer2");
     HiveConf hiveConf = this.getHiveConf();
     super.stop();
+    if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
+      try {
+        removeServerInstanceFromZooKeeper();
+      } catch (Exception e) {
+        LOG.error("Error removing znode for this HiveServer2 instance from ZooKeeper.", e);
+      }
+    }
   }
 
   private static void startHiveServer2() throws Throwable {
@@ -133,6 +368,63 @@ public class HiveServer2 extends CompositeService {
             Thread.currentThread().interrupt();
           }
         }
+      }
+      String zooKeeperEnsemble = ZooKeeperHiveHelper.getQuorumServers(hiveConf);
+      LOG.error("hive server: "+zooKeeperEnsemble);
+      LOG.info("hive config: "+hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY));
+      if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
+        server.addServerInstanceToZooKeeper(hiveConf);
+      }
+    }
+  }
+
+  static void deleteServerInstancesFromZooKeeper(String versionNumber) throws Exception {
+    HiveConf hiveConf = new HiveConf();
+    String zooKeeperEnsemble = ZooKeeperHiveHelper.getQuorumServers(hiveConf);
+    String rootNamespace = hiveConf.getVar(HiveConf.ConfVars.HIVE_SERVER2_ZOOKEEPER_NAMESPACE);
+    int baseSleepTime = (int) hiveConf.getTimeVar(HiveConf.ConfVars.HIVE_ZOOKEEPER_CONNECTION_BASESLEEPTIME, TimeUnit.MILLISECONDS);
+    int maxRetries = hiveConf.getIntVar(HiveConf.ConfVars.HIVE_ZOOKEEPER_CONNECTION_MAX_RETRIES);
+    CuratorFramework zooKeeperClient =
+        CuratorFrameworkFactory.builder().connectString(zooKeeperEnsemble)
+            .retryPolicy(new ExponentialBackoffRetry(baseSleepTime, maxRetries)).build();
+    zooKeeperClient.start();
+    List<String> znodePaths =
+        zooKeeperClient.getChildren().forPath(
+            ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + rootNamespace);
+    List<String> znodePathsUpdated;
+    // Now for each path that is for the given versionNumber, delete the znode from ZooKeeper
+    for (int i = 0; i < znodePaths.size(); i++) {
+      String znodePath = znodePaths.get(i);
+      deleteSignal = new CountDownLatch(1);
+      if (znodePath.contains("version=" + versionNumber + ";")) {
+        String fullZnodePath =
+            ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + rootNamespace
+                + ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + znodePath;
+        LOG.warn("Will attempt to remove the znode: " + fullZnodePath + " from ZooKeeper");
+        System.out.println("Will attempt to remove the znode: " + fullZnodePath + " from ZooKeeper");
+        zooKeeperClient.delete().guaranteed().inBackground(new DeleteCallBack())
+            .forPath(fullZnodePath);
+        // Wait for the delete to complete
+        deleteSignal.await();
+        // Get the updated path list
+        znodePathsUpdated =
+            zooKeeperClient.getChildren().forPath(
+                ZooKeeperHiveHelper.ZOOKEEPER_PATH_SEPARATOR + rootNamespace);
+        // Gives a list of any new paths that may have been created to maintain the persistent ephemeral node
+        znodePathsUpdated.removeAll(znodePaths);
+        // Add the new paths to the znodes list. We'll try for their removal as well.
+        znodePaths.addAll(znodePathsUpdated);
+      }
+    }
+    zooKeeperClient.close();
+  }
+
+  private static class DeleteCallBack implements BackgroundCallback {
+    @Override
+    public void processResult(CuratorFramework zooKeeperClient, CuratorEvent event)
+        throws Exception {
+      if (event.getType() == CuratorEventType.DELETE) {
+        deleteSignal.countDown();
       }
     }
   }
@@ -203,6 +495,11 @@ public class HiveServer2 extends CompositeService {
         if (commandLine.hasOption('H')) {
           return new ServerOptionsProcessorResponse(new HelpOptionExecutor(serverName, options));
         }
+        // Process --deregister
+        if (commandLine.hasOption("deregister")) {
+          return new ServerOptionsProcessorResponse(new DeregisterOptionExecutor(
+              commandLine.getOptionValue("deregister")));
+        }
       } catch (ParseException e) {
         // Error out & exit - we were not able to parse the args successfully
         System.err.println("Error starting HiveServer2 with given arguments: ");
@@ -272,6 +569,28 @@ public class HiveServer2 extends CompositeService {
         LOG.fatal("Error starting HiveServer2", t);
         System.exit(-1);
       }
+    }
+  }
+
+  static class DeregisterOptionExecutor implements ServerOptionsExecutor {
+    private final String versionNumber;
+
+    DeregisterOptionExecutor(String versionNumber) {
+      this.versionNumber = versionNumber;
+    }
+
+    @Override
+    public void execute() {
+      try {
+        deleteServerInstancesFromZooKeeper(versionNumber);
+      } catch (Exception e) {
+        LOG.fatal("Error deregistering HiveServer2 instances for version: " + versionNumber
+            + " from ZooKeeper", e);
+        System.out.println("Error deregistering HiveServer2 instances for version: " + versionNumber
+            + " from ZooKeeper." + e);
+        System.exit(-1);
+      }
+      System.exit(0);
     }
   }
 }


### PR DESCRIPTION
JIRA Issue:  https://issues.apache.org/jira/browse/SPARK-19541

## What changes were proposed in this pull request?

Currently, We use the spark ThriftServer frequently, and there are many connects between the client and only ThriftServer.When the ThriftServer is down ,we cannot get the service again.So we need to consider the ThriftServer HA as well as master HA. 
For ThriftServer, we want to import the pattern of HiveServer HA to provide ThriftServer HA. Therefore, we need to start multiple thrift server which register on the zookeeper. Then the client  can find the thrift server by just connecting to the zookeeper.So the beeline can get the service from other thrift server when one is down.

## How was this patch tested?

manual tests



