### PR TITLE
[SPARK-19693][SQL] Make the SET mapreduce.job.reduces automatically converted to spark.sql.shuffle.partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -675,6 +675,10 @@ object SQLConf {
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
+
+  object Replaced {
+    val MAPREDUCE_JOB_REDUCES = "mapreduce.job.reduces"
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1019,6 +1019,18 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     spark.sessionState.conf.clear()
   }
 
+  test("SET mapreduce.job.reduces automatically converted to spark.sql.shuffle.partitions") {
+    spark.sessionState.conf.clear()
+    val numReduces = 20
+    val before = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS.key).toInt
+    sql(s"SET mapreduce.job.reduces=${numReduces.toString}")
+    val after = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS.key).toInt
+    assert(before != after)
+    assert(numReduces === after)
+    intercept[IllegalArgumentException](sql(s"SET mapreduce.job.reduces=-1"))
+    spark.sessionState.conf.clear()
+  }
+
   test("apply schema") {
     val schema1 = StructType(
       StructField("f1", IntegerType, false) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1021,12 +1021,12 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
 
   test("SET mapreduce.job.reduces automatically converted to spark.sql.shuffle.partitions") {
     spark.sessionState.conf.clear()
-    val numReduces = 20
     val before = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS.key).toInt
-    sql(s"SET mapreduce.job.reduces=${numReduces.toString}")
+    val newConf = before + 1
+    sql(s"SET mapreduce.job.reduces=${newConf.toString}")
     val after = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS.key).toInt
     assert(before != after)
-    assert(numReduces === after)
+    assert(newConf === after)
     intercept[IllegalArgumentException](sql(s"SET mapreduce.job.reduces=-1"))
     spark.sessionState.conf.clear()
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make the `SET mapreduce.job.reduces` automatically converted to `spark.sql.shuffle.partitions`, it's similar to `SET mapred.reduce.tasks`.

## How was this patch tested?

unit tests
