### PR TITLE
[SPARK-19805][TEST] Log the row type when query result dose not match

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -313,12 +313,12 @@ object QueryTest {
       isSorted: Boolean = false): Option[String] = {
     if (prepareAnswer(expectedAnswer, isSorted) != prepareAnswer(sparkAnswer, isSorted)) {
       val getRowType: Option[Row] => String = row =>
-        "RowType" + row.map(row =>
+        row.map(row =>
             if (row.schema == null) {
-              "[]"
+              "struct<>"
             } else {
-              s"[${row.schema.fields.map(_.dataType.typeName).mkString(",")}]"
-            }).getOrElse("[]")
+                s"${row.schema.catalogString}"
+            }).getOrElse("struct<>")
 
       val errorMessage =
         s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -312,13 +312,23 @@ object QueryTest {
       sparkAnswer: Seq[Row],
       isSorted: Boolean = false): Option[String] = {
     if (prepareAnswer(expectedAnswer, isSorted) != prepareAnswer(sparkAnswer, isSorted)) {
+      val expectedAnswerType = "RowType" + expectedAnswer.headOption
+        .map(row => s"[${row.schema.fields.map(_.dataType.typeName).mkString(",")}]")
+        .getOrElse("[]")
+
+      val sparkAnswerType = "RowType" + sparkAnswer.headOption
+        .map(row => s"[${row.schema.fields.map(_.dataType.typeName).mkString(",")}]")
+        .getOrElse("[]")
+
       val errorMessage =
         s"""
          |== Results ==
          |${sideBySide(
         s"== Correct Answer - ${expectedAnswer.size} ==" +:
+         expectedAnswerType +:
          prepareAnswer(expectedAnswer, isSorted).map(_.toString()),
         s"== Spark Answer - ${sparkAnswer.size} ==" +:
+         sparkAnswerType +:
          prepareAnswer(sparkAnswer, isSorted).map(_.toString())).mkString("\n")}
         """.stripMargin
       return Some(errorMessage)

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -312,23 +312,23 @@ object QueryTest {
       sparkAnswer: Seq[Row],
       isSorted: Boolean = false): Option[String] = {
     if (prepareAnswer(expectedAnswer, isSorted) != prepareAnswer(sparkAnswer, isSorted)) {
-      val expectedAnswerType = "RowType" + expectedAnswer.headOption
-        .map(row => s"[${row.schema.fields.map(_.dataType.typeName).mkString(",")}]")
-        .getOrElse("[]")
-
-      val sparkAnswerType = "RowType" + sparkAnswer.headOption
-        .map(row => s"[${row.schema.fields.map(_.dataType.typeName).mkString(",")}]")
-        .getOrElse("[]")
+      val getRowType: Option[Row] => String = row =>
+        "RowType" + row.map(row =>
+            if (row.schema == null) {
+              "[]"
+            } else {
+              s"[${row.schema.fields.map(_.dataType.typeName).mkString(",")}]"
+            }).getOrElse("[]")
 
       val errorMessage =
         s"""
          |== Results ==
          |${sideBySide(
         s"== Correct Answer - ${expectedAnswer.size} ==" +:
-         expectedAnswerType +:
+         getRowType(expectedAnswer.headOption) +:
          prepareAnswer(expectedAnswer, isSorted).map(_.toString()),
         s"== Spark Answer - ${sparkAnswer.size} ==" +:
-         sparkAnswerType +:
+         getRowType(sparkAnswer.headOption) +:
          prepareAnswer(sparkAnswer, isSorted).map(_.toString())).mkString("\n")}
         """.stripMargin
       return Some(errorMessage)


### PR DESCRIPTION
## What changes were proposed in this pull request?

improve the log message when query result does not match.

before pr:

```
== Results ==
!== Correct Answer - 3 ==   == Spark Answer - 3 ==
 [1]                        [1]
 [2]                        [2]
 [3]                        [3]

```

after pr:

~~== Results ==
!== Correct Answer - 3 ==   == Spark Answer - 3 ==
!RowType[string]            RowType[integer]
 [1]                        [1]
 [2]                        [2]
 [3]                        [3]~~

```
== Results ==
!== Correct Answer - 3 ==   == Spark Answer - 3 ==
!struct<value:string>       struct<value:int>
 [1]                        [1]
 [2]                        [2]
 [3]                        [3]
```

## How was this patch tested?

Jenkins
