### PR TITLE
[SPARK-20132][Docs] Add documentation for column string functions

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -250,11 +250,39 @@ class Column(object):
         raise TypeError("Column is not iterable")
 
     # string methods
+    _rlike_doc = """ Return a Boolean :class:`Column` based on a regex match.\n
+                :param other: an extended regex expression\n
+
+                >>> df.filter( df.name.rlike('ice$') ).collect()
+                [Row(name=u'Alice', age=1)]
+                """
+    _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.\n
+               :param other: a SQL LIKE pattern\n
+               See :func:`pyspark.sql.Column.rlike` for a regex version\n
+
+               >>> df.filter( df.name.like('Al%') ).collect()
+               [Row(name=u'Alice', age=1)]
+                """
+    _startswith_doc = ''' Return a Boolean :class:`Column` based on a string match.\n
+                     :param other: string at end of line (do not use a regex `^`)\n
+                     >>> df.filter(df.name.startswith('Al')).collect()
+                     [Row(name=u'Alice', age=1)]
+                     >>> df.filter(df.name.startswith('^Al')).collect()
+                     []
+                     '''
+    _endswith_doc = ''' Return a Boolean :class:`Column` based on matching end of string.\n
+                   :param other: string at end of line (do not use a regex `$`)\n
+                   >>> df.filter(df.name.endswith('ice')).collect()
+                   [Row(name=u'Alice', age=1)]
+                   >>> df.filter(df.name.endswith('ice$')).collect()
+                   []
+                   '''
+
     contains = _bin_op("contains")
-    rlike = _bin_op("rlike")
-    like = _bin_op("like")
-    startswith = _bin_op("startsWith")
-    endswith = _bin_op("endsWith")
+    rlike = _bin_op("rlike", _rlike_doc)
+    like = _bin_op("like", _like_doc)
+    startswith = _bin_op("startsWith", _startswith_doc)
+    endswith = _bin_op("endsWith", _endswith_doc)
 
     @ignore_unicode_prefix
     @since(1.3)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -250,17 +250,17 @@ class Column(object):
         raise TypeError("Column is not iterable")
 
     # string methods
-    _rlike_doc = """ Return a Boolean :class:`Column` based on a regex match.\n
+    _rlike_doc = """ Return a Boolean :class:`Column` based on a regex match.
                      :param other: an extended regex expression
 
-                     >>> df.filter( df.name.rlike('ice$') ).collect()
+                     >>> df.filter(df.name.rlike('ice$')).collect()
                      [Row(name=u'Alice', age=1)]
                  """
-    _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.\n
+    _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.
                     :param other: a SQL LIKE pattern\n
                     See :func:`rlike` for a regex version
 
-                    >>> df.filter( df.name.like('Al%') ).collect()
+                    >>> df.filter(df.name.like('Al%')).collect()
                     [Row(name=u'Alice', age=1)]
                 """
     _startswith_doc = """ Return a Boolean :class:`Column` based on a string match.\n
@@ -333,24 +333,24 @@ class Column(object):
     desc = _unary_op("desc", "Returns a sort expression based on the"
                              " descending order of the given column name.")
 
-    _isNull_doc = ''' True if the current expression is null. Often combined with 
+    _isNull_doc = """ True if the current expression is null. Often combined with 
                       :func:`DataFrame.filter` to select rows with null values.
 
                       >>> df2.collect()
                       [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
-                      >>> df2.filter( df2.height.isNull ).collect()
+                      >>> df2.filter(df2.height.isNull).collect()
                       [Row(name=u'Alice', height=None)]
-                  '''
-    _isNotNull_doc = ''' True if the current expression is null. Often combined with 
+                  """
+    _isNotNull_doc = """ True if the current expression is null. Often combined with 
                          :func:`DataFrame.filter` to select rows with non-null values.
 
                          >>> df2.collect()
                          [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
-                         >>> df2.filter( df2.height.isNotNull ).collect()
+                         >>> df2.filter(df2.height.isNotNull).collect()
                          [Row(name=u'Tom', height=80)]
-                     '''
+                     """
 
-    isNull = _unary_op("isNull", _isNull_doc ) 
+    isNull = _unary_op("isNull", _isNull_doc) 
     isNotNull = _unary_op("isNotNull", _isNotNull_doc)
 
     @since(1.3)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -251,32 +251,34 @@ class Column(object):
 
     # string methods
     _rlike_doc = """ Return a Boolean :class:`Column` based on a regex match.\n
-                :param other: an extended regex expression\n
+                     :param other: an extended regex expression
 
