### PR TITLE
[SPARK-18364][YARN] Expose metrics for YarnShuffleService

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -176,7 +176,8 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
   /**
    * A simple class to wrap all shuffle service wrapper metrics
    */
-  private class ShuffleMetrics implements MetricSet {
+  @VisibleForTesting
+  public class ShuffleMetrics implements MetricSet {
     private final Map<String, Metric> allMetrics;
     // Time latency for open block request in ms
     private final Timer openBlockRequestLatencyMillis = new Timer();
@@ -185,7 +186,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     // Block transfer rate in byte per second
     private final Meter blockTransferRateBytes = new Meter();
 
-    private ShuffleMetrics() {
+    public ShuffleMetrics() {
       allMetrics = new HashMap<>();
       allMetrics.put("openBlockRequestLatencyMillis", openBlockRequestLatencyMillis);
       allMetrics.put("registerExecutorRequestLatencyMillis", registerExecutorRequestLatencyMillis);

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.server.api.*;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,13 +58,13 @@ import org.apache.spark.network.yarn.util.HadoopConfigProvider;
 
 /**
  * An external shuffle service used by Spark on Yarn.
- *
+ * <p>
  * This is intended to be a long-running auxiliary service that runs in the NodeManager process.
  * A Spark application may connect to this service by setting `spark.shuffle.service.enabled`.
  * The application also automatically derives the service port through `spark.shuffle.service.port`
  * specified in the Yarn configuration. This is so that both the clients and the server agree on
  * the same port to communicate on.
- *
+ * <p>
  * The service also optionally supports authentication. This ensures that executors from one
  * application cannot read the shuffle files written by those from another. This feature can be
  * enabled by setting `spark.authenticate` in the Yarn configuration before starting the NM.
@@ -100,7 +99,7 @@ public class YarnShuffleService extends AuxiliaryService {
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final String APP_CREDS_KEY_PREFIX = "AppCreds";
   private static final LevelDBProvider.StoreVersion CURRENT_VERSION = new LevelDBProvider
-      .StoreVersion(1, 0);
+    .StoreVersion(1, 0);
 
   // just for integration tests that want to look at this file -- in general not sensible as
   // a static
@@ -177,14 +176,14 @@ public class YarnShuffleService extends AuxiliaryService {
         MetricsSystemImpl metricsSystem = (MetricsSystemImpl) DefaultMetricsSystem.instance();
 
         Method registerSourceMethod = metricsSystem.getClass().getDeclaredMethod("registerSource",
-                String.class, String.class, MetricsSource.class);
+          String.class, String.class, MetricsSource.class);
         registerSourceMethod.setAccessible(true);
         registerSourceMethod.invoke(metricsSystem, "shuffleService", "Metrics on the Spark " +
-                "Shuffle Service", serviceMetrics);
+          "Shuffle Service", serviceMetrics);
         logger.info("Registered metrics with Hadoop's DefaultMetricsSystem");
       } catch (Exception e) {
         logger.warn("Unable to register Spark Shuffle Service metrics with Node Manager; " +
-                "proceeding without metrics", e);
+          "proceeding without metrics", e);
       }
 
       // If authentication is enabled, set up the shuffle server to use a
@@ -205,7 +204,7 @@ public class YarnShuffleService extends AuxiliaryService {
       boundPort = port;
       String authEnabledString = authEnabled ? "enabled" : "not enabled";
       logger.info("Started YARN shuffle service for Spark on port {}. " +
-        "Authentication is {}.  Registered executor file is {}", port, authEnabledString,
+          "Authentication is {}.  Registered executor file is {}", port, authEnabledString,
         registeredExecutorFile);
     } catch (Exception e) {
       if (stopOnFailure) {
@@ -222,7 +221,7 @@ public class YarnShuffleService extends AuxiliaryService {
 
     // Make sure this is protected in case its not in the NM recovery dir
     FileSystem fs = FileSystem.getLocal(_conf);
-    fs.mkdirs(new Path(secretsFile.getPath()), new FsPermission((short)0700));
+    fs.mkdirs(new Path(secretsFile.getPath()), new FsPermission((short) 0700));
 
     db = LevelDBProvider.initLevelDB(secretsFile, CURRENT_VERSION, mapper);
     logger.info("Recovery location is: " + secretsFile.getPath());
@@ -363,10 +362,10 @@ public class YarnShuffleService extends AuxiliaryService {
    */
   protected File initRecoveryDb(String dbFileName) {
     if (_recoveryPath != null) {
-        File recoveryFile = new File(_recoveryPath.toUri().getPath(), dbFileName);
-        if (recoveryFile.exists()) {
-          return recoveryFile;
-        }
+      File recoveryFile = new File(_recoveryPath.toUri().getPath(), dbFileName);
+      if (recoveryFile.exists()) {
+        return recoveryFile;
+      }
     }
     // db doesn't exist in recovery path go check local dirs for it
     String[] localDirs = _conf.getTrimmedStrings("yarn.nodemanager.local-dirs");
@@ -433,8 +432,8 @@ public class YarnShuffleService extends AuxiliaryService {
     @Override
     public String toString() {
       return Objects.toStringHelper(this)
-          .add("appId", appId)
-          .toString();
+        .add("appId", appId)
+        .toString();
     }
   }
 

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -179,7 +179,7 @@ public class YarnShuffleService extends AuxiliaryService {
         Method registerSourceMethod = metricsSystem.getClass().getDeclaredMethod("registerSource",
                 String.class, String.class, MetricsSource.class);
         registerSourceMethod.setAccessible(true);
-        registerSourceMethod.invoke(metricsSystem, "shuffleservice", "Metrics on the Spark " +
+        registerSourceMethod.invoke(metricsSystem, "shuffleService", "Metrics on the Spark " +
                 "Shuffle Service", serviceMetrics);
         logger.info("Registered metrics with Hadoop's DefaultMetricsSystem");
       } catch (Exception e) {

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -19,8 +19,9 @@ package org.apache.spark.network.yarn;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -35,9 +36,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.server.api.*;
-import org.apache.spark.network.util.LevelDBProvider;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
 
@@ -50,6 +54,7 @@ import org.apache.spark.network.sasl.ShuffleSecretManager;
 import org.apache.spark.network.server.TransportServer;
 import org.apache.spark.network.server.TransportServerBootstrap;
 import org.apache.spark.network.shuffle.ExternalShuffleBlockHandler;
+import org.apache.spark.network.util.LevelDBProvider;
 import org.apache.spark.network.util.TransportConf;
 import org.apache.spark.network.yarn.util.HadoopConfigProvider;
 
@@ -165,6 +170,22 @@ public class YarnShuffleService extends AuxiliaryService {
 
       TransportConf transportConf = new TransportConf("shuffle", new HadoopConfigProvider(conf));
       blockHandler = new ExternalShuffleBlockHandler(transportConf, registeredExecutorFile);
+
+      // register metrics on the block handler into the Node Manager's metrics system.
+      try {
+        YarnShuffleServiceMetrics serviceMetrics = new YarnShuffleServiceMetrics(blockHandler.getAllMetrics());
+        MetricsSystemImpl metricsSystem = (MetricsSystemImpl) DefaultMetricsSystem.instance();
+
+        Method registerSourceMethod = metricsSystem.getClass().getDeclaredMethod("registerSource",
+                String.class, String.class, MetricsSource.class);
+        registerSourceMethod.setAccessible(true);
+        registerSourceMethod.invoke(metricsSystem, "shuffleservice", "Metrics on the Spark " +
+                "Shuffle Service", serviceMetrics);
+        logger.info("Registered metrics with Hadoop's DefaultMetricsSystem");
+      } catch (Exception e) {
+        logger.warn("Unable to register Spark Shuffle Service metrics with Node Manager; " +
+                "proceeding without metrics", e);
+      }
 
       // If authentication is enabled, set up the shuffle server to use a
       // special RPC handler that filters out unauthenticated fetch requests

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.metrics2.MetricsSource;
-import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -173,7 +172,8 @@ public class YarnShuffleService extends AuxiliaryService {
 
       // register metrics on the block handler into the Node Manager's metrics system.
       try {
-        YarnShuffleServiceMetrics serviceMetrics = new YarnShuffleServiceMetrics(blockHandler.getAllMetrics());
+        YarnShuffleServiceMetrics serviceMetrics = new YarnShuffleServiceMetrics(
+          blockHandler.getAllMetrics());
         MetricsSystemImpl metricsSystem = (MetricsSystemImpl) DefaultMetricsSystem.instance();
 
         Method registerSourceMethod = metricsSystem.getClass().getDeclaredMethod("registerSource",

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.yarn;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.Timer;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+
+import java.util.Map;
+
+/**
+ * Modeled off of YARN's NodeManagerMetrics.
+ */
+public class YarnShuffleServiceMetrics implements MetricsSource {
+
+    private final MetricSet metricSet;
+
+    public YarnShuffleServiceMetrics(MetricSet metricSet) {
+        this.metricSet = metricSet;
+    }
+
+    /**
+     * Get metrics from the source
+     *
+     * @param collector to contain the resulting metrics snapshot
+     * @param all       if true, return all metrics even if unchanged.
+     */
+    @Override
+    public void getMetrics(MetricsCollector collector, boolean all) {
+        MetricsRecordBuilder metricsRecordBuilder = collector.addRecord("shuffleService");
+
+        for (Map.Entry<String, Metric> entry : metricSet.getMetrics().entrySet()) {
+            String name = entry.getKey();
+
+            // The metric types used in ExternalShuffleBlockHandler.ShuffleMetrics
+            if (entry.getValue() instanceof Timer) {
+                Timer t = (Timer) entry.getValue();
+                metricsRecordBuilder
+                        .addCounter(new ShuffleServiceMetricsInfo(name + "_count", "Count of timer " + name),
+                                t.getCount())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate15", "15 minute rate of timer " + name),
+                                t.getFifteenMinuteRate())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate5", "5 minute rate of timer " + name),
+                                t.getFiveMinuteRate())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate1", "1 minute rate of timer " + name),
+                                t.getOneMinuteRate())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rateMean", "Mean rate of timer " + name),
+                                t.getMeanRate());
+            } else if (entry.getValue() instanceof Meter) {
+                Meter m = (Meter) entry.getValue();
+                metricsRecordBuilder
+                        .addCounter(new ShuffleServiceMetricsInfo(name + "_count", "Count of meter " + name),
+                                m.getCount())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate15", "15 minute rate of meter " + name),
+                                m.getFifteenMinuteRate())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate5", "5 minute rate of meter " + name),
+                                m.getFiveMinuteRate())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate1", "1 minute rate of meter " + name),
+                                m.getOneMinuteRate())
+                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rateMean", "Mean rate of meter " + name),
+                                m.getMeanRate());
+            } else if (entry.getValue() instanceof Gauge) {
+                Gauge m = (Gauge) entry.getValue();
+                Object gaugeValue = m.getValue();
+                if (gaugeValue instanceof Integer) {
+                    Integer intValue = (Integer) gaugeValue;
+                    metricsRecordBuilder
+                            .addGauge(new ShuffleServiceMetricsInfo(name, "Integer value of " +
+                                    "gauge " + name), intValue.intValue());
+                }
+            }
+        }
+    }
+
+    private static class ShuffleServiceMetricsInfo implements MetricsInfo {
+
+        private final String name;
+        private final String description;
+
+        ShuffleServiceMetricsInfo(String name, String description) {
+            this.name = name;
+            this.description = description;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+    }
+}

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -17,11 +17,7 @@
 
 package org.apache.spark.network.yarn;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.*;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -34,83 +30,89 @@ import java.util.Map;
  */
 public class YarnShuffleServiceMetrics implements MetricsSource {
 
-    private final MetricSet metricSet;
+  private final MetricSet metricSet;
 
-    public YarnShuffleServiceMetrics(MetricSet metricSet) {
-        this.metricSet = metricSet;
+  public YarnShuffleServiceMetrics(MetricSet metricSet) {
+    this.metricSet = metricSet;
+  }
+
+  /**
+   * Get metrics from the source
+   *
+   * @param collector to contain the resulting metrics snapshot
+   * @param all       if true, return all metrics even if unchanged.
+   */
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder metricsRecordBuilder = collector.addRecord("shuffleService");
+
+    for (Map.Entry<String, Metric> entry : metricSet.getMetrics().entrySet()) {
+      String name = entry.getKey();
+
+      // The metric types used in ExternalShuffleBlockHandler.ShuffleMetrics
+      if (entry.getValue() instanceof Timer) {
+        Timer t = (Timer) entry.getValue();
+        metricsRecordBuilder
+          .addCounter(new ShuffleServiceMetricsInfo(name + "_count", "Count of timer " + name),
+            t.getCount())
+          .addGauge(
+            new ShuffleServiceMetricsInfo(name + "_rate15", "15 minute rate of timer " + name),
+            t.getFifteenMinuteRate())
+          .addGauge(
+            new ShuffleServiceMetricsInfo(name + "_rate5", "5 minute rate of timer " + name),
+            t.getFiveMinuteRate())
+          .addGauge(
+            new ShuffleServiceMetricsInfo(name + "_rate1", "1 minute rate of timer " + name),
+            t.getOneMinuteRate())
+          .addGauge(new ShuffleServiceMetricsInfo(name + "_rateMean", "Mean rate of timer " + name),
+            t.getMeanRate());
+      } else if (entry.getValue() instanceof Meter) {
+        Meter m = (Meter) entry.getValue();
+        metricsRecordBuilder
+          .addCounter(new ShuffleServiceMetricsInfo(name + "_count", "Count of meter " + name),
+            m.getCount())
+          .addGauge(
+            new ShuffleServiceMetricsInfo(name + "_rate15", "15 minute rate of meter " + name),
+            m.getFifteenMinuteRate())
+          .addGauge(
+            new ShuffleServiceMetricsInfo(name + "_rate5", "5 minute rate of meter " + name),
+            m.getFiveMinuteRate())
+          .addGauge(
+            new ShuffleServiceMetricsInfo(name + "_rate1", "1 minute rate of meter " + name),
+            m.getOneMinuteRate())
+          .addGauge(new ShuffleServiceMetricsInfo(name + "_rateMean", "Mean rate of meter " + name),
+            m.getMeanRate());
+      } else if (entry.getValue() instanceof Gauge) {
+        Gauge m = (Gauge) entry.getValue();
+        Object gaugeValue = m.getValue();
+        if (gaugeValue instanceof Integer) {
+          Integer intValue = (Integer) gaugeValue;
+          metricsRecordBuilder
+            .addGauge(new ShuffleServiceMetricsInfo(name, "Integer value of " +
+              "gauge " + name), intValue.intValue());
+        }
+      }
+    }
+  }
+
+  private static class ShuffleServiceMetricsInfo implements MetricsInfo {
+
+    private final String name;
+    private final String description;
+
+    ShuffleServiceMetricsInfo(String name, String description) {
+      this.name = name;
+      this.description = description;
     }
 
-    /**
-     * Get metrics from the source
-     *
-     * @param collector to contain the resulting metrics snapshot
-     * @param all       if true, return all metrics even if unchanged.
-     */
     @Override
-    public void getMetrics(MetricsCollector collector, boolean all) {
-        MetricsRecordBuilder metricsRecordBuilder = collector.addRecord("shuffleService");
-
-        for (Map.Entry<String, Metric> entry : metricSet.getMetrics().entrySet()) {
-            String name = entry.getKey();
-
-            // The metric types used in ExternalShuffleBlockHandler.ShuffleMetrics
-            if (entry.getValue() instanceof Timer) {
-                Timer t = (Timer) entry.getValue();
-                metricsRecordBuilder
-                        .addCounter(new ShuffleServiceMetricsInfo(name + "_count", "Count of timer " + name),
-                                t.getCount())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate15", "15 minute rate of timer " + name),
-                                t.getFifteenMinuteRate())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate5", "5 minute rate of timer " + name),
-                                t.getFiveMinuteRate())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate1", "1 minute rate of timer " + name),
-                                t.getOneMinuteRate())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rateMean", "Mean rate of timer " + name),
-                                t.getMeanRate());
-            } else if (entry.getValue() instanceof Meter) {
-                Meter m = (Meter) entry.getValue();
-                metricsRecordBuilder
-                        .addCounter(new ShuffleServiceMetricsInfo(name + "_count", "Count of meter " + name),
-                                m.getCount())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate15", "15 minute rate of meter " + name),
-                                m.getFifteenMinuteRate())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate5", "5 minute rate of meter " + name),
-                                m.getFiveMinuteRate())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rate1", "1 minute rate of meter " + name),
-                                m.getOneMinuteRate())
-                        .addGauge(new ShuffleServiceMetricsInfo(name + "_rateMean", "Mean rate of meter " + name),
-                                m.getMeanRate());
-            } else if (entry.getValue() instanceof Gauge) {
-                Gauge m = (Gauge) entry.getValue();
-                Object gaugeValue = m.getValue();
-                if (gaugeValue instanceof Integer) {
-                    Integer intValue = (Integer) gaugeValue;
-                    metricsRecordBuilder
-                            .addGauge(new ShuffleServiceMetricsInfo(name, "Integer value of " +
-                                    "gauge " + name), intValue.intValue());
-                }
-            }
-        }
+    public String name() {
+      return name;
     }
 
