### PR TITLE
[SPARK-20109][MLlib] Rewrote toBlockMatrix method on IndexedRowMatrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/CoordinateMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/CoordinateMatrix.scala
@@ -125,6 +125,13 @@ class CoordinateMatrix @Since("1.0.0") (
       s"colsPerBlock needs to be greater than 0. colsPerBlock: $colsPerBlock")
     val m = numRows()
     val n = numCols()
+
+    // Since block matrices require an integer row and col index
+    require(math.ceil(m.toDouble / rowsPerBlock) <= Int.MaxValue,
+      "Number of rows divided by rowsPerBlock cannot exceed maximum integer.")
+    require(math.ceil(n.toDouble / colsPerBlock) <= Int.MaxValue,
+      "Number of cols divided by colsPerBlock cannot exceed maximum integer.")
+
     val numRowBlocks = math.ceil(m.toDouble / rowsPerBlock).toInt
     val numColBlocks = math.ceil(n.toDouble / colsPerBlock).toInt
     val partitioner = GridPartitioner(numRowBlocks, numColBlocks, entries.partitions.length)

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -113,12 +113,13 @@ class IndexedRowMatrix @Since("1.0.0") (
     require(colsPerBlock > 0,
       s"colsPerBlock needs to be greater than 0. colsPerBlock: $colsPerBlock")
 
-    // Since block matrices require an integer row index
-    require(numRows() / rowsPerBlock.toDouble <= Int.MaxValue,
-      "Number of rows divided by rowsPerBlock cannot exceed maximum integer.")
-
     val m = numRows()
     val n = numCols()
+
+    // Since block matrices require an integer row index
+    require(math.ceil(m.toDouble / rowsPerBlock) <= Int.MaxValue,
+      "Number of rows divided by rowsPerBlock cannot exceed maximum integer.")
+
     // The remainder calculations only matter when m % rowsPerBlock != 0 or n % colsPerBlock != 0
     val remainderRowBlockIndex = m / rowsPerBlock
     val remainderColBlockIndex = n / colsPerBlock
@@ -170,7 +171,7 @@ class IndexedRowMatrix @Since("1.0.0") (
 
         ((blockRow, blockColumn), finalMatrix)
     }
-    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, this.numRows(), this.numCols())
+    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, m, n)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -114,7 +114,7 @@ class IndexedRowMatrix @Since("1.0.0") (
       s"colsPerBlock needs to be greater than 0. colsPerBlock: $colsPerBlock")
 
     // Since block matrices require an integer row index
