### PR TITLE
[SPARK-19525][CORE] Compressing checkpoints.

### DIFF
--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -95,7 +95,6 @@ private[spark] object CompressionCodec {
   val FALLBACK_COMPRESSION_CODEC = "snappy"
   val DEFAULT_COMPRESSION_CODEC = "lz4"
   val ALL_COMPRESSION_CODECS = shortCompressionCodecNames.values.toSeq
-  val ALL_COMPRESSION_CODECS_SHORT: Set[String] = shortCompressionCodecNames.keySet
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -95,6 +95,7 @@ private[spark] object CompressionCodec {
   val FALLBACK_COMPRESSION_CODEC = "snappy"
   val DEFAULT_COMPRESSION_CODEC = "lz4"
   val ALL_COMPRESSION_CODECS = shortCompressionCodecNames.values.toSeq
+  val ALL_COMPRESSION_CODECS_SHORT: Set[String] = shortCompressionCodecNames.keySet
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -21,11 +21,14 @@ import java.io.File
 
 import scala.reflect.ClassTag
 
+import com.google.common.io.ByteStreams
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rdd._
 import org.apache.spark.storage.{BlockId, StorageLevel, TestBlockId}
 import org.apache.spark.util.Utils
+
 
 trait RDDCheckpointTester { self: SparkFunSuite =>
 
@@ -238,6 +241,16 @@ trait RDDCheckpointTester { self: SparkFunSuite =>
   protected def generateFatPairRDD(): RDD[(Int, Int)] = {
     new FatPairRDD(sparkContext.makeRDD(1 to 100, 4), partitioner).mapValues(x => x)
   }
+
+  protected def testBasicCheckpoint(sc: SparkContext, reliableCheckpoint: Boolean): Unit = {
+    val parCollection = sc.makeRDD(1 to 4)
+    val flatMappedRDD = parCollection.flatMap(x => 1 to x)
+    checkpoint(flatMappedRDD, reliableCheckpoint)
+    assert(flatMappedRDD.dependencies.head.rdd === parCollection)
+    val result = flatMappedRDD.collect()
+    assert(flatMappedRDD.dependencies.head.rdd != parCollection)
+    assert(flatMappedRDD.collect() === result)
+  }
 }
 
 /**
@@ -251,9 +264,13 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
     super.beforeEach()
     checkpointDir = File.createTempFile("temp", "", Utils.createTempDir())
     checkpointDir.delete()
+  }
+
+  private def startSparkContext(): Unit = {
     sc = new SparkContext("local", "test")
     sc.setCheckpointDir(checkpointDir.toString)
   }
+
 
   override def afterEach(): Unit = {
     try {
@@ -266,13 +283,68 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   override def sparkContext: SparkContext = sc
 
   runTest("basic checkpointing") { reliableCheckpoint: Boolean =>
-    val parCollection = sc.makeRDD(1 to 4)
-    val flatMappedRDD = parCollection.flatMap(x => 1 to x)
-    checkpoint(flatMappedRDD, reliableCheckpoint)
-    assert(flatMappedRDD.dependencies.head.rdd === parCollection)
-    val result = flatMappedRDD.collect()
-    assert(flatMappedRDD.dependencies.head.rdd != parCollection)
-    assert(flatMappedRDD.collect() === result)
+    startSparkContext()
+    testBasicCheckpoint(sc, reliableCheckpoint)
+  }
+
+  runTest("compression with snappy", skipLocalCheckpoint = true) { reliableCheckpoint: Boolean =>
+    val sparkConf = new SparkConf()
+    sparkConf.set("spark.checkpoint.compress.codec", "snappy")
+    sc = new SparkContext("local", "test", sparkConf)
+    sc.setCheckpointDir(checkpointDir.toString)
+    testBasicCheckpoint(sc, reliableCheckpoint = true)
+  }
+
+  runTest("compression with lz4", skipLocalCheckpoint = true) { reliableCheckpoint: Boolean =>
+    val sparkConf = new SparkConf()
+    sparkConf.set("spark.checkpoint.compress.codec", "lz4")
+    sc = new SparkContext("local", "test", sparkConf)
+    sc.setCheckpointDir(checkpointDir.toString)
+    testBasicCheckpoint(sc, reliableCheckpoint = true)
+  }
+
+  runTest("compression with lzf", skipLocalCheckpoint = true) { reliableCheckpoint: Boolean =>
+    val sparkConf = new SparkConf()
+    sparkConf.set("spark.checkpoint.compress.codec", "lzf")
+    sc = new SparkContext("local", "test", sparkConf)
+    sc.setCheckpointDir(checkpointDir.toString)
+    testBasicCheckpoint(sc, reliableCheckpoint = true)
+  }
+
+  private def testCompression(compressionCodec: String): Unit = {
+    val sparkConf = new SparkConf()
+    sparkConf.set("spark.checkpoint.compress.codec", compressionCodec)
+    sc = new SparkContext("local", "test", sparkConf)
+    sc.setCheckpointDir(checkpointDir.toString)
+    val initialSize = 20
+    // Use just one partition for now since compression works best on large data sets.
+    val collection = sc.makeRDD(1 to initialSize, numSlices = 1)
+    val flatMappedRDD = collection.flatMap(x => 1 to x)
+    checkpoint(flatMappedRDD, reliableCheckpoint = true)
+    assert(flatMappedRDD.collect().length == initialSize * (initialSize + 1)/2,
+      "The checkpoint was lossy!")
+    val checkpointPath = new Path(flatMappedRDD.getCheckpointFile.get)
+    val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+    val fileStatus = fs.listStatus(checkpointPath).find(_.getPath.getName.startsWith("part-")).get
+    val compressedSize = fileStatus.getLen
+    assert(compressedSize > 0, "The checkpoint file was not written!")
+    val compressedInputStream = CompressionCodec.createCodec(sparkConf, compressionCodec)
+      .compressedInputStream(fs.open(fileStatus.getPath))
+    val uncompressedSize = ByteStreams.toByteArray(compressedInputStream).length
+    compressedInputStream.close()
+    assert(compressedSize < uncompressedSize, "The compression was not successful!")
+  }
+
+  runTest("compression size snappy", skipLocalCheckpoint = true) { _: Boolean =>
+    testCompression("snappy")
+  }
+
+  runTest("compression size lzf", skipLocalCheckpoint = true) { _: Boolean =>
+    testCompression("lzf")
+  }
+
+  runTest("compression size lz4", skipLocalCheckpoint = true) { _: Boolean =>
+    testCompression("lz4")
   }
 
   runTest("checkpointing partitioners", skipLocalCheckpoint = true) { _: Boolean =>
@@ -312,6 +384,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
       }
     }
 
+    startSparkContext()
     testPartitionerCheckpointing(partitioner)
 
     // Test that corrupted partitioner file does not prevent recovery of RDD
@@ -319,6 +392,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("RDDs with one-to-one dependencies") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     testRDD(_.map(x => x.toString), reliableCheckpoint)
     testRDD(_.flatMap(x => 1 to x), reliableCheckpoint)
     testRDD(_.filter(_ % 2 == 0), reliableCheckpoint)
@@ -332,6 +406,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("ParallelCollectionRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     val parCollection = sc.makeRDD(1 to 4, 2)
     val numPartitions = parCollection.partitions.size
     checkpoint(parCollection, reliableCheckpoint)
@@ -348,6 +423,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("BlockRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     val blockId = TestBlockId("id")
     val blockManager = SparkEnv.get.blockManager
     blockManager.putSingle(blockId, "test", StorageLevel.MEMORY_ONLY)
@@ -365,6 +441,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("ShuffleRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     testRDD(rdd => {
       // Creating ShuffledRDD directly as PairRDDFunctions.combineByKey produces a MapPartitionedRDD
       new ShuffledRDD[Int, Int, Int](rdd.map(x => (x % 2, 1)), partitioner)
@@ -372,12 +449,14 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("UnionRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     def otherRDD: RDD[Int] = sc.makeRDD(1 to 10, 1)
     testRDD(_.union(otherRDD), reliableCheckpoint)
     testRDDPartitions(_.union(otherRDD), reliableCheckpoint)
   }
 
   runTest("CartesianRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     def otherRDD: RDD[Int] = sc.makeRDD(1 to 10, 1)
     testRDD(new CartesianRDD(sc, _, otherRDD), reliableCheckpoint)
     testRDDPartitions(new CartesianRDD(sc, _, otherRDD), reliableCheckpoint)
@@ -401,6 +480,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("CoalescedRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     testRDD(_.coalesce(2), reliableCheckpoint)
     testRDDPartitions(_.coalesce(2), reliableCheckpoint)
 
@@ -423,6 +503,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("CoGroupedRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     val longLineageRDD1 = generateFatPairRDD()
 
     // Collect the RDD as sequences instead of arrays to enable equality tests in testRDD
@@ -441,6 +522,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("ZippedPartitionsRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     testRDD(rdd => rdd.zip(rdd.map(x => x)), reliableCheckpoint)
     testRDDPartitions(rdd => rdd.zip(rdd.map(x => x)), reliableCheckpoint)
 
@@ -466,6 +548,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("PartitionerAwareUnionRDD") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     testRDD(rdd => {
       new PartitionerAwareUnionRDD[(Int, Int)](sc, Array(
         generateFatPairRDD(),
@@ -500,6 +583,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("CheckpointRDD with zero partitions") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     val rdd = new BlockRDD[Int](sc, Array.empty[BlockId])
     assert(rdd.partitions.size === 0)
     assert(rdd.isCheckpointed === false)
@@ -514,6 +598,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
   }
 
   runTest("checkpointAllMarkedAncestors") { reliableCheckpoint: Boolean =>
+    startSparkContext()
     testCheckpointAllMarkedAncestors(reliableCheckpoint, checkpointAllMarkedAncestors = true)
     testCheckpointAllMarkedAncestors(reliableCheckpoint, checkpointAllMarkedAncestors = false)
   }


### PR DESCRIPTION
Spark Streaming's latency performance improves greatly for smaller batches if we enable compression of
checkpoints.

## What changes were proposed in this pull request?

- Compress each partition before writing to persistent file system.
- Decompress each partition before reading from persistent file system.
- Default behavior should be to not compress.
- Add logging for checkpoint durations for A/B testing with and without compression enabled.

## How was this patch tested?

This was tested using existing unit tests for backwards compatibility and with new tests for this functionality. It has also been used in our production system for almost a year.

Please review http://spark.apache.org/contributing.html before opening a pull request.
