### PR TITLE
[SPARK-20027][DOCS] Compilation fix in java docs.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/ClientChallenge.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/ClientChallenge.java
@@ -28,7 +28,7 @@ import org.apache.spark.network.protocol.Encoders;
 /**
  * The client challenge message, used to initiate authentication.
  *
- * see README.md
+ * Please see crypto/README.md for more details of implementation.
  */
 public class ClientChallenge implements Encodable {
   /** Serialization tag used to catch incorrect payloads. */

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/ClientChallenge.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/ClientChallenge.java
@@ -28,7 +28,7 @@ import org.apache.spark.network.protocol.Encoders;
 /**
  * The client challenge message, used to initiate authentication.
  *
- * @see README.md
+ * see README.md
  */
 public class ClientChallenge implements Encodable {
   /** Serialization tag used to catch incorrect payloads. */

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/ServerResponse.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/ServerResponse.java
@@ -28,7 +28,7 @@ import org.apache.spark.network.protocol.Encoders;
 /**
  * Server's response to client's challenge.
  *
- * @see README.md
+ * see README.md
  */
 public class ServerResponse implements Encodable {
   /** Serialization tag used to catch incorrect payloads. */

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/ServerResponse.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/ServerResponse.java
@@ -28,7 +28,7 @@ import org.apache.spark.network.protocol.Encoders;
 /**
  * Server's response to client's challenge.
  *
- * see README.md
+ * Please see crypto/README.md for more details.
  */
 public class ServerResponse implements Encodable {
   /** Serialization tag used to catch incorrect payloads. */

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -863,7 +863,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * This is done solely for better performance and is not expected to be used by end users.
    *
    * {@link LongWrapper} could have been used here but using `int` directly save the extra cost of
-   * conversion from `long` -> `int`
+   * conversion from `long` to `int`
    */
   public static class IntWrapper {
     public int value = 0;

--- a/sql/core/src/main/java/org/apache/spark/api/java/function/FlatMapGroupsWithStateFunction.java
+++ b/sql/core/src/main/java/org/apache/spark/api/java/function/FlatMapGroupsWithStateFunction.java
@@ -28,7 +28,8 @@ import org.apache.spark.sql.KeyedState;
  * ::Experimental::
  * Base interface for a map function used in
  * {@link org.apache.spark.sql.KeyValueGroupedDataset#flatMapGroupsWithState(
- * FlatMapGroupsWithStateFunction, org.apache.spark.sql.Encoder, org.apache.spark.sql.Encoder)}.
+ * FlatMapGroupsWithStateFunction, org.apache.spark.sql.streaming.OutputMode,
+ * org.apache.spark.sql.Encoder, org.apache.spark.sql.Encoder)}
  * @since 2.1.1
  */
 @Experimental


### PR DESCRIPTION
## What changes were proposed in this pull request?

During build/sbt publish-local, build breaks due to javadocs errors. This patch fixes those errors.

## How was this patch tested?

Tested by running the sbt build.