### PR TITLE
[SPARK-20172][Core] Add file permission check when listing files in FsHistoryProvider

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -28,6 +28,7 @@ import scala.util.control.NonFatal
 import com.google.common.primitives.Longs
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
+import org.apache.hadoop.fs.permission.FsAction
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
@@ -352,6 +353,28 @@ class SparkHadoopUtil extends Logging {
         logDebug("Failed to decode $token: $e", e)
     }
     buffer.toString
+  }
+
+  private[spark] def checkAccessPermission(status: FileStatus, mode: FsAction): Boolean = {
+    val perm = status.getPermission
+    val ugi = UserGroupInformation.getCurrentUser
+
+    if (ugi.getShortUserName == status.getOwner) {
+      if (perm.getUserAction.implies(mode)) {
+        return true
+      }
+    } else if (ugi.getGroupNames.contains(status.getGroup)) {
+      if (perm.getGroupAction.implies(mode)) {
+        return true
+      }
+    } else if (perm.getOtherAction.implies(mode)) {
+      return true
+    }
+
+    logDebug(s"Permission denied: user=${ugi.getShortUserName}, " +
+      s"path=${status.getPath}:${status.getOwner}:${status.getGroup}" +
+      s"${if (status.isDirectory) "d" else "-"}$perm")
+    false
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.fs.permission.FsAction
 import org.apache.hadoop.hdfs.DistributedFileSystem
 import org.apache.hadoop.hdfs.protocol.HdfsConstants
-import org.apache.hadoop.security.AccessControlException
+import org.apache.hadoop.security.{AccessControlException, UserGroupInformation}
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -321,22 +321,38 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .filter { entry =>
           try {
             val prevFileSize = fileToAppInfo.get(entry.getPath()).map{_.fileSize}.getOrElse(0L)
-            fs.access(entry.getPath, FsAction.READ)
+
+            def canAccess = {
+              val perm = entry.getPermission
+              val ugi = UserGroupInformation.getCurrentUser
+              val user = ugi.getShortUserName
+              val groups = ugi.getGroupNames
+              if (user == entry.getOwner && perm.getUserAction.implies(FsAction.READ)) {
+                true
+              } else if (groups.contains(entry.getGroup) &&
+                  perm.getGroupAction.implies(FsAction.READ)) {
+                true
+              } else if (perm.getOtherAction.implies(FsAction.READ)) {
+                true
+              } else {
+                throw new AccessControlException(s"Permission denied: user=$user, " +
+                  s"path=${entry.getPath}:${entry.getOwner}:${entry.getGroup}" +
+                  s"${if (entry.isDirectory) "d" else "-"}$perm")
+              }
+            }
+
             !entry.isDirectory() &&
               // FsHistoryProvider generates a hidden file which can't be read.  Accidentally
               // reading a garbage file is safe, but we would log an error which can be scary to
               // the end-user.
               !entry.getPath().getName().startsWith(".") &&
-              prevFileSize < entry.getLen()
+              prevFileSize < entry.getLen() &&
+              canAccess
           } catch {
             case _: AccessControlException =>
               // Do not use "logInfo" since these messages can get pretty noisy if printed on
               // every poll.
               logDebug(s"No permission to read $entry, ignoring.")
-              false
-
-            case e: Exception =>
-              logDebug(s"Fail to get status of $entry", e)
               false
           }
         }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -334,6 +334,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
               // every poll.
               logDebug(s"No permission to read $entry, ignoring.")
               false
+
+            case e: Exception =>
+              logDebug(s"Fail to get status of $entry", e)
+              false
           }
         }
         .flatMap { entry => Some(entry) }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.permission.{FsAction, FsPermission}
