### PR TITLE
[SPARK-20115] [CORE] Fix DAGScheduler to recompute all the lost shuffle blocks when external shuffle service is unavailable

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -172,7 +172,8 @@ class DAGScheduler(
 
   // For tracking failed nodes, we use the MapOutputTracker's epoch number, which is sent with
   // every task. When we detect a node failing, we note the current epoch number and failed
-  // executor, increment it for new tasks, and use this to ignore stray ShuffleMapTask results.
+  // executor or host, increment it for new tasks, and use this to ignore stray
+  // ShuffleMapTask results.
   //
   // TODO: Garbage collect information about failure epochs when we know there are no more
   //       stray messages to detect.
@@ -1348,7 +1349,14 @@ class DAGScheduler(
 
           // TODO: mark the executor as failed only if there were lots of fetch failures on it
           if (bmAddress != null) {
-            handleExecutorLost(bmAddress.executorId, filesLost = true, Some(task.epoch))
+            if (env.blockManager.externalShuffleServiceEnabled) {
+              val currentEpoch = Some(task.epoch).getOrElse(mapOutputTracker.getEpoch)
+              removeExecutor(bmAddress.executorId, currentEpoch)
+              handleExternalShuffleFailure(bmAddress.host, currentEpoch)
+            }
+            else {
+              handleExecutorLost(bmAddress.executorId, filesLost = true, Some(task.epoch))
+            }
           }
         }
 
@@ -1369,6 +1377,30 @@ class DAGScheduler(
   }
 
   /**
+   * Removes an executor from the driver endpoint.
+   *
+   * @param execId id of the executor to be removed
+   * @param currentEpoch epoch during which the executor failure was caught to avoid allowing
+   *                     stray failures from possibly retriggering the detection of an
+   *                     executor as lost.
+   *
+   * @return boolean value indicating whether the executor was removed or not
+   */
+  private[scheduler] def removeExecutor(execId: String, currentEpoch: Long): Boolean = {
+    if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
+      failedEpoch(execId) = currentEpoch
+      logInfo("Executor lost: %s (epoch %d)".format(execId, currentEpoch))
+      blockManagerMaster.removeExecutor(execId)
+      true
+    }
+    else {
+      logDebug("Additional executor lost message for " + execId +
+        "(epoch " + currentEpoch + ")")
+      false
+    }
+  }
+
+  /**
    * Responds to an executor being lost. This is called inside the event loop, so it assumes it can
    * modify the scheduler's internal state. Use executorLost() to post a loss event from outside.
    *
@@ -1385,37 +1417,75 @@ class DAGScheduler(
       filesLost: Boolean,
       maybeEpoch: Option[Long] = None) {
     val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
-    if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
-      failedEpoch(execId) = currentEpoch
-      logInfo("Executor lost: %s (epoch %d)".format(execId, currentEpoch))
-      blockManagerMaster.removeExecutor(execId)
-
-      if (filesLost || !env.blockManager.externalShuffleServiceEnabled) {
-        logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
-        // TODO: This will be really slow if we keep accumulating shuffle map stages
-        for ((shuffleId, stage) <- shuffleIdToMapStage) {
-          stage.removeOutputsOnExecutor(execId)
-          mapOutputTracker.registerMapOutputs(
-            shuffleId,
-            stage.outputLocInMapOutputTrackerFormat(),
-            changeEpoch = true)
-        }
-        if (shuffleIdToMapStage.isEmpty) {
-          mapOutputTracker.incrementEpoch()
-        }
-        clearCacheLocs()
-      }
-    } else {
-      logDebug("Additional executor lost message for " + execId +
-               "(epoch " + currentEpoch + ")")
+    val executorRemoved = removeExecutor(execId, currentEpoch)
+    if (executorRemoved && (filesLost || !env.blockManager.externalShuffleServiceEnabled)) {
+      handleInternalShuffleFailure(execId, currentEpoch)
     }
+  }
+
+  /**
+   * Responds to an internal shuffle becoming unavailable for an executor.
+   *
+   * We will assume that we've lost all the shuffle blocks for the executor.
+   *
+   * @param execId id of the executor for which internal shuffle is unavailable
+   * @param currentEpoch epoch during which the failure was caught.
+   */
+  private[scheduler] def handleInternalShuffleFailure(execId: String, currentEpoch: Long): Unit = {
+    logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
+    cleanShuffleOutputs((stage: ShuffleMapStage) => {
+      stage.removeOutputsOnExecutor(execId)
+    })
+  }
+
+  /**
+   * Responds to an external shuffle service becoming unavailable on a host.
+   *
+   * We will assume that we've lost all the shuffle blocks on that host if FetchFailed occurred
+   * while external shuffle is being used.
+   *
+   * @param host address of the host on which external shuffle is unavailable
+   * @param currentEpoch epoch during which the failure was caught. This is passed to avoid
+   *                     allowing stray fetch failures from possibly retriggering the detection
+   *                     of external shuffle service becoming unavailable.
+   */
+  private[scheduler] def  handleExternalShuffleFailure(host: String, currentEpoch: Long): Unit = {
+    if (!failedEpoch.contains(host) || failedEpoch(host) < currentEpoch) {
+      failedEpoch(host) = currentEpoch
+      logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))
+      cleanShuffleOutputs((stage: ShuffleMapStage) => {
+        stage.removeOutputsOnHost(host)
+      })
+    } else {
+      logDebug(("Additional Shuffle files " +
+        "lost message for host: %s (epoch %d)").format(host, currentEpoch))
+    }
+  }
+
+  private[scheduler] def cleanShuffleOutputs(outputsCleaner: ShuffleMapStage => _): Unit = {
+    // TODO: This will be really slow if we keep accumulating shuffle map stages
+    for ((shuffleId, stage) <- shuffleIdToMapStage) {
+      outputsCleaner(stage)
+      mapOutputTracker.registerMapOutputs(
+        shuffleId,
+        stage.outputLocInMapOutputTrackerFormat(),
+        changeEpoch = true)
+    }
+    if (shuffleIdToMapStage.isEmpty) {
+      mapOutputTracker.incrementEpoch()
+    }
+    clearCacheLocs()
   }
 
   private[scheduler] def handleExecutorAdded(execId: String, host: String) {
     // remove from failedEpoch(execId) ?
     if (failedEpoch.contains(execId)) {
-      logInfo("Host added was in lost list earlier: " + host)
+      logInfo("Executor %s added was in lost list earlier.".format(execId))
       failedEpoch -= execId
+    }
+
+    if (failedEpoch.contains(host)) {
+      failedEpoch -= host
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Spark’s DAGScheduler currently does not recompute all the lost shuffle blocks on a host when a FetchFailed exception occurs, while fetching shuffle blocks from another executor with external shuffle service enabled. Instead it only recomputes the lost shuffle blocks computed by the executor for which the FetchFailed exception occurred. This works fine for Internal shuffle scenario, where the executors serve their own shuffle blocks and hence only the shuffle blocks for that executor should be considered lost. However, when External Shuffle Service is being used, a FetchFailed exception would mean that the external shuffle service running on that host has become unavailable. This in turn is sufficient to assume that all the shuffle blocks which were managed by the Shuffle service on that host are lost. Therefore, just recomputing the shuffle blocks associated with the particular Executor for which FetchFailed exception occurred is not sufficient. We need to recompute all the shuffle blocks, managed by that service because there could be multiple executors running on that host.

Since not all the shuffle blocks (for all the executors on the host) are recomputed, this causes future attempts of the reduce stage to fail as well because the new tasks scheduled still keep trying to reach the old location of the shuffle blocks (which were not recomputed) and keep throwing further FetchFailed exceptions. This ultimately causes the job to fail, after the reduce stage has been retried 4 times.

Following changes are proposed to address the above issue:
1. In case of FetchFailed exception when using external shuffle service, mark all the shuffle outputs on the host as failed (due to failure of external shuffle service).
2. Thus recompute all the lost shuffle blocks, instead of for just one executor.

## How was this patch tested?
1. Added unit test for the change in functionality.
2. Tested on a cluster with Spark running on Yarn (with external shuffle enabled), by performing the following steps:
- Start a word count job, and wait for the Map stage to be completed
- During the reduce stage, stop the external shuffle service on a host
- Wait for fetch failed exception to occur, while fetching shuffle blocks from the host
- Check that in the reattempt of the Map stage, Spark computes all the lost shuffle blocks for the host on which shuffle service was stopped
- Job completes successfully, since reduce stage in next reattempt finds all the shuffle blocks
@kayousterhout @mridulm @rxin