### PR TITLE
[SPARK-19852][PYSPARK][ML] Update Python API setHandleInvalid for StringIndexer

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1938,8 +1938,10 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, Ja
     >>> testData2 = sc.parallelize([Row(id=0, label="a"), Row(id=1, label="d"),
     ...     Row(id=2, label="e")], 2)
     >>> dfKeep= spark.createDataFrame(testData2)
-    >>> tdK = stringIndexer.setHandleInvalid("keep").fit(stringIndDf).transform(dfKeep)
-    >>> itdK = inverter.transform(tdK)
+    >>> modelKeep = stringIndexer.setHandleInvalid("keep").fit(stringIndDf)
+    >>> tdK = modelKeep.transform(dfKeep)
+    >>> itdK = IndexToString(inputCol="indexed", outputCol="label2",
+    ...     labels=modelKeep.labels).transform(tdK)
     >>> sorted(set([(i[0], str(i[1])) for i in itdK.select(itdK.id, itdK.label2).collect()]),
     ...     key=lambda x: x[0])
     [(0, 'a'), (6, 'd'), (6, 'e')]

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1917,8 +1917,7 @@ class StandardScalerModel(JavaModel, JavaMLReadable, JavaMLWritable):
 
 
 @inherit_doc
-class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, HasHandleInvalid, JavaMLReadable,
-                    JavaMLWritable):
+class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
     """
     A label indexer that maps a string column of labels to an ML column of label indices.
     If the input column is numeric, we cast it to string and index the string values.
@@ -1936,6 +1935,14 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, HasHandleInvalid, 
     >>> sorted(set([(i[0], str(i[1])) for i in itd.select(itd.id, itd.label2).collect()]),
     ...     key=lambda x: x[0])
     [(0, 'a'), (1, 'b'), (2, 'c'), (3, 'a'), (4, 'a'), (5, 'c')]
+    >>> testData2 = sc.parallelize([Row(id=0, label="a"), Row(id=1, label="d"),
+    ...     Row(id=2, label="e")], 2)
+    >>> dfKeep= spark.createDataFrame(testData2)
+    >>> tdKeep = stringIndexer.setHandleInvalid("keep").fit(stringIndDf).transform(dfKeep)
+    >>> itdKeep = inverter.transform(tdKeep)
+    >>> sorted(set([(i[0], str(i[1])) for i in itdKeep.select(itdKeep.id, itdKeep.label2).collect()]),
+    ...     key=lambda x: x[0])
+    [(0, 'a'), (6, 'd'), (6, 'e')]
     >>> stringIndexerPath = temp_path + "/string-indexer"
     >>> stringIndexer.save(stringIndexerPath)
     >>> loadedIndexer = StringIndexer.load(stringIndexerPath)
@@ -1955,6 +1962,11 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, HasHandleInvalid, 
     .. versionadded:: 1.4.0
     """
 
