### PR TITLE
[SPARK-20050][DStream] Kafka 0.10 DirectStream doesn't commit last processed batch's offset when graceful shutdown

### DIFF
--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -661,7 +661,7 @@ class DirectKafkaStreamSuite
       ssc.stop(true, true)
     }
 
-    val   kafkaParams = getKafkaParams(
+    val kafkaParams = getKafkaParams(
       "enable.auto.commit" -> "false",
       "auto.offset.reset" -> "earliest"
     )

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.streaming.kafka010
 
 import java.io.File
 import java.lang.{ Long => JLong }
-import java.util.{ Arrays, HashMap => JHashMap, Map => JMap }
+import java.util.{ Arrays, HashMap => JHashMap, LinkedList => JLinkedList, Map => JMap }
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -617,6 +617,80 @@ class DirectKafkaStreamSuite
     ssc.stop()
   }
 
+  test("offset commit when graceful shutdown") {
+    val topic = "offset_graceful_shutdown"
+    kafkaTestUtils.createTopic(topic)
+
+    // Send Messages for this test
+    kafkaTestUtils.sendMessages(topic, (1 to 100).map { _.toString }.toArray)
+
+    def createKafkaDirectStream(
+        ssc: StreamingContext,
+        kafkaParams: JHashMap[String, Object]
+      ): Unit = {
+      val kafkaStream = withClue("Error creating direct stream") {
+        KafkaUtils.createDirectStream[String, String](
+          ssc,
+          preferredHosts,
+          ConsumerStrategies.Subscribe[String, String](List(topic), kafkaParams.asScala)
+        )
+      }
+
+      kafkaStream.map { input =>
+        input.offset
+      }.foreachRDD { rdd =>
+        rdd.collect.foreach { input =>
+          DirectKafkaStreamSuite.list.add(input)
+        }
+      }
+
+      // commit offset manually
+      kafkaStream.foreachRDD { rdd =>
+        val offsetRanges = rdd.asInstanceOf[HasOffsetRanges].offsetRanges
+        kafkaStream.asInstanceOf[CanCommitOffsets].commitAsync(offsetRanges)
+      }
+    }
+
+    def runStreaming(ssc: StreamingContext): Unit = {
+      ssc.start()
+
+      // Wait for processing a few batches of Spark Streaming
+      Thread.sleep(5 * 1000)
+
+      // graceful shutdown
+      ssc.stop(true, true)
+    }
+
+    val   kafkaParams = getKafkaParams(
+      "enable.auto.commit" -> "false",
+      "auto.offset.reset" -> "earliest"
+    )
+
+    val conf = sparkConf.clone
+    // Limit number of records processing in each batches for doing easily this test,
+    // because some records should be processed in the last bach before graceful shutdown.
+    conf.set("spark.streaming.backpressure.enabled", "true")
+        .set("spark.streaming.kafka.maxRatePerPartition", "1")
+        .set("spark.streaming.backpressure.pid.minRate", "1")
+
+    ssc = new StreamingContext(conf, Milliseconds(1 * 1000))
+    createKafkaDirectStream(ssc, kafkaParams)
+    runStreaming(ssc)
+
+    Thread.sleep(5 * 1000)
+
+    // Re-start Spark Streaming Processing
+    ssc = new StreamingContext(conf, Milliseconds(1 * 1000))
+    createKafkaDirectStream(ssc, kafkaParams)
+    runStreaming(ssc)
+
+    val processedOffset = DirectKafkaStreamSuite.list.toArray()
+    assert(
+      processedOffset.length == processedOffset.distinct.length,
+      "Some records processed more than once before and after graceful shutdown of Spark Streaming"
+    )
+  }
+
   /** Get the generated offset ranges from the DirectKafkaStream */
   private def getOffsetRanges[K, V](
       kafkaStream: DStream[ConsumerRecord[K, V]]): Seq[(Time, Array[OffsetRange])] = {
@@ -668,6 +742,9 @@ class DirectKafkaStreamSuite
 
 object DirectKafkaStreamSuite {
   val total = new AtomicLong(-1L)
+
+  // For "offset commit when graceful shutdown"
+  val list = new JLinkedList[Long]()
 
   class InputInfoCollector extends StreamingListener {
     val numRecordsSubmitted = new AtomicLong(0L)

--- a/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
@@ -65,6 +65,12 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
     }
   }
 
+  def close(): Unit = {
+    this.synchronized {
+      inputStreams.par.foreach(_.close())
+    }
+  }
+
   def setContext(ssc: StreamingContext) {
     this.synchronized {
       outputStreams.foreach(_.setContext(ssc))

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/InputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/InputDStream.scala
@@ -111,4 +111,12 @@ abstract class InputDStream[T: ClassTag](_ssc: StreamingContext)
 
   /** Method called to stop receiving data. Subclasses must implement this method. */
   def stop(): Unit
+
+  /**
+   * Method called to close this InputDStream after all batches processed.
+   * If necessary, subclasses implements this method.
+   */
+  def close(): Unit = {
+    // Nothing to do in default.
+  }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -147,6 +147,7 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
         Thread.sleep(pollTime)
       }
       logInfo("Waited for jobs to be processed and checkpoints to be written")
+      graph.close()
     } else {
       logInfo("Stopping JobGenerator immediately")
       // Stop timer and graph immediately, ignore unprocessed data and pending jobs


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we use KafkaDirectStream(Kafka0.10) with `enable.auto.commit` is `false`, 
some record's offsets do not commit to Kafka at graceful shutdown, such below.

Sample code

```
val kafkaParams = Map[String, Object]("enable.auto.commit" -> "false")
val kafkaStream = KafkaUtils.createDirectStream[String, String](ssc, ... , kafkaParams.asScala)

kafkaStream.map { input =>
  "key: " + input.key.toString + " value: " + input.value.toString + " offset: " + input.offset.toString
  }.foreachRDD { rdd =>
    rdd.foreach { input =>
    println(input)
  }
}

kafkaStream.foreachRDD { rdd =>
  val offsetRanges = rdd.asInstanceOf[HasOffsetRanges].offsetRanges
  kafkaStream.asInstanceOf[CanCommitOffsets].commitAsync(offsetRanges)
}
```

output at first time

```
key: null value: 1 offset: 101452472
key: null value: 2 offset: 101452473
key: null value: 3 offset: 101452474
key: null value: 4 offset: 101452475
key: null value: 5 offset: 101452476
key: null value: 6 offset: 101452477
key: null value: 7 offset: 101452478
key: null value: 8 offset: 101452479
key: null value: 9 offset: 101452480  // this is a last record before shutdown Spark Streaming gracefully
```

output at second time

```
key: null value: 7 offset: 101452478   // duplicate
key: null value: 8 offset: 101452479   // duplicate
key: null value: 9 offset: 101452480   // duplicate
key: null value: 10 offset: 101452481
```

This is because offset will commit at the beginning of each batches, and will not commit after all batches processed.



## How was this patch tested?

Added tests `offset commit when graceful shtudown` in `DirectKafkaStreamSuite.scala`