+import org.apache.hadoop.security.UserGroupInformation
+import org.scalatest.Matchers
+
+import org.apache.spark.SparkFunSuite
+
+class SparkHadoopUtilSuite extends SparkFunSuite with Matchers {
+  test("check file permission") {
+    import FsAction._
+    val user = UserGroupInformation.getCurrentUser.getShortUserName
+    val groups = UserGroupInformation.getCurrentUser.getGroupNames
+    require(!groups.isEmpty)
+    val sparkHadoopUtil = new SparkHadoopUtil
+
+    // If file is owned by user and user has access permission
+    var status = fileStatus(user, groups.head, READ_WRITE, READ_WRITE, NONE)
+    sparkHadoopUtil.checkAccessPermission(status, READ) should be (true)
+    sparkHadoopUtil.checkAccessPermission(status, WRITE) should be (true)
+
+    // If file is owned by user but user has no access permission
+    status = fileStatus(user, groups.head, NONE, READ_WRITE, NONE)
+    sparkHadoopUtil.checkAccessPermission(status, READ) should be (false)
+    sparkHadoopUtil.checkAccessPermission(status, WRITE) should be (false)
+
+    // If file is owned by user's group and user's group has access permission
+    status = fileStatus("test", groups.head, NONE, READ_WRITE, NONE)
+    sparkHadoopUtil.checkAccessPermission(status, READ) should be (true)
+    sparkHadoopUtil.checkAccessPermission(status, WRITE) should be (true)
+
+    // If file is owned by user's group but user's group has no access permission
+    status = fileStatus("test", groups.head, READ_WRITE, NONE, NONE)
+    sparkHadoopUtil.checkAccessPermission(status, READ) should be (false)
+    sparkHadoopUtil.checkAccessPermission(status, WRITE) should be (false)
+
+    // If file is owned by other user and this user has access permission
+    status = fileStatus("test", "test", READ_WRITE, READ_WRITE, READ_WRITE)
+    sparkHadoopUtil.checkAccessPermission(status, READ) should be (true)
+    sparkHadoopUtil.checkAccessPermission(status, WRITE) should be (true)
+
+    // If file is owned by other user but this user has no access permission
+    status = fileStatus("test", "test", READ_WRITE, READ_WRITE, NONE)
+    sparkHadoopUtil.checkAccessPermission(status, READ) should be (false)
+    sparkHadoopUtil.checkAccessPermission(status, WRITE) should be (false)
+  }
+
+  private def fileStatus(
+      owner: String,
+      group: String,
+      userAction: FsAction,
+      groupAction: FsAction,
+      otherAction: FsAction): FileStatus = {
+    new FileStatus(0L,
+      false,
+      0,
+      0L,
+      0L,
+      0L,
+      new FsPermission(userAction, groupAction, otherAction),
+      owner,
+      group,
+      null)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -31,12 +31,8 @@ import org.apache.spark.SparkFunSuite
 class SparkHadoopUtilSuite extends SparkFunSuite with Matchers {
   test("check file permission") {
     import FsAction._
-    val user = UserGroupInformation.getCurrentUser.getShortUserName
-    val groups = UserGroupInformation.getCurrentUser.getGroupNames
-    require(!groups.isEmpty)
-
-    val testUser = user + "-" + Random.nextInt(100)
-    val testGroups = groups.map { g => g + "-" + Random.nextInt(100) }
+    val testUser = s"user-${Random.nextInt(100)}"
+    val testGroups = Array(s"group-${Random.nextInt(100)}")
     val testUgi = UserGroupInformation.createUserForTesting(testUser, testGroups)
 
     testUgi.doAs(new PrivilegedExceptionAction[Void] {
@@ -53,12 +49,8 @@ class SparkHadoopUtilSuite extends SparkFunSuite with Matchers {
         sparkHadoopUtil.checkAccessPermission(status, READ) should be(false)
         sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(false)
 
-        var otherUser = "test"
-        var otherGroup = "test"
-        while (otherUser == testUser || testGroups.contains(otherGroup)) {
-          otherUser = s"test-${Random.nextInt(100)}"
-          otherGroup = s"test-${Random.nextInt(100)}"
-        }
+        val otherUser = s"test-${Random.nextInt(100)}"
+        val otherGroup = s"test-${Random.nextInt(100)}"
 
         // If file is owned by user's group and user's group has access permission
         status = fileStatus(otherUser, testGroups.head, NONE, READ_WRITE, NONE)

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -27,6 +27,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import com.google.common.io.{ByteStreams, Files}
+import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.hdfs.DistributedFileSystem
 import org.json4s.jackson.JsonMethods._
 import org.mockito.Matchers.any
@@ -570,6 +571,34 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
       securityManager.checkUIViewPermissions("user5") should be (false)
     }
  }
+
+  test("log without read permission should be filtered out before actual reading") {
+    class TestFsHistoryProvider extends FsHistoryProvider(createTestConf()) {
+      var mergeApplicationListingCall = 0
+      override protected def mergeApplicationListing(fileStatus: FileStatus): Unit = {
+        super.mergeApplicationListing(fileStatus)
+        mergeApplicationListingCall += 1
+      }
+    }
+
+    val provider = new TestFsHistoryProvider
+    val log = newLogFile("app1", Some("app1"), inProgress = true)
+    writeFile(log, true, None,
+      SparkListenerApplicationStart("app1", Some("app1"), System.currentTimeMillis(),
+         "test", Some("attempt1")),
+      SparkListenerApplicationEnd(System.currentTimeMillis()))
+
+    // Set the read permission to false to simulate access permission not allowed scenario.
+    log.setReadable(false)
+
+    updateAndCheck(provider) { list =>
+      list.size should be (0)
+    }
+
+    // Because we already filter out logs without read permission, so it will get a empty file list
+    // and not invoke mergeApplicationListing() call.
+    provider.mergeApplicationListingCall should be (0)
+  }
 
   /**
    * Asks the provider to check for logs and calls a function to perform checks on the updated

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -27,8 +27,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import com.google.common.io.{ByteStreams, Files}
-import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.hadoop.fs.permission.FsAction
+import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.hdfs.DistributedFileSystem
 import org.json4s.jackson.JsonMethods._
 import org.mockito.Matchers.any
@@ -38,7 +37,6 @@ import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
-import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.io._
 import org.apache.spark.scheduler._
@@ -156,20 +154,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
       SparkListenerApplicationStart("app1-2", Some("app1-2"), 1L, "test", None),
       SparkListenerApplicationEnd(2L)
       )
-
-    val path = new Path(logFile2.toURI)
-    val fs = path.getFileSystem(SparkHadoopUtil.get.conf)
-    val status = fs.getFileStatus(path)
-    SparkHadoopUtil.get.checkAccessPermission(status, FsAction.READ) should be (true)
-
     logFile2.setReadable(false, false)
-    val status1 = fs.getFileStatus(path)
-    SparkHadoopUtil.get.checkAccessPermission(status1, FsAction.READ) should be (false)
-
-    logFile2.setReadable(false, true)
-    val status2 = fs.getFileStatus(path)
-    SparkHadoopUtil.get.checkAccessPermission(status2, FsAction.READ) should be (false)
-
 
     updateAndCheck(provider) { list =>
       list.size should be (1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the current Spark's HistoryServer we expected to get `AccessControlException` during listing all the files, but unfortunately it was not worked because we actually doesn't check the access permission and no other calls will throw such exception. What was worse is that this check will be deferred until reading files, which is not necessary and quite verbose, since it will be printed out the exception in every 10 seconds when checking the files.

So here with this fix, we actually check the read permission during listing the files, which could avoid unnecessary file read later on and suppress the verbose log.

## How was this patch tested?

Add unit test to verify.