### PR TITLE
[SPARK-17498][ML] StringIndexer enhancement for handling unseen labels

### DIFF
--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -502,7 +502,7 @@ for more details on the API.
 ## StringIndexer
 
 `StringIndexer` encodes a string column of labels to a column of label indices.
-The indices are in `[0, numLabels)`, ordered by label frequencies, so the most frequent label gets index `0`.
+The indices are in `[0, numLabels]`, ordered by label frequencies, so the most frequent label gets index `0`.
 If the input column is numeric, we cast it to string and index the string
 values. When downstream pipeline components such as `Estimator` or
 `Transformer` make use of this string-indexed label, you must set the input
@@ -542,12 +542,13 @@ column, we should get the following:
 "a" gets index `0` because it is the most frequent, followed by "c" with index `1` and "b" with
 index `2`.
 
-Additionally, there are two strategies regarding how `StringIndexer` will handle
+Additionally, there are three strategies regarding how `StringIndexer` will handle
 unseen labels when you have fit a `StringIndexer` on one dataset and then use it
 to transform another:
 
 - throw an exception (which is the default)
 - skip the row containing the unseen label entirely
+- map the unseen labels with indices [numLabels]
 
 **Examples**
 
@@ -561,6 +562,7 @@ Let's go back to our previous example but this time reuse our previously defined
  1  | b
  2  | c
  3  | d
+ 4  | e
 ~~~~
 
 If you've not set how `StringIndexer` handles unseen labels or set it to
@@ -576,7 +578,22 @@ will be generated:
  2  | c        | 1.0
 ~~~~
 
-Notice that the row containing "d" does not appear.
+Notice that the rows containing "d" or "e" do not appear.
+
+If you had called `setHandleInvalid("keep")`, the following dataset
+will be generated:
+
+~~~~
+ id | category | categoryIndex
+----|----------|---------------
+ 0  | a        | 0.0
+ 1  | b        | 2.0
+ 2  | c        | 1.0
+ 3  | d        | 3.0
+ 4  | e        | 3.0
+~~~~
+
+Notice that the rows containing "d" or "e" are mapped with indices "3.0"
 
 <div class="codetabs">
 

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -549,7 +549,7 @@ to transform another:
 
 - throw an exception (which is the default)
 - skip the row containing the unseen label entirely
-- map the unseen labels with indices [numLabels]
+- put unseen labels in a special additional bucket, at index numLabels
 
 **Examples**
 
@@ -594,7 +594,7 @@ will be generated:
  4  | e        | 3.0
 ~~~~
 
-Notice that the rows containing "d" or "e" are mapped with indices "3.0"
+Notice that the rows containing "d" or "e" are mapped to index "3.0"
 
 <div class="codetabs">
 

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -502,7 +502,8 @@ for more details on the API.
 ## StringIndexer
 
 `StringIndexer` encodes a string column of labels to a column of label indices.
-The indices are in `[0, numLabels]`, ordered by label frequencies, so the most frequent label gets index `0`.
+The indices are in `[0, numLabels)`, ordered by label frequencies, so the most frequent label gets index `0`.
+The unseen labels will be put at index numLabels if user chooses to keep them.
 If the input column is numeric, we cast it to string and index the string
 values. When downstream pipeline components such as `Estimator` or
 `Transformer` make use of this string-indexed label, you must set the input
@@ -580,7 +581,7 @@ will be generated:
 
 Notice that the rows containing "d" or "e" do not appear.
 
-If you had called `setHandleInvalid("keep")`, the following dataset
+If you call `setHandleInvalid("keep")`, the following dataset
 will be generated:
 
 ~~~~

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -56,14 +56,6 @@ private[feature] trait StringIndexerBase extends Params with HasInputCol with Ha
     "error (throw an error), or 'keep' (map unseen labels with indices [numLabels]).",
     ParamValidators.inArray(supportedHandleInvalids))
 
