### PR TITLE
[SPARK-19997] [SQL]fix proxy ugi could not get tgt to cause metastore connecting problem

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.hive.client
 
 import java.io.{File, PrintStream}
+import java.lang.reflect.UndeclaredThrowableException
+import java.security.PrivilegedExceptionAction
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -27,7 +29,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.{TableType => HiveTableType}
-import org.apache.hadoop.hive.metastore.api.{Database => HiveDatabase, FieldSchema}
+import org.apache.hadoop.hive.metastore.api.{FieldSchema, Database => HiveDatabase}
 import org.apache.hadoop.hive.metastore.api.{SerDeInfo, StorageDescriptor}
 import org.apache.hadoop.hive.ql.Driver
 import org.apache.hadoop.hive.ql.metadata.{Hive, Partition => HivePartition, Table => HiveTable}
@@ -189,7 +191,7 @@ private[hive] class HiveClientImpl(
         if (clientLoader.cachedHive != null) {
           Hive.set(clientLoader.cachedHive.asInstanceOf[Hive])
         }
-        SessionState.start(state)
+        doAsRealUser(SessionState.start(state))
         state.out = new PrintStream(outputBuffer, true, "UTF-8")
         state.err = new PrintStream(outputBuffer, true, "UTF-8")
         state
@@ -894,5 +896,25 @@ private[hive] class HiveClientImpl(
           .map(_.asScala.toMap).orNull),
         parameters =
           if (hp.getParameters() != null) hp.getParameters().asScala.toMap else Map.empty)
+  }
+
+
+  /**
+   * Run some code as the real logged in user (which may differ from the current user, for
+   * example, when using proxying).
+   */
+  private def doAsRealUser[T](fn: => T): T = {
+    val currentUser = UserGroupInformation.getCurrentUser()
+    val realUser = Option(currentUser.getRealUser()).getOrElse(currentUser)
+
+    // For some reason the Scala-generated anonymous class ends up causing an
+    // UndeclaredThrowableException, even if you annotate the method with @throws.
+    try {
+      realUser.doAs(new PrivilegedExceptionAction[T]() {
+        override def run(): T = fn
+      })
+    } catch {
+      case e: UndeclaredThrowableException => throw Option(e.getCause()).getOrElse(e)
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pass the real user ugi instead of proxy ugi for hive metastore client to find right Kerberos tgt

## How was this patch tested?

manually

before
 ```java
17/03/17 16:05:41 INFO hive.metastore: Trying to connect to metastore with URI thrift://xxxxxx:9083
17/03/17 16:05:41 ERROR transport.TSaslTransport: SASL negotiation failure
javax.security.sasl.SaslException: GSS initiate failed [Caused by GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)]
```
after
```java
17/03/17 17:27:48 INFO hive.metastore: Trying to connect to metastore with URI thrift://xxxxxxxx:9083
17/03/17 17:27:48 INFO hive.metastore: Connected to metastore.
```

