### PR TITLE
[SPARK-20043][ML] DecisionTreeModel: ImpurityCalculator builder fails for uppercase impurity type Gini

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Impurity.scala
@@ -184,7 +184,7 @@ private[spark] object ImpurityCalculator {
    * the given stats.
    */
   def getCalculator(impurity: String, stats: Array[Double]): ImpurityCalculator = {
-    impurity match {
+    impurity.toLowerCase match {
       case "gini" => new GiniCalculator(stats)
       case "entropy" => new EntropyCalculator(stats)
       case "variance" => new VarianceCalculator(stats)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -389,17 +389,15 @@ class DecisionTreeClassifierSuite
   test("SPARK-20043: " +
        "ImpurityCalculator builder fails for uppercase impurity type Gini in model read/write") {
     val rdd = TreeTests.getTreeReadWriteData(sc)
-
     val data: DataFrame =
       TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 2)
 
     val dt = new DecisionTreeClassifier()
       .setImpurity("Gini")
       .setMaxDepth(2)
-
     val model = dt.fit(data)
 
-    testDefaultReadWrite(model, false)
+    testDefaultReadWrite(model)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -386,7 +386,7 @@ class DecisionTreeClassifierSuite
       allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
 
-  test("SAPRK-20043: " +
+  test("SPARK-20043: " +
        "ImpurityCalculator builder fails for uppercase impurity type Gini in model read/write") {
     val rdd = TreeTests.getTreeReadWriteData(sc)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -385,6 +385,20 @@ class DecisionTreeClassifierSuite
     testEstimatorAndModelReadWrite(dt, continuousData, allParamSettings ++ Map("maxDepth" -> 0),
       allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
+
+  test("read/write: ImpurityCalculator builder did not recognize impurity type: Gini") {
+    val rdd = TreeTests.getTreeReadWriteData(sc)
+
+    val categoricalData: DataFrame =
+      TreeTests.setMetadata(rdd, Map(0 -> 2, 1 -> 3), numClasses = 2)
+
+    // BUG: see SPARK-20043
+    val dt = new DecisionTreeClassifier().setImpurity("Gini")
+
+    val model = dt.fit(categoricalData)
+
+    testDefaultReadWrite(model, false)
+  }
 }
 
 private[ml] object DecisionTreeClassifierSuite extends SparkFunSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -386,16 +386,18 @@ class DecisionTreeClassifierSuite
       allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
 
-  test("read/write: ImpurityCalculator builder did not recognize impurity type: Gini") {
+  test("SAPRK-20043: " +
+       "ImpurityCalculator builder fails for uppercase impurity type Gini in model read/write") {
     val rdd = TreeTests.getTreeReadWriteData(sc)
 
-    val categoricalData: DataFrame =
-      TreeTests.setMetadata(rdd, Map(0 -> 2, 1 -> 3), numClasses = 2)
+    val data: DataFrame =
+      TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 2)
 
-    // BUG: see SPARK-20043
-    val dt = new DecisionTreeClassifier().setImpurity("Gini")
+    val dt = new DecisionTreeClassifier()
+      .setImpurity("Gini")
+      .setMaxDepth(2)
 
-    val model = dt.fit(categoricalData)
+    val model = dt.fit(data)
 
     testDefaultReadWrite(model, false)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -179,16 +179,18 @@ class DecisionTreeRegressorSuite
       TreeTests.allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
 
-  test("read/write: ImpurityCalculator builder did not recognize impurity type: Variance") {
+  test("SAPRK-20043: " +
+       "ImpurityCalculator builder fails for uppercase impurity type in model read/write") {
     val rdd = TreeTests.getTreeReadWriteData(sc)
 
-    val continuousData: DataFrame =
+    val data: DataFrame =
       TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 0)
 
-    // BUG: see SPARK-20043
-    val dt = new DecisionTreeRegressor().setImpurity("Variance")
+    val dt = new DecisionTreeRegressor()
+      .setImpurity("Variance")
+      .setMaxDepth(2)
 
-    val model = dt.fit(continuousData)
+    val model = dt.fit(data)
 
     testDefaultReadWrite(model, false)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -178,20 +178,6 @@ class DecisionTreeRegressorSuite
       TreeTests.allParamSettings ++ Map("maxDepth" -> 0),
       TreeTests.allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
-
-  test("SPARK-20043: " +
-       "ImpurityCalculator builder fails for uppercase impurity type in model read/write") {
-    val rdd = TreeTests.getTreeReadWriteData(sc)
-    val data: DataFrame =
-      TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 0)
-
-    val dt = new DecisionTreeRegressor()
-      .setImpurity("Variance")
-      .setMaxDepth(2)
-    val model = dt.fit(data)
-
-    testDefaultReadWrite(model)
-  }
 }
 
 private[ml] object DecisionTreeRegressorSuite extends SparkFunSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -179,7 +179,7 @@ class DecisionTreeRegressorSuite
       TreeTests.allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
 
-  test("SAPRK-20043: " +
+  test("SPARK-20043: " +
        "ImpurityCalculator builder fails for uppercase impurity type in model read/write") {
     val rdd = TreeTests.getTreeReadWriteData(sc)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -178,6 +178,20 @@ class DecisionTreeRegressorSuite
       TreeTests.allParamSettings ++ Map("maxDepth" -> 0),
       TreeTests.allParamSettings ++ Map("maxDepth" -> 0), checkModelData)
   }
+
+  test("read/write: ImpurityCalculator builder did not recognize impurity type: Variance") {
+    val rdd = TreeTests.getTreeReadWriteData(sc)
+
+    val continuousData: DataFrame =
+      TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 0)
+
+    // BUG: see SPARK-20043
+    val dt = new DecisionTreeRegressor().setImpurity("Variance")
+
+    val model = dt.fit(continuousData)
+
+    testDefaultReadWrite(model, false)
+  }
 }
 
 private[ml] object DecisionTreeRegressorSuite extends SparkFunSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -182,17 +182,15 @@ class DecisionTreeRegressorSuite
   test("SPARK-20043: " +
        "ImpurityCalculator builder fails for uppercase impurity type in model read/write") {
     val rdd = TreeTests.getTreeReadWriteData(sc)
-
     val data: DataFrame =
       TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 0)
 
     val dt = new DecisionTreeRegressor()
       .setImpurity("Variance")
       .setMaxDepth(2)
-
     val model = dt.fit(data)
 
-    testDefaultReadWrite(model, false)
+    testDefaultReadWrite(model)
   }
 }
 


### PR DESCRIPTION
Fix bug: DecisionTreeModel can't recongnize Impurity "Gini" when loading

TODO:
+ [x] add unit test
+ [x] fix the bug