-    private static class ShuffleServiceMetricsInfo implements MetricsInfo {
-
-        private final String name;
-        private final String description;
-
-        ShuffleServiceMetricsInfo(String name, String description) {
-            this.name = name;
-            this.description = description;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public String description() {
-            return description;
-        }
+    @Override
+    public String description() {
+      return description;
     }
+  }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -16,15 +16,16 @@
  */
 package org.apache.spark.network.yarn
 
+import scala.collection.JavaConverters._
+
 import org.apache.hadoop.metrics2.MetricsRecordBuilder
 import org.mockito.Matchers._
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.Matchers
-import scala.collection.JavaConverters._
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.network.server.OneForOneStreamManager
 import org.apache.spark.network.shuffle.{ExternalShuffleBlockHandler, ExternalShuffleBlockResolver}
-import org.apache.spark.SparkFunSuite
 
 class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.network.yarn
+
+import org.apache.hadoop.metrics2.MetricsRecordBuilder
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.server.OneForOneStreamManager
+import org.apache.spark.network.shuffle.{ExternalShuffleBlockHandler, ExternalShuffleBlockResolver}
+import org.mockito.Matchers._
+import org.mockito.Mockito.{mock, times, verify, when}
+import org.scalatest.Matchers
+
+import scala.collection.JavaConverters._
+
+class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
+
+  val streamManager = mock(classOf[OneForOneStreamManager])
+  val blockResolver = mock(classOf[ExternalShuffleBlockResolver])
+  when(blockResolver.getRegisteredExecutorsSize).thenReturn(42)
+
+  val metrics = new ExternalShuffleBlockHandler(streamManager, blockResolver).getAllMetrics
+
+  test("metrics named as expected") {
+    val allMetrics = Set(
+      "openBlockRequestLatencyMillis", "registerExecutorRequestLatencyMillis",
+      "blockTransferRateBytes", "registeredExecutorsSize")
+
+    metrics.getMetrics.keySet().asScala should be (allMetrics)
+  }
+
+  // these three metrics have the same effect on the collector
+  for (testname <- Seq("openBlockRequestLatencyMillis",
+      "registerExecutorRequestLatencyMillis",
+      "blockTransferRateBytes")) {
+    test(s"$testname - collector receives correct types") {
+      val builder = mock(classOf[MetricsRecordBuilder])
+      when(builder.addCounter(any(), anyLong())).thenReturn(builder)
+      when(builder.addGauge(any(), anyDouble())).thenReturn(builder)
+
+      YarnShuffleServiceMetrics.collectMetric(builder, testname,
+        metrics.getMetrics.get(testname))
+
+      verify(builder).addCounter(anyObject(), anyLong())
+      verify(builder, times(4)).addGauge(anyObject(), anyDouble())
+    }
+  }
+
+  // this metric writes only one gauge to the collector
+  test("registeredExecutorsSize - collector receives correct types") {
+    val builder = mock(classOf[MetricsRecordBuilder])
+    when(builder.addCounter(any(), anyLong())).thenReturn(builder)
+    when(builder.addGauge(any(), anyDouble())).thenReturn(builder)
+
+    YarnShuffleServiceMetrics.collectMetric(builder, "registeredExecutorsSize",
+      metrics.getMetrics.get("registeredExecutorsSize"))
+
+    // only one
+    verify(builder).addGauge(anyObject(), anyInt())
+  }
+}

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -17,14 +17,14 @@
 package org.apache.spark.network.yarn
 
 import org.apache.hadoop.metrics2.MetricsRecordBuilder
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.network.server.OneForOneStreamManager
-import org.apache.spark.network.shuffle.{ExternalShuffleBlockHandler, ExternalShuffleBlockResolver}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.Matchers
-
 import scala.collection.JavaConverters._