-    require(numRows() / rowsPerBlock < Int.MaxValue,
+    require(numRows() / rowsPerBlock.toDouble <= Int.MaxValue,
       "Number of rows divided by rowsPerBlock cannot exceed maximum integer.")
 
     val m = numRows()

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -98,7 +98,6 @@ class IndexedRowMatrix @Since("1.0.0") (
     toBlockMatrix(1024, 1024)
   }
 
-
   /**
    * Converts to BlockMatrix. Creates blocks of `SparseMatrix`.
    * @param rowsPerBlock The number of rows of each block. The blocks at the bottom edge may have
@@ -153,7 +152,7 @@ class IndexedRowMatrix @Since("1.0.0") (
         .map({ case (values, blockColumn) =>
           ((blockRow.toInt, blockColumn), (rowInBlock.toInt, values))
         })
-    }).groupByKey(GridPartitioner(numRowBlocks, numColBlocks, rowsPerBlock, colsPerBlock)).map({
+    }).groupByKey(GridPartitioner(numRowBlocks, numColBlocks, rows.getNumPartitions)).map({
       case ((blockRow, blockColumn), itr) =>
         val actualNumRows: Int =
           if (blockRow == lastRowBlockIndex) lastRowBlockSize else rowsPerBlock

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -140,7 +140,7 @@ class IndexedRowMatrix @Since("1.0.0") (
               ((blockRow.toInt, blockColumn), (rowInBlock.toInt, values.zipWithIndex))
             }
       }
-    }.groupByKey(GridPartitioner(numRowBlocks, numColBlocks, rows.getNumPartitions)).map{
+    }.groupByKey(GridPartitioner(numRowBlocks, numColBlocks, rows.getNumPartitions)).map {
       case ((blockRow, blockColumn), itr) =>
         val actualNumRows =
           if (blockRow == lastRowBlockIndex) lastRowBlockSize else rowsPerBlock
@@ -157,7 +157,7 @@ class IndexedRowMatrix @Since("1.0.0") (
           }
         }
         val denseMatrix = new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray)
-        val finalMatrix = if (countForValues / arraySize.toDouble > 0.5) {
+        val finalMatrix = if (countForValues / arraySize.toDouble >= 0.5) {
           denseMatrix
         } else {
           denseMatrix.toSparse
@@ -165,7 +165,7 @@ class IndexedRowMatrix @Since("1.0.0") (
 
         ((blockRow, blockColumn), finalMatrix)
     }
-    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock)
+    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, this.numRows(), this.numCols())
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -98,6 +98,28 @@ class IndexedRowMatrix @Since("1.0.0") (
     toBlockMatrix(1024, 1024)
   }
 
+
+  /**
+   * Converts to BlockMatrix. Creates blocks of `SparseMatrix`.
+   * @param rowsPerBlock The number of rows of each block. The blocks at the bottom edge may have
+   *                     a smaller value. Must be an integer value greater than 0.
+   * @param colsPerBlock The number of columns of each block. The blocks at the right edge may have
+   *                     a smaller value. Must be an integer value greater than 0.
+   * @return a [[BlockMatrix]]
+   */
+  @Since("1.3.0")
+  def toBlockMatrix(rowsPerBlock: Int, colsPerBlock: Int): BlockMatrix = {
+    // TODO: This implementation may be optimized
+    toCoordinateMatrix().toBlockMatrix(rowsPerBlock, colsPerBlock)
+  }
+
+  /**
+    * Converts to BlockMatrix. Creates blocks of `DenseMatrix` with size 1024 x 1024.
+    */
+  def toBlockMatrixDense(): BlockMatrix = {
+    toBlockMatrixDense(1024, 1024)
+  }
+
   /**
     * Converts to BlockMatrix. Creates blocks of `DenseMatrix`.
     * @param rowsPerBlock The number of rows of each block. The blocks at the bottom edge may have
@@ -150,20 +172,6 @@ class IndexedRowMatrix @Since("1.0.0") (
         ((blockRow, blockColumn), new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray))
     })
     new BlockMatrix(blocks, rowsPerBlock, colsPerBlock)
-  }
-
-  /**
-   * Converts to BlockMatrix. Creates blocks of `SparseMatrix`.
-   * @param rowsPerBlock The number of rows of each block. The blocks at the bottom edge may have
-   *                     a smaller value. Must be an integer value greater than 0.
-   * @param colsPerBlock The number of columns of each block. The blocks at the right edge may have
-   *                     a smaller value. Must be an integer value greater than 0.
-   * @return a [[BlockMatrix]]
-   */
-  @Since("1.3.0")
-  def toBlockMatrix(rowsPerBlock: Int, colsPerBlock: Int): BlockMatrix = {
-    // TODO: This implementation may be optimized
-    toCoordinateMatrix().toBlockMatrix(rowsPerBlock, colsPerBlock)
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -140,12 +140,12 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(blockMat2.numCols() === n)
     assert(blockMat2.toBreeze() === idxRowMatSparse.toBreeze())
 
-    assert(blockMat.blocks.map { case (_, matrix: Matrix) =>
+    assert(blockMat.blocks.collect().forall{ case (_, matrix: Matrix) =>
       matrix.isInstanceOf[SparseMatrix]
-    }.reduce(_ && _))
-    assert(blockMat2.blocks.map { case (_, matrix: Matrix) =>
+    })
+    assert(blockMat2.blocks.collect().forall{ case (_, matrix: Matrix) =>
       matrix.isInstanceOf[SparseMatrix]
-    }.reduce(_ && _))
+    })
   }
 
   test("toBlockMatrix mixed backing") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -114,22 +114,22 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
     val idxRowMat = new IndexedRowMatrix(indexedRows)
 
     // Tests when n % colsPerBlock != 0
-    val blockMat = idxRowMat.toBlockMatrix(2, 2)
+    val blockMat = idxRowMat.toBlockMatrixDense(2, 2)
     assert(blockMat.numRows() === m)
     assert(blockMat.numCols() === n)
     assert(blockMat.toBreeze() === idxRowMat.toBreeze())
 
     // Tests when m % rowsPerBlock != 0
-    val blockMat2 = idxRowMat.toBlockMatrix(3, 1)
+    val blockMat2 = idxRowMat.toBlockMatrixDense(3, 1)
     assert(blockMat2.numRows() === m)
     assert(blockMat2.numCols() === n)
     assert(blockMat2.toBreeze() === idxRowMat.toBreeze())
 
     intercept[IllegalArgumentException] {
-      idxRowMat.toBlockMatrix(-1, 2)
+      idxRowMat.toBlockMatrixDense(-1, 2)
     }
     intercept[IllegalArgumentException] {
-      idxRowMat.toBlockMatrix(2, 0)
+      idxRowMat.toBlockMatrixDense(2, 0)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -89,10 +89,41 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("toBlockMatrix") {
     val idxRowMat = new IndexedRowMatrix(indexedRows)
+
+    // Tests when n % colsPerBlock != 0
     val blockMat = idxRowMat.toBlockMatrix(2, 2)
     assert(blockMat.numRows() === m)
     assert(blockMat.numCols() === n)
     assert(blockMat.toBreeze() === idxRowMat.toBreeze())
+
+    // Tests when m % rowsPerBlock != 0
+    val blockMat2 = idxRowMat.toBlockMatrix(3, 1)
+    assert(blockMat2.numRows() === m)
+    assert(blockMat2.numCols() === n)
+    assert(blockMat2.toBreeze() === idxRowMat.toBreeze())
+
+    intercept[IllegalArgumentException] {
+      idxRowMat.toBlockMatrix(-1, 2)
+    }
+    intercept[IllegalArgumentException] {
+      idxRowMat.toBlockMatrix(2, 0)
+    }
+  }
+
+  test("toBlockMatrixDense") {
+    val idxRowMat = new IndexedRowMatrix(indexedRows)
+
+    // Tests when n % colsPerBlock != 0
+    val blockMat = idxRowMat.toBlockMatrix(2, 2)
+    assert(blockMat.numRows() === m)
+    assert(blockMat.numCols() === n)
+    assert(blockMat.toBreeze() === idxRowMat.toBreeze())
+
+    // Tests when m % rowsPerBlock != 0
+    val blockMat2 = idxRowMat.toBlockMatrix(3, 1)
+    assert(blockMat2.numRows() === m)
+    assert(blockMat2.numCols() === n)
+    assert(blockMat2.toBreeze() === idxRowMat.toBreeze())
 
     intercept[IllegalArgumentException] {
       idxRowMat.toBlockMatrix(-1, 2)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -110,29 +110,6 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
     }
   }
 
-  test("toBlockMatrixDense") {
-    val idxRowMat = new IndexedRowMatrix(indexedRows)
-
-    // Tests when n % colsPerBlock != 0
-    val blockMat = idxRowMat.toBlockMatrixDense(2, 2)
-    assert(blockMat.numRows() === m)
-    assert(blockMat.numCols() === n)
-    assert(blockMat.toBreeze() === idxRowMat.toBreeze())
-
-    // Tests when m % rowsPerBlock != 0
-    val blockMat2 = idxRowMat.toBlockMatrixDense(3, 1)
-    assert(blockMat2.numRows() === m)
-    assert(blockMat2.numCols() === n)
-    assert(blockMat2.toBreeze() === idxRowMat.toBreeze())
-
-    intercept[IllegalArgumentException] {
-      idxRowMat.toBlockMatrixDense(-1, 2)
-    }
-    intercept[IllegalArgumentException] {
-      idxRowMat.toBlockMatrixDense(2, 0)
-    }
-  }
-
   test("multiply a local matrix") {
     val A = new IndexedRowMatrix(indexedRows)
     val B = Matrices.dense(3, 2, Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0))

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -110,9 +110,11 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
     }
 
     assert(blockMat.blocks.map { case (_, matrix: Matrix) =>
-      matrix.isInstanceOf[DenseMatrix]}.reduce(_ && _))
+      matrix.isInstanceOf[DenseMatrix]
+    }.reduce(_ && _))
     assert(blockMat2.blocks.map { case (_, matrix: Matrix) =>
-      matrix.isInstanceOf[DenseMatrix]}.reduce(_ && _))
+      matrix.isInstanceOf[DenseMatrix]
+    }.reduce(_ && _))
   }
 
   test("toBlockMatrix sparse backing") {
@@ -139,9 +141,11 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(blockMat2.toBreeze() === idxRowMatSparse.toBreeze())
 
     assert(blockMat.blocks.map { case (_, matrix: Matrix) =>
-      matrix.isInstanceOf[SparseMatrix]}.reduce(_ && _))
+      matrix.isInstanceOf[SparseMatrix]
+    }.reduce(_ && _))
     assert(blockMat2.blocks.map { case (_, matrix: Matrix) =>
-      matrix.isInstanceOf[SparseMatrix]}.reduce(_ && _))
+      matrix.isInstanceOf[SparseMatrix]
+    }.reduce(_ && _))
   }
 
   test("toBlockMatrix mixed backing") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -108,16 +108,19 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
     intercept[IllegalArgumentException] {
       idxRowMatDense.toBlockMatrix(2, 0)
     }
