### PR TITLE
SPARK-19927: Support the --hivevar in the spark-sql command line and in the beeline

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/server/SparkSQLOperationManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/server/SparkSQLOperationManager.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.hive.thriftserver.server
 import java.util.{Map => JMap}
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.collection.JavaConverters._
+
 import org.apache.hive.service.cli._
 import org.apache.hive.service.cli.operation.{ExecuteStatementOperation, Operation, OperationManager}
 import org.apache.hive.service.cli.session.HiveSession
@@ -50,6 +52,8 @@ private[thriftserver] class SparkSQLOperationManager()
     require(sqlContext != null, s"Session handle: ${parentSession.getSessionHandle} has not been" +
       s" initialized or had already closed.")
     val sessionState = sqlContext.sessionState.asInstanceOf[HiveSessionState]
+    parentSession.getSessionState.getHiveVariables.asScala.foreach(kv =>
+      sqlContext.conf.setConfString(kv._1, kv._2))
     val runInBackground = async && sessionState.hiveThriftServerAsync
     val operation = new SparkExecuteStatementOperation(parentSession, statement, confOverlay,
       runInBackground)(sqlContext, sessionToActivePool)

--- a/sql/hive-thriftserver/src/test/resources/TestSQL.sql
+++ b/sql/hive-thriftserver/src/test/resources/TestSQL.sql
@@ -1,0 +1,1 @@
+select date_add('${today}', -1);

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -283,4 +283,10 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       "SET conf3;" -> "conftest"
     )
   }
+
+  test("apply hivevar from cli command") {
+    val sqlFile = Thread.currentThread().getContextClassLoader.getResource("TestSQL.sql")
+    runCliWithin(2.minute, Seq("--hivevar", "today=2017-3-13", "-f",
+      sqlFile.getFile))(s"" -> "today=2017-3-13")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Read hivevar of hivevariables into sqlContext.conf in SparkSQLOperationManager
- Adds TestSQL.sql as test resource
- Adds spark-sql CLI test case in CliSuite

## How was this patch tested?
Added a test case for spark-sql CLI mode
Manual test for Beeline mode

