### PR TITLE
[SPARK-19925][SPARKR] Fix SparkR spark.getSparkFiles fails when it was called on executors.

### DIFF
--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -330,7 +330,13 @@ spark.addFile <- function(path, recursive = FALSE) {
 #'}
 #' @note spark.getSparkFilesRootDirectory since 2.1.0
 spark.getSparkFilesRootDirectory <- function() {
-  callJStatic("org.apache.spark.SparkFiles", "getRootDirectory")
+  if (Sys.getenv("IS_RUNNING_ON_WORKER") == "") {
+    # Running on driver.
+    callJStatic("org.apache.spark.SparkFiles", "getRootDirectory")
+  } else {
+    # Running on worker.
+    Sys.getenv("SPARKFILES_ROOT_DIR")
+  }
 }
 
 #' Get the absolute path of a file added through spark.addFile.
@@ -345,7 +351,8 @@ spark.getSparkFilesRootDirectory <- function() {
 #'}
 #' @note spark.getSparkFiles since 2.1.0
 spark.getSparkFiles <- function(fileName) {
-  callJStatic("org.apache.spark.SparkFiles", "get", as.character(fileName))
+  rootDir <- spark.getSparkFilesRootDirectory()
+  paste0(rootDir, "/", as.character(fileName))
 }
 
 #' Run a function over a list of elements, distributing the computations with Spark

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -330,12 +330,12 @@ spark.addFile <- function(path, recursive = FALSE) {
 #'}
 #' @note spark.getSparkFilesRootDirectory since 2.1.0
 spark.getSparkFilesRootDirectory <- function() {
-  if (Sys.getenv("IS_RUNNING_ON_WORKER") == "") {
+  if (Sys.getenv("SPARKR_IS_RUNNING_ON_WORKER") == "") {
     # Running on driver.
     callJStatic("org.apache.spark.SparkFiles", "getRootDirectory")
   } else {
     # Running on worker.
-    Sys.getenv("SPARKFILES_ROOT_DIR")
+    Sys.getenv("SPARKR_SPARKFILES_ROOT_DIR")
   }
 }
 
@@ -351,8 +351,7 @@ spark.getSparkFilesRootDirectory <- function() {
 #'}
 #' @note spark.getSparkFiles since 2.1.0
 spark.getSparkFiles <- function(fileName) {
-  rootDir <- spark.getSparkFilesRootDirectory()
-  paste0(rootDir, "/", as.character(fileName))
+  file.path(spark.getSparkFilesRootDirectory(), as.character(fileName))
 }
 
 #' Run a function over a list of elements, distributing the computations with Spark

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -351,7 +351,13 @@ spark.getSparkFilesRootDirectory <- function() {
 #'}
 #' @note spark.getSparkFiles since 2.1.0
 spark.getSparkFiles <- function(fileName) {
-  file.path(spark.getSparkFilesRootDirectory(), as.character(fileName))
+  if (Sys.getenv("SPARKR_IS_RUNNING_ON_WORKER") == "") {
+    # Running on driver.
+    callJStatic("org.apache.spark.SparkFiles", "get", as.character(fileName))
+  } else {
+    # Running on worker.
+    file.path(spark.getSparkFilesRootDirectory(), as.character(fileName))
+  }
 }
 
 #' Run a function over a list of elements, distributing the computations with Spark

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -182,7 +182,6 @@ test_that("add and get file to be downloaded with Spark job on every node", {
   seq <- seq(from = 1, to = 10, length.out = 5)
   f <- function(seq) { spark.getSparkFiles(filename) }
   results <- spark.lapply(seq, f)
-  # In local mode, the SparkFiles path in driver and executors should be the same.
   for (i in 1:5) { expect_equal(basename(results[[i]]), filename) }
 
   unlink(path)

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -181,7 +181,9 @@ test_that("add and get file to be downloaded with Spark job on every node", {
   # Test spark.getSparkFiles works well on executors.
   seq <- seq(from = 1, to = 10, length.out = 5)
   f <- function(seq) { spark.getSparkFiles(filename) }
-  spark.lapply(seq, f)
+  results <- spark.lapply(seq, f)
+  # In local mode, the SparkFiles path in driver and executors should be the same.
+  for (i in 1:5) { expect_equal(basename(results[[i]]), filename) }
 
   unlink(path)
 

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -180,9 +180,8 @@ test_that("add and get file to be downloaded with Spark job on every node", {
 
   # Test spark.getSparkFiles works well on executors.
   seq <- seq(from = 1, to = 10, length.out = 5)
-  f <- function(seq) { readLines(spark.getSparkFiles(filename)) }
-  results <- spark.lapply(seq, f)
-  for (i in 1:5) { expect_equal(results[[i]], words) }
+  f <- function(seq) { spark.getSparkFiles(filename) }
+  spark.lapply(seq, f)
 
   unlink(path)
 

--- a/R/pkg/inst/tests/testthat/test_context.R
+++ b/R/pkg/inst/tests/testthat/test_context.R
@@ -177,6 +177,13 @@ test_that("add and get file to be downloaded with Spark job on every node", {
   spark.addFile(path)
   download_path <- spark.getSparkFiles(filename)
   expect_equal(readLines(download_path), words)
+
+  # Test spark.getSparkFiles works well on executors.
+  seq <- seq(from = 1, to = 10, length.out = 5)
+  f <- function(seq) { readLines(spark.getSparkFiles(filename)) }
+  results <- spark.lapply(seq, f)
+  for (i in 1:5) { expect_equal(results[[i]], words) }
+
   unlink(path)
 
   # Test add directory recursively.

--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -17,7 +17,7 @@
 
 # Worker daemon
 
-Sys.setenv(IS_RUNNING_ON_WORKER = TRUE)
+Sys.setenv(SPARKR_IS_RUNNING_ON_WORKER = TRUE)
 
 rLibDir <- Sys.getenv("SPARKR_RLIBDIR")
 connectionTimeout <- as.integer(Sys.getenv("SPARKR_BACKEND_CONNECTION_TIMEOUT", "6000"))

--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -17,8 +17,6 @@
 
 # Worker daemon
 
-Sys.setenv(SPARKR_IS_RUNNING_ON_WORKER = TRUE)
-
 rLibDir <- Sys.getenv("SPARKR_RLIBDIR")
 connectionTimeout <- as.integer(Sys.getenv("SPARKR_BACKEND_CONNECTION_TIMEOUT", "6000"))
 dirs <- strsplit(rLibDir, ",")[[1]]

--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -17,6 +17,8 @@
 
 # Worker daemon
 
+Sys.setenv(IS_RUNNING_ON_WORKER = TRUE)
+
 rLibDir <- Sys.getenv("SPARKR_RLIBDIR")
 connectionTimeout <- as.integer(Sys.getenv("SPARKR_BACKEND_CONNECTION_TIMEOUT", "6000"))
 dirs <- strsplit(rLibDir, ",")[[1]]

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -347,6 +347,7 @@ private[r] object RRunner {
     pb.environment().put("SPARKR_RLIBDIR", rLibDir.mkString(","))
     pb.environment().put("SPARKR_WORKER_PORT", port.toString)
     pb.environment().put("SPARKR_BACKEND_CONNECTION_TIMEOUT", rConnectionTimeout.toString)
+    pb.environment().put("SPARKFILES_ROOT_DIR", SparkFiles.getRootDirectory())
     pb.redirectErrorStream(true)  // redirect stderr into stdout
     val proc = pb.start()
     val errThread = startStdoutThread(proc)

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -347,7 +347,7 @@ private[r] object RRunner {
     pb.environment().put("SPARKR_RLIBDIR", rLibDir.mkString(","))
     pb.environment().put("SPARKR_WORKER_PORT", port.toString)
     pb.environment().put("SPARKR_BACKEND_CONNECTION_TIMEOUT", rConnectionTimeout.toString)
-    pb.environment().put("SPARKFILES_ROOT_DIR", SparkFiles.getRootDirectory())
+    pb.environment().put("SPARKR_SPARKFILES_ROOT_DIR", SparkFiles.getRootDirectory())
     pb.redirectErrorStream(true)  // redirect stderr into stdout
     val proc = pb.start()
     val errThread = startStdoutThread(proc)

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -348,6 +348,7 @@ private[r] object RRunner {
     pb.environment().put("SPARKR_WORKER_PORT", port.toString)
     pb.environment().put("SPARKR_BACKEND_CONNECTION_TIMEOUT", rConnectionTimeout.toString)
     pb.environment().put("SPARKR_SPARKFILES_ROOT_DIR", SparkFiles.getRootDirectory())
+    pb.environment().put("SPARKR_IS_RUNNING_ON_WORKER", "TRUE")
     pb.redirectErrorStream(true)  // redirect stderr into stdout
     val proc = pb.start()
     val errThread = startStdoutThread(proc)


### PR DESCRIPTION
## What changes were proposed in this pull request?
SparkR ```spark.getSparkFiles``` fails when it was called on executors, see details at [SPARK-19925](https://issues.apache.org/jira/browse/SPARK-19925).

## How was this patch tested?
Add unit tests, and verify this fix at standalone and yarn cluster.