+
     assert(blockMat.blocks.map { case (_, matrix: Matrix) =>
+      matrix.isInstanceOf[DenseMatrix]}.reduce(_ && _))
+    assert(blockMat2.blocks.map { case (_, matrix: Matrix) =>
       matrix.isInstanceOf[DenseMatrix]}.reduce(_ && _))
   }
 
   test("toBlockMatrix sparse backing") {
     val sparseData = Seq(
-      (3L, Vectors.sparse(3, Seq((0, 4.0))))
+      (2L, Vectors.sparse(3, Seq((0, 4.0))))
     ).map(x => IndexedRow(x._1, x._2))
 
-    val idxRowMatSparse = new IndexedRowMatrix(sc.parallelize(sparseData))
+    val idxRowMatSparse = new IndexedRowMatrix(sc.parallelize(sparseData), m, n)
 
     // Tests when n % colsPerBlock != 0
     val blockMat = idxRowMatSparse.toBlockMatrix(2, 2)
@@ -133,27 +136,44 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(blockMat.blocks.map { case (_, matrix: Matrix) =>
       matrix.isInstanceOf[SparseMatrix]}.reduce(_ && _))
+    assert(blockMat2.blocks.map { case (_, matrix: Matrix) =>
+      matrix.isInstanceOf[SparseMatrix]}.reduce(_ && _))
   }
 
   test("toBlockMatrix mixed backing") {
     val mixedData = Seq(
       (0L, Vectors.dense(1, 2, 3)),
       (3L, Vectors.sparse(3, Seq((0, 4.0)))))
+      .map(x => IndexedRow(x._1, x._2))
 
     val idxRowMatMixed = new IndexedRowMatrix(
-      sc.parallelize(mixedData.map(x => IndexedRow(x._1, x._2))))
+      sc.parallelize(mixedData))
 
