### PR TITLE
[SPARK-20098][PYSPARK] dataType's typeName fix 

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -190,7 +190,10 @@ class DataTypeTests(unittest.TestCase):
 
     def test_struct_field_type_name(self):
         struct_field = StructField()
-        self.assertRaises(typeError('StructField does not have typename. You can use self.dataType.simpleString() instead.'), struct_field.typeName)
+        self.assertRaises(typeError(
+            "StructField does not have typename. \
+            You can use self.dataType.simpleString() instead."),
+            struct_field.typeName)
 
 
 class SQLTests(ReusedPySparkTestCase):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -189,11 +189,8 @@ class DataTypeTests(unittest.TestCase):
         self.assertEqual(len(row), 0)
 
     def test_struct_field_type_name(self):
-        struct_field = StructField()
-        self.assertRaises(typeError(
-            "StructField does not have typename. \
-            You can use self.dataType.simpleString() instead."),
-            struct_field.typeName)
+        struct_field = StructField("a", IntegerType())
+        self.assertRaises(TypeError, struct_field.typeName)
 
 
 class SQLTests(ReusedPySparkTestCase):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -188,6 +188,10 @@ class DataTypeTests(unittest.TestCase):
         row = Row()
         self.assertEqual(len(row), 0)
 
+    def test_struct_field_type_name(self):
+        struct_field = StructField()
+        self.assertRaises(typeError('StructField does not have typename. You can use self.dataType.simpleString() instead.'), struct_field.typeName)
+
 
 class SQLTests(ReusedPySparkTestCase):
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -439,7 +439,9 @@ class StructField(DataType):
         return self.dataType.fromInternal(obj)
 
     def typeName(self):
-        raise TypeError('StructField does not have typename. You can use self.dataType.simpleString() instead.')
+        raise TypeError(
+            "StructField does not have typename. \
+            You can use self.dataType.simpleString() instead.")
 
 
 class StructType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -440,8 +440,8 @@ class StructField(DataType):
 
     def typeName(self):
         raise TypeError(
-            "StructField does not have typename. \
-            You can use self.dataType.simpleString() instead.")
+            "StructField does not have typeName."
+            "Use typeName on its type explicitly instead.")
 
 
 class StructType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -441,7 +441,7 @@ class StructField(DataType):
     def typeName(self):
         raise TypeError(
             "StructField does not have typeName."
-            "Use typeName on its type explicitly instead.")
+            "Use typeName on its type explicitly instead. ")
 
 
 class StructType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -440,8 +440,8 @@ class StructField(DataType):
 
     def typeName(self):
         raise TypeError(
-            "StructField does not have typeName."
-            "Use typeName on its type explicitly instead. ")
+            "StructField does not have typeName. "
+            "Use typeName on its type explicitly instead.")
 
 
 class StructType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -62,7 +62,7 @@ class DataType(object):
                            "StringType": "string",
                            "BinaryType": "binary",
                            "BooleanType": "boolean",
-                           "DateType": "Date",
+                           "DateType": "date",
                            "TimestampType": "timestamp",
                            "DecimalType": "decimal",
                            "DoubleType": "double",

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -439,7 +439,7 @@ class StructField(DataType):
         return self.dataType.fromInternal(obj)
 
     def typeName(self):
-        raise TypeError('StructField does not have typename')
+        raise TypeError('StructField does not have typename. You can use self.dataType.simpleString() instead.')
 
 
 class StructType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -57,25 +57,7 @@ class DataType(object):
 
     @classmethod
     def typeName(cls):
-        typeTypeNameMap = {"DataType": "data",
-                           "NullType": "null",
-                           "StringType": "string",
-                           "BinaryType": "binary",
-                           "BooleanType": "boolean",
-                           "DateType": "date",
-                           "TimestampType": "timestamp",
-                           "DecimalType": "decimal",
-                           "DoubleType": "double",
-                           "FloatType": "float",
-                           "ByteType": "byte",
-                           "IntegerType": "integer",
-                           "LongType": "long",
-                           "ShortType": "short",
-                           "ArrayType": "array",
-                           "MapType": "map",
-                           "StructField": "struct",
-                           "StructType": "struct"}
-        return typeTypeNameMap[cls.__name__]
+        return cls.__name__[:-4].lower()
 
     def simpleString(self):
         return self.typeName()
@@ -455,6 +437,9 @@ class StructField(DataType):
 
     def fromInternal(self, obj):
         return self.dataType.fromInternal(obj)
+
+    def typeName(self):
+        raise TypeError('StructField does not have typename')
 
 
 class StructType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -57,7 +57,25 @@ class DataType(object):
 
     @classmethod
     def typeName(cls):
-        return cls.__name__[:-4].lower()
+        typeTypeNameMap = {"DataType": "data",
+                           "NullType": "null",
+                           "StringType": "string",
+                           "BinaryType": "binary",
+                           "BooleanType": "boolean",
+                           "DateType": "Date",
+                           "TimestampType": "timestamp",
+                           "DecimalType": "decimal",
+                           "DoubleType": "double",
+                           "FloatType": "float",
+                           "ByteType": "byte",
+                           "IntegerType": "integer",
+                           "LongType": "long",
+                           "ShortType": "short",
+                           "ArrayType": "array",
+                           "MapType": "map",
+                           "StructField": "struct",
+                           "StructType": "struct"}
+        return typeTypeNameMap[cls.__name__]
 
     def simpleString(self):
         return self.typeName()


### PR DESCRIPTION
## What changes were proposed in this pull request?
`typeName`  classmethod has been fixed by using type -> typeName map. 

## How was this patch tested?
local build
