### PR TITLE
[SPARK-19651][CORE] ParallelCollectionRDD.collect should not issue a Spark job

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
@@ -83,7 +83,7 @@ private[spark] class ParallelCollectionPartition[T: ClassTag](
 }
 
 private[spark] class ParallelCollectionRDD[T: ClassTag](
-    sc: SparkContext,
+    @transient private val sc: SparkContext,
     @transient private val data: Seq[T],
     numSlices: Int,
     locationPrefs: Map[Int, Seq[String]])


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ParallelCollectionRDD` already keeps the data, it doesn't make sense to send the data to executors and collect it back when users call `collect`.

This PR override the `collect` method in `ParallelCollectionRDD`, and return the data directly, with a round-trip serialization to simulate the previously behavior and make sure `collect` returns a new copy of data.

same thing applies to `take`

## How was this patch tested?

existing tests.