+    // Tests when n % colsPerBlock != 0
     val blockMat = idxRowMatMixed.toBlockMatrix(2, 2)
     assert(blockMat.numRows() === m)
     assert(blockMat.numCols() === n)
     assert(blockMat.toBreeze() === idxRowMatMixed.toBreeze())
 
+    // Tests when m % rowsPerBlock != 0
+    val blockMat2 = idxRowMatMixed.toBlockMatrix(3, 1)
+    assert(blockMat2.numRows() === m)
+    assert(blockMat2.numCols() === n)
+    assert(blockMat2.toBreeze() === idxRowMatMixed.toBreeze())
+
     val blocks = blockMat.blocks.collect()
+
+    /* Diagram of mixed data blockmat. Lines indicate blocking.
+    1 2 | 3
+    0 0 | 0
+    -------
+    0 0 | 0
+    4 0 | 0
+     */
 
     blocks.forall { case((row, col), matrix) =>
       if (row == 0) matrix.isInstanceOf[DenseMatrix] else matrix.isInstanceOf[SparseMatrix]}
   }
-
 
   test("multiply a local matrix") {
     val A = new IndexedRowMatrix(indexedRows)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -117,19 +117,23 @@ class IndexedRowMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("toBlockMatrix sparse backing") {
     val sparseData = Seq(
-      (2L, Vectors.sparse(3, Seq((0, 4.0))))
+      (7L, Vectors.sparse(6, Seq((0, 4.0))))
     ).map(x => IndexedRow(x._1, x._2))
 
-    val idxRowMatSparse = new IndexedRowMatrix(sc.parallelize(sparseData), m, n)
+    // Gonna make m and n larger here so the matrices can easily be completely sparse:
+    val m = 8
+    val n = 6
+
+    val idxRowMatSparse = new IndexedRowMatrix(sc.parallelize(sparseData))
 
     // Tests when n % colsPerBlock != 0
-    val blockMat = idxRowMatSparse.toBlockMatrix(2, 2)
+    val blockMat = idxRowMatSparse.toBlockMatrix(4, 4)
     assert(blockMat.numRows() === m)
     assert(blockMat.numCols() === n)
     assert(blockMat.toBreeze() === idxRowMatSparse.toBreeze())
 
     // Tests when m % rowsPerBlock != 0
-    val blockMat2 = idxRowMatSparse.toBlockMatrix(3, 1)
+    val blockMat2 = idxRowMatSparse.toBlockMatrix(3, 3)
     assert(blockMat2.numRows() === m)
     assert(blockMat2.numCols() === n)
     assert(blockMat2.toBreeze() === idxRowMatSparse.toBreeze())


### PR DESCRIPTION
## What changes were proposed in this pull request?

- ~~I added the method `toBlockMatrixDense` to the IndexedRowMatrix class. The current implementation of `toBlockMatrix` is insufficient for users with relatively dense IndexedRowMatrix objects, since it assumes sparsity.~~

EDIT: Ended up deciding that there should be just a single `toBlockMatrix` method, which creates a BlockMatrix whose blocks may be dense or sparse depending on the sparsity of the rows. This method will work better on any current use case of `toBlockMatrix` and doesn't go through `CoordinateMatrix` like the old method. 

## How was this patch tested?

~~I used the same tests already written for `toBlockMatrix()` to test this method. I also added a new additional unit test for an edge case that was not adequately tested by current test suite.~~

I ran the original `IndexedRowMatrix` tests, plus wrote more to better handle edge cases ignored by original tests. 
