### PR TITLE
[SPARK-19882][SQL] Pivot with null as the dictinct pivot value throws NPE

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -216,4 +216,10 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext{
       Row("d", 15000.0, 48000.0) :: Row("J", 20000.0, 30000.0) :: Nil
     )
   }
+
+  test("pivot with null should not throw NPE") {
+    checkAnswer(
+      Seq(Tuple1(None), Tuple1(Some(1))).toDF("a").groupBy($"a").pivot("a").count(),
+      Row(null, 1, 0) :: Row(1, 0, 1) :: Nil)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to fix two problems as below:

**Use previous code path to handle `null` in distinct pivot values**

An optimisation to this was introduced to prevent each input gets evaluated on every aggregate which seems making it slow when `pivotValues` are too many. It seems this tightly assumes that this distinct pivot value can't be `null`.

I could not find a clean and easy workaround to support this and wonder if it is worth. Please guide me if anyone knows a clean and short way to fix it in this two aggregation path.

**Fix to count `null`**

```scala
Seq(Tuple1(None), Tuple1(Some(1))).toDF("a").groupBy($"a").count().show()
```

Before (Spark 1.6),

```
+----+----+---+
|   a|null|  1|
+----+----+---+
|null|   0|  0|
|   1|   0|  1|
+----+----+---+
```

Before (current master), <- this is currently a regression

```
java.lang.NullPointerException was thrown.
java.lang.NullPointerException
  at org.apache.spark.sql.catalyst.expressions.aggregate.PivotFirst$$anonfun$4.apply(PivotFirst.scala:145)
  at org.apache.spark.sql.catalyst.expressions.aggregate.PivotFirst$$anonfun$4.apply(PivotFirst.scala:143)
  at scala.collection.immutable.List.map(List.scala:273)
  at org.apache.spark.sql.catalyst.expressions.aggregate.PivotFirst.<init>(PivotFirst.scala:143)
  at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolvePivot$$anonfun$apply$7$$anonfun$24.apply(Analyzer.scala:509)
```

After,

```
+----+----+---+
|   a|null|  1|
+----+----+---+
|null|   1|  0|
|   1|   0|  1|
+----+----+---+
```

It seems we should count null given

```scala
Seq(Tuple1(None), Tuple1(Some(1))).toDF("a").groupBy($"a").count().show()
```

```
+----+-----+
|   a|count|
+----+-----+
|null|    1|
|   1|    1|
+----+-----+
```


## How was this patch tested?

Unit tests in `DataFramePivotSuite`.