### PR TITLE
[SPARK-19926][PYSPARK] Make pyspark exception more user-friendly

### DIFF
--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -24,7 +24,7 @@ class CapturedException(Exception):
         self.stackTrace = stackTrace
 
     def __str__(self):
-        return repr(self.desc)
+        return str(self.desc)
 
 
 class AnalysisException(CapturedException):

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -18,7 +18,7 @@
 import py4j
 import sys
 
-if sys.version > '3':
+if sys.version >= '3':
     unicode = str
 
 

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -16,6 +16,10 @@
 #
 
 import py4j
+import sys
+
+if sys.version > '3':
+    unicode = str
 
 
 class CapturedException(Exception):
@@ -24,7 +28,11 @@ class CapturedException(Exception):
         self.stackTrace = stackTrace
 
     def __str__(self):
-        return str(self.desc)
+        desc = self.desc
+        if isinstance(desc, unicode):
+            return str(desc.encode('utf-8'))
+        else:
+            return str(desc)
 
 
 class AnalysisException(CapturedException):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exception in pyspark is a little difficult to read.

before pr, like:

```
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "/root/dev/spark/dist/python/pyspark/sql/streaming.py", line 853, in start
    return self._sq(self._jwrite.start())
  File "/root/dev/spark/dist/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 1133, in __call__
  File "/root/dev/spark/dist/python/pyspark/sql/utils.py", line 69, in deco
    raise AnalysisException(s.split(': ', 1)[1], stackTrace)
pyspark.sql.utils.AnalysisException: u'Append output mode not supported when there are streaming aggregations on streaming DataFrames/DataSets without watermark;;\nAggregate [window#17, word#5], [window#17 AS window#11, word#5, count(1) AS count#16L]\n+- Filter ((t#6 >= window#17.start) && (t#6 < window#17.end))\n   +- Expand [ArrayBuffer(named_struct(start, ((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(0 as bigint)) - cast(1 as bigint)) * 30000000) + 0), end, (((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(0 as bigint)) - cast(1 as bigint)) * 30000000) + 0) + 30000000)), word#5, t#6-T30000ms), ArrayBuffer(named_struct(start, ((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(1 as bigint)) - cast(1 as bigint)) * 30000000) + 0), end, (((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(1 as bigint)) - cast(1 as bigint)) * 30000000) + 0) + 30000000)), word#5, t#6-T30000ms)], [window#17, word#5, t#6-T30000ms]\n      +- EventTimeWatermark t#6: timestamp, interval 30 seconds\n         +- Project [cast(word#0 as string) AS word#5, cast(t#1 as timestamp) AS t#6]\n            +- StreamingRelation DataSource(org.apache.spark.sql.SparkSession@c4079ca,csv,List(),Some(StructType(StructField(word,StringType,true), StructField(t,IntegerType,true))),List(),None,Map(sep -> ;, path -> /tmp/data),None), FileSource[/tmp/data], [word#0, t#1]\n'
```

after pr:

```
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "/root/dev/spark/dist/python/pyspark/sql/streaming.py", line 853, in start
    return self._sq(self._jwrite.start())
  File "/root/dev/spark/dist/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 1133, in __call__
  File "/root/dev/spark/dist/python/pyspark/sql/utils.py", line 69, in deco
    raise AnalysisException(s.split(': ', 1)[1], stackTrace)
pyspark.sql.utils.AnalysisException: Append output mode not supported when there are streaming aggregations on streaming DataFrames/DataSets without watermark;;
Aggregate [window#17, word#5], [window#17 AS window#11, word#5, count(1) AS count#16L]
+- Filter ((t#6 >= window#17.start) && (t#6 < window#17.end))
   +- Expand [ArrayBuffer(named_struct(start, ((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(0 as bigint)) - cast(1 as bigint)) * 30000000) + 0), end, (((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(0 as bigint)) - cast(1 as bigint)) * 30000000) + 0) + 30000000)), word#5, t#6-T30000ms), ArrayBuffer(named_struct(start, ((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(1 as bigint)) - cast(1 as bigint)) * 30000000) + 0), end, (((((CEIL((cast((precisetimestamp(t#6) - 0) as double) / cast(30000000 as double))) + cast(1 as bigint)) - cast(1 as bigint)) * 30000000) + 0) + 30000000)), word#5, t#6-T30000ms)], [window#17, word#5, t#6-T30000ms]
      +- EventTimeWatermark t#6: timestamp, interval 30 seconds
         +- Project [cast(word#0 as string) AS word#5, cast(t#1 as timestamp) AS t#6]
            +- StreamingRelation DataSource(org.apache.spark.sql.SparkSession@5265083b,csv,List(),Some(StructType(StructField(word,StringType,true), StructField(t,IntegerType,true))),List(),None,Map(sep -> ;, path -> /tmp/data),None), FileSource[/tmp/data], [word#0, t#1]
```

IMHO, the root cause is the `repr` is not user-friendly
```
class CapturedException(Exception):
    def __init__(self, desc, stackTrace):
        self.desc = desc
        self.stackTrace = stackTrace

    def __str__(self):
        return repr(self.desc)
               ▲▲▲▲
```  

This pr change `repr` to `str`

|str()|	repr()|
|----|------|
|make object readable|need code that reproduces object|
|generate output for end user|generate output for developer|

## How was this patch tested?

Jenkins
