### PR TITLE
[SPARK-19631][CORE] OutputCommitCoordinator should not allow commits for already failed tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -159,7 +159,7 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
       partition: PartitionId,
       attemptNumber: TaskAttemptNumber): Boolean = synchronized {
     stageStates.get(stage) match {
-      case Some(state) if attemptFailed(stage, partition, attemptNumber) =>
+      case Some(state) if attemptFailed(state, partition, attemptNumber) =>
         logInfo(s"Denying attemptNumber=$attemptNumber to commit for stage=$stage," +
         s" partition=$partition as task attempt $attemptNumber has already failed.")
         false
@@ -192,12 +192,10 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
   }
 
   private def attemptFailed(
-      stage: StageId,
+      stageState: StageState,
       partition: PartitionId,
       attempt: TaskAttemptNumber): Boolean = synchronized {
-    stageStates.get(stage).exists { state =>
-      state.failures.get(partition).exists(_.contains(attempt))
-    }
+    stageState.failures.get(partition).exists(_.contains(attempt))
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -48,9 +48,9 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
   private type StageId = Int
   private type PartitionId = Int
   private type TaskAttemptNumber = Int
-  private case class StageState(
-      authorizedCommitters: Array[TaskAttemptNumber],
-      failures: mutable.Map[PartitionId, mutable.Set[TaskAttemptNumber]])
+  private case class StageState(authorizedCommitters: Array[TaskAttemptNumber]) {
+    val failures = mutable.Map[PartitionId, mutable.Set[TaskAttemptNumber]]()
+  }
 
   private val NO_AUTHORIZED_COMMITTER: TaskAttemptNumber = -1
 
@@ -114,9 +114,8 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
       maxPartitionId: Int): Unit = {
     val arr = new Array[TaskAttemptNumber](maxPartitionId + 1)
     java.util.Arrays.fill(arr, NO_AUTHORIZED_COMMITTER)
-    val failures = mutable.Map[PartitionId, mutable.Set[TaskAttemptNumber]]()
     synchronized {
-      stageStates(stage) = new StageState(arr, failures)
+      stageStates(stage) = new StageState(arr)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -161,7 +161,7 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
     stageStates.get(stage) match {
       case Some(state) if attemptFailed(state, partition, attemptNumber) =>
         logInfo(s"Denying attemptNumber=$attemptNumber to commit for stage=$stage," +
-        s" partition=$partition as task attempt $attemptNumber has already failed.")
+          s" partition=$partition as task attempt $attemptNumber has already failed.")
         false
       case Some(state) =>
         state.authorizedCommitters(partition) match {

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -48,25 +48,28 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
   private type StageId = Int
   private type PartitionId = Int
   private type TaskAttemptNumber = Int
+  private case class StageState(authorizedCommitters: Array[TaskAttemptNumber],
+                                failures: mutable.Map[PartitionId, mutable.Set[TaskAttemptNumber]])
 
   private val NO_AUTHORIZED_COMMITTER: TaskAttemptNumber = -1
 
   /**
-   * Map from active stages's id => partition id => task attempt with exclusive lock on committing
-   * output for that partition.
+   * Map from active stages's id => authorized task attempts for each partition id, which hold an
+   * exclusive lock on committing task output for that partition as well as any known failed
+   * attempts in the stage.
    *
    * Entries are added to the top-level map when stages start and are removed they finish
    * (either successfully or unsuccessfully).
    *
    * Access to this map should be guarded by synchronizing on the OutputCommitCoordinator instance.
    */
-  private val authorizedCommittersByStage = mutable.Map[StageId, Array[TaskAttemptNumber]]()
+  private val stageStates = mutable.Map[StageId, StageState]()
 
   /**
    * Returns whether the OutputCommitCoordinator's internal data structures are all empty.
    */
   def isEmpty: Boolean = {
-    authorizedCommittersByStage.isEmpty
+    stageStates.isEmpty
   }
 
   /**
@@ -110,14 +113,15 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
       maxPartitionId: Int): Unit = {
     val arr = new Array[TaskAttemptNumber](maxPartitionId + 1)
     java.util.Arrays.fill(arr, NO_AUTHORIZED_COMMITTER)
+    val failures = mutable.Map[PartitionId, mutable.Set[TaskAttemptNumber]]()
     synchronized {
-      authorizedCommittersByStage(stage) = arr
+      stageStates(stage) = new StageState(arr, failures)
     }
   }
 
   // Called by DAGScheduler
   private[scheduler] def stageEnd(stage: StageId): Unit = synchronized {
-    authorizedCommittersByStage.remove(stage)
+    stageStates.remove(stage)
   }
 
   // Called by DAGScheduler
@@ -126,7 +130,7 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
       partition: PartitionId,
       attemptNumber: TaskAttemptNumber,
       reason: TaskEndReason): Unit = synchronized {
-    val authorizedCommitters = authorizedCommittersByStage.getOrElse(stage, {
+    val stageState = stageStates.getOrElse(stage, {
       logDebug(s"Ignoring task completion for completed stage")
       return
     })
@@ -137,10 +141,15 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
         logInfo(s"Task was denied committing, stage: $stage, partition: $partition, " +
           s"attempt: $attemptNumber")
       case otherReason =>
-        if (authorizedCommitters(partition) == attemptNumber) {
+        // Mark the attempt as failed to blacklist from future commit protocol
+        stageState.failures.get(partition) match {
+          case Some(failures) => failures += attemptNumber
+          case None => stageState.failures(partition) = mutable.Set(attemptNumber)
+        }
+        if (stageState.authorizedCommitters(partition) == attemptNumber) {
           logDebug(s"Authorized committer (attemptNumber=$attemptNumber, stage=$stage, " +
             s"partition=$partition) failed; clearing lock")
-          authorizedCommitters(partition) = NO_AUTHORIZED_COMMITTER
+          stageState.authorizedCommitters(partition) = NO_AUTHORIZED_COMMITTER
         }
     }
   }
@@ -149,7 +158,7 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
     if (isDriver) {
       coordinatorRef.foreach(_ send StopCoordinator)
       coordinatorRef = None
-      authorizedCommittersByStage.clear()
+      stageStates.clear()
     }
   }
 
@@ -158,13 +167,17 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
       stage: StageId,
       partition: PartitionId,
       attemptNumber: TaskAttemptNumber): Boolean = synchronized {
-    authorizedCommittersByStage.get(stage) match {
-      case Some(authorizedCommitters) =>
-        authorizedCommitters(partition) match {
+    stageStates.get(stage) match {
+      case Some(state) if attemptFailed(stage, partition, attemptNumber) =>
+        logWarning(s"Denying attemptNumber=$attemptNumber to commit for stage=$stage," +
+        s" partition=$partition as task attempt $attemptNumber has already failed.")
+        false
+      case Some(state) =>
+        state.authorizedCommitters(partition) match {
           case NO_AUTHORIZED_COMMITTER =>
             logDebug(s"Authorizing attemptNumber=$attemptNumber to commit for stage=$stage, " +
               s"partition=$partition")
-            authorizedCommitters(partition) = attemptNumber
+            state.authorizedCommitters(partition) = attemptNumber
             true
           case existingCommitter =>
             // Coordinator should be idempotent when receiving AskPermissionToCommit.
@@ -181,9 +194,20 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
             }
         }
       case None =>
-        logDebug(s"Stage $stage has completed, so not allowing attempt number $attemptNumber of" +
-          s"partition $partition to commit")
+        logDebug(s"Stage $stage has completed, so not allowing" +
+          s" attempt number $attemptNumber of partition $partition to commit")
         false
+    }
+  }
+
+  private def attemptFailed(stage: StageId,
+                            partition: PartitionId,
+                            attempt: TaskAttemptNumber): Boolean = synchronized {
+    stageStates.get(stage) match {
+      case Some(state) =>
+        state.failures.get(partition)
+          .exists(_.contains(attempt))
+      case None => false
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -55,7 +55,7 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
 
   /**
    * Map from active stages's id => authorized task attempts for each partition id, which hold an
-   * exclusive lock on committing task output for that partition as well as any known failed
+   * exclusive lock on committing task output for that partition, as well as any known failed
    * attempts in the stage.
    *
    * Entries are added to the top-level map when stages start and are removed they finish
@@ -203,11 +203,8 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
   private def attemptFailed(stage: StageId,
                             partition: PartitionId,
                             attempt: TaskAttemptNumber): Boolean = synchronized {
-    stageStates.get(stage) match {
-      case Some(state) =>
-        state.failures.get(partition)
-          .exists(_.contains(attempt))
-      case None => false
+    stageStates.get(stage).exists { state =>
+      state.failures.get(partition).exists(_.contains(attempt))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously it was possible for there to be a race between a task failure and committing the output of a task. For example, the driver may mark a task attempt as failed due to an executor heartbeat timeout (possibly due to GC), but the task attempt actually ends up coordinating with the OutputCommitCoordinator once the executor recovers and committing its result. This will lead to any retry attempt failing because the task result has already been committed despite the original attempt failing.

This ensures that any previously failed task attempts cannot enter the commit protocol.

## How was this patch tested?

Added a unit test