+    handleInvalid = Param(Params._dummy(), "handleInvalid", "how to handle unseen labels. " +
+                          "Options are 'skip' (filter out rows with unseen labels), " +
+                          "error (throw an error), or 'keep' (put unseen labels in a special " +
+                          "additional bucket, at index numLabels).",
+                          typeConverter=TypeConverters.toString)
     @keyword_only
     def __init__(self, inputCol=None, outputCol=None, handleInvalid="error"):
         """
@@ -1978,6 +1990,20 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, HasHandleInvalid, 
 
     def _create_model(self, java_model):
         return StringIndexerModel(java_model)
+
+    @since("2.2.0")
+    def setHandleInvalid(self, value):
+        """
+        Sets the value of :py:attr:`handleInvalid`.
+        """
+        return self._set(handleInvalid=value)
+
+    @since("2.2.0")
+    def getHandleInvalid(self):
+        """
+        Gets the value of :py:attr:`handleInvalid` or its default value.
+        """
+        return self.getOrDefault(self.handleInvalid)
 
 
 class StringIndexerModel(JavaModel, JavaMLReadable, JavaMLWritable):

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1938,9 +1938,9 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, Ja
     >>> testData2 = sc.parallelize([Row(id=0, label="a"), Row(id=1, label="d"),
     ...     Row(id=2, label="e")], 2)
     >>> dfKeep= spark.createDataFrame(testData2)
-    >>> tdKeep = stringIndexer.setHandleInvalid("keep").fit(stringIndDf).transform(dfKeep)
-    >>> itdKeep = inverter.transform(tdKeep)
-    >>> sorted(set([(i[0], str(i[1])) for i in itdKeep.select(itdKeep.id, itdKeep.label2).collect()]),
+    >>> tdK = stringIndexer.setHandleInvalid("keep").fit(stringIndDf).transform(dfKeep)
+    >>> itdK = inverter.transform(tdK)
+    >>> sorted(set([(i[0], str(i[1])) for i in itdK.select(itdK.id, itdK.label2).collect()]),
     ...     key=lambda x: x[0])
     [(0, 'a'), (6, 'd'), (6, 'e')]
     >>> stringIndexerPath = temp_path + "/string-indexer"
@@ -1967,6 +1967,7 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, Ja
                           "error (throw an error), or 'keep' (put unseen labels in a special " +
                           "additional bucket, at index numLabels).",
                           typeConverter=TypeConverters.toString)
+
     @keyword_only
     def __init__(self, inputCol=None, outputCol=None, handleInvalid="error"):
         """

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1936,7 +1936,7 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, Ja
     ...     key=lambda x: x[0])
     [(0, 'a'), (1, 'b'), (2, 'c'), (3, 'a'), (4, 'a'), (5, 'c')]
     >>> testData2 = sc.parallelize([Row(id=0, label="a"), Row(id=1, label="d"),
-    ...     Row(id=2, label="e")], 2)
+    ...     Row(id=2, label=None)], 2)
     >>> dfKeep= spark.createDataFrame(testData2)
     >>> modelKeep = stringIndexer.setHandleInvalid("keep").fit(stringIndDf)
     >>> tdK = modelKeep.transform(dfKeep)
@@ -1962,10 +1962,10 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, Ja
     .. versionadded:: 1.4.0
     """
 
-    handleInvalid = Param(Params._dummy(), "handleInvalid", "how to handle unseen labels. " +
-                          "Options are 'skip' (filter out rows with unseen labels), " +
-                          "error (throw an error), or 'keep' (put unseen labels in a special " +
-                          "additional bucket, at index numLabels).",
+    handleInvalid = Param(Params._dummy(), "handleInvalid", "how to handle invalid data (unseen " +
+                          "labels or NULL values). Options are 'skip' (filter out rows with " +
+                          "invalid data), error (throw an error), or 'keep' (put invalid data " +
+                          "in a special additional bucket, at index numLabels).",
                           typeConverter=TypeConverters.toString)
 
     @keyword_only

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1940,11 +1940,9 @@ class StringIndexer(JavaEstimator, HasInputCol, HasOutputCol, JavaMLReadable, Ja
     >>> dfKeep= spark.createDataFrame(testData2)
     >>> modelKeep = stringIndexer.setHandleInvalid("keep").fit(stringIndDf)
     >>> tdK = modelKeep.transform(dfKeep)
-    >>> itdK = IndexToString(inputCol="indexed", outputCol="label2",
-    ...     labels=modelKeep.labels).transform(tdK)
-    >>> sorted(set([(i[0], str(i[1])) for i in itdK.select(itdK.id, itdK.label2).collect()]),
+    >>> sorted(set([(i[0], i[1]) for i in tdK.select(tdK.id, tdK.indexed).collect()]),
     ...     key=lambda x: x[0])
-    [(0, 'a'), (6, 'd'), (6, 'e')]
+    [(0, 0.0), (1, 3.0), (2, 3.0)]
     >>> stringIndexerPath = temp_path + "/string-indexer"
     >>> stringIndexer.save(stringIndexerPath)
     >>> loadedIndexer = StringIndexer.load(stringIndexerPath)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to maintain API parity with changes made in SPARK-17498 to support a new option
'keep' in StringIndexer to handle unseen labels with pyspark

## How was this patch tested?
existing tests
testing is done with new doctests

Signed-off-by: VinceShieh <vincent.xie@intel.com>