-                >>> df.filter( df.name.rlike('ice$') ).collect()
-                [Row(name=u'Alice', age=1)]
-                """
-    _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.\n
-               :param other: a SQL LIKE pattern\n
-               See :func:`pyspark.sql.Column.rlike` for a regex version\n
-
-               >>> df.filter( df.name.like('Al%') ).collect()
-               [Row(name=u'Alice', age=1)]
-                """
-    _startswith_doc = ''' Return a Boolean :class:`Column` based on a string match.\n
-                     :param other: string at end of line (do not use a regex `^`)\n
-                     >>> df.filter(df.name.startswith('Al')).collect()
+                     >>> df.filter( df.name.rlike('ice$') ).collect()
                      [Row(name=u'Alice', age=1)]
-                     >>> df.filter(df.name.startswith('^Al')).collect()
-                     []
-                     '''
-    _endswith_doc = ''' Return a Boolean :class:`Column` based on matching end of string.\n
-                   :param other: string at end of line (do not use a regex `$`)\n
-                   >>> df.filter(df.name.endswith('ice')).collect()
-                   [Row(name=u'Alice', age=1)]
-                   >>> df.filter(df.name.endswith('ice$')).collect()
-                   []
-                   '''
+                 """
+    _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.\n
+                    :param other: a SQL LIKE pattern\n
+                    See :func:`pyspark.sql.Column.rlike` for a regex version
+
+                    >>> df.filter( df.name.like('Al%') ).collect()
+                    [Row(name=u'Alice', age=1)]
+                """
+    _startswith_doc = """ Return a Boolean :class:`Column` based on a string match.\n
+                          :param other: string at end of line (do not use a regex `^`)
+
+                          >>> df.filter(df.name.startswith('Al')).collect()
+                          [Row(name=u'Alice', age=1)]
+                          >>> df.filter(df.name.startswith('^Al')).collect()
+                          []
+                     """
+    _endswith_doc = """ Return a Boolean :class:`Column` based on matching end of string.\n
+                        :param other: string at end of line (do not use a regex `$`)
+
+                        >>> df.filter(df.name.endswith('ice')).collect()
+                        [Row(name=u'Alice', age=1)]
+                        >>> df.filter(df.name.endswith('ice$')).collect()
+                        []
+                    """
 
     contains = _bin_op("contains")
     rlike = _bin_op("rlike", _rlike_doc)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -258,7 +258,7 @@ class Column(object):
                  """
     _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.\n
                     :param other: a SQL LIKE pattern\n
-                    See :func:`pyspark.sql.Column.rlike` for a regex version
+                    See :func:`rlike` for a regex version
 
                     >>> df.filter( df.name.like('Al%') ).collect()
                     [Row(name=u'Alice', age=1)]
@@ -333,8 +333,25 @@ class Column(object):
     desc = _unary_op("desc", "Returns a sort expression based on the"
                              " descending order of the given column name.")
 
-    isNull = _unary_op("isNull", "True if the current expression is null.")
-    isNotNull = _unary_op("isNotNull", "True if the current expression is not null.")
+    _isNull_doc = ''' True if the current expression is null. Often combined with 
+                      :func:`DataFrame.filter` to select rows with null values.
+
+                      >>> df2.collect()
+                      [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
+                      >>> df2.filter( df2.height.isNull ).collect()
+                      [Row(name=u'Alice', height=None)]
+                  '''
+    _isNotNull_doc = ''' True if the current expression is null. Often combined with 
+                         :func:`DataFrame.filter` to select rows with non-null values.
+
+                         >>> df2.collect()
+                         [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
+                         >>> df2.filter( df2.height.isNotNull ).collect()
+                         [Row(name=u'Tom', height=80)]
+                     '''
+
+    isNull = _unary_op("isNull", _isNull_doc ) 
+    isNotNull = _unary_op("isNotNull", _isNotNull_doc)
 
     @since(1.3)
     def alias(self, *alias, **kwargs):

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -256,7 +256,7 @@ class Column(object):
     :param other: an extended regex expression
 
     >>> df.filter(df.name.rlike('ice$')).collect()
-    [Row(name=u'Alice', age=1)]
+    [Row(age=2, name=u'Alice')]
     """
     _like_doc = """
     Return a Boolean :class:`Column` based on a SQL LIKE match.
@@ -266,7 +266,7 @@ class Column(object):
     See :func:`rlike` for a regex version
 
     >>> df.filter(df.name.like('Al%')).collect()
-    [Row(name=u'Alice', age=1)]
+    [Row(age=2, name=u'Alice')]
     """
     _startswith_doc = """
     Return a Boolean :class:`Column` based on a string match.
@@ -274,7 +274,7 @@ class Column(object):
     :param other: string at end of line (do not use a regex `^`)
 
     >>> df.filter(df.name.startswith('Al')).collect()
-    [Row(name=u'Alice', age=1)]
+    [Row(age=2, name=u'Alice')]
     >>> df.filter(df.name.startswith('^Al')).collect()
     []
     """
