### PR TITLE
Dynamic Batch Interval Adjustment

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchController.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchController.scala
@@ -99,7 +99,7 @@ object BatchController {
     // is the dynamic batch interval enabled
     var isEnable: Boolean = false
     def isDynamicBatchIntervalEnabled(conf: SparkConf): Boolean =
-      conf.getBoolean("spark.streaming.dynamicBatchInterval.enabled", true)
+      conf.getBoolean("spark.streaming.dynamicBatchInterval.enabled", false)
 
     def getBatchIntervalEnabled(): Boolean = isEnable
     def setBatchIntervalEnabled(enabled: Boolean): Unit = {

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchController.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchController.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.scheduler
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.streaming.scheduler.batch.BatchEstimator
+import org.apache.spark.util.ThreadUtils
+import scala.concurrent.{Future ,ExecutionContext}
+
+abstract class BatchController(val streamUID: Int, batchEstimator: BatchEstimator)
+  extends StreamingListener with Serializable with Logging {
+
+  init()
+
+  protected def publish(rate: Long): Unit
+
+  @transient
+  implicit private var executionContext: ExecutionContext = _
+
+  @transient
+  private var batchInterval: AtomicLong = _
+
+  var totalDelay: Long = -1L
+  var schedulerDelay: Long = -1L
+  var numRecords: Long = -1L
+  var processingDelay: Long = -1L
+  var batchIntevl: Long = -1L
+
+  /**
+    * An initialization method called both from the constructor and Serialization code.
+    */
+  private def init() {
+    executionContext = ExecutionContext.fromExecutorService(
+      ThreadUtils.newDaemonSingleThreadExecutor("stream-batchInteval-update"))
+    batchInterval = new AtomicLong(-1L)
+  }
+
+  /**
+    * Computing the Batch Intarvel and Publish it
+    */
+  private def computeAndPublish(processTime: Long, batchIntevl: Long): Unit =
+    Future[Unit]{
+      val newBatchInterval = batchEstimator.compute(processTime, batchIntevl)
+      logInfo(s" #####  the newBatchInterval is $newBatchInterval")
+      newBatchInterval.foreach{ s =>
+        batchInterval.set(s)
+        logInfo(s" ##### after setting newBatchInterval is $batchInterval")
+        publish(getLatestBatchInterval())
+      }
+    }
+
+  def getLatestBatchInterval(): Long = batchInterval.get()
+
+
+  /**
+    * Compute the batch interval after completed
+    * @param batchCompleted
+    */
+  override def onBatchCompleted (batchCompleted: StreamingListenerBatchCompleted) {
+    totalDelay = batchCompleted.batchInfo.totalDelay.get
+    schedulerDelay = batchCompleted.batchInfo.schedulingDelay.get
+    numRecords = batchCompleted.batchInfo.numRecords
+    processingDelay = batchCompleted.batchInfo.processingDelay.get
+    batchIntevl = batchCompleted.batchInfo.batchInterval
+
+    logInfo(s"processingDelay $processingDelay | batchInterval $batchIntevl " +
+      s"| totalDelay $totalDelay | schedulerDelay $schedulerDelay | numRecords $numRecords")
+
+    for{
+      processingTime <- batchCompleted.batchInfo.processingDelay
+      batchInterval <- Option(batchCompleted.batchInfo.batchInterval)
+    } computeAndPublish(processingTime, batchInterval)
+
+    logInfo(s" ##### Hear onBatchCompleted msg and begin to compute.")
+  }
+}
+  /**
+    *Get the configure
+    */
+object BatchController {
+    // is the dynamic batch interval enabled
+    var isEnable: Boolean = false
+    def isDynamicBatchIntervalEnabled(conf: SparkConf): Boolean =
+      conf.getBoolean("spark.streaming.dynamicBatchInterval.enabled", true)
+
+    def getBatchIntervalEnabled(): Boolean = isEnable
+    def setBatchIntervalEnabled(enabled: Boolean): Unit = {
+      isEnable = enabled
+    }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
@@ -23,6 +23,7 @@ import org.apache.spark.streaming.Time
 /**
  * :: DeveloperApi ::
  * Class having information on completed batches.
+ * @param batchInterval Time of the batch Intercval
  * @param batchTime   Time of the batch
  * @param streamIdToInputInfo A map of input stream id to its input info
  * @param submissionTime  Clock time of when jobs of this batch was submitted to
@@ -33,6 +34,7 @@ import org.apache.spark.streaming.Time
  */
 @DeveloperApi
 case class BatchInfo(
+    batchInterval: Long,
     batchTime: Time,
     streamIdToInputInfo: Map[Int, StreamInputInfo],
     submissionTime: Long,

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobSet.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobSet.scala
@@ -27,6 +27,7 @@ import org.apache.spark.streaming.Time
  */
 private[streaming]
 case class JobSet(
+    batchInterval: Long,
     time: Time,
     jobs: Seq[Job],
     streamIdToInputInfo: Map[Int, StreamInputInfo] = Map.empty) {
@@ -62,6 +63,7 @@ case class JobSet(
 
   def toBatchInfo: BatchInfo = {
     BatchInfo(
+      batchInterval,
       time,
       streamIdToInputInfo,
       submissionTime,

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BasicBatchEstimator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BasicBatchEstimator.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.streaming.scheduler.batch
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+
+class BasicBatchEstimator(conf: SparkConf)
+  extends BatchEstimator with Logging{
+  // The batch interval list
+  private var batchList: Array[Long] = null
+
+  // The id of the batch interval list
+  private var id: Int = 0
+
+  // The length of the batch interval list
+  private var length: Int = 0
+
+  init(conf)
+
+  /** Initialize the batchList from the configure */
+  def init(conf: SparkConf ) : Unit = {
+    conf.get("spark.streaming.BatchEstimator", "basic") match {
+      case "basic" =>
+        val batchinfo = conf.get(
+          "spark.streaming.BatchEstimator.basic.batchList", "2,3,4,5,6")
+        val batchStr = batchinfo.split(",")
+        length = batchStr.length
+        batchList = new Array[Long](length)
+        for(i <- 0 until length) {
+          batchList(i) = toMaybeLong(batchStr.apply(i))
+        }
+      case estimator =>
+        throw new IllegalArgumentException(s"Unknown rate estimator: $estimator")
+    }
+  }
+
+  /** Convert A String to a Long value */
+  def toMaybeLong(s : String ): Long = {
+    return scala.util.Try(s.toLong).toOption.getOrElse(0)
+  }
+
+  /** algorithm to get the next batch interval */
+  def compute(latestProcessingTime: Long, latestBatchInterval: Long): Option[Long] = {
+    this.synchronized {
+      if (id >= length) {
+        id = 0
+      }
+      var batch = batchList.apply(id) * 1000
+      id = id + 1
+      if(batch == 0) {
+        batch = latestBatchInterval
+      }
+      return Some(batch)
+    }
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BasicBatchEstimator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BasicBatchEstimator.scala
@@ -39,7 +39,7 @@ class BasicBatchEstimator(conf: SparkConf)
     conf.get("spark.streaming.BatchEstimator", "basic") match {
       case "basic" =>
         val batchinfo = conf.get(
-          "spark.streaming.BatchEstimator.basic.batchList", "2,3,4,5,6")
+          "spark.streaming.BatchEstimator.basic.batchList", "0")
         val batchStr = batchinfo.split(",")
         length = batchStr.length
         batchList = new Array[Long](length)

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BatchEstimator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BatchEstimator.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.streaming.scheduler.batch
+
+import org.apache.spark.streaming.Duration
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+
+
+trait BatchEstimator extends Serializable {
+  def compute(processingTime: Long, batchInterval: Long) : Option[Long]
+}
+
+object BatchEstimator extends Logging{
+
+  //
+  def create(conf: SparkConf, batchInterval: Duration): BatchEstimator = {
+
+    if (isDefaultBatchIntervalEnabled(conf)) {
+      conf.get("spark.streaming.BatchEstimator", "default") match {
+        case "default" =>
+          val proportional = conf.getDouble(
+            "spark.streaming.BatchEstimator.default.proportional", 0.85)
+          val converge = conf.getDouble("spark.streaming.BatchEstimator.default.converge", 30)
+          val gradient = conf.getDouble("spark.streaming.BatchEstimator.default.gradient", 0.85)
+          val stateThreshold = conf.getDouble(
+            "spark.streaming.BatchEstimator.default.stateThreshold", 1.4)
+
+          new DefaultBatchEstimator(proportional, converge, gradient, stateThreshold)
+
+        case estimator =>
+          throw new IllegalArgumentException(s"Unkown rate estimator: $estimator")
+      }
+    } else {
+      conf.get("spark.streaming.BatchEstimator", "basic") match {
+        case "basic" =>
+          new BasicBatchEstimator(conf)
+
+        case estimator =>
+          throw new IllegalArgumentException(s"Unkown rate estimator: $estimator")
+      }
+    }
+  }
+
+
+  def isDefaultBatchIntervalEnabled(conf: SparkConf): Boolean =
+    conf.getBoolean("spark.streaming.DefaultBatchInterval.enabled", false)
+
+  def isBasicBatchIntervalEnabled(conf: SparkConf): Boolean =
+    conf.getBoolean("spark.streaming.BasicBatchInterval.enabled", true)
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BatchEstimator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/BatchEstimator.scala
@@ -61,5 +61,5 @@ object BatchEstimator extends Logging{
     conf.getBoolean("spark.streaming.DefaultBatchInterval.enabled", false)
 
   def isBasicBatchIntervalEnabled(conf: SparkConf): Boolean =
-    conf.getBoolean("spark.streaming.BasicBatchInterval.enabled", true)
+    conf.getBoolean("spark.streaming.BasicBatchInterval.enabled", false)
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/DefaultBatchEstimator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/batch/DefaultBatchEstimator.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.streaming.scheduler.batch
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.internal.Logging
+
+//noinspection ScalaStyle
+class DefaultBatchEstimator(
+  proportional: Double, // Decreasing factor
+  converge: Double,     // Convergence factor
+  gradient: Double,      // Slope of stability line
+  stateThreshold: Double // State judgment threshold
+) extends BatchEstimator with Logging{
+
+  private var firstRun: Boolean = true      //mark the first run
+  private var latestSecondProcessingTime: Long = -1L
+  private var latestSecondBatchInterval: Long = -1L
+  private var PLarge: Long = -1L      //Larger Processing Time
+  private var PSmall: Long = -1L      //Smaller Processing Time
+  private var BLarge: Long = -1L      //Larger Batch Interval
+  private var BSmall: Long = -1L      //Smaller Batch Interval
+  private var currentSlope: Double = -1L
+  private var slopeDeviation: Double = -1L
+  private var angleDeviation: Double = -1L
+  private var nextBatchInterval: Long = -1L
+  private var tmpGrd: Double = -1L      // temporary gradient
+
+  var count: AtomicInteger = _          //counter
+  var latestStable:Boolean = true
+  var latencyCount: AtomicInteger = _
+
+  init()
+
+  def init(){
+    logInfo(s"the computer argument proportional: $proportional converge: $converge gradient: $gradient ")
+    count = new AtomicInteger(0)
+    latencyCount = new AtomicInteger(0)
+  }
+
+  /**
+    * algorithm to get the next batch interval
+    *
+    * @param latestProcessingTime
+    * @param latestBatchInterval
+    *
+    * */
+  def compute(latestProcessingTime: Long, latestBatchInterval: Long): Option[Long] ={
+    logInfo(s"Compute the $count batch interval by latestSecondProcessingTime $latestSecondProcessingTime latestSecondBatchInterval" +
+      s" $latestSecondBatchInterval latestProcessingTime $latestProcessingTime "+
+      s"and latestBatchInterval $latestBatchInterval  tmpGrd $tmpGrd")
+
+    BLarge = Math.max(latestSecondBatchInterval,latestBatchInterval)
+    BSmall = Math.min(latestSecondBatchInterval,latestBatchInterval)
+
+    PLarge = Math.max(latestSecondProcessingTime,latestProcessingTime)
+    PSmall = Math.min(latestSecondProcessingTime,latestProcessingTime)
+
+    currentSlope = latestProcessingTime.toDouble / latestBatchInterval.toDouble
+    slopeDeviation = Math.atan(gradient) - Math.atan(currentSlope)   // Computing the Slope Difference
+    angleDeviation = slopeDeviation * 180 / Math.PI
+    logInfo(s"latestStable $latestStable | currentSlope $currentSlope | latencyCount $latencyCount | slopeDeviation $slopeDeviation | angleDeviation $angleDeviation stateThreshold $stateThreshold")
+
+    /** Update the latest processing time and the latest batch interval*/
+    def end {
+      latestSecondProcessingTime = latestProcessingTime
+      latestSecondBatchInterval = latestBatchInterval
+    }
+
+    this.synchronized{
+      count.set(count.incrementAndGet())
+
+      // enable the function, but not return the result
+      if(latestProcessingTime < 200){
+        return Some(latestBatchInterval)
+      }
+
+      //The first time
+      if(firstRun){
+        end
+        firstRun = false
+        return Some(latestBatchInterval)      // unchange batch interval
+      }
+      // system is convergence
+      if(currentSlope < gradient && angleDeviation < converge){
+        nextBatchInterval = latestBatchInterval
+        end
+        latestStable = true
+        return Some(nextBatchInterval)
+      }else if(currentSlope < gradient && angleDeviation > converge){     // reduce the batch interval
+        nextBatchInterval = (Math.floor(proportional * BSmall / 200) * 200).toLong
+        latestStable = true
+        end
+        return Some(nextBatchInterval)
+      }else{     // System is not stable
+        // must have two unstable situation
+        if(latestStable == false) {
+          // Batch Interval is not changed
+          if (BLarge == BSmall) {
+            latencyCount.set(latencyCount.incrementAndGet())
+            if(latencyCount.get() >= 2 ){
+              tmpGrd = currentSlope
+            }else {
+              tmpGrd = (latestProcessingTime + latestSecondProcessingTime).toDouble / (latestSecondBatchInterval + latestBatchInterval).toDouble
+            }
+          } else {
+            latencyCount.set(0)   // reset
+            tmpGrd = (PLarge - PSmall).toDouble / (BLarge - BSmall).toDouble
+          }
+
+          // judge the state
+          if (tmpGrd > stateThreshold) {
+            // Reduce batch interval
+            nextBatchInterval = (Math.floor(proportional * BSmall / 200) * 200).toLong
+            end
+            return Some(nextBatchInterval)
+          } else {
+            // Increase batch interval
+            nextBatchInterval = (Math.floor(BLarge / gradient / 200) * 200).toLong
+            end
+            return Some(nextBatchInterval)
+          }
+        }else{
+          latestStable = false
+          end
+          return Some(latestBatchInterval)
+        }
+      }
+    }
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/RecurringTimer.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/RecurringTimer.scala
@@ -21,7 +21,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.util.{Clock, SystemClock}
 
 private[streaming]
-class RecurringTimer(clock: Clock, period: Long, callback: (Long) => Unit, name: String)
+class RecurringTimer(clock: Clock, var period: Long, callback: (Long) => Unit, name: String)
   extends Logging {
 
   private val thread = new Thread("RecurringTimer - " + name) {

--- a/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
@@ -62,12 +62,8 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
       0 -> StreamInputInfo(0, 300L),
       1 -> StreamInputInfo(1, 300L, Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> "test")))
 
-    // onStreamingStarted
-    listener.onStreamingStarted(StreamingListenerStreamingStarted(100L))
-    listener.startTime should be (100)
-
     // onBatchSubmitted
-    val batchInfoSubmitted = BatchInfo(Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
+    val batchInfoSubmitted = BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
     listener.onBatchSubmitted(StreamingListenerBatchSubmitted(batchInfoSubmitted))
     listener.waitingBatches should be (List(BatchUIData(batchInfoSubmitted)))
     listener.runningBatches should be (Nil)
@@ -81,7 +77,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
     // onBatchStarted
     val batchInfoStarted =
-      BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+      BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
     listener.onBatchStarted(StreamingListenerBatchStarted(batchInfoStarted))
     listener.waitingBatches should be (Nil)
     listener.runningBatches should be (List(BatchUIData(batchInfoStarted)))
@@ -124,7 +120,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
     // onBatchCompleted
     val batchInfoCompleted =
-      BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+      BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
     listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
     listener.waitingBatches should be (Nil)
     listener.runningBatches should be (Nil)
@@ -166,7 +162,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     val streamIdToInputInfo = Map(0 -> StreamInputInfo(0, 300L), 1 -> StreamInputInfo(1, 300L))
 
     val batchInfoCompleted =
-      BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+      BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
 
     for(_ <- 0 until (limit + 10)) {
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
@@ -184,7 +180,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     // fulfill completedBatchInfos
     for(i <- 0 until limit) {
       val batchInfoCompleted = BatchInfo(
-          Time(1000 + i * 100), Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
+          1000, Time(1000 + i * 100), Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
       val jobStart = createJobStart(Time(1000 + i * 100), outputOpId = 0, jobId = 1)
       listener.onJobStart(jobStart)
@@ -195,7 +191,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     listener.onJobStart(jobStart)
 
     val batchInfoSubmitted =
-      BatchInfo(Time(1000 + limit * 100), Map.empty, (1000 + limit * 100), None, None, Map.empty)
+      BatchInfo(1000, Time(1000 + limit * 100), Map.empty, (1000 + limit * 100), None, None, Map.empty)
     listener.onBatchSubmitted(StreamingListenerBatchSubmitted(batchInfoSubmitted))
 
     // We still can see the info retrieved from onJobStart
@@ -212,7 +208,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     // A lot of "onBatchCompleted"s happen before "onJobStart"
     for(i <- limit + 1 to limit * 2) {
       val batchInfoCompleted = BatchInfo(
-          Time(1000 + i * 100), Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
+          1000, Time(1000 + i * 100), Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
     }
 
@@ -238,12 +234,12 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
       // onBatchSubmitted
       val batchInfoSubmitted =
-        BatchInfo(Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
+        BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
       listener.onBatchSubmitted(StreamingListenerBatchSubmitted(batchInfoSubmitted))
 
       // onBatchStarted
       val batchInfoStarted =
-        BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+        BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
       listener.onBatchStarted(StreamingListenerBatchStarted(batchInfoStarted))
 
       // onJobStart
@@ -261,7 +257,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
       // onBatchCompleted
       val batchInfoCompleted =
-        BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+        BatchInfo(1000, Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
     }
 


### PR DESCRIPTION
The current Spark Streaming version cannot support the change of batch interval at runtime, given that the speed of input data streams may not highly dynamic from current Internet applications. If we have to do so, one must stop the program first, modify the corresponding code, and then restart the program. However, this will interrupt the execution of entire program, and may cause the data loss. Towards this end, our contribution is to implement a Dynamic Batch Interval Adjustment functionality that can help change the batch interval size at runtime.

This functionality contains two algorithms. One is dynamic adjustment, and the other is static adjustment. The former can predict the size of input data stream and as a result the processing time, by using the most recent processing time and used batch interval. In this way, one can decide whether the batch interval needs to be changed or not, to avoid the data backlog, and secure the system stability. On the other hand, the static adjustment needs the user to manually change the configuration file.

JIRA Issue: [https://issues.apache.org/jira/browse/SPARK-19663](url)
My report: [https://github.com/floatingtony/System-Lever-Optimization-of-Spark-Streaming](url)

