### PR TITLE
[SPARK-19690][SS] Join a streaming DataFrame with a batch DataFrame which has an aggregation may not work

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -232,7 +232,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         EventTimeWatermarkExec(columnName, delay, planLater(child)) :: Nil
 
       case PhysicalAggregation(
-        namedGroupingExpressions, aggregateExpressions, rewrittenResultExpressions, child) =>
+        namedGroupingExpressions, aggregateExpressions, rewrittenResultExpressions, child)
+        if child.isStreaming =>
 
         aggregate.AggUtils.planStreamingAggregation(
           namedGroupingExpressions,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -61,6 +61,22 @@ class StreamSuite extends StreamTest {
       CheckAnswer(Row(1, 1, "one"), Row(2, 2, "two"), Row(4, 4, "four")))
   }
 
+  test("join with batch table which has an aggregation") {
+    // Make a table and ensure it will be broadcast.
+    val smallTable = Seq((1, "one"), (2, "two"), (4, "four"), (2, "two"))
+      .toDF("number", "word").groupBy("word").count()
+
+    // Join the input stream with a table.
+    val inputData = MemoryStream[Int]
+    val joined = inputData.toDS().toDF().join(smallTable, $"value" === $"count")
+
+    testStream(joined)(
+      AddData(inputData, 1),
+      CheckAnswer(Row(1, "one", 1), Row(1, "four", 1)),
+      AddData(inputData, 2),
+      CheckAnswer(Row(1, "one", 1), Row(1, "four", 1), Row(2, "two", 2)))
+  }
+
   test("union two streams") {
     val inputData1 = MemoryStream[Int]
     val inputData2 = MemoryStream[Int]


### PR DESCRIPTION
## What changes were proposed in this pull request?

`StatefulAggregationStrategy` should check logicplan is streaming or not

Test code:

```
case class Record(key: Int, value: String)
val df = spark.createDataFrame((1 to 100).map(i => Record(i, s"value_$i"))).groupBy("value").count
val lines = spark.readStream.format("socket").option("host", "localhost").option("port", "9999").load 
val words = lines.as[String].flatMap(_.split(" ")) 
val result = words.join(df, "value")
```

before pr:

```
== Physical Plan ==
*Project [value#13, count#19L]
+- *BroadcastHashJoin [value#13], [value#1], Inner, BuildRight
   :- *Filter isnotnull(value#13)
   :  +- *SerializeFromObject [staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, input[0, java.lang.String, true], true) AS value#13]
   :     +- MapPartitions <function1>, obj#12: java.lang.String
   :        +- DeserializeToObject value#5.toString, obj#11: java.lang.String
   :           +- StreamingRelation textSocket, [value#5]
   +- BroadcastExchange HashedRelationBroadcastMode(List(input[0, string, true]))
      +- *HashAggregate(keys=[value#1], functions=[count(1)])
         +- StateStoreSave [value#1], OperatorStateId(<unknown>,0,0), Append, 0
            +- *HashAggregate(keys=[value#1], functions=[merge_count(1)])
               +- StateStoreRestore [value#1], OperatorStateId(<unknown>,0,0)
                  +- *HashAggregate(keys=[value#1], functions=[merge_count(1)])
                     +- Exchange hashpartitioning(value#1, 200)
                        +- *HashAggregate(keys=[value#1], functions=[partial_count(1)])
                           +- *Project [value#1]
                              +- *Filter isnotnull(value#1)
                                 +- LocalTableScan [key#0, value#1]
```

after pr:

```
== Physical Plan ==
*Project [value#13, count#19L]
+- *BroadcastHashJoin [value#13], [value#1], Inner, BuildRight
   :- *Filter isnotnull(value#13)
   :  +- *SerializeFromObject [staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, input[0, java.lang.String, true], true) AS value#13]
   :     +- MapPartitions <function1>, obj#12: java.lang.String
   :        +- DeserializeToObject value#5.toString, obj#11: java.lang.String
   :           +- StreamingRelation textSocket, [value#5]
   +- BroadcastExchange HashedRelationBroadcastMode(List(input[0, string, true]))
      +- *HashAggregate(keys=[value#1], functions=[count(1)])
         +- Exchange hashpartitioning(value#1, 200)
            +- *HashAggregate(keys=[value#1], functions=[partial_count(1)])
               +- *Project [value#1]
                  +- *Filter isnotnull(value#1)
                     +- LocalTableScan [key#0, value#1]
```

## How was this patch tested?

add new unit test.
