### PR TITLE
[SPARK-19507][PySpark][SQL] Show field name in _verify_type error

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -627,7 +627,6 @@ class RDD(object):
     def sortByKey(self, ascending=True, numPartitions=None, keyfunc=lambda x: x):
         """
         Sorts this RDD, which is assumed to consist of (key, value) pairs.
-        # noqa
 
         >>> tmp = [('a', 1), ('b', 2), ('1', 3), ('d', 4), ('2', 5)]
         >>> sc.parallelize(tmp).sortByKey().first()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -513,7 +513,7 @@ class SparkSession(object):
             schema = StructType().add("value", schema)
 
             def prepare(obj):
-                verify_func(obj, dataType)
+                verify_func(obj, dataType, name='value')
                 return obj,
         else:
             if isinstance(schema, list):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2389,9 +2389,12 @@ class TypesTest(unittest.TestCase):
                 (None, FloatType()),
                 (None, StringType()),
                 (None, StructType([]))]:
-            _verify_type(obj, data_type, nullable=True)
             msg = "_verify_type(%s, %s, nullable=True)" % (obj, data_type)
-            self.assertTrue(True, msg)
+            try:
+                _verify_type(obj, data_type, nullable=True)
+            except Exception as e:
+                traceback.print_exc()
+                self.fail(msg)
 
     def test_verify_type_not_nullable(self):
         import array
@@ -2477,6 +2480,7 @@ class TypesTest(unittest.TestCase):
             # Array
             ([], ArrayType(IntegerType()), None),
             (["1", None], ArrayType(StringType(), containsNull=True), None),
+            (["1", None], ArrayType(StringType(), containsNull=False), ValueError),
             ([1, 2], ArrayType(IntegerType()), None),
             ([1, "2"], ArrayType(IntegerType()), TypeError),
             ((1, 2), ArrayType(IntegerType()), None),
@@ -2488,6 +2492,8 @@ class TypesTest(unittest.TestCase):
             ({"a": 1}, MapType(IntegerType(), IntegerType()), TypeError),
             ({"a": "1"}, MapType(StringType(), IntegerType()), TypeError),
             ({"a": None}, MapType(StringType(), IntegerType(), valueContainsNull=True), None),
+            ({"a": None}, MapType(StringType(), IntegerType(), valueContainsNull=False),
+             ValueError),
 
             # Struct
             ({"s": "a", "i": 1}, MyStructType, None),
@@ -2509,6 +2515,7 @@ class TypesTest(unittest.TestCase):
             (MyObj(s="a", i=None), MyStructType, None),
             (MyObj(s="a"), MyStructType, None),
             (MyObj(s="a", i="1"), MyStructType, TypeError),
+            (MyObj(s=None, i="1"), MyStructType, ValueError),
         ]
 
         for obj, data_type, exp in spec:
@@ -2519,7 +2526,6 @@ class TypesTest(unittest.TestCase):
                 except Exception as e:
                     traceback.print_exc()
                     self.fail(msg)
-                self.assertTrue(True, msg)
             else:
                 with self.assertRaises(exp, msg=msg):
                     _verify_type(obj, data_type, nullable=False)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2392,11 +2392,8 @@ class TypesTest(unittest.TestCase):
             self.assertTrue(str(e).startswith(name))
 
     def test_verify_type_ok_nullable(self):
-        for obj, data_type in [
-                (None, IntegerType()),
-                (None, FloatType()),
-                (None, StringType()),
-                (None, StructType([]))]:
+        obj = None
+        for data_type in [IntegerType(), FloatType(), StringType(), StructType([])]:
             msg = "_verify_type(%s, %s, nullable=True)" % (obj, data_type)
             try:
                 _verify_type(obj, data_type, nullable=True)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2383,6 +2383,14 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
 
 class TypesTest(unittest.TestCase):
 
+    def test_verify_type_exception_msg(self):
+        name = "test_name"
+        try:
+            _verify_type(None, StringType(), nullable=False, name=name)
+            self.fail('Expected _verify_type() to throw so test can check exception message')
+        except Exception as e:
+            self.assertTrue(str(e).startswith(name))
+
     def test_verify_type_ok_nullable(self):
         for obj, data_type in [
                 (None, IntegerType()),
@@ -2523,7 +2531,7 @@ class TypesTest(unittest.TestCase):
             if exp is None:
                 try:
                     _verify_type(obj, data_type, nullable=False)
-                except Exception as e:
+                except Exception:
                     traceback.print_exc()
                     self.fail(msg)
             else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add better error messages to _verify_type to track down which columns are not compliant with the schema.

## How was this patch tested?

Unit tests, doctest, hand inspection in REPL.

## Legal

This is my original work and I license the work to the project under the project’s open source license.