### PR TITLE
[SPARK-16957][MLlib] Use midpoints for split values.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -31,7 +31,7 @@ sealed abstract class Node extends Serializable {
   //       code into the new API and deprecate the old API.  SPARK-3727
 
   /** Prediction a leaf node makes, or which an internal node would make if it were a leaf node */
-  def prediction: Double
+  def prediction: Double 
 
   /** Impurity measure at this node (for training data) */
   def impurity: Double

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -31,7 +31,7 @@ sealed abstract class Node extends Serializable {
   //       code into the new API and deprecate the old API.  SPARK-3727
 
   /** Prediction a leaf node makes, or which an internal node would make if it were a leaf node */
-  def prediction: Double 
+  def prediction: Double
 
   /** Impurity measure at this node (for training data) */
   def impurity: Double

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1042,7 +1042,6 @@ private[spark] object RandomForest extends Logging {
           // makes the gap between currentCount and targetCount smaller,
           // previous value is a split threshold.
           if (previousGap < currentGap) {
-            // perhaps weighted mean will be used later, see SPARK-16957 and Github PR 17556.
             splitsBuilder += (valueCounts(index - 1)._1 + valueCounts(index)._1) / 2.0
             targetCount += stride
           }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1016,7 +1016,7 @@ private[spark] object RandomForest extends Logging {
       } else if (possibleSplits <= numSplits) {
         // if possible splits is not enough or just enough, just return all possible splits
         val splits = for {
-          i <- 0 until valueCounts.length - 1
+          i <- 0 until possibleSplits
         } yield (valueCounts(i)._1 + valueCounts(i + 1)._1) / 2
 
         splits.toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1015,13 +1015,13 @@ private[spark] object RandomForest extends Logging {
         (preValue * preCount + curValue * curCount) / (preCount.toDouble + curCount)
       }
 
-      // if possible splits is not enough or just enough, just return all possible splits
       val possibleSplits = valueCounts.length - 1
       if (possibleSplits == 0) {
         // constant feature
         Array.empty[Double]
 
       } else if (possibleSplits <= numSplits) {
+        // if possible splits is not enough or just enough, just return all possible splits
         valueCounts
           .sliding(2)
           .map(x => weightedMean(x(0), x(1)))

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1024,7 +1024,7 @@ private[spark] object RandomForest extends Logging {
       } else if (possibleSplits <= numSplits) {
         valueCounts
           .sliding(2)
-          .map{x => weightedMean(x(0), x(1))}
+          .map(x => weightedMean(x(0), x(1)))
           .toArray
 
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1019,7 +1019,6 @@ private[spark] object RandomForest extends Logging {
       if (possibleSplits == 0) {
         // constant feature
         Array.empty[Double]
-
       } else if (possibleSplits <= numSplits) {
         // if possible splits is not enough or just enough, just return all possible splits
         valueCounts
@@ -1053,7 +1052,6 @@ private[spark] object RandomForest extends Logging {
           if (previousGap < currentGap) {
             val pre = valueCounts(index - 1)
             val cur = valueCounts(index)
-
             splitsBuilder += weightedMean(pre, cur)
             targetCount += stride
           }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1015,11 +1015,11 @@ private[spark] object RandomForest extends Logging {
         Array.empty[Double]
       } else if (possibleSplits <= numSplits) {
         // if possible splits is not enough or just enough, just return all possible splits
-        valueCounts
-          .sliding(2)
-          .map(x => (x(0)._1 + x(1)._1) / 2)
-          .toArray
+        val splits = for {
+          i <- 0 until valueCounts.length - 1
+        } yield (valueCounts(i)._1 + valueCounts(i + 1)._1) / 2
 
+        splits.toArray
       } else {
         // stride between splits
         val stride: Double = numSamples.toDouble / (numSplits + 1)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1012,7 +1012,7 @@ private[spark] object RandomForest extends Logging {
       def weightedMean(pre: (Double, Int), cur: (Double, Int)): Double = {
         val (preValue, preCount) = pre
         val (curValue, curCount) = cur
-        (preValue * preCount + curValue * curCount) / (preCount + curCount)
+        (preValue * preCount + curValue * curCount) / (preCount.toDouble + curCount)
       }
 
       // if possible splits is not enough or just enough, just return all possible splits

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1015,11 +1015,9 @@ private[spark] object RandomForest extends Logging {
         Array.empty[Double]
       } else if (possibleSplits <= numSplits) {
         // if possible splits is not enough or just enough, just return all possible splits
-        val splits = for {
-          i <- 0 until possibleSplits
-        } yield (valueCounts(i)._1 + valueCounts(i + 1)._1) / 2
-
-        splits.toArray
+        (1 to possibleSplits)
+          .map(index => (valueCounts(index - 1)._1 + valueCounts(index)._1) / 2.0)
+          .toArray
       } else {
         // stride between splits
         val stride: Double = numSamples.toDouble / (numSplits + 1)
@@ -1044,10 +1042,8 @@ private[spark] object RandomForest extends Logging {
           // makes the gap between currentCount and targetCount smaller,
           // previous value is a split threshold.
           if (previousGap < currentGap) {
-            val pre = valueCounts(index - 1)
-            val cur = valueCounts(index)
             // perhaps weighted mean will be used later, see SPARK-16957 and Github PR 17556.
-            splitsBuilder += (pre._1 + cur._1) / 2
+            splitsBuilder += (valueCounts(index - 1)._1 + valueCounts(index)._1) / 2.0
             targetCount += stride
           }
           index += 1

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1017,7 +1017,11 @@ private[spark] object RandomForest extends Logging {
 
       // if possible splits is not enough or just enough, just return all possible splits
       val possibleSplits = valueCounts.length - 1
-      if (possibleSplits <= numSplits) {
+      if (possibleSplits == 0) {
+        // constant feature
+        Array.empty[Double]
+
+      } else if (possibleSplits <= numSplits) {
         valueCounts
           .sliding(2)
           .map{x => weightedMean(x(0), x(1))}

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -1009,9 +1009,9 @@ private[spark] object RandomForest extends Logging {
       // sort distinct values
       val valueCounts = valueCountMap.toSeq.sortBy(_._1).toArray
 
-      def weightedMean(pre: (Double, Int), cru: (Double, Int)): Double = {
+      def weightedMean(pre: (Double, Int), cur: (Double, Int)): Double = {
         val (preValue, preCount) = pre
-        val (curValue, curCount) = cru
+        val (curValue, curCount) = cur
         (preValue * preCount + curValue * curCount) / (preCount + curCount)
       }
 
@@ -1052,9 +1052,9 @@ private[spark] object RandomForest extends Logging {
           // previous value is a split threshold.
           if (previousGap < currentGap) {
             val pre = valueCounts(index - 1)
-            val cru = valueCounts(index)
+            val cur = valueCounts(index)
 
-            splitsBuilder += weightedMean(pre, cru)
+            splitsBuilder += weightedMean(pre, cur)
             targetCount += stride
           }
           index += 1

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -87,6 +87,17 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(splits(0).length === 0)
   }
 
+  test("SPARK-16957: Use weighted midpoints for split values.") {
+    val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
+      Map(), Set(),
+      Array(2), Gini, QuantileStrategy.Sort,
+      0, 0, 0.0, 0, 0
+    )
+    val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
+    val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
+    assert(splits === Array(0.5))
+  }
+
   test("find splits for a continuous feature") {
     // find splits for normal case
     {

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -113,7 +113,8 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(0.5))
+      val expSplits = Array((0 * 4 + 0 * 4) / (4 + 4))  // = 0.5
+      assert(splits === expSplits)
     }
 
     // find splits should not return identical splits
@@ -126,7 +127,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(1.8, 2.2))
+      val expSplits = Array((1.0 * 2 + 2.0 * 8) / (2 + 8),
+                            (2.0 * 8 + 3.0 * 2) / (8 + 2)) // = (1.8, 2.2)
+      assert(splits === expSplits)
       // check returned splits are distinct
       assert(splits.distinct.length === splits.length)
     }
@@ -141,7 +144,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5)
         .map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(2.0625, 3.5))
+      val expSplits = Array((2.0 * 15 + 3.0 * 1) / (15 + 1),
+                            (3.0 * 1 + 4.0 * 1) / (1 + 1)) // = (2.0625, 3.5)
+      assert(splits === expSplits)
     }
 
     // find splits when most samples close to the maximum
@@ -153,7 +158,8 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(1.9375))
+      val expSplits = Array((1.0 * 1 + 2.0 * 15) / (1 + 15))  // = (1.9375)
+      assert(splits === expSplits)
     }
 
     // find splits for constant feature

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -116,17 +116,17 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       {
         val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
         val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-        val expSplits = Array((0.0 * 4 + 1.0 * 4) / (4 + 4))  // = 0.5
-        assert(splits === expSplits)
+        val expectedSplits = Array((0.0 * 4 + 1.0 * 4) / (4 + 4))  // = 0.5
+        assert(splits === expectedSplits)
       }
 
       // possibleSplits > numSplits
       {
         val featureSamples = Array(0, 0, 1, 1, 2, 2, 3, 3).map(_.toDouble)
         val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-        val expSplits = Array((0.0 * 2 + 1.0 * 2) / (2 + 2),
-                              (2.0 * 2 + 3.0 * 2) / (2 + 2))  // = (0.5, 2.5)
-        assert(splits === expSplits)
+        val expectedSplits = Array((0.0 * 2 + 1.0 * 2) / (2 + 2),
+                                   (2.0 * 2 + 3.0 * 2) / (2 + 2))  // = (0.5, 2.5)
+        assert(splits === expectedSplits)
       }
     }
 
@@ -140,9 +140,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expSplits = Array((1.0 * 2 + 2.0 * 8) / (2 + 8),
-                            (2.0 * 8 + 3.0 * 2) / (8 + 2)) // = (1.8, 2.2)
-      assert(splits === expSplits)
+      val expectedSplits = Array((1.0 * 2 + 2.0 * 8) / (2 + 8),
+                                 (2.0 * 8 + 3.0 * 2) / (8 + 2)) // = (1.8, 2.2)
+      assert(splits === expectedSplits)
       // check returned splits are distinct
       assert(splits.distinct.length === splits.length)
     }
@@ -157,9 +157,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5)
         .map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expSplits = Array((2.0 * 15 + 3.0 * 1) / (15 + 1),
-                            (3.0 * 1 + 4.0 * 1) / (1 + 1)) // = (2.0625, 3.5)
-      assert(splits === expSplits)
+      val expectedSplits = Array((2.0 * 15 + 3.0 * 1) / (15 + 1),
+                                 (3.0 * 1 + 4.0 * 1) / (1 + 1)) // = (2.0625, 3.5)
+      assert(splits === expectedSplits)
     }
 
     // find splits when most samples close to the maximum
@@ -171,8 +171,8 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expSplits = Array((1.0 * 1 + 2.0 * 15) / (1 + 15))  // = (1.9375)
-      assert(splits === expSplits)
+      val expectedSplits = Array((1.0 * 1 + 2.0 * 15) / (1 + 15))  // = (1.9375)
+      assert(splits === expectedSplits)
     }
 
     // find splits for constant feature

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -104,7 +104,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       assert(splits.distinct.length === splits.length)
     }
 
-    // SPARK-16957: Use weighted midpoints for split values.
+    // SPARK-16957: Use midpoints for split values.
     {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
@@ -116,7 +116,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       {
         val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
         val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-        val expectedSplits = Array((0.0 * 4 + 1.0 * 4) / (4 + 4))  // = 0.5
+        val expectedSplits = Array((0.0 + 1.0) / 2)
         assert(splits === expectedSplits)
       }
 
@@ -124,8 +124,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       {
         val featureSamples = Array(0, 0, 1, 1, 2, 2, 3, 3).map(_.toDouble)
         val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-        val expectedSplits = Array((0.0 * 2 + 1.0 * 2) / (2 + 2),
-                                   (2.0 * 2 + 3.0 * 2) / (2 + 2))  // = (0.5, 2.5)
+        val expectedSplits = Array((0.0 + 1.0) / 2, (2.0 + 3.0) / 2)
         assert(splits === expectedSplits)
       }
     }
@@ -140,8 +139,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expectedSplits = Array((1.0 * 2 + 2.0 * 8) / (2 + 8),
-                                 (2.0 * 8 + 3.0 * 2) / (8 + 2)) // = (1.8, 2.2)
+      val expectedSplits = Array((1.0 + 2.0) / 2, (2.0 + 3.0) / 2)
       assert(splits === expectedSplits)
       // check returned splits are distinct
       assert(splits.distinct.length === splits.length)
@@ -157,8 +155,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5)
         .map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expectedSplits = Array((2.0 * 15 + 3.0 * 1) / (15 + 1),
-                                 (3.0 * 1 + 4.0 * 1) / (1 + 1)) // = (2.0625, 3.5)
+      val expectedSplits = Array((2.0 + 3.0) / 2, (3.0 + 4.0) / 2)
       assert(splits === expectedSplits)
     }
 
@@ -171,7 +168,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       )
       val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expectedSplits = Array((1.0 * 1 + 2.0 * 15) / (1 + 15))  // = (1.9375)
+      val expectedSplits = Array((1.0 + 2.0) / 2)
       assert(splits === expectedSplits)
     }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -123,9 +123,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
         Array(5), Gini, QuantileStrategy.Sort,
         0, 0, 0.0, 0, 0
       )
