### PR TITLE
[SPARK-19876][SS] Follow up: Refactored BatchCommitLog to simplify logic

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/BatchCommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/BatchCommitLog.scala
@@ -48,7 +48,7 @@ class BatchCommitLog(sparkSession: SparkSession, path: String)
   import BatchCommitLog._
 
   def add(batchId: Long): Unit = {
-    super.add(batchId, SERIALIZED_VOID)
+    super.add(batchId, EMPTY_JSON)
   }
 
   override def add(batchId: Long, metadata: String): Boolean = {
@@ -63,10 +63,7 @@ class BatchCommitLog(sparkSession: SparkSession, path: String)
       throw new IllegalStateException("Incomplete log file in the offset commit log")
     }
     parseVersion(lines.next.trim, VERSION)
-    // read metadata
-    val metadata = lines.next.trim
-    assert(metadata == SERIALIZED_VOID, s"Batch commit log has unexpected metadata: $metadata ")
-    metadata
+    EMPTY_JSON
   }
 
   override protected def serialize(metadata: String, out: OutputStream): Unit = {
@@ -75,12 +72,12 @@ class BatchCommitLog(sparkSession: SparkSession, path: String)
     out.write('\n')
 
     // write metadata
-    out.write(SERIALIZED_VOID.getBytes(UTF_8))
+    out.write(EMPTY_JSON.getBytes(UTF_8))
   }
 }
 
 object BatchCommitLog {
   private val VERSION = 1
-  private val SERIALIZED_VOID = "{}"
+  private val EMPTY_JSON = "{}"
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -106,6 +106,7 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
    * metadata has already been stored, this method will return `false`.
    */
   override def add(batchId: Long, metadata: T): Boolean = {
+    require(metadata != null, "'null' metadata cannot written to a metadata log")
     get(batchId).map(_ => false).getOrElse {
       // Only write metadata when the batch has not yet been written
       writeBatch(batchId, metadata)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -305,7 +305,7 @@ class StreamExecution(
               if (dataAvailable) {
                 // Update committed offsets.
                 committedOffsets ++= availableOffsets
-                batchCommitLog.add(currentBatchId, null)
+                batchCommitLog.add(currentBatchId)
                 logDebug(s"batch ${currentBatchId} committed")
                 // We'll increase currentBatchId after we complete processing current batch's data
                 currentBatchId += 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Existing logic seemingly writes null to the BatchCommitLog, even though it does additional checks to write '{}' (valid json) to the log. This PR simplifies the logic by disallowing use of `log.add(batchId, metadata)` and instead using `log.add(batchId)`. No question of specifying metadata, so no confusion related to null. 

## How was this patch tested?
Existing tests pass. 