### PR TITLE
[SPARK-19594][Structured Streaming] StreamingQueryListener fails to handle QueryTerminatedEvent if more then one listeners exists

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -52,7 +52,7 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
    * Post the event to all registered listeners. The `postToAll` caller should guarantee calling
    * `postToAll` in the same thread for all events.
    */
-  final def postToAll(event: E): Unit = {
+  def postToAll(event: E): Unit = {
     // JavaConverters can create a JIterableWrapper if we use asScala.
     // However, this method will be called frequently. To avoid the wrapper cost, here we use
     // Java Iterator directly.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryListenerBus.scala
@@ -76,9 +76,8 @@ class StreamingQueryListenerBus(sparkListenerBus: LiveListenerBus)
   }
 
   /**
-   * Post the event to all registered listeners. The `postToAll` caller should guarantee calling
-   * `postToAll` in the same thread for all events. also remove the query id after all listeners
-   * process the QueryTerminatedEvent
+   * Override the parent `postToAll` to remove the query id from `activeQueryRunIds` after all
+   * the listeners process `QueryTerminatedEvent`. (SPARK-19594)
    */
   override def postToAll(event: Event): Unit = {
     super.postToAll(event)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -133,50 +133,13 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
     }
   }
 
-  testQuietly("multiple listeners, check trigger events are generated correctly") {
-    val clock = new StreamManualClock
-    val inputData = new MemoryStream[Int](0, sqlContext)
-    val df = inputData.toDS().as[Long].map { 10 / _ }
-    val numOfListenersToTest = 5
-    val listeners = (1 to numOfListenersToTest).map(_ => new EventCollector)
+  test("SPARK-19594: all of listeners should receive QueryTerminatedEvent") {
+    val df = MemoryStream[Int].toDS().as[Long]
+    val listeners = (1 to 5).map(_ => new EventCollector)
     try {
-      // No events until started
       listeners.foreach(listener => spark.streams.addListener(listener))
-      listeners.foreach(listener => assert(listener.startEvent === null))
-      listeners.foreach(listener => assert(listener.progressEvents.isEmpty))
-        listeners.foreach(listener => assert(listener.terminationEvent === null))
-
       testStream(df, OutputMode.Append)(
-
-        // Start event generated when query started
-        StartStream(ProcessingTime(100), triggerClock = clock),
-        AssertOnQuery { query =>
-          listeners.foreach(listener => assert(listener.startEvent !== null))
-          listeners.foreach(listener => assert(listener.startEvent.id === query.id))
-          listeners.foreach(listener => assert(listener.startEvent.runId === query.runId))
-          listeners.foreach(listener => assert(listener.startEvent.name === query.name))
-          listeners.foreach(listener => assert(listener.progressEvents.isEmpty))
-          listeners.foreach(listener => assert(listener.terminationEvent === null))
-          true
-        },
-
-        // Progress event generated when data processed
-        AddData(inputData, 1, 2),
-        AdvanceManualClock(100),
-        CheckAnswer(10, 5),
-        AssertOnQuery { query =>
-          listeners.foreach(listener => assert(listener.progressEvents.nonEmpty))
-          // SPARK-18868: We can't use query.lastProgress, because in progressEvents, we filter
-          // out non-zero input rows, but the lastProgress may be a zero input row trigger
-          val lastNonZeroProgress = query.recentProgress.filter(_.numInputRows > 0).lastOption
-            .getOrElse(fail("No progress updates received in StreamingQuery!"))
-          listeners.foreach(listener =>
-            assert(listener.progressEvents.last.json === lastNonZeroProgress.json))
-          listeners.foreach(listener => assert(listener.terminationEvent === null))
-          true
-        },
-
-        // Termination event generated when stopped cleanly
+        StartStream(),
         StopStream,
         AssertOnQuery { query =>
           eventually(Timeout(streamingTimeout)) {
@@ -188,35 +151,10 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
           listeners.foreach(listener => listener.checkAsyncErrors())
           listeners.foreach(listener => listener.reset())
           true
-        },
-
-        // Termination event generated with exception message when stopped with error
-        StartStream(ProcessingTime(100), triggerClock = clock),
-        AddData(inputData, 0),
-        AdvanceManualClock(100),
-        ExpectFailure[SparkException](),
-        AssertOnQuery { query =>
-          eventually(Timeout(streamingTimeout)) {
-            listeners.foreach(listener => assert(listener.terminationEvent !== null))
-            listeners.foreach(listener => assert(listener.terminationEvent.id === query.id))
-            listeners.foreach(listener => assert(listener.terminationEvent.exception.nonEmpty))
-            // Make sure that the exception message reported through listener
-            // contains the actual exception and relevant stack trace
-            listeners.foreach(listener =>
-              assert(!listener.terminationEvent.exception.get.contains("StreamingQueryException")))
-            listeners.foreach(listener =>
-              assert(
-                listener.terminationEvent.exception.get.contains("java.lang.ArithmeticException")))
-            listeners.foreach(listener =>
-              assert(
-                listener.terminationEvent.exception.get.contains("StreamingQueryListenerSuite")))
-          }
-          listeners.foreach(listener => listener.checkAsyncErrors())
-          true
         }
       )
     } finally {
-      listeners.foreach(listener => spark.streams.removeListener(listener))
+      listeners.foreach(spark.streams.removeListener)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

currently if multiple streaming queries listeners exists, when a QueryTerminatedEvent is triggered, only one of the listeners will be invoked while the rest of the listeners will ignore the event.
this is caused since the the streaming queries listeners bus holds a set of running queries ids and when a termination event is triggered, after the first listeners is handling the event, the terminated query id is being removed from the set. 
in this PR, the query id will be removed from the set only after all the listeners handles the event

## How was this patch tested?

a test with multiple listeners has been added to StreamingQueryListenerSuite