-      val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3).map(_.toDouble)
+      val featureSamples = Array(1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(1.0, 2.0))
+      assert(splits === Array(1.8, 2.2))
       // check returned splits are distinct
       assert(splits.distinct.length === splits.length)
     }
@@ -137,9 +137,10 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
         Array(3), Gini, QuantileStrategy.Sort,
         0, 0, 0.0, 0, 0
       )
-      val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5).map(_.toDouble)
+      val featureSamples = Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5)
+        .map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(2.0, 3.0))
+      assert(splits === Array(2.0625, 3.5))
     }
 
     // find splits when most samples close to the maximum
@@ -149,9 +150,9 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
         Array(2), Gini, QuantileStrategy.Sort,
         0, 0, 0.0, 0, 0
       )
-      val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
+      val featureSamples = Array(0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2).map(_.toDouble)
       val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      assert(splits === Array(1.0))
+      assert(splits === Array(1.9375))
     }
 
     // find splits for constant feature

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -108,13 +108,26 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     {
       val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
         Map(), Set(),
-        Array(2), Gini, QuantileStrategy.Sort,
+        Array(3), Gini, QuantileStrategy.Sort,
         0, 0, 0.0, 0, 0
       )
-      val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
-      val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-      val expSplits = Array((0 * 4 + 0 * 4) / (4 + 4))  // = 0.5
-      assert(splits === expSplits)
+
+      // possibleSplits <= numSplits
+      {
+        val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
+        val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
+        val expSplits = Array((0.0 * 4 + 1.0 * 4) / (4 + 4))  // = 0.5
+        assert(splits === expSplits)
+      }
+
+      // possibleSplits > numSplits
+      {
+        val featureSamples = Array(0, 0, 1, 1, 2, 2, 3, 3).map(_.toDouble)
+        val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
+        val expSplits = Array((0.0 * 2 + 1.0 * 2) / (2 + 2),
+                              (2.0 * 2 + 3.0 * 2) / (2 + 2))  // = (0.5, 2.5)
+        assert(splits === expSplits)
+      }
     }
 
     // find splits should not return identical splits

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -87,17 +87,6 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(splits(0).length === 0)
   }
 
