### PR TITLE
Remove two useless blank lines in HashJoin.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -72,8 +72,6 @@ trait HashJoin {
     }
   }
 
-
-
   protected def buildSideKeyGenerator(): Projection =
     UnsafeProjection.create(buildKeys)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove two useless blank lines in HashJoin.scala

## How was this patch tested?

compile codes.