### PR TITLE
[SPARK-19915][SQL] Exclude cartesian product candidates to reduce the search space

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -138,10 +138,10 @@ object JoinReorderDP extends PredicateHelper {
 
     // Level i maintains all found plans for i + 1 items.
     // Create the initial plans: each plan is a single item with zero cost.
-    val itemIndex = items.zipWithIndex.map(_.swap).toMap
+    val itemIndex = items.zipWithIndex
     val foundPlans = mutable.Buffer[JoinPlanMap](itemIndex.map {
-      case (id, item) => Set(id) -> JoinPlan(Set(id), item, Set(), Cost(0, 0))
-    })
+      case (item, id) => Set(id) -> JoinPlan(Set(id), item, Set(), Cost(0, 0))
+    }.toMap)
 
     // Build plans for next levels until the last level has only one plan. This plan contains
     // all items that can be joined, so there's no need to continue.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.CatalystConf
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, Expression, PredicateHelper}
 import org.apache.spark.sql.catalyst.plans.{Inner, InnerLike}
 import org.apache.spark.sql.catalyst.plans.logical.{BinaryNode, Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.internal.SQLConf
 
 
 /**
@@ -31,19 +31,19 @@ import org.apache.spark.sql.catalyst.rules.Rule
  * We may have several join reorder algorithms in the future. This class is the entry of these
  * algorithms, and chooses which one to use.
  */
-case class CostBasedJoinReorder(conf: CatalystConf) extends Rule[LogicalPlan] with PredicateHelper {
+case class CostBasedJoinReorder(conf: SQLConf) extends Rule[LogicalPlan] with PredicateHelper {
   def apply(plan: LogicalPlan): LogicalPlan = {
     if (!conf.cboEnabled || !conf.joinReorderEnabled) {
       plan
     } else {
-      val result = plan transform {
+      val result = plan transformDown {
         case p @ Project(projectList, j @ Join(_, _, _: InnerLike, _)) =>
           reorder(p, p.outputSet)
         case j @ Join(_, _, _: InnerLike, _) =>
           reorder(j, j.outputSet)
       }
       // After reordering is finished, convert OrderedJoin back to Join
-      result transform {
+      result transformDown {
         case oj: OrderedJoin => oj.join
       }
     }
@@ -75,8 +75,8 @@ case class CostBasedJoinReorder(conf: CatalystConf) extends Rule[LogicalPlan] wi
         val (rightPlans, rightConditions) = extractInnerJoins(right)
         (leftPlans ++ rightPlans, cond.toSet.flatMap(splitConjunctivePredicates) ++
           leftConditions ++ rightConditions)
-      case Project(projectList, join) if projectList.forall(_.isInstanceOf[Attribute]) =>
-        extractInnerJoins(join)
+      case Project(projectList, j: Join) if projectList.forall(_.isInstanceOf[Attribute]) =>
+        extractInnerJoins(j)
       case _ =>
         (Seq(plan), Set())
     }
@@ -87,8 +87,8 @@ case class CostBasedJoinReorder(conf: CatalystConf) extends Rule[LogicalPlan] wi
       val replacedLeft = replaceWithOrderedJoin(left)
       val replacedRight = replaceWithOrderedJoin(right)
       OrderedJoin(j.copy(left = replacedLeft, right = replacedRight))
-    case p @ Project(_, join) =>
-      p.copy(child = replaceWithOrderedJoin(join))
+    case p @ Project(projectList, j: Join) =>
+      p.copy(child = replaceWithOrderedJoin(j))
     case _ =>
       plan
   }
@@ -128,38 +128,43 @@ case class CostBasedJoinReorder(conf: CatalystConf) extends Rule[LogicalPlan] wi
 object JoinReorderDP extends PredicateHelper {
 
   def search(
-      conf: CatalystConf,
+      conf: SQLConf,
       items: Seq[LogicalPlan],
       conditions: Set[Expression],
       topOutput: AttributeSet): Option[LogicalPlan] = {
 
     // Level i maintains all found plans for i + 1 items.
     // Create the initial plans: each plan is a single item with zero cost.
-    val itemIndex = items.zipWithIndex
+    val itemIndex = items.zipWithIndex.map(_.swap).toMap
     val foundPlans = mutable.Buffer[JoinPlanMap](itemIndex.map {
-      case (item, id) => Set(id) -> JoinPlan(Set(id), item, Set(), Cost(0, 0))
-    }.toMap)
+      case (id, item) => Set(id) -> JoinPlan(Set(id), item, Set(), Cost(0, 0))
+    })
 
-    for (lev <- 1 until items.length) {
+    // Build plans for next levels until the last level has only one plan. This plan contains
+    // all items that can be joined, so there's no need to continue.
+    while (foundPlans.size < items.length && foundPlans.last.size > 1) {
       // Build plans for the next level.
       foundPlans += searchLevel(foundPlans, conf, conditions, topOutput)
     }
 
-    val plansLastLevel = foundPlans(items.length - 1)
-    if (plansLastLevel.isEmpty) {
-      // Failed to find a plan, fall back to the original plan
-      None
-    } else {
-      // There must be only one plan at the last level, which contains all items.
-      assert(plansLastLevel.size == 1 && plansLastLevel.head._1.size == items.length)
-      Some(plansLastLevel.head._2.plan)
+    // Find the best plan
+    assert(foundPlans.last.size <= 1)
+    val bestJoinPlan = foundPlans.last.headOption
+    // Put cartesian products (inner join without join condition) at the end of the plan.
+    bestJoinPlan.map { case (itemIds, joinPlan) =>
+      val itemsNotJoined = itemIndex.keySet -- itemIds
+      var completePlan = joinPlan.plan
+      itemsNotJoined.foreach { id =>
+        completePlan = Join(completePlan, itemIndex(id), Inner, None)
+      }
+      completePlan
     }
   }
 
   /** Find all possible plans at the next level, based on existing levels. */
   private def searchLevel(
       existingLevels: Seq[JoinPlanMap],
-      conf: CatalystConf,
+      conf: SQLConf,
       conditions: Set[Expression],
       topOutput: AttributeSet): JoinPlanMap = {
 
@@ -185,11 +190,14 @@ object JoinReorderDP extends PredicateHelper {
           // Should not join two overlapping item sets.
           if (oneSidePlan.itemIds.intersect(otherSidePlan.itemIds).isEmpty) {
             val joinPlan = buildJoin(oneSidePlan, otherSidePlan, conf, conditions, topOutput)
-            // Check if it's the first plan for the item set, or it's a better plan than
-            // the existing one due to lower cost.
-            val existingPlan = nextLevel.get(joinPlan.itemIds)
-            if (existingPlan.isEmpty || joinPlan.cost.lessThan(existingPlan.get.cost)) {
-              nextLevel.update(joinPlan.itemIds, joinPlan)
+            if (joinPlan.isDefined) {
+              val newJoinPlan = joinPlan.get
+              // Check if it's the first plan for the item set, or it's a better plan than
+              // the existing one due to lower cost.
+              val existingPlan = nextLevel.get(newJoinPlan.itemIds)
+              if (existingPlan.isEmpty || newJoinPlan.betterThan(existingPlan.get, conf)) {
+                nextLevel.update(newJoinPlan.itemIds, newJoinPlan)
+              }
             }
           }
         }
@@ -203,64 +211,47 @@ object JoinReorderDP extends PredicateHelper {
   private def buildJoin(
       oneJoinPlan: JoinPlan,
       otherJoinPlan: JoinPlan,
-      conf: CatalystConf,
+      conf: SQLConf,
       conditions: Set[Expression],
-      topOutput: AttributeSet): JoinPlan = {
+      topOutput: AttributeSet): Option[JoinPlan] = {
 
     val onePlan = oneJoinPlan.plan
     val otherPlan = otherJoinPlan.plan
-    // Now both onePlan and otherPlan become intermediate joins, so the cost of the
-    // new join should also include their own cardinalities and sizes.
-    val newCost = if (isCartesianProduct(onePlan) || isCartesianProduct(otherPlan)) {
-      // We consider cartesian product very expensive, thus set a very large cost for it.
-      // This enables to plan all the cartesian products at the end, because having a cartesian
-      // product as an intermediate join will significantly increase a plan's cost, making it
-      // impossible to be selected as the best plan for the items, unless there's no other choice.
-      Cost(
-        rows = BigInt(Long.MaxValue) * BigInt(Long.MaxValue),
-        size = BigInt(Long.MaxValue) * BigInt(Long.MaxValue))
-    } else {
-      val onePlanStats = onePlan.stats(conf)
-      val otherPlanStats = otherPlan.stats(conf)
-      Cost(
-        rows = oneJoinPlan.cost.rows + onePlanStats.rowCount.get +
-          otherJoinPlan.cost.rows + otherPlanStats.rowCount.get,
-        size = oneJoinPlan.cost.size + onePlanStats.sizeInBytes +
-          otherJoinPlan.cost.size + otherPlanStats.sizeInBytes)
-    }
-
-    // Put the deeper side on the left, tend to build a left-deep tree.
-    val (left, right) = if (oneJoinPlan.itemIds.size >= otherJoinPlan.itemIds.size) {
-      (onePlan, otherPlan)
-    } else {
-      (otherPlan, onePlan)
-    }
     val joinConds = conditions
       .filterNot(l => canEvaluate(l, onePlan))
       .filterNot(r => canEvaluate(r, otherPlan))
       .filter(e => e.references.subsetOf(onePlan.outputSet ++ otherPlan.outputSet))
-    // We use inner join whether join condition is empty or not. Since cross join is
-    // equivalent to inner join without condition.
-    val newJoin = Join(left, right, Inner, joinConds.reduceOption(And))
-    val collectedJoinConds = joinConds ++ oneJoinPlan.joinConds ++ otherJoinPlan.joinConds
-    val remainingConds = conditions -- collectedJoinConds
-    val neededAttr = AttributeSet(remainingConds.flatMap(_.references)) ++ topOutput
-    val neededFromNewJoin = newJoin.outputSet.filter(neededAttr.contains)
-    val newPlan =
-      if ((newJoin.outputSet -- neededFromNewJoin).nonEmpty) {
-        Project(neededFromNewJoin.toSeq, newJoin)
+    if (joinConds.isEmpty) {
+      // Cartesian product is very expensive, so we exclude them from candidate plans.
+      // This also helps us to reduce the search space. Unjoinable items will be put at the end
+      // of the plan when the reordering phase finishes.
+      None
+    } else {
+      // Put the deeper side on the left, tend to build a left-deep tree.
+      val (left, right) = if (oneJoinPlan.itemIds.size >= otherJoinPlan.itemIds.size) {
+        (onePlan, otherPlan)
       } else {
-        newJoin
+        (otherPlan, onePlan)
       }
+      val newJoin = Join(left, right, Inner, joinConds.reduceOption(And))
+      val collectedJoinConds = joinConds ++ oneJoinPlan.joinConds ++ otherJoinPlan.joinConds
+      val remainingConds = conditions -- collectedJoinConds
+      val neededAttr = AttributeSet(remainingConds.flatMap(_.references)) ++ topOutput
+      val neededFromNewJoin = newJoin.outputSet.filter(neededAttr.contains)
+      val newPlan =
+        if ((newJoin.outputSet -- neededFromNewJoin).nonEmpty) {
+          Project(neededFromNewJoin.toSeq, newJoin)
+        } else {
+          newJoin
+        }
 
-    val itemIds = oneJoinPlan.itemIds.union(otherJoinPlan.itemIds)
-    JoinPlan(itemIds, newPlan, collectedJoinConds, newCost)
-  }
-
-  private def isCartesianProduct(plan: LogicalPlan): Boolean = plan match {
-    case Join(_, _, _, None) => true
-    case Project(_, Join(_, _, _, None)) => true
-    case _ => false
+      val itemIds = oneJoinPlan.itemIds.union(otherJoinPlan.itemIds)
+      // Now the root node of onePlan/otherPlan becomes an intermediate join (if it's a non-leaf
+      // item), so the cost of the new join should also include its own cost.
+      val newPlanCost = oneJoinPlan.planCost + oneJoinPlan.rootCost(conf) +
+        otherJoinPlan.planCost + otherJoinPlan.rootCost(conf)
+      Some(JoinPlan(itemIds, newPlan, collectedJoinConds, newPlanCost))
+    }
   }
 
   /** Map[set of item ids, join plan for these items] */
@@ -272,26 +263,39 @@ object JoinReorderDP extends PredicateHelper {
    * @param itemIds Set of item ids participating in this partial plan.
    * @param plan The plan tree with the lowest cost for these items found so far.
    * @param joinConds Join conditions included in the plan.
-   * @param cost The cost of this plan is the sum of costs of all intermediate joins.
+   * @param planCost The cost of this plan tree is the sum of costs of all intermediate joins.
    */
-  case class JoinPlan(itemIds: Set[Int], plan: LogicalPlan, joinConds: Set[Expression], cost: Cost)
+  case class JoinPlan(
+      itemIds: Set[Int],
+      plan: LogicalPlan,
+      joinConds: Set[Expression],
+      planCost: Cost) {
+
+    /** Get the cost of the root node of this plan tree. */
+    def rootCost(conf: SQLConf): Cost = {
+      if (itemIds.size > 1) {
+        val rootStats = plan.stats(conf)
+        Cost(rootStats.rowCount.get, rootStats.sizeInBytes)
+      } else {
+        // If the plan is a leaf item, it has zero cost.
+        Cost(0, 0)
+      }
+    }
+
+    def betterThan(other: JoinPlan, conf: SQLConf): Boolean = {
+      if (other.planCost.rows == 0 || other.planCost.size == 0) {
+        false
+      } else {
+        val relativeRows = BigDecimal(this.planCost.rows) / BigDecimal(other.planCost.rows)
+        val relativeSize = BigDecimal(this.planCost.size) / BigDecimal(other.planCost.size)
+        relativeRows * conf.joinReorderCardWeight +
+          relativeSize * (1 - conf.joinReorderCardWeight) < 1
+      }
+    }
+  }
 }
 
 /** This class defines the cost model. */
 case class Cost(rows: BigInt, size: BigInt) {
-  /**
-   * An empirical value for the weights of cardinality (number of rows) in the cost formula:
-   * cost = rows * weight + size * (1 - weight), usually cardinality is more important than size.
-   */
-  val weight = 0.7
-
-  def lessThan(other: Cost): Boolean = {
-    if (other.rows == 0 || other.size == 0) {
-      false
-    } else {
-      val relativeRows = BigDecimal(rows) / BigDecimal(other.rows)
-      val relativeSize = BigDecimal(size) / BigDecimal(other.size)
-      relativeRows * weight + relativeSize * (1 - weight) < 1
-    }
-  }
+  def +(other: Cost): Cost = Cost(this.rows + other.rows, this.size + other.size)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -712,6 +712,7 @@ object SQLConf {
 
   val JOIN_REORDER_CARD_WEIGHT =
     buildConf("spark.sql.cbo.joinReorder.card.weight")
+      .internal()
       .doc("The weight of cardinality (number of rows) for plan cost comparison in join reorder: " +
         "rows * weight + size * (1 - weight).")
       .doubleConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -715,7 +715,7 @@ object SQLConf {
       .doc("The weight of cardinality (number of rows) for plan cost comparison in join reorder: " +
         "rows * weight + size * (1 - weight).")
       .doubleConf
-      .checkValue(weight => weight >= 0 && weight <= 1, "The weight value must be in [0, 1]")
+      .checkValue(weight => weight >= 0 && weight <= 1, "The weight value must be in [0, 1].")
       .createWithDefault(0.7)
 
   val SESSION_LOCAL_TIMEZONE =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -710,6 +710,14 @@ object SQLConf {
       .intConf
       .createWithDefault(12)
 
+  val JOIN_REORDER_CARD_WEIGHT =
+    buildConf("spark.sql.cbo.joinReorder.card.weight")
+      .doc("The weight of cardinality (number of rows) for plan cost comparison in join reorder: " +
+        "rows * weight + size * (1 - weight).")
+      .doubleConf
+      .checkValue(weight => weight >= 0 && weight <= 1, "The weight value must be in [0, 1]")
+      .createWithDefault(0.7)
+
   val SESSION_LOCAL_TIMEZONE =
     buildConf("spark.sql.session.timeZone")
       .doc("""The ID of session local timezone, e.g. "GMT", "America/Los_Angeles", etc.""")
@@ -966,6 +974,8 @@ class SQLConf extends Serializable with Logging {
   def joinReorderEnabled: Boolean = getConf(SQLConf.JOIN_REORDER_ENABLED)
 
   def joinReorderDPThreshold: Int = getConf(SQLConf.JOIN_REORDER_DP_THRESHOLD)
+
+  def joinReorderCardWeight: Double = getConf(SQLConf.JOIN_REORDER_CARD_WEIGHT)
 
   def windowExecBufferSpillThreshold: Int = getConf(WINDOW_EXEC_BUFFER_SPILL_THRESHOLD)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinReorderSuite.scala
@@ -215,6 +215,8 @@ class JoinReorderSuite extends PlanTest with StatsEstimationTestBase {
       case (j1: Join, j2: Join) =>
         (sameJoinPlan(j1.left, j2.left) && sameJoinPlan(j1.right, j2.right)) ||
           (sameJoinPlan(j1.left, j2.right) && sameJoinPlan(j1.right, j2.left))
+      case _ if plan1.children.nonEmpty && plan2.children.nonEmpty =>
+        (plan1.children, plan2.children).zipped.forall { case (c1, c2) => sameJoinPlan(c1, c2) }
       case _ =>
         plan1 == plan2
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have some concerns about removing size in the cost model [in the previous pr](https://github.com/apache/spark/pull/17240). It's a tradeoff between code structure and algorithm completeness. I tend to keep the size and thus create this new pr without changing cost model.

What this pr does:
1. It deals with consecutive inner joinable items. During reordering, it excludes cartesian products in reordering procedure. 
Given A Join B on A.key = B.key Join C on B.value = C.value:
level 0: {A}, {B}, {C}
level 1: {A, B}, ~~{A, C}~~, {B, C}
level 2: {A, B, C}
When the number of items increases, this significantly reduces the search space and memory overhead of memo. Otherwise every combination of items will exist in the memo.

2. This pr also includes a bug fix: if an item (basic reordering unit) is a project(_, child), current solution will lost the project.

## How was this patch tested?

Added test cases.