### PR TITLE
[SPARK-20348] [ML] Support squared hinge loss (L2 loss) for LinearSVC

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification
 
+import java.util.Locale
+
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector => BDV}
@@ -42,7 +44,26 @@ import org.apache.spark.sql.functions.{col, lit}
 /** Params for linear SVM Classifier. */
 private[classification] trait LinearSVCParams extends ClassifierParams with HasRegParam
   with HasMaxIter with HasFitIntercept with HasTol with HasStandardization with HasWeightCol
-  with HasThreshold with HasAggregationDepth
+  with HasThreshold with HasAggregationDepth {
+
+  /**
+   * Specifies the loss function. Currently "hinge" and "squared_hinge" are supported.
+   * "hinge" is the standard SVM loss (a.k.a. L1 loss) while "squared_hinge" is the square of
+   * the hinge loss (a.k.a. L2 loss).
+   *
+   * @see <a href="https://en.wikipedia.org/wiki/Hinge_loss">Hinge loss (Wikipedia)</a>
+   *
+   * @group param
+   */
+  @Since("2.3.0")
+  final val lossFunction: Param[String] = new Param(this, "lossFunction", "Specifies the loss " +
+    "function. hinge is the standard SVM loss while squared_hinge is the square of the hinge loss.",
+    (s: String) => LinearSVC.supportedLoss.contains(s.toLowerCase(Locale.ROOT)))
+
+  /** @group getParam */
+  @Since("2.3.0")
+  def getLossFunction: String = $(lossFunction)
+}
 
 /**
  * :: Experimental ::
@@ -50,7 +71,8 @@ private[classification] trait LinearSVCParams extends ClassifierParams with HasR
  * <a href = "https://en.wikipedia.org/wiki/Support_vector_machine#Linear_SVM">
  *   Linear SVM Classifier</a>
  *
- * This binary classifier optimizes the Hinge Loss using the OWLQN optimizer.
+ * This binary classifier optimizes the Hinge Loss (or Squared Hinge Loss) using the
+ * OWLQN optimizer.
  *
  */
 @Since("2.2.0")
