### PR TITLE
[SPARK-10764][ML] Add optional caching to Pipelines

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -326,7 +326,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
       assert(expected.pipelineModel.stages.length === actual.pipelineModel.stages.length)
       expected.pipelineModel.stages.zip(actual.pipelineModel.stages).foreach {
         case (exTransformer, acTransformer) =>
-          assert(exTransformer.params === acTransformer.params)
+          assert(exTransformer.params.map(_.name) === acTransformer.params.map(_.name))
       }
       assert(expected.resolvedFormula.label === actual.resolvedFormula.label)
       assert(expected.resolvedFormula.terms === actual.resolvedFormula.terms)


### PR DESCRIPTION

## What changes were proposed in this pull request?
This PR is to allow users to persist the output of a particular `PipelineStage` in the `Pipeline`. It also allows users to persist only a subset of output that is actually needed for the next stage instead of the whole big data frame.

For example, while running LDA a pipeline may look something like `Tokenizer` -> `StopWordRemover` -> `CountVectorizer` -> `LDA`. Here a user might want to `persist` the data frame coming out of `CountVectorizer` so that the LDA iterations work on this persisted data. Also, we need the flexibility to persist only the subset of columns (say docId, and features) that are needed for `LDA` rather than all extra columns that may have been added by the previous stages.

Also, another issue is that once the pipeline is fit on a data, for the `transform` on the same data it has to pass through all the previous stages again. In many cases this can be optimized if we already had access to data cached in the intermediate stage. In the example above, it will be useful if the data previously persisted in `CountVectorizer` can be reused to get `topicDistributions` from the `LDA` on the train data set itself. Otherwise, the data needs to *again* pass through all the stages.

For this, the `PipelineStage` exposes following methods
* `persist(level: StorageLevel, colExprs: String*)` - where the user can specify storage level and subset of the output dataframe of the stage to be persisted.
* `persist(colExprs: String*)` - uses default storage level.
* `getPersistedDf(): Option[DataFrame]` - to retrieve the cached data frame for a stage. This will be useful when we only need to run the pipeline from a specific stage. For instance, `pipelineModel.transform(countVectorizer.getPersistedDf.get)` should only run the final `LDA` stage of the pipeline. The persisted dataframe s only available once the `Pipeline.fit` has been called.

Changes in `Pipeline`
* The `fit` method checks whether a particular stage is marked to persist its output. If yes, it marks the output data frame as persistent according to the storage level and column subset. For `Executors` in the stage, it associates the persistant dataframe with both the `Executor` as well as the resultant `Transformer`.
* The `transformSchema` methods is changes so that the column pruning as result of specifying subset columns for persisting is taken into account.

Changes in `PipelineModel`
* `transform(dataset)` method now checks if the dataset argument was persisted in any of the stages during `Pipeline.fit`. If yes, it ensures only the stages after that stage are run (else all the stages are run). These two cases are handled for `transformSchema`.

## How was this patch tested?
* Existing tests
* Added new test in `PipelineSuite` to test above scenarios.
