### PR TITLE
[SPARK-20173][SQL][hive-thriftserver] Throw NullPointerException when HiveThriftServer2 is shutdown

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -82,7 +82,9 @@ object HiveThriftServer2 extends Logging {
 
     ShutdownHookManager.addShutdownHook { () =>
       SparkSQLEnv.stop()
-      uiTab.foreach(_.detach())
+      if (uiTab != null) {
+        uiTab.foreach(_.detach())
+      }
     }
 
     val executionHive = HiveUtils.newClientForExecution(

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -46,7 +46,7 @@ import org.apache.spark.util.{ShutdownHookManager, Utils}
  */
 object HiveThriftServer2 extends Logging {
   var LOG = LogFactory.getLog(classOf[HiveServer2])
-  var uiTab: Option[ThriftServerTab] = _
+  var uiTab: Option[ThriftServerTab] = None
   var listener: HiveThriftServer2Listener = _
 
   /**
@@ -82,9 +82,7 @@ object HiveThriftServer2 extends Logging {
 
     ShutdownHookManager.addShutdownHook { () =>
       SparkSQLEnv.stop()
-      if (uiTab != null) {
-        uiTab.foreach(_.detach())
-      }
+      uiTab.foreach(_.detach())
     }
 
     val executionHive = HiveUtils.newClientForExecution(


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the shutdown hook called before the variable `uiTab` is set , it will throw a NullPointerException. 

## How was this patch tested?

manual tests
