### PR TITLE
[SPARK-20239][Core] Improve HistoryServer's ACL mechanism

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -86,7 +86,7 @@ private[history] abstract class ApplicationHistoryProvider {
    * @return Count of application event logs that are currently under process
    */
   def getEventLogsUnderProcess(): Int = {
-    return 0;
+    0
   }
 
   /**
@@ -95,7 +95,7 @@ private[history] abstract class ApplicationHistoryProvider {
    * @return 0 if this is undefined or unsupported, otherwise the last updated time in millis
    */
   def getLastUpdatedTime(): Long = {
-    return 0;
+    0
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -303,8 +303,8 @@ object HistoryServer extends Logging {
     }
 
     if (config.getBoolean("spark.acls.enable", config.getBoolean("spark.ui.acls.enable", false))) {
-      logInfo(s"Either spark.acls.enable or spark.ui.acles.enable is configured, clearing it and " +
-        s"only honor spark.history.ui.acl.enable")
+      logInfo(s"Either spark.acls.enable or spark.ui.acls.enable is configured, clearing it and " +
+        s"only using spark.history.ui.acl.enable")
       config.set("spark.acls.enable", "false")
       config.set("spark.ui.acls.enable", "false")
     }

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -301,6 +301,14 @@ object HistoryServer extends Logging {
       logDebug(s"Clearing ${SecurityManager.SPARK_AUTH_CONF}")
       config.set(SecurityManager.SPARK_AUTH_CONF, "false")
     }
+
+    if (config.getBoolean("spark.acls.enable", config.getBoolean("spark.ui.acls.enable", false))) {
+      logInfo(s"Either spark.acls.enable or spark.ui.acles.enable is configured, clearing it and " +
+        s"only honor spark.history.ui.acl.enable")
+      config.set("spark.acls.enable", "false")
+      config.set("spark.ui.acls.enable", "false")
+    }
+
     new SecurityManager(config)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -303,8 +303,8 @@ object HistoryServer extends Logging {
     }
 
     if (config.getBoolean("spark.acls.enable", config.getBoolean("spark.ui.acls.enable", false))) {
-      logInfo(s"Either spark.acls.enable or spark.ui.acls.enable is configured, clearing it and " +
-        s"only using spark.history.ui.acl.enable")
+      logInfo("Either spark.acls.enable or spark.ui.acls.enable is configured, clearing it and " +
+        "only using spark.history.ui.acl.enable")
       config.set("spark.acls.enable", "false")
       config.set("spark.ui.acls.enable", "false")
     }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
@@ -185,7 +185,7 @@ private[v1] class ApiRootResource extends ApiRequestContext {
   def getEventLogs(
       @PathParam("appId") appId: String): EventLogDownloadResource = {
     try {
-      // withSparkUI will throw NotFoundException if attemptId is existed for this application.
+      // withSparkUI will throw NotFoundException if attemptId exists for this application.
       // So we need to try again with attempt id "1".
       withSparkUI(appId, None) { _ =>
         new EventLogDownloadResource(uiRoot, appId, None)

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
@@ -184,14 +184,27 @@ private[v1] class ApiRootResource extends ApiRequestContext {
   @Path("applications/{appId}/logs")
   def getEventLogs(
       @PathParam("appId") appId: String): EventLogDownloadResource = {
-    new EventLogDownloadResource(uiRoot, appId, None)
+    try {
+      // withSparkUI will throw NotFoundException if attemptId is existed for this application.
+      // So we need to try again with attempt id "1".
+      withSparkUI(appId, None) { _ =>
+        new EventLogDownloadResource(uiRoot, appId, None)
+      }
+    } catch {
+      case _: NotFoundException =>
+        withSparkUI(appId, Some("1")) { _ =>
+          new EventLogDownloadResource(uiRoot, appId, None)
+        }
+    }
   }
 
   @Path("applications/{appId}/{attemptId}/logs")
   def getEventLogs(
       @PathParam("appId") appId: String,
       @PathParam("attemptId") attemptId: String): EventLogDownloadResource = {
-    new EventLogDownloadResource(uiRoot, appId, Some(attemptId))
+    withSparkUI(appId, Some(attemptId)) { _ =>
+      new EventLogDownloadResource(uiRoot, appId, Some(attemptId))
+    }
   }
 
   @Path("version")
@@ -291,7 +304,6 @@ private[v1] trait ApiRequestContext {
       case None => throw new NotFoundException("no such app: " + appId)
     }
   }
-
 }
 
 private[v1] class ForbiddenException(msg: String) extends WebApplicationException(

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -209,7 +209,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
   }
 
   // Test that the files are downloaded correctly, and validate them.
-  def doDownloadTest(appId: String, attemptId: Option[Int]): Unit = {
+  def doDownloadTest(appId: String, attemptId: Option[Int], user: String = null): Unit = {
 
     val url = attemptId match {
       case Some(id) =>
@@ -218,8 +218,13 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         new URL(s"${generateURL(s"applications/$appId")}/logs")
     }
 
-    val (code, inputStream, error) = HistoryServerSuite.connectAndGetInputStream(url)
-    code should be (HttpServletResponse.SC_OK)
+    val headers = if (user != null) Seq(FakeAuthFilter.FAKE_HTTP_USER -> user) else Nil
+    val (code, inputStream, error) = HistoryServerSuite.connectAndGetInputStream(url, headers)
+    if (code != HttpServletResponse.SC_OK) {
+      throw new IllegalStateException(
+        s"Return code $code is not equal to ${HttpServletResponse.SC_OK}")
+    }
+
     inputStream should not be None
     error should be (None)
 
@@ -565,8 +570,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     assert(jobcount === getNumJobs("/jobs"))
 
     // no need to retain the test dir now the tests complete
-    logDir.deleteOnExit();
-
+    logDir.deleteOnExit()
   }
 
   test("ui and api authorization checks") {
@@ -599,6 +603,36 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         val sc = TestUtils.httpResponseCode(new URL(url), headers = headers)
         assert(sc === expectedCode, s"Unexpected status code $sc for $url (user = $user)")
       }
+    }
+  }
+
+  test("acls with downloading files") {
+    val admin = "root"
+    val owner = "irashid"
+    val other = "alice"
+    val appId = "local-1430917381535"
+
+    stop()
+    init("spark.ui.filters" -> classOf[FakeAuthFilter].getName(),
+      "spark.history.ui.acls.enable" -> "true",
+      "spark.history.ui.admin.acls" -> admin)
+
+    doDownloadTest(appId, None, admin)
+    doDownloadTest(appId, None, owner)
+    intercept[IllegalStateException](doDownloadTest(appId, None, other)).getMessage should be (
+      s"Return code ${HttpServletResponse.SC_FORBIDDEN} is not " +
+        s"equal to ${HttpServletResponse.SC_OK}")
+
+    (1 to 2).foreach { attemptId => doDownloadTest(appId, Some(attemptId), admin) }
+    (1 to 2).foreach { attemptId => doDownloadTest(appId, Some(attemptId), owner) }
+    // Should throw exception, since user "alice" has no permission to access file, so it will
+    // return as an empty file.
+    (1 to 2).foreach { attemptId =>
+      val exception = intercept[IllegalStateException](
+        doDownloadTest(appId, Some(attemptId), other))
+      exception.getMessage should be (
+        s"Return code ${HttpServletResponse.SC_FORBIDDEN} is not " +
+          s"equal to ${HttpServletResponse.SC_OK}")
     }
   }
 
@@ -649,9 +683,11 @@ object HistoryServerSuite {
     (code, inString, errString)
   }
 
-  def connectAndGetInputStream(url: URL): (Int, Option[InputStream], Option[String]) = {
+  def connectAndGetInputStream(url: URL,
+      headers: Seq[(String, String)] = Nil): (Int, Option[InputStream], Option[String]) = {
     val connection = url.openConnection().asInstanceOf[HttpURLConnection]
     connection.setRequestMethod("GET")
+    headers.foreach { case (k, v) => connection.setRequestProperty(k, v) }
     connection.connect()
     val code = connection.getResponseCode()
     val inStream = try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current SHS (Spark History Server) two different ACLs:

* ACL of base URL, it is controlled by "spark.acls.enabled" or "spark.ui.acls.enabled", and with this enabled, only user configured with "spark.admin.acls" (or group) or "spark.ui.view.acls" (or group), or the user who started SHS could list all the applications, otherwise none of them can be listed. This will also affect REST APIs which listing the summary of all apps and one app.
* Per application ACL. This is controlled by "spark.history.ui.acls.enabled". With this enabled only history admin user and user/group who ran this app can access the details of this app.

With this two ACLs, we may encounter several unexpected behaviors:

1. if base URL's ACL (`spark.acls.enable`) is enabled but user A has no view permission. User "A" cannot see the app list but could still access details of it's own app.
2. if ACLs of base URL (`spark.acls.enable`) is disabled, then user "A" could download any application's event log, even it is not run by user "A".
3. The changes of Live UI's ACL will affect History UI's ACL which share the same conf file.

The unexpected behaviors is mainly because we have two different ACLs, ideally we should have only one to manage all.

So to improve SHS's ACL mechanism, here in this PR proposed to:

1. Disable "spark.acls.enable" and only use "spark.history.ui.acls.enable" for history server.
2. Check permission for event-log download REST API.

With this PR:

1. Admin user could see/download the list of all applications, as well as application details.
2. Normal user could see the list of all applications, but can only download and check the details of applications accessible to him.
 
## How was this patch tested?

New UTs are added, also verified in real cluster.

CC @tgravescs @vanzin please help to review, this PR changes the semantics you did previously. Thanks a lot.
