### PR TITLE
[SPARK-19550][BUILD][WIP] Addendum: select Java 1.7 for scalac 2.10, still

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -234,7 +234,9 @@ object SparkBuild extends PomBuild {
     },
 
     javacJVMVersion := "1.8",
-    scalacJVMVersion := "1.8",
+    // SBT Scala 2.10 build still doesn't support Java 8, because scalac 2.10 doesn't, but,
+    // it also doesn't touch Java 8 code and it's OK to emit Java 7 bytecode in this case
+    scalacJVMVersion := (if (System.getProperty("scala-2.10") == "true") "1.7" else "1.8"),
 
     javacOptions in Compile ++= Seq(
       "-encoding", "UTF-8",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Go back to selecting source/target 1.7 for Scala 2.10 builds, because the SBT-based build for 2.10 won't work otherwise.

## How was this patch tested?

Existing tests, but, we need to verify this vs what the SBT build would exactly run on Jenkins