### PR TITLE
[SPARK-18278] [Scheduler] Documentation to point to Kubernetes cluster scheduler

### DIFF
--- a/docs/cluster-overview.md
+++ b/docs/cluster-overview.md
@@ -52,7 +52,11 @@ The system currently supports three cluster managers:
 * [Apache Mesos](running-on-mesos.html) -- a general cluster manager that can also run Hadoop MapReduce
   and service applications.
 * [Hadoop YARN](running-on-yarn.html) -- the resource manager in Hadoop 2.
-
+* [Kubernetes (experimental)](https://github.com/apache-spark-on-k8s/spark) -- In addition to the above,
+there is experimental support for Kubernetes. Kubernetes is an open-source platform
+for providing container-centric infrastructure. Kubernetes support is being actively
+developed in an [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/) Github organization
+and is intended to eventually merge into the Apache Spark project. For documentation, refer to that project's README.
 
 # Submitting Applications
 

--- a/docs/cluster-overview.md
+++ b/docs/cluster-overview.md
@@ -55,8 +55,8 @@ The system currently supports three cluster managers:
 * [Kubernetes (experimental)](https://github.com/apache-spark-on-k8s/spark) -- In addition to the above,
 there is experimental support for Kubernetes. Kubernetes is an open-source platform
 for providing container-centric infrastructure. Kubernetes support is being actively
-developed in an [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/) Github organization
-and is intended to eventually merge into the Apache Spark project. For documentation, refer to that project's README.
+developed in an [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/) Github organization. 
+For documentation, refer to that project's README.
 
 # Submitting Applications
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,7 @@ options for deployment:
   * [Mesos](running-on-mesos.html): deploy a private cluster using
       [Apache Mesos](http://mesos.apache.org)
   * [YARN](running-on-yarn.html): deploy Spark on top of Hadoop NextGen (YARN)
+  * [Kubernetes (experimental)](https://github.com/apache-spark-on-k8s/spark): deploy Spark on top of Kubernetes
 
 **Other Documents:**
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding documentation to point to Kubernetes cluster scheduler being developed out-of-repo in https://github.com/apache-spark-on-k8s/spark
cc @rxin @srowen @tnachen @ash211 @mccheah @erikerlandson 

## How was this patch tested?

Docs only change
