### PR TITLE
[Spark-19535][ML] RecommendForAllUsers RecommendForAllItems for ALS on Dataframe 

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -327,6 +327,15 @@ class ALSModel private[ml] (
 
   @Since("1.6.0")
   override def write: MLWriter = new ALSModel.ALSModelWriter(this)
+
+  // TODO: output is DataFrame ?? DataSet ?? what exactly is the output schema?
+  def recommendForAllUsers(): DataFrame = {
+
+  }
+
+  def recommendForAllItems(): DataFrame = {
+
+  }
 }
 
 @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -335,37 +335,39 @@ class ALSModel private[ml] (
    * Returns top `numItems` items recommended for each user, for all users.
    * @param numItems max number of recommendations for each user
    * @return a DataFrame of (userCol: Int, recommendations), where recommendations are
-   *         stored as an array of (itemId: Int, rating: Float) tuples.
+   *         stored as an array of (itemCol: Int, rating: Float) Rows.
    */
   @Since("2.2.0")
   def recommendForAllUsers(numItems: Int): DataFrame = {
-    recommendForAll(userFactors, itemFactors, $(userCol), numItems)
+    recommendForAll(userFactors, itemFactors, $(userCol), $(itemCol), numItems)
   }
 
   /**
    * Returns top `numUsers` users recommended for each item, for all items.
    * @param numUsers max number of recommendations for each item
    * @return a DataFrame of (itemCol: Int, recommendations), where recommendations are
-   *         stored as an array of (userId: Int, rating: Float) tuples.
+   *         stored as an array of (userCol: Int, rating: Float) Rows.
    */
   @Since("2.2.0")
   def recommendForAllItems(numUsers: Int): DataFrame = {
-    recommendForAll(itemFactors, userFactors, $(itemCol), numUsers)
+    recommendForAll(itemFactors, userFactors, $(itemCol), $(userCol), numUsers)
   }
 
   /**
    * Makes recommendations for all users (or items).
    * @param srcFactors src factors for which to generate recommendations
    * @param dstFactors dst factors used to make recommendations
-   * @param srcOutputColumn name of the column for the source in the output DataFrame
+   * @param srcOutputColumn name of the column for the source ID in the output DataFrame
+   * @param dstOutputColumn name of the column for the destination ID in the output DataFrame
    * @param num max number of recommendations for each record
    * @return a DataFrame of (srcOutputColumn: Int, recommendations), where recommendations are
-   *         stored as an array of (dstId: Int, rating: Float) tuples.
+   *         stored as an array of (dstOutputColumn: Int, rating: Float) Rows.
    */
   private def recommendForAll(
       srcFactors: DataFrame,
       dstFactors: DataFrame,
       srcOutputColumn: String,
+      dstOutputColumn: String,
       num: Int): DataFrame = {
     import srcFactors.sparkSession.implicits._
 
@@ -376,8 +378,21 @@ class ALSModel private[ml] (
         predict(srcFactors("features"), dstFactors("features")))
     // We'll force the IDs to be Int. Unfortunately this converts IDs to Int in the output.
     val topKAggregator = new TopByKeyAggregator[Int, Int, Float](num, Ordering.by(_._2))
-    ratings.as[(Int, Int, Float)].groupByKey(_._1).agg(topKAggregator.toColumn)
+    val recs = ratings.as[(Int, Int, Float)].groupByKey(_._1).agg(topKAggregator.toColumn)
       .toDF(srcOutputColumn, "recommendations")
+
+    // There is some performance hit from converting the (Int, Float) tuples to
+    // (dstOutputColumn: Int, rating: Float) structs using .rdd. Need SPARK-16483 for a fix.
+    val schema = new StructType()
+      .add(srcOutputColumn, IntegerType)
+      .add("recommendations",
+        ArrayType(
+          StructType(
+            StructField(dstOutputColumn, IntegerType, nullable = false) ::
+            StructField("rating", FloatType, nullable = false) ::
+            Nil
+      )))
+    recs.sparkSession.createDataFrame(recs.rdd, schema)
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.recommendation
+
+import scala.language.implicitConversions
+import scala.reflect.runtime.universe.TypeTag
+
+import org.apache.spark.sql.{Encoder, Encoders}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.expressions.Aggregator
+import org.apache.spark.util.BoundedPriorityQueue
+
+/**
+ * TODO: Some comments go here about the class
+ * TODO: should probably move it to somewhere else
+ */
+
+private[recommendation] class TopByKeyAggregator[K1: TypeTag, K2: TypeTag, V: TypeTag]
+  (num: Int, ord: Ordering[(K2, V)])
+  extends Aggregator[(K1, K2, V), BoundedPriorityQueue[(K2, V)], Array[(K2, V)]] {
+
+  override def zero: BoundedPriorityQueue[(K2, V)] = new BoundedPriorityQueue[(K2, V)](num)(ord)
+  override def reduce(
+    q: BoundedPriorityQueue[(K2, V)],
+    a: (K1, K2, V)): BoundedPriorityQueue[(K2, V)] = q += {(a._2, a._3)}
+  override def merge(
+      q1: BoundedPriorityQueue[(K2, V)],
+      q2: BoundedPriorityQueue[(K2, V)]): BoundedPriorityQueue[(K2, V)] = q1 ++= q2
+  override def finish(r: BoundedPriorityQueue[(K2, V)]): Array[(K2, V)] =
+    r.toArray.sorted(ord.reverse)
+  override def bufferEncoder: Encoder[BoundedPriorityQueue[(K2, V)]] =
+    Encoders.kryo[BoundedPriorityQueue[(K2, V)]]
+  override def outputEncoder: Encoder[Array[(K2, V)]] = ExpressionEncoder[Array[(K2, V)]]
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
@@ -25,25 +25,36 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.expressions.Aggregator
 import org.apache.spark.util.BoundedPriorityQueue
 
+
 /**
  * Works on rows of the form (K1, K2, V) where K1 & K2 are IDs and V is the score value. Finds
  * the top `num` K2 items based on the given Ordering.
  */
-
 private[recommendation] class TopByKeyAggregator[K1: TypeTag, K2: TypeTag, V: TypeTag]
   (num: Int, ord: Ordering[(K2, V)])
   extends Aggregator[(K1, K2, V), BoundedPriorityQueue[(K2, V)], Array[(K2, V)]] {
 
   override def zero: BoundedPriorityQueue[(K2, V)] = new BoundedPriorityQueue[(K2, V)](num)(ord)
+
   override def reduce(
-    q: BoundedPriorityQueue[(K2, V)],
-    a: (K1, K2, V)): BoundedPriorityQueue[(K2, V)] = q += {(a._2, a._3)}
+      q: BoundedPriorityQueue[(K2, V)],
+      a: (K1, K2, V)): BoundedPriorityQueue[(K2, V)] = {
+    q += {(a._2, a._3)}
+  }
+
   override def merge(
       q1: BoundedPriorityQueue[(K2, V)],
-      q2: BoundedPriorityQueue[(K2, V)]): BoundedPriorityQueue[(K2, V)] = q1 ++= q2
-  override def finish(r: BoundedPriorityQueue[(K2, V)]): Array[(K2, V)] =
+      q2: BoundedPriorityQueue[(K2, V)]): BoundedPriorityQueue[(K2, V)] = {
+    q1 ++= q2
+  }
+
+  override def finish(r: BoundedPriorityQueue[(K2, V)]): Array[(K2, V)] = {
     r.toArray.sorted(ord.reverse)
-  override def bufferEncoder: Encoder[BoundedPriorityQueue[(K2, V)]] =
+  }
+
+  override def bufferEncoder: Encoder[BoundedPriorityQueue[(K2, V)]] = {
     Encoders.kryo[BoundedPriorityQueue[(K2, V)]]
+  }
+
   override def outputEncoder: Encoder[Array[(K2, V)]] = ExpressionEncoder[Array[(K2, V)]]
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
@@ -56,5 +56,5 @@ private[recommendation] class TopByKeyAggregator[K1: TypeTag, K2: TypeTag, V: Ty
     Encoders.kryo[BoundedPriorityQueue[(K2, V)]]
   }
 
-  override def outputEncoder: Encoder[Array[(K2, V)]] = ExpressionEncoder[Array[(K2, V)]]
+  override def outputEncoder: Encoder[Array[(K2, V)]] = ExpressionEncoder[Array[(K2, V)]]()
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/TopByKeyAggregator.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.expressions.Aggregator
 import org.apache.spark.util.BoundedPriorityQueue
 
 /**
- * TODO: Some comments go here about the class
- * TODO: should probably move it to somewhere else
+ * Works on rows of the form (K1, K2, V) where K1 & K2 are IDs and V is the score value. Finds
+ * the top `num` K2 items based on the given Ordering.
  */
 
 private[recommendation] class TopByKeyAggregator[K1: TypeTag, K2: TypeTag, V: TypeTag]

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -693,7 +693,7 @@ class ALSSuite
       1 -> Array(Row(3, 39f), Row(5, 33f)),
       2 -> Array(Row(3, 51f), Row(5, 45f))
     )
-    checkRecommendations(topItems, expected)
+    checkRecommendations(topItems, expected, "item")
   }
 
   test("recommendForAllUsers with k = num_items") {
@@ -706,7 +706,7 @@ class ALSSuite
       1 -> Array(Row(3, 39f), Row(5, 33f), Row(4, 26f), Row(6, 16f)),
       2 -> Array(Row(3, 51f), Row(5, 45f), Row(4, 30f), Row(6, 18f))
     )
