### PR TITLE
[SPARK-20013][SQL]add a newTablePath parameter for renameTable in ExternalCatalog

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -92,7 +92,11 @@ abstract class ExternalCatalog {
 
   def dropTable(db: String, table: String, ignoreIfNotExists: Boolean, purge: Boolean): Unit
 
-  def renameTable(db: String, oldName: String, newName: String): Unit
+  def renameTable(
+      db: String,
+      oldName: String,
+      newName: String,
+      newTablePath: Option[String]): Unit
 
   /**
    * Alter a table whose database and name match the ones specified in `tableDefinition`, assuming

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -264,7 +264,11 @@ class InMemoryCatalog(
     }
   }
 
-  override def renameTable(db: String, oldName: String, newName: String): Unit = synchronized {
+  override def renameTable(
+      db: String,
+      oldName: String,
+      newName: String,
+      newTablePath: Option[String]): Unit = synchronized {
     requireTableExists(db, oldName)
     requireTableNotExists(db, newName)
     val oldDesc = catalog(db).tables(oldName)
@@ -275,7 +279,9 @@ class InMemoryCatalog(
         "Managed table should always have table location, as we will assign a default location " +
           "to it if it doesn't have one.")
       val oldDir = new Path(oldDesc.table.location)
-      val newDir = new Path(new Path(catalog(db).db.locationUri), newName)
+
+      require(newTablePath.isDefined)
+      val newDir = new Path(newTablePath.get)
       try {
         val fs = oldDir.getFileSystem(hadoopConfig)
         fs.rename(oldDir, newDir)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -519,9 +519,13 @@ class SessionCatalog(
       requireDbExists(db)
       if (oldName.database.isDefined || !tempTables.contains(oldTableName)) {
         requireTableExists(TableIdentifier(oldTableName, Some(db)))
-        requireTableNotExists(TableIdentifier(newTableName, Some(db)))
+
+        val newTableIdentifier = TableIdentifier(newTableName, Some(db))
+        requireTableNotExists(newTableIdentifier)
         validateName(newTableName)
-        externalCatalog.renameTable(db, oldTableName, newTableName)
+
+        val newTablePath = CatalogUtils.URIToString(defaultTablePath(newTableIdentifier))
+        externalCatalog.renameTable(db, oldTableName, newTableName, Some(newTablePath))
       } else {
         if (newName.database.isDefined) {
           throw new AnalysisException(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -196,30 +196,6 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     catalog.dropTable("db2", "unknown_table", ignoreIfNotExists = true, purge = false)
   }
 
-  test("rename table") {
-    val catalog = newBasicCatalog()
-    assert(catalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
-    catalog.renameTable("db2", "tbl1", "tblone")
-    assert(catalog.listTables("db2").toSet == Set("tblone", "tbl2"))
-  }
-
-  test("rename table when database/table does not exist") {
-    val catalog = newBasicCatalog()
-    intercept[AnalysisException] {
-      catalog.renameTable("unknown_db", "unknown_table", "unknown_table")
-    }
-    intercept[AnalysisException] {
-      catalog.renameTable("db2", "unknown_table", "unknown_table")
-    }
-  }
-
-  test("rename table when destination table already exists") {
-    val catalog = newBasicCatalog()
-    intercept[AnalysisException] {
-      catalog.renameTable("db2", "tbl1", "tbl2")
-    }
-  }
-
   test("alter table") {
     val catalog = newBasicCatalog()
     val tbl1 = catalog.getTable("db2", "tbl1")
@@ -710,18 +686,6 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     assert(catalog.listFunctions("db2", "func*").toSet == Set("func1", "func2"))
   }
 
-  // --------------------------------------------------------------------------
-  // File System operations
-  // --------------------------------------------------------------------------
-
-  private def exists(uri: URI, children: String*): Boolean = {
-    val base = new Path(uri)
-    val finalPath = children.foldLeft(base) {
-      case (parent, child) => new Path(parent, child)
-    }
-    base.getFileSystem(new Configuration()).exists(finalPath)
-  }
-
   test("create/drop database should create/delete the directory") {
     val catalog = newBasicCatalog()
     val db = newDb("mydb")
@@ -730,40 +694,6 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
 
     catalog.dropDatabase("mydb", ignoreIfNotExists = false, cascade = false)
     assert(!exists(db.locationUri))
-  }
-
-  test("create/drop/rename table should create/delete/rename the directory") {
-    val catalog = newBasicCatalog()
-    val db = catalog.getDatabase("db1")
-    val table = CatalogTable(
-      identifier = TableIdentifier("my_table", Some("db1")),
-      tableType = CatalogTableType.MANAGED,
-      storage = CatalogStorageFormat.empty,
-      schema = new StructType().add("a", "int").add("b", "string"),
-      provider = Some(defaultProvider)
-    )
-
-    catalog.createTable(table, ignoreIfExists = false)
-    assert(exists(db.locationUri, "my_table"))
-
-    catalog.renameTable("db1", "my_table", "your_table")
-    assert(!exists(db.locationUri, "my_table"))
-    assert(exists(db.locationUri, "your_table"))
-
-    catalog.dropTable("db1", "your_table", ignoreIfNotExists = false, purge = false)
-    assert(!exists(db.locationUri, "your_table"))
-
-    val externalTable = CatalogTable(
-      identifier = TableIdentifier("external_table", Some("db1")),
-      tableType = CatalogTableType.EXTERNAL,
-      storage = CatalogStorageFormat(
-        Some(Utils.createTempDir().toURI),
-        None, None, None, false, Map.empty),
-      schema = new StructType().add("a", "int").add("b", "string"),
-      provider = Some(defaultProvider)
-    )
-    catalog.createTable(externalTable, ignoreIfExists = false)
-    assert(!exists(db.locationUri, "external_table"))
   }
 
   test("create/drop/rename partitions should create/delete/rename the directory") {
@@ -954,4 +884,14 @@ abstract class CatalogTestUtils {
     catalog.listPartitions(db, table).map(_.spec).toSet == parts.map(_.spec).toSet
   }
 
+  // --------------------------------------------------------------------------
+  // File System operations
+  // --------------------------------------------------------------------------
+  def exists(uri: URI, children: String*): Boolean = {
+    val base = new Path(uri)
+    val finalPath = children.foldLeft(base) {
+      case (parent, child) => new Path(parent, child)
+    }
+    base.getFileSystem(new Configuration()).exists(finalPath)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1412,7 +1412,8 @@ abstract class SessionCatalogSuite extends PlanTest {
       assert(!exists(db.locationUri, "my_table"))
       assert(exists(db.locationUri, "your_table"))
 
-      catalog.externalCatalog.dropTable("db1", "your_table", ignoreIfNotExists = false, purge = false)
+      catalog.externalCatalog.dropTable(
+        "db1", "your_table", ignoreIfNotExists = false, purge = false)
       assert(!exists(db.locationUri, "your_table"))
 
       val externalTable = CatalogTable(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1393,7 +1393,6 @@ abstract class SessionCatalogSuite extends PlanTest {
     }
   }
 
-
   test("create/drop/rename table should create/delete/rename the directory") {
     withBasicCatalog { catalog =>
       val db = catalog.externalCatalog.getDatabase("db1")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -464,7 +464,11 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.dropTable(db, table, ignoreIfNotExists, purge)
   }
 
-  override def renameTable(db: String, oldName: String, newName: String): Unit = withClient {
+  override def renameTable(
+      db: String,
+      oldName: String,
+      newName: String,
+      newTablePath: Option[String]): Unit = withClient {
     val rawTable = getRawTable(db, oldName)
 
     // Note that Hive serde tables don't use path option in storage properties to store the value
@@ -476,8 +480,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     val storageWithNewPath = if (rawTable.tableType == MANAGED && hasPathOption) {
       // If it's a managed table with path option and we are renaming it, then the path option
       // becomes inaccurate and we need to update it according to the new table name.
-      val newTablePath = defaultTablePath(TableIdentifier(newName, Some(db)))
-      updateLocationInStorageProps(rawTable, Some(newTablePath))
+      require(newTablePath.isDefined)
+      updateLocationInStorageProps(rawTable, newTablePath)
     } else {
       rawTable.storage
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when we create / rename a managed table, we should get the defaultTablePath for them in ExternalCatalog, then we have two defaultTablePath logic in its two subclass HiveExternalCatalog and InMemoryCatalog, additionally there is also a defaultTablePath in SessionCatalog, so till now we have three defaultTablePath in three classes. 
we'd better to unify them up to SessionCatalog

To unify them, we should move some logic from ExternalCatalog to SessionCatalog, renameTable is one of this.

while limit to the simple parameters in renameTable 
```
  def renameTable(db: String, oldName: String, newName: String): Unit
```
even if we move the defaultTablePath logic to SessionCatalog, we can not pass it to renameTable.

So we can add a newTablePath parameter  for renameTable in ExternalCatalog 
## How was this patch tested?
delete some tests in ExternalCatalogSuite which already existed in SessionCatalogSuite,
and move some other tests  in ExternalCatalogSuite which does not exist in SessionCatalogSuite