### PR TITLE
[SPARK-19626][YARN]Using the correct config to set credentials update time

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/CredentialUpdater.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/CredentialUpdater.scala
@@ -55,14 +55,10 @@ private[spark] class CredentialUpdater(
 
   /** Start the credential updater task */
   def start(): Unit = {
-    val startTime = sparkConf.get(CREDENTIALS_RENEWAL_TIME)
-    val remainingTime = startTime - System.currentTimeMillis()
-    if (remainingTime <= 0) {
-      credentialUpdater.schedule(credentialUpdaterRunnable, 1, TimeUnit.MINUTES)
-    } else {
-      logInfo(s"Scheduling credentials refresh from HDFS in $remainingTime millis.")
-      credentialUpdater.schedule(credentialUpdaterRunnable, remainingTime, TimeUnit.MILLISECONDS)
-    }
+    val startTime = sparkConf.get(CREDENTIALS_UPDATE_TIME)
+    val remainingTime = Math.max(1, startTime - System.currentTimeMillis())
+    logInfo(s"Scheduling credentials refresh from HDFS in $remainingTime millis.")
+    credentialUpdater.schedule(credentialUpdaterRunnable, remainingTime, TimeUnit.MILLISECONDS)
   }
 
   private def updateCredentialsIfRequired(): Unit = {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/CredentialUpdater.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/CredentialUpdater.scala
@@ -56,9 +56,13 @@ private[spark] class CredentialUpdater(
   /** Start the credential updater task */
   def start(): Unit = {
     val startTime = sparkConf.get(CREDENTIALS_UPDATE_TIME)
-    val remainingTime = Math.max(1, startTime - System.currentTimeMillis())
-    logInfo(s"Scheduling credentials refresh from HDFS in $remainingTime millis.")
-    credentialUpdater.schedule(credentialUpdaterRunnable, remainingTime, TimeUnit.MILLISECONDS)
+    val remainingTime = startTime - System.currentTimeMillis()
+    if (remainingTime <= 0) {
+      credentialUpdater.schedule(credentialUpdaterRunnable, 1, TimeUnit.MINUTES)
+    } else {
+      logInfo(s"Scheduling credentials refresh from HDFS in $remainingTime millis.")
+      credentialUpdater.schedule(credentialUpdaterRunnable, remainingTime, TimeUnit.MILLISECONDS)
+    }
   }
 
   private def updateCredentialsIfRequired(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In https://github.com/apache/spark/pull/14065, we introduced a configurable credential manager for Spark running on YARN. Also two configs `spark.yarn.credentials.renewalTime` and `spark.yarn.credentials.updateTime` were added, one is for the credential renewer and the other updater. But now we just query `spark.yarn.credentials.renewalTime` by mistake during CREDENTIALS UPDATING, where should be actually `spark.yarn.credentials.updateTime` . 

This PR fixes this mistake.

## How was this patch tested?

existing test

cc @jerryshao @vanzin 