### PR TITLE
[SPARK-19910][SQL] `stack` should not reject NULL values due to type mismatch

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -54,7 +54,6 @@ object TypeCoercion {
       FunctionArgumentConversion ::
       CaseWhenCoercion ::
       IfCoercion ::
-      StackCoercion ::
       Division ::
       PropagateTypes ::
       ImplicitTypeCasts ::
@@ -646,22 +645,6 @@ object TypeCoercion {
         If(Literal.create(null, BooleanType), left, right)
       case If(pred, left, right) if pred.dataType == NullType =>
         If(Cast(pred, BooleanType), left, right)
-    }
-  }
-
-  /**
-   * Coerces NullTypes of a Stack function to the corresponding column types.
-   */
-  object StackCoercion extends Rule[LogicalPlan] {
-    def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
-      case s @ Stack(children) if s.childrenResolved =>
-        val schema = s.elementSchema
-        Stack(children.zipWithIndex.map {
-          case (e, 0) => e
-          case (Literal(null, NullType), index: Int) =>
-            Literal.create(null, schema.fields((index - 1) % schema.length).dataType)
-          case (e, _) => e
-        })
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -54,6 +54,7 @@ object TypeCoercion {
       FunctionArgumentConversion ::
       CaseWhenCoercion ::
       IfCoercion ::
+      StackCoercion ::
       Division ::
       PropagateTypes ::
       ImplicitTypeCasts ::
@@ -645,6 +646,22 @@ object TypeCoercion {
         If(Literal.create(null, BooleanType), left, right)
       case If(pred, left, right) if pred.dataType == NullType =>
         If(Cast(pred, BooleanType), left, right)
+    }
+  }
+
+  /**
+   * Coerces NullTypes of a Stack function to the corresponding column types.
+   */
+  object StackCoercion extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
+      case s @ Stack(children) if s.childrenResolved =>
+        val schema = s.elementSchema
+        Stack(children.zipWithIndex.map {
+          case (e, 0) => e
+          case (Literal(null, NullType), index: Int) =>
+            Literal.create(null, schema.fields((index - 1) % schema.length).dataType)
+          case (e, _) => e
+        })
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -653,7 +653,7 @@ object TypeCoercion {
    * Coerces NullTypes in the Stack expression to the column types of the corresponding positions.
    */
   object StackCoercion extends Rule[LogicalPlan] {
-    def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
+    def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
       case s @ Stack(children) if s.childrenResolved && s.hasFoldableRowNums =>
         Stack(children.zipWithIndex.map {
           case (e, 0) => e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -654,7 +654,7 @@ object TypeCoercion {
    */
   object StackCoercion extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
-      case s @ Stack(children) if s.childrenResolved && s.hasFoldableRowNums =>
+      case s @ Stack(children) if s.childrenResolved && s.hasFoldableNumRows =>
         Stack(children.zipWithIndex.map {
           case (e, 0) => e
           case (Literal(null, NullType), index: Int) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -654,7 +654,7 @@ object TypeCoercion {
    */
   object StackCoercion extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
-      case s @ Stack(children) if s.childrenResolved =>
+      case s @ Stack(children @ Literal(_, IntegerType) :: _) if s.childrenResolved =>
         val schema = s.elementSchema
         Stack(children.zipWithIndex.map {
           case (e, 0) => e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -650,7 +650,7 @@ object TypeCoercion {
   }
 
   /**
-   * Coerces NullTypes of a Stack function to the corresponding column types.
+   * Coerces NullTypes in the Stack expression to the column types of the corresponding positions.
    */
   object StackCoercion extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -654,8 +654,8 @@ object TypeCoercion {
    */
   object StackCoercion extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
-      case s @ Stack(children @ head :: _)
-          if s.childrenResolved && head.dataType == IntegerType && head.foldable =>
+      case s @ Stack(children) if s.childrenResolved && s.children.head.dataType == IntegerType &&
+          s.children.head.foldable =>
         val schema = s.elementSchema
         Stack(children.zipWithIndex.map {
           case (e, 0) => e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -656,9 +656,10 @@ object TypeCoercion {
     def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
       case s @ Stack(children) if s.childrenResolved && s.hasFoldableNumRows =>
         Stack(children.zipWithIndex.map {
+          // The first child is the number of rows for stack.
           case (e, 0) => e
           case (Literal(null, NullType), index: Int) =>
-            Literal.create(null, s.findDataType(index - 1))
+            Literal.create(null, s.findDataType(index))
           case (e, _) => e
         })
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -654,7 +654,8 @@ object TypeCoercion {
    */
   object StackCoercion extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
-      case s @ Stack(children @ Literal(_, IntegerType) :: _) if s.childrenResolved =>
+      case s @ Stack(children @ head :: _)
+          if s.childrenResolved && head.dataType == IntegerType && head.foldable =>
         val schema = s.elementSchema
         Stack(children.zipWithIndex.map {
           case (e, 0) => e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -654,13 +654,11 @@ object TypeCoercion {
    */
   object StackCoercion extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
-      case s @ Stack(children) if s.childrenResolved && s.children.head.dataType == IntegerType &&
-          s.children.head.foldable =>
-        val schema = s.elementSchema
+      case s @ Stack(children) if s.childrenResolved && s.hasFoldableRowNums =>
         Stack(children.zipWithIndex.map {
           case (e, 0) => e
           case (Literal(null, NullType), index: Int) =>
-            Literal.create(null, schema.fields((index - 1) % schema.length).dataType)
+            Literal.create(null, s.findDataType(index - 1))
           case (e, _) => e
         })
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -173,9 +173,9 @@ case class Stack(children: Seq[Expression]) extends Generator {
   }
 
   override def elementSchema: StructType =
-    StructType(children.tail.take(numFields).zipWithIndex.map {
-      case (e, index) if e.dataType != NullType => StructField(s"col$index", e.dataType)
-      case (_, index) => StructField(s"col$index", findDataType(index))
+    StructType(children.tail.take(numFields).zipWithIndex.map { case (e, index) =>
+      val dataType = if (e.dataType != NullType) e.dataType else findDataType(index)
+      StructField(s"col$index", dataType)
     })
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -173,9 +173,8 @@ case class Stack(children: Seq[Expression]) extends Generator {
   }
 
   override def elementSchema: StructType =
-    StructType(children.tail.take(numFields).zipWithIndex.map { case (e, index) =>
-      val dataType = if (e.dataType != NullType) e.dataType else findDataType(index)
-      StructField(s"col$index", dataType)
+    StructType(children.tail.take(numFields).zipWithIndex.map {
+      case (e, index) => StructField(s"col$index", e.dataType)
     })
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -163,9 +163,9 @@ case class Stack(children: Seq[Expression]) extends Generator {
     }
   }
 
-  def findDataType(column: Int): DataType = {
+  def findDataType(index: Int): DataType = {
     // Find the first data type except NullType.
-    val firstDataIndex = (column % numFields) + 1
+    val firstDataIndex = ((index - 1) % numFields) + 1
     for (i <- firstDataIndex until children.length by numFields) {
       if (children(i).dataType != NullType) {
         return children(i).dataType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -146,8 +146,7 @@ case class Stack(children: Seq[Expression]) extends Generator {
     } else {
       for (i <- 1 until children.length) {
         val j = (i - 1) % numFields
-        if (children(i).dataType != NullType &&
-          children(i).dataType != elementSchema.fields(j).dataType) {
+        if (children(i).dataType != elementSchema.fields(j).dataType) {
           return TypeCheckResult.TypeCheckFailure(
             s"Argument ${j + 1} (${elementSchema.fields(j).dataType}) != " +
               s"Argument $i (${children(i).dataType})")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -138,7 +138,10 @@ case class Stack(children: Seq[Expression]) extends Generator {
   private lazy val numRows = children.head.eval().asInstanceOf[Int]
   private lazy val numFields = Math.ceil((children.length - 1.0) / numRows).toInt
 
-  def hasFoldableRowNums: Boolean = {
+  /**
+   * Return true iff there is at least one child which is a foldable IntegerType.
+   */
+  def hasFoldableNumRows: Boolean = {
     children.nonEmpty && children.head.dataType == IntegerType && children.head.foldable
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -139,7 +139,7 @@ case class Stack(children: Seq[Expression]) extends Generator {
   private lazy val numFields = Math.ceil((children.length - 1.0) / numRows).toInt
 
   /**
-   * Return true iff there is at least one child which is a foldable IntegerType.
+   * Return true iff the first child exists and has a foldable IntegerType.
    */
   def hasFoldableNumRows: Boolean = {
     children.nonEmpty && children.head.dataType == IntegerType && children.head.foldable

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -714,20 +714,6 @@ class TypeCoercionSuite extends PlanTest {
     )
   }
 
-  test("type coercion for Stack") {
-    val rule = TypeCoercion.StackCoercion
-
-    ruleTest(rule,
-      Stack(Seq(Literal(3), Literal(1), Literal(2), Literal(null))),
-      Stack(Seq(Literal(3), Literal(1), Literal(2), Literal.create(null, IntegerType))))
-    ruleTest(rule,
-      Stack(Seq(Literal(3), Literal(1.0), Literal(null), Literal(3.0))),
-      Stack(Seq(Literal(3), Literal(1.0), Literal.create(null, DoubleType), Literal(3.0))))
-    ruleTest(rule,
-      Stack(Seq(Literal(3), Literal(null), Literal("2"), Literal("3"))),
-      Stack(Seq(Literal(3), Literal.create(null, StringType), Literal("2"), Literal("3"))))
-  }
-
   test("BooleanEquality type cast") {
     val be = TypeCoercion.BooleanEquality
     // Use something more than a literal to avoid triggering the simplification rules.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -714,6 +714,20 @@ class TypeCoercionSuite extends PlanTest {
     )
   }
 
+  test("type coercion for Stack") {
+    val rule = TypeCoercion.StackCoercion
+
+    ruleTest(rule,
+      Stack(Seq(Literal(3), Literal(1), Literal(2), Literal(null))),
+      Stack(Seq(Literal(3), Literal(1), Literal(2), Literal.create(null, IntegerType))))
+    ruleTest(rule,
+      Stack(Seq(Literal(3), Literal(1.0), Literal(null), Literal(3.0))),
+      Stack(Seq(Literal(3), Literal(1.0), Literal.create(null, DoubleType), Literal(3.0))))
+    ruleTest(rule,
+      Stack(Seq(Literal(3), Literal(null), Literal("2"), Literal("3"))),
+      Stack(Seq(Literal(3), Literal.create(null, StringType), Literal("2"), Literal("3"))))
+  }
+
   test("BooleanEquality type cast") {
     val be = TypeCoercion.BooleanEquality
     // Use something more than a literal to avoid triggering the simplification rules.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -726,6 +726,9 @@ class TypeCoercionSuite extends PlanTest {
     ruleTest(rule,
       Stack(Seq(Literal(3), Literal(null), Literal("2"), Literal("3"))),
       Stack(Seq(Literal(3), Literal.create(null, StringType), Literal("2"), Literal("3"))))
+    ruleTest(rule,
+      Stack(Seq(Literal(3), Literal(null), Literal(null), Literal(null))),
+      Stack(Seq(Literal(3), Literal(null), Literal(null), Literal(null))))
 
     ruleTest(rule,
       Stack(Seq(Literal(2),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -739,6 +739,30 @@ class TypeCoercionSuite extends PlanTest {
         Literal.create(null, IntegerType), Literal.create(null, StringType))))
 
     ruleTest(rule,
+      Stack(Seq(Literal(2),
+        Literal(1), Literal(null),
+        Literal(null), Literal("2"))),
+      Stack(Seq(Literal(2),
+        Literal(1), Literal.create(null, StringType),
+        Literal.create(null, IntegerType), Literal("2"))))
+
+    ruleTest(rule,
+      Stack(Seq(Literal(2),
+        Literal(null), Literal(1),
+        Literal("2"), Literal(null))),
+      Stack(Seq(Literal(2),
+        Literal.create(null, StringType), Literal(1),
+        Literal("2"), Literal.create(null, IntegerType))))
+
+    ruleTest(rule,
+      Stack(Seq(Literal(2),
+        Literal(null), Literal(null),
+        Literal(1), Literal("2"))),
+      Stack(Seq(Literal(2),
+        Literal.create(null, IntegerType), Literal.create(null, StringType),
+        Literal(1), Literal("2"))))
+
+    ruleTest(rule,
       Stack(Seq(Subtract(Literal(3), Literal(1)),
         Literal(1), Literal("2"),
         Literal(null), Literal(null))),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -726,6 +726,22 @@ class TypeCoercionSuite extends PlanTest {
     ruleTest(rule,
       Stack(Seq(Literal(3), Literal(null), Literal("2"), Literal("3"))),
       Stack(Seq(Literal(3), Literal.create(null, StringType), Literal("2"), Literal("3"))))
+
+    ruleTest(rule,
+      Stack(Seq(Literal(2),
+        Literal(1), Literal("2"),
+        Literal(null), Literal(null))),
+      Stack(Seq(Literal(2),
+        Literal(1), Literal("2"),
+        Literal.create(null, IntegerType), Literal.create(null, StringType))))
+
+    ruleTest(rule,
+      Stack(Seq(Subtract(Literal(3), Literal(1)),
+        Literal(1), Literal("2"),
+        Literal(null), Literal(null))),
+      Stack(Seq(Subtract(Literal(3), Literal(1)),
+        Literal(1), Literal("2"),
+        Literal.create(null, IntegerType), Literal.create(null, StringType))))
   }
 
   test("BooleanEquality type cast") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratorExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratorExpressionSuite.scala
@@ -81,4 +81,13 @@ class GeneratorExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(Stack(Seq(Literal(1), Literal(1), Literal(1.0))).checkInputDataTypes().isSuccess)
     assert(Stack(Seq(Literal(2), Literal(1), Literal(1.0))).checkInputDataTypes().isFailure)
   }
+
+  test("SPARK-19910 `stack` should not reject NULL values due to type mismatch") {
+    assert(Stack(Seq(3, 1, 2, null).map(Literal(_))).checkInputDataTypes().isSuccess)
+    assert(Stack(Seq(3, 1, null, 3).map(Literal(_))).checkInputDataTypes().isSuccess)
+    assert(Stack(Seq(3, null, 2, 3).map(Literal(_))).checkInputDataTypes().isSuccess)
+    assert(Stack(Seq(3, null, 2, 3).map(Literal(_))).elementSchema.head.dataType == IntegerType)
+    assert(Stack(Seq(3, null, 2, "3").map(Literal(_))).checkInputDataTypes().isFailure)
+    assert(Stack(Seq(3, null, "2", 3).map(Literal(_))).checkInputDataTypes().isFailure)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratorExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratorExpressionSuite.scala
@@ -81,13 +81,4 @@ class GeneratorExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(Stack(Seq(Literal(1), Literal(1), Literal(1.0))).checkInputDataTypes().isSuccess)
     assert(Stack(Seq(Literal(2), Literal(1), Literal(1.0))).checkInputDataTypes().isFailure)
   }
-
-  test("SPARK-19910 `stack` should not reject NULL values due to type mismatch") {
-    assert(Stack(Seq(3, 1, 2, null).map(Literal(_))).checkInputDataTypes().isSuccess)
-    assert(Stack(Seq(3, 1, null, 3).map(Literal(_))).checkInputDataTypes().isSuccess)
-    assert(Stack(Seq(3, null, 2, 3).map(Literal(_))).checkInputDataTypes().isSuccess)
-    assert(Stack(Seq(3, null, 2, 3).map(Literal(_))).elementSchema.head.dataType == IntegerType)
-    assert(Stack(Seq(3, null, 2, "3").map(Literal(_))).checkInputDataTypes().isFailure)
-    assert(Stack(Seq(3, null, "2", 3).map(Literal(_))).checkInputDataTypes().isFailure)
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -39,9 +39,9 @@ class GeneratorFunctionSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.selectExpr("stack(3, 1, 2, 3)"), Row(1) :: Row(2) :: Row(3) :: Nil)
     checkAnswer(df.selectExpr("stack(4, 1, 2, 3)"), Row(1) :: Row(2) :: Row(3) :: Row(null) :: Nil)
 
-    // Various column types
-    checkAnswer(df.selectExpr("stack(3, 1, 1.1, 'a', 2, 2.2, 'b', 3, 3.3, 'c')"),
-      Row(1, 1.1, "a") :: Row(2, 2.2, "b") :: Row(3, 3.3, "c") :: Nil)
+    // Various column types and null values
+    checkAnswer(df.selectExpr("stack(3, 1, 1.1, null, 2, null, 'b', null, 3.3, 'c')"),
+      Row(1, 1.1, null) :: Row(2, null, "b") :: Row(null, 3.3, "c") :: Nil)
 
     // Repeat generation at every input row
     checkAnswer(spark.range(2).selectExpr("stack(2, 1, 2, 3)"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -39,7 +39,11 @@ class GeneratorFunctionSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.selectExpr("stack(3, 1, 2, 3)"), Row(1) :: Row(2) :: Row(3) :: Nil)
     checkAnswer(df.selectExpr("stack(4, 1, 2, 3)"), Row(1) :: Row(2) :: Row(3) :: Row(null) :: Nil)
 
-    // Various column types and null values
+    // Various column types
+    checkAnswer(df.selectExpr("stack(3, 1, 1.1, 'a', 2, 2.2, 'b', 3, 3.3, 'c')"),
+      Row(1, 1.1, "a") :: Row(2, 2.2, "b") :: Row(3, 3.3, "c") :: Nil)
+
+    // Null values
     checkAnswer(df.selectExpr("stack(3, 1, 1.1, null, 2, null, 'b', null, 3.3, 'c')"),
       Row(1, 1.1, null) :: Row(2, null, "b") :: Row(null, 3.3, "c") :: Nil)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since `stack` function generates a table with nullable columns, it should allow mixed null values.

```scala
scala> sql("select stack(3, 1, 2, 3)").printSchema
root
 |-- col0: integer (nullable = true)

scala> sql("select stack(3, 1, 2, null)").printSchema
org.apache.spark.sql.AnalysisException: cannot resolve 'stack(3, 1, 2, NULL)' due to data type mismatch: Argument 1 (IntegerType) != Argument 3 (NullType); line 1 pos 7;
```

## How was this patch tested?

Pass the Jenkins with a new test case.