### PR TITLE
[SPARK-20119][test-maven]Fix the test case fail in DataSourceScanExecRedactionSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
@@ -31,7 +31,7 @@ class DataSourceScanExecRedactionSuite extends QueryTest with SharedSQLContext {
 
   override def beforeAll(): Unit = {
     sparkConf.set("spark.redaction.string.regex",
-      "spark-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+      "file:/[\\w_]+")
     super.beforeAll()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changed the pattern to match the first n characters in the location field so that the string truncation does not affect it.

### How was this patch tested?
N/A