### PR TITLE
[SPARK-17495] [SQL] Support Decimal type in Hive-hash

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -771,8 +771,8 @@ object HiveHashFunction extends InterpretedHashFunction {
       return null
     }
 
-    val maxScale =
-      Math.min(HIVE_DECIMAL_MAX_SCALE, Math.min(HIVE_DECIMAL_MAX_PRECISION - intDigits, result.scale))
+    val maxScale = Math.min(HIVE_DECIMAL_MAX_SCALE,
+      Math.min(HIVE_DECIMAL_MAX_PRECISION - intDigits, result.scale))
     if (result.scale > maxScale) {
       result = result.setScale(maxScale, RoundingMode.HALF_UP)
       // Trimming is again necessary, because rounding may introduce new trailing 0's.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -643,7 +643,7 @@ case class HiveHash(children: Seq[Expression]) extends HashExpression[Int] {
       result: String): String = {
     s"""
       $result = ${HiveHashFunction.getClass.getName.stripSuffix("$")}.normalizeDecimal(
-       $input.toJavaBigDecimal(), true).hashCode();"""
+        $input.toJavaBigDecimal()).hashCode();"""
   }
 
   override protected def genHashCalendarInterval(input: String, result: String): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -748,17 +748,14 @@ object HiveHashFunction extends InterpretedHashFunction {
 
   // Mimics normalization done for decimals in Hive at HiveDecimalV1.normalize()
   def normalizeDecimal(input: BigDecimal, allowRounding: Boolean): BigDecimal = {
-    if (input == null) {
-      return null
-    }
+    if (input == null) return null
 
     def trimDecimal(input: BigDecimal) = {
       var result = input
       if (result.compareTo(BigDecimal.ZERO) == 0) {
         // Special case for 0, because java doesn't strip zeros correctly on that number.
         result = BigDecimal.ZERO
-      }
-      else {
+      } else {
         result = result.stripTrailingZeros
         if (result.scale < 0) {
           // no negative scale decimals

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -642,7 +642,7 @@ case class HiveHash(children: Seq[Expression]) extends HashExpression[Int] {
       input: String,
       result: String): String = {
     s"""
