### PR TITLE
[SPARK-19881][SQL] Support Dynamic Partition Inserts params with SET command

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -32,6 +32,7 @@ import org.apache.thrift.TException
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.catalog._
@@ -791,6 +792,20 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       // columns. Here we Lowercase the column names before passing the partition spec to Hive
       // client, to satisfy Hive.
       orderedPartitionSpec.put(colName.toLowerCase, partition(colName))
+    }
+
+    // Access SQLConf to get 'Dynamic Partition Inserts' parameter specified dynamically
+    // after HiveClient is created
+    val sqlConf = SparkSession.getActiveSession.get.sessionState.conf
+    Seq(
+      "hive.exec.max.dynamic.partitions",
+      "hive.exec.max.dynamic.partitions.pernode",
+      "hive.exec.max.created.files",
+      "hive.error.on.empty.partition"
+    ).foreach { param =>
+      if (sqlConf.contains(param)) {
+        client.runSqlHive(s"set $param=${sqlConf.getConfString(param)}")
+      }
     }
 
     client.loadDynamicPartitions(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since Spark 2.0.0, `SET` commands do not pass the values to HiveClient. In most case, Spark handles well. However, for the dynamic partition insert, users meet the following misleading situation. 

```scala
scala> spark.range(1001).selectExpr("id as key", "id as value").registerTempTable("t1001")

scala> sql("create table p (value int) partitioned by (key int)").show

scala> sql("insert into table p partition(key) select key, value from t1001")
org.apache.spark.SparkException:
Dynamic partition strict mode requires at least one static partition column.
To turn this off set hive.exec.dynamic.partition.mode=nonstrict

scala> sql("set hive.exec.dynamic.partition.mode=nonstrict")

scala> sql("insert into table p partition(key) select key, value from t1001")
org.apache.hadoop.hive.ql.metadata.HiveException:
Number of dynamic partitions created is 1001, which is more than 1000.
To solve this try to set hive.exec.max.dynamic.partitions to at least 1001.

scala> sql("set hive.exec.max.dynamic.partitions=1001")

scala> sql("set hive.exec.max.dynamic.partitions").show(false)
+--------------------------------+-----+
|key                             |value|
+--------------------------------+-----+
|hive.exec.max.dynamic.partitions|1001 |
+--------------------------------+-----+

scala> sql("insert into table p partition(key) select key, value from t1001")
org.apache.hadoop.hive.ql.metadata.HiveException:
Number of dynamic partitions created is 1001, which is more than 1000.
To solve this try to set hive.exec.max.dynamic.partitions to at least 1001.
```

The last error is the same with the previous one. `HiveClient` does not know new value 1001. While users control `hive.exec.dynamic.partition.mode`, there is no way to change the default value of `hive.exec.max.dynamic.partitions` of `HiveCilent` with `SET` command.

The root cause is that `hive` parameters are passed to `HiveClient` on creating. So, the workaround is to use `--hiveconf` when starting `spark-shell`. However, it is still unchangeable in `spark-shell`. We had better handle this case without misleading error messages ending infinite loop.

## How was this patch tested?

Manual.