-  /** @group getParam */
-  @Since("2.1.0")
-  def getHandleInvalid: String = $(handleInvalid)
-
-  /** @group setParam */
-  @Since("2.1.0")
-  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
-  setDefault(handleInvalid, ERROR_UNSEEN_LABEL)
   /** Validates and transforms the input schema. */
   protected def validateAndTransformSchema(schema: StructType): StructType = {
     val inputColName = $(inputCol)
@@ -104,6 +96,15 @@ class StringIndexer @Since("1.4.0") (
   /** @group setParam */
   @Since("1.4.0")
   def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /** @group getParam */
+  @Since("2.1.0")
+  def getHandleInvalid: String = $(handleInvalid)
+
+  /** @group setParam */
+  @Since("2.1.0")
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+  setDefault(handleInvalid, ERROR_UNSEEN_LABEL)
 
   @Since("2.0.0")
   override def fit(dataset: Dataset[_]): StringIndexerModel = {
@@ -170,6 +171,15 @@ class StringIndexerModel (
   /** @group setParam */
   @Since("1.4.0")
   def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /** @group getParam */
+  @Since("2.1.0")
+  def getHandleInvalid: String = $(handleInvalid)
+
+  /** @group setParam */
+  @Since("2.1.0")
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+  setDefault(handleInvalid, ERROR_UNSEEN_LABEL)
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.feature
 
+import scala.language.existentials
+
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkException

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -53,7 +53,7 @@ private[feature] trait StringIndexerBase extends Params with HasInputCol with Ha
   setDefault(handleInvalid, StringIndexer.ERROR_UNSEEN_LABEL)
 
   /** @group getParam */
-  @Since("2.1.0")
+  @Since("2.2.0")
   def getHandleInvalid: String = $(handleInvalid)
 
   /** Validates and transforms the input schema. */
@@ -172,7 +172,7 @@ class StringIndexerModel (
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
   /** @group setParam */
-  @Since("2.1.0")
+  @Since("2.2.0")
   def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
   setDefault(handleInvalid, StringIndexer.ERROR_UNSEEN_LABEL)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -45,7 +45,7 @@ private[feature] trait StringIndexerBase extends Params with HasInputCol with Ha
    * Default: "error"
    * @group param
    */
-  @Since("2.1.0")
+  @Since("1.6.0")
   val handleInvalid: Param[String] = new Param[String](this, "handleInvalid", "how to handle " +
     "unseen labels. Options are 'skip' (filter out rows with unseen labels), " +
     "error (throw an error), or 'keep' (put unseen labels in a special additional bucket, " +
@@ -55,7 +55,7 @@ private[feature] trait StringIndexerBase extends Params with HasInputCol with Ha
   setDefault(handleInvalid, StringIndexer.ERROR_UNSEEN_LABEL)
 
   /** @group getParam */
-  @Since("2.2.0")
+  @Since("1.6.0")
   def getHandleInvalid: String = $(handleInvalid)
 
   /** Validates and transforms the input schema. */
@@ -92,7 +92,7 @@ class StringIndexer @Since("1.4.0") (
   def this() = this(Identifiable.randomUID("strIdx"))
 
   /** @group setParam */
-  @Since("2.2.0")
+  @Since("1.6.0")
   def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
 
   /** @group setParam */
@@ -167,16 +167,16 @@ class StringIndexerModel (
   }
 
   /** @group setParam */
+  @Since("1.6.0")
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+
+  /** @group setParam */
   @Since("1.4.0")
   def setInputCol(value: String): this.type = set(inputCol, value)
 
   /** @group setParam */
   @Since("1.4.0")
   def setOutputCol(value: String): this.type = set(outputCol, value)
-
-  /** @group setParam */
-  @Since("2.2.0")
-  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -94,7 +94,7 @@ class StringIndexerSuite
     val transformedKeep = indexer.transform(df2)
     val attrKeep = Attribute.fromStructField(transformedKeep.schema("labelIndex"))
       .asInstanceOf[NominalAttribute]
-    assert(attrKeep.values.get === Array("b", "a"))
+    assert(attrKeep.values.get === Array("b", "a", "__unknown"))
     val outputKeep = transformedKeep.select("id", "labelIndex").rdd.map { r =>
       (r.getInt(0), r.getDouble(1))
     }.collect().toSet

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -78,11 +78,11 @@ class StringIndexerSuite
 
     indexer.setHandleInvalid("skip")
     // Verify that we skip the c record
-    var transformed = indexer.transform(df2)
-    var attr = Attribute.fromStructField(transformed.schema("labelIndex"))
+    val transformedSkip = indexer.transform(df2)
+    val attrSkip = Attribute.fromStructField(transformedSkip.schema("labelIndex"))
       .asInstanceOf[NominalAttribute]
-    assert(attr.values.get === Array("b", "a"))
-    val outputSkip = transformed.select("id", "labelIndex").rdd.map { r =>
+    assert(attrSkip.values.get === Array("b", "a"))
+    val outputSkip = transformedSkip.select("id", "labelIndex").rdd.map { r =>
       (r.getInt(0), r.getDouble(1))
     }.collect().toSet
     // a -> 1, b -> 0
@@ -91,11 +91,11 @@ class StringIndexerSuite
 
     indexer.setHandleInvalid("keep")
     // Verify that we keep the unseen records
-    transformed = indexer.transform(df2)
-    attr = Attribute.fromStructField(transformed.schema("labelIndex"))
+    val transformedKeep = indexer.transform(df2)
+    val attrKeep = Attribute.fromStructField(transformedKeep.schema("labelIndex"))
       .asInstanceOf[NominalAttribute]
-    assert(attr.values.get === Array("b", "a"))
-    val outputKeep = transformed.select("id", "labelIndex").rdd.map { r =>
+    assert(attrKeep.values.get === Array("b", "a"))
+    val outputKeep = transformedKeep.select("id", "labelIndex").rdd.map { r =>
       (r.getInt(0), r.getDouble(1))
     }.collect().toSet
     // a -> 1, b -> 0, c -> 2, d -> 3

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -905,12 +905,8 @@ object MimaExcludes {
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ui.exec.ExecutorsListener.executorToTasksMax"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ui.exec.ExecutorsListener.executorToJvmGCTime")
     ) ++ Seq(
-      // [SPARK-17498][ML] Enhance StringIndexer to handle unseen labels
-      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.StringIndexer"),
-      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.StringIndexerModel")
-    ) ++ Seq(
-      // [SPARK-17365][Core] Remove/Kill multiple executors together to reduce RPC call time
-      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.SparkContext")
+      // [SPARK-17163] Unify logistic regression interface. Private constructor has new signature.
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.LogisticRegressionModel.this")
     ) ++ Seq(
       // [SPARK-17365][Core] Remove/Kill multiple executors together to reduce RPC call time
       ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.SparkContext")

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -908,6 +908,10 @@ object MimaExcludes {
       // [SPARK-17163] Unify logistic regression interface. Private constructor has new signature.
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.LogisticRegressionModel.this")
     ) ++ Seq(
+      // [SPARK-17498] StringIndexer enhancement for handling unseen labels
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.StringIndexer"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.StringIndexerModel")
+    ) ++ Seq(
       // [SPARK-17365][Core] Remove/Kill multiple executors together to reduce RPC call time
       ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.SparkContext")
     ) ++ Seq(

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -905,8 +905,12 @@ object MimaExcludes {
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ui.exec.ExecutorsListener.executorToTasksMax"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ui.exec.ExecutorsListener.executorToJvmGCTime")
     ) ++ Seq(
-      // [SPARK-17163] Unify logistic regression interface. Private constructor has new signature.
-      ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.LogisticRegressionModel.this")
+      // [SPARK-17498][ML] Enhance StringIndexer to handle unseen labels
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.StringIndexer"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.StringIndexerModel")
+    ) ++ Seq(
+      // [SPARK-17365][Core] Remove/Kill multiple executors together to reduce RPC call time
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.SparkContext")
     ) ++ Seq(
       // [SPARK-17365][Core] Remove/Kill multiple executors together to reduce RPC call time
       ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.SparkContext")


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is an enhancement to ML StringIndexer. 
Before this PR, String Indexer only supports "skip"/"error" options to deal with unseen records.
But those unseen records might still be useful and user would like to keep the unseen labels in
certain use cases, This PR enables StringIndexer to support keeping unseen labels as
indices [numLabels].

'''Before
StringIndexer().setHandleInvalid("skip")
StringIndexer().setHandleInvalid("error")
'''After
support the third option "keep"
StringIndexer().setHandleInvalid("keep")

## How was this patch tested?
Test added in StringIndexerSuite

Signed-off-by: VinceShieh <vincent.xie@intel.com>
(Please fill in changes proposed in this fix)