### PR TITLE
[SPARK-20008] [SQL] DISTINCT and EXCEPT Support on DataFrame with Zero Columns

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -70,6 +70,9 @@ public final class UnsafeFixedWidthAggregationMap {
    *         schema, false otherwise.
    */
   public static boolean supportsAggregationBufferSchema(StructType schema) {
+    if (schema.length() == 0) {
+      return false;
+    }
     for (StructField field: schema.fields()) {
       if (!UnsafeRow.isMutable(field.dataType())) {
         return false;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -147,9 +147,13 @@ case class ObjectHashAggregateExec(
 
 object ObjectHashAggregateExec {
   def supportsAggregate(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
-    aggregateExpressions.map(_.aggregateFunction).exists {
-      case _: TypedImperativeAggregate[_] => true
-      case _ => false
+    if (aggregateExpressions.isEmpty) {
+      false
+    } else {
+      aggregateExpressions.map(_.aggregateFunction).exists {
+        case _: TypedImperativeAggregate[_] => true
+        case _ => false
+      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -147,13 +147,9 @@ case class ObjectHashAggregateExec(
 
 object ObjectHashAggregateExec {
   def supportsAggregate(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
-    if (aggregateExpressions.isEmpty) {
-      false
-    } else {
-      aggregateExpressions.map(_.aggregateFunction).exists {
-        case _: TypedImperativeAggregate[_] => true
-        case _ => false
-      }
+    aggregateExpressions.map(_.aggregateFunction).exists {
+      case _: TypedImperativeAggregate[_] => true
+      case _ => false
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -78,7 +78,9 @@ case class SortAggregateExec(
       // Because the constructor of an aggregation iterator will read at least the first row,
       // we need to get the value of iter.hasNext first.
       val hasInput = iter.hasNext
-      if (!hasInput && groupingExpressions.nonEmpty) {
+      if (!hasInput && aggregateExpressions.isEmpty && groupingExpressions.isEmpty) {
+        Iterator[UnsafeRow]()
+      } else if (!hasInput && groupingExpressions.nonEmpty) {
         // This is a grouped aggregate and the input iterator is empty,
         // so return an empty iterator.
         Iterator[UnsafeRow]()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1704,6 +1704,39 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df, Row(BigDecimal(0.0)) :: Nil)
   }
 
+  test("Distinct on a Dataframe with zero column") {
+    // Distinct on zero-row RDD with zero column returns 0 row
+    assert(spark.sparkContext.emptyRDD.distinct().count() == 0)
+    // Distinct on zero-row DataFrame with zero column returns 0 row
+    assert(spark.emptyDataFrame.distinct().count() == 0)
+
+    val rddNoCols = sparkContext.parallelize(1 to 10).map(_ => Row.empty)
+    val dfNoCols = spark.createDataFrame(rddNoCols, StructType(Seq.empty))
+    // Distinct on multi-row RDD with zero column returns 1 row
+    assert(rddNoCols.distinct().count() == 1)
+    // Distinct on multi-row DataFrame with zero column returns 1 row
+    checkAnswer(dfNoCols.distinct(), Row())
+  }
+
+  test("Except on two Dataframe with zero column") {
+    // Substract two zero-row RDD with zero column returns 0 row
+    assert(spark.sparkContext.emptyRDD.subtract(spark.sparkContext.emptyRDD).count() == 0)
+    // Except two zero-row DataFrame with zero column returns 0 row
+    assert(spark.emptyDataFrame.except(spark.emptyDataFrame).count() == 0)
+
+    val rddNoCols10Rows = sparkContext.parallelize(1 to 10).map(_ => Row.empty)
+    val dfNoCols10Rows = spark.createDataFrame(rddNoCols10Rows, StructType(Seq.empty))
+    val rddNoCols5Rows = sparkContext.parallelize(1 to 5).map(_ => Row.empty)
+    val dfNoCols5Rows = spark.createDataFrame(rddNoCols5Rows, StructType(Seq.empty))
+
+    // Our EXCEPT follow the SQL compliance
+    assert(dfNoCols10Rows.except(dfNoCols10Rows).count() == 0)
+    assert(dfNoCols10Rows.except(dfNoCols5Rows).count() == 0)
+    assert(dfNoCols5Rows.except(dfNoCols10Rows).count() == 0)
+    assert(dfNoCols5Rows.except(spark.emptyDataFrame).count() == 1)
+    assert(spark.emptyDataFrame.except(dfNoCols5Rows).count() == 0)
+  }
+
   test("SPARK-19893: cannot run set operations with map type") {
     val df = spark.range(1).select(map(lit("key"), $"id").as("m"))
     val e = intercept[AnalysisException](df.intersect(df))


### PR DESCRIPTION
### What changes were proposed in this pull request?
So far, our aggregate does not consider the input with zero column. This PR is to fix the issue. 

After the fix, both `DISTINCT` and `EXCEPT` can correctly behave when the DataFrame has zero column.

### How was this patch tested?
Added test cases to check both in different scenarios.