### PR TITLE
[Minor][SparkR]: Add run command comment in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ R-unit-tests.log
 R/unit-tests.out
 R/cran-check.out
 R/pkg/vignettes/sparkr-vignettes.html
+R.Rcheck/
+testthat.Rcheck/
 build/*.jar
 build/apache-maven*
 build/scala*

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,6 @@ R-unit-tests.log
 R/unit-tests.out
 R/cran-check.out
 R/pkg/vignettes/sparkr-vignettes.html
-R.Rcheck/
-testthat.Rcheck/
 build/*.jar
 build/apache-maven*
 build/scala*

--- a/examples/src/main/r/RSparkSQLExample.R
+++ b/examples/src/main/r/RSparkSQLExample.R
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+# To run this example use
+# ./bin/spark-submit examples/src/main/r/RSparkSQLExample.R
+
 library(SparkR)
 
 # $example on:init_session$

--- a/examples/src/main/r/dataframe.R
+++ b/examples/src/main/r/dataframe.R
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+# To run this example use
+# ./bin/spark-submit examples/src/main/r/dataframe.R
+
 library(SparkR)
 
 # Initialize SparkSession


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two examples in r folder missing the run commands.

In this PR, I just add the missing comment, which is consistent with other examples.

## How was this patch tested?

Manual test.