### PR TITLE
[SPARK-19915][SQL] Improve join reorder: simplify cost evaluation, postpone column pruning, exclude cartesian product

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -119,7 +119,8 @@ abstract class Optimizer(sessionCatalog: SessionCatalog, conf: CatalystConf)
     Batch("Check Cartesian Products", Once,
       CheckCartesianProducts(conf)) ::
     Batch("Join Reorder", Once,
-      CostBasedJoinReorder(conf)) ::
+      CostBasedJoinReorder(conf),
+      ColumnPruning) ::
     Batch("Decimal Optimizations", fixedPoint,
       DecimalAggregates(conf)) ::
     Batch("Typed Filter Optimization", fixedPoint,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinReorderSuite.scala
@@ -97,12 +97,11 @@ class JoinReorderSuite extends PlanTest with StatsEstimationTestBase {
       t1.join(t2).join(t3).where((nameToAttr("t1.k-1-2") === nameToAttr("t2.k-1-5")) &&
         (nameToAttr("t1.v-1-10") === nameToAttr("t3.v-1-100")))
 
-    // The cost of original plan (use only cardinality to simplify explanation):
+    // The cost of original plan:
     // cost = cost(t1 J t2) = 1000 * 20 / 5 = 4000
     // In contrast, the cost of the best plan:
     // cost = cost(t1 J t3) = 1000 * 100 / 100 = 1000 < 4000
-    // so (t1 J t3) J t2 is better (has lower cost, i.e. intermediate result size) than
-    // the original order (t1 J t2) J t3.
+    // so (t1 J t3) J t2 is better than the original order (t1 J t2) J t3.
     val bestPlan =
       t1.join(t3, Inner, Some(nameToAttr("t1.v-1-10") === nameToAttr("t3.v-1-100")))
       .join(t2, Inner, Some(nameToAttr("t1.k-1-2") === nameToAttr("t2.k-1-5")))
@@ -152,7 +151,7 @@ class JoinReorderSuite extends PlanTest with StatsEstimationTestBase {
         (nameToAttr("t1.k-1-2") === nameToAttr("t2.k-1-5")) &&
         (nameToAttr("t4.v-1-10") === nameToAttr("t3.v-1-100")))
 
-    // The cost of original plan (use only cardinality to simplify explanation):
+    // The cost of original plan:
     // cost(t1 J t4) = 1000 * 2000 / 2 = 1000000, cost(t1t4 J t2) = 1000000 * 20 / 5 = 4000000,
     // cost = cost(t1 J t4) + cost(t1t4 J t2) = 5000000
     // In contrast, the cost of the best plan (a bushy tree):

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinReorderSuite.scala
@@ -42,7 +42,8 @@ class JoinReorderSuite extends PlanTest with StatsEstimationTestBase {
         ColumnPruning,
         CollapseProject) ::
       Batch("Join Reorder", Once,
-        CostBasedJoinReorder(conf)) :: Nil
+        CostBasedJoinReorder(conf),
+        ColumnPruning) :: Nil
   }
 
   /** Set up tables and columns for testing */


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Usually cardinality is more important than size, we can simplify cost evaluation by using only cardinality. Note that this also enables us to not care about column pruing during reordering. Because otherwise, project will influence the output size of intermediate joins.
2. Do column pruning during reordering is troublesome. Given the first change, we can do it right after reordering, then logics for adding projects on intermediate joins can be removed. This makes the code simpler and more reliable.
3. Exclude cartesian products in the "memo". This significantly reduces the search space and memory overhead of memo. Otherwise every combination of items will exist in the memo. We can find those unjoinable items after reordering is finished and put them at the end.

## How was this patch tested?

Not related.