@@ -284,7 +284,7 @@ class Column(object):
     :param other: string at end of line (do not use a regex `$`)
 
     >>> df.filter(df.name.endswith('ice')).collect()
-    [Row(name=u'Alice', age=1)]
+    [Row(age=2, name=u'Alice')]
     >>> df.filter(df.name.endswith('ice$')).collect()
     []
     """
@@ -346,19 +346,17 @@ class Column(object):
     True if the current expression is null. Often combined with
     :func:`DataFrame.filter` to select rows with null values.
 
-    >>> df2.collect()
-    [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
+    >>> df2 = sc.parallelize([Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]).toDF()
     >>> df2.filter(df2.height.isNull).collect()
-    [Row(name=u'Alice', height=None)]
+    [Row(height=None, name=u'Alice')]
     """
     _isNotNull_doc = """
     True if the current expression is null. Often combined with
     :func:`DataFrame.filter` to select rows with non-null values.
 
-    >>> df2.collect()
-    [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
+    >>> df2 = sc.parallelize([Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]).toDF()
     >>> df2.filter(df2.height.isNotNull).collect()
-    [Row(name=u'Tom', height=80)]
+    [Row(height=80, name=u'Tom')]
     """
 
     isNull = _unary_op("isNull", _isNull_doc)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -290,10 +290,10 @@ class Column(object):
     """
 
     contains = _bin_op("contains")
-    rlike = _bin_op("rlike", _rlike_doc)
-    like = _bin_op("like", _like_doc)
-    startswith = _bin_op("startsWith", _startswith_doc)
-    endswith = _bin_op("endsWith", _endswith_doc)
+    rlike = ignore_unicode_prefix(_bin_op("rlike", _rlike_doc))
+    like = ignore_unicode_prefix(_bin_op("like", _like_doc))
+    startswith = ignore_unicode_prefix(_bin_op("startsWith", _startswith_doc))
+    endswith = ignore_unicode_prefix(_bin_op("endsWith", _endswith_doc))
 
     @ignore_unicode_prefix
     @since(1.3)
@@ -361,8 +361,8 @@ class Column(object):
     [Row(height=80, name=u'Tom')]
     """
 
-    isNull = _unary_op("isNull", _isNull_doc)
-    isNotNull = _unary_op("isNotNull", _isNotNull_doc)
+    isNull = ignore_unicode_prefix(_unary_op("isNull", _isNull_doc))
+    isNotNull = ignore_unicode_prefix(_unary_op("isNotNull", _isNotNull_doc))
 
     @since(1.3)
     def alias(self, *alias, **kwargs):

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -346,16 +346,18 @@ class Column(object):
     True if the current expression is null. Often combined with
     :func:`DataFrame.filter` to select rows with null values.
 
+    >>> from pyspark.sql import Row
     >>> df2 = sc.parallelize([Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]).toDF()
-    >>> df2.filter(df2.height.isNull).collect()
+    >>> df2.filter(df2.height.isNull()).collect()
     [Row(height=None, name=u'Alice')]
     """
     _isNotNull_doc = """
     True if the current expression is null. Often combined with
     :func:`DataFrame.filter` to select rows with non-null values.
 
+    >>> from pyspark.sql import Row
     >>> df2 = sc.parallelize([Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]).toDF()
