### PR TITLE
[SPARK-24101][ML][MLLIB] ML Evaluators should use weight column - added weight column for multiclass classification evaluator

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
@@ -69,7 +69,7 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
   def setLabelCol(value: String): this.type = set(labelCol, value)
 
   /** @group setParam */
-  @Since("2.2.0")
+  @Since("2.4.0")
   def setWeightCol(value: String): this.type = set(weightCol, value)
 
   setDefault(metricName -> "f1")
@@ -86,9 +86,6 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
         .rdd.map {
         case Row(prediction: Double, label: Double, weight: Double) => (prediction, label, weight)
       }
-    dataset.select(col($(predictionCol)), col($(labelCol)).cast(DoubleType)).rdd.map {
-      case Row(prediction: Double, label: Double) => (prediction, label)
-    }.values.countByValue()
     val metrics = new MulticlassMetrics(predictionAndLabelsWithWeights)
     val metric = $(metricName) match {
       case "f1" => metrics.weightedFMeasure

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
@@ -69,7 +69,7 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
   def setLabelCol(value: String): this.type = set(labelCol, value)
 
   /** @group setParam */
-  @Since("2.4.0")
+  @Since("3.0.0")
   def setWeightCol(value: String): this.type = set(weightCol, value)
 
   setDefault(metricName -> "f1")

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.evaluation
 
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.param.{Param, ParamMap, ParamValidators}
-import org.apache.spark.ml.param.shared.{HasLabelCol, HasPredictionCol}
+import org.apache.spark.ml.param.shared.{HasLabelCol, HasPredictionCol, HasWeightCol}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable, SchemaUtils}
 import org.apache.spark.mllib.evaluation.MulticlassMetrics
 import org.apache.spark.sql.{Dataset, Row}
@@ -33,7 +33,8 @@ import org.apache.spark.sql.types.DoubleType
 @Since("1.5.0")
 @Experimental
 class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") override val uid: String)
