### PR TITLE
[SPARK-20066] [CORE] Add explicit SecurityManager(SparkConf) constructor

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -187,6 +187,7 @@ private[spark] class SecurityManager(
     val ioEncryptionKey: Option[Array[Byte]] = None)
   extends Logging with SecretKeyHolder {
 
+  def this(sparkConf: SparkConf) {this(sparkConf, None)}
   import SecurityManager._
 
   // allow all users/groups to have view/modify permissions

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -188,6 +188,7 @@ private[spark] class SecurityManager(
   extends Logging with SecretKeyHolder {
 
   def this(sparkConf: SparkConf) {this(sparkConf, None)}
+
   import SecurityManager._
 
   // allow all users/groups to have view/modify permissions


### PR DESCRIPTION
for backwards compatibility with Java.

## What changes were proposed in this pull request?
This adds an explicit SecurityManager(SparkConf) constructor in addition to the existing constructor that takes 2 arguments - SparkConf and ioEncryptionKey.  The second argument has a default but that's still not enough if this code is invoked from Java because of [this issue].(http://stackoverflow.com/questions/13059528/instantiate-a-scala-class-from-java-and-use-the-default-parameters-of-the-const)

## How was this patch tested?
This patch was tested using some simple Java test code: https://github.com/markgrover/spark-20066

In that repo:
Before this PR:
mvn clean package -Dspark.version=2.1.0 fails.
mvn clean package -Dspark.version=2.0.0 passes.

After this PR and a local `mvn clean install` of spark:
mvn -o clean package -Dspark.version=2.2.0-SNAPSHOT passes.