### PR TITLE
[SPARK-19999]: Workaround JDK-8165231 to identify PPC64 architectures as supporting unaligned access

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -46,18 +46,22 @@ public final class Platform {
   private static final boolean unaligned;
   static {
     boolean _unaligned;
-    // use reflection to access unaligned field
-    try {
-      Class<?> bitsClass =
-        Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
-      Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
-      unalignedMethod.setAccessible(true);
-      _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
-    } catch (Throwable t) {
-      // We at least know x86 and x64 support unaligned access.
-      String arch = System.getProperty("os.arch", "");
-      //noinspection DynamicRegexReplaceableByCompiledPattern
-      _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64|aarch64)$");
+    if (arch.matches("^(ppc64le | ppc64)$")) {
+        _unaligned = true;
+    } else {
+        //Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231)
+        try {
+            Class<?> bitsClass =
+                    Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
+            Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
+            unalignedMethod.setAccessible(true);
+            _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
+        } catch (Throwable t) {
+            // We at least know x86 and x64 support unaligned access.
+            String arch = System.getProperty("os.arch", "");
+            //noinspection DynamicRegexReplaceableByCompiledPattern
+            _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64|aarch64)$");
+        }
     }
     unaligned = _unaligned;
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -46,6 +46,7 @@ public final class Platform {
   private static final boolean unaligned;
   static {
     boolean _unaligned;
+    String arch = System.getProperty("os.arch", "");
     if (arch.matches("^(ppc64le | ppc64)$")) {
       // Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231), but ppc64 and ppc64le support it
       _unaligned = true;
@@ -58,7 +59,6 @@ public final class Platform {
         _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
       } catch (Throwable t) {
         // We at least know x86 and x64 support unaligned access.
-        String arch = System.getProperty("os.arch", "");
         //noinspection DynamicRegexReplaceableByCompiledPattern
         _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64|aarch64)$");
       }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -47,21 +47,21 @@ public final class Platform {
   static {
     boolean _unaligned;
     if (arch.matches("^(ppc64le | ppc64)$")) {
-        _unaligned = true;
+      _unaligned = true;
     } else {
-        //Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231)
-        try {
-            Class<?> bitsClass =
-                Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
-            Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
-            unalignedMethod.setAccessible(true);
-            _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
-        } catch (Throwable t) {
-            // We at least know x86 and x64 support unaligned access.
-            String arch = System.getProperty("os.arch", "");
-            //noinspection DynamicRegexReplaceableByCompiledPattern
-            _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64|aarch64)$");
-        }
+      //Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231)
+      try {
+        Class<?> bitsClass =
+          Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
+        Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
+        unalignedMethod.setAccessible(true);
+        _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
+      } catch (Throwable t) {
+        // We at least know x86 and x64 support unaligned access.
+        String arch = System.getProperty("os.arch", "");
+        //noinspection DynamicRegexReplaceableByCompiledPattern
+        _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64|aarch64)$");
+      }
     }
     unaligned = _unaligned;
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -52,7 +52,7 @@ public final class Platform {
         //Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231)
         try {
             Class<?> bitsClass =
-                    Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
+                Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
             Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
             unalignedMethod.setAccessible(true);
             _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -47,7 +47,7 @@ public final class Platform {
   static {
     boolean _unaligned;
     String arch = System.getProperty("os.arch", "");
-    if (arch.matches("^(ppc64le | ppc64)$")) {
+    if (arch.equals("ppc64le") || arch.equals("ppc64")) {
       // Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231), but ppc64 and ppc64le support it
       _unaligned = true;
     } else {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -47,9 +47,9 @@ public final class Platform {
   static {
     boolean _unaligned;
     if (arch.matches("^(ppc64le | ppc64)$")) {
+      // Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231), but ppc64 and ppc64le support it
       _unaligned = true;
     } else {
-      //Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231)
       try {
         Class<?> bitsClass =
           Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());


### PR DESCRIPTION
 java.nio.Bits.unaligned() does not return true for the ppc64le arch.
see https://bugs.openjdk.java.net/browse/JDK-8165231
## What changes were proposed in this pull request?
check architecture

## How was this patch tested?

unit test

