### PR TITLE
[SPARK-17608][SPARKR]:Long type has incorrect serialization/deserialization

### DIFF
--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -55,6 +55,7 @@ readTypedObject <- function(con, type) {
     "l" = readList(con),
     "e" = readEnv(con),
     "s" = readStruct(con),
+    "B" = readDouble(con),
     "n" = NULL,
     "j" = getJobj(readString(con)),
     stop(paste("Unsupported type for deserialization", type)))

--- a/R/pkg/R/serialize.R
+++ b/R/pkg/R/serialize.R
@@ -83,6 +83,7 @@ writeObject <- function(con, object, writeType = TRUE) {
          Date = writeDate(con, object),
          POSIXlt = writeTime(con, object),
          POSIXct = writeTime(con, object),
+         bigint = writeDouble(con, object),
          stop(paste("Unsupported type for serialization", type)))
 }
 
@@ -157,6 +158,7 @@ writeType <- function(con, class) {
                  Date = "D",
                  POSIXlt = "t",
                  POSIXct = "t",
+                 bigint = "B",
                  stop(paste("Unsupported type for serialization", class)))
   writeBin(charToRaw(type), con)
 }

--- a/R/pkg/inst/tests/testthat/test_Serde.R
+++ b/R/pkg/inst/tests/testthat/test_Serde.R
@@ -28,6 +28,10 @@ test_that("SerDe of primitive types", {
   expect_equal(x, 1)
   expect_equal(class(x), "numeric")
 
+  x <- callJStatic("SparkRHandler", "echo", 1380742793415240)
+  expect_equal(x, 1380742793415240)
+  expect_equal(class(x), "numeric")
+
   x <- callJStatic("SparkRHandler", "echo", TRUE)
   expect_true(x)
   expect_equal(class(x), "logical")
@@ -42,6 +46,11 @@ test_that("SerDe of list of primitive types", {
   y <- callJStatic("SparkRHandler", "echo", x)
   expect_equal(x, y)
   expect_equal(class(y[[1]]), "integer")
+
+  x <- list(1380742793415240, 13807427934152401, 13807427934152402)
+  y <- callJStatic("SparkRHandler", "echo", x)
+  expect_equal(x, y)
+  expect_equal(class(y[[1]]), "numeric")
 
   x <- list(1, 2, 3)
   y <- callJStatic("SparkRHandler", "echo", x)
@@ -66,7 +75,8 @@ test_that("SerDe of list of primitive types", {
 
 test_that("SerDe of list of lists", {
   x <- list(list(1L, 2L, 3L), list(1, 2, 3),
-            list(TRUE, FALSE), list("a", "b", "c"))
+            list(TRUE, FALSE), list("a", "b", "c"),
+            list(1380742793415240, 1380742793415240))
   y <- callJStatic("SparkRHandler", "echo", x)
   expect_equal(x, y)
 

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -3202,8 +3202,7 @@ test_that("dapply with bigint type", {
          },
          schema)
   result <- collect(df1)
-  resultString <- sprintf("%.10f", result$a[1])
-  expect_equal(resultString, "1380742793415240.0000000000")
+  expect_equal(result$a[1], 1380742793415240)
 })
 
 test_that("catalog APIs, listTables, listColumns, listFunctions", {

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -3188,6 +3188,24 @@ test_that("catalog APIs, currentDatabase, setCurrentDatabase, listDatabases", {
   expect_equal(dbs[[1]], "default")
 })
 
+test_that("dapply with bigint type", {
+  df <- createDataFrame(
+        list(list(1380742793415240, 1, "1"), list(1380742793415240, 2, "2"),
+        list(1380742793415240, 3, "3")), c("a", "b", "c"))
+  schema <- structType(structField("a", "bigint"), structField("b", "bigint"),
+                       structField("c", "string"), structField("d", "bigint"))
+  df1 <- dapply(
+         df,
+         function(x) {
+           y <- x[x[1] > 1, ]
+           y <- cbind(y, y[1] + 1L)
+         },
+         schema)
+  result <- collect(df1)
+  resultString <- sprintf("%.10f", result$a[1])
+  expect_equal(resultString, "1380742793415240.0000000000")
+})
+
 test_that("catalog APIs, listTables, listColumns, listFunctions", {
   tb <- listTables()
   count <- count(tables())

--- a/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
@@ -84,6 +84,7 @@ private[spark] object SerDe {
       case 'l' => readList(dis, jvmObjectTracker)
       case 'D' => readDate(dis)
       case 't' => readTime(dis)
+      case 'B' => new java.lang.Double(readDouble(dis))
       case 'j' => jvmObjectTracker(JVMObjectId(readString(dis)))
       case _ =>
         if (sqlReadObject == null) {
@@ -198,6 +199,7 @@ private[spark] object SerDe {
       case 'b' => readBooleanArr(dis)
       case 'j' => readStringArr(dis).map(x => jvmObjectTracker(JVMObjectId(x)))
       case 'r' => readBytesArr(dis)
+      case 'B' => readDoubleArr(dis)
       case 'a' =>
         val len = readInt(dis)
         (0 until len).map(_ => readArray(dis, jvmObjectTracker)).toArray
@@ -278,6 +280,7 @@ private[spark] object SerDe {
       case "list" => dos.writeByte('l')
       case "map" => dos.writeByte('e')
       case "jobj" => dos.writeByte('j')
+      case "bigint" => dos.writeByte('B')
       case _ => throw new IllegalArgumentException(s"Invalid type $typeStr")
     }
   }

--- a/core/src/test/scala/org/apache/spark/api/r/RBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/r/RBackendSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.api.r
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+
 import org.apache.spark.SparkFunSuite
 
 class RBackendSuite extends SparkFunSuite {
@@ -27,5 +29,22 @@ class RBackendSuite extends SparkFunSuite {
     backend.close()
     assert(tracker.get(id) === None)
     assert(tracker.size === 0)
+  }
+
+  test("read and write bigint in the buffer") {
+    val bos = new ByteArrayOutputStream()
+    val dos = new DataOutputStream(bos)
+    val tracker = new JVMObjectTracker
+    SerDe.writeObject(dos, 1380742793415240L.asInstanceOf[Object],
+      tracker)
+    val buf = bos.toByteArray
+    val bis = new ByteArrayInputStream(buf)
+    val dis = new DataInputStream(bis)
+    val data = SerDe.readObject(dis, tracker)
+    assert(data.asInstanceOf[Double] === 1380742793415240L)
+    bos.close()
+    bis.close()
+    dos.close()
+    dis.close()
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`bigint` is not supported in schema and the serialization is not `Double`.

Add `bigint` support in schema and serialized and deserialized as `Double`.

This fix is orthogonal to the precision problem in 
https://issues.apache.org/jira/browse/SPARK-12360  

## How was this patch tested?

Add a new unit test.