### PR TITLE
[SPARK-19840][SQL] Disallow creating permanent functions with invalid class names

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1937,19 +1937,6 @@ class SQLTests(ReusedPySparkTestCase):
             className="org.apache.spark.sql.catalyst.expressions.Add",
             isTemporary=True))
         self.assertEquals(functions, functionsDefault)
-        spark.catalog.registerFunction("temp_func", lambda x: str(x))
-        spark.sql("CREATE FUNCTION func1 AS 'org.apache.spark.data.bricks'")
-        spark.sql("CREATE FUNCTION some_db.func2 AS 'org.apache.spark.data.bricks'")
-        newFunctions = dict((f.name, f) for f in spark.catalog.listFunctions())
-        newFunctionsSomeDb = dict((f.name, f) for f in spark.catalog.listFunctions("some_db"))
-        self.assertTrue(set(functions).issubset(set(newFunctions)))
-        self.assertTrue(set(functions).issubset(set(newFunctionsSomeDb)))
-        self.assertTrue("temp_func" in newFunctions)
-        self.assertTrue("func1" in newFunctions)
-        self.assertTrue("func2" not in newFunctions)
-        self.assertTrue("temp_func" in newFunctionsSomeDb)
-        self.assertTrue("func1" not in newFunctionsSomeDb)
-        self.assertTrue("func2" in newFunctionsSomeDb)
         self.assertRaisesRegexp(
             AnalysisException,
             "does_not_exist",
@@ -2353,6 +2340,27 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
             self.assertTrue(range_frame_match())
 
         importlib.reload(window)
+
+    def test_list_functions(self):
+        from pyspark.sql.catalog import Function
+        spark = self.spark
+        catalog = spark.sparkSession.catalog
+        catalog._reset()
+        spark.sql("CREATE DATABASE some_db")
+        functions = dict((f.name, f) for f in catalog.listFunctions())
+        catalog.registerFunction("temp_func", lambda x: str(x))
+        spark.sql("CREATE FUNCTION func1 AS 'java.lang.Integer'")
+        spark.sql("CREATE FUNCTION some_db.func2 AS 'java.lang.Integer'")
+        newFunctions = dict((f.name, f) for f in catalog.listFunctions())
+        newFunctionsSomeDb = dict((f.name, f) for f in catalog.listFunctions("some_db"))
+        self.assertTrue(set(functions).issubset(set(newFunctions)))
+        self.assertTrue(set(functions).issubset(set(newFunctionsSomeDb)))
+        self.assertTrue("temp_func" in newFunctions)
+        self.assertTrue("func1" in newFunctions)
+        self.assertTrue("func2" not in newFunctions)
+        self.assertTrue("temp_func" in newFunctionsSomeDb)
+        self.assertTrue("func1" not in newFunctionsSomeDb)
+        self.assertTrue("func2" in newFunctionsSomeDb)
 
 if __name__ == "__main__":
     from pyspark.sql.tests import *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -63,7 +63,10 @@ case class CreateFunctionCommand(
     } else {
       // For a permanent, we will store the metadata into underlying external catalog.
       // This function will be loaded into the FunctionRegistry when a query uses it.
-      // We do not load it into FunctionRegistry right now.
+      // We do not load it into FunctionRegistry right now. However, we need to validate.
+      catalog.loadFunctionResources(resources)
+      catalog.makeFunctionBuilder(functionName, className)
+
       // TODO: should we also parse "IF NOT EXISTS"?
       catalog.createFunction(
         CatalogFunction(FunctionIdentifier(functionName, databaseName), className, resources),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -137,7 +137,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
-  test("Disallow creating permanent functions with invalid class names") {
+  test("SPARK-19840: Disallow creating permanent functions with invalid class names") {
     val e = intercept[ClassNotFoundException] {
       sql("CREATE FUNCTION function_with_invalid_classname AS 'org.invalid'")
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -137,6 +137,13 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
+  test("Disallow creating permanent functions with invalid class names") {
+    val e = intercept[ClassNotFoundException] {
+      sql("CREATE FUNCTION function_with_invalid_classname AS 'org.invalid'")
+    }
+    assert(e.getMessage().contains("org.invalid"))
+  }
+
   test("SPARK-6835: udtf in lateral view") {
     val df = Seq((1, 1)).toDF("c1", "c2")
     df.createOrReplaceTempView("table1")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark raises exceptions on creating invalid **temporary** functions, but doesn't for creating **permanent** functions. This makes a weird situation like the following; users can see the function with `SHOW FUNCTIONS` or `DESC FUNCTION`, but they also see `Undefined function` errors. This PR aims to disallow creating permanent functions with invalid class names. This will prevent the typos in JAR file names at `USING JAR` syntax, too. After this PR, `CREATE FUNCTION` and `CREATE TEMPORARY FUNCTION` will show `ClassNotFoundException` exceptions consistently for these cases.

**BEFORE**
```scala
scala> sql("CREATE TEMPORARY FUNCTION function_with_invalid_classname AS 'org.invalid'").show
java.lang.ClassNotFoundException: org.invalid at 
...

scala> sql("CREATE FUNCTION function_with_invalid_classname AS 'org.invalid'").show
++
||
++
++

scala> sql("SHOW FUNCTIONS LIKE 'function_*'").show(false)
+---------------------------------------+
|function                               |
+---------------------------------------+
|default.function_with_invalid_classname|
+---------------------------------------+

scala> sql("DESC FUNCTION function_with_invalid_classname").show(false)
+-------------------------------------------------+
|function_desc                                    |
+-------------------------------------------------+
|Function: default.function_with_invalid_classname|
|Class: org.invalid                               |
|Usage: N/A.                                      |
+-------------------------------------------------+

scala> sql("SELECT function_with_invalid_classname()").show
org.apache.spark.sql.AnalysisException: Undefined function: 'function_with_invalid_classname'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.; line 1 pos 7
```

**AFTER**
```scala
scala> sql("CREATE FUNCTION function_with_invalid_classname AS 'org.invalid'").show
java.lang.ClassNotFoundException: org.invalid
```

## How was this patch tested?

Pass Jenkins tests with a new test case.