### PR TITLE
[SPARK-19973] Display num of executors for the stage.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -572,7 +572,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Aggregated Metrics by Executor</a>
-            ({executorTable.toNodeSeq.size})
+            ({executorTable.toNodeSeq.size} executors supplied)
           </h4>
         </span>
         <div class="aggregated-metrics collapsible-table">

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -572,6 +572,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Aggregated Metrics by Executor</a>
+            ({executorTable.toNodeSeq.size})
           </h4>
         </span>
         <div class="aggregated-metrics collapsible-table">

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -572,7 +572,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Aggregated Metrics by Executor</a>
-            ({executorTable.toNodeSeq.size} executors supplied)
+            ({executorTable.toNodeSeq.size} executors)
           </h4>
         </span>
         <div class="aggregated-metrics collapsible-table">


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `StagePage` the total num of executors are not displayed. Since executorId may not be consecutive. It is useful to display the total number, which is useful when check how many executors are supplied during the stage.

## How was this patch tested?
Manually test.