-  test("SPARK-16957: Use weighted midpoints for split values.") {
-    val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
-      Map(), Set(),
-      Array(2), Gini, QuantileStrategy.Sort,
-      0, 0, 0.0, 0, 0
-    )
-    val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
-    val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
-    assert(splits === Array(0.5))
-  }
-
   test("find splits for a continuous feature") {
     // find splits for normal case
     {
@@ -113,6 +102,18 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       assert(fakeMetadata.numBins(0) === 6)
       // check returned splits are distinct
       assert(splits.distinct.length === splits.length)
+    }
+
+    // SPARK-16957: Use weighted midpoints for split values.
+    {
+      val fakeMetadata = new DecisionTreeMetadata(1, 0, 0, 0,
+        Map(), Set(),
+        Array(2), Gini, QuantileStrategy.Sort,
+        0, 0, 0.0, 0, 0
+      )
+      val featureSamples = Array(0, 1, 0, 0, 1, 0, 1, 1).map(_.toDouble)
+      val splits = RandomForest.findSplitsForContinuousFeature(featureSamples, fakeMetadata, 0)
+      assert(splits === Array(0.5))
     }
 
     // find splits should not return identical splits

--- a/python/pyspark/mllib/tree.py
+++ b/python/pyspark/mllib/tree.py
@@ -199,9 +199,9 @@ class DecisionTree(object):
 
         >>> print(model.toDebugString())
         DecisionTreeModel classifier of depth 1 with 3 nodes
-          If (feature 0 <= 0.0)
+          If (feature 0 <= 0.5)
            Predict: 0.0
-          Else (feature 0 > 0.0)
+          Else (feature 0 > 0.5)
            Predict: 1.0
         <BLANKLINE>
         >>> model.predict(array([1.0]))
@@ -383,14 +383,14 @@ class RandomForest(object):
           Tree 0:
             Predict: 1.0
           Tree 1:
-            If (feature 0 <= 1.0)
+            If (feature 0 <= 1.5)
              Predict: 0.0
-            Else (feature 0 > 1.0)
+            Else (feature 0 > 1.5)
              Predict: 1.0
           Tree 2:
-            If (feature 0 <= 1.0)
+            If (feature 0 <= 1.5)
              Predict: 0.0
-            Else (feature 0 > 1.0)
+            Else (feature 0 > 1.5)
              Predict: 1.0
         <BLANKLINE>
         >>> model.predict([2.0])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use midpoints for split values now, and maybe later to make it weighted.

## How was this patch tested?

+ [x] add unit test.
+ [x] revise Split's unit test.