### PR TITLE
[SPARK-20157]In the menu ‘Storage’in Web UI, click the Go button, and…

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
@@ -152,9 +152,7 @@ private[ui] trait PagedTable[T] {
    * }}}
    */
   private[ui] def pageNavigation(page: Int, pageSize: Int, totalPages: Int): Seq[Node] = {
-    if (totalPages == 1) {
-      Nil
-    } else {
+
       // A group includes all page numbers will be shown in the page navigation.
       // The size of group is 10 means there are 10 page numbers will be shown.
       // The first group is 1 to 10, the second is 2 to 20, and so on
@@ -266,7 +264,6 @@ private[ui] trait PagedTable[T] {
         </div>
       </div>
     }
-  }
 
   /**
    * Return a link to jump to a page.

--- a/core/src/test/scala/org/apache/spark/ui/PagedTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/PagedTableSuite.scala
@@ -73,7 +73,8 @@ class PagedTableSuite extends SparkFunSuite {
       override def goButtonFormPath: String = ""
     }
 
-    assert(pagedTable.pageNavigation(1, 10, 1) === Nil)
+    assert(
+      (pagedTable.pageNavigation(1, 10, 1).head \\ "li").map(_.text.trim) === Seq("1"))
     assert(
       (pagedTable.pageNavigation(1, 10, 2).head \\ "li").map(_.text.trim) === Seq("1", "2", ">"))
     assert(


### PR DESCRIPTION
… shows no paging menu interface.

## What changes were proposed in this pull request?

Choose 'show' text box, fill in the data to show a number greater than or equal to the data to the total number of article. Click on the "Go" button, display interface display the total number of the data, but the page menu disappear, cause I want to continue to choose "show" text box and fill in the article to show the data number, can only leave the interface, select specific link click again come in to look at it.

## How was this patch tested?

 manual tests