@@ -62,6 +84,15 @@ class LinearSVC @Since("2.2.0") (
 
   @Since("2.2.0")
   def this() = this(Identifiable.randomUID("linearsvc"))
+
+  /**
+   * Set the loss function. Default is "hinge".
+   *
+   * @group setParam
+   */
+  @Since("2.3.0")
+  def setLossFunction(value: String): this.type = set(lossFunction, value)
+  setDefault(lossFunction -> "hinge")
 
   /**
    * Set the regularization parameter.
@@ -202,8 +233,8 @@ class LinearSVC @Since("2.2.0") (
       val featuresStd = summarizer.variance.toArray.map(math.sqrt)
       val regParamL2 = $(regParam)
       val bcFeaturesStd = instances.context.broadcast(featuresStd)
-      val costFun = new LinearSVCCostFun(instances, $(fitIntercept),
-        $(standardization), bcFeaturesStd, regParamL2, $(aggregationDepth))
+      val costFun = new LinearSVCCostFun(instances, $(fitIntercept), $(standardization),
+        bcFeaturesStd, regParamL2, $(aggregationDepth), $(lossFunction)toLowerCase(Locale.ROOT))
 
       def regParamL1Fun = (index: Int) => 0D
       val optimizer = new BreezeOWLQN[Int, BDV[Double]]($(maxIter), 10, regParamL1Fun, $(tol))
@@ -260,6 +291,8 @@ object LinearSVC extends DefaultParamsReadable[LinearSVC] {
 
   @Since("2.2.0")
   override def load(path: String): LinearSVC = super.load(path)
+
+  private[classification] val supportedLoss = Array("hinge", "squared_hinge")
 }
 
 /**
@@ -355,7 +388,8 @@ object LinearSVCModel extends MLReadable[LinearSVCModel] {
 }
 
 /**
- * LinearSVCCostFun implements Breeze's DiffFunction[T] for hinge loss function
+ * LinearSVCCostFun implements Breeze's DiffFunction[T] for loss function ("hinge" or
+ * "squared_hinge").
  */
 private class LinearSVCCostFun(
     instances: RDD[Instance],
@@ -363,7 +397,8 @@ private class LinearSVCCostFun(
     standardization: Boolean,
     bcFeaturesStd: Broadcast[Array[Double]],
     regParamL2: Double,
-    aggregationDepth: Int) extends DiffFunction[BDV[Double]] {
+    aggregationDepth: Int,
+    lossFunction: String) extends DiffFunction[BDV[Double]] {
 
   override def calculate(coefficients: BDV[Double]): (Double, BDV[Double]) = {
     val coeffs = Vectors.fromBreeze(coefficients)
@@ -376,7 +411,7 @@ private class LinearSVCCostFun(
       val combOp = (c1: LinearSVCAggregator, c2: LinearSVCAggregator) => c1.merge(c2)
 
       instances.treeAggregate(
-        new LinearSVCAggregator(bcCoeffs, bcFeaturesStd, fitIntercept)
+        new LinearSVCAggregator(bcCoeffs, bcFeaturesStd, fitIntercept, lossFunction)
       )(seqOp, combOp, aggregationDepth)
     }
 
@@ -421,8 +456,9 @@ private class LinearSVCCostFun(
 }
 
 /**
- * LinearSVCAggregator computes the gradient and loss for hinge loss function, as used
- * in binary classification for instances in sparse or dense vector in an online fashion.
+ * LinearSVCAggregator computes the gradient and loss for loss function ("hinge" or
+ * "squared_hinge"), as used in binary classification for instances in sparse or dense vector
+ * in an online fashion.
  *
  * Two LinearSVCAggregator can be merged together to have a summary of loss and gradient of
  * the corresponding joint dataset.
@@ -436,7 +472,8 @@ private class LinearSVCCostFun(
 private class LinearSVCAggregator(
     bcCoefficients: Broadcast[Vector],
     bcFeaturesStd: Broadcast[Array[Double]],
-    fitIntercept: Boolean) extends Serializable {
+    fitIntercept: Boolean,
+    lossFunction: String) extends Serializable {
 
   private val numFeatures: Int = bcFeaturesStd.value.length
   private val numFeaturesPlusIntercept: Int = if (fitIntercept) numFeatures + 1 else numFeatures
@@ -477,16 +514,26 @@ private class LinearSVCAggregator(
         sum
       }
       // Our loss function with {0, 1} labels is max(0, 1 - (2y - 1) (f_w(x)))
-      // Therefore the gradient is -(2y - 1)*x
       val labelScaled = 2 * label - 1.0
       val loss = if (1.0 > labelScaled * dotProduct) {
-        weight * (1.0 - labelScaled * dotProduct)
+        val hingeLoss = 1.0 - labelScaled * dotProduct
+        lossFunction match {
+          case "hinge" => hingeLoss * weight
+          case "squared_hinge" => hingeLoss * hingeLoss * weight
+          case unexpected => throw new SparkException(
+            s"unexpected lossFunction in LinearSVCAggregator: $unexpected")
+        }
       } else {
         0.0
       }
 
       if (1.0 > labelScaled * dotProduct) {
-        val gradientScale = -labelScaled * weight
+        val gradientScale = lossFunction match {
+          case "hinge" => -labelScaled * weight
+          case "squared_hinge" => (labelScaled * dotProduct - 1) * labelScaled * 2
+          case unexpected => throw new SparkException(
+            s"unexpected lossFunction in LinearSVCAggregator: $unexpected")
+        }
         features.foreachActive { (index, value) =>
           if (localFeaturesStd(index) != 0.0 && value != 0.0) {
             localGradientSumArray(index) += value * gradientScale / localFeaturesStd(index)


### PR DESCRIPTION
## What changes were proposed in this pull request?

While Hinge loss is the standard loss function for linear SVM, Squared hinge loss (a.k.a. L2 loss) is also popular in practice. L2-SVM is differentiable and imposes a bigger (quadratic vs. linear) loss for points which violate the margin. Some introduction can be found from http://mccormickml.com/2015/01/06/what-is-an-l2-svm/

Liblinear and scikit learn both offer squared hinge loss as the default loss function for linear SVM.

## How was this patch tested?

strengthen existing unit test and add new unit test for comparison.
