### PR TITLE
[SPARK-19573][SQL] Make NaN/null handling consistent in approxQuantile

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -245,7 +245,7 @@ object ApproximatePercentile {
         val result = new Array[Double](percentages.length)
         var i = 0
         while (i < percentages.length) {
-          result(i) = summaries.query(percentages(i))
+          result(i) = summaries.query(percentages(i)).get
           i += 1
         }
         result

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -245,6 +245,7 @@ object ApproximatePercentile {
         val result = new Array[Double](percentages.length)
         var i = 0
         while (i < percentages.length) {
+          // Since summaries.count != 0, the query here never return None.
           result(i) = summaries.query(percentages(i)).get
           i += 1
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
@@ -180,6 +180,7 @@ class QuantileSummaries(
     require(quantile >= 0 && quantile <= 1.0, "quantile should be in the range [0.0, 1.0]")
     require(headSampled.isEmpty,
       "Cannot operate on an uncompressed summary, call compress() first")
+    require(sampled.nonEmpty, "buffer of quantile statistics should not be empty")
 
     if (quantile <= relativeError) {
       return sampled.head.value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
@@ -181,9 +181,7 @@ class QuantileSummaries(
     require(headSampled.isEmpty,
       "Cannot operate on an uncompressed summary, call compress() first")
 
-    if (sampled.isEmpty) {
-      return None
-    }
+    if (sampled.isEmpty) return None
 
     if (quantile <= relativeError) {
       return Some(sampled.head.value)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
@@ -177,21 +177,21 @@ class QuantileSummaries(
    * @param quantile the target quantile
    * @return
    */
-  def query(quantile: Double): Double = {
+  def query(quantile: Double): Option[Double] = {
     require(quantile >= 0 && quantile <= 1.0, "quantile should be in the range [0.0, 1.0]")
     require(headSampled.isEmpty,
       "Cannot operate on an uncompressed summary, call compress() first")
 
     if (sampled.isEmpty) {
-      throw new SparkException("buffer of quantile statistics should not be empty")
+      return None
     }
 
     if (quantile <= relativeError) {
-      return sampled.head.value
+      return Some(sampled.head.value)
     }
 
     if (quantile >= 1 - relativeError) {
-      return sampled.last.value
+      return Some(sampled.last.value)
     }
 
     // Target rank
@@ -205,11 +205,11 @@ class QuantileSummaries(
       minRank += curSample.g
       val maxRank = minRank + curSample.delta
       if (maxRank - targetError <= rank && rank <= minRank + targetError) {
-        return curSample.value
+        return Some(curSample.value)
       }
       i += 1
     }
-    sampled.last.value
+    Some(sampled.last.value)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.util
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.util.QuantileSummaries.Stats
 
 /**
@@ -180,7 +181,10 @@ class QuantileSummaries(
     require(quantile >= 0 && quantile <= 1.0, "quantile should be in the range [0.0, 1.0]")
     require(headSampled.isEmpty,
       "Cannot operate on an uncompressed summary, call compress() first")
-    require(sampled.nonEmpty, "buffer of quantile statistics should not be empty")
+
+    if (sampled.isEmpty) {
+      throw new SparkException("buffer of quantile statistics should not be empty")
+    }
 
     if (quantile <= relativeError) {
       return sampled.head.value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/QuantileSummaries.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst.util
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.util.QuantileSummaries.Stats
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
@@ -100,6 +100,13 @@ class QuantileSummariesSuite extends SparkFunSuite {
       checkQuantile(0.1, data, s)
       checkQuantile(0.001, data, s)
     }
+
+    test(s"Test on empty QuantileSummaries") {
+      val s = buildSummary(Seq.empty[Double], epsi, compression)
+      assert(s.count == 0, s"Found count=${s.count} but data size=0")
+      assert(s.sampled.isEmpty, s"if QuantileSummaries is empty, sampled should be empty")
+      assert(s.query(0.9).isEmpty, "if QuantileSummaries is empty, query should return None")
+    }
   }
 
   // Tests for merging procedure

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
@@ -105,7 +105,7 @@ class QuantileSummariesSuite extends SparkFunSuite {
       checkQuantile(0.001, data, s)
     }
 
-    test(s"Test on empty QuantileSummaries") {
+    test(s"Tests with empty data and epsi=$epsi") {
       val emptyData = Seq.empty[Double]
       val s = buildSummary(emptyData, epsi, compression)
       assert(s.count == 0, s"Found count=${s.count} but data size=0")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
@@ -105,7 +105,7 @@ class QuantileSummariesSuite extends SparkFunSuite {
       checkQuantile(0.001, data, s)
     }
 
-    test(s"Tests on empty data with epsi=$epsi, compression=$compression") {
+    test(s"Tests on empty data with epsi=$epsi and seq=$seq_name, compression=$compression") {
       val emptyData = Seq.empty[Double]
       val s = buildSummary(emptyData, epsi, compression)
       assert(s.count == 0, s"Found count=${s.count} but data size=0")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
@@ -105,7 +105,7 @@ class QuantileSummariesSuite extends SparkFunSuite {
       checkQuantile(0.001, data, s)
     }
 
-    test(s"Tests with empty data and epsi=$epsi") {
+    test(s"Tests on empty data with epsi=$epsi, compression=$compression") {
       val emptyData = Seq.empty[Double]
       val s = buildSummary(emptyData, epsi, compression)
       assert(s.count == 0, s"Found count=${s.count} but data size=0")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuantileSummariesSuite.scala
@@ -55,7 +55,7 @@ class QuantileSummariesSuite extends SparkFunSuite {
   }
 
   private def checkQuantile(quant: Double, data: Seq[Double], summary: QuantileSummaries): Unit = {
-    val approx = summary.query(quant)
+    val approx = summary.query(quant).get
     // The rank of the approximation.
     val rank = data.count(_ < approx) // has to be <, not <= to be exact
     val lower = math.floor((quant - summary.relativeError) * data.size)
@@ -74,9 +74,9 @@ class QuantileSummariesSuite extends SparkFunSuite {
 
     test(s"Extremas with epsi=$epsi and seq=$seq_name, compression=$compression") {
       val s = buildSummary(data, epsi, compression)
-      val min_approx = s.query(0.0)
+      val min_approx = s.query(0.0).get
       assert(min_approx == data.min, s"Did not return the min: min=${data.min}, got $min_approx")
-      val max_approx = s.query(1.0)
+      val max_approx = s.query(1.0).get
       assert(max_approx == data.max, s"Did not return the max: max=${data.max}, got $max_approx")
     }
 
@@ -118,9 +118,9 @@ class QuantileSummariesSuite extends SparkFunSuite {
       val s1 = buildSummary(data1, epsi, compression)
       val s2 = buildSummary(data2, epsi, compression)
       val s = s1.merge(s2)
-      val min_approx = s.query(0.0)
+      val min_approx = s.query(0.0).get
       assert(min_approx == data.min, s"Did not return the min: min=${data.min}, got $min_approx")
-      val max_approx = s.query(1.0)
+      val max_approx = s.query(1.0).get
       assert(max_approx == data.max, s"Did not return the max: max=${data.max}, got $max_approx")
       checkQuantile(0.9999, data, s)
       checkQuantile(0.9, data, s)
@@ -137,9 +137,9 @@ class QuantileSummariesSuite extends SparkFunSuite {
       val s1 = buildSummary(data11, epsi, compression)
       val s2 = buildSummary(data12, epsi, compression)
       val s = s1.merge(s2)
-      val min_approx = s.query(0.0)
+      val min_approx = s.query(0.0).get
       assert(min_approx == data.min, s"Did not return the min: min=${data.min}, got $min_approx")
-      val max_approx = s.query(1.0)
+      val max_approx = s.query(1.0).get
       assert(max_approx == data.max, s"Did not return the max: max=${data.max}, got $max_approx")
       checkQuantile(0.9999, data, s)
       checkQuantile(0.9, data, s)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -64,7 +64,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @return the approximate quantiles at the given probabilities
    *
    * @note null and NaN values will be removed from the numerical column before calculation. If
-   *   the dataframe is empty or all rows contain null or NaN, null is returned.
+   *   the dataframe is empty or the column only contains null or NaN, an empty array is returned.
    *
    * @since 2.0.0
    */
@@ -72,8 +72,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       col: String,
       probabilities: Array[Double],
       relativeError: Double): Array[Double] = {
-    val res = approxQuantile(Array(col), probabilities, relativeError)
-    Option(res).map(_.head).orNull
+    approxQuantile(Array(col), probabilities, relativeError).head
   }
 
   /**
@@ -89,8 +88,8 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    * @return the approximate quantiles at the given probabilities of each column
    *
-   * @note null and NaN values will be ignored in numerical columns before calculation. If
-   *   the dataframe is empty, or all rows in some column contain null or NaN, null is returned.
+   * @note null and NaN values will be ignored in numerical columns before calculation. For
+   *   columns only containing null or NaN values, an empty array is returned.
    *
    * @since 2.2.0
    */
@@ -98,12 +97,8 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       cols: Array[String],
       probabilities: Array[Double],
       relativeError: Double): Array[Array[Double]] = {
-    try {
-      StatFunctions.multipleApproxQuantiles(df.select(cols.map(col): _*), cols,
-        probabilities, relativeError).map(_.toArray).toArray
-    } catch {
-      case e: NoSuchElementException => null
-    }
+    StatFunctions.multipleApproxQuantiles(df.select(cols.map(col): _*), cols,
+      probabilities, relativeError).map(_.toArray).toArray
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -97,8 +97,11 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       cols: Array[String],
       probabilities: Array[Double],
       relativeError: Double): Array[Array[Double]] = {
-    StatFunctions.multipleApproxQuantiles(df.select(cols.map(col): _*), cols,
-      probabilities, relativeError).map(_.toArray).toArray
+    StatFunctions.multipleApproxQuantiles(
+      df.select(cols.map(col): _*),
+      cols,
+      probabilities,
+      relativeError).map(_.toArray).toArray
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -89,8 +89,8 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    * @return the approximate quantiles at the given probabilities of each column
    *
-   * @note Rows containing any null or NaN values will be removed before calculation. If
-   *   the dataframe is empty or all rows contain null or NaN, null is returned.
+   * @note null and NaN values will be removed from the numerical column before calculation. If
+   *   the dataframe is empty, or all rows in some column contain null or NaN, null is returned.
    *
    * @since 2.2.0
    */
@@ -98,9 +98,8 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       cols: Array[String],
       probabilities: Array[Double],
       relativeError: Double): Array[Array[Double]] = {
-    // TODO: Update NaN/null handling to keep consistent with the single-column version
     try {
-      StatFunctions.multipleApproxQuantiles(df.select(cols.map(col): _*).na.drop(), cols,
+      StatFunctions.multipleApproxQuantiles(df.select(cols.map(col): _*), cols,
         probabilities, relativeError).map(_.toArray).toArray
     } catch {
       case e: NoSuchElementException => null

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -89,7 +89,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    * @return the approximate quantiles at the given probabilities of each column
    *
-   * @note null and NaN values will be removed from the numerical column before calculation. If
+   * @note null and NaN values will be ignored in numerical columns before calculation. If
    *   the dataframe is empty, or all rows in some column contain null or NaN, null is returned.
    *
    * @since 2.2.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -55,7 +55,7 @@ object StatFunctions extends Logging {
    *
    * @return for each column, returns the requested approximations
    *
-   * @note null and NaN values will be removed from the numerical column before calculation.
+   * @note null and NaN values will be ignored in numerical columns before calculation.
    */
   def multipleApproxQuantiles(
       df: DataFrame,
@@ -80,9 +80,8 @@ object StatFunctions extends Logging {
     def apply(summaries: Array[QuantileSummaries], row: Row): Array[QuantileSummaries] = {
       var i = 0
       while (i < summaries.length) {
-        val item = row(i)
-        if (item != null) {
-          val v = item.asInstanceOf[Double]
+        if (!row.isNullAt(i)) {
+          val v = row.getDouble(i)
           if (!v.isNaN) {
             summaries(i) = summaries(i).insert(v)
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.stat
 
-import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.expressions.{Cast, GenericInternalRow}
@@ -101,12 +100,7 @@ object StatFunctions extends Logging {
     val summaries = df.select(columns: _*).rdd.aggregate(emptySummaries)(apply, merge)
 
     summaries.map { summary =>
-      val res = probabilities.map(summary.query)
-      if (res.exists(_.isEmpty)) {
-        Seq.empty[Double]
-      } else {
-        res.map(_.get)
-      }
+      probabilities.flatMap(summary.query)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -55,7 +55,8 @@ object StatFunctions extends Logging {
    *
    * @return for each column, returns the requested approximations
    *
-   * @note null and NaN values will be ignored in numerical columns before calculation.
+   * @note null and NaN values will be ignored in numerical columns before calculation. For
+   *   a column only containing null or NaN values, an empty array is returned.
    */
   def multipleApproxQuantiles(
       df: DataFrame,
@@ -98,7 +99,13 @@ object StatFunctions extends Logging {
     }
     val summaries = df.select(columns: _*).rdd.aggregate(emptySummaries)(apply, merge)
 
-    summaries.map { summary => probabilities.map(summary.query) }
+    summaries.map { summary =>
+      try {
+        probabilities.map(summary.query)
+      } catch {
+        case e: IllegalArgumentException => Seq.empty[Double]
+      }
+    }
   }
 
   /** Calculate the Pearson Correlation Coefficient for the given columns */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.stat
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.expressions.{Cast, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
@@ -103,7 +104,7 @@ object StatFunctions extends Logging {
       try {
         probabilities.map(summary.query)
       } catch {
-        case e: IllegalArgumentException => Seq.empty[Double]
+        case e: SparkException => Seq.empty[Double]
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -83,9 +83,7 @@ object StatFunctions extends Logging {
       while (i < summaries.length) {
         if (!row.isNullAt(i)) {
           val v = row.getDouble(i)
-          if (!v.isNaN) {
-            summaries(i) = summaries(i).insert(v)
-          }
+          if (!v.isNaN) summaries(i) = summaries(i).insert(v)
         }
         i += 1
       }
@@ -99,9 +97,7 @@ object StatFunctions extends Logging {
     }
     val summaries = df.select(columns: _*).rdd.aggregate(emptySummaries)(apply, merge)
 
-    summaries.map { summary =>
-      probabilities.flatMap(summary.query)
-    }
+    summaries.map { summary => probabilities.flatMap(summary.query) }
   }
 
   /** Calculate the Pearson Correlation Coefficient for the given columns */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.execution.stat
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.expressions.{Cast, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
@@ -101,10 +101,11 @@ object StatFunctions extends Logging {
     val summaries = df.select(columns: _*).rdd.aggregate(emptySummaries)(apply, merge)
 
     summaries.map { summary =>
-      try {
-        probabilities.map(summary.query)
-      } catch {
-        case e: SparkException => Seq.empty[Double]
+      val res = probabilities.map(summary.query)
+      if (res.exists(_.isEmpty)) {
+        Seq.empty[Double]
+      } else {
+        res.map(_.get)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -54,6 +54,8 @@ object StatFunctions extends Logging {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    *
    * @return for each column, returns the requested approximations
+   *
+   * @note null and NaN values will be removed from the numerical column before calculation.
    */
   def multipleApproxQuantiles(
       df: DataFrame,
@@ -78,7 +80,13 @@ object StatFunctions extends Logging {
     def apply(summaries: Array[QuantileSummaries], row: Row): Array[QuantileSummaries] = {
       var i = 0
       while (i < summaries.length) {
-        summaries(i) = summaries(i).insert(row.getDouble(i))
+        val item = row(i)
+        if (item != null) {
+          val v = item.asInstanceOf[Double]
+          if (!v.isNaN) {
+            summaries(i) = summaries(i).insert(v)
+          }
+        }
         i += 1
       }
       summaries

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -171,15 +171,6 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
       df.stat.approxQuantile(Array("singles", "doubles"), Array(q1, q2), -1.0)
     }
     assert(e2.getMessage.contains("Relative Error must be non-negative"))
-
-    // return null if the dataset is empty
-    val res1 = df.selectExpr("*").limit(0)
-      .stat.approxQuantile("singles", Array(q1, q2), epsilons.head)
-    assert(res1 === null)
-
-    val res2 = df.selectExpr("*").limit(0)
-      .stat.approxQuantile(Array("singles", "doubles"), Array(q1, q2), epsilons.head)
-    assert(res2 === null)
   }
 
   test("approximate quantile 2: test relativeError greater than 1 return the same result as 1") {
@@ -214,11 +205,13 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
     val q1 = 0.5
     val q2 = 0.8
     val epsilon = 0.1
-    val rows = spark.sparkContext.parallelize(Seq(Row(Double.NaN, 1.0), Row(1.0, -1.0),
-      Row(-1.0, Double.NaN), Row(Double.NaN, Double.NaN), Row(null, null), Row(null, 1.0),
-      Row(-1.0, null), Row(Double.NaN, null)))
+    val rows = spark.sparkContext.parallelize(Seq(Row(Double.NaN, 1.0, Double.NaN),
+      Row(1.0, -1.0, null), Row(-1.0, Double.NaN, null), Row(Double.NaN, Double.NaN, null),
+      Row(null, null, Double.NaN), Row(null, 1.0, null), Row(-1.0, null, Double.NaN),
+      Row(Double.NaN, null, null)))
     val schema = StructType(Seq(StructField("input1", DoubleType, nullable = true),
-      StructField("input2", DoubleType, nullable = true)))
+      StructField("input2", DoubleType, nullable = true),
+      StructField("input3", DoubleType, nullable = true)))
     val dfNaN = spark.createDataFrame(rows, schema)
     val resNaN1 = dfNaN.stat.approxQuantile("input1", Array(q1, q2), epsilon)
     assert(resNaN1.count(_.isNaN) === 0)
@@ -237,6 +230,19 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
     assert(resNaN1(1) === resNaNAll(0)(1))
     assert(resNaN2(0) === resNaNAll(1)(0))
     assert(resNaN2(1) === resNaNAll(1)(1))
+
+    // return null if the dataset is empty
+    val res1 = dfNaN.selectExpr("*").limit(0)
+      .stat.approxQuantile("input1", Array(q1, q2), epsilon)
+    assert(res1 === null)
+
+    val res2 = dfNaN.selectExpr("*").limit(0)
+      .stat.approxQuantile(Array("input1", "input2"), Array(q1, q2), epsilon)
+    assert(res2 === null)
+
+    // return null if all rows in some column contain null or NaN
+    val res3 = dfNaN.stat.approxQuantile(Array("input1", "input3"), Array(q1, q2), epsilon)
+    assert(res3 === null)
   }
 
   test("crosstab") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
update `StatFunctions.multipleApproxQuantiles` to handle NaN/null


## How was this patch tested?
existing tests and added tests