-    >>> df2.filter(df2.height.isNotNull).collect()
+    >>> df2.filter(df2.height.isNotNull()).collect()
     [Row(height=80, name=u'Tom')]
     """
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -250,35 +250,44 @@ class Column(object):
         raise TypeError("Column is not iterable")
 
     # string methods
-    _rlike_doc = """ Return a Boolean :class:`Column` based on a regex match.
-                     :param other: an extended regex expression
+    _rlike_doc = """
+    Return a Boolean :class:`Column` based on a regex match.
 
-                     >>> df.filter(df.name.rlike('ice$')).collect()
-                     [Row(name=u'Alice', age=1)]
-                 """
-    _like_doc = """ Return a Boolean :class:`Column` based on a SQL LIKE match.
-                    :param other: a SQL LIKE pattern\n
-                    See :func:`rlike` for a regex version
+    :param other: an extended regex expression
 
-                    >>> df.filter(df.name.like('Al%')).collect()
-                    [Row(name=u'Alice', age=1)]
-                """
-    _startswith_doc = """ Return a Boolean :class:`Column` based on a string match.\n
-                          :param other: string at end of line (do not use a regex `^`)
+    >>> df.filter(df.name.rlike('ice$')).collect()
+    [Row(name=u'Alice', age=1)]
+    """
+    _like_doc = """
+    Return a Boolean :class:`Column` based on a SQL LIKE match.
 
-                          >>> df.filter(df.name.startswith('Al')).collect()
-                          [Row(name=u'Alice', age=1)]
-                          >>> df.filter(df.name.startswith('^Al')).collect()
-                          []
-                     """
-    _endswith_doc = """ Return a Boolean :class:`Column` based on matching end of string.\n
-                        :param other: string at end of line (do not use a regex `$`)
+    :param other: a SQL LIKE pattern
 
-                        >>> df.filter(df.name.endswith('ice')).collect()
-                        [Row(name=u'Alice', age=1)]
-                        >>> df.filter(df.name.endswith('ice$')).collect()
-                        []
-                    """
+    See :func:`rlike` for a regex version
+
+    >>> df.filter(df.name.like('Al%')).collect()
+    [Row(name=u'Alice', age=1)]
+    """
+    _startswith_doc = """
+    Return a Boolean :class:`Column` based on a string match.
+
+    :param other: string at end of line (do not use a regex `^`)
+
+    >>> df.filter(df.name.startswith('Al')).collect()
+    [Row(name=u'Alice', age=1)]
+    >>> df.filter(df.name.startswith('^Al')).collect()
+    []
+    """
+    _endswith_doc = """
+    Return a Boolean :class:`Column` based on matching end of string.
+
+    :param other: string at end of line (do not use a regex `$`)
+
+    >>> df.filter(df.name.endswith('ice')).collect()
+    [Row(name=u'Alice', age=1)]
+    >>> df.filter(df.name.endswith('ice$')).collect()
+    []
+    """
 
     contains = _bin_op("contains")
     rlike = _bin_op("rlike", _rlike_doc)
@@ -333,24 +342,26 @@ class Column(object):
     desc = _unary_op("desc", "Returns a sort expression based on the"
                              " descending order of the given column name.")
 
-    _isNull_doc = """ True if the current expression is null. Often combined with 
-                      :func:`DataFrame.filter` to select rows with null values.
+    _isNull_doc = """
+    True if the current expression is null. Often combined with
+    :func:`DataFrame.filter` to select rows with null values.
 
-                      >>> df2.collect()
-                      [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
-                      >>> df2.filter(df2.height.isNull).collect()
-                      [Row(name=u'Alice', height=None)]
-                  """
-    _isNotNull_doc = """ True if the current expression is null. Often combined with 
-                         :func:`DataFrame.filter` to select rows with non-null values.
+    >>> df2.collect()
+    [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
+    >>> df2.filter(df2.height.isNull).collect()
+    [Row(name=u'Alice', height=None)]
+    """
+    _isNotNull_doc = """
+    True if the current expression is null. Often combined with
+    :func:`DataFrame.filter` to select rows with non-null values.
 
-                         >>> df2.collect()
-                         [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
-                         >>> df2.filter(df2.height.isNotNull).collect()
-                         [Row(name=u'Tom', height=80)]
-                     """
+    >>> df2.collect()
+    [Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)]
+    >>> df2.filter(df2.height.isNotNull).collect()
+    [Row(name=u'Tom', height=80)]
+    """
 
-    isNull = _unary_op("isNull", _isNull_doc) 
+    isNull = _unary_op("isNull", _isNull_doc)
     isNotNull = _unary_op("isNotNull", _isNotNull_doc)
 
     @since(1.3)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add docstrings to column.py for the Column functions `rlike`, `like`, `startswith`, and `endswith`. Pass these docstrings through `_bin_op`

There may be a better place to put the docstrings. I put them immediately above the Column class.

## How was this patch tested?

I ran `make html` on my local computer to remake the documentation, and verified that the html pages were displaying the docstrings correctly. I tried running `dev-tests`, and the formatting tests passed. However, my mvn build didn't work I think due to issues on my computer.

These docstrings are my original work and free license. 

@davies has done the most recent work reorganizing `_bin_op`