### PR TITLE
[SPARK-19824][Core] Standalone master JSON not showing cores for running applications

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -44,7 +44,7 @@ private[deploy] object JsonProtocol {
     ("starttime" -> obj.startTime) ~
     ("id" -> obj.id) ~
     ("name" -> obj.desc.name) ~
-    ("cores" -> obj.desc.maxCores) ~
+    ("cores" -> obj.coresGranted) ~
     ("user" -> obj.desc.user) ~
     ("memoryperslave" -> obj.desc.memoryPerExecutorMB) ~
     ("submitdate" -> obj.submitDate.toString) ~


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fix tries to address the issue raised in SPARK-19824 where
the JSON API of the standalone master ("/json") does not show
the number of cores for a running (active) application, which is
available on the master UI.

The reason was that in master UI, `coresGranted` was used:
https://github.com/apache/spark/blob/v2.1.0/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala#L220
while in JSON API, the `desc.maxCores` was used. In case
there is no limit on `maxCores`, this filed will be missing on
JSON API. (Master UI show cores granted so the field is always available).

This fix address the discrepancy by changing JSON API to use
`coredGranted` so that UI and JSON API are consistent.

## How was this patch tested?

The test was done manually.

Please review http://spark.apache.org/contributing.html before opening a pull request.
