### PR TITLE
[SPARK-19991]FileSegmentManagedBuffer performance improvement

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -47,8 +47,12 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
     this(conf.lazyFileDescriptor(), conf.memoryMapBytes(), file, offset, length);
   }
 
-  public FileSegmentManagedBuffer(boolean lazyFileDescriptor, int memoryMapBytes,
-                                  File file, long offset, long length) {
+  public FileSegmentManagedBuffer(
+      boolean lazyFileDescriptor,
+      int memoryMapBytes,
+      File file,
+      long offset,
+      long length) {
     this.lazyFileDescriptor = lazyFileDescriptor;
     this.memoryMapBytes = memoryMapBytes;
     this.file = file;

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -37,13 +37,20 @@ import org.apache.spark.network.util.TransportConf;
  * A {@link ManagedBuffer} backed by a segment in a file.
  */
 public final class FileSegmentManagedBuffer extends ManagedBuffer {
-  private final TransportConf conf;
+  private final boolean lazyFileDescriptor;
+  private final int memoryMapBytes;
   private final File file;
   private final long offset;
   private final long length;
 
   public FileSegmentManagedBuffer(TransportConf conf, File file, long offset, long length) {
-    this.conf = conf;
+    this(conf.lazyFileDescriptor(), conf.memoryMapBytes(), file, offset, length);
+  }
+
+  public FileSegmentManagedBuffer(boolean lazyFileDescriptor, int memoryMapBytes,
+                                  File file, long offset, long length) {
+    this.lazyFileDescriptor = lazyFileDescriptor;
+    this.memoryMapBytes = memoryMapBytes;
     this.file = file;
     this.offset = offset;
     this.length = length;
@@ -60,7 +67,7 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
     try {
       channel = new RandomAccessFile(file, "r").getChannel();
       // Just copy the buffer if it's sufficiently small, as memory mapping has a high overhead.
-      if (length < conf.memoryMapBytes()) {
+      if (length < memoryMapBytes) {
         ByteBuffer buf = ByteBuffer.allocate((int) length);
         channel.position(offset);
         while (buf.remaining() != 0) {
@@ -129,7 +136,7 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
 
   @Override
   public Object convertToNetty() throws IOException {
-    if (conf.lazyFileDescriptor()) {
+    if (lazyFileDescriptor) {
       return new DefaultFileRegion(file, offset, length);
     } else {
       FileChannel fileChannel = new FileInputStream(file).getChannel();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -78,7 +78,8 @@ public class ExternalShuffleBlockResolver {
   // Single-threaded Java executor used to perform expensive recursive directory deletion.
   private final Executor directoryCleaner;
 
-  private final TransportConf conf;
+  private final boolean lazyFileDescriptor;
+  private final int memoryMapBytes;
 
   @VisibleForTesting
   final File registeredExecutorFile;
@@ -102,7 +103,8 @@ public class ExternalShuffleBlockResolver {
       TransportConf conf,
       File registeredExecutorFile,
       Executor directoryCleaner) throws IOException {
-    this.conf = conf;
+    this.lazyFileDescriptor = conf.lazyFileDescriptor();
+    this.memoryMapBytes = conf.memoryMapBytes();
     this.registeredExecutorFile = registeredExecutorFile;
     int indexCacheEntries = conf.getInt("spark.shuffle.service.index.cache.entries", 1024);
     CacheLoader<File, ShuffleIndexInformation> indexCacheLoader =
@@ -245,7 +247,8 @@ public class ExternalShuffleBlockResolver {
       ShuffleIndexInformation shuffleIndexInformation = shuffleIndexCache.get(indexFile);
       ShuffleIndexRecord shuffleIndexRecord = shuffleIndexInformation.getIndex(reduceId);
       return new FileSegmentManagedBuffer(
-        conf,
+          lazyFileDescriptor,
+          memoryMapBytes,
         getFile(executor.localDirs, executor.subDirsPerLocalDir,
           "shuffle_" + shuffleId + "_" + mapId + "_0.data"),
         shuffleIndexRecord.getOffset(),

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -247,8 +247,8 @@ public class ExternalShuffleBlockResolver {
       ShuffleIndexInformation shuffleIndexInformation = shuffleIndexCache.get(indexFile);
       ShuffleIndexRecord shuffleIndexRecord = shuffleIndexInformation.getIndex(reduceId);
       return new FileSegmentManagedBuffer(
-          lazyFileDescriptor,
-          memoryMapBytes,
+        lazyFileDescriptor,
+        memoryMapBytes,
         getFile(executor.localDirs, executor.subDirsPerLocalDir,
           "shuffle_" + shuffleId + "_" + mapId + "_0.data"),
         shuffleIndexRecord.getOffset(),

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyStreamManager.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyStreamManager.scala
@@ -42,7 +42,8 @@ private[netty] class NettyStreamManager(rpcEnv: NettyRpcEnv)
   private val files = new ConcurrentHashMap[String, File]()
   private val jars = new ConcurrentHashMap[String, File]()
   private val dirs = new ConcurrentHashMap[String, File]()
-
+  private val lazyFileDescriptor = rpcEnv.transportConf.lazyFileDescriptor()
+  private val memoryMapBytes = rpcEnv.transportConf.memoryMapBytes()
   override def getChunk(streamId: Long, chunkIndex: Int): ManagedBuffer = {
     throw new UnsupportedOperationException()
   }
@@ -59,7 +60,7 @@ private[netty] class NettyStreamManager(rpcEnv: NettyRpcEnv)
     }
 
     if (file != null && file.isFile()) {
-      new FileSegmentManagedBuffer(rpcEnv.transportConf, file, 0, file.length())
+      new FileSegmentManagedBuffer(lazyFileDescriptor, memoryMapBytes, file, 0, file.length())
     } else {
       null
     }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -278,7 +278,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     when(corruptStream.read(any(), any(), any())).thenThrow(new IOException("corrupt"))
     val corruptBuffer = mock(classOf[ManagedBuffer])
     when(corruptBuffer.createInputStream()).thenReturn(corruptStream)
-    val corruptLocalBuffer = new FileSegmentManagedBuffer(null, new File("a"), 0, 100)
+    val corruptLocalBuffer = new FileSegmentManagedBuffer(true, 1024, new File("a"), 0, 100)
 
     val transfer = mock(classOf[BlockTransferService])
     when(transfer.fetchBlocks(any(), any(), any(), any(), any())).thenAnswer(new Answer[Unit] {


### PR DESCRIPTION
FileSegmentManagedBuffer performance improvement.


## What changes were proposed in this pull request?

When we do not set the value of the configuration items `spark.storage.memoryMapThreshold` and `spark.shuffle.io.lazyFD`, 
each call to the cFileSegmentManagedBuffer.nioByteBuffer or FileSegmentManagedBuffer.createInputStream method creates a NoSuchElementException instance. This is a more time-consuming operation.

In the use case, this PR can improve the performance of about 3.5%

The test code:

``` scala

(1 to 10).foreach { i =>
  val numPartition = 10000
  val rdd = sc.parallelize(0 until numPartition).repartition(numPartition).flatMap { t =>
    (0 until numPartition).map(r => r * numPartition + t)
  }.repartition(numPartition)
  val serializeStart = System.currentTimeMillis()
  rdd.sum()
  val serializeFinish = System.currentTimeMillis()
  println(f"Test $i: ${(serializeFinish - serializeStart) / 1000D}%1.2f")
}


```

and `spark-defaults.conf` file:

```
spark.master                                      yarn-client
spark.executor.instances                          20
spark.driver.memory                               64g
spark.executor.memory                             30g
spark.executor.cores                              5
spark.default.parallelism                         100 
spark.sql.shuffle.partitions                      100
spark.serializer                                  org.apache.spark.serializer.KryoSerializer
spark.driver.maxResultSize                        0
spark.ui.enabled                                  false 
spark.driver.extraJavaOptions                     -XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1HeapRegionSize=16M -XX:MetaspaceSize=512M 
spark.executor.extraJavaOptions                   -XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1HeapRegionSize=16M -XX:MetaspaceSize=256M 
spark.cleaner.referenceTracking.blocking          true
spark.cleaner.referenceTracking.blocking.shuffle  true

```

The test results are as follows

| [SPARK-19991](https://github.com/witgo/spark/tree/SPARK-19991) |https://github.com/apache/spark/commit/68ea290b3aa89b2a539d13ea2c18bdb5a651b2bf |
|---| --- | 
|226.09 s| 235.21 s|

## How was this patch tested?

Existing tests.
