### PR TITLE
[SPARK-16931][PYTHON][SQL] Add Python wrapper for bucketBy 

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -563,7 +563,7 @@ class DataFrameWriter(OptionUtils):
         self._jwrite = self._jwrite.partitionBy(_to_seq(self._spark._sc, cols))
         return self
 
-    @since(2.2)
+    @since(2.3)
     def bucketBy(self, numBuckets, *cols):
         """Buckets the output by the given columns on the file system.
 
@@ -593,7 +593,7 @@ class DataFrameWriter(OptionUtils):
         self._jwrite = self._jwrite.bucketBy(numBuckets, col, _to_seq(self._spark._sc, cols))
         return self
 
-    @since(2.2)
+    @since(2.3)
     def sortBy(self, *cols):
         """Sorts the output in each bucket by the given columns on the file system.
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -569,6 +569,9 @@ class DataFrameWriter(OptionUtils):
 
         :param numBuckets: the number of buckets to save
         :param cols: name of columns
+        
+        .. note:: Applicable for file-based data sources in combination with 
+                  :py:meth:`DataFrameWriter.saveAsTable`.
 
         >>> (df.write.format('parquet')
         ...     .bucketBy(100, 'year', 'month')

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -572,7 +572,8 @@ class DataFrameWriter(OptionUtils):
 
         >>> (df.write.format('parquet')
         ...     .bucketBy(100, 'year', 'month')
-        ...     .saveAsTable(os.path.join(tempfile.mkdtemp(), 'bucketed_table')))
+        ...     .mode("overwrite")
+        ...     .saveAsTable('bucketed_table'))
         """
         if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
             cols = cols[0]
@@ -598,7 +599,8 @@ class DataFrameWriter(OptionUtils):
         >>> (df.write.format('parquet')
         ...     .bucketBy(100, 'year', 'month')
         ...     .sortBy('day')
-        ...     .saveAsTable(os.path.join(tempfile.mkdtemp(), 'sorted_bucketed_table')))
+        ...     .mode("overwrite")
+        ...     .saveAsTable('sorted_bucketed_table'))
         """
         if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
             cols = cols[0]

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -570,7 +570,7 @@ class DataFrameWriter(OptionUtils):
         :param numBuckets: the number of buckets to save
         :param cols: name of columns
         
-        .. note:: Applicable for file-based data sources in combination with 
+        .. note:: Applicable for file-based data sources in combination with
                   :py:meth:`DataFrameWriter.saveAsTable`.
 
         >>> (df.write.format('parquet')

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -577,6 +577,12 @@ class DataFrameWriter(OptionUtils):
         if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
             cols = cols[0]
 
+        if not isinstance(numBuckets, int):
+            raise TypeError("numBuckets should be an int, got {0}.".format(type(numBuckets)))
+
+        if not all(isinstance(c, basestring) for c in cols):
+            raise TypeError("cols argument should be a string or a sequence of strings.")
+
         col = cols[0]
         cols = cols[1:]
 
@@ -596,6 +602,9 @@ class DataFrameWriter(OptionUtils):
         """
         if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
             cols = cols[0]
+
+        if not all(isinstance(c, basestring) for c in cols):
+            raise TypeError("cols argument should be a string or a sequence of strings.")
 
         col = cols[0]
         cols = cols[1:]

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -563,7 +563,7 @@ class DataFrameWriter(OptionUtils):
         self._jwrite = self._jwrite.partitionBy(_to_seq(self._spark._sc, cols))
         return self
 
-    @since(2.1)
+    @since(2.2)
     def bucketBy(self, numBuckets, *cols):
         """Buckets the output by the given columns on the file system.
 
@@ -589,7 +589,7 @@ class DataFrameWriter(OptionUtils):
         self._jwrite = self._jwrite.bucketBy(numBuckets, col, _to_seq(self._spark._sc, cols))
         return self
 
-    @since(2.1)
+    @since(2.2)
     def sortBy(self, *cols):
         """Sorts the output in each bucket by the given columns on the file system.
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -563,6 +563,46 @@ class DataFrameWriter(OptionUtils):
         self._jwrite = self._jwrite.partitionBy(_to_seq(self._spark._sc, cols))
         return self
 
+    @since(2.1)
+    def bucketBy(self, numBuckets, *cols):
+        """Buckets the output by the given columns on the file system.
+
+        :param numBuckets: the number of buckets to save
+        :param cols: name of columns
+
+        >>> (df.write.format('parquet')
+        ...     .bucketBy(100, 'year', 'month')
+        ...     .saveAsTable(os.path.join(tempfile.mkdtemp(), 'bucketed_table')))
+        """
+        if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
+            cols = cols[0]
+
+        col = cols[0]
+        cols = cols[1:]
+
+        self._jwrite = self._jwrite.bucketBy(numBuckets, col, _to_seq(self._spark._sc, cols))
+        return self
+
+    @since(2.1)
+    def sortBy(self, *cols):
+        """Sorts the output in each bucket by the given columns on the file system.
+
+        :param cols: name of columns
+
+        >>> (df.write.format('parquet')
+        ...     .bucketBy(100, 'year', 'month')
+        ...     .sortBy('day')
+        ...     .saveAsTable(os.path.join(tempfile.mkdtemp(), 'sorted_bucketed_table')))
+        """
+        if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
+            cols = cols[0]
+
+        col = cols[0]
+        cols = cols[1:]
+
+        self._jwrite = self._jwrite.sortBy(col, _to_seq(self._spark._sc, cols))
+        return self
+
     @since(1.4)
     def save(self, path=None, format=None, mode=None, partitionBy=None, **options):
         """Saves the contents of the :class:`DataFrame` to a data source.

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -569,7 +569,7 @@ class DataFrameWriter(OptionUtils):
 
         :param numBuckets: the number of buckets to save
         :param cols: name of columns
-        
+
         .. note:: Applicable for file-based data sources in combination with
                   :py:meth:`DataFrameWriter.saveAsTable`.
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -565,7 +565,8 @@ class DataFrameWriter(OptionUtils):
 
     @since(2.3)
     def bucketBy(self, numBuckets, *cols):
-        """Buckets the output by the given columns on the file system.
+        """Buckets the output by the given columns.If specified,
+        the output is laid out on the file system similar to Hive's bucketing scheme.
 
         :param numBuckets: the number of buckets to save
         :param cols: name of columns

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -211,6 +211,12 @@ class SQLTests(ReusedPySparkTestCase):
         sqlContext2 = SQLContext(self.sc)
         self.assertTrue(sqlContext1.sparkSession is sqlContext2.sparkSession)
 
+    def tearDown(self):
+        super(SQLTests, self).tearDown()
+
+        # tear down test_bucketed_write state
+        self.spark.sql("DROP TABLE IF EXISTS pyspark_bucket")
+
     def test_row_should_be_read_only(self):
         row = Row(a=1, b=2)
         self.assertEqual(1, row.a)
@@ -2234,8 +2240,6 @@ class SQLTests(ReusedPySparkTestCase):
             .sortBy("y", "z")
             .mode("overwrite").saveAsTable("pyspark_bucket"))
         self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
