### PR TITLE
[SPARK-18646][REPL] Set parent classloader as null for ExecutorClassLoader

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
@@ -38,6 +38,8 @@ import org.apache.spark.util.{ParentClassLoader, Utils}
  * Allows the user to specify if user class path should be first.
  * This class loader delegates getting/finding resources to parent loader,
  * which makes sense until REPL never provide resource dynamically.
+ * This class does not set parent classloader since this class loader
+ * has higher precedence over its parent class loader.
  */
 class ExecutorClassLoader(
     conf: SparkConf,

--- a/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
@@ -44,7 +44,7 @@ class ExecutorClassLoader(
     env: SparkEnv,
     classUri: String,
     parent: ClassLoader,
-    userClassPathFirst: Boolean) extends ClassLoader with Logging {
+    userClassPathFirst: Boolean) extends ClassLoader(null) with Logging {
   val uri = new URI(classUri)
   val directory = uri.getPath
 

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -111,8 +111,12 @@ class ExecutorClassLoaderSuite
     val parentLoader = new URLClassLoader(urls2, null)
     val classLoader = new ExecutorClassLoader(new SparkConf(), null, url1, parentLoader, true)
 
-    // load 'scala.Option'
+    // load 'scala.Option', using Class.forName to do the exact same behavior as
+    // what JavaDeserializationStream does
+
+    // scalastyle:off classforname
     val optionClass = Class.forName("scala.Option", false, classLoader)
+    // scalastyle:on classforname
     assert(optionClass.getClassLoader == classLoader, "scala.Option didn't come from ExecutorClassLoader")
   }
 

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -23,10 +23,11 @@ import java.nio.channels.{FileChannel, ReadableByteChannel}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Paths, StandardOpenOption}
 import java.util
+import java.util.{Arrays, Collections}
+import javax.tools.{JavaFileObject, SimpleJavaFileObject, ToolProvider}
 
 import scala.io.Source
 import scala.language.implicitConversions
-
 import com.google.common.io.Files
 import org.mockito.Matchers.anyString
 import org.mockito.Mockito._
@@ -34,7 +35,6 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.mock.MockitoSugar
-
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.RpcEnv
@@ -75,6 +75,43 @@ class ExecutorClassLoaderSuite
     } finally {
       super.afterAll()
     }
+  }
+
+  test("child over system classloader") {
+    // JavaFileObject for scala.Option class
+    val scalaOptionFile = new SimpleJavaFileObject(
+      URI.create(s"string:///scala/Option.java"),
+      JavaFileObject.Kind.SOURCE) {
+
+      override def getCharContent(ignoreEncodingErrors: Boolean): CharSequence = {
+        "package scala; class Option {}"
+      }
+    }
+    // compile fake scala.Option class
+    ToolProvider
+      .getSystemJavaCompiler
+      .getTask(null, null, null, null, null, Collections.singletonList(scalaOptionFile)).call()
+
+    // create 'scala' dir in tempDir1
+    val scalaDir = new File(tempDir1, "scala")
+    assert(scalaDir.mkdir(), s"Failed to create 'scala' directory in $tempDir1")
+
+    // move the generated class into scala dir
+    val filename = "Option.class"
+    val result = new File(filename)
+    assert(result.exists(), "Compiled file not found: " + result.getAbsolutePath)
+
+    val out = new File(scalaDir, filename)
+    Files.move(result, out)
+    assert(out.exists(), "Destination file not moved: " + out.getAbsolutePath)
+
+    // construct class loader tree
+    val parentLoader = new URLClassLoader(urls2, null)
+    val classLoader = new ExecutorClassLoader(new SparkConf(), null, url1, parentLoader, true)
+
+    // load 'scala.Option'
+    val optionClass = Class.forName("scala.Option", false, classLoader)
+    assert(optionClass.getClassLoader == classLoader, "scala.Option didn't come from ExecutorClassLoader")
   }
 
   test("child first") {

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -23,11 +23,12 @@ import java.nio.channels.{FileChannel, ReadableByteChannel}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Paths, StandardOpenOption}
 import java.util
-import java.util.{Arrays, Collections}
+import java.util.Collections
 import javax.tools.{JavaFileObject, SimpleJavaFileObject, ToolProvider}
 
 import scala.io.Source
 import scala.language.implicitConversions
+
 import com.google.common.io.Files
 import org.mockito.Matchers.anyString
 import org.mockito.Mockito._
@@ -35,6 +36,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.mock.MockitoSugar
+
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.RpcEnv

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -109,15 +109,19 @@ class ExecutorClassLoaderSuite
 
     // construct class loader tree
     val parentLoader = new URLClassLoader(urls2, null)
-    val classLoader = new ExecutorClassLoader(new SparkConf(), null, url1, parentLoader, true)
+    val classLoader = new ExecutorClassLoader(
+      new SparkConf(), null, url1, parentLoader, true)
 
     // load 'scala.Option', using Class.forName to do the exact same behavior as
     // what JavaDeserializationStream does
 
+
     // scalastyle:off classforname
     val optionClass = Class.forName("scala.Option", false, classLoader)
     // scalastyle:on classforname
-    assert(optionClass.getClassLoader == classLoader, "scala.Option didn't come from ExecutorClassLoader")
+
+    assert(optionClass.getClassLoader == classLoader,
+      "scala.Option didn't come from ExecutorClassLoader")
   }
 
   test("child first") {

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -112,9 +112,8 @@ class ExecutorClassLoaderSuite
     val classLoader = new ExecutorClassLoader(
       new SparkConf(), null, url1, parentLoader, true)
 
-    // load 'scala.Option', using Class.forName to do the exact same behavior as
+    // load 'scala.Option', using ClassforName to do the exact same behavior as
     // what JavaDeserializationStream does
-
 
     // scalastyle:off classforname
     val optionClass = Class.forName("scala.Option", false, classLoader)


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default, a class loader will have java's system class loader as its parent, however this ExecutorClassLoader should always resolve classes from given 'paren't class loader.

Problem happens when an application has a class loader structure like below

System-Classloader [ClassA, Runtime]
    |
Application-Classloader [ClassA, Spark, Jackson etc etc] : **parent**
    |
Executor Class Loader

The application serializes ClassA using Application class loader however Spark deserializes the class using System Class loader, this leads to various problems.

The change here to pass null to the parent class so that a link between ExecutorClassLoader and SystemClassLoader no longer exists.

For most of situations, the parent class loader is the system class loader so this wouldn't have any impact.

## How was this patch tested?

UTs