### PR TITLE
[SPARK-20249][ML][PYSPARK] Add summary for LinearSVCModel

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaLinearSVCExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaLinearSVCExample.java
@@ -20,6 +20,7 @@ package org.apache.spark.examples.ml;
 // $example on$
 import org.apache.spark.ml.classification.LinearSVC;
 import org.apache.spark.ml.classification.LinearSVCModel;
+import org.apache.spark.ml.classification.LinearSVCTrainingSummary;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -47,6 +48,15 @@ public class JavaLinearSVCExample {
     // Print the coefficients and intercept for LinearSVC
     System.out.println("Coefficients: "
       + lsvcModel.coefficients() + " Intercept: " + lsvcModel.intercept());
+
+    LinearSVCTrainingSummary trainingSummary = lsvcModel.summary();
+    System.out.println("Total Iteration: " + trainingSummary.totalIterations());
+    // Obtain the objective per iteration.
+    double[] objectiveHistory = trainingSummary.objectiveHistory();
+    System.out.println("objectiveHistory:");
+    for (double lossPerIteration : objectiveHistory) {
+      System.out.println(lossPerIteration);
+    }
     // $example off$
 
     spark.stop();

--- a/examples/src/main/python/ml/linearsvc.py
+++ b/examples/src/main/python/ml/linearsvc.py
@@ -37,10 +37,17 @@ if __name__ == "__main__":
     # Fit the model
     lsvcModel = lsvc.fit(training)
 
-    # Print the coefficients and intercept for linearsSVC
+    # Print the coefficients and intercept for LinearSVC
     print("Coefficients: " + str(lsvcModel.coefficients))
     print("Intercept: " + str(lsvcModel.intercept))
 
+    trainingSummary = lsvcModel.summary
+    print("Total Iteration: " + str(trainingSummary.totalIterations))
+    # Obtain the objective per iteration.
+    objectiveHistory = trainingSummary.objectiveHistory
+    print("objectiveHistory:")
+    for objective in objectiveHistory:
+        print(objective)
     # $example off$
 
     spark.stop()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/LinearSVCExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LinearSVCExample.scala
@@ -44,6 +44,12 @@ object LinearSVCExample {
 
     // Print the coefficients and intercept for linear svc
     println(s"Coefficients: ${lsvcModel.coefficients} Intercept: ${lsvcModel.intercept}")
+    val trainingSummary = lsvcModel.summary
+    println(s"Total Iteration: ${trainingSummary.totalIterations}")
+    // Obtain the objective per iteration.
+    val objectiveHistory = trainingSummary.objectiveHistory
+    println("objectiveHistory:")
+    objectiveHistory.foreach(loss => println(loss))
     // $example off$
 
     spark.stop()

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -172,6 +172,47 @@ class LinearSVCModel(JavaModel, JavaClassificationModel, JavaMLWritable, JavaMLR
         """
         return self._call_java("intercept")
 
+    @property
+    @since("2.2.0")
+    def summary(self):
+        """
+        Gets summary (e.g. objective history, total iterations) of model
+        trained on the training set.
+        """
+
+        java_blrt_summary = self._call_java("summary")
+        return LinearSVCTrainingSummary(java_blrt_summary)
+
+
+@inherit_doc
+class LinearSVCTrainingSummary(JavaWrapper):
+    """
+    .. note:: Experimental
+
+    Abstraction for LinearSVC Training results.
+    Currently, the training summary ignores the training weights except
+    for the objective trace.
+
+    .. versionadded:: 2.2.0
+    """
+
+    @property
+    @since("2.2.0")
+    def objectiveHistory(self):
+        """
+        Objective function (scaled loss + regularization) at each
+        iteration.
+        """
+        return self._call_java("objectiveHistory")
+
+    @property
+    @since("2.2.0")
+    def totalIterations(self):
+        """
+        Number of training iterations until termination.
+        """
+        return self._call_java("totalIterations")
+
 
 @inherit_doc
 class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasMaxIter,

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -174,14 +174,26 @@ class LinearSVCModel(JavaModel, JavaClassificationModel, JavaMLWritable, JavaMLR
 
     @property
     @since("2.2.0")
+    def hasSummary(self):
+        """
+        Indicates whether a training summary exists for this model
+        instance.
+        """
+        return self._call_java("hasSummary")
+
+    @property
+    @since("2.2.0")
     def summary(self):
         """
         Gets summary (e.g. objective history, total iterations) of model
         trained on the training set.
         """
-
-        java_blrt_summary = self._call_java("summary")
-        return LinearSVCTrainingSummary(java_blrt_summary)
+        if self.hasSummary:
+            java_blrt_summary = self._call_java("summary")
+            return LinearSVCTrainingSummary(java_blrt_summary)
+        else:
+            raise RuntimeError("No training summary available for this %s" %
+                               self.__class__.__name__)
 
 
 @inherit_doc
@@ -189,7 +201,7 @@ class LinearSVCTrainingSummary(JavaWrapper):
     """
     .. note:: Experimental
 
-    Abstraction for LinearSVC Training results.
+    Linear SVC Training results.
     Currently, the training summary ignores the training weights except
     for the objective trace.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add summary for `LinearSVCModel` so that user can get the training process status, such as loss value of each iteration and total iteration number. 

## How was this patch tested?

Tested manually in both spark example and pyspark example. 

