### PR TITLE
[SPARK-19353][CORE] Generalize PipedRDD to use I/O formats

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -774,12 +774,41 @@ abstract class RDD[T: ClassTag](
       separateWorkingDir: Boolean = false,
       bufferSize: Int = 8192,
       encoding: String = Codec.defaultCharsetCodec.name): RDD[String] = withScope {
-    new PipedRDD(this, command, env,
+    val inputWriter = new TextInputWriter[T](
+      encoding,
       if (printPipeContext ne null) sc.clean(printPipeContext) else null,
-      if (printRDDElement ne null) sc.clean(printRDDElement) else null,
+      if (printRDDElement ne null) sc.clean(printRDDElement) else null)
+    val outputReader = new TextOutputReader(encoding)
+    pipeFormatted(command, env, separateWorkingDir, bufferSize, inputWriter, outputReader)
+  }
+
+  /**
+   * Return an RDD created by piping elements to a forked external process. The resulting RDD
+   * is computed by executing the given process once per partition. All elements
+   * of each input partition are written to a process's stdin. The resulting partition
+   * consists of the process's stdout output.
+   *
+   * @param command command to run in forked process.
+   * @param env environment variables to set.
+   * @param separateWorkingDir Use separate working directories for each task.
+   * @param bufferSize Buffer size for the stdin writer for the piped process.
+   * @param inputWriter the format to use for serializing the elements of this RDD into
+   *                    the process's stdin.
+   * @param outputReader the format to use for reading elements into the resulting RDD
+   *                     from process's stdout.
+   * @return the result RDD
+   */
+  def pipeFormatted[O: ClassTag](
+      command: Seq[String],
+      env: Map[String, String] = Map(),
+      separateWorkingDir: Boolean = false,
+      bufferSize: Int = 8192,
+      inputWriter: InputWriter[T],
+      outputReader: OutputReader[O]): RDD[O] = withScope {
+    new PipedRDD(this, command, env,
       separateWorkingDir,
       bufferSize,
-      encoding)
+      inputWriter, outputReader)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch allows to use arbitrary input and output formats when streaming data to and from the piped process. The API uses java.io.Data{Input,Output} for I/O, therefore all methods operating on multibyte primitives assume big-endian byte order.

The change is fully backward-compatible in terms of both public API and behaviour. Additionally, existing line-based format is available via TextInputWriter/TextOutputReader.

## Why is it worth merging?

Prior to this patch the only way to stream binary data (think ProtoBuf records or NumPy arrays) from PipedRDD was via Base64. The piped process had to Base64-encode the output, which would then be Base64-decoded on the Spark side. Apart from wasting CPU cycles on the executors, Base64 increases the output of the piped process by 25%. The new API allows to get rid of this overhead.

Note that Hadoop streaming has undergone a similar change in the past. The text-only I/O format was [complemented](https://issues.apache.org/jira/browse/HADOOP-1722) by two binary formats: typedbytes and rawbytes.

## How was this patch tested?

PipedRDD unit tests and in-house integration tests.