### PR TITLE
[SPARK-15531] [DEPLOY] Complement launcher JVM memory settings to avoid the conflict with system-wide settings

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -68,7 +68,7 @@ fi
 # The exit code of the launcher is appended to the output, so the parent shell removes it from the
 # command array and checks the value to see if the launcher succeeded.
 build_command() {
-  "$RUNNER" -Xmx128m -cp "$LAUNCH_CLASSPATH" org.apache.spark.launcher.Main "$@"
+  "$RUNNER" -Xms128m -Xmx128m -cp "$LAUNCH_CLASSPATH" org.apache.spark.launcher.Main "$@"
   printf "%d\0" $?
 }
 

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -55,7 +55,7 @@ if not "x%JAVA_HOME%"=="x" set RUNNER=%JAVA_HOME%\bin\java
 rem The launcher library prints the command to be executed in a single line suitable for being
 rem executed by the batch interpreter. So read all the output of the launcher into a variable.
 set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%RANDOM%.txt
-"%RUNNER%" -Xmx128m -cp "%LAUNCH_CLASSPATH%" org.apache.spark.launcher.Main %* > %LAUNCHER_OUTPUT%
+"%RUNNER%" -Xms128m -Xmx128m -cp "%LAUNCH_CLASSPATH%" org.apache.spark.launcher.Main %* > %LAUNCHER_OUTPUT%
 for /f "tokens=*" %%i in (%LAUNCHER_OUTPUT%) do (
   set SPARK_CMD=%%i
 )


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is well-known that having a lot of memory on a server JVM tries to allocate a huge chunk of it for the heap by default when it starts.

I'm using the JAVA_TOOL_OPTIONS environment variable to override default JVM settings and set an adequate system-wide heap size. When command line options merge with JAVA_TOOL_OPTIONS I'm getting the following error because my initial heap size (1g for instance) exceeds the maximum heap size (128m) provided in the code:
```
Error occurred during initialization of VM
Incompatible minimum and maximum heap sizes specified
```
I debugged the launcher scripts, and it seems there is no visible way to fix this issue outside the code. Therefore, my proposal is to provide an initial heap size in the code too.

## How was this patch tested?

Jenkins tests.