### PR TITLE
[SPARK-19843] [SQL] [Followup] Classdoc for `IntWrapper` and `LongWrapper`

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -850,8 +850,23 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return fromString(sb.toString());
   }
 
+  /**
+   * Wrapper over `long` to allow result of parsing long from string to be accessed via reference.
+   * This is done solely for better performance and is not expected to be used by end users.
+   */
   public static class LongWrapper {
     public long value = 0;
+  }
+
+  /**
+   * Wrapper over `int` to allow result of parsing integer from string to be accessed via reference.
+   * This is done solely for better performance and is not expected to be used by end users.
+   *
+   * {@link LongWrapper} could have been used here but using `int` directly save the extra cost of
+   * conversion from `long` -> `int`
+   */
+  public static class IntWrapper {
+    public int value = 0;
   }
 
   /**
@@ -940,10 +955,6 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
 
     toLongResult.value = result;
     return true;
-  }
-
-  public static class IntWrapper {
-    public int value = 0;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is as per suggestion by @rxin at : https://github.com/apache/spark/pull/17184#discussion_r104841735

## How was this patch tested?

NA as this is a documentation change