### PR TITLE
[SPARK-19756][SQL] drop the table cache after inserting into a data source table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -148,6 +148,9 @@ case class InsertIntoHadoopFsRelationCommand(
         options = options)
 
       fileIndex.foreach(_.refresh())
+      catalogTable.foreach { table =>
+        sparkSession.sharedState.cacheManager.uncacheQuery(sparkSession.table(table.identifier))
+      }
     } else {
       logInfo("Skipping insertion into a relation that already exists.")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we inserting into a table, we should uncache it to avoid exposing stale data. This is the existing behavior for hive tables, see `InsertIntoHiveTable`, this PR fixes this problem for data source tables.

## How was this patch tested?

new regression test