### PR TITLE
[SPARK-19748][SQL]refresh function has a wrong order to do cache invalidate and regenerate the inmemory var for InMemoryFileIndex with FileStatusCache

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -66,8 +66,8 @@ class InMemoryFileIndex(
   }
 
   override def refresh(): Unit = {
-    refresh0()
     fileStatusCache.invalidateAll()
+    refresh0()
   }
 
   private def refresh0(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -182,7 +182,7 @@ class FileIndexSuite extends SharedSQLContext {
   test("refresh for InMemoryFileIndex with FileStatusCache") {
     withTempDir { dir =>
       val fileStatusCache = FileStatusCache.getOrCreate(spark)
-      val dirPath = new Path(dir.getCanonicalPath)
+      val dirPath = new Path(dir.getAbsolutePath)
       val catalog = new InMemoryFileIndex(spark, Seq(dirPath), Map.empty,
         None, fileStatusCache) {
         def leafFilePaths: Seq[Path] = leafFiles.keys.toSeq
@@ -197,11 +197,13 @@ class FileIndexSuite extends SharedSQLContext {
 
       catalog.refresh()
 
-      val path = new Path(file.getCanonicalPath)
-      assert(catalog.leafFilePaths.nonEmpty && catalog
-        .leafFilePaths.forall(p => p.toString.startsWith("file:/")))
-      assert(catalog.leafDirPaths.nonEmpty && catalog
-        .leafDirPaths.forall(p => p.toString.startsWith("file:/")))
+      assert(catalog.leafFilePaths.size == 1)
+      assert(catalog.leafFilePaths.head.toString.stripSuffix("/") ==
+        s"file:${file.getAbsolutePath.stripSuffix("/")}")
+
+      assert(catalog.leafDirPaths.size == 1)
+      assert(catalog.leafDirPaths.head.toString.stripSuffix("/") ==
+        s"file:${dir.getAbsolutePath.stripSuffix("/")}")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -186,15 +186,14 @@ class FileIndexSuite extends SharedSQLContext {
       val fs = dirPath.getFileSystem(spark.sessionState.newHadoopConf())
       val catalog =
         new InMemoryFileIndex(spark, Seq(dirPath), Map.empty, None, fileStatusCache) {
-        def leafFilePaths: Seq[Path] = leafFiles.keys.toSeq
-        def leafDirPaths: Seq[Path] = leafDirToChildrenFiles.keys.toSeq
-      }
-
-      assert(catalog.leafDirPaths.isEmpty)
-      assert(catalog.leafFilePaths.isEmpty)
+          def leafFilePaths: Seq[Path] = leafFiles.keys.toSeq
+          def leafDirPaths: Seq[Path] = leafDirToChildrenFiles.keys.toSeq
+        }
 
       val file = new File(dir, "text.txt")
       stringToFile(file, "text")
+      assert(catalog.leafDirPaths.isEmpty)
+      assert(catalog.leafFilePaths.isEmpty)
 
       catalog.refresh()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we refresh a InMemoryFileIndex with a FileStatusCache, it will first use the FileStatusCache to re-generate the cachedLeafFiles etc, then call FileStatusCache.invalidateAll. 

While the order to do these two actions is wrong, this lead to the refresh action does not take effect.

```
  override def refresh(): Unit = {
    refresh0()
    fileStatusCache.invalidateAll()
  }

  private def refresh0(): Unit = {
    val files = listLeafFiles(rootPaths)
    cachedLeafFiles =
      new mutable.LinkedHashMap[Path, FileStatus]() ++= files.map(f => f.getPath -> f)
    cachedLeafDirToChildrenFiles = files.toArray.groupBy(_.getPath.getParent)
    cachedPartitionSpec = null
  }
```
## How was this patch tested?
unit test added