### PR TITLE
[SPARK-20315] [SQL] Set ScalaUDF's deterministic to true 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkException
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.types.DataType
@@ -44,6 +45,14 @@ case class ScalaUDF(
     inputTypes: Seq[DataType] = Nil,
     udfName: Option[String] = None)
   extends Expression with ImplicitCastInputTypes with NonSQLExpression {
+
+  // the user-defined functions must be deterministic.
+  if (!super.deterministic) {
+    val name = udfName.getOrElse("")
+    throw new AnalysisException(s"User-defined functions must be deterministic. Name: $name.")
+  }
+
+  final override def deterministic: Boolean = true
 
   override def nullable: Boolean = true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -47,11 +47,6 @@ case class ScalaUDF(
   extends Expression with ImplicitCastInputTypes with NonSQLExpression {
 
   // the user-defined functions must be deterministic.
-  if (!super.deterministic) {
-    val name = udfName.getOrElse("")
-    throw new AnalysisException(s"User-defined functions must be deterministic. Name: $name.")
-  }
-
   final override def deterministic: Boolean = true
 
   override def nullable: Boolean = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.types.DataType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.expressions
 import java.util.Locale
 
 import org.apache.spark.{SparkException, SparkFunSuite}
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -31,13 +30,6 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     val stringUdf = ScalaUDF((s: String) => s + "x", StringType, Literal("a") :: Nil)
     checkEvaluation(stringUdf, "ax")
-  }
-
-  test("non-deterministic children") {
-    val e = intercept[AnalysisException] {
-      ScalaUDF((i: Int) => i + 1, IntegerType, Rand(1) :: Nil, Nil, Some("udf"))
-    }.getMessage
-    assert(e.contains("User-defined functions must be deterministic. Name: udf."))
   }
 
   test("better error message for NPE") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import java.util.Locale
 
 import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -30,6 +31,13 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     val stringUdf = ScalaUDF((s: String) => s + "x", StringType, Literal("a") :: Nil)
     checkEvaluation(stringUdf, "ax")
+  }
+
+  test("non-deterministic children") {
+    val e = intercept[AnalysisException] {
+      ScalaUDF((i: Int) => i + 1, IntegerType, Rand(1) :: Nil, Nil, Some("udf"))
+    }.getMessage
+    assert(e.contains("User-defined functions must be deterministic. Name: udf."))
   }
 
   test("better error message for NPE") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
ScalaUDF is always assumed to deterministic, based on the previous discussion in https://github.com/apache/spark/pull/13087. However, the current master still sets it based on the children's deterministic values. 

This PR is to correct it by always setting it to true, even if the children's deterministic values are not true.

### How was this patch tested?
Added a test case.