### PR TITLE
[SPARK-16475][SQL] broadcast hint for SQL queries - disallow space as the delimiter

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -380,7 +380,6 @@ hint
 
 hintStatement
     : hintName=identifier
-    | hintName=identifier '(' parameters+=identifier parameters+=identifier ')'
     | hintName=identifier '(' parameters+=identifier (',' parameters+=identifier)* ')'
     ;
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -505,7 +505,13 @@ class PlanParserSuite extends PlanTest {
     val m2 = intercept[ParseException] {
       parsePlan("SELECT /*+ MAPJOIN(default.t) */ * from default.t")
     }.getMessage
-    assert(m2.contains("no viable alternative at input"))
+    assert(m2.contains("mismatched input '.' expecting {')', ','}"))
+
+    // Disallow space as the delimiter.
+    val m3 = intercept[ParseException] {
+      parsePlan("SELECT /*+ INDEX(a b c) */ * from default.t")
+    }.getMessage
+    assert(m3.contains("mismatched input 'b' expecting {')', ','}"))
 
     comparePlans(
       parsePlan("SELECT /*+ HINT */ * FROM t"),
@@ -524,7 +530,7 @@ class PlanParserSuite extends PlanTest {
       Hint("STREAMTABLE", Seq("a", "b", "c"), table("t").select(star())))
 
     comparePlans(
-      parsePlan("SELECT /*+ INDEX(t emp_job_ix) */ * FROM t"),
+      parsePlan("SELECT /*+ INDEX(t, emp_job_ix) */ * FROM t"),
       Hint("INDEX", Seq("t", "emp_job_ix"), table("t").select(star())))
 
     comparePlans(


### PR DESCRIPTION
## What changes were proposed in this pull request?

A follow-up to disallow space as the delimiter in broadcast hint.

## How was this patch tested?

Jenkins test.

Please review http://spark.apache.org/contributing.html before opening a pull request.
