### PR TITLE
[SPARK-20197][SPARKR] CRAN check fail with package installation

### DIFF
--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -61,7 +61,6 @@ unsetHiveContext <- function() {
 # Tests for SparkSQL functions in SparkR
 
 filesBefore <- list.files(path = sparkRDir, all.files = TRUE)
-filesBeforeWd <- list.files(path = sparkRDirWd, all.files = TRUE)
 sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
@@ -3045,12 +3044,13 @@ compare_list <- function(list1, list2) {
   expect_equal(sort(list1, na.last = TRUE), sort(list2, na.last = TRUE))
 }
 
-check_no_file_created <- function(dirRoot, listFilesBeforeAllTests, listFileBeforeThisTestFile) {
+# This should always be the **very last test** in this test file.
+test_that("No extra files are created in SPARK_HOME by starting session and making calls", {
   # Check that it is not creating any extra file.
   # Does not check the tempdir which would be cleaned up after.
-  filesAfter <- list.files(path = dirRoot, all.files = TRUE)
+  filesAfter <- list.files(path = sparkRDir, all.files = TRUE)
 
-  expect_true(length(listFilesBeforeAllTests) > 0)
+  expect_true(length(sparkRFilesBefore) > 0)
   # first, ensure derby.log is not there
   expect_false("derby.log" %in% filesAfter)
   # second, ensure only spark-warehouse is created when calling SparkSession, enableHiveSupport = F
@@ -3061,20 +3061,11 @@ check_no_file_created <- function(dirRoot, listFilesBeforeAllTests, listFileBefo
   # sparkRWhitelistSQLDirs is also defined in run-all.R, and should contain only 2 whitelisted dirs,
   # here allow the first value, spark-warehouse, in the diff, everything else should be exactly the
   # same as before any test is run.
-  compare_list(listFilesBeforeAllTests,
-               setdiff(listFileBeforeThisTestFile, sparkRWhitelistSQLDirs[[1]]))
+  compare_list(sparkRFilesBefore, setdiff(filesBefore, sparkRWhitelistSQLDirs[[1]]))
   # third, ensure only spark-warehouse and metastore_db are created when enableHiveSupport = T
   # note: as the note above, after running all tests in this file while enableHiveSupport = T, we
   # check the list of files again. This time we allow both whitelisted dirs to be in the diff.
-  compare_list(listFilesBeforeAllTests, setdiff(filesAfter, sparkRWhitelistSQLDirs))
-}
-
-# This should always be the **very last test** in this test file.
-test_that("No extra files are created in SPARK_HOME by starting session and making calls", {
-  # Need to check 2 sets of directories: SPARK_HOME, and current working directory.
-  # Apparently this is different when running tests via R CMD check on package.
-  check_no_file_created(sparkRDir, sparkRFilesBefore, filesBefore)
-  check_no_file_created(sparkRDirWd, sparkRFilesBeforeWd, filesBeforeWd)
+  compare_list(sparkRFilesBefore, setdiff(filesAfter, sparkRWhitelistSQLDirs))
 })
 
 unlink(parquetPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -61,6 +61,7 @@ unsetHiveContext <- function() {
 # Tests for SparkSQL functions in SparkR
 
 filesBefore <- list.files(path = sparkRDir, all.files = TRUE)
+filesBeforeWd <- list.files(path = sparkRDirWd, all.files = TRUE)
 sparkSession <- sparkR.session()
 sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
 
@@ -3044,13 +3045,12 @@ compare_list <- function(list1, list2) {
   expect_equal(sort(list1, na.last = TRUE), sort(list2, na.last = TRUE))
 }
 
-# This should always be the **very last test** in this test file.
-test_that("No extra files are created in SPARK_HOME by starting session and making calls", {
+check_no_file_created <- function(dirRoot, listFilesBeforeAllTests, listFileBeforeThisTestFile) {
   # Check that it is not creating any extra file.
   # Does not check the tempdir which would be cleaned up after.
-  filesAfter <- list.files(path = sparkRDir, all.files = TRUE)
+  filesAfter <- list.files(path = dirRoot, all.files = TRUE)
 
-  expect_true(length(sparkRFilesBefore) > 0)
+  expect_true(length(listFilesBeforeAllTests) > 0)
   # first, ensure derby.log is not there
   expect_false("derby.log" %in% filesAfter)
   # second, ensure only spark-warehouse is created when calling SparkSession, enableHiveSupport = F
@@ -3061,11 +3061,20 @@ test_that("No extra files are created in SPARK_HOME by starting session and maki
   # sparkRWhitelistSQLDirs is also defined in run-all.R, and should contain only 2 whitelisted dirs,
   # here allow the first value, spark-warehouse, in the diff, everything else should be exactly the
   # same as before any test is run.
-  compare_list(sparkRFilesBefore, setdiff(filesBefore, sparkRWhitelistSQLDirs[[1]]))
+  compare_list(listFilesBeforeAllTests,
+               setdiff(listFileBeforeThisTestFile, sparkRWhitelistSQLDirs[[1]]))
   # third, ensure only spark-warehouse and metastore_db are created when enableHiveSupport = T
   # note: as the note above, after running all tests in this file while enableHiveSupport = T, we
   # check the list of files again. This time we allow both whitelisted dirs to be in the diff.
-  compare_list(sparkRFilesBefore, setdiff(filesAfter, sparkRWhitelistSQLDirs))
+  compare_list(listFilesBeforeAllTests, setdiff(filesAfter, sparkRWhitelistSQLDirs))
+}
+
+# This should always be the **very last test** in this test file.
+test_that("No extra files are created in SPARK_HOME by starting session and making calls", {
+  # Need to check 2 sets of directories: SPARK_HOME, and current working directory.
+  # Apparently this is different when running tests via R CMD check on package.
+  check_no_file_created(sparkRDir, sparkRFilesBefore, filesBefore)
+  check_no_file_created(sparkRDirWd, sparkRFilesBeforeWd, filesBeforeWd)
 })
 
 unlink(parquetPath)

--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -22,19 +22,13 @@ library(SparkR)
 options("warn" = 2)
 
 # Setup global test environment
-# Ensure Spark is installed before referencing SPARK_HOME
+# Install Spark first to set SPARK_HOME
 install.spark()
 
-sparkRWhitelistSQLDirs <- c("spark-warehouse", "metastore_db")
-
 sparkRDir <- file.path(Sys.getenv("SPARK_HOME"), "R")
+sparkRFilesBefore <- list.files(path = sparkRDir, all.files = TRUE)
+sparkRWhitelistSQLDirs <- c("spark-warehouse", "metastore_db")
 invisible(lapply(sparkRWhitelistSQLDirs,
                  function(x) { unlink(file.path(sparkRDir, x), recursive = TRUE, force = TRUE)}))
-sparkRFilesBefore <- list.files(path = sparkRDir, all.files = TRUE)
-
-sparkRDirWd <- getwd()
-invisible(lapply(sparkRWhitelistSQLDirs,
-                 function(x) { unlink(file.path(sparkRDirWd, x), recursive = TRUE, force = TRUE)}))
-sparkRFilesBeforeWd <- list.files(path = sparkRDirWd, all.files = TRUE)
 
 test_package("SparkR")

--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -22,12 +22,19 @@ library(SparkR)
 options("warn" = 2)
 
 # Setup global test environment
-sparkRDir <- file.path(Sys.getenv("SPARK_HOME"), "R")
-sparkRFilesBefore <- list.files(path = sparkRDir, all.files = TRUE)
+# Ensure Spark is installed before referencing SPARK_HOME
+install.spark()
+
 sparkRWhitelistSQLDirs <- c("spark-warehouse", "metastore_db")
+
+sparkRDir <- file.path(Sys.getenv("SPARK_HOME"), "R")
 invisible(lapply(sparkRWhitelistSQLDirs,
                  function(x) { unlink(file.path(sparkRDir, x), recursive = TRUE, force = TRUE)}))
+sparkRFilesBefore <- list.files(path = sparkRDir, all.files = TRUE)
 
-install.spark()
+sparkRDirWd <- getwd()
+invisible(lapply(sparkRWhitelistSQLDirs,
+                 function(x) { unlink(file.path(sparkRDirWd, x), recursive = TRUE, force = TRUE)}))
+sparkRFilesBeforeWd <- list.files(path = sparkRDirWd, all.files = TRUE)
 
 test_package("SparkR")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test failed because SPARK_HOME is not set before Spark is installed.