### PR TITLE
[SPARK-20204][SQL][Followup] SQLConf should react to change in default timezone settings

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -147,6 +147,15 @@ private[spark] class TypedConfigBuilder[T](
     }
   }
 
+  /** Creates a [[ConfigEntry]] with a function has a default value */
+  def createWithDefaultFunction(defaultFunc: () => T): ConfigEntry[T] = {
+    val entry =
+      new ConfigEntryWithDefaultFunction[T](parent.key, defaultFunc, converter,
+      stringConverter, parent._doc, parent._public)
+    parent._onCreate.foreach(_ (entry))
+    entry
+  }
+
   /**
    * Creates a [[ConfigEntry]] that has a default value. The default value is provided as a
    * [[String]] and must be a valid value for the entry.

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -147,7 +147,7 @@ private[spark] class TypedConfigBuilder[T](
     }
   }
 
-  /** Creates a [[ConfigEntry]] with a function has a default value */
+  /** Creates a [[ConfigEntry]] with a function to determine the default value */
   def createWithDefaultFunction(defaultFunc: () => T): ConfigEntry[T] = {
     val entry = new ConfigEntryWithDefaultFunction[T](parent.key, defaultFunc, converter,
       stringConverter, parent._doc, parent._public)

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -149,8 +149,7 @@ private[spark] class TypedConfigBuilder[T](
 
   /** Creates a [[ConfigEntry]] with a function has a default value */
   def createWithDefaultFunction(defaultFunc: () => T): ConfigEntry[T] = {
-    val entry =
-      new ConfigEntryWithDefaultFunction[T](parent.key, defaultFunc, converter,
+    val entry = new ConfigEntryWithDefaultFunction[T](parent.key, defaultFunc, converter,
       stringConverter, parent._doc, parent._public)
     parent._onCreate.foreach(_ (entry))
     entry

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala
@@ -78,7 +78,24 @@ private class ConfigEntryWithDefault[T] (
   def readFrom(reader: ConfigReader): T = {
     reader.get(key).map(valueConverter).getOrElse(_defaultValue)
   }
+}
 
+private class ConfigEntryWithDefaultFunction[T] (
+     key: String,
+     _defaultFunction: () => T,
+     valueConverter: String => T,
+     stringConverter: T => String,
+     doc: String,
+     isPublic: Boolean)
+  extends ConfigEntry(key, valueConverter, stringConverter, doc, isPublic) {
+
+  override def defaultValue: Option[T] = Some(_defaultFunction())
+
+  override def defaultValueString: String = stringConverter(_defaultFunction())
+
+  def readFrom(reader: ConfigReader): T = {
+    reader.get(key).map(valueConverter).getOrElse(_defaultFunction())
+  }
 }
 
 private class ConfigEntryWithDefaultString[T] (

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.internal.config
 
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -49,6 +50,26 @@ class ConfigEntrySuite extends SparkFunSuite {
     val dConf = ConfigBuilder(testKey("double")).doubleConf.createWithDefault(0.0)
     conf.set(dConf, 20.0)
     assert(conf.get(dConf) === 20.0)
+  }
+
+  test("conf entry: timezone") {
+    val tzStart = TimeZone.getDefault().getID()
+    val conf = new SparkConf()
+    val dConf = ConfigBuilder(testKey("tz"))
+      .stringConf
+      .createWithDefaultFunction(() => TimeZone.getDefault().getID())
+
+    val tzConf = conf.get(dConf)
+    assert(tzStart === tzConf)
+
+    // Pick a timezone which is not the current timezone
+    val availableTzs: Seq[String] = TimeZone.getAvailableIDs();
+    val newTz = availableTzs.find(_ != tzStart).getOrElse(tzStart)
+    TimeZone.setDefault(TimeZone.getTimeZone(newTz))
+
+    val tzChanged = conf.get(dConf)
+    assert(tzChanged === newTz)
+    TimeZone.setDefault(TimeZone.getTimeZone(tzStart))
   }
 
   test("conf entry: boolean") {

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -52,25 +52,7 @@ class ConfigEntrySuite extends SparkFunSuite {
     assert(conf.get(dConf) === 20.0)
   }
 
-  test("conf entry: timezone") {
-    val tzStart = TimeZone.getDefault().getID()
-    val conf = new SparkConf()
-    val dConf = ConfigBuilder(testKey("tz"))
-      .stringConf
-      .createWithDefaultFunction(() => TimeZone.getDefault().getID())
 
-    val tzConf = conf.get(dConf)
-    assert(tzStart === tzConf)
-
-    // Pick a timezone which is not the current timezone
-    val availableTzs: Seq[String] = TimeZone.getAvailableIDs();
-    val newTz = availableTzs.find(_ != tzStart).getOrElse(tzStart)
-    TimeZone.setDefault(TimeZone.getTimeZone(newTz))
-
-    val tzChanged = conf.get(dConf)
-    assert(tzChanged === newTz)
-    TimeZone.setDefault(TimeZone.getTimeZone(tzStart))
-  }
 
   test("conf entry: boolean") {
     val conf = new SparkConf()
@@ -271,5 +253,14 @@ class ConfigEntrySuite extends SparkFunSuite {
       .stringConf
       .createWithDefault(null)
     testEntryRef(nullConf, ref(nullConf))
+  }
+
+  test("conf entry : default function") {
+    var data = 0
+    val conf = new SparkConf()
+    val iConf = ConfigBuilder(testKey("int")).intConf.createWithDefaultFunction(() => data)
+    assert(conf.get(iConf) === 0)
+    data = 2
+    assert(conf.get(iConf) === 2)
   }
 }

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.internal.config
 
-import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -51,8 +50,6 @@ class ConfigEntrySuite extends SparkFunSuite {
     conf.set(dConf, 20.0)
     assert(conf.get(dConf) === 20.0)
   }
-
-
 
   test("conf entry: boolean") {
     val conf = new SparkConf()
@@ -258,7 +255,7 @@ class ConfigEntrySuite extends SparkFunSuite {
   test("conf entry : default function") {
     var data = 0
     val conf = new SparkConf()
-    val iConf = ConfigBuilder(testKey("int")).intConf.createWithDefaultFunction(() => data)
+    val iConf = ConfigBuilder(testKey("intval")).intConf.createWithDefaultFunction(() => data)
     assert(conf.get(iConf) === 0)
     data = 2
     assert(conf.get(iConf) === 2)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -752,7 +752,7 @@ object SQLConf {
     buildConf("spark.sql.session.timeZone")
       .doc("""The ID of session local timezone, e.g. "GMT", "America/Los_Angeles", etc.""")
       .stringConf
-      .createWithDefault(TimeZone.getDefault().getID())
+      .createWithDefaultFunction(() => TimeZone.getDefault().getID())
 
   val WINDOW_EXEC_BUFFER_SPILL_THRESHOLD =
     buildConf("spark.sql.windowExec.buffer.spill.threshold")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -752,7 +752,7 @@ object SQLConf {
     buildConf("spark.sql.session.timeZone")
       .doc("""The ID of session local timezone, e.g. "GMT", "America/Los_Angeles", etc.""")
       .stringConf
-      .createWithDefaultFunction(() => TimeZone.getDefault().getID())
+      .createWithDefaultFunction(() => TimeZone.getDefault.getID)
 
   val WINDOW_EXEC_BUFFER_SPILL_THRESHOLD =
     buildConf("spark.sql.windowExec.buffer.spill.threshold")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make sure SESSION_LOCAL_TIMEZONE reflects the change in JVM's default timezone setting. Currently several timezone related tests fail as the change to default timezone is not picked up by SQLConf.

## How was this patch tested?
Added an unit test in ConfigEntrySuite


