### PR TITLE
[SPARK-20181] [CORE] tries to bind the port to avoid jetty noise

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2219,6 +2219,10 @@ private[spark] object Utils extends Logging {
         userPort(startPort, offset)
       }
       try {
+        if (tryPort > 0) {
+          // Try to bind the port to avoid a noisy Jetty warning on failure.
+          new ServerSocket(tryPort).close()
+        }
         val (service, port) = startService(tryPort)
         logInfo(s"Successfully started service$serviceString on port $port.")
         return (service, port)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Try to bind the desired port and release it before entering Jetty code, so there is less likelihood of hitting the BindException and thus seeing the warning log statement.

## How was this patch tested?

Manual Testing:

Before the change:

1. Launch spark-shell, configured to bind to port 4040 => observed successful bind to 4040
2. Launch spark-shell again, same config => WARN log & stack trace appear similar to Jira description, and port successfully binds to 4041.

After the change:

Repeat 1. and 2. above => No WARN log appears, and port successfully binds to 4041
