### PR TITLE
[SPARK-20242][Web UI] Add spark.ui.stopDelay

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -251,3 +251,8 @@ a.expandbutton {
 .table-cell-width-limited td {
   max-width: 600px;
 }
+
+.stop-delayed {
+  color: red;
+  margin-bottom: 1em;
+}

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.ui
 
 import java.util.{Date, ServiceLoader}
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.JavaConverters._
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
-import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationAttemptInfo, ApplicationInfo,
-  UIRoot}
+import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationAttemptInfo, ApplicationInfo, UIRoot}
 import org.apache.spark.storage.StorageStatusListener
 import org.apache.spark.ui.JettyUtils._
 import org.apache.spark.ui.env.{EnvironmentListener, EnvironmentTab}
@@ -33,7 +33,7 @@ import org.apache.spark.ui.exec.{ExecutorsListener, ExecutorsTab}
 import org.apache.spark.ui.jobs.{JobProgressListener, JobsTab, StagesTab}
 import org.apache.spark.ui.scope.RDDOperationGraphListener
 import org.apache.spark.ui.storage.{StorageListener, StorageTab}
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{SignalUtils, Utils}
 
 /**
  * Top level user interface for a Spark application.
@@ -58,6 +58,9 @@ private[spark] class SparkUI private (
 
   val killEnabled = sc.map(_.conf.getBoolean("spark.ui.killEnabled", true)).getOrElse(false)
 
+  private val stopDelayThread = new AtomicReference[Thread]()
+  private val stopDelaySeconds = conf.getOption("spark.ui.stopDelay").map(Utils.timeStringAsSeconds)
+
   var appId: String = _
 
   private var streamingJobProgressListener: Option[SparkListener] = None
@@ -80,6 +83,9 @@ private[spark] class SparkUI private (
     attachHandler(createRedirectHandler(
       "/stages/stage/kill", "/stages/", stagesTab.handleKillRequest,
       httpMethods = Set("GET", "POST")))
+    attachHandler(createRedirectHandler(
+      "/proceed-with-ui-stop", "/jobs/", _ => proceedWithStop("web UI action"),
+      httpMethods = Set("GET", "POST")))
   }
   initialize()
 
@@ -93,10 +99,51 @@ private[spark] class SparkUI private (
     appId = id
   }
 
+  def activeStopDelay: Option[Long] =
+    stopDelaySeconds.filter(_ => stopDelayThread.get() != null)
+
   /** Stop the server behind this web interface. Only valid after bind(). */
   override def stop() {
-    super.stop()
-    logInfo(s"Stopped Spark web UI at $webUrl")
+
+    def reallyStop(): Unit = {
+      super.stop()
+      logInfo(s"Stopped Spark web UI at $webUrl")
+    }
+
+    stopDelaySeconds match {
+      case Some(stopDelaySeconds) =>
+        if (stopDelayThread.compareAndSet(null, Thread.currentThread())) {
+          delayStop(stopDelaySeconds)
+          reallyStop()
+        }
+      case None =>
+        reallyStop()
+    }
+  }
+
+  private def delayStop(stopDelaySeconds: Long): Unit = {
+
+    SignalUtils.register("INT") {
+      proceedWithStop(s"received SIGINT")
+      true
+    }
+
+    logInfo(s"Delaying stop of Spark web UI at $webUrl " +
+      s"for $stopDelaySeconds seconds as set in spark.ui.stopDelay. " +
+      s"Stopping can be resumed immediately in the Spark UI, or by sending SIGINT.")
+
+    try Thread.sleep(1000 * stopDelaySeconds)
+    catch { case _: InterruptedException => }
+
+    stopDelayThread.set(null)
+    Thread.interrupted()
+  }
+
+  def proceedWithStop(reason: String): Unit = {
+    Option(stopDelayThread.get).foreach { stopThread =>
+      logInfo(s"Proceeding to stop Spark web UI ($reason)")
+      stopThread.interrupt()
+    }
   }
 
   def getSparkUI(appId: String): Option[SparkUI] = {

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -311,6 +311,24 @@ private[ui] class AllJobsPage(parent: JobsTab) extends WebUIPage("") {
 
       val summary: NodeSeq =
         <div>
+          {
+            parent.activeStopDelay match {
+              case None =>
+              case Some(delay) =>
+                val confirm =
+                  s"if (window.confirm('Are you sure you allow the Spark UI to stop?')) " +
+                    "{ this.parentNode.submit(); return true; } else { return false; }"
+                val action = s"${parent.basePath}/proceed-with-ui-stop"
+                <div class="stop-delayed">
+                  <strong>The Spark UI has been asked to stop, but that is being delayed for
+                    {delay}s.
+                    <form action={action} method="POST" style="display:inline">
+                      <a href="#" onclick={confirm}>(stop now)</a>
+                    </form>
+                  </strong>
+                </div>
+            }
+          }
           <ul class="unstyled">
             <li>
               <strong>User:</strong>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobsTab.scala
@@ -30,6 +30,9 @@ private[ui] class JobsTab(parent: SparkUI) extends SparkUITab(parent, "jobs") {
   val executorListener = parent.executorsListener
   val operationGraphListener = parent.operationGraphListener
 
+  def activeStopDelay: Option[Long] =
+    parent.activeStopDelay
+
   def isFairScheduler: Boolean =
     jobProgresslistener.schedulingMode == Some(SchedulingMode.FAIR)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -661,6 +661,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.ui.stopDelay</code></td>
+  <td>(none)</td>
+  <td>
+    A period of time to delay the stopping of the Web UI, so that it can be inspected after the application finishes.
+  </td>
+</tr>
+<tr>
   <td><code>spark.ui.enabled</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a spark.ui.stopDelay configuration property that can be used to keep the UI running when an application has finished. This is very useful for debugging, especially when the driver application is running remotely.

## How was this patch tested?

This patch was tested manually. E.g. here's a screenshot from `bin/spark-submit run-example --conf spark.ui.stopDelay=30s SparkPi 100`:

![image](https://cloud.githubusercontent.com/assets/151714/24754984/c5b1657e-1ad8-11e7-99c8-982919afc94e.png)
