### PR TITLE
[SPARK-19737][SQL] New analysis rule for reporting unregistered functions without relying on relation resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1052,13 +1052,10 @@ class Analyzer(
    */
   object LookupFunctions extends Rule[LogicalPlan] {
     override def apply(plan: LogicalPlan): LogicalPlan = plan.transformAllExpressions {
-      case f: UnresolvedFunction =>
+      case f: UnresolvedFunction if !catalog.functionExists(f.name) =>
         withPosition(f) {
-          if (!catalog.functionExists(f.name)) {
-            throw new AnalysisException(s"undefined function ${f.name}")
-          }
+          throw new NoSuchFunctionException(f.name.database.getOrElse("default"), f.name.funcName)
         }
-        f
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -117,6 +117,8 @@ class Analyzer(
     Batch("Hints", fixedPoint,
       new ResolveHints.ResolveBroadcastHints(conf),
       ResolveHints.RemoveAllHints),
+    Batch("Simple Sanity Check", Once,
+      LookupFunctions),
     Batch("Substitution", fixedPoint,
       CTESubstitution,
       WindowsSubstitution,
@@ -1035,6 +1037,28 @@ class Analyzer(
           case other => resolved
         }
       }
+    }
+  }
+
+  /**
+   * Checks whether a function identifier referenced by an [[UnresolvedFunction]] is defined in the
+   * function registry. Note that this rule doesn't try to resolve the [[UnresolvedFunction]]. It
+   * only performs simple existence check according to the function identifier to quickly identify
+   * undefined functions without triggering relation resolution, which may incur potentially
+   * expensive partition/schema discovery process in some cases.
+   *
+   * @see [[ResolveFunctions]]
+   * @see https://issues.apache.org/jira/browse/SPARK-19737
+   */
+  object LookupFunctions extends Rule[LogicalPlan] {
+    override def apply(plan: LogicalPlan): LogicalPlan = plan.transformAllExpressions {
+      case f: UnresolvedFunction =>
+        withPosition(f) {
+          if (!catalog.functionExists(f.name)) {
+            throw new AnalysisException(s"undefined function ${f.name}")
+          }
+        }
+        f
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.analysis
 import scala.beans.{BeanInfo, BeanProperty}
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
@@ -393,14 +392,6 @@ class AnalysisErrorSuite extends AnalysisTest {
     "more than one generators in SELECT",
     listRelation.select(Explode('list), Explode('list)),
     "Only one generator allowed per select clause but found 2: explode(list), explode(list)" :: Nil
-  )
-
-  errorTest(
-    "SPARK-19737: detect undefined functions without triggering relation resolution",
-    UnresolvedRelation(TableIdentifier("unknown")).select(
-      UnresolvedFunction("foo", Nil, isDistinct = false)
-    ),
-    "undefined function foo" :: Nil
   )
 
   test("SPARK-6452 regression test") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import scala.beans.{BeanInfo, BeanProperty}
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
@@ -392,6 +393,14 @@ class AnalysisErrorSuite extends AnalysisTest {
     "more than one generators in SELECT",
     listRelation.select(Explode('list), Explode('list)),
     "Only one generator allowed per select clause but found 2: explode(list), explode(list)" :: Nil
+  )
+
+  errorTest(
+    "SPARK-19737: detect undefined functions without triggering relation resolution",
+    UnresolvedRelation(TableIdentifier("unknown")).select(
+      UnresolvedFunction("foo", Nil, isDistinct = false)
+    ),
+    "undefined function foo" :: Nil
   )
 
   test("SPARK-6452 regression test") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1209,12 +1209,12 @@ class SessionCatalogSuite extends PlanTest {
       val cause = intercept[AnalysisException] {
         analyzer.execute(
           UnresolvedRelation(TableIdentifier("undefined_table")).select(
-            UnresolvedFunction("undefine_fn", Nil, isDistinct = false)
+            UnresolvedFunction("undefined_fn", Nil, isDistinct = false)
           )
         )
       }
 
-      assert(cause.getMessage.contains("undefined function undefined_fn"))
+      assert(cause.getMessage.contains("Undefined function: 'undefined_fn'"))
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1205,15 +1205,16 @@ class SessionCatalogSuite extends PlanTest {
       val catalog = new SessionCatalog(newBasicCatalog(), new SimpleFunctionRegistry, conf)
       val analyzer = new Analyzer(catalog, conf)
 
+      // The analyzer should report the undefined function rather than the undefined table first.
       val cause = intercept[AnalysisException] {
         analyzer.execute(
-          UnresolvedRelation(TableIdentifier("unknown")).select(
-            UnresolvedFunction("foo", Nil, isDistinct = false)
+          UnresolvedRelation(TableIdentifier("undefined_table")).select(
+            UnresolvedFunction("undefine_fn", Nil, isDistinct = false)
           )
         )
       }
 
-      assert(cause.getMessage.contains("undefined function foo"))
+      assert(cause.getMessage.contains("undefined function undefined_fn"))
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -199,6 +199,11 @@ private[sql] class HiveSessionCatalog(
     }
   }
 
+  // TODO Removes this method after implementing Spark native "histogram_numeric".
+  override def functionExists(name: FunctionIdentifier): Boolean = {
+    super.functionExists(name) || hiveFunctions.contains(name.funcName)
+  }
+
   /** List of functions we pass over to Hive. Note that over time this list should go to 0. */
   // We have a list of Hive built-in functions that we do not support. So, we will check
   // Hive's function registry and lazily load needed functions into our own function registry.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a new `Once` analysis rule batch consists of a single analysis rule `LookupFunctions` that performs simple existence check over `UnresolvedFunctions` without actually resolving them.

The benefit of this rule is that it doesn't require function arguments to be resolved first and therefore doesn't rely on relation resolution, which may incur potentially expensive partition/schema discovery cost.

Please refer to [SPARK-19737][1] for more details about the motivation.

## How was this patch tested?

New test case added in `AnalysisErrorSuite`.

[1]: https://issues.apache.org/jira/browse/SPARK-19737