### PR TITLE
[SPARK-20280][CORE] FileStatusCache Weigher integer overflow

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
@@ -99,37 +99,39 @@ private class SharedInMemoryCache(maxSizeInBytes: Long) extends Logging {
 
   // we use a composite cache key in order to distinguish entries inserted by different clients
   private val cache: Cache[(ClientId, Path), Array[FileStatus]] = {
-    /* [[Weigher]].weigh returns Int so we could only cache objects < 2GB
-     * instead, the weight is divided by this factor (which is smaller
-     * than the size of one [[FileStatus]]).
-     * so it will support objects up to 64GB in size.
-     */
+    // [[Weigher]].weigh returns Int so we could only cache objects < 2GB
+    // instead, the weight is divided by this factor (which is smaller
+    // than the size of one [[FileStatus]]).
+    // so it will support objects up to 64GB in size.
     val weightScale = 32
+    val weigher = new Weigher[(ClientId, Path), Array[FileStatus]] {
+      override def weigh(key: (ClientId, Path), value: Array[FileStatus]): Int = {
+        val estimate = (SizeEstimator.estimate(key) + SizeEstimator.estimate(value)) / weightScale
+        if (estimate > Int.MaxValue) {
+          logWarning(s"Cached table partition metadata size is too big. Approximating to " +
+            s"${Int.MaxValue.toLong * weightScale}.")
+          Int.MaxValue
+        } else {
+          estimate.toInt
+        }
+      }
+    }
+    val removalListener = new RemovalListener[(ClientId, Path), Array[FileStatus]]() {
+      override def onRemoval(
+          removed: RemovalNotification[(ClientId, Path),
+          Array[FileStatus]]): Unit = {
+        if (removed.getCause == RemovalCause.SIZE &&
+          warnedAboutEviction.compareAndSet(false, true)) {
+          logWarning(
+            "Evicting cached table partition metadata from memory due to size constraints " +
+              "(spark.sql.hive.filesourcePartitionFileCacheSize = "
+              + maxSizeInBytes + " bytes). This may impact query planning performance.")
+        }
+      }
+    }
     CacheBuilder.newBuilder()
-      .weigher(new Weigher[(ClientId, Path), Array[FileStatus]] {
-        override def weigh(key: (ClientId, Path), value: Array[FileStatus]): Int = {
-          val estimate = (SizeEstimator.estimate(key) + SizeEstimator.estimate(value)) / weightScale
-          if (estimate > Int.MaxValue) {
-            logWarning(s"Cached table partition metadata size is too big. Approximating to " +
-              s"${Int.MaxValue.toLong * weightScale}.")
-            Int.MaxValue
-          } else {
-            estimate.toInt
-          }
-        }
-      })
-      .removalListener(new RemovalListener[(ClientId, Path), Array[FileStatus]]() {
-        override def onRemoval(removed: RemovalNotification[(ClientId, Path), Array[FileStatus]])
-        : Unit = {
-          if (removed.getCause == RemovalCause.SIZE &&
-            warnedAboutEviction.compareAndSet(false, true)) {
-            logWarning(
-              "Evicting cached table partition metadata from memory due to size constraints " +
-                "(spark.sql.hive.filesourcePartitionFileCacheSize = "
-                + maxSizeInBytes + " bytes). This may impact query planning performance.")
-          }
-        }
-      })
+      .weigher(weigher)
+      .removalListener(removalListener)
       .maximumWeight(maxSizeInBytes / weightScale)
       .build[(ClientId, Path), Array[FileStatus]]()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -235,17 +235,6 @@ class FileIndexSuite extends SharedSQLContext {
     }
     val fileStatusCache = FileStatusCache.getOrCreate(spark)
     fileStatusCache.putLeafFiles(new Path("/tmp", "abc"), files.toArray)
-    // scalastyle:off
-    /* this would fail with:
-     * [info]   java.lang.IllegalStateException: Weights must be non-negative
-     * [info]   at com.google.common.base.Preconditions.checkState(Preconditions.java:149)
-     * [info]   at com.google.common.cache.LocalCache$Segment.setValue(LocalCache.java:2223)
-     * [info]   at com.google.common.cache.LocalCache$Segment.put(LocalCache.java:2944)
-     * [info]   at com.google.common.cache.LocalCache.put(LocalCache.java:4212)
-     * [info]   at com.google.common.cache.LocalCache$LocalManualCache.put(LocalCache.java:4804)
-     * [info]   at org.apache.spark.sql.execution.datasources.SharedInMemoryCache$$anon$3.putLeafFiles(FileStatusCache.scala:131)
-     */
-    // scalastyle:on
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Weigher.weigh needs to return Int but it is possible for an Array[FileStatus] to have size > Int.maxValue. To avoid this, the size is scaled down by a factor of 32. The maximumWeight of the cache is also scaled down by the same factor. 

## How was this patch tested?
New test in FileIndexSuite
