### PR TITLE
[SPARK-19815][SQL] Not orderable should be applied to right key instead of left key

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -170,7 +170,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
          if !conf.preferSortMergeJoin && canBuildRight(joinType) && canBuildLocalHashMap(right)
            && muchSmaller(right, left) ||
-           !RowOrdering.isOrderable(leftKeys) =>
+           !RowOrdering.isOrderable(rightKeys) =>
         Seq(joins.ShuffledHashJoinExec(
           leftKeys, rightKeys, joinType, BuildRight, condition, planLater(left), planLater(right)))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the orderable condition.

## How was this patch tested?
Relies on existing test.

Please review http://spark.apache.org/contributing.html before opening a pull request.
