### PR TITLE
[SPARK-20230] FetchFailedExceptions should invalidate file caches in MapOutputTracker even if newer stages are launched

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1281,10 +1281,24 @@ class DAGScheduler(
         val failedStage = stageIdToStage(task.stageId)
         val mapStage = shuffleIdToMapStage(shuffleId)
 
+        def invalidateLostFilesAndExecutor(): Unit = {
+          // Mark the map whose fetch failed as broken in the map stage
+          if (mapId != -1) {
+            mapStage.removeOutputLoc(mapId, bmAddress)
+            mapOutputTracker.unregisterMapOutput(shuffleId, mapId, bmAddress)
+          }
+
+          // TODO: mark the executor as failed only if there were lots of fetch failures on it
+          if (bmAddress != null) {
+            handleExecutorLost(bmAddress.executorId, filesLost = true, Some(task.epoch))
+          }
+        }
+
         if (failedStage.latestInfo.attemptId != task.stageAttemptId) {
           logInfo(s"Ignoring fetch failure from $task as it's from $failedStage attempt" +
             s" ${task.stageAttemptId} and there is a more recent attempt for that stage " +
             s"(attempt ID ${failedStage.latestInfo.attemptId}) running")
+          invalidateLostFilesAndExecutor()
         } else {
           // It is likely that we receive multiple FetchFailed for a single stage (because we have
           // multiple tasks running concurrently on different executors). In that case, it is
@@ -1340,16 +1354,7 @@ class DAGScheduler(
               )
             }
           }
-          // Mark the map whose fetch failed as broken in the map stage
-          if (mapId != -1) {
-            mapStage.removeOutputLoc(mapId, bmAddress)
-            mapOutputTracker.unregisterMapOutput(shuffleId, mapId, bmAddress)
-          }
-
-          // TODO: mark the executor as failed only if there were lots of fetch failures on it
-          if (bmAddress != null) {
-            handleExecutorLost(bmAddress.executorId, filesLost = true, Some(task.epoch))
-          }
+          invalidateLostFilesAndExecutor()
         }
 
       case commitDenied: TaskCommitDenied =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If you lose instances that have shuffle outputs, you will start observing messages like:
```
17/03/24 11:49:23 WARN TaskSetManager: Lost task 0.0 in stage 64.1 (TID 3849, 172.128.196.240, executor 0): FetchFailed(BlockManagerId(4, 172.128.200.157, 4048, None), shuffleId=16, mapId=2, reduceId=3, message=
```
Generally, these messages are followed by:
```
17/03/24 11:49:23 INFO DAGScheduler: Executor lost: 4 (epoch 20)
17/03/24 11:49:23 INFO BlockManagerMasterEndpoint: Trying to remove executor 4 from BlockManagerMaster.
17/03/24 11:49:23 INFO BlockManagerMaster: Removed 4 successfully in removeExecutor
17/03/24 11:49:23 INFO DAGScheduler: Shuffle files lost for executor: 4 (epoch 20)
17/03/24 11:49:23 INFO ShuffleMapStage: ShuffleMapStage 63 is now unavailable on executor 4 (73/89, false)
```
which is great. Spark resubmits tasks for data that has been lost. However, if you have cascading instance failures, then you may come across:
```
17/03/24 11:48:39 INFO DAGScheduler: Ignoring fetch failure from ResultTask(64, 46) as it's from ResultStage 64 attempt 0 and there is a more recent attempt for that stage (attempt ID 1) running
```
which don't invalidate file outputs. In later retries of the stage, Spark will attempt to access files on machines that don't exist anymore, and then after 4 tries, Spark will give up. If it had not ignored the fetch failure, and invalidated the cache, then most of the lost files could have been computed during one of the previous retries.

## How was this patch tested?

Will add tests based on feedback