### PR TITLE
[SPARK-20360][PYTHON] reprs for interpreters

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -249,15 +249,21 @@ class SparkContext(object):
     def _repr_html_(self):
         return """
         <div>
-            <p><b>Spark Context</b></p>
-            <ul>
-                <li>Spark <code>v{spark_version}</code></li>
-                <li><a href="{spark_ui_url}">Spark UI</a></li>
-            </ul>
+            <p><b>SparkContext</b></p>
+
+            <p><a href="{sc.uiWebUrl}">Spark UI</a></p>
+
+            <dl>
+              <dt>Version</dt>
+                <dd><code>v{sc.version}</code></dd>
+              <dt>Master</dt>
+                <dd><code>{sc.master}</code></dd>
+              <dt>AppName</dt>
+                <dd><code>{sc.appName}</code></dd>
+            </dl>
         </div>
         """.format(
-            spark_version=self.version,
-            spark_ui_url=self.uiWebUrl,
+            sc=self
         )
 
     def _initialize_context(self, jconf):

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -240,6 +240,20 @@ class SparkContext(object):
         if isinstance(threading.current_thread(), threading._MainThread):
             signal.signal(signal.SIGINT, signal_handler)
 
+    def _repr_html_(self):
+        return """
+        <div>
+            <p><b>Spark Context</b></p>
+            <ul>
+                <li>Spark <code>v{spark_version}</code></li>
+                <li><a href="{spark_ui_url}">Spark UI</a></li>
+            </ul>
+        </div>
+        """.format(
+            spark_version=self.version,
+            spark_ui_url=self.uiWebUrl,
+        )
+
     def _initialize_context(self, jconf):
         """
         Initialize SparkContext in function to allow subclass specific initialization

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -240,6 +240,12 @@ class SparkContext(object):
         if isinstance(threading.current_thread(), threading._MainThread):
             signal.signal(signal.SIGINT, signal_handler)
 
+    def __repr__(self):
+        return "<SparkContext master={master} appName={appName}>".format(
+            master=self.master,
+            appName=self.appName,
+        )
+
     def _repr_html_(self):
         return """
         <div>

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -221,6 +221,9 @@ class SparkSession(object):
                 or SparkSession._instantiatedSession._sc._jsc is None:
             SparkSession._instantiatedSession = self
 
+    def _repr_html_(self):
+        return self.sparkContext._repr_html_()
+
     @since(2.0)
     def newSession(self):
         """

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -222,7 +222,15 @@ class SparkSession(object):
             SparkSession._instantiatedSession = self
 
     def _repr_html_(self):
-        return self.sparkContext._repr_html_()
+        return """
+            <div>
+                <p><b>SparkSession - {catalogImplementation}</b></p>
+                {sc_HTML}
+            </div>
+        """.format(
+            catalogImplementation=self.conf.get("spark.sql.catalogImplementation"),
+            sc_HTML=self.sparkContext._repr_html_()
+        )
 
     @since(2.0)
     def newSession(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Establishes a very minimal `_repr_html_` for PySpark's `SparkContext`.

## How was this patch tested?

nteract:

![screen shot 2017-04-17 at 3 41 29 pm](https://cloud.githubusercontent.com/assets/836375/25107701/d57090ba-2385-11e7-8147-74bc2c50a41b.png)

Jupyter:

![screen shot 2017-04-17 at 3 53 19 pm](https://cloud.githubusercontent.com/assets/836375/25107725/05bf1fe8-2386-11e7-93e1-07a20c917dde.png)

Hydrogen:

![screen shot 2017-04-17 at 3 49 55 pm](https://cloud.githubusercontent.com/assets/836375/25107664/a75e1ddc-2385-11e7-8477-258661833007.png)