### PR TITLE
[SPARK-19784][SQL][WIP]refresh table after alter the location

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -754,6 +754,8 @@ case class AlterTableSetLocationCommand(
         // No partition spec is specified, so we set the location for the table itself
         catalog.alterTable(table.withNewStorage(locationUri = Some(location)))
     }
+
+    sparkSession.catalog.refreshTable(table.identifier.table)
     Seq.empty[Row]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -755,9 +755,7 @@ case class AlterTableSetLocationCommand(
         catalog.alterTable(table.withNewStorage(locationUri = Some(location)))
     }
 
-    if (DDLUtils.isDatasourceTable(table)) {
-      sparkSession.catalog.refreshTable(table.identifier.table)
-    }
+    sparkSession.sessionState.catalog.refreshTable(table.identifier)
     Seq.empty[Row]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -755,7 +755,9 @@ case class AlterTableSetLocationCommand(
         catalog.alterTable(table.withNewStorage(locationUri = Some(location)))
     }
 
-    sparkSession.catalog.refreshTable(table.identifier.table)
+    if (DDLUtils.isDatasourceTable(table)) {
+      sparkSession.catalog.refreshTable(table.identifier.table)
+    }
     Seq.empty[Row]
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1588,7 +1588,7 @@ class HiveDDLSuite
     }
   }
 
-  test("refresh table after alter the location") {
+  test("refresh non-cached table after alter the location") {
     withTable("t", "t1", "t2", "t3") {
       withTempDir { dir =>
         spark.sql(
@@ -1596,7 +1596,6 @@ class HiveDDLSuite
             |CREATE TABLE t(a string)
             |USING parquet
           """.stripMargin)
-
         spark.sql("INSERT INTO TABLE t SELECT 1")
         checkAnswer(spark.table("t"), Row("1") :: Nil)
         spark.sql(s"ALTER TABLE t SET LOCATION '$dir'")
@@ -1610,13 +1609,11 @@ class HiveDDLSuite
             |USING parquet
             |PARTITIONED BY(b)
           """.stripMargin)
-
         spark.sql("INSERT INTO TABLE t1  PARTITION(b=1) SELECT 2")
         checkAnswer(spark.table("t1"), Row("2", "1") :: Nil)
         spark.sql(s"ALTER TABLE t1 PARTITION(b=1)SET LOCATION '$dir'")
         checkAnswer(spark.table("t1"), Nil)
       }
-
 
       withTempDir { dir =>
         spark.sql(
@@ -1624,7 +1621,6 @@ class HiveDDLSuite
             |CREATE TABLE t2(a string)
             |USING hive
           """.stripMargin)
-
         spark.sql("INSERT INTO TABLE t2 SELECT 1")
         checkAnswer(spark.table("t2"), Row("1") :: Nil)
         spark.sql(s"ALTER TABLE t2 SET LOCATION '$dir'")
@@ -1638,7 +1634,6 @@ class HiveDDLSuite
             |USING hive
             |PARTITIONED BY(b)
           """.stripMargin)
-
         spark.sql("INSERT INTO TABLE t3  PARTITION(b=1) SELECT 2")
         checkAnswer(spark.table("t3"), Row("2", "1") :: Nil)
         spark.sql(s"ALTER TABLE t3 PARTITION(b=1)SET LOCATION '$dir'")


### PR DESCRIPTION
## What changes were proposed in this pull request?
currently if we alter the location of a table, there are two situations that is not we expected.
1. we select from it from datasource table, it still return the data of the old location, because cached `tableRelation` still has the old location.
2. if the table data is cached before alter the location for both datasource/hive tables, it will return the cached data.

## How was this patch tested?
unit test added