### PR TITLE
[SPARK-19863][DStream] Whether or not use CachedKafkaConsumer need to be configured, when you use DirectKafkaInputDStream t

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -73,6 +73,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
     }
     kc
   }
+  val useConsumerCache = _ssc.conf.getBoolean("spark.streaming.kafka.consumer.cache.enable", true)
 
   override def persist(newLevel: StorageLevel): DStream[ConsumerRecord[K, V]] = {
     logError("Kafka ConsumerRecord is not serializable. " +
@@ -213,8 +214,8 @@ private[spark] class DirectKafkaInputDStream[K, V](
       val fo = currentOffsets(tp)
       OffsetRange(tp.topic, tp.partition, fo, uo)
     }
-    val rdd = new KafkaRDD[K, V](
-      context.sparkContext, executorKafkaParams, offsetRanges.toArray, getPreferredHosts, true)
+    val rdd = new KafkaRDD[K, V](context.sparkContext, executorKafkaParams, offsetRanges.toArray,
+      getPreferredHosts, useConsumerCache)
 
     // Report the record number and metadata of this batch interval to InputInfoTracker.
     val description = offsetRanges.filter { offsetRange =>

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
@@ -70,8 +70,8 @@ object KafkaUtils extends Logging {
     val kp = new ju.HashMap[String, Object](kafkaParams)
     fixKafkaParams(kp)
     val osr = offsetRanges.clone()
-
-    new KafkaRDD[K, V](sc, kp, osr, preferredHosts, true)
+    val useConsumerCache = sc.conf.getBoolean("spark.streaming.kafka.consumer.cache.enable", true)
+    new KafkaRDD[K, V](sc, kp, osr, preferredHosts, useConsumerCache)
   }
 
   /**


### PR DESCRIPTION

## What changes were proposed in this pull request?
Whether or not use CachedKafkaConsumer need to be configured, when you use DirectKafkaInputDStream to connect the kafka in a Spark Streaming application. In Spark 2.x, the kafka consumer was replaced by CachedKafkaConsumer (some KafkaConsumer will keep establishing the kafka cluster), and cannot change the way. In fact ,The KafkaRDD(used by DirectKafkaInputDStream to connect kafka) provide the parameter useConsumerCache to choose Whether to use the CachedKafkaConsumer, but the DirectKafkaInputDStream always set the parameter true.

## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
