### PR TITLE
[SPARK-20187][SQL] Replace loadTable with moveFile to speed up load table for many output files

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -694,25 +694,12 @@ private[hive] class HiveClientImpl(
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = withHiveState {
-    val tbl = client.getTable(tableName)
-    val fs = tbl.getDataLocation.getFileSystem(conf)
-    if (replace) {
-      shim.moveFile(
-        client,
-        conf,
-        new Path(loadPath),
-        tbl.getPath,
-        fs,
-        replace,
-        isSrcLocal)
-    } else {
-      shim.loadTable(
-        client,
-        new Path(loadPath),
-        tableName,
-        replace,
-        isSrcLocal)
-    }
+    shim.loadTable(
+      client,
+      new Path(loadPath),
+      tableName,
+      replace,
+      isSrcLocal)
   }
 
   def loadDynamicPartitions(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -694,12 +694,25 @@ private[hive] class HiveClientImpl(
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = withHiveState {
-    shim.loadTable(
-      client,
-      new Path(loadPath),
-      tableName,
-      replace,
-      isSrcLocal)
+    val tbl = client.getTable(tableName)
+    val fs = tbl.getDataLocation.getFileSystem(conf)
+    if (replace) {
+      shim.moveFile(
+        client,
+        conf,
+        new Path(loadPath),
+        tbl.getPath,
+        fs,
+        replace,
+        isSrcLocal)
+    } else {
+      shim.loadTable(
+        client,
+        new Path(loadPath),
+        tableName,
+        replace,
+        isSrcLocal)
+    }
   }
 
   def loadDynamicPartitions(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -121,15 +121,6 @@ private[client] sealed abstract class Shim {
       numDP: Int,
       listBucketingEnabled: Boolean): Unit
 
-  def moveFile(
-      hive: Hive,
-      conf: HiveConf,
-      srcf: Path,
-      destf: Path,
-      fs: FileSystem,
-      replace: Boolean,
-      isSrcLocal: Boolean): Unit
-
   def createFunction(hive: Hive, db: String, func: CatalogFunction): Unit
 
   def dropFunction(hive: Hive, db: String, name: String): Unit
@@ -249,16 +240,6 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       classOf[JMap[String, String]],
       JBoolean.TYPE,
       JInteger.TYPE,
-      JBoolean.TYPE,
-      JBoolean.TYPE)
-  private lazy val moveFileMethod =
-    findMethod(
-      classOf[Hive],
-      "moveFile",
-      classOf[HiveConf],
-      classOf[Path],
-      classOf[Path],
-      classOf[FileSystem],
       JBoolean.TYPE,
       JBoolean.TYPE)
   private lazy val dropIndexMethod =
@@ -395,17 +376,6 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       listBucketingEnabled: Boolean): Unit = {
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       numDP: JInteger, holdDDLTime, listBucketingEnabled: JBoolean)
-  }
-
-  override def moveFile(
-      hive: Hive,
-      conf: HiveConf,
-      srcf: Path,
-      destf: Path,
-      fs: FileSystem,
-      replace: Boolean,
-      isSrcLocal: Boolean): Unit = {
-    moveFileMethod.invoke(hive, conf, srcf, destf, fs, replace: JBoolean, isSrcLocal: JBoolean)
   }
 
   override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
@@ -832,6 +802,27 @@ private[client] class Shim_v1_1 extends Shim_v1_0 {
   // throws an exception if the index does not exist
   protected lazy val throwExceptionInDropIndex = JBoolean.TRUE
 
+  private lazy val loadTableMethod =
+    findMethod(
+      classOf[Hive],
+      "loadTable",
+      classOf[Path],
+      classOf[String],
+      JBoolean.TYPE,
+      JBoolean.TYPE,
+      JBoolean.TYPE,
+      JBoolean.TYPE,
+      JBoolean.TYPE)
+  private lazy val moveFileMethod =
+    findMethod(
+      classOf[Hive],
+      "moveFile",
+      classOf[HiveConf],
+      classOf[Path],
+      classOf[Path],
+      classOf[FileSystem],
+      JBoolean.TYPE,
+      JBoolean.TYPE)
   private lazy val dropIndexMethod =
     findMethod(
       classOf[Hive],
@@ -841,6 +832,22 @@ private[client] class Shim_v1_1 extends Shim_v1_0 {
       classOf[String],
       JBoolean.TYPE,
       JBoolean.TYPE)
+  override def loadTable(
+      hive: Hive,
+      loadPath: Path,
+      tableName: String,
+      replace: Boolean,
+      isSrcLocal: Boolean): Unit = {
+    if (replace) {
+      val tbl = hive.getTable(tableName)
+      moveFileMethod.invoke(hive, hive.getConf, loadPath, tbl.getPath,
+        tbl.getPath.getFileSystem(hive.getConf), replace: JBoolean, isSrcLocal: JBoolean)
+      alterTable(hive, tableName, tbl)
+    } else {
+      loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, holdDDLTime,
+        isSrcLocal: JBoolean, isSkewedStoreAsSubdir, isAcid)
+    }
+  }
 
   override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
     dropIndexMethod.invoke(hive, dbName, tableName, indexName, throwExceptionInDropIndex,
@@ -944,6 +951,15 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
       JBoolean.TYPE,
       JBoolean.TYPE,
       JLong.TYPE)
+  private lazy val moveFileMethod =
+    findMethod(
+      classOf[Hive],
+      "moveFile",
+      classOf[HiveConf],
+      classOf[Path],
+      classOf[Path],
+      JBoolean.TYPE,
+      JBoolean.TYPE)
 
   override def loadPartition(
       hive: Hive,
@@ -965,8 +981,15 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = {
-    loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, isSrcLocal: JBoolean,
-      isSkewedStoreAsSubdir, isAcid)
+    if (replace) {
+      val tbl = hive.getTable(tableName)
+      moveFileMethod.invoke(hive, hive.getConf, loadPath, tbl.getPath,
+        replace: JBoolean, isSrcLocal: JBoolean)
+      alterTable(hive, tableName, tbl)
+    } else {
+      loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, isSrcLocal: JBoolean,
+        isSkewedStoreAsSubdir, isAcid)
+    }
   }
 
   override def loadDynamicPartitions(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -126,7 +126,7 @@ case class InsertIntoHiveTable(
       hadoopConf: Configuration,
       stagingDir: String): Path = {
     getStagingDir(
-      new Path(extURI.getScheme, extURI.getAuthority, extURI.getPath),
+      new Path(extURI.getScheme, extURI.getAuthority, extURI.getPath).getParent,
       hadoopConf,
       stagingDir)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HiveClientImpl.loadTable](https://github.com/apache/spark/blob/v2.1.0/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L667) load files one by one, so this step will take a long time if a job generates many files. This PR replace `Hive.loadTable` with [`Hive.moveFile`](https://github.com/apache/hive/blob/release-1.2.1/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L2567) to speed up this step for `create table tableName as select ...` and `insert overwrite table tableName select ...`.

## How was this patch tested?

manual tests
