### PR TITLE
[SPARK-19773][SparkR] SparkDataFrame should not allow duplicate names

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -50,7 +50,7 @@ setClass("SparkDataFrame",
 # Validate "SparkDataFrame"
 # SparkDataFrame should not allow duplicate column names
 validSparkDataFrame <- function(object) {
-  cols <- colnames
+  cols <- colnames(object)
   if (length(cols) != length(unique(cols))) {
     stop("Duplicate column names.")
   } else {
@@ -65,6 +65,7 @@ setMethod("initialize", "SparkDataFrame", function(.Object, sdf, isCached) {
   .Object@env$isCached <- isCached
 
   .Object@sdf <- sdf
+  validObject(.Object)
   .Object
 })
 

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -47,6 +47,19 @@ setClass("SparkDataFrame",
          slots = list(env = "environment",
                       sdf = "jobj"))
 
+# Validate "SparkDataFrame"
+# SparkDataFrame should not allow duplicate column names
+validSparkDataFrame <- function(object) {
+  cols <- colnames
+  if (length(cols) != length(unique(cols))) {
+    stop("Duplicate column names.")
+  } else {
+    TRUE
+  }
+}
+
+setValidity("SparkDataFrame", validSparkDataFrame)
+
 setMethod("initialize", "SparkDataFrame", function(.Object, sdf, isCached) {
   .Object@env <- new.env()
   .Object@env$isCached <- isCached
@@ -366,6 +379,7 @@ setMethod("colnames<-",
               stop("Column names cannot contain the '.' symbol.")
             }
 
+            
             sdf <- callJMethod(x@sdf, "toDF", as.list(value))
             dataFrame(sdf)
           })

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -380,7 +380,6 @@ setMethod("colnames<-",
               stop("Column names cannot contain the '.' symbol.")
             }
 
-            
             sdf <- callJMethod(x@sdf, "toDF", as.list(value))
             dataFrame(sdf)
           })

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -400,6 +400,13 @@ test_that("create DataFrame from list or data.frame", {
   bytes <- as.raw(c(1, 2, 3))
   df <- createDataFrame(list(list(bytes)))
   expect_equal(collect(df)[[1]][[1]], bytes)
+
+  # check for duplicate names
+  l <- list(list(1, 2), list(3, 4))
+  expect_error(createDataFrame(l, c("a", "a")), "Duplicate column names.")
+  df <- createDataFrame(l, c("a", "b"))
+  expect_error(names(df)[2] <- "a", "Duplicate column names.")
+
 })
 
 test_that("create DataFrame with different data types", {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SparkDataFrame in SparkR seems to accept duplicate names at creation, but incurs error when calling methods downstream. For example, we can do: 
```
l <- list(list(1, 2), list(3, 4))
df <- createDataFrame(l, c("a", "a"))
head(df)
```
But an error occurs when we do `df$a = df$a * 2.0`.

In this PR, I add validity check for duplicate names at initialization. 

## How was this patch tested?
new tests.