-
-        self.spark.sql("DROP TABLE IF EXISTS pyspark_bucket")
 
 
 class HiveSparkSubmitTests(SparkSubmitTests):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2187,6 +2187,61 @@ class SQLTests(ReusedPySparkTestCase):
         df = self.spark.createDataFrame(data, schema=schema)
         df.collect()
 
+    def test_bucketed_write(self):
+        data = [
+            (1, "foo", 3.0), (2, "foo", 5.0),
+            (3, "bar", -1.0), (4, "bar", 6.0),
+        ]
+        df = self.spark.createDataFrame(data, ["x", "y", "z"])
+
+        # Test write with one bucketing column
+        df.write.bucketBy(3, "x").mode("overwrite").saveAsTable("pyspark_bucket")
+        self.assertEqual(
+            len([c for c in self.spark.catalog.listColumns("pyspark_bucket")
+                 if c.name == "x" and c.isBucket]),
+            1
+        )
+        self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
+
+        # Test write two bucketing columns
+        df.write.bucketBy(3, "x", "y").mode("overwrite").saveAsTable("pyspark_bucket")
+        self.assertEqual(
+            len([c for c in self.spark.catalog.listColumns("pyspark_bucket")
+                 if c.name in ("x", "y") and c.isBucket]),
+            2
+        )
+        self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
+
+        # Test write with bucket and sort
+        df.write.bucketBy(2, "x").sortBy("z").mode("overwrite").saveAsTable("pyspark_bucket")
+        self.assertEqual(
+            len([c for c in self.spark.catalog.listColumns("pyspark_bucket")
+                 if c.name == "x" and c.isBucket]),
+            1
+        )
+        self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
+
+        # Test write with a list of columns
+        df.write.bucketBy(3, ["x", "y"]).mode("overwrite").saveAsTable("pyspark_bucket")
+        self.assertEqual(
+            len([c for c in self.spark.catalog.listColumns("pyspark_bucket")
+                 if c.name in ("x", "y") and c.isBucket]),
+            2
+        )
+        self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
+
+        # Test write with bucket and sort with a list of columns
+        (df.write.bucketBy(2, "x")
+            .sortBy(["y", "z"])
+            .mode("overwrite").saveAsTable("pyspark_bucket"))
+        self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
+
+        # Test write with bucket and sort with multiple columns
+        (df.write.bucketBy(2, "x")
+            .sortBy("y", "z")
+            .mode("overwrite").saveAsTable("pyspark_bucket"))
+        self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
+
 
 class HiveSparkSubmitTests(SparkSubmitTests):
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2235,6 +2235,8 @@ class SQLTests(ReusedPySparkTestCase):
             .mode("overwrite").saveAsTable("pyspark_bucket"))
         self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
 
+        self.spark.sql("DROP TABLE IF EXISTS pyspark_bucket")
+
 
 class HiveSparkSubmitTests(SparkSubmitTests):
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds Python wrappers for `DataFrameWriter.bucketBy` and `DataFrameWriter.sortBy` ([SPARK-16931](https://issues.apache.org/jira/browse/SPARK-16931))

## How was this patch tested?

Unit tests covering new feature.

__Note__: Based on work of @GregBowyer (f49b9a23468f7af32cb53d2b654272757c151725)

CC @HyukjinKwon 