### PR TITLE
[SPARK-20305][Spark Core]Master may keep in the state of "COMPELETING…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -539,7 +539,7 @@ private[deploy] class Master(
 
   private def completeRecovery() {
     // Ensure "only-once" recovery semantics using a short synchronization period.
-    if (state != RecoveryState.RECOVERING) { return }
+    if (state != RecoveryState.RECOVERING && state != RecoveryState.COMPLETING_RECOVERY) { return }
     state = RecoveryState.COMPLETING_RECOVERY
 
     // Kill off any workers and apps that didn't respond to us.

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -539,28 +539,33 @@ private[deploy] class Master(
 
   private def completeRecovery() {
     // Ensure "only-once" recovery semantics using a short synchronization period.
-    if (state != RecoveryState.RECOVERING && state != RecoveryState.COMPLETING_RECOVERY) { return }
+    if (state != RecoveryState.RECOVERING) { return }
     state = RecoveryState.COMPLETING_RECOVERY
+    try{
+      // Kill off any workers and apps that didn't respond to us.
+      workers.filter(_.state == WorkerState.UNKNOWN).foreach(removeWorker)
+      apps.filter(_.state == ApplicationState.UNKNOWN).foreach(finishApplication)
 
-    // Kill off any workers and apps that didn't respond to us.
-    workers.filter(_.state == WorkerState.UNKNOWN).foreach(removeWorker)
-    apps.filter(_.state == ApplicationState.UNKNOWN).foreach(finishApplication)
-
-    // Reschedule drivers which were not claimed by any workers
-    drivers.filter(_.worker.isEmpty).foreach { d =>
-      logWarning(s"Driver ${d.id} was not found after master recovery")
-      if (d.desc.supervise) {
-        logWarning(s"Re-launching ${d.id}")
-        relaunchDriver(d)
-      } else {
-        removeDriver(d.id, DriverState.ERROR, None)
-        logWarning(s"Did not re-launch ${d.id} because it was not supervised")
+      // Reschedule drivers which were not claimed by any workers
+      drivers.filter(_.worker.isEmpty).foreach { d =>
+        logWarning(s"Driver ${d.id} was not found after master recovery")
+        if (d.desc.supervise) {
+          logWarning(s"Re-launching ${d.id}")
+          relaunchDriver(d)
+        } else {
+          removeDriver(d.id, DriverState.ERROR, None)
+          logWarning(s"Did not re-launch ${d.id} because it was not supervised")
+        }
       }
-    }
 
-    state = RecoveryState.ALIVE
-    schedule()
-    logInfo("Recovery complete - resuming operations!")
+      state = RecoveryState.ALIVE
+      schedule()
+      logInfo("Recovery complete - resuming operations!")
+    } catch {
+      case e: Throwable =>
+        logError("Shutting down Master for the exception during recovery", e)
+        rpcEnv.shutdown()
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Master may keep in the state of "COMPELETING_RECOVERY",then all the application registered cannot get resources, when the leader master change.
This happend when a exception was thrown during the Master trying to recovery(completeRecovery method in the master.scala  ). Then the leader will always in COMPLETING_RECOVERY state ,for the leader can only change to alive from state of RecoveryState.RECOVERING.

## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
