### PR TITLE
[SPARK-19970][SQL][BRANCH-1.6] Table owner should be USER instead of PRINCIPAL in kerberized clusters

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -376,7 +376,7 @@ private[hive] class ClientWrapper(
     table.serdeProperties.foreach { case (k, v) => qlTable.setSerdeParam(k, v) }
 
     // set owner
-    qlTable.setOwner(conf.getUser)
+    qlTable.setOwner(state.getAuthenticator().getUserName())
     // set create time
     qlTable.setCreateTime((System.currentTimeMillis() / 1000).asInstanceOf[Int])
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the kerberized hadoop cluster, when Spark creates tables, the owner of tables are filled with PRINCIPAL strings instead of USER names. This is inconsistent with Hive and causes problems when using [ROLE](https://cwiki.apache.org/confluence/display/Hive/SQL+Standard+Based+Hive+Authorization) in Hive. We had better to fix this. For Apache Spark 1.6, it happens only with `CREATE TABLE ... AS SELECT` (CTAS) statement.

**BEFORE**
```scala
scala> sql("create table t_ctas as select 1").show
scala> sql("desc formatted t_ctas").show(false)
...
|Owner:                      |spark@EXAMPLE.COM                                         |       |
```

**AFTER**
```scala
scala> sql("create table t_ctas as select 1").show
scala> sql("desc formatted t_ctas").show(false)
...
|Owner:                      |spark                                         |       |
```

## How was this patch tested?

Manually do `create table` and `desc formatted` because this happens in Kerberized clusters.