### PR TITLE
[SPARK-19950][SQL] Fix to ignore nullable when df.load() is executed for file-based data source

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -370,8 +370,8 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
    *
    * 1. If A and B have the same name and data type, they are merged to a field C with the same name
    *    and data type.  C is nullable if and only if either A or B is nullable.
-   * 2. If A doesn't exist in `that`, it's included in the result schema.
-   * 3. If B doesn't exist in `this`, it's also included in the result schema.
+   * 2. If A doesn't exist in `that`, it's included in the result schema with nullable.
+   * 3. If B doesn't exist in `this`, it's also included in the result schema with nullable.
    * 4. Otherwise, `this` and `that` are considered as conflicting schemas and an exception would be
    *    thrown.
    */
@@ -473,7 +473,7 @@ object StructType extends AbstractDataType {
                   nullable = leftNullable || rightNullable)
               }
               .orElse {
-                Some(leftField)
+                Some(leftField.copy(nullable = true))
               }
               .foreach(newFields += _)
         }
@@ -482,7 +482,7 @@ object StructType extends AbstractDataType {
         rightFields
           .filterNot(f => leftMapped.get(f.name).nonEmpty)
           .foreach { f =>
-            newFields += f
+            newFields += f.copy(nullable = true)
           }
 
         StructType(newFields)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -374,7 +374,7 @@ case class DataSource(
         HadoopFsRelation(
           fileCatalog,
           partitionSchema = partitionSchema,
-          dataSchema = dataSchema.asNullable,
+          dataSchema = dataSchema,
           bucketSpec = bucketSpec,
           format,
           caseInsensitiveOptions)(sparkSession)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -374,7 +374,8 @@ case class DataSource(
         HadoopFsRelation(
           fileCatalog,
           partitionSchema = partitionSchema,
-          dataSchema = dataSchema,
+          dataSchema =
+            if (format.isInstanceOf[ParquetFileFormat]) dataSchema else dataSchema.asNullable,
           bucketSpec = bucketSpec,
           format,
           caseInsensitiveOptions)(sparkSession)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -190,6 +190,11 @@ private[parquet] class ParquetRowConverter(
     var i = 0
     while (i < currentRow.numFields) {
       fieldConverters(i).updater.end()
+      if (currentRow.isNullAt(i) && !catalystType(i).nullable) {
+        throw new UnsupportedOperationException(
+          "Should not contain null for non-nullable " + catalystType(i).dataType +
+          " schema at column index " + i)
+      }
       i += 1
     }
     updater.set(currentRow)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -737,24 +737,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("loadWithSchema") {
-    withTempDir { dir =>
-      val field = "id"
-      val df = spark.range(0, 5, 1, 1).toDF(field)
-      val result = Array(Row(0L), Row(1L), Row(2L), Row(3L), Row(4L))
-
-      Seq("parquet", "json").foreach { fmt =>
-        val path = new File(dir, fmt).getCanonicalPath
-
-        val schema = StructType(Seq(StructField(field, LongType, false)))
-        df.write.format(fmt).mode("overwrite").save(path)
-        val dfRead = spark.read.format(fmt).schema(schema).load(path)
-        assert(dfRead.collect === result)
-        assert(dfRead.schema.equals(schema))
-      }
-    }
-  }
-
   ignore("show") {
     // This test case is intended ignored, but to make sure it compiles correctly
     testData.select($"*").show()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -737,6 +737,24 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("loadWithSchema") {
+    withTempDir { dir =>
+      val field = "id"
+      val df = spark.range(0, 5, 1, 1).toDF(field)
+      val result = Array(Row(0L), Row(1L), Row(2L), Row(3L), Row(4L))
+
+      Seq("parquet", "json").foreach { fmt =>
+        val path = new File(dir, fmt).getCanonicalPath
+
+        val schema = StructType(Seq(StructField(field, LongType, false)))
+        df.write.format(fmt).mode("overwrite").save(path)
+        val dfRead = spark.read.format(fmt).schema(schema).load(path)
+        assert(dfRead.collect === result)
+        assert(dfRead.schema.equals(schema))
+      }
+    }
+  }
+
   ignore("show") {
     // This test case is intended ignored, but to make sure it compiles correctly
     testData.select($"*").show()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -159,7 +159,8 @@ class PlannerSuite extends SharedSQLContext {
 
       withTempView("testPushed") {
         val exp = sql("select * from testPushed where key = 15").queryExecution.sparkPlan
-        assert(exp.toString.contains("PushedFilters: [IsNotNull(key), EqualTo(key,15)]"))
+        print(s"${exp.toString}\n")
+        assert(exp.toString.contains("PushedFilters: EqualTo(key,15)]"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -159,8 +159,7 @@ class PlannerSuite extends SharedSQLContext {
 
       withTempView("testPushed") {
         val exp = sql("select * from testPushed where key = 15").queryExecution.sparkPlan
-        print(s"${exp.toString}\n")
-        assert(exp.toString.contains("PushedFilters: EqualTo(key,15)]"))
+        assert(exp.toString.contains("PushedFilters: [EqualTo(key,15)]"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -404,7 +404,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
           pathToNonPartitionedTable,
           userSpecifiedSchema = None,
           userSpecifiedPartitionCols = partitionCols,
-          expectedSchema = new StructType().add("num", IntegerType).add("str", StringType),
+          expectedSchema = new StructType().add("num", IntegerType, false).add("str", StringType),
           expectedPartitionCols = Seq.empty[String])
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -458,8 +458,8 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSQLContext {
       readParquetFile(path.toString) { df =>
         assertResult(df.schema) {
           StructType(
-            StructField("a", BooleanType, nullable = true) ::
-              StructField("b", IntegerType, nullable = true) ::
+            StructField("a", BooleanType, nullable = false) ::
+              StructField("b", IntegerType, nullable = false) ::
               Nil)
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -26,7 +26,6 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql._

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -27,6 +27,8 @@ import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.commons.lang3.exception.ExceptionUtils
 
+import org.scalatest.BeforeAndAfter
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -21,12 +21,11 @@ import java.io.File
 import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
-import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -26,7 +26,6 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -21,11 +21,12 @@ import java.io.File
 import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
+import org.apache.commons.lang3.exception.ExceptionUtils
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1374,7 +1374,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         checkAnswer(spark.table("old"), Row(1, "a"))
 
         val expectedSchema = StructType(Seq(
-          StructField("i", IntegerType, nullable = true),
+          StructField("i", IntegerType, nullable = false),
           StructField("j", StringType, nullable = true)))
         assert(table("old").schema === expectedSchema)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes a problem that was reported in [Databricks forum](https://forums.databricks.com/questions/7123/nullable-seemingly-ignored-when-reading-parquet.html).  When the following code is executed, a schema for ``id`` has ``nullable = true`` while `read.schema()` specifies ``nullable = false``.

I realized this is because current Spark sets `true` into ``nullable`` in its schema for file-based data source. This PR makes this conservative setting precise.

```java
val field = "id"
val df = spark.range(0, 5, 1, 1).toDF(field)
val fmt = "parquet"
val path = "/tmp/parquet"
val schema = StructType(Seq(StructField(field, LongType, false)))
df.write.format(fmt).mode("overwrite").save(path)
val dfRead = spark.read.format(fmt).schema(schema).load(path)
dfRead.printSchema
```

## How was this patch tested?

added new test in `DataFrameReaderWriterSuite`