-  extends Evaluator with HasPredictionCol with HasLabelCol with DefaultParamsWritable {
+  extends Evaluator with HasPredictionCol with HasLabelCol
+    with HasWeightCol with DefaultParamsWritable {
 
   @Since("1.5.0")
   def this() = this(Identifiable.randomUID("mcEval"))
@@ -67,6 +68,10 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
   @Since("1.5.0")
   def setLabelCol(value: String): this.type = set(labelCol, value)
 
+  /** @group setParam */
+  @Since("2.2.0")
+  def setWeightCol(value: String): this.type = set(weightCol, value)
+
   setDefault(metricName -> "f1")
 
   @Since("2.0.0")
@@ -75,11 +80,16 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
     SchemaUtils.checkColumnType(schema, $(predictionCol), DoubleType)
     SchemaUtils.checkNumericType(schema, $(labelCol))
 
-    val predictionAndLabels =
-      dataset.select(col($(predictionCol)), col($(labelCol)).cast(DoubleType)).rdd.map {
-        case Row(prediction: Double, label: Double) => (prediction, label)
+    val predictionAndLabelsWithWeights =
+      dataset.select(col($(predictionCol)), col($(labelCol)).cast(DoubleType),
+        if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol)))
+        .rdd.map {
+        case Row(prediction: Double, label: Double, weight: Double) => (prediction, label, weight)
       }
-    val metrics = new MulticlassMetrics(predictionAndLabels)
+    dataset.select(col($(predictionCol)), col($(labelCol)).cast(DoubleType)).rdd.map {
+      case Row(prediction: Double, label: Double) => (prediction, label)
+    }.values.countByValue()
+    val metrics = new MulticlassMetrics(predictionAndLabelsWithWeights)
     val metric = $(metricName) match {
       case "f1" => metrics.weightedFMeasure
       case "weightedPrecision" => metrics.weightedPrecision

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.DataFrame
  *                         (prediction, label) pairs.
  */
 @Since("1.1.0")
-class MulticlassMetrics @Since("2.4.0") (predAndLabelsWithOptWeight: RDD[_]) {
+class MulticlassMetrics @Since("3.0.0") (predAndLabelsWithOptWeight: RDD[_]) {
   val predLabelsWeight: RDD[(Double, Double, Double)] = predAndLabelsWithOptWeight.map {
     case (prediction: Double, label: Double, weight: Double) =>
       (prediction, label, weight)

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -27,13 +27,17 @@ import org.apache.spark.sql.DataFrame
 /**
  * Evaluator for multiclass classification.
  *
- * @param predLabelsWeight an RDD of (prediction, label, weight).
+ * @param predAndLabelsWithOptWeight an RDD of (prediction, label, weight) or
+ *                         (prediction, label) pairs.
  */
 @Since("1.1.0")
-class MulticlassMetrics @Since("2.4.0") (predLabelsWeight: RDD[(Double, Double, Double)]) {
-  @Since("1.1.0")
-  def this(predAndLabels: RDD[(Double, Double)]) =
-    this(predAndLabels.map(r => (r._1, r._2, 1.0)))
+class MulticlassMetrics @Since("2.4.0") (predAndLabelsWithOptWeight: RDD[_]) {
+  val predLabelsWeight: RDD[(Double, Double, Double)] = predAndLabelsWithOptWeight.map {
+    case (prediction: Double, label: Double, weight: Double) =>
+      (prediction, label, weight)
+    case (prediction: Double, label: Double) =>
+      (prediction, label, 1.0)
+  }
 
   /**
    * An auxiliary constructor taking a DataFrame.

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -54,17 +54,15 @@ class MulticlassMetrics @Since("3.0.0") (predAndLabelsWithOptWeight: RDD[_]) {
     .collectAsMap()
   private lazy val labelCount: Double = labelCountByClass.values.sum
   private lazy val tpByClass: Map[Double, Double] = predLabelsWeight
-    .filter(predLabelWeight => predLabelWeight._1 == predLabelWeight._2)
     .map {
-      case (_: Double, label: Double, weight: Double) =>
-        (label, weight)
+      case (prediction: Double, label: Double, weight: Double) =>
+        (label, if (label == prediction) weight else 0.0)
     }.reduceByKey(_ + _)
     .collectAsMap()
   private lazy val fpByClass: Map[Double, Double] = predLabelsWeight
-    .filter(predLabelWeight => predLabelWeight._1 != predLabelWeight._2)
     .map {
-      case (prediction: Double, _: Double, weight: Double) =>
-        (prediction, weight)
+      case (prediction: Double, label: Double, weight: Double) =>
+        (prediction, if (prediction != label) weight else 0.0)
     }.reduceByKey(_ + _)
     .collectAsMap()
   private lazy val confusions = predLabelsWeight

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -27,10 +27,11 @@ import org.apache.spark.sql.DataFrame
 /**
  * Evaluator for multiclass classification.
  *
- * @param predictionAndLabels an RDD of (prediction, label) pairs.
+ * @param predAndLabelsWithOptWeight an RDD of (prediction, label, weight) or
+ *                                   (prediction, label) pairs.
  */
 @Since("1.1.0")
-class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Double)]) {
+class MulticlassMetrics @Since("1.1.0") (predAndLabelsWithOptWeight: RDD[_]) {
 
   /**
    * An auxiliary constructor taking a DataFrame.
@@ -39,21 +40,33 @@ class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Doubl
   private[mllib] def this(predictionAndLabels: DataFrame) =
     this(predictionAndLabels.rdd.map(r => (r.getDouble(0), r.getDouble(1))))
 
-  private lazy val labelCountByClass: Map[Double, Long] = predictionAndLabels.values.countByValue()
-  private lazy val labelCount: Long = labelCountByClass.values.sum
-  private lazy val tpByClass: Map[Double, Int] = predictionAndLabels
-    .map { case (prediction, label) =>
-      (label, if (label == prediction) 1 else 0)
+  private lazy val labelCountByClass: Map[Double, Double] =
+    predAndLabelsWithOptWeight.map {
+      case (prediction: Double, label: Double) =>
+        (label, 1.0)
+      case (prediction: Double, label: Double, weight: Double) =>
+        (label, weight)
+    }.mapValues(weight => weight).reduceByKey(_ + _).collect().toMap
+  private lazy val labelCount: Double = labelCountByClass.values.sum
+  private lazy val tpByClass: Map[Double, Double] = predAndLabelsWithOptWeight
+    .map { case (prediction: Double, label: Double) =>
+      (label, if (label == prediction) 1.0 else 0.0)
+    case (prediction: Double, label: Double, weight: Double) =>
+      (label, if (label == prediction) weight else 0.0)
     }.reduceByKey(_ + _)
     .collectAsMap()
-  private lazy val fpByClass: Map[Double, Int] = predictionAndLabels
-    .map { case (prediction, label) =>
-      (prediction, if (prediction != label) 1 else 0)
+  private lazy val fpByClass: Map[Double, Double] = predAndLabelsWithOptWeight
+    .map { case (prediction: Double, label: Double) =>
+      (prediction, if (prediction != label) 1.0 else 0.0)
+    case (prediction: Double, label: Double, weight: Double) =>
+      (prediction, if (prediction != label) weight else 0.0)
     }.reduceByKey(_ + _)
     .collectAsMap()
-  private lazy val confusions = predictionAndLabels
-    .map { case (prediction, label) =>
-      ((label, prediction), 1)
+  private lazy val confusions = predAndLabelsWithOptWeight
+    .map { case (prediction: Double, label: Double) =>
+      ((label, prediction), 1.0)
+    case (prediction: Double, label: Double, weight: Double) =>
+      ((label, prediction), weight)
     }.reduceByKey(_ + _)
     .collectAsMap()
 
@@ -71,7 +84,7 @@ class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Doubl
     while (i < n) {
       var j = 0
       while (j < n) {
-        values(i + j * n) = confusions.getOrElse((labels(i), labels(j)), 0).toDouble
+        values(i + j * n) = confusions.getOrElse((labels(i), labels(j)), 0.0)
         j += 1
       }
       i += 1
@@ -92,8 +105,8 @@ class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Doubl
    */
   @Since("1.1.0")
   def falsePositiveRate(label: Double): Double = {
-    val fp = fpByClass.getOrElse(label, 0)
-    fp.toDouble / (labelCount - labelCountByClass(label))
+    val fp = fpByClass.getOrElse(label, 0.0)
+    fp / (labelCount - labelCountByClass(label))
   }
 
   /**
@@ -103,7 +116,7 @@ class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Doubl
   @Since("1.1.0")
   def precision(label: Double): Double = {
     val tp = tpByClass(label)
-    val fp = fpByClass.getOrElse(label, 0)
+    val fp = fpByClass.getOrElse(label, 0.0)
     if (tp + fp == 0) 0 else tp.toDouble / (tp + fp)
   }
 
@@ -112,7 +125,7 @@ class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Doubl
    * @param label the label.
    */
   @Since("1.1.0")
-  def recall(label: Double): Double = tpByClass(label).toDouble / labelCountByClass(label)
+  def recall(label: Double): Double = tpByClass(label) / labelCountByClass(label)
 
   /**
    * Returns f-measure for a given label (category)
@@ -140,7 +153,7 @@ class MulticlassMetrics @Since("1.1.0") (predictionAndLabels: RDD[(Double, Doubl
    * out of the total number of instances.)
    */
   @Since("2.0.0")
-  lazy val accuracy: Double = tpByClass.values.sum.toDouble / labelCount
+  lazy val accuracy: Double = tpByClass.values.sum / labelCount
 
   /**
    * Returns weighted true positive rate

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -50,7 +50,7 @@ class MulticlassMetrics @Since("2.4.0") (predAndLabelsWithOptWeight: RDD[_]) {
     predLabelsWeight.map {
       case (prediction: Double, label: Double, weight: Double) =>
         (label, weight)
-    }.mapValues(weight => weight).reduceByKey(_ + _).collect().toMap
+    }.reduceByKey(_ + _).collect().toMap
   private lazy val labelCount: Double = labelCountByClass.values.sum
   private lazy val tpByClass: Map[Double, Double] = predLabelsWeight
     .map {

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -31,12 +31,14 @@ import org.apache.spark.sql.DataFrame
  *                         (prediction, label) pairs.
  */
 @Since("1.1.0")
-class MulticlassMetrics @Since("3.0.0") (predAndLabelsWithOptWeight: RDD[_]) {
+class MulticlassMetrics @Since("1.1.0") (predAndLabelsWithOptWeight: RDD[_ <: Product]) {
   val predLabelsWeight: RDD[(Double, Double, Double)] = predAndLabelsWithOptWeight.map {
     case (prediction: Double, label: Double, weight: Double) =>
       (prediction, label, weight)
     case (prediction: Double, label: Double) =>
       (prediction, label, 1.0)
+    case other =>
+      throw new IllegalArgumentException(s"Expected tuples, got $other")
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/MulticlassMetrics.scala
@@ -48,20 +48,23 @@ class MulticlassMetrics @Since("3.0.0") (predAndLabelsWithOptWeight: RDD[_]) {
 
   private lazy val labelCountByClass: Map[Double, Double] =
     predLabelsWeight.map {
-      case (prediction: Double, label: Double, weight: Double) =>
+      case (_: Double, label: Double, weight: Double) =>
         (label, weight)
-    }.reduceByKey(_ + _).collect().toMap
+    }.reduceByKey(_ + _)
+    .collectAsMap()
   private lazy val labelCount: Double = labelCountByClass.values.sum
   private lazy val tpByClass: Map[Double, Double] = predLabelsWeight
+    .filter(predLabelWeight => predLabelWeight._1 == predLabelWeight._2)
     .map {
-      case (prediction: Double, label: Double, weight: Double) =>
-        (label, if (label == prediction) weight else 0.0)
+      case (_: Double, label: Double, weight: Double) =>
+        (label, weight)
     }.reduceByKey(_ + _)
     .collectAsMap()
   private lazy val fpByClass: Map[Double, Double] = predLabelsWeight
+    .filter(predLabelWeight => predLabelWeight._1 != predLabelWeight._2)
     .map {
-      case (prediction: Double, label: Double, weight: Double) =>
-        (prediction, if (prediction != label) weight else 0.0)
+      case (prediction: Double, _: Double, weight: Double) =>
+        (prediction, weight)
     }.reduceByKey(_ + _)
     .collectAsMap()
   private lazy val confusions = predLabelsWeight

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
@@ -158,9 +158,6 @@ class MulticlassMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(metrics.accuracy  ~==
       (2.0 * w1 + 2.0 * w1 + 1.0 * w2 + 1.0 * w2) / tw relTol delta)
-    assert(metrics.accuracy  ~==  metrics.precision relTol delta)
-    assert(metrics.accuracy  ~==  metrics.recall relTol delta)
-    assert(metrics.accuracy  ~==  metrics.fMeasure relTol delta)
     assert(metrics.accuracy  ~==  metrics.weightedRecall relTol delta)
     val weight0 = (2 * w1 + 1 * w2 + 1 * w1) / tw
     val weight1 = (1 * w2 + 2 * w1 + 1 * w2) / tw

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
@@ -18,13 +18,11 @@
 package org.apache.spark.mllib.evaluation
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.linalg.Matrices
 import org.apache.spark.ml.util.TestingUtils._
-import org.apache.spark.mllib.linalg.Matrices
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 class MulticlassMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
-
-  import testImplicits._
 
   val delta = 1e-7
 
@@ -60,44 +58,44 @@ class MulticlassMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
     val f2measure1 = (1 + 2 * 2) * precision1 * recall1 / (2 * 2 * precision1 + recall1)
     val f2measure2 = (1 + 2 * 2) * precision2 * recall2 / (2 * 2 * precision2 + recall2)
 
-    assert(metrics.confusionMatrix.asML ~== confusionMatrix.asML relTol delta)
-    assert(metrics.truePositiveRate(0.0) ~== tpRate0 absTol delta)
-    assert(metrics.truePositiveRate(1.0) ~== tpRate1 absTol delta)
-    assert(metrics.truePositiveRate(2.0) ~== tpRate2 absTol delta)
-    assert(metrics.falsePositiveRate(0.0) ~== fpRate0 absTol delta)
-    assert(metrics.falsePositiveRate(1.0) ~== fpRate1 absTol delta)
-    assert(metrics.falsePositiveRate(2.0) ~== fpRate2 absTol delta)
-    assert(metrics.precision(0.0) ~== precision0 absTol delta)
-    assert(metrics.precision(1.0) ~== precision1 absTol delta)
-    assert(metrics.precision(2.0) ~== precision2 absTol delta)
-    assert(metrics.recall(0.0) ~== recall0 absTol delta)
-    assert(metrics.recall(1.0) ~== recall1 absTol delta)
-    assert(metrics.recall(2.0) ~== recall2 absTol delta)
-    assert(metrics.fMeasure(0.0) ~== f1measure0 absTol delta)
-    assert(metrics.fMeasure(1.0) ~== f1measure1 absTol delta)
-    assert(metrics.fMeasure(2.0) ~== f1measure2 absTol delta)
-    assert(metrics.fMeasure(0.0, 2.0) ~== f2measure0 absTol delta)
-    assert(metrics.fMeasure(1.0, 2.0) ~== f2measure1 absTol delta)
-    assert(metrics.fMeasure(2.0, 2.0) ~== f2measure2 absTol delta)
+    assert(metrics.confusionMatrix.asML ~== confusionMatrix relTol delta)
+    assert(metrics.truePositiveRate(0.0) ~== tpRate0 relTol delta)
+    assert(metrics.truePositiveRate(1.0) ~== tpRate1 relTol delta)
+    assert(metrics.truePositiveRate(2.0) ~== tpRate2 relTol delta)
+    assert(metrics.falsePositiveRate(0.0) ~== fpRate0 relTol delta)
+    assert(metrics.falsePositiveRate(1.0) ~== fpRate1 relTol delta)
+    assert(metrics.falsePositiveRate(2.0) ~== fpRate2 relTol delta)
+    assert(metrics.precision(0.0) ~== precision0 relTol delta)
+    assert(metrics.precision(1.0) ~== precision1 relTol delta)
+    assert(metrics.precision(2.0) ~== precision2 relTol delta)
+    assert(metrics.recall(0.0) ~== recall0 relTol delta)
+    assert(metrics.recall(1.0) ~== recall1 relTol delta)
+    assert(metrics.recall(2.0) ~== recall2 relTol delta)
+    assert(metrics.fMeasure(0.0) ~== f1measure0 relTol delta)
+    assert(metrics.fMeasure(1.0) ~== f1measure1 relTol delta)
+    assert(metrics.fMeasure(2.0) ~== f1measure2 relTol delta)
+    assert(metrics.fMeasure(0.0, 2.0) ~== f2measure0 relTol delta)
+    assert(metrics.fMeasure(1.0, 2.0) ~== f2measure1 relTol delta)
+    assert(metrics.fMeasure(2.0, 2.0) ~== f2measure2 relTol delta)
 
     assert(metrics.accuracy ~==
-      (2.0 + 3.0 + 1.0) / ((2 + 3 + 1) + (1 + 1 + 1)) absTol delta)
-    assert(metrics.accuracy ~== metrics.weightedRecall absTol delta)
+      (2.0 + 3.0 + 1.0) / ((2 + 3 + 1) + (1 + 1 + 1)) relTol delta)
+    assert(metrics.accuracy ~== metrics.weightedRecall relTol delta)
     val weight0 = 4.0 / 9
     val weight1 = 4.0 / 9
     val weight2 = 1.0 / 9
     assert(metrics.weightedTruePositiveRate ~==
-      (weight0 * tpRate0 + weight1 * tpRate1 + weight2 * tpRate2) absTol delta)
+      (weight0 * tpRate0 + weight1 * tpRate1 + weight2 * tpRate2) relTol delta)
     assert(metrics.weightedFalsePositiveRate ~==
-      (weight0 * fpRate0 + weight1 * fpRate1 + weight2 * fpRate2) absTol delta)
+      (weight0 * fpRate0 + weight1 * fpRate1 + weight2 * fpRate2) relTol delta)
     assert(metrics.weightedPrecision ~==
-      (weight0 * precision0 + weight1 * precision1 + weight2 * precision2) absTol delta)
+      (weight0 * precision0 + weight1 * precision1 + weight2 * precision2) relTol delta)
     assert(metrics.weightedRecall ~==
-      (weight0 * recall0 + weight1 * recall1 + weight2 * recall2) absTol delta)
+      (weight0 * recall0 + weight1 * recall1 + weight2 * recall2) relTol delta)
     assert(metrics.weightedFMeasure ~==
-      (weight0 * f1measure0 + weight1 * f1measure1 + weight2 * f1measure2) absTol delta)
+      (weight0 * f1measure0 + weight1 * f1measure1 + weight2 * f1measure2) relTol delta)
     assert(metrics.weightedFMeasure(2.0) ~==
-      (weight0 * f2measure0 + weight1 * f2measure1 + weight2 * f2measure2) absTol delta)
+      (weight0 * f2measure0 + weight1 * f2measure1 + weight2 * f2measure2) relTol delta)
     assert(metrics.labels === labels)
   }
 
@@ -138,47 +136,47 @@ class MulticlassMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
     val f2measure1 = (1 + 2 * 2) * precision1 * recall1 / (2 * 2 * precision1 + recall1)
     val f2measure2 = (1 + 2 * 2) * precision2 * recall2 / (2 * 2 * precision2 + recall2)
 
-    assert(metrics.confusionMatrix.asML ~== confusionMatrix.asML relTol delta)
-    assert(metrics.truePositiveRate(0.0) ~== tpRate0 absTol delta)
-    assert(metrics.truePositiveRate(1.0) ~== tpRate1 absTol delta)
-    assert(metrics.truePositiveRate(2.0)  ~==  tpRate2 absTol delta)
-    assert(metrics.falsePositiveRate(0.0)  ~==  fpRate0 absTol delta)
-    assert(metrics.falsePositiveRate(1.0)  ~==  fpRate1 absTol delta)
-    assert(metrics.falsePositiveRate(2.0)  ~==  fpRate2 absTol delta)
-    assert(metrics.precision(0.0)  ~==  precision0 absTol delta)
-    assert(metrics.precision(1.0)  ~==  precision1 absTol delta)
-    assert(metrics.precision(2.0)  ~==  precision2 absTol delta)
-    assert(metrics.recall(0.0)  ~==  recall0 absTol delta)
-    assert(metrics.recall(1.0)  ~==  recall1 absTol delta)
-    assert(metrics.recall(2.0)  ~==  recall2 absTol delta)
-    assert(metrics.fMeasure(0.0)  ~==  f1measure0 absTol delta)
-    assert(metrics.fMeasure(1.0)  ~==  f1measure1 absTol delta)
-    assert(metrics.fMeasure(2.0)  ~==  f1measure2 absTol delta)
-    assert(metrics.fMeasure(0.0, 2.0)  ~==  f2measure0 absTol delta)
-    assert(metrics.fMeasure(1.0, 2.0)  ~==  f2measure1 absTol delta)
-    assert(metrics.fMeasure(2.0, 2.0)  ~==  f2measure2 absTol delta)
+    assert(metrics.confusionMatrix.asML ~== confusionMatrix relTol delta)
+    assert(metrics.truePositiveRate(0.0) ~== tpRate0 relTol delta)
+    assert(metrics.truePositiveRate(1.0) ~== tpRate1 relTol delta)
+    assert(metrics.truePositiveRate(2.0)  ~==  tpRate2 relTol delta)
+    assert(metrics.falsePositiveRate(0.0)  ~==  fpRate0 relTol delta)
+    assert(metrics.falsePositiveRate(1.0)  ~==  fpRate1 relTol delta)
+    assert(metrics.falsePositiveRate(2.0)  ~==  fpRate2 relTol delta)
+    assert(metrics.precision(0.0)  ~==  precision0 relTol delta)
+    assert(metrics.precision(1.0)  ~==  precision1 relTol delta)
+    assert(metrics.precision(2.0)  ~==  precision2 relTol delta)
+    assert(metrics.recall(0.0)  ~==  recall0 relTol delta)
+    assert(metrics.recall(1.0)  ~==  recall1 relTol delta)
+    assert(metrics.recall(2.0)  ~==  recall2 relTol delta)
+    assert(metrics.fMeasure(0.0)  ~==  f1measure0 relTol delta)
+    assert(metrics.fMeasure(1.0)  ~==  f1measure1 relTol delta)
+    assert(metrics.fMeasure(2.0)  ~==  f1measure2 relTol delta)
+    assert(metrics.fMeasure(0.0, 2.0)  ~==  f2measure0 relTol delta)
+    assert(metrics.fMeasure(1.0, 2.0)  ~==  f2measure1 relTol delta)
+    assert(metrics.fMeasure(2.0, 2.0)  ~==  f2measure2 relTol delta)
 
     assert(metrics.accuracy  ~==
-      (2.0 * w1 + 2.0 * w1 + 1.0 * w2 + 1.0 * w2) / tw absTol delta)
-    assert(metrics.accuracy  ~==  metrics.precision absTol delta)
-    assert(metrics.accuracy  ~==  metrics.recall absTol delta)
-    assert(metrics.accuracy  ~==  metrics.fMeasure absTol delta)
-    assert(metrics.accuracy  ~==  metrics.weightedRecall absTol delta)
+      (2.0 * w1 + 2.0 * w1 + 1.0 * w2 + 1.0 * w2) / tw relTol delta)
+    assert(metrics.accuracy  ~==  metrics.precision relTol delta)
+    assert(metrics.accuracy  ~==  metrics.recall relTol delta)
+    assert(metrics.accuracy  ~==  metrics.fMeasure relTol delta)
+    assert(metrics.accuracy  ~==  metrics.weightedRecall relTol delta)
     val weight0 = (2 * w1 + 1 * w2 + 1 * w1) / tw
     val weight1 = (1 * w2 + 2 * w1 + 1 * w2) / tw
     val weight2 = 1 * w2 / tw
     assert(metrics.weightedTruePositiveRate  ~==
-      (weight0 * tpRate0 + weight1 * tpRate1 + weight2 * tpRate2) absTol delta)
+      (weight0 * tpRate0 + weight1 * tpRate1 + weight2 * tpRate2) relTol delta)
     assert(metrics.weightedFalsePositiveRate  ~==
-      (weight0 * fpRate0 + weight1 * fpRate1 + weight2 * fpRate2) absTol delta)
+      (weight0 * fpRate0 + weight1 * fpRate1 + weight2 * fpRate2) relTol delta)
     assert(metrics.weightedPrecision  ~==
-      (weight0 * precision0 + weight1 * precision1 + weight2 * precision2) absTol delta)
+      (weight0 * precision0 + weight1 * precision1 + weight2 * precision2) relTol delta)
     assert(metrics.weightedRecall  ~==
-      (weight0 * recall0 + weight1 * recall1 + weight2 * recall2) absTol delta)
+      (weight0 * recall0 + weight1 * recall1 + weight2 * recall2) relTol delta)
     assert(metrics.weightedFMeasure  ~==
-      (weight0 * f1measure0 + weight1 * f1measure1 + weight2 * f1measure2) absTol delta)
+      (weight0 * f1measure0 + weight1 * f1measure1 + weight2 * f1measure2) relTol delta)
     assert(metrics.weightedFMeasure(2.0)  ~==
-      (weight0 * f2measure0 + weight1 * f2measure1 + weight2 * f2measure2) absTol delta)
+      (weight0 * f2measure0 + weight1 * f2measure1 + weight2 * f2measure2) relTol delta)
     assert(metrics.labels === labels)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/MulticlassMetricsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 class MulticlassMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
 
-  val delta = 1e-7
+  private val delta = 1e-7
 
   test("Multiclass evaluation metrics") {
     /*


### PR DESCRIPTION
## What changes were proposed in this pull request?

The evaluators BinaryClassificationEvaluator, RegressionEvaluator, and MulticlassClassificationEvaluator and the corresponding metrics classes BinaryClassificationMetrics, RegressionMetrics and MulticlassMetrics should use sample weight data.

I've closed the PR: https://github.com/apache/spark/pull/16557
 as recommended in favor of creating three pull requests, one for each of the evaluators (binary/regression/multiclass) to make it easier to review/update.

Note: I've updated the JIRA to:
https://issues.apache.org/jira/browse/SPARK-24101
Which is a child of JIRA:
https://issues.apache.org/jira/browse/SPARK-18693

## How was this patch tested?

I added tests to the metrics class.
