### PR TITLE
[SPARK-19903][PYSPARK][SS] window operator miss the `watermark` metadata of time column

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1164,7 +1164,7 @@ def window(timeColumn, windowDuration, slideDuration=None, startTime=None):
 
     sc = SparkContext._active_spark_context
     if isinstance(timeColumn, Column):
-        raise TypeError("timeColumn should be the name of time column, and provided as a string.")
+        time_col = _to_java_column(timeColumn._jc.toString().encode('utf8'))
     else:
         time_col = _to_java_column(timeColumn)
     check_string_field(windowDuration, "windowDuration")

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1163,7 +1163,10 @@ def window(timeColumn, windowDuration, slideDuration=None, startTime=None):
             raise TypeError("%s should be provided as a string" % fieldName)
 
     sc = SparkContext._active_spark_context
-    time_col = _to_java_column(timeColumn)
+    if isinstance(timeColumn, Column):
+        raise TypeError("timeColumn should be the name of time column, and provided as a string.")
+    else:
+        time_col = _to_java_column(timeColumn)
     check_string_field(windowDuration, "windowDuration")
     if slideDuration and startTime:
         check_string_field(slideDuration, "slideDuration")


### PR DESCRIPTION
## What changes were proposed in this pull request?

reproduce code:

```
import sys
from pyspark.sql import SparkSession
from pyspark.sql.functions import explode, split, window
bootstrapServers = sys.argv[1]
subscribeType = sys.argv[2]
topics = sys.argv[3]
spark = SparkSession\
  .builder\
  .appName("StructuredKafkaWordCount")\
  .getOrCreate()

lines = spark\
  .readStream\
  .format("kafka")\
  .option("kafka.bootstrap.servers", bootstrapServers)\
  .option(subscribeType, topics)\
  .load()\
  .selectExpr("CAST(value AS STRING)", "CAST(timestamp AS TIMESTAMP)")

words = lines.select(explode(split(lines.value, ' ')).alias('word'),lines.timestamp)

windowedCounts = words.withWatermark("timestamp", "30 seconds").groupBy(
window(words.timestamp, "30 seconds", "30 seconds"), words.word
).count()

query = windowedCounts\
  .writeStream\
  .outputMode('append')\
  .format('console')\ 
  .option("truncate", "false")\
  .start()
query.awaitTermination()
```

An exception was thrown:

```
pyspark.sql.utils.AnalysisException: Append output mode not supported when there are streaming aggregations on streaming DataFrames/DataSets without watermark;;
Aggregate [window#32, word#21], [window#32 AS window#26, word#21, count(1) AS count#31L]
+- Filter ((timestamp#16 >= window#32.start) && (timestamp#16 < window#32.end))
   +- Expand [ArrayBuffer(named_struct(start, ...]
      +- EventTimeWatermark timestamp#16: timestamp, interval 10 seconds
         +- Project [word#21, timestamp#16]
            +- Generate explode(split(value#15,  )), true, false, [word#21]
               +- Project [cast(value#1 as string) AS value#15, cast(timestamp#5 as timestamp) AS timestamp#16]
                  +- StreamingRelation DataSource(org.apache.spark.sql.SparkSession ...]
```

~~IIUC, the root cause is:  `words.withWatermark("timestamp", "30 seconds")` add the watermark metadata into time column, but in `groupBy(
window(words.timestamp, "30 seconds", "30 seconds"), words.word
)`, the `words.timestamp` miss the metadata. At last, it failed to pass the check:~~

use @viirya 's more clear explanation:

For now, after withWatermark, we only update the metadata for the column of event time. The expression id is the same. So once we use the column before adding watermark words.timestamp as grouping expression, it binds to the old attribute before watermarking.

```
if (watermarkAttributes.isEmpty) {
      throwError(
            s"$outputMode output mode not supported when there are streaming aggregations on " +
                s"streaming DataFrames/DataSets without watermark")(plan)
}
```

In this pr, pass a `UnresolvedAttribute` to `window` instead of a `Column`

## How was this patch tested?

Jenkins