### PR TITLE
[SPARK-19595][SQL] Support json array in from_json

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1773,11 +1773,11 @@ def json_tuple(col, *fields):
 @since(2.1)
 def from_json(col, schema, options={}):
     """
-    Parses a column containing a JSON string into a [[StructType]] with the
-    specified schema. Returns `null`, in the case of an unparseable string.
+    Parses a column containing a JSON object or array string into a [[StructType]] or [[ArrayType]]
+    with the specified schema. Returns `null`, in the case of an unparseable string.
 
-    :param col: string column in json format
-    :param schema: a StructType to use when parsing the json column
+    :param col: string column in json object or array format
+    :param schema: a StructType or ArrayType to use when parsing the json column
     :param options: options to control parsing. accepts the same options as the json datasource
 
     >>> from pyspark.sql.types import *
@@ -1786,6 +1786,11 @@ def from_json(col, schema, options={}):
     >>> df = spark.createDataFrame(data, ("key", "value"))
     >>> df.select(from_json(df.value, schema).alias("json")).collect()
     [Row(json=Row(a=1))]
+    >>> data = [(1, '''[{"a": 1}]''')]
+    >>> schema = ArrayType(StructType([StructField("a", IntegerType())]))
+    >>> df = spark.createDataFrame(data, ("key", "value"))
+    >>> df.select(from_json(df.value, schema).alias("json")).collect()
+    [Row(json=[Row(a=1)])]
     """
 
     sc = SparkContext._active_spark_context

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1773,10 +1773,10 @@ def json_tuple(col, *fields):
 @since(2.1)
 def from_json(col, schema, options={}):
     """
-    Parses a column containing a JSON object or array string into a [[StructType]] or [[ArrayType]]
+    Parses a column containing a JSON string into a [[StructType]] or [[ArrayType]]
     with the specified schema. Returns `null`, in the case of an unparseable string.
 
-    :param col: string column in json object or array format
+    :param col: string column in json format
     :param schema: a StructType or ArrayType to use when parsing the json column
     :param options: options to control parsing. accepts the same options as the json datasource
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -496,10 +496,10 @@ case class JsonToStruct(
   override def checkInputDataTypes(): TypeCheckResult = {
     super.checkInputDataTypes()
     schema match {
-      case st: StructType => TypeCheckResult.TypeCheckSuccess
-      case ArrayType(st: StructType, _) => TypeCheckResult.TypeCheckSuccess
+      case _: StructType => TypeCheckResult.TypeCheckSuccess
+      case ArrayType(_: StructType, _) => TypeCheckResult.TypeCheckSuccess
       case _ => TypeCheckResult.TypeCheckFailure(
-        s"Input schema ${schema.simpleString} must be a struct or an array of struct.")
+        s"Input schema ${schema.simpleString} must be a struct or an array of structs.")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -493,14 +493,11 @@ case class JsonToStruct(
   def this(schema: DataType, options: Map[String, String], child: Expression) =
     this(schema, options, child, None)
 
-  override def checkInputDataTypes(): TypeCheckResult = {
-    super.checkInputDataTypes()
-    schema match {
-      case _: StructType => TypeCheckResult.TypeCheckSuccess
-      case ArrayType(_: StructType, _) => TypeCheckResult.TypeCheckSuccess
-      case _ => TypeCheckResult.TypeCheckFailure(
-        s"Input schema ${schema.simpleString} must be a struct or an array of structs.")
-    }
+  override def checkInputDataTypes(): TypeCheckResult = schema match {
+    case _: StructType | ArrayType(_: StructType, _) =>
+      super.checkInputDataTypes()
+    case _ => TypeCheckResult.TypeCheckFailure(
+      s"Input schema ${schema.simpleString} must be a struct or an array of structs.")
   }
 
   @transient

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -39,13 +39,7 @@ private[sql] class SparkSQLJsonProcessingException(msg: String) extends RuntimeE
  */
 class JacksonParser(
     schema: StructType,
-    options: JSONOptions,
-    arraySupport: Boolean = true,
-    objectSupport: Boolean = true) extends Logging {
-
-  // One of both should be true. Otherwise, this parser can't parse any json.
-  require(arraySupport || objectSupport)
-
+    options: JSONOptions) extends Logging {
   import JacksonUtils._
   import ParseModes._
   import com.fasterxml.jackson.core.JsonToken._
@@ -171,7 +165,7 @@ class JacksonParser(
     val elementConverter = makeConverter(st)
     val fieldConverters = st.map(_.dataType).map(makeConverter).toArray
     (parser: JsonParser) => parseJsonToken[Seq[InternalRow]](parser, st) {
-      case START_OBJECT if objectSupport => convertObject(parser, st, fieldConverters) :: Nil
+      case START_OBJECT => convertObject(parser, st, fieldConverters) :: Nil
         // SPARK-3308: support reading top level JSON arrays and take every element
         // in such an array as a row
         //
@@ -185,7 +179,7 @@ class JacksonParser(
         // List([str_a_1,null])
         // List([str_a_2,null], [null,str_b_3])
         //
-      case START_ARRAY if arraySupport =>
+      case START_ARRAY =>
         val array = convertArray(parser, elementConverter)
         // Here, as we support reading top level JSON arrays and take every element
         // in such an array as a row, this case is possible.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -40,6 +40,7 @@ private[sql] class SparkSQLJsonProcessingException(msg: String) extends RuntimeE
 class JacksonParser(
     schema: StructType,
     options: JSONOptions) extends Logging {
+
   import JacksonUtils._
   import ParseModes._
   import com.fasterxml.jackson.core.JsonToken._

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3004,11 +3004,11 @@ object functions {
     from_json(e, schema, options.asScala.toMap)
 
   /**
-   * (Java-specific) Parses a column containing a JSON object or array string into a `StructType`
-   * or `ArrayType` with the specified schema. Returns `null`, in the case of an unparseable string.
+   * (Java-specific) Parses a column containing a JSON string into a `StructType` or `ArrayType`
+   * with the specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON object or array data.
-   * @param schema the schema to use when parsing the json object or array string
+   * @param e a string column containing JSON data.
+   * @param schema the schema to use when parsing the json string
    * @param options options to control how the json is parsed. accepts the same options and the
    *                json data source.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3056,7 +3056,7 @@ object functions {
       case at @ ArrayType(_: StructType, _) => from_json(e, at, options)
       case dt =>
         throw new IllegalArgumentException(
-          s"Input schema ${dt.simpleString} must be a struct or an array of struct.")
+          s"Input schema ${dt.simpleString} must be a struct or an array of structs.")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2980,12 +2980,7 @@ object functions {
    * @since 2.2.0
    */
   def from_json(e: Column, schema: DataType, options: Map[String, String]): Column = withExpr {
-    schema match {
-      case _: StructType | ArrayType(_: StructType, _) => JsonToStruct(schema, options, e.expr)
-      case dt =>
-        throw new IllegalArgumentException(
-          s"Input schema ${dt.simpleString} must be a struct or an array of structs.")
-    }
+    JsonToStruct(schema, options, e.expr)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2953,43 +2953,47 @@ object functions {
   }
 
   /**
-   * (Scala-specific) Parses a column containing a JSON object string into a `StructType` with the
+   * (Scala-specific) Parses a column containing a JSON string into a `StructType` with the
    * specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON object data.
-   * @param schema the schema to use when parsing the json object string
+   * @param e a string column containing JSON data.
+   * @param schema the schema to use when parsing the json string
    * @param options options to control how the json is parsed. accepts the same options and the
    *                json data source.
    *
    * @group collection_funcs
    * @since 2.1.0
    */
-  def from_json(e: Column, schema: StructType, options: Map[String, String]): Column = withExpr {
-    JsonToStruct(schema, options, e.expr)
-  }
+  def from_json(e: Column, schema: StructType, options: Map[String, String]): Column =
+    from_json(e, schema.asInstanceOf[DataType], options)
 
   /**
-   * (Scala-specific) Parses a column containing a JSON array string into a `ArrayType` with the
-   * specified schema. Returns `null`, in the case of an unparseable string.
+   * (Scala-specific) Parses a column containing a JSON string into a `StructType` or `ArrayType`
+   * with the specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON array data.
-   * @param schema the schema to use when parsing the json array string
+   * @param e a string column containing JSON data.
+   * @param schema the schema to use when parsing the json string
    * @param options options to control how the json is parsed. accepts the same options and the
    *                json data source.
    *
    * @group collection_funcs
    * @since 2.2.0
    */
-  def from_json(e: Column, schema: ArrayType, options: Map[String, String]): Column = withExpr {
-    JsonToStruct(schema, options, e.expr)
+  def from_json(e: Column, schema: DataType, options: Map[String, String]): Column = withExpr {
+    schema match {
+      case _: StructType | ArrayType(_: StructType, _) => JsonToStruct(schema, options, e.expr)
+      case dt =>
+        throw new IllegalArgumentException(
+          s"Input schema ${dt.simpleString} must be a struct or an array of structs.")
+    }
   }
 
   /**
-   * (Java-specific) Parses a column containing a JSON object string into a `StructType` with the
+   * (Java-specific) Parses a column containing a JSON string into a `StructType` with the
    * specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON object data.
-   * @param schema the schema to use when parsing the json object string
+   * @param e a string column containing JSON data.
+   * @param schema the schema to use when parsing the json string
    * @param options options to control how the json is parsed. accepts the same options and the
    *                json data source.
    *
@@ -3000,26 +3004,26 @@ object functions {
     from_json(e, schema, options.asScala.toMap)
 
   /**
-   * (Java-specific) Parses a column containing a JSON array string into a `ArrayType` with the
-   * specified schema. Returns `null`, in the case of an unparseable string.
+   * (Java-specific) Parses a column containing a JSON object or array string into a `StructType`
+   * or `ArrayType` with the specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON array data.
-   * @param schema the schema to use when parsing the json array string
+   * @param e a string column containing JSON object or array data.
+   * @param schema the schema to use when parsing the json object or array string
    * @param options options to control how the json is parsed. accepts the same options and the
    *                json data source.
    *
    * @group collection_funcs
    * @since 2.2.0
    */
-  def from_json(e: Column, schema: ArrayType, options: java.util.Map[String, String]): Column =
+  def from_json(e: Column, schema: DataType, options: java.util.Map[String, String]): Column =
     from_json(e, schema, options.asScala.toMap)
 
   /**
-   * Parses a column containing a JSON object string into a `StructType` with the specified schema.
+   * Parses a column containing a JSON string into a `StructType` with the specified schema.
    * Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON object data.
-   * @param schema the schema to use when parsing the json object string
+   * @param e a string column containing JSON data.
+   * @param schema the schema to use when parsing the json string
    *
    * @group collection_funcs
    * @since 2.1.0
@@ -3028,37 +3032,30 @@ object functions {
     from_json(e, schema, Map.empty[String, String])
 
   /**
-   * Parses a column containing a JSON array string into a `ArrayType` with the specified schema.
-   * Returns `null`, in the case of an unparseable string.
+   * Parses a column containing a JSON string into a `StructType` or `ArrayType`
+   * with the specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON array data.
-   * @param schema the schema to use when parsing the json array string
+   * @param e a string column containing JSON data.
+   * @param schema the schema to use when parsing the json string
    *
    * @group collection_funcs
    * @since 2.2.0
    */
-  def from_json(e: Column, schema: ArrayType): Column =
+  def from_json(e: Column, schema: DataType): Column =
     from_json(e, schema, Map.empty[String, String])
 
   /**
-   * Parses a column containing a JSON object or array string into a `StructType` or `ArrayType`
+   * Parses a column containing a JSON string into a `StructType` or `ArrayType`
    * with the specified schema. Returns `null`, in the case of an unparseable string.
    *
-   * @param e a string column containing JSON object or array data.
+   * @param e a string column containing JSON data.
    * @param schema the schema to use when parsing the json string as a json string
    *
    * @group collection_funcs
    * @since 2.1.0
    */
-  def from_json(e: Column, schema: String, options: java.util.Map[String, String]): Column = {
-    DataType.fromJson(schema) match {
-      case st: StructType => from_json(e, st, options)
-      case at @ ArrayType(_: StructType, _) => from_json(e, at, options)
-      case dt =>
-        throw new IllegalArgumentException(
-          s"Input schema ${dt.simpleString} must be a struct or an array of structs.")
-    }
-  }
+  def from_json(e: Column, schema: String, options: java.util.Map[String, String]): Column =
+    from_json(e, DataType.fromJson(schema), options)
 
   /**
    * (Scala-specific) Converts a column containing a `StructType` into a JSON string with the

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -143,7 +143,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
     }.getMessage
 
     assert(message.contains(
-      "Input schema array<string> must be a struct or an array of struct."))
+      "Input schema array<string> must be a struct or an array of structs."))
   }
 
   test("to_json") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql
 
-import scala.collection.JavaConverters._
-
 import org.apache.spark.sql.functions.{from_json, struct, to_json}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
@@ -139,7 +137,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
     val df = Seq("""{"a" 1}""").toDS()
     val schema = ArrayType(StringType)
     val message = intercept[IllegalArgumentException] {
-      df.select(from_json($"value", schema.json, Map.empty[String, String].asJava))
+      df.select(from_json($"value", schema))
     }.getMessage
 
     assert(message.contains(
@@ -163,10 +161,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       df.select(from_json($"value", schema)),
-      Row(Seq(Row(1, "a"), Row(2, null), Row(null, null))))
-
-    checkAnswer(
-      df.select(from_json($"value", schema.json, Map.empty[String, String].asJava)),
       Row(Seq(Row(1, "a"), Row(2, null), Row(null, null))))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -136,7 +136,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
   test("from_json invalid schema") {
     val df = Seq("""{"a" 1}""").toDS()
     val schema = ArrayType(StringType)
-    val message = intercept[IllegalArgumentException] {
+    val message = intercept[AnalysisException] {
       df.select(from_json($"value", schema))
     }.getMessage
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -144,14 +144,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       "Input schema array<string> must be a struct or an array of structs."))
   }
 
-  test("to_json") {
-    val df = Seq(Tuple1(Tuple1(1))).toDF("a")
-
-    checkAnswer(
-      df.select(to_json($"a")),
-      Row("""{"_1":1}""") :: Nil)
-  }
-
   test("from_json array support") {
     val df = Seq("""[{"a": 1, "b": "a"}, {"a": 2}, { }]""").toDS()
     val schema = ArrayType(
@@ -162,6 +154,14 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.select(from_json($"value", schema)),
       Row(Seq(Row(1, "a"), Row(2, null), Row(null, null))))
+  }
+
+  test("to_json") {
+    val df = Seq(Tuple1(Tuple1(1))).toDF("a")
+
+    checkAnswer(
+      df.select(to_json($"a")),
+      Row("""{"_1":1}""") :: Nil)
   }
 
   test("to_json with option") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to both,

**Do not allow json arrays with multiple elements and return null in `from_json` with `StructType` as the schema.**

Currently, it only reads the single row when the input is a json array. So, the codes below:

```scala
import org.apache.spark.sql.functions._
import org.apache.spark.sql.types._
val schema = StructType(StructField("a", IntegerType) :: Nil)
Seq(("""[{"a": 1}, {"a": 2}]""")).toDF("struct").select(from_json(col("struct"), schema)).show()
```
prints 

```
+--------------------+
|jsontostruct(struct)|
+--------------------+
|                 [1]|
+--------------------+
```

This PR simply suggests to print this as `null` if the schema is `StructType` and input is json array.with multiple elements

```
+--------------------+
|jsontostruct(struct)|
+--------------------+
|                null|
+--------------------+
``` 

**Support json arrays in `from_json` with `ArrayType` as the schema.**


```scala
import org.apache.spark.sql.functions._
import org.apache.spark.sql.types._
val schema = ArrayType(StructType(StructField("a", IntegerType) :: Nil))
Seq(("""[{"a": 1}, {"a": 2}]""")).toDF("array").select(from_json(col("array"), schema)).show()
```

prints

```
+-------------------+
|jsontostruct(array)|
+-------------------+
|         [[1], [2]]|
+-------------------+
```

## How was this patch tested?

Unit test in `JsonExpressionsSuite`, `JsonFunctionsSuite`, Python doctests and manual test.