### PR TITLE
Encryption of shuffle files

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -28,11 +28,7 @@ If your applications are using event logging, the directory where the event logs
 ## Encryption
 
 Spark supports SSL for HTTP protocols. SASL encryption is supported for the block transfer service
-and the RPC endpoints.
-
-Encryption is not yet supported for data stored by Spark in temporary local storage, such as shuffle
-files, cached data, and other application files. If encrypting this data is desired, a workaround is
-to configure your cluster manager to store application data on encrypted disks.
+and the RPC endpoints. Shuffle files can also be encrypted if desired.
 
 ### SSL Configuration
 


### PR DESCRIPTION
Hello

According to my understanding of commits 4b4e329e49f8af28fa6301bd06c48d7097eaf9e6 & 8b325b17ecdf013b7a6edcb7ee3773546bd914df, one may now encrypt shuffle files regardless of the cluster manager in use.

However I have limited understanding of the code, I'm not able to find out whether theses changes also comprise all "temporary local storage, such as shuffle files, cached data, and other application files".

Please feel free to amend or reject my PR if I'm wrong.

dud