-    checkRecommendations(topItems, expected)
+    checkRecommendations(topItems, expected, "item")
   }
 
   test("recommendForAllItems with k < num_users") {
@@ -720,7 +720,7 @@ class ALSSuite
       5 -> Array(Row(2, 45f), Row(0, 42f)),
       6 -> Array(Row(0, 28f), Row(2, 18f))
     )
-    checkRecommendations(topUsers, expected)
+    checkRecommendations(topUsers, expected, "user")
   }
 
   test("recommendForAllItems with k = num_users") {
@@ -734,15 +734,20 @@ class ALSSuite
       5 -> Array(Row(2, 45f), Row(0, 42f), Row(1, 33f)),
       6 -> Array(Row(0, 28f), Row(2, 18f), Row(1, 16f))
     )
-    checkRecommendations(topUsers, expected)
+    checkRecommendations(topUsers, expected, "user")
   }
 
-  private def checkRecommendations(topK: DataFrame, expected: Map[Int, Array[Row]]): Unit = {
+  private def checkRecommendations(
+      topK: DataFrame,
+      expected: Map[Int, Array[Row]],
+      dstColName: String): Unit = {
     assert(topK.columns.contains("recommendations"))
     topK.collect().foreach { row =>
       val id = row.getInt(0)
       val recs = row.getAs[WrappedArray[Row]]("recommendations")
       assert(recs === expected(id))
+      assert(recs(0).fieldIndex(dstColName) == 0)
+      assert(recs(0).fieldIndex("rating") == 1)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -368,7 +368,7 @@ class ALSSuite
       implicitPrefs: Boolean = false,
       numUserBlocks: Int = 2,
       numItemBlocks: Int = 3,
-      targetRMSE: Double = 0.05): ALSModel = {
+      targetRMSE: Double = 0.05): Unit = {
     val spark = this.spark
     import spark.implicits._
     val als = new ALS()
@@ -411,8 +411,6 @@ class ALSSuite
 
     // copied model must have the same parent.
     MLTestingUtils.checkCopy(model)
-
-    model
   }
 
   test("exact rank-1 matrix") {

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/TopByKeyAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/TopByKeyAggregatorSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.recommendation
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.sql.Dataset
+
+
+class TopByKeyAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  private def getTopK(k: Int): Dataset[(Int, Array[(Int, Float)])] = {
+    val sqlContext = spark.sqlContext
+    import sqlContext.implicits._
+
+    val topKAggregator = new TopByKeyAggregator[Int, Int, Float](k, Ordering.by(_._2))
+    Seq(
+      (0, 3, 54f),
+      (0, 4, 44f),
+      (0, 5, 42f),
+      (0, 6, 28f),
+      (1, 3, 39f),
+      (1, 4, 26f),
+      (1, 5, 33f),
+      (1, 6, 16f),
+      (2, 3, 51f),
+      (2, 4, 30f),
+      (2, 5, 45f),
+      (2, 6, 18f)
+    ).toDS().groupByKey(_._1).agg(topKAggregator.toColumn)
+  }
+
+  test("topByKey with k < #items") {
+    val topK = getTopK(2)
+    assert(topK.count() === 3)
+
+    val expected = Map(
+      0 -> Array((3, 54f), (4, 44f)),
+      1 -> Array((3, 39f), (5, 33f)),
+      2 -> Array((3, 51f), (5, 45f))
+    )
+    checkTopK(topK, expected)
+  }
+
+  test("topByKey with k > #items") {
+    val topK = getTopK(5)
+    assert(topK.count() === 3)
+
+    val expected = Map(
+      0 -> Array((3, 54f), (4, 44f), (5, 42f), (6, 28f)),
+      1 -> Array((3, 39f), (5, 33f), (4, 26f), (6, 16f)),
+      2 -> Array((3, 51f), (5, 45f), (4, 30f), (6, 18f))
+    )
+    checkTopK(topK, expected)
+  }
+
+  private def checkTopK(
+      topK: Dataset[(Int, Array[(Int, Float)])],
+      expected: Map[Int, Array[(Int, Float)]]): Unit = {
+    topK.collect().foreach { record =>
+      val id = record._1
+      val recs = record._2
+      assert(recs === expected(id))
+    }
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/TopByKeyAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/TopByKeyAggregatorSuite.scala
@@ -35,11 +35,7 @@ class TopByKeyAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
       (0, 5, 42f),
       (0, 6, 28f),
       (1, 3, 39f),
-      (1, 4, 26f),
-      (1, 5, 33f),
-      (1, 6, 16f),
       (2, 3, 51f),
-      (2, 4, 30f),
       (2, 5, 45f),
       (2, 6, 18f)
     ).toDS().groupByKey(_._1).agg(topKAggregator.toColumn)
@@ -51,7 +47,7 @@ class TopByKeyAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val expected = Map(
       0 -> Array((3, 54f), (4, 44f)),
-      1 -> Array((3, 39f), (5, 33f)),
+      1 -> Array((3, 39f)),
       2 -> Array((3, 51f), (5, 45f))
     )
     checkTopK(topK, expected)
@@ -63,8 +59,8 @@ class TopByKeyAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val expected = Map(
       0 -> Array((3, 54f), (4, 44f), (5, 42f), (6, 28f)),
-      1 -> Array((3, 39f), (5, 33f), (4, 26f), (6, 16f)),
-      2 -> Array((3, 51f), (5, 45f), (4, 30f), (6, 18f))
+      1 -> Array((3, 39f)),
+      2 -> Array((3, 51f), (5, 45f), (6, 18f))
     )
     checkTopK(topK, expected)
   }
@@ -72,10 +68,6 @@ class TopByKeyAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
   private def checkTopK(
       topK: Dataset[(Int, Array[(Int, Float)])],
       expected: Map[Int, Array[(Int, Float)]]): Unit = {
-    topK.collect().foreach { record =>
-      val id = record._1
-      val recs = record._2
-      assert(recs === expected(id))
-    }
+    topK.collect().foreach { case (id, recs) => assert(recs === expected(id)) }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a simple implementation of RecommendForAllUsers & RecommendForAllItems for the Dataframe version of ALS. It uses Dataframe operations (not a wrapper on the RDD implementation). Haven't benchmarked against a wrapper, but unit test examples do work.

## How was this patch tested?

Unit tests
```
$ build/sbt
> mllib/testOnly *ALSSuite -- -z "recommendFor"
> mllib/testOnly
```
