### PR TITLE
[MINOR][R] Reorder `Collate` fields in DESCRIPTION file

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -51,9 +51,9 @@ Collate:
     'serialize.R'
     'sparkR.R'
     'stats.R'
+    'streaming.R'
     'types.R'
     'utils.R'
     'window.R'
-    'streaming.R'
 RoxygenNote: 5.0.1
 VignetteBuilder: knitr


### PR DESCRIPTION
## What changes were proposed in this pull request?

It seems cran check scripts corrects `R/pkg/DESCRIPTION` and follows the order in `Collate` fields.

This PR proposes to fix this so that running this script does not show up a diff in this file.

## How was this patch tested?

Manually via `./R/check-cran.sh`.