### PR TITLE
[SPARK-19818][SparkR] rbind should check for name consistency of input data frames

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2642,6 +2642,7 @@ generateAliasesForIntersectedCols <- function (x, intersectedColNames, suffix) {
 #'
 #' Return a new SparkDataFrame containing the union of rows in this SparkDataFrame
 #' and another SparkDataFrame. This is equivalent to \code{UNION ALL} in SQL.
+#' Input SparkDataFrames can have different schemas (names and data types).
 #'
 #' Note: This does not remove duplicate rows across the two SparkDataFrames.
 #'
@@ -2685,7 +2686,8 @@ setMethod("unionAll",
 
 #' Union two or more SparkDataFrames
 #'
-#' Union two or more SparkDataFrames. This is equivalent to \code{UNION ALL} in SQL.
+#' Union two or more SparkDataFrames by row. In constrast with \link{union}, this method
+#' requires that the SparkDataFrames to be unioned have the same column names.
 #'
 #' Note: This does not remove duplicate rows across the two SparkDataFrames.
 #'
@@ -2712,7 +2714,7 @@ setMethod("rbind",
             nm <- lapply(list(x, ...), names)
             if (!isTRUE(Reduce(all.equal, nm))) {
               stop("Names of input data frames are different.")
-            }            
+            }
             if (nargs() == 3) {
               union(x, ...)
             } else {

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2686,7 +2686,7 @@ setMethod("unionAll",
 
 #' Union two or more SparkDataFrames
 #'
-#' Union two or more SparkDataFrames by row. In constrast to \link{union}, this method
+#' Union two or more SparkDataFrames by row. As in R's \code{rbind}, this method
 #' requires that the input SparkDataFrames have the same column names.
 #'
 #' Note: This does not remove duplicate rows across the two SparkDataFrames.

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2686,8 +2686,8 @@ setMethod("unionAll",
 
 #' Union two or more SparkDataFrames
 #'
-#' Union two or more SparkDataFrames by row. In constrast with \link{union}, this method
-#' requires that the SparkDataFrames to be unioned have the same column names.
+#' Union two or more SparkDataFrames by row. In constrast to \link{union}, this method
+#' requires that the input SparkDataFrames have the same column names.
 #'
 #' Note: This does not remove duplicate rows across the two SparkDataFrames.
 #'

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2712,7 +2712,7 @@ setMethod("rbind",
           signature(... = "SparkDataFrame"),
           function(x, ..., deparse.level = 1) {
             nm <- lapply(list(x, ...), names)
-            if (!isTRUE(Reduce(all.equal, nm))) {
+            if (length(unique(nm)) != 1) {
               stop("Names of input data frames are different.")
             }
             if (nargs() == 3) {

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2666,7 +2666,7 @@ generateAliasesForIntersectedCols <- function (x, intersectedColNames, suffix) {
 setMethod("union",
           signature(x = "SparkDataFrame", y = "SparkDataFrame"),
           function(x, y) {
-            if (!all.equal(names(x), names(y))){
+            if (!isTRUE(all.equal(names(x), names(y)))) {
               stop("Names of input data frames are different.")
             }
             unioned <- callJMethod(x@sdf, "union", y@sdf)

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2666,6 +2666,9 @@ generateAliasesForIntersectedCols <- function (x, intersectedColNames, suffix) {
 setMethod("union",
           signature(x = "SparkDataFrame", y = "SparkDataFrame"),
           function(x, y) {
+            if (!all.equal(names(x), names(y))){
+              stop("Names of input data frames are different.")
+            }
             unioned <- callJMethod(x@sdf, "union", y@sdf)
             dataFrame(unioned)
           })

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -2666,9 +2666,6 @@ generateAliasesForIntersectedCols <- function (x, intersectedColNames, suffix) {
 setMethod("union",
           signature(x = "SparkDataFrame", y = "SparkDataFrame"),
           function(x, y) {
-            if (!isTRUE(all.equal(names(x), names(y)))) {
-              stop("Names of input data frames are different.")
-            }
             unioned <- callJMethod(x@sdf, "union", y@sdf)
             dataFrame(unioned)
           })
@@ -2712,6 +2709,10 @@ setMethod("unionAll",
 setMethod("rbind",
           signature(... = "SparkDataFrame"),
           function(x, ..., deparse.level = 1) {
+            nm <- lapply(list(x, ...), names)
+            if (!isTRUE(Reduce(all.equal, nm))) {
+              stop("Names of input data frames are different.")
+            }            
             if (nargs() == 3) {
               union(x, ...)
             } else {

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1822,7 +1822,7 @@ test_that("union(), rbind(), except(), and intersect() on a DataFrame", {
   expect_equal(count(excepted), 2)
   expect_equal(first(excepted)$name, "Justin")
 
-  expected_error(union(df, df2[, c(2, 1)]),
+  expect_error(union(df, df2[, c(2, 1)]),
                  "Names of input data frames are different.")
 
   intersected <- arrange(intersect(df, df2), df$age)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1817,13 +1817,17 @@ test_that("union(), rbind(), except(), and intersect() on a DataFrame", {
   expect_equal(count(unioned2), 12)
   expect_equal(first(unioned2)$name, "Michael")
 
+  df3 <- df2
+  names(df3)[1] <- "newName"
+  expect_error(union(df, df3),
+               "Names of input data frames are different.")
+  expect_error(union(df, df2, df3),
+               "Names of input data frames are different.")
+
   excepted <- arrange(except(df, df2), desc(df$age))
   expect_is(unioned, "SparkDataFrame")
   expect_equal(count(excepted), 2)
   expect_equal(first(excepted)$name, "Justin")
-
-  expect_error(union(df, df2[, c(2, 1)]),
-                 "Names of input data frames are different.")
 
   intersected <- arrange(intersect(df, df2), df$age)
   expect_is(unioned, "SparkDataFrame")

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1819,9 +1819,9 @@ test_that("union(), rbind(), except(), and intersect() on a DataFrame", {
 
   df3 <- df2
   names(df3)[1] <- "newName"
-  expect_error(union(df, df3),
+  expect_error(rbind(df, df3),
                "Names of input data frames are different.")
-  expect_error(union(df, df2, df3),
+  expect_error(rbind(df, df2, df3),
                "Names of input data frames are different.")
 
   excepted <- arrange(except(df, df2), desc(df$age))

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1822,6 +1822,9 @@ test_that("union(), rbind(), except(), and intersect() on a DataFrame", {
   expect_equal(count(excepted), 2)
   expect_equal(first(excepted)$name, "Justin")
 
+  expected_error(union(df, df2[, c(2, 1)]),
+                 "Names of input data frames are different.")
+
   intersected <- arrange(intersect(df, df2), df$age)
   expect_is(unioned, "SparkDataFrame")
   expect_equal(count(intersected), 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added checks for name consistency of input data frames in union. 

## How was this patch tested?
new test. 