### PR TITLE
[SPARK-19861][SS] watermark should not be a negative time.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -580,7 +580,7 @@ class Dataset[T] private[sql](
       val millisPerMonth = CalendarInterval.MICROS_PER_DAY / 1000 * 31
       parsedDelay.milliseconds + parsedDelay.months * millisPerMonth
     }
-    assert(delayMs >= 0, s"delay threshold should not be a negative time: $delayThreshold")
+    require(delayMs >= 0, s"delay threshold should not be a negative time: $delayThreshold")
     EventTimeWatermark(UnresolvedAttribute(eventTime), parsedDelay, logicalPlan)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -563,7 +563,7 @@ class Dataset[T] private[sql](
    * @param eventTime the name of the column that contains the event time of the row.
    * @param delayThreshold the minimum delay to wait to data to arrive late, relative to the latest
    *                       record that has been processed in the form of an interval
-   *                       (e.g. "1 minute" or "5 hours"). NOTE: This should not be a negative time.
+   *                       (e.g. "1 minute" or "5 hours"). NOTE: This should not be negative.
    *
    * @group streaming
    * @since 2.1.0
@@ -576,11 +576,8 @@ class Dataset[T] private[sql](
     val parsedDelay =
       Option(CalendarInterval.fromString("interval " + delayThreshold))
         .getOrElse(throw new AnalysisException(s"Unable to parse time delay '$delayThreshold'"))
-    val delayMs = {
-      val millisPerMonth = CalendarInterval.MICROS_PER_DAY / 1000 * 31
-      parsedDelay.milliseconds + parsedDelay.months * millisPerMonth
-    }
-    require(delayMs >= 0, s"delay threshold should not be a negative time: $delayThreshold")
+    require(parsedDelay.milliseconds >= 0 && parsedDelay.months >= 0,
+      s"delay threshold ($delayThreshold) should not be negative.")
     EventTimeWatermark(UnresolvedAttribute(eventTime), parsedDelay, logicalPlan)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -576,7 +576,7 @@ class Dataset[T] private[sql](
     val parsedDelay =
       Option(CalendarInterval.fromString("interval " + delayThreshold))
         .getOrElse(throw new AnalysisException(s"Unable to parse time delay '$delayThreshold'"))
-    assert(parsedDelay.microseconds > 0,
+    assert(parsedDelay.microseconds >= 0,
       s"delay threshold should not be a negative time: $delayThreshold")
     EventTimeWatermark(UnresolvedAttribute(eventTime), parsedDelay, logicalPlan)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -576,8 +576,11 @@ class Dataset[T] private[sql](
     val parsedDelay =
       Option(CalendarInterval.fromString("interval " + delayThreshold))
         .getOrElse(throw new AnalysisException(s"Unable to parse time delay '$delayThreshold'"))
-    assert(parsedDelay.microseconds >= 0,
-      s"delay threshold should not be a negative time: $delayThreshold")
+    val delayMs = {
+      val millisPerMonth = CalendarInterval.MICROS_PER_DAY / 1000 * 31
+      parsedDelay.milliseconds + parsedDelay.months * millisPerMonth
+    }
+    assert(delayMs >= 0, s"delay threshold should not be a negative time: $delayThreshold")
     EventTimeWatermark(UnresolvedAttribute(eventTime), parsedDelay, logicalPlan)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -563,7 +563,7 @@ class Dataset[T] private[sql](
    * @param eventTime the name of the column that contains the event time of the row.
    * @param delayThreshold the minimum delay to wait to data to arrive late, relative to the latest
    *                       record that has been processed in the form of an interval
-   *                       (e.g. "1 minute" or "5 hours").
+   *                       (e.g. "1 minute" or "5 hours"). NOTE: This should not be a negative time.
    *
    * @group streaming
    * @since 2.1.0
@@ -576,6 +576,8 @@ class Dataset[T] private[sql](
     val parsedDelay =
       Option(CalendarInterval.fromString("interval " + delayThreshold))
         .getOrElse(throw new AnalysisException(s"Unable to parse time delay '$delayThreshold'"))
+    assert(parsedDelay.microseconds > 0,
+      s"delay threshold should not be a negative time: $delayThreshold")
     EventTimeWatermark(UnresolvedAttribute(eventTime), parsedDelay, logicalPlan)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -306,27 +306,27 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Loggin
     )
   }
 
-  test("delay threshold should not be a negative time.") {
+  test("delay threshold should not be negative.") {
     val inputData = MemoryStream[Int].toDF()
     var e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "-1 year")
     }
-    assert(e.getMessage contains "delay threshold should not be a negative time")
+    assert(e.getMessage contains "should not be negative.")
 
     e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "1 year -13 months")
     }
-    assert(e.getMessage contains "delay threshold should not be a negative time")
+    assert(e.getMessage contains "should not be negative.")
 
     e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "1 month -40 days")
     }
-    assert(e.getMessage contains "delay threshold should not be a negative time")
+    assert(e.getMessage contains "should not be negative.")
 
     e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "-10 seconds")
     }
