### PR TITLE
[SPARK-20079][Core][yarn] Re registration of AM hangs spark cluster in yarn-client mode.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -249,6 +249,11 @@ private[spark] class ExecutorAllocationManager(
    * yarn-client mode when AM re-registers after a failure.
    */
   def reset(): Unit = synchronized {
+    /**
+     * When some tasks need to be scheduled, resetting the initializing field may cause
+     * it to not be set to false in yarn.
+     * SPARK-20079: https://issues.apache.org/jira/browse/SPARK-20079
+     */
     if (maxNumExecutorsNeeded() == 0) {
       initializing = true
     }

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -250,8 +250,8 @@ private[spark] class ExecutorAllocationManager(
    */
   def reset(): Unit = synchronized {
     /**
-     * When some tasks need to be scheduled, resetting the initializing field may cause
-     * it to not be set to false in yarn.
+     * When some tasks need to be scheduled and initial executor = 0, resetting the initializing
+     * field may cause it to not be set to false in yarn.
      * SPARK-20079: https://issues.apache.org/jira/browse/SPARK-20079
      */
     if (maxNumExecutorsNeeded() == 0) {

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -249,14 +249,6 @@ private[spark] class ExecutorAllocationManager(
    * yarn-client mode when AM re-registers after a failure.
    */
   def reset(): Unit = synchronized {
-    /**
-     * When some tasks need to be scheduled and initial executor = 0, resetting the initializing
-     * field may cause it to not be set to false in yarn.
-     * SPARK-20079: https://issues.apache.org/jira/browse/SPARK-20079
-     */
-    if (maxNumExecutorsNeeded() == 0) {
-      initializing = true
-    }
     numExecutorsTarget = initialNumExecutors
     numExecutorsToAdd = 1
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -249,7 +249,9 @@ private[spark] class ExecutorAllocationManager(
    * yarn-client mode when AM re-registers after a failure.
    */
   def reset(): Unit = synchronized {
-    initializing = true
+    if (maxNumExecutorsNeeded() == 0) {
+      initializing = true
+    }
     numExecutorsTarget = initialNumExecutors
     numExecutorsToAdd = 1
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -863,9 +863,6 @@ class ExecutorAllocationManagerSuite
     assert(!initializing(manager))
     manager.reset()
     assert(!initializing(manager))
-    sc.listenerBus.postToAll(SparkListenerStageCompleted(stageInfo))
-    manager.reset()
-    assert(initializing(manager))
   }
 
   test("reset the state of allocation manager") {

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -854,6 +854,20 @@ class ExecutorAllocationManagerSuite
     assert(maxNumExecutorsNeeded(manager) === 1)
   }
 
+  test("SPARK-20079: Re registration of AM hangs spark cluster in yarn-client mode") {
+    sc = createSparkContext()
+    val manager = sc.executorAllocationManager.get
+    assert(initializing(manager))
+    val stageInfo = createStageInfo(0, 2)
+    sc.listenerBus.postToAll(SparkListenerStageSubmitted(stageInfo))
+    assert(!initializing(manager))
+    manager.reset()
+    assert(!initializing(manager))
+    sc.listenerBus.postToAll(SparkListenerStageCompleted(stageInfo))
+    manager.reset()
+    assert(initializing(manager))
+  }
+
   test("reset the state of allocation manager") {
     sc = createSparkContext()
     val manager = sc.executorAllocationManager.get
@@ -988,6 +1002,7 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
    | Helper methods for accessing private methods and fields |
    * ------------------------------------------------------- */
 
+  private val _initializing = PrivateMethod[Boolean]('initializing)
   private val _numExecutorsToAdd = PrivateMethod[Int]('numExecutorsToAdd)
   private val _numExecutorsTarget = PrivateMethod[Int]('numExecutorsTarget)
   private val _maxNumExecutorsNeeded = PrivateMethod[Int]('maxNumExecutorsNeeded)
@@ -1010,6 +1025,10 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
   private val _onExecutorBusy = PrivateMethod[Unit]('onExecutorBusy)
   private val _localityAwareTasks = PrivateMethod[Int]('localityAwareTasks)
   private val _hostToLocalTaskCount = PrivateMethod[Map[String, Int]]('hostToLocalTaskCount)
+
+  private def initializing(manager: ExecutorAllocationManager): Boolean = {
+    manager invokePrivate _initializing()
+  }
 
   private def numExecutorsToAdd(manager: ExecutorAllocationManager): Int = {
     manager invokePrivate _numExecutorsToAdd()


### PR DESCRIPTION
When there is some need of task scheduling, `ExecutorAllocationManager` instances do not reset the `initializing` field 

## How was this patch tested?
Unit tests.
