### PR TITLE
[SPARK-20156] [SQL] [FOLLOW-UP] Java String toLowerCase "Turkish locale bug" in Database and Table DDLs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableValuedFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableValuedFunctions.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import java.util.Locale
+
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Range}
 import org.apache.spark.sql.catalyst.rules._
@@ -103,7 +105,7 @@ object ResolveTableValuedFunctions extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case u: UnresolvedTableValuedFunction if u.functionArgs.forall(_.resolved) =>
-      builtinFunctions.get(u.functionName.toLowerCase()) match {
+      builtinFunctions.get(u.functionName.toLowerCase(Locale.ROOT)) match {
         case Some(tvf) =>
           val resolved = tvf.flatMap { case (argList, resolver) =>
             argList.implicitCast(u.functionArgs) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -114,14 +114,14 @@ class SessionCatalog(
    * Format table name, taking into account case sensitivity.
    */
   protected[this] def formatTableName(name: String): String = {
-    if (conf.caseSensitiveAnalysis) name else name.toLowerCase
+    if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
   }
 
   /**
    * Format database name, taking into account case sensitivity.
    */
   protected[this] def formatDatabaseName(name: String): String = {
-    if (conf.caseSensitiveAnalysis) name else name.toLowerCase
+    if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.internal
 
+import java.util.Locale
+
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
@@ -114,7 +116,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
     // System preserved database should not exists in metastore. However it's hard to guarantee it
     // for every session, because case-sensitivity differs. Here we always lowercase it to make our
     // life easier.
-    val globalTempDB = sparkContext.conf.get(GLOBAL_TEMP_DATABASE).toLowerCase
+    val globalTempDB = sparkContext.conf.get(GLOBAL_TEMP_DATABASE).toLowerCase(Locale.ROOT)
     if (externalCatalog.databaseExists(globalTempDB)) {
       throw new SparkException(
         s"$globalTempDB is a system preserved database, please rename your existing database " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2297,21 +2297,23 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     }
 
     test(s"basic DDL using locale tr - caseSensitive $caseSensitive") {
-      withLocale("tr") {
-        val dbName = "DaTaBaSeI"
-        withDatabase(dbName) {
-          sql(s"CREATE DATABASE $dbName")
-          sql(s"USE $dbName")
+      withSQLConf(SQLConf.CASE_SENSITIVE.key -> s"$caseSensitive") {
+        withLocale("tr") {
+          val dbName = "DaTaBaSeI"
+          withDatabase(dbName) {
+            sql(s"CREATE DATABASE $dbName")
+            sql(s"USE $dbName")
 
-          val tabName = "tAbI"
-          withTable(tabName) {
-            sql(s"CREATE TABLE $tabName(c1 int) USING PARQUET")
-            sql(s"INSERT OVERWRITE TABLE $tabName SELECT 1")
-            checkAnswer(sql(s"SELECT c1 FROM $tabName"), Row(1) :: Nil)
-            sql(s"DROP TABLE $tabName")
+            val tabName = "tAbI"
+            withTable(tabName) {
+              sql(s"CREATE TABLE $tabName(c1 int) USING PARQUET")
+              sql(s"INSERT OVERWRITE TABLE $tabName SELECT 1")
+              checkAnswer(sql(s"SELECT c1 FROM $tabName"), Row(1) :: Nil)
+              sql(s"DROP TABLE $tabName")
+            }
+
+            sql(s"DROP DATABASE $dbName")
           }
-
-          sql(s"DROP DATABASE $dbName")
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2295,5 +2295,25 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
         }
       }
     }
+
+    test(s"basic DDL using locale tr - caseSensitive $caseSensitive") {
+      withLocale("tr") {
+        val dbName = "DaTaBaSeI"
+        withDatabase(dbName) {
+          sql(s"CREATE DATABASE $dbName")
+          sql(s"USE $dbName")
+
+          val tabName = "tAbI"
+          withTable(tabName) {
+            sql(s"CREATE TABLE $tabName(c1 int) USING PARQUET")
+            sql(s"INSERT OVERWRITE TABLE $tabName SELECT 1")
+            checkAnswer(sql(s"SELECT c1 FROM $tabName"), Row(1) :: Nil)
+            sql(s"DROP TABLE $tabName")
+          }
+
+          sql(s"DROP DATABASE $dbName")
+        }
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2299,20 +2299,17 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     test(s"basic DDL using locale tr - caseSensitive $caseSensitive") {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> s"$caseSensitive") {
         withLocale("tr") {
-          val dbName = "DaTaBaSeI"
+          val dbName = "DaTaBaSe_I"
           withDatabase(dbName) {
             sql(s"CREATE DATABASE $dbName")
             sql(s"USE $dbName")
 
-            val tabName = "tAbI"
+            val tabName = "tAb_I"
             withTable(tabName) {
-              sql(s"CREATE TABLE $tabName(c1 int) USING PARQUET")
+              sql(s"CREATE TABLE $tabName(col_I int) USING PARQUET")
               sql(s"INSERT OVERWRITE TABLE $tabName SELECT 1")
-              checkAnswer(sql(s"SELECT c1 FROM $tabName"), Row(1) :: Nil)
-              sql(s"DROP TABLE $tabName")
+              checkAnswer(sql(s"SELECT col_I FROM $tabName"), Row(1) :: Nil)
             }
-
-            sql(s"DROP DATABASE $dbName")
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.test
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
-import java.util.UUID
+import java.util.{Locale, UUID}
 
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
@@ -225,6 +225,32 @@ private[sql] trait SQLTestUtils
         spark.sql(s"USE ${DEFAULT_DATABASE}")
       }
       spark.sql(s"DROP DATABASE $dbName CASCADE")
+    }
+  }
+
+  /**
+   * Drops database `dbName` after calling `f`.
+   */
+  protected def withDatabase(dbNames: String*)(f: => Unit): Unit = {
+    try f finally {
+      dbNames.foreach { name =>
+        spark.sql(s"DROP DATABASE IF EXISTS $name")
+      }
+    }
+  }
+
+  /**
+   * Enables Locale `language` before executing `f`, then switches back to the default locale of JVM
+   * after `f` returns.
+   */
+  protected def withLocale(language: String)(f: => Unit): Unit = {
+    val originalLocale = Locale.getDefault
+    try {
+      // Add Locale setting
+      Locale.setDefault(new Locale(language))
+      f
+    } finally {
+      Locale.setDefault(originalLocale)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Database and Table names conform the Hive standard ("[a-zA-z_0-9]+"), i.e. if this name only contains characters, numbers, and _. 

When calling `toLowerCase` on the names, we should add `Locale.ROOT` to the `toLowerCase`for avoiding inadvertent locale-sensitive variation in behavior (aka the "Turkish locale problem").

### How was this patch tested?
Added a test case