### PR TITLE
[MINOR][PYTHON] Fix typo docstring: 'top' -> 'topic'

### DIFF
--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -262,7 +262,7 @@ class OffsetRange(object):
 
 class TopicAndPartition(object):
     """
-    Represents a specific top and partition for Kafka.
+    Represents a specific topic and partition for Kafka.
     """
 
     def __init__(self, topic, partition):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix typo in docstring.