### PR TITLE
[SPARK-20078] [MESOS] Mesos executor configurability for task name and labels

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -368,23 +368,6 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.mesos.task.name</code></td>
-  <td>Task</td>
-  <td>
-    Set the task name for the executors that are spun up (in coarse-grained mode).
-    The names will also be appended with the executor number. Ex. Task 0, Task 1, etc.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.task.labels</code></td>
-  <td>(none)</td>
-  <td>
-    Set the mesos labels to add to each task. Labels are free-form key-value pairs.
-    Key-value pairs should be separated by a colon, and commas used to list more than one.
-    Ex. key:value,key2:value2.
-  </td>
-</tr>
-<tr>
   <td><code>spark.mesos.executor.home</code></td>
   <td>driver side <code>SPARK_HOME</code></td>
   <td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -368,6 +368,23 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.mesos.task.name</code></td>
+  <td>Task</td>
+  <td>
+    Set the task name for the executors that are spun up (in coarse-grained mode).
+    The names will also be appended with the executor number. Ex. Task 0, Task 1, etc.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.task.labels</code></td>
+  <td>(none)</td>
+  <td>
+    Set the mesos labels to add to each task. Labels are free-form key-value pairs.
+    Key-value pairs should be separated by a colon, and commas used to list more than one.
+    Ex. key:value,key2:value2.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.executor.home</code></td>
   <td>driver side <code>SPARK_HOME</code></td>
   <td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -67,10 +67,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private val maxGpus = conf.getInt("spark.mesos.gpus.max", 0)
 
-  private val taskName = conf.get("spark.mesos.task.name", "Task").toString
-
-  private val taskLabels = conf.get("spark.mesos.task.labels", "").toString
-
   private[this] val shutdownTimeoutMS =
     conf.getTimeAsMs("spark.mesos.coarse.shutdownTimeout", "10s")
       .ensuring(_ >= 0, "spark.mesos.coarse.shutdownTimeout must be >= 0")
@@ -407,23 +403,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             .setTaskId(TaskID.newBuilder().setValue(taskId.toString).build())
             .setSlaveId(offer.getSlaveId)
             .setCommand(createCommand(offer, taskCPUs + extraCoresPerExecutor, taskId))
-            .setName(s"$taskName $taskId")
-
-          val labelsBuilder = taskBuilder.getLabelsBuilder
-
-          taskLabels.split(",").foreach(label => {
-            label.split(":") match {
-              case Array(key, value) =>
-                labelsBuilder.addLabels(Label.newBuilder()
-                  .setKey(key)
-                  .setValue(value)
-                  .build())
-              case _ =>
-                logWarning(s"Unable to parse $label into a key:value label for the task.")
-            }
-          })
-
-          taskBuilder.setLabels(labelsBuilder)
+            .setName(s"${sc.appName} $taskId")
 
           taskBuilder.addAllResources(resourcesToUse.asJava)
           taskBuilder.setContainer(MesosSchedulerBackendUtil.containerInfo(sc.conf))

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -465,63 +465,14 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
   }
 
   test("mesos sets configurable task name") {
-    val taskName = "mesos.test.task"
-    setBackend(Map(
-      "spark.mesos.task.name" -> taskName
-    ))
+    setBackend()
 
     val offers = List(Resources(backend.executorMemory(sc), 1))
     offerResources(offers)
     val launchedTasks = verifyTaskLaunched(driver, "o1")
 
     // Add " 0" to the taskName to match the executor number that is appended
-    assert(launchedTasks.head.getName == s"$taskName 0")
-  }
-
-  test("mesos sets configurable labels on tasks") {
-    val taskLabelsString = "mesos:test,label:test"
-    setBackend(Map(
-      "spark.mesos.task.labels" -> taskLabelsString
-    ))
-
-    // Build up the labels
-    val taskLabels = Protos.Labels.newBuilder()
-      .addLabels(Protos.Label.newBuilder()
-        .setKey("mesos").setValue("test").build())
-      .addLabels(Protos.Label.newBuilder()
-        .setKey("label").setValue("test").build())
-      .build()
-
-    val offers = List(Resources(backend.executorMemory(sc), 1))
-    offerResources(offers)
-    val launchedTasks = verifyTaskLaunched(driver, "o1")
-
-    val labels = launchedTasks.head.getLabels
-
-    assert(launchedTasks.head.getLabels.equals(taskLabels))
-  }
-
-  test("mesos ignored invalid labels and sets configurable labels on tasks") {
-    val taskLabelsString = "mesos:test,label:test,incorrect:label:here"
-    setBackend(Map(
-      "spark.mesos.task.labels" -> taskLabelsString
-    ))
-
-    // Build up the labels
-    val taskLabels = Protos.Labels.newBuilder()
-      .addLabels(Protos.Label.newBuilder()
-        .setKey("mesos").setValue("test").build())
-      .addLabels(Protos.Label.newBuilder()
-        .setKey("label").setValue("test").build())
-      .build()
-
-    val offers = List(Resources(backend.executorMemory(sc), 1))
-    offerResources(offers)
-    val launchedTasks = verifyTaskLaunched(driver, "o1")
-
-    val labels = launchedTasks.head.getLabels
-
-    assert(launchedTasks.head.getLabels.equals(taskLabels))
+    assert(launchedTasks.head.getName == s"${sc.appName} 0")
   }
 
   test("mesos supports spark.mesos.network.name") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -464,7 +464,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     assert(!uris.asScala.head.getCache)
   }
 
