### PR TITLE
[SPARK-20248][ SQL]Spark SQL add limit parameter to enhance the reliability.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -346,6 +346,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val THRIFTSERVER_RESULT_LIMIT =
+    buildConf("spark.sql.thriftServer.retainedResults")
+      .internal()
+      .doc("The number of sql results returned by Thrift Server, and 0 is unlimited.")
+      .intConf
+      .createWithDefault(200)
+
   val THRIFTSERVER_UI_STATEMENT_LIMIT =
     buildConf("spark.sql.thriftserver.ui.retainedStatements")
       .doc("The number of SQL statements kept in the JDBC/ODBC web UI history.")

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -121,7 +121,12 @@ private[hive] class SparkExecuteStatementOperation(
         result.toLocalIterator.asScala
       } else {
         if (resultList.isEmpty) {
-          resultList = Some(result.collect())
+          val limited = sqlContext.getConf(SQLConf.THRIFTSERVER_RESULT_LIMIT.key).toInt
+          resultList = if (limited > 0) {
+            Some(result.take(result.queryExecution.analyzed.maxRows.getOrElse(limited).toInt))
+          } else {
+            Some(result.collect())
+          }
         }
         resultList.get.iterator
       }
@@ -242,7 +247,12 @@ private[hive] class SparkExecuteStatementOperation(
           resultList = None
           result.toLocalIterator.asScala
         } else {
-          resultList = Some(result.collect())
+          val limited = sqlContext.getConf(SQLConf.THRIFTSERVER_RESULT_LIMIT.key).toInt
+          resultList = if (limited > 0) {
+            Some(result.take(result.queryExecution.analyzed.maxRows.getOrElse(limited).toInt))
+          } else {
+            Some(result.collect())
+          }
           resultList.get.iterator
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a parameter "spark.sql.thriftServer.retainedResults" with default value 200, when user run a query without a limit, this will implicitly add a limit to this query. When user run a query with a limit,we do nothing. If this parameter is set to 0,we do nothing too.


## How was this patch tested?
manual tests
