### PR TITLE
[SPARK-17636] Parquet filter push down doesn't handle struct fields

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -364,7 +364,7 @@ case class NullPropagation(conf: CatalystConf) extends Rule[LogicalPlan] {
       case e @ GetArrayItem(_, Literal(null, _)) => Literal.create(null, e.dataType)
       case e @ GetMapValue(Literal(null, _), _) => Literal.create(null, e.dataType)
       case e @ GetMapValue(_, Literal(null, _)) => Literal.create(null, e.dataType)
-      case e @ GetStructField(Literal(null, _), _, _) => Literal.create(null, e.dataType)
+      case e @ GetStructField(Literal(null, _), _, _, _) => Literal.create(null, e.dataType)
       case e @ GetArrayStructFields(Literal(null, _), _, _, _, _) =>
         Literal.create(null, e.dataType)
       case e @ EqualNullSafe(Literal(null, _), r) => IsNull(r)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -141,7 +141,7 @@ package object util {
     case Literal(s: UTF8String, StringType) => PrettyAttribute(s.toString, StringType)
     case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)
     case e: GetStructField =>
-      val name = e.name.getOrElse(e.childSchema(e.ordinal).name)
+      val name = e.name
       PrettyAttribute(usePrettyExpression(e.child).sql + "." + name, e.dataType)
     case e: GetArrayStructFields =>
       PrettyAttribute(usePrettyExpression(e.child) + "." + e.field.name, e.dataType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -439,51 +439,51 @@ object DataSourceStrategy extends Strategy with Logging {
    */
   protected[sql] def translateFilter(predicate: Expression): Option[Filter] = {
     predicate match {
-      case expressions.EqualTo(a: Attribute, Literal(v, t)) =>
+      case expressions.EqualTo(a: NamedExpression, Literal(v, t)) =>
         Some(sources.EqualTo(a.name, convertToScala(v, t)))
-      case expressions.EqualTo(Literal(v, t), a: Attribute) =>
+      case expressions.EqualTo(Literal(v, t), a: NamedExpression) =>
         Some(sources.EqualTo(a.name, convertToScala(v, t)))
 
-      case expressions.EqualNullSafe(a: Attribute, Literal(v, t)) =>
+      case expressions.EqualNullSafe(a: NamedExpression, Literal(v, t)) =>
         Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
-      case expressions.EqualNullSafe(Literal(v, t), a: Attribute) =>
+      case expressions.EqualNullSafe(Literal(v, t), a: NamedExpression) =>
         Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
 
-      case expressions.GreaterThan(a: Attribute, Literal(v, t)) =>
+      case expressions.GreaterThan(a: NamedExpression, Literal(v, t)) =>
         Some(sources.GreaterThan(a.name, convertToScala(v, t)))
-      case expressions.GreaterThan(Literal(v, t), a: Attribute) =>
+      case expressions.GreaterThan(Literal(v, t), a: NamedExpression) =>
         Some(sources.LessThan(a.name, convertToScala(v, t)))
 
-      case expressions.LessThan(a: Attribute, Literal(v, t)) =>
+      case expressions.LessThan(a: NamedExpression, Literal(v, t)) =>
         Some(sources.LessThan(a.name, convertToScala(v, t)))
-      case expressions.LessThan(Literal(v, t), a: Attribute) =>
+      case expressions.LessThan(Literal(v, t), a: NamedExpression) =>
         Some(sources.GreaterThan(a.name, convertToScala(v, t)))
 
-      case expressions.GreaterThanOrEqual(a: Attribute, Literal(v, t)) =>
+      case expressions.GreaterThanOrEqual(a: NamedExpression, Literal(v, t)) =>
         Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
-      case expressions.GreaterThanOrEqual(Literal(v, t), a: Attribute) =>
+      case expressions.GreaterThanOrEqual(Literal(v, t), a: NamedExpression) =>
         Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
 
-      case expressions.LessThanOrEqual(a: Attribute, Literal(v, t)) =>
+      case expressions.LessThanOrEqual(a: NamedExpression, Literal(v, t)) =>
         Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
-      case expressions.LessThanOrEqual(Literal(v, t), a: Attribute) =>
+      case expressions.LessThanOrEqual(Literal(v, t), a: NamedExpression) =>
         Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
 
-      case expressions.InSet(a: Attribute, set) =>
+      case expressions.InSet(a: NamedExpression, set) =>
         val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
         Some(sources.In(a.name, set.toArray.map(toScala)))
 
       // Because we only convert In to InSet in Optimizer when there are more than certain
       // items. So it is possible we still get an In expression here that needs to be pushed
       // down.
-      case expressions.In(a: Attribute, list) if !list.exists(!_.isInstanceOf[Literal]) =>
+      case expressions.In(a: NamedExpression, list) if !list.exists(!_.isInstanceOf[Literal]) =>
         val hSet = list.map(e => e.eval(EmptyRow))
         val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
         Some(sources.In(a.name, hSet.toArray.map(toScala)))
 
-      case expressions.IsNull(a: Attribute) =>
+      case expressions.IsNull(a: NamedExpression) =>
         Some(sources.IsNull(a.name))
-      case expressions.IsNotNull(a: Attribute) =>
+      case expressions.IsNotNull(a: NamedExpression) =>
         Some(sources.IsNotNull(a.name))
 
       case expressions.And(left, right) =>
@@ -498,13 +498,13 @@ object DataSourceStrategy extends Strategy with Logging {
       case expressions.Not(child) =>
         translateFilter(child).map(sources.Not)
 
-      case expressions.StartsWith(a: Attribute, Literal(v: UTF8String, StringType)) =>
+      case expressions.StartsWith(a: NamedExpression, Literal(v: UTF8String, StringType)) =>
         Some(sources.StringStartsWith(a.name, v.toString))
 
-      case expressions.EndsWith(a: Attribute, Literal(v: UTF8String, StringType)) =>
+      case expressions.EndsWith(a: NamedExpression, Literal(v: UTF8String, StringType)) =>
         Some(sources.StringEndsWith(a.name, v.toString))
 
-      case expressions.Contains(a: Attribute, Literal(v: UTF8String, StringType)) =>
+      case expressions.Contains(a: NamedExpression, Literal(v: UTF8String, StringType)) =>
         Some(sources.StringContains(a.name, v.toString))
 
       case _ => None


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes `DataSourceStrategy#translateFilter` to operate on a `NamedExpressions` rather than just and `Attribute`, as it switches off of the `name` property, defined in `NamedExpressions`. `GetStructField` now implements `NamedExpression`.

## How was this patch tested?

Testing thus far is manual, using debugger, explain plan output, and logging from the ElasticSearch connector. This patch includes no test changes; please advise on where/how to add test coverage.