### PR TITLE
[SPARK-19555][SQL] Improve the performance of StringUtils.escapeLikeRegex method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -24,6 +24,8 @@ import org.apache.spark.unsafe.types.UTF8String
 
 object StringUtils {
 
+  // replace the _ with .{1} exactly match 1 time of any character
+  // replace the % with .*, match 0 or more times with any character
   def escapeLikeRegex(v: String): String = {
     if (!v.isEmpty) {
       val sb = new StringBuilder("(?s)")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -17,31 +17,37 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import java.lang.StringBuilder
 import java.util.regex.{Pattern, PatternSyntaxException}
 
 import org.apache.spark.unsafe.types.UTF8String
 
 object StringUtils {
 
-  // replace the _ with .{1} exactly match 1 time of any character
-  // replace the % with .*, match 0 or more times with any character
   def escapeLikeRegex(v: String): String = {
     if (!v.isEmpty) {
-      "(?s)" + (' ' +: v.init).zip(v).flatMap {
-        case (prev, '\\') => ""
-        case ('\\', c) =>
-          c match {
-            case '_' => "_"
-            case '%' => "%"
-            case _ => Pattern.quote("\\" + c)
-          }
-        case (prev, c) =>
-          c match {
-            case '_' => "."
-            case '%' => ".*"
-            case _ => Pattern.quote(Character.toString(c))
-          }
-      }.mkString
+      val sb = new StringBuilder("(?s)")
+      var prev = ' '
+      for (c <- v) {
+        val out = (prev, c) match {
+          case (prev, '\\') => ""
+          case ('\\', c) =>
+            c match {
+              case '_' => "_"
+              case '%' => "%"
+              case _ => Pattern.quote("\\" + c)
+            }
+          case (prev, c) =>
+            c match {
+              case '_' => "."
+              case '%' => ".*"
+              case _ => Pattern.quote(Character.toString(c))
+            }
+        }
+        prev = c
+        sb.append(out)
+      }
+      sb.toString()
     } else {
       v
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Copied from [SPARK-19555 JIRA](https://issues.apache.org/jira/browse/SPARK-19555)

Spark's `StringUtils.escapeLikeRegex()` method is written inefficiently, performing tons of object allocations due to the use `zip()`, `flatMap()` , and `mkString`. Instead, I think method should be rewritten in an imperative style using a Java string builder.

This method can become a performance bottleneck in cases where regex expressions are used with non-constant-foldable expressions (e.g. the regex expression comes from the data rather than being part of the query).

## How was this patch tested?

Existing tests.

## Performance Comparison ##


|number of rows|before|after|
| ------------- |:-------------:| -----:|
|10M|12s|4.5s|
|100M|120s|45s|

Perf testing code:


```sh
./bin/spark-shell --master "local-cluster[2,1,10240]"
```

```scala
    def perf(f: => Unit, n: Int = 3): Unit = {
      for (i <- 0 to n - 1) {
        val before = System.currentTimeMillis
        f
        val after = System.currentTimeMillis
        println(s"function took ${after - before} ms")
      }
    }

    val n = 10000000
    val df = sc.parallelize(0 to n, 2).map(i => (i.toString, "%9999")).toDF("a", "b").cache
    df.count()
    df.createOrReplaceTempView("df")

    perf {
      sql("select count(*) from df where a like b").show()
    }
```