### PR TITLE
[SPARK-20070][SQL] Fix 2.10 build

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -225,6 +225,6 @@ private[spark] case class ConfigBuilder(key: String) {
   }
 
   def regexConf: TypedConfigBuilder[Regex] = {
-    new TypedConfigBuilder(this, regexFromString(_, this.key), _.regex)
+    new TypedConfigBuilder(this, regexFromString(_, this.key), _.toString)
   }
 }

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -100,10 +100,10 @@ class ConfigEntrySuite extends SparkFunSuite {
     val rConf = ConfigBuilder(testKey("regex")).regexConf.createWithDefault(".*".r)
 
     conf.set(rConf, "[0-9a-f]{8}".r)
-    assert(conf.get(rConf).regex === "[0-9a-f]{8}")
+    assert(conf.get(rConf).toString === "[0-9a-f]{8}")
 
     conf.set(rConf.key, "[0-9a-f]{4}")
-    assert(conf.get(rConf).regex === "[0-9a-f]{4}")
+    assert(conf.get(rConf).toString === "[0-9a-f]{4}")
 
     conf.set(rConf.key, "[.")
     val e = intercept[IllegalArgumentException](conf.get(rConf))


### PR DESCRIPTION
## What changes were proposed in this pull request?
Commit https://github.com/apache/spark/commit/91fa80fe8a2480d64c430bd10f97b3d44c007bcc broke the build for scala 2.10. The commit uses `Regex.regex` field which is not available in Scala 2.10. This PR fixes this.

## How was this patch tested?
Existing tests.