-    assert(e.getMessage contains "delay threshold should not be a negative time")
+    assert(e.getMessage contains "should not be negative.")
   }
 
   test("the new watermark should override the old one") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -319,7 +319,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Loggin
     assert(e.getMessage contains "delay threshold should not be a negative time")
 
     e = intercept[AssertionError] {
-      inputData.withWatermark("value", "1 months -40 days")
+      inputData.withWatermark("value", "1 month -40 days")
     }
     assert(e.getMessage contains "delay threshold should not be a negative time")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -305,6 +305,14 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Loggin
     )
   }
 
+  test("delay threshold should not be a negative time.") {
+    val inputData = MemoryStream[Int].toDF()
+    val e = intercept[AssertionError] {
+      inputData.withWatermark("value", "-1 minute")
+    }
+    assert(e.getMessage contains "delay threshold should not be a negative time")
+  }
+
   private def assertNumStateRows(numTotalRows: Long): AssertOnQuery = AssertOnQuery { q =>
     val progressWithData = q.recentProgress.filter(_.numInputRows > 0).lastOption.get
     assert(progressWithData.stateOperators(0).numRowsTotal === numTotalRows)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -307,8 +307,23 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Loggin
 
   test("delay threshold should not be a negative time.") {
     val inputData = MemoryStream[Int].toDF()
-    val e = intercept[AssertionError] {
-      inputData.withWatermark("value", "-1 minute")
+    var e = intercept[AssertionError] {
+      inputData.withWatermark("value", "-1 year")
+    }
+    assert(e.getMessage contains "delay threshold should not be a negative time")
+
+    e = intercept[AssertionError] {
+      inputData.withWatermark("value", "1 year -13 months")
+    }
+    assert(e.getMessage contains "delay threshold should not be a negative time")
+
+    e = intercept[AssertionError] {
+      inputData.withWatermark("value", "1 months -40 days")
+    }
+    assert(e.getMessage contains "delay threshold should not be a negative time")
+
+    e = intercept[AssertionError] {
+      inputData.withWatermark("value", "-10 seconds")
     }
     assert(e.getMessage contains "delay threshold should not be a negative time")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -308,22 +308,22 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Loggin
 
   test("delay threshold should not be a negative time.") {
     val inputData = MemoryStream[Int].toDF()
-    var e = intercept[AssertionError] {
+    var e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "-1 year")
     }
     assert(e.getMessage contains "delay threshold should not be a negative time")
 
-    e = intercept[AssertionError] {
+    e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "1 year -13 months")
     }
     assert(e.getMessage contains "delay threshold should not be a negative time")
 
-    e = intercept[AssertionError] {
+    e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "1 month -40 days")
     }
     assert(e.getMessage contains "delay threshold should not be a negative time")
 
-    e = intercept[AssertionError] {
+    e = intercept[IllegalArgumentException] {
       inputData.withWatermark("value", "-10 seconds")
     }
     assert(e.getMessage contains "delay threshold should not be a negative time")


### PR DESCRIPTION
## What changes were proposed in this pull request?

`watermark` should not be negative. This behavior is invalid, check it before real run.

## How was this patch tested?

add new unit test.