-  test("mesos sets configurable task name") {
+  test("mesos sets task name to spark.app.name") {
     setBackend()
 
     val offers = List(Resources(backend.executorMemory(sc), 1))
@@ -472,7 +472,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     val launchedTasks = verifyTaskLaunched(driver, "o1")
 
     // Add " 0" to the taskName to match the executor number that is appended
-    assert(launchedTasks.head.getName == s"${sc.appName} 0")
+    assert(launchedTasks.head.getName == "test-mesos-dynamic-alloc 0")
   }
 
   test("mesos supports spark.mesos.network.name") {

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -478,8 +478,31 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     assert(launchedTasks.head.getName == s"$taskName 0")
   }
 
-  test("mesos sets configurable label on tasks") {
+  test("mesos sets configurable labels on tasks") {
     val taskLabelsString = "mesos:test,label:test"
+    setBackend(Map(
+      "spark.mesos.task.labels" -> taskLabelsString
+    ))
+
+    // Build up the labels
+    val taskLabels = Protos.Labels.newBuilder()
+      .addLabels(Protos.Label.newBuilder()
+        .setKey("mesos").setValue("test").build())
+      .addLabels(Protos.Label.newBuilder()
+        .setKey("label").setValue("test").build())
+      .build()
+
+    val offers = List(Resources(backend.executorMemory(sc), 1))
+    offerResources(offers)
+    val launchedTasks = verifyTaskLaunched(driver, "o1")
+
+    val labels = launchedTasks.head.getLabels
+
+    assert(launchedTasks.head.getLabels.equals(taskLabels))
+  }
+
+  test("mesos ignored invalid labels and sets configurable labels on tasks") {
+    val taskLabelsString = "mesos:test,label:test,incorrec:label:here"
     setBackend(Map(
       "spark.mesos.task.labels" -> taskLabelsString
     ))

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -502,7 +502,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
   }
 
   test("mesos ignored invalid labels and sets configurable labels on tasks") {
-    val taskLabelsString = "mesos:test,label:test,incorrec:label:here"
+    val taskLabelsString = "mesos:test,label:test,incorrect:label:here"
     setBackend(Map(
       "spark.mesos.task.labels" -> taskLabelsString
     ))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding configurable mesos executor names and labels using `spark.mesos.task.name` and `spark.mesos.task.labels`.

Labels were defined as `k1:v1,k2:v2`.

@mgummelt 

## How was this patch tested?

Added unit tests to verify labels were added correctly, with incorrect labels being ignored and added a test to test the name of the executor.

Tested with: `./build/sbt -Pmesos mesos/test`

Please review http://spark.apache.org/contributing.html before opening a pull request.
