### PR TITLE
[SPARK-19962] [MLlib]  add DictVectorizer to ml.feature

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/DictVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/DictVectorizer.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.ml.Estimator
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.shared.{HasInputCols, HasOutputCol}
+import org.apache.spark.ml.util.{DefaultParamsWritable, Identifiable}
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
+
+class DictVectorizer(override val uid: String)
+	extends Estimator[DictVectorizerModel]
+    with HasInputCols with HasOutputCol with DefaultParamsWritable{
+	def this() = this(Identifiable.randomUID("dictVec"))
+
+  def setInputCols(value: Array[String]): this.type = set(inputCols, value)
+
+
+  /**
+    * Fits a model to the input data.
+    */
+  override def fit(dataset: Dataset[_]): DictVectorizerModel = {
+    new DictVectorizerModel("x", Array("xx"))
+  }
+
+  override def copy(extra: ParamMap): Estimator[DictVectorizerModel] = defaultCopy(extra)
+
+  /**
+    * :: DeveloperApi ::
+    *
+    * Check transform validity and derive the output schema from the input schema.
+    *
+    * We check validity for interactions between parameters during `transformSchema` and
+    * raise an exception if any parameter value is invalid. Parameter value checks which
+    * do not depend on other parameters are handled by `Param.validate()`.
+    *
+    * Typical implementation should first conduct verification on schema change and parameter
+    * validity, including complex parameter interaction checks.
+    */
+  override def transformSchema(schema: StructType): StructType = {
+
+  }
+}
+
+class DictVectorizerModel( val uid: String, val vocabulary: Array[String],
+                          val sep: String = "=") {
+  def this() = this(Identifiable.randomUID("dictVec"))
+
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
@@ -54,7 +54,6 @@ class DictVectorizerSuite
 
     // copied model must have the same parent.
     MLTestingUtils.checkCopy(indexer)
-
     val transformed = indexer.transform(df)
     val attr = Attribute.fromStructField(transformed.schema("labelIndex"))
       .asInstanceOf[NominalAttribute]

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
@@ -19,10 +19,13 @@ package org.apache.spark.ml.feature
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
-import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.linalg.VectorUDT
 import org.apache.spark.ml.param.{ParamMap, ParamsSuite}
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
+import org.apache.spark.mllib.linalg.DenseVector
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.sql.Row
+
 
 class DictVectorizerSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
@@ -63,11 +66,9 @@ class DictVectorizerSuite
   test("DictVectorizer transforms") {
       val data = Seq(
         (0, "a", "x", Seq("x", "xx")),
-        (1, "b", "x", Seq("x")),
-        (2, "c", "x", Seq("x", "xx")),
-        (3, "a", "x", Seq("x", "xx")),
-        (4, "a", "x", Seq("x", "xx")),
-        (5, "c", "x", Seq("x", "xx")))
+        (0, "a", "x", Seq("x", "xx")),
+        (0, "a", "x", Seq("x", "xx")),
+        (0, "a", "x", Seq("x", "xx")))
 
       val df = data.toDF("id", "label", "name", "hobbies")
       val vec = new DictVectorizer()
@@ -77,6 +78,14 @@ class DictVectorizerSuite
 
     val transformed = vec.transform(df)
     transformed.show()
+    // scalastyle:off
+    println(transformed.schema)
+
+    transformed.select("labelIndex").collect().foreach {
+      case Row(v: VectorUDT) =>
+        println(v)
+    }
+
     }
 //    val transformed = indexer.transform(df)
 //

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
 import org.apache.spark.ml.linalg.Vectors
-import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.param.{ParamMap, ParamsSuite}
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
@@ -53,8 +53,12 @@ class DictVectorizerSuite
       .fit(df)
 
     // copied model must have the same parent.
+    // scalastyle:off
+
     MLTestingUtils.checkCopy(indexer)
+
     val transformed = indexer.transform(df)
+
     val attr = Attribute.fromStructField(transformed.schema("labelIndex"))
       .asInstanceOf[NominalAttribute]
     assert(attr.values.get === Array("a", "c", "b", "x"))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+class DictVectorizerSuite
+  extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
+  import testImplicits._
+
+  test("params") {
+    ParamsSuite.checkParams(new DictVectorizer)
+    ParamsSuite.checkParams(new DictVectorizer("dict"))
+    val model = new DictVectorizerModel("dict", Array("a", "b"))
+    val modelWithoutUid = new DictVectorizerModel(Array("a", "b"))
+    ParamsSuite.checkParams(model)
+    ParamsSuite.checkParams(modelWithoutUid)
+  }
+
+  test("DictVectorizer") {
+    val data = Seq(
+      (0, "a", "x", Seq("x", "xx")),
+      (1, "b", "x", Seq("x")),
+      (2, "c", "x", Seq("x", "xx")),
+      (3, "a", "x", Seq("x", "xx")),
+      (4, "a", "x", Seq("x", "xx")),
+      (5, "c", "x", Seq("x", "xx")))
+
+    val df = data.toDF("id", "label", "name", "hobbies")
+    val indexer = new DictVectorizer()
+      .setInputCols(Array("label", "id", "name", "hobbies"))
+      .setOutputCol("labelIndex")
+      .fit(df)
+
+    // copied model must have the same parent.
+    MLTestingUtils.checkCopy(indexer)
+
+    val transformed = indexer.transform(df)
+    val attr = Attribute.fromStructField(transformed.schema("labelIndex"))
+      .asInstanceOf[NominalAttribute]
+    assert(attr.values.get === Array("a", "c", "b", "x"))
+    val output = transformed.select("id", "labelIndex").rdd.map { r =>
+      (r.getInt(0), r.getDouble(1))
+    }.collect().toSet
+    // a -> 0, b -> 2, c -> 1
+    val expected = Set((0, 0.0), (1, 2.0), (2, 1.0), (3, 0.0), (4, 0.0), (5, 1.0))
+    assert(output === expected)
+  }
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
add a new estimator`DictVectorizer` and transformer `DictVectorizerModel` for dataframe.

## How was this patch tested?

unit test in `mllib/src/test/scala/org/apache/spark/ml/feature/DictVectorizerSuite.scala`

