### PR TITLE
[SPARK-20088] Do not create new SparkContext in SparkR createSparkContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/r/RRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRDD.scala
@@ -136,7 +136,7 @@ private[r] object RRDD {
                          .mkString(File.separator))
     }
 
-    val jsc = new JavaSparkContext(sparkConf)
+    val jsc = new JavaSparkContext(SparkContext.getOrCreate(sparkConf))
     jars.foreach { jar =>
       jsc.addJar(jar)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Instead of creating new `JavaSparkContext` we use `SparkContext.getOrCreate`.

## How was this patch tested?
Existing tests