-      $result = org.apache.spark.sql.catalyst.expressions.HiveHashFunction.normalizeDecimal(
+      $result = ${HiveHashFunction.getClass.getName.stripSuffix("$")}.normalizeDecimal(
        $input.toJavaBigDecimal(), true).hashCode();"""
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
@@ -75,7 +75,6 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkConsistencyBetweenInterpretedAndCodegen(Crc32, BinaryType)
   }
 
-
   def checkHiveHash(input: Any, dataType: DataType, expected: Long): Unit = {
     // Note : All expected hashes need to be computed using Hive 1.2.1
     val actual = HiveHashFunction.hash(input, dataType, seed = 0)
@@ -370,6 +369,48 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       .add("structOfArrayAndMap",
         new StructType().add("array", arrayOfString).add("map", mapOfString))
       .add("structOfUDT", structOfUDT))
+
+  test("hive-hash for decimal") {
+    def checkHiveHashForDecimal(
+        input: String,
+        precision: Int,
+        scale: Int,
+        expected: Long): Unit = {
+      val decimal = Decimal.apply(new java.math.BigDecimal(input))
+      decimal.changePrecision(precision, scale)
+      val decimalType = DataTypes.createDecimalType(precision, scale)
+      checkHiveHash(decimal, decimalType, expected)
+    }
+
+    checkHiveHashForDecimal("18", 38, 0, 558)
+    checkHiveHashForDecimal("-18", 38, 0, -558)
+    checkHiveHashForDecimal("-18", 38, 12, -558)
+    checkHiveHashForDecimal("18446744073709001000", 38, 19, -17070057)
+    checkHiveHashForDecimal("-18446744073709001000", 38, 22, 17070057)
+    checkHiveHashForDecimal("-18446744073709001000", 38, 3, 17070057)
+    checkHiveHashForDecimal("18446744073709001000", 38, 4, -17070057)
+    checkHiveHashForDecimal("9223372036854775807", 38, 4, 2147482656)
+    checkHiveHashForDecimal("-9223372036854775807", 38, 5, -2147482656)
+    checkHiveHashForDecimal("00000.00000000000", 38, 34, 0)
+    checkHiveHashForDecimal("-00000.00000000000", 38, 11, 0)
+    checkHiveHashForDecimal("123456.1234567890", 38, 2, 382713974)
+    checkHiveHashForDecimal("123456.1234567890", 38, 20, 1871500252)
+    checkHiveHashForDecimal("123456.1234567890", 38, 10, 1871500252)
+    checkHiveHashForDecimal("-123456.1234567890", 38, 10, -1871500234)
+    checkHiveHashForDecimal("123456.1234567890", 38, 0, 3827136)
+    checkHiveHashForDecimal("-123456.1234567890", 38, 0, -3827136)
+    checkHiveHashForDecimal("123456.1234567890", 38, 20, 1871500252)
+    checkHiveHashForDecimal("-123456.1234567890", 38, 20, -1871500234)
+    checkHiveHashForDecimal("123456.123456789012345678901234567890", 38, 0, 3827136)
+    checkHiveHashForDecimal("-123456.123456789012345678901234567890", 38, 0, -3827136)
+    checkHiveHashForDecimal("123456.123456789012345678901234567890", 38, 10, 1871500252)
+    checkHiveHashForDecimal("-123456.123456789012345678901234567890", 38, 10, -1871500234)
+    checkHiveHashForDecimal("123456.123456789012345678901234567890", 38, 20, 236317582)
+    checkHiveHashForDecimal("-123456.123456789012345678901234567890", 38, 20, -236317544)
+    checkHiveHashForDecimal("123456.123456789012345678901234567890", 38, 30, 1728235666)
+    checkHiveHashForDecimal("-123456.123456789012345678901234567890", 38, 30, -1728235608)
+    checkHiveHashForDecimal("123456.123456789012345678901234567890", 38, 31, 1728235666)
+  }
 
   test("SPARK-18207: Compute hash for a lot of expressions") {
     val N = 1000

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
@@ -376,17 +376,20 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         precision: Int,
         scale: Int,
         expected: Long): Unit = {
-      val decimal = Decimal.apply(new java.math.BigDecimal(input))
-      decimal.changePrecision(precision, scale)
       val decimalType = DataTypes.createDecimalType(precision, scale)
+      val decimal = {
+        val value = Decimal.apply(new java.math.BigDecimal(input))
+        if (value.changePrecision(precision, scale)) value else null
+      }
+
       checkHiveHash(decimal, decimalType, expected)
     }
 
     checkHiveHashForDecimal("18", 38, 0, 558)
     checkHiveHashForDecimal("-18", 38, 0, -558)
     checkHiveHashForDecimal("-18", 38, 12, -558)
-    checkHiveHashForDecimal("18446744073709001000", 38, 19, -17070057)
-    checkHiveHashForDecimal("-18446744073709001000", 38, 22, 17070057)
+    checkHiveHashForDecimal("18446744073709001000", 38, 19, 0)
+    checkHiveHashForDecimal("-18446744073709001000", 38, 22, 0)
     checkHiveHashForDecimal("-18446744073709001000", 38, 3, 17070057)
     checkHiveHashForDecimal("18446744073709001000", 38, 4, -17070057)
     checkHiveHashForDecimal("9223372036854775807", 38, 4, 2147482656)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive hash to support Decimal datatype. [Hive internally normalises decimals](https://github.com/apache/hive/blob/4ba713ccd85c3706d195aeef9476e6e6363f1c21/storage-api/src/java/org/apache/hadoop/hive/common/type/HiveDecimalV1.java#L307) and I have ported that logic as-is to HiveHash.

## How was this patch tested?

Added unit tests