### PR TITLE
[SPARK-19909][SS] Batches will fail in case that temporary checkpoint dir is on local file system while metadata dir is on HDFS

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -206,7 +206,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) {
       if (useTempCheckpointLocation) {
         // Delete the temp checkpoint when a query is being stopped without errors.
         deleteCheckpointOnStop = true
-        Utils.createTempDir(namePrefix = s"temporary").getCanonicalPath
+        Utils.createTempDir(namePrefix = s"temporary").getCanonicalFile.toURI.toString
       } else {
         throw new AnalysisException(
           "checkpointLocation must be specified either " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we try to run Structured Streaming in local mode but use HDFS for the storage, batches will be fail because of error like as follows.

```
val handle = stream.writeStream.format("console").start()
17/03/09 16:54:45 ERROR StreamMetadata: Error writing stream metadata StreamMetadata(fc07a0b1-5423-483e-a59d-b2206a49491e) to /private/var/folders/4y/tmspvv353y59p3w4lknrf7cc0000gn/T/temporary-79d4fe05-4301-4b6d-a902-dff642d0ddca/metadata
org.apache.hadoop.security.AccessControlException: Permission denied: user=kou, access=WRITE, inode="/private/var/folders/4y/tmspvv353y59p3w4lknrf7cc0000gn/T/temporary-79d4fe05-4301-4b6d-a902-dff642d0ddca/metadata":hdfs:supergroup:drwxr-xr-x
```

It's because that a temporary checkpoint directory is created on local file system but metadata whose path is based on the checkpoint directory will be created on HDFS.

This PR will fixe this issue.

## How was this patch tested?

I tested manually in local mode with HDFS.