+
+import org.apache.spark.network.server.OneForOneStreamManager
+import org.apache.spark.network.shuffle.{ExternalShuffleBlockHandler, ExternalShuffleBlockResolver}
+import org.apache.spark.SparkFunSuite
 
 class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
 


### PR DESCRIPTION
Registers the shuffle server's metrics with the Hadoop Node Manager's
DefaultMetricsSystem.

## What changes were proposed in this pull request?

Expose the shuffle service metrics not only on the ExternalShuffleService as done in SPARK-16405, but also in the YarnShuffleService.  Because the YARN Node Manager's metrics system is the Hadoop-internal one and not the Dropwizard Metrics system that Spark uses, this requires a conversion from DW metrics to Hadoop metrics.

## How was this patch tested?

Manual deploy of new yarn-shuffle jar into a Node Manager and verifying that the metrics appear in the Node Manager-standard location.  This is JMX with an query endpoint at `/jmx`.

Resulting metrics look like this:

```
[user@host ~]$ curl -sk -XGET https://`hostname -f`:8042/jmx | jq . | grep 'shuffleservice' -B 1 -A 18
    {
      "name": "Hadoop:service=NodeManager,name=shuffleservice",
      "modelerType": "shuffleservice",
      "tag.Hostname": "<redacted>",
      "openBlockRequestLatencyMillis_count": 1,
      "openBlockRequestLatencyMillis_rate15": 0.0011080303990206543,
      "openBlockRequestLatencyMillis_rate5": 0.0033057092356765017,
      "openBlockRequestLatencyMillis_rate1": 0.015991117074135343,
      "openBlockRequestLatencyMillis_rateMean": 0.003843993699021382,
      "blockTransferRateBytes_count": 118,
      "blockTransferRateBytes_rate15": 0.1307475870844372,
      "blockTransferRateBytes_rate5": 0.39007368980982715,
      "blockTransferRateBytes_rate1": 1.8869518147479705,
      "blockTransferRateBytes_rateMean": 0.45359183094454836,
      "registeredExecutorsSize": 2,
      "registerExecutorRequestLatencyMillis_count": 2,
      "registerExecutorRequestLatencyMillis_rate15": 0.001697343764758814,
      "registerExecutorRequestLatencyMillis_rate5": 0.002970701813078509,
      "registerExecutorRequestLatencyMillis_rate1": 0.0005857750515146702,
      "registerExecutorRequestLatencyMillis_rateMean": 0.007687995987242345
    },
[user@host ~]$
```