### PR TITLE
[SPARK-17080][SQL][FOLLOWUP] Improve documentation, change buildJoin method structure and add a debug log

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -123,7 +123,8 @@ case class CostBasedJoinReorder(conf: SQLConf) extends Rule[LogicalPlan] with Pr
  * We also prune cartesian product candidates when building a new plan if there exists no join
  * condition involving references from both left and right. This pruning strategy significantly
  * reduces the search space.
- * For example, given A J B J C J D, plans maintained for each level will be as follows:
+ * E.g., given A J B J C J D with join conditions A.k1 = B.k1 and B.k2 = C.k2 and C.k3 = D.k3,
+ * plans maintained for each level are as follows:
  * level 0: p({A}), p({B}), p({C}), p({D})
  * level 1: p({A, B}), p({B, C}), p({C, D})
  * level 2: p({A, B, C}), p({B, C, D})

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -156,9 +156,9 @@ object JoinReorderDP extends PredicateHelper with Logging {
       foundPlans += searchLevel(foundPlans, conf, conditions, topOutput)
     }
 
-    val durationInMs = (System.nanoTime() - startTime) / (1000 * 1000)
-    logDebug(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
-      s"${items.length}, number of plans in memo: ${foundPlans.map(_.size).sum}")
+//    val durationInMs = (System.nanoTime() - startTime) / (1000 * 1000)
+//    logDebug(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
+//      s"${items.length}, number of plans in memo: ${foundPlans.map(_.size).sum}")
 
     // The last level must have one and only one plan, because all items are joinable.
     assert(foundPlans.size == items.length && foundPlans.last.size == 1)
@@ -226,7 +226,7 @@ object JoinReorderDP extends PredicateHelper with Logging {
       conditions: Set[Expression],
       topOutput: AttributeSet): Option[JoinPlan] = {
 
-    if (oneJoinPlan.itemIds.intersect(otherJoinPlan.itemIds).isEmpty) {
+    if (oneJoinPlan.itemIds.intersect(otherJoinPlan.itemIds).nonEmpty) {
       // Should not join two overlapping item sets.
       return None
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -156,9 +156,9 @@ object JoinReorderDP extends PredicateHelper with Logging {
       foundPlans += searchLevel(foundPlans, conf, conditions, topOutput)
     }
 
-//    val durationInMs = (System.nanoTime() - startTime) / (1000 * 1000)
-//    logDebug(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
-//      s"${items.length}, number of plans in memo: ${foundPlans.map(_.size).sum}")
+    val durationInMs = (System.nanoTime() - startTime) / (1000 * 1000)
+    logDebug(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
+      s"${items.length}, number of plans in memo: ${foundPlans.map(_.size).sum}")
 
     // The last level must have one and only one plan, because all items are joinable.
     assert(foundPlans.size == items.length && foundPlans.last.size == 1)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -708,6 +708,7 @@ object SQLConf {
     buildConf("spark.sql.cbo.joinReorder.dp.threshold")
       .doc("The maximum number of joined nodes allowed in the dynamic programming algorithm.")
       .intConf
+      .checkValue(number => number > 0, "The maximum number must be a positive integer.")
       .createWithDefault(12)
 
   val JOIN_REORDER_CARD_WEIGHT =


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Improve documentation for class `Cost` and `JoinReorderDP` and method `buildJoin()`.
2. Change code structure of `buildJoin()` to make the logic clearer.
3. Add a debug-level log to record information for join reordering, including time cost, the number of items and the number of plans in memo.

## How was this patch tested?

Not related.