### PR TITLE
[SPARK-20065][SS][WIP] Avoid to output empty parquet files

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -292,7 +292,10 @@ object FileFormatWriter extends Logging {
     override def execute(iter: Iterator[InternalRow]): Set[String] = {
       var fileCounter = 0
       var recordsInFile: Long = 0L
-      newOutputWriter(fileCounter)
+      // Skip the empty partition to avoid creating a mass of 'empty' files.
+      if (iter.hasNext) {
+        newOutputWriter(fileCounter)
+      }
       while (iter.hasNext) {
         if (description.maxRecordsPerFile > 0 && recordsInFile >= description.maxRecordsPerFile) {
           fileCounter += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -140,10 +140,10 @@ class ParquetFileFormat
       // initialized.
       private val parquetLogRedirector = ParquetLogRedirector.INSTANCE
 
-        override def newInstance(
-          path: String,
-          dataSchema: StructType,
-          context: TaskAttemptContext): OutputWriter = {
+      override def newInstance(
+        path: String,
+        dataSchema: StructType,
+        context: TaskAttemptContext): OutputWriter = {
         new ParquetOutputWriter(path, context)
       }
 


### PR DESCRIPTION
## Problem Description

Reported by Silvio Fiorito

I've got a Kafka topic which I'm querying, running a windowed aggregation, with a 30 second watermark, 10 second trigger, writing out to Parquet with append output mode.

Every 10 second trigger generates a file, regardless of whether there was any data for that trigger, or whether any records were actually finalized by the watermark.

Is this expected behavior or should it not write out these empty files?

```
val df = spark.readStream.format("kafka")....

val query = df
  .withWatermark("timestamp", "30 seconds")
  .groupBy(window($"timestamp", "10 seconds"))
  .count()
  .select(date_format($"window.start", "HH:mm:ss").as("time"), $"count")

query
  .writeStream
  .format("parquet")
  .option("checkpointLocation", aggChk)
  .trigger(ProcessingTime("10 seconds"))
  .outputMode("append")
  .start(aggPath)
```

As the query executes, do a file listing on "aggPath" and you'll see 339 byte files at a minimum until we arrive at the first watermark and the initial batch is finalized. Even after that though, as there are empty batches it'll keep generating empty files every trigger.

## What changes were proposed in this pull request?

Check the partition is empty or not, and skip empty partition to avoid output empty file.

## How was this patch tested?

Jenkins
