### PR TITLE
[SPARK-19664][SQL]put hive.metastore.warehouse.dir in hadoopconf to overwrite its original value

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -64,9 +64,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
       logInfo(s"Setting hive.metastore.warehouse.dir ($hiveWarehouseDir) to the value of " +
         s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
-      if (hiveWarehouseDir != null) {
-        sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
-      }
+      sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkContext.conf.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkWarehouseDir
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -62,8 +62,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
       // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
-      logInfo(s"${WAREHOUSE_PATH.key} is set, Setting " +
-        s"hive.metastore.warehouse.dir ($hiveWarehouseDir) to the value of " +
+      logInfo(s"Setting hive.metastore.warehouse.dir ($hiveWarehouseDir) to the value of " +
         s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
       if (hiveWarehouseDir != null) {
         sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -42,7 +42,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   val warehousePath = {
     val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
-      logInfo(s"load config from hive-site.xml $configFile")
+      logInfo(s"loading hive config file $configFile")
       sparkContext.hadoopConfiguration.addResource(configFile)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -61,7 +61,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
       // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
-      sparkContext.conf.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
+      sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkWarehouseDir
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -42,6 +42,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   val warehousePath = {
     val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
+      logInfo(s"load config from hive-site.xml $configFile")
       sparkContext.hadoopConfiguration.addResource(configFile)
     }
 
@@ -61,7 +62,13 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
       // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
-      sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
+      logInfo(s"${WAREHOUSE_PATH.key} is set, Setting " +
+        s"hive.metastore.warehouse.dir ($hiveWarehouseDir) to the value of " +
+        s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
+      if (hiveWarehouseDir != null) {
+        sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
+      }
+      sparkContext.conf.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkWarehouseDir
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -42,7 +42,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   val warehousePath = {
     val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
-      logInfo(s"loading hive config file $configFile")
+      logInfo(s"loading hive config file: $configFile")
       sparkContext.hadoopConfiguration.addResource(configFile)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -46,6 +46,8 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       sparkContext.hadoopConfiguration.addResource(configFile)
     }
 
+    // hive.metastore.warehouse.dir only stay in hadoopConf
+    sparkContext.conf.remove("hive.metastore.warehouse.dir")
     // Set the Hive metastore warehouse path to the one we use
     val hiveWarehouseDir = sparkContext.hadoopConfiguration.get("hive.metastore.warehouse.dir")
     if (hiveWarehouseDir != null && !sparkContext.conf.contains(WAREHOUSE_PATH.key)) {
@@ -62,13 +64,11 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
       // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
-      logInfo(s"Setting hive.metastore.warehouse.dir ($hiveWarehouseDir) to the value of " +
+      logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
         s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
       sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
-      sparkContext.conf.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkWarehouseDir
     }
-
   }
   logInfo(s"Warehouse path is '$warehousePath'.")
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

In [SPARK-15959](https://issues.apache.org/jira/browse/SPARK-15959), we bring back the `hive.metastore.warehouse.dir` , while in the logic, when use the value of  `spark.sql.warehouse.dir` to overwrite `hive.metastore.warehouse.dir` , it set it to `sparkContext.conf` which does not overwrite the value is hadoopConf, I think it should put in `sparkContext.hadoopConfiguration` and overwrite the original value of hadoopConf

https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala#L64

## How was this patch tested?
N/A