### PR TITLE
[SPARK-19751][SQL] Throw an exception if bean class has one's own class in fields

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -123,6 +123,10 @@ object JavaTypeInference {
         val properties = getJavaBeanReadableProperties(other)
         val fields = properties.map { property =>
           val returnType = typeToken.method(property.getReadMethod).getReturnType
+          if (other == returnType.getRawType) {
+            throw new UnsupportedOperationException(
+              s"Cannot use one's own class in the fields of class ${other.getName}")
+          }
           val (dataType, nullable) = inferDataType(returnType)
           new StructField(property.getName, dataType, nullable)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -105,17 +105,17 @@ object JavaTypeInference {
       case c: Class[_] if c == classOf[java.sql.Timestamp] => (TimestampType, true)
 
       case _ if typeToken.isArray =>
-        val (dataType, nullable) = inferDataType(typeToken.getComponentType)
+        val (dataType, nullable) = inferDataType(typeToken.getComponentType, seenTypeSet)
         (ArrayType(dataType, nullable), true)
 
       case _ if iterableType.isAssignableFrom(typeToken) =>
-        val (dataType, nullable) = inferDataType(elementType(typeToken))
+        val (dataType, nullable) = inferDataType(elementType(typeToken), seenTypeSet)
         (ArrayType(dataType, nullable), true)
 
       case _ if mapType.isAssignableFrom(typeToken) =>
         val (keyType, valueType) = mapKeyValueType(typeToken)
-        val (keyDataType, _) = inferDataType(keyType)
-        val (valueDataType, nullable) = inferDataType(valueType)
+        val (keyDataType, _) = inferDataType(keyType, seenTypeSet)
+        val (valueDataType, nullable) = inferDataType(valueType, seenTypeSet)
         (MapType(keyDataType, valueDataType, nullable), true)
 
       case other =>
@@ -124,16 +124,39 @@ object JavaTypeInference {
         val properties = getJavaBeanReadableProperties(other)
         val fields = properties.map { property =>
           val returnType = typeToken.method(property.getReadMethod).getReturnType
-          if (seenTypeSet.contains(returnType.getRawType)) {
-            throw new UnsupportedOperationException(
-              "Cannot have circular references in bean class, but got the circular reference of " +
-                s"class ${returnType.getRawType}")
+          val types = extractRawTypes(returnType)
+          types.foreach { tpe =>
+            if (other == tpe || seenTypeSet.contains(tpe)) {
+              throw new UnsupportedOperationException(
+                "Cannot have circular references in bean class, but got the circular reference " +
+                  s"of class $tpe")
+            }
           }
-          val (dataType, nullable) = inferDataType(returnType, seenTypeSet + other)
+          val (dataType, nullable) = inferDataType(returnType, seenTypeSet ++ types)
           new StructField(property.getName, dataType, nullable)
         }
         (new StructType(fields), true)
     }
+  }
+
+  private def isBuiltInType(typeToken: TypeToken[_]): Boolean = typeToken.getRawType match {
+      case c: Class[_] if c.getCanonicalName.startsWith("java.") => true
+      case _ => false
+  }
+
+  private def extractRawTypes(typeToken: TypeToken[_]): Seq[Class[_]] = {
+    val tokens = typeToken match {
+      case _ if typeToken.isArray =>
+        typeToken.getComponentType :: Nil
+      case _ if iterableType.isAssignableFrom(typeToken) =>
+        elementType(typeToken) :: Nil
+      case _ if mapType.isAssignableFrom(typeToken) =>
+        val (keyType, valueType) = mapKeyValueType(typeToken)
+        keyType :: valueType :: Nil
+      case t =>
+        t :: Nil
+    }
+    tokens.filterNot(isBuiltInType).map(_.getRawType)
   }
 
   def getJavaBeanReadableProperties(beanClass: Class[_]): Array[PropertyDescriptor] = {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -424,22 +424,34 @@ public class JavaDataFrameSuite {
     Assert.assertEquals(2L, df.collectAsList().get(0).getLong(0));
   }
 
-  public class SelfClassInFieldBean implements Serializable {
-    private SelfClassInFieldBean child;
+  public class CircularReference1Bean implements Serializable {
+    private CircularReference2Bean child;
 
-    public SelfClassInFieldBean getChild() {
+    public CircularReference2Bean getChild() {
       return child;
     }
 
-    public void setChild(SelfClassInFieldBean child) {
+    public void setChild(CircularReference2Bean child) {
+      this.child = child;
+    }
+  }
+
+  public class CircularReference2Bean implements Serializable {
+    private CircularReference1Bean child;
+
+    public CircularReference1Bean getChild() {
+      return child;
+    }
+
+    public void setChild(CircularReference1Bean child) {
       this.child = child;
     }
   }
 
   @Test(expected = UnsupportedOperationException.class)
-  public void testSelfClassInFieldBean() {
-    SelfClassInFieldBean bean = new SelfClassInFieldBean();
-    bean.setChild(new SelfClassInFieldBean());
-    spark.createDataFrame(Arrays.asList(bean), SelfClassInFieldBean.class);
+  public void testCircularReferenceBean() {
+    CircularReference1Bean bean = new CircularReference1Bean();
+    bean.setChild(new CircularReference2Bean());
+    spark.createDataFrame(Arrays.asList(bean), CircularReference1Bean.class);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -423,4 +423,23 @@ public class JavaDataFrameSuite {
     Assert.assertEquals(1L, df.count());
     Assert.assertEquals(2L, df.collectAsList().get(0).getLong(0));
   }
+
+  public class SelfClassInFieldBean implements Serializable {
+    private SelfClassInFieldBean child;
+
+    public SelfClassInFieldBean getChild() {
+      return child;
+    }
+
+    public void setChild(SelfClassInFieldBean child) {
+      this.child = child;
+    }
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSelfClassInFieldBean() {
+    SelfClassInFieldBean bean = new SelfClassInFieldBean();
+    bean.setChild(new SelfClassInFieldBean());
+    spark.createDataFrame(Arrays.asList(bean), SelfClassInFieldBean.class);
+  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -448,10 +448,11 @@ public class JavaDataFrameSuite {
     }
   }
 
+  // Checks a simple case for DataFrame here and put exhaustive tests for the issue
+  // of circular references in `JavaDatasetSuite`.
   @Test(expected = UnsupportedOperationException.class)
   public void testCircularReferenceBean() {
     CircularReference1Bean bean = new CircularReference1Bean();
-    bean.setChild(new CircularReference2Bean());
     spark.createDataFrame(Arrays.asList(bean), CircularReference1Bean.class);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1289,4 +1289,23 @@ public class JavaDatasetSuite implements Serializable {
     Assert.assertEquals(df.schema().length(), 0);
     Assert.assertEquals(df.collectAsList().size(), 1);
   }
+
+  public class SelfClassInFieldBean implements Serializable {
+    private SelfClassInFieldBean child;
+
+    public SelfClassInFieldBean getChild() {
+      return child;
+    }
+
+    public void setChild(SelfClassInFieldBean child) {
+      this.child = child;
+    }
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSelfClassInFieldBean() {
+    SelfClassInFieldBean bean = new SelfClassInFieldBean();
+    bean.setChild(new SelfClassInFieldBean());
+    spark.createDataset(Arrays.asList(bean), Encoders.bean(SelfClassInFieldBean.class));
+  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1314,10 +1314,66 @@ public class JavaDatasetSuite implements Serializable {
     }
   }
 
+  public class CircularReference3Bean implements Serializable {
+    private CircularReference3Bean[] child;
+
+    public CircularReference3Bean[] getChild() {
+      return child;
+    }
+
+    public void setChild(CircularReference3Bean[] child) {
+      this.child = child;
+    }
+  }
+
+  public class CircularReference4Bean implements Serializable {
+    private Map<String, CircularReference5Bean> child;
+
+    public Map<String, CircularReference5Bean> getChild() {
+      return child;
+    }
+
+    public void setChild(Map<String, CircularReference5Bean> child) {
+      this.child = child;
+    }
+  }
+
+  public class CircularReference5Bean implements Serializable {
+    private String id;
+    private List<CircularReference4Bean> child;
+
+    public String getId() {
+      return id;
+    }
+
+    public List<CircularReference4Bean> getChild() {
+      return child;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public void setChild(List<CircularReference4Bean> child) {
+      this.child = child;
+    }
+  }
+
   @Test(expected = UnsupportedOperationException.class)
-  public void testCircularReferenceBean() {
+  public void testCircularReferenceBean1() {
     CircularReference1Bean bean = new CircularReference1Bean();
-    bean.setChild(new CircularReference2Bean());
     spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference1Bean.class));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCircularReferenceBean2() {
+    CircularReference3Bean bean = new CircularReference3Bean();
+    spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference3Bean.class));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCircularReferenceBean3() {
+    CircularReference4Bean bean = new CircularReference4Bean();
+    spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference4Bean.class));
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1290,22 +1290,34 @@ public class JavaDatasetSuite implements Serializable {
     Assert.assertEquals(df.collectAsList().size(), 1);
   }
 
-  public class SelfClassInFieldBean implements Serializable {
-    private SelfClassInFieldBean child;
+  public class CircularReference1Bean implements Serializable {
+    private CircularReference2Bean child;
 
-    public SelfClassInFieldBean getChild() {
+    public CircularReference2Bean getChild() {
       return child;
     }
 
-    public void setChild(SelfClassInFieldBean child) {
+    public void setChild(CircularReference2Bean child) {
+      this.child = child;
+    }
+  }
+
+  public class CircularReference2Bean implements Serializable {
+    private CircularReference1Bean child;
+
+    public CircularReference1Bean getChild() {
+      return child;
+    }
+
+    public void setChild(CircularReference1Bean child) {
       this.child = child;
     }
   }
 
   @Test(expected = UnsupportedOperationException.class)
-  public void testSelfClassInFieldBean() {
-    SelfClassInFieldBean bean = new SelfClassInFieldBean();
-    bean.setChild(new SelfClassInFieldBean());
-    spark.createDataset(Arrays.asList(bean), Encoders.bean(SelfClassInFieldBean.class));
+  public void testCircularReferenceBean() {
+    CircularReference1Bean bean = new CircularReference1Bean();
+    bean.setChild(new CircularReference2Bean());
+    spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference1Bean.class));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The current master throws `StackOverflowError` in `createDataFrame`/`createDataset` if bean has one's own class in fields;
```
public class SelfClassInFieldBean implements Serializable {
  private SelfClassInFieldBean child;
  ...
}
```
This pr added code to throw `UnsupportedOperationException` in that case as soon as possible.

## How was this patch tested?
Added tests in `JavaDataFrameSuite` and `JavaDatasetSuite`.
