### PR TITLE
[SPARK-14681][ML] Added getter for impurityStats

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -43,6 +43,11 @@ sealed abstract class Node extends Serializable {
    */
   private[ml] def impurityStats: ImpurityCalculator
 
+  /** Getter method for the impurity stats */
+  def getImpurityStats(): Array[Double] = {
+    impurityStats.stats
+  }
+
   /** Recursive prediction helper method */
   private[ml] def predictImpl(features: Vector): LeafNode
 


### PR DESCRIPTION
Adding a simple getter method for the impurity stats.

I'm using this in https://github.com/RedisLabs/spark-redis-ml to export the stats to Redis.

No tests added.