### PR TITLE
[SPARK-19733][ML]Removed unnecessary castings and refactored checked casts in ALS.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -80,7 +80,7 @@ private[recommendation] trait ALSModelParams extends Params with HasPredictionCo
 
   /**
    * Attempts to safely cast a user/item id to an Int. Throws an exception if the value is
-   * out of integer range.
+   * out of integer range or contains a fractional part.
    */
   protected[recommendation] val checkedCast = udf { (n: Any) =>
     n match {
@@ -461,8 +461,7 @@ class ALS(@Since("1.4.0") override val uid: String) extends Estimator[ALSModel] 
 
     val r = if ($(ratingCol) != "") col($(ratingCol)).cast(FloatType) else lit(1.0f)
     val ratings = dataset
-      .select(checkedCast(col($(userCol))),
-        checkedCast(col($(itemCol))), r)
+      .select(checkedCast(col($(userCol))), checkedCast(col($(itemCol))), r)
       .rdd
       .map { row =>
         Rating(row.getInt(0), row.getInt(1), row.getFloat(2))

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -82,17 +82,19 @@ private[recommendation] trait ALSModelParams extends Params with HasPredictionCo
    * Attempts to safely cast a user/item id to an Int. Throws an exception if the value is
    * out of integer range.
    */
-  protected val checkedCast = udf { (n: Any) =>
+  protected[recommendation] val checkedCast = udf { (n: Any) =>
     n match {
       case v: Int => v // Avoid unnecessary casting
       case v: Number =>
-        val intV = v.intValue()
+        val intV = v.intValue
         // Checks if number within Int range and has no fractional part.
         if (v.doubleValue == intV) {
           intV
         } else {
           throw new IllegalArgumentException(s"ALS only supports values in Integer range " +
-            s"for columns ${$(userCol)} and ${$(itemCol)}. Value $n was out of Integer range.")
+            s"and without fractional part for columns ${$(userCol)} and ${$(itemCol)}. " +
+            s"Value $n was either out of Integer range or contained a fractional part that " +
+            s"could not be converted.")
         }
       case _ => throw new IllegalArgumentException(s"ALS only supports values in Integer range " +
         s"for columns ${$(userCol)} and ${$(itemCol)}. Value $n was not numeric.")

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -87,7 +87,8 @@ private[recommendation] trait ALSModelParams extends Params with HasPredictionCo
       case v: Int => v // Avoid unnecessary casting
       case v: Number =>
         val intV = v.intValue()
-        if (v == intV) { // True for Byte/Short, Long within the Int range and Double/Float with no fractional part.
+        // True for Byte/Short, Long within the Int range and Double/Float with no fractional part.
+        if (v == intV) {
           intV
         }
         else {

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -87,16 +87,15 @@ private[recommendation] trait ALSModelParams extends Params with HasPredictionCo
       case v: Int => v // Avoid unnecessary casting
       case v: Number =>
         val intV = v.intValue()
-        // True for Byte/Short, Long within the Int range and Double/Float with no fractional part.
-        if (v == intV) {
+        // Checks if number within Int range and has no fractional part.
+        if (v.doubleValue == intV) {
           intV
-        }
-        else {
+        } else {
           throw new IllegalArgumentException(s"ALS only supports values in Integer range " +
             s"for columns ${$(userCol)} and ${$(itemCol)}. Value $n was out of Integer range.")
         }
       case _ => throw new IllegalArgumentException(s"ALS only supports values in Integer range " +
-        s"for columns ${$(userCol)} and ${$(itemCol)}. Value $n is not numeric.")
+        s"for columns ${$(userCol)} and ${$(itemCol)}. Value $n was not numeric.")
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -208,62 +208,63 @@ class ALSSuite
 
   test("CheckedCast") {
     val checkedCast = new ALS().checkedCast
-    val df = spark.sqlContext.range(1)
+    val df = spark.range(1)
 
     withClue("Valid Integer Ids") {
-      df.select(checkedCast( lit(123) )).collect()
+      df.select(checkedCast(lit(123))).collect()
     }
 
     withClue("Valid Long Ids") {
-      df.select(checkedCast( lit(1231L) )).collect()
+      df.select(checkedCast(lit(1231L))).collect()
     }
 
     withClue("Valid Decimal Ids") {
-      df.select(checkedCast( lit(123).cast(DecimalType(15, 2)) )).collect()
+      df.select(checkedCast(lit(123).cast(DecimalType(15, 2)))).collect()
     }
 
     withClue("Valid Double Ids") {
-      df.select(checkedCast( lit(123.0) )).collect()
+      df.select(checkedCast(lit(123.0))).collect()
     }
 
+    val msg = "either out of Integer range or contained a fractional part"
     withClue("Invalid Long: out of range") {
       val e: SparkException = intercept[SparkException] {
-        df.select(checkedCast( lit(1231000000000L) )).collect()
+        df.select(checkedCast(lit(1231000000000L))).collect()
       }
-      assert(e.getMessage.contains("either out of Integer range or contained a fractional part"))
+      assert(e.getMessage.contains(msg))
     }
 
     withClue("Invalid Decimal: out of range") {
       val e: SparkException = intercept[SparkException] {
-        df.select(checkedCast( lit(1231000000000.0).cast(DecimalType(15, 2)) )).collect()
+        df.select(checkedCast(lit(1231000000000.0).cast(DecimalType(15, 2)))).collect()
       }
-      assert(e.getMessage.contains("either out of Integer range or contained a fractional part"))
+      assert(e.getMessage.contains(msg))
     }
 
     withClue("Invalid Decimal: fractional part") {
       val e: SparkException = intercept[SparkException] {
-        df.select(checkedCast( lit(123.1).cast(DecimalType(15, 2)) )).collect()
+        df.select(checkedCast(lit(123.1).cast(DecimalType(15, 2)))).collect()
       }
-      assert(e.getMessage.contains("either out of Integer range or contained a fractional part"))
+      assert(e.getMessage.contains(msg))
     }
 
     withClue("Invalid Double: out of range") {
       val e: SparkException = intercept[SparkException] {
-        df.select(checkedCast( lit(1231000000000.0) )).collect()
+        df.select(checkedCast(lit(1231000000000.0))).collect()
       }
-      assert(e.getMessage.contains("either out of Integer range or contained a fractional part"))
+      assert(e.getMessage.contains(msg))
     }
 
     withClue("Invalid Double: fractional part") {
       val e: SparkException = intercept[SparkException] {
-        df.select(checkedCast( lit(123.1) )).collect()
+        df.select(checkedCast(lit(123.1))).collect()
       }
-      assert(e.getMessage.contains("either out of Integer range or contained a fractional part"))
+      assert(e.getMessage.contains(msg))
     }
 
     withClue("Invalid Type") {
       val e: SparkException = intercept[SparkException] {
-        df.select(checkedCast( lit("123.1") )).collect()
+        df.select(checkedCast(lit("123.1"))).collect()
       }
       assert(e.getMessage.contains("was not numeric"))
     }
@@ -574,34 +575,35 @@ class ALSSuite
       (0, big, small, 0, big, small, 2.0),
       (1, 1L, 1d, 0, 0L, 0d, 5.0)
     ).toDF("user", "user_big", "user_small", "item", "item_big", "item_small", "rating")
+    val msg = "either out of Integer range or contained a fractional part"
     withClue("fit should fail when ids exceed integer range. ") {
       assert(intercept[SparkException] {
         als.fit(df.select(df("user_big").as("user"), df("item"), df("rating")))
-      }.getCause.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getCause.getMessage.contains(msg))
       assert(intercept[SparkException] {
         als.fit(df.select(df("user_small").as("user"), df("item"), df("rating")))
-      }.getCause.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getCause.getMessage.contains(msg))
       assert(intercept[SparkException] {
         als.fit(df.select(df("item_big").as("item"), df("user"), df("rating")))
-      }.getCause.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getCause.getMessage.contains(msg))
       assert(intercept[SparkException] {
         als.fit(df.select(df("item_small").as("item"), df("user"), df("rating")))
-      }.getCause.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getCause.getMessage.contains(msg))
     }
     withClue("transform should fail when ids exceed integer range. ") {
       val model = als.fit(df)
       assert(intercept[SparkException] {
         model.transform(df.select(df("user_big").as("user"), df("item"))).first
-      }.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getMessage.contains(msg))
       assert(intercept[SparkException] {
         model.transform(df.select(df("user_small").as("user"), df("item"))).first
-      }.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getMessage.contains(msg))
       assert(intercept[SparkException] {
         model.transform(df.select(df("item_big").as("item"), df("user"))).first
-      }.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getMessage.contains(msg))
       assert(intercept[SparkException] {
         model.transform(df.select(df("item_small").as("item"), df("user"))).first
-      }.getMessage.contains("out of Integer range or contained a fractional part"))
+      }.getMessage.contains(msg))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The original ALS was performing unnecessary casting to the user and item ids because the protected checkedCast() method required a double. I removed the castings and refactored the method to receive Any and efficiently handle all permitted numeric values.

## How was this patch tested?

I tested it by running the unit-tests and by manually validating the result of checkedCast for various legal and illegal values.
