### PR TITLE
CatalogTableType constructor access modifier renders useless when case class factory is public

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -322,7 +322,7 @@ case class CatalogStatistics(
 }
 
 
-case class CatalogTableType private(name: String)
+class CatalogTableType private(val name: String)
 object CatalogTableType {
   val EXTERNAL = new CatalogTableType("EXTERNAL")
   val MANAGED = new CatalogTableType("MANAGED")


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CatalogTableType` seems to implement an union data type enumerating all possible catalog table types. 

It is built using a case class with a single value attribute "name". Wisely, it seems to be intended to be set only by the case class private constructor within the companion object with the idea of users not being able to create `CatalogTableType` instances but using those enumerated within that object.

However, making the case class constructor private does't forbid users creating whichever instances they want to create since the case class factory is still public. e.g:

```
scala> case class C private(x: Int)
defined class C

scala> C(1)
res0: C = C(1) // Should users be able to do this?

scala> new C(1) //This is the expected behaviour.
<console>:13: error: constructor C in class C cannot be accessed in object $iw
       new C(1)
```

This PR makes `CatalogTableType` a regular class, if matching the name was necessary, its companion object could implement `unapply`. Alternatives ways of solving this could be just using Scala's enumeration or model `CatalogTableType` using algebraic data types based on extending an interface, e.g:

```
trait CatalogTableType { val name: String } 

object CatalogTableType {
  object EXTERNAL extends CatalogTableType { val name = "EXTERNAL" }
  object INTERNAL extends CatalogTableType { val name = "INTERNAL" }
  object VIEW     extends CatalogTableType { val name = "VIEW" }
}
```

## How was this patch tested?

This PR does not add new functionality and has thus been tested by your current test suite.