### PR TITLE
[SPARK-20311][SQL] Support aliases for table value functions

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -472,15 +472,19 @@ identifierComment
     ;
 
 relationPrimary
-    : tableIdentifier sample? (AS? strictIdentifier)?                                        #tableName
-    | '(' queryNoWith ')' sample? (AS? strictIdentifier)?                                    #aliasedQuery
-    | '(' relation ')' sample? (AS? strictIdentifier)?                                       #aliasedRelation
-    | inlineTable                                                                            #inlineTableDefault2
-    | identifier '(' (expression (',' expression)*)? ')' (AS? identifier identifierList?)?   #tableValuedFunction
+    : tableIdentifier sample? (AS? strictIdentifier)?                 #tableName
+    | '(' queryNoWith ')' sample? (AS? strictIdentifier)?             #aliasedQuery
+    | '(' relation ')' sample? (AS? strictIdentifier)?                #aliasedRelation
+    | inlineTable                                                     #inlineTableDefault2
+    | identifier '(' (expression (',' expression)*)? ')' tableAlias   #tableValuedFunction
     ;
 
 inlineTable
-    : VALUES expression (',' expression)*  (AS? identifier identifierList?)?
+    : VALUES expression (',' expression)*  tableAlias
+    ;
+
+tableAlias
+    : (AS? identifier identifierList?)?
     ;
 
 rowFormat

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -472,15 +472,19 @@ identifierComment
     ;
 
 relationPrimary
-    : tableIdentifier sample? (AS? strictIdentifier)?                 #tableName
-    | '(' queryNoWith ')' sample? (AS? strictIdentifier)?             #aliasedQuery
-    | '(' relation ')' sample? (AS? strictIdentifier)?                #aliasedRelation
-    | inlineTable                                                     #inlineTableDefault2
-    | identifier '(' (expression (',' expression)*)? ')' tableAlias   #tableValuedFunction
+    : tableIdentifier sample? (AS? strictIdentifier)?      #tableName
+    | '(' queryNoWith ')' sample? (AS? strictIdentifier)?  #aliasedQuery
+    | '(' relation ')' sample? (AS? strictIdentifier)?     #aliasedRelation
+    | inlineTable                                          #inlineTableDefault2
+    | functionTable                                        #tableValuedFunction
     ;
 
 inlineTable
     : VALUES expression (',' expression)*  tableAlias
+    ;
+
+functionTable
+    : identifier '(' (expression (',' expression)*)? ')' tableAlias
     ;
 
 tableAlias

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -472,11 +472,11 @@ identifierComment
     ;
 
 relationPrimary
-    : tableIdentifier sample? (AS? strictIdentifier)?               #tableName
-    | '(' queryNoWith ')' sample? (AS? strictIdentifier)?           #aliasedQuery
-    | '(' relation ')' sample? (AS? strictIdentifier)?              #aliasedRelation
-    | inlineTable                                                   #inlineTableDefault2
-    | identifier '(' (expression (',' expression)*)? ')'            #tableValuedFunction
+    : tableIdentifier sample? (AS? strictIdentifier)?                                        #tableName
+    | '(' queryNoWith ')' sample? (AS? strictIdentifier)?                                    #aliasedQuery
+    | '(' relation ')' sample? (AS? strictIdentifier)?                                       #aliasedRelation
+    | inlineTable                                                                            #inlineTableDefault2
+    | identifier '(' (expression (',' expression)*)? ')' (AS? identifier identifierList?)?   #tableValuedFunction
     ;
 
 inlineTable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -69,7 +69,10 @@ case class UnresolvedInlineTable(
  *   select * from range(10);
  * }}}
  */
-case class UnresolvedTableValuedFunction(functionName: String, functionArgs: Seq[Expression])
+case class UnresolvedTableValuedFunction(
+    functionName: String,
+    functionArgs: Seq[Expression],
+    outputNames: Seq[String])
   extends LeafNode {
 
   override def output: Seq[Attribute] = Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -66,7 +66,10 @@ case class UnresolvedInlineTable(
 /**
  * A table-valued function, e.g.
  * {{{
- *   select * from range(10);
+ *   select id from range(10);
+ *
+ *   // Assign alias names
+ *   select t.a from range(10) t(a);
  * }}}
  */
 case class UnresolvedTableValuedFunction(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -687,15 +687,16 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
    */
   override def visitTableValuedFunction(ctx: TableValuedFunctionContext)
       : LogicalPlan = withOrigin(ctx) {
-    val aliases = if (ctx.tableAlias.identifierList != null) {
-      visitIdentifierList(ctx.tableAlias.identifierList)
+    val func = ctx.functionTable
+    val aliases = if (func.tableAlias.identifierList != null) {
+      visitIdentifierList(func.tableAlias.identifierList)
     } else {
       Seq.empty
     }
 
     val tvf = UnresolvedTableValuedFunction(
-      ctx.identifier.getText, ctx.expression.asScala.map(expression), aliases)
-    tvf.optionalMap(ctx.tableAlias.identifier)(aliasPlan)
+      func.identifier.getText, func.expression.asScala.map(expression), aliases)
+    tvf.optionalMap(func.tableAlias.identifier)(aliasPlan)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -498,12 +498,16 @@ case class Sort(
 
 /** Factory for constructing new `Range` nodes. */
 object Range {
-  def apply(start: Long, end: Long, step: Long, numSlices: Option[Int]): Range = {
-    val output = StructType(StructField("id", LongType, nullable = false) :: Nil).toAttributes
+
+  def apply(start: Long, end: Long, step: Long, numSlices: Option[Int], outputName: Option[String])
+    : Range = {
+    val name = outputName.getOrElse("id")
+    val output = StructType(StructField(name, LongType, nullable = false) :: Nil).toAttributes
     new Range(start, end, step, numSlices, output)
   }
+
   def apply(start: Long, end: Long, step: Long, numSlices: Int): Range = {
-    Range(start, end, step, Some(numSlices))
+    Range(start, end, step, Some(numSlices), None)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -498,16 +498,12 @@ case class Sort(
 
 /** Factory for constructing new `Range` nodes. */
 object Range {
-
-  def apply(start: Long, end: Long, step: Long, numSlices: Option[Int], outputName: Option[String])
-    : Range = {
-    val name = outputName.getOrElse("id")
-    val output = StructType(StructField(name, LongType, nullable = false) :: Nil).toAttributes
+  def apply(start: Long, end: Long, step: Long, numSlices: Option[Int]): Range = {
+    val output = StructType(StructField("id", LongType, nullable = false) :: Nil).toAttributes
     new Range(start, end, step, numSlices, output)
   }
-
   def apply(start: Long, end: Long, step: Long, numSlices: Int): Range = {
-    Range(start, end, step, Some(numSlices), None)
+    Range(start, end, step, Some(numSlices))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -442,13 +442,15 @@ class AnalysisSuite extends AnalysisTest with ShouldMatchers {
   }
 
   test("SPARK-20311 range(N) as alias") {
-    def rangeWithAliases(outputNames: Seq[String]): LogicalPlan = {
-      SubqueryAlias("t", UnresolvedTableValuedFunction("range", Literal(7) :: Nil, outputNames))
+    def rangeWithAliases(args: Seq[Int], outputNames: Seq[String]): LogicalPlan = {
+      SubqueryAlias("t", UnresolvedTableValuedFunction("range", args.map(Literal(_)), outputNames))
         .select(star())
     }
-    assertAnalysisSuccess(rangeWithAliases("a" :: Nil))
+    assertAnalysisSuccess(rangeWithAliases(3 :: Nil, "a" :: Nil))
+    assertAnalysisSuccess(rangeWithAliases(1 :: 4 :: Nil, "b" :: Nil))
+    assertAnalysisSuccess(rangeWithAliases(2 :: 6 :: 2 :: Nil, "c" :: Nil))
     assertAnalysisError(
-      rangeWithAliases("a" :: "b" :: Nil),
+      rangeWithAliases(3 :: Nil, "a" :: "b" :: Nil),
       Seq("expected 1 columns but found 2 columns"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.Cross
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types._
@@ -440,5 +439,16 @@ class AnalysisSuite extends AnalysisTest with ShouldMatchers {
       caseSensitive = false)
 
     checkAnalysis(SubqueryAlias("tbl", testRelation).as("tbl2"), testRelation)
+  }
+
+  test("SPARK-20311 range(N) as alias") {
+    def rangeWithAliases(outputNames: Seq[String]): LogicalPlan = {
+      SubqueryAlias("t", UnresolvedTableValuedFunction("range", Literal(7) :: Nil, outputNames))
+        .select(star())
+    }
+    assertAnalysisSuccess(rangeWithAliases("a" :: Nil))
+    assertAnalysisError(
+      rangeWithAliases("a" :: "b" :: Nil),
+      Seq("expected 1 columns but found 2 columns"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -468,7 +468,18 @@ class PlanParserSuite extends PlanTest {
   test("table valued function") {
     assertEqual(
       "select * from range(2)",
-      UnresolvedTableValuedFunction("range", Literal(2) :: Nil).select(star()))
+      UnresolvedTableValuedFunction("range", Literal(2) :: Nil, Seq.empty).select(star()))
+  }
+
+  test("SPARK-20311 range(N) as alias") {
+    assertEqual(
+      "select * from range(10) AS t",
+      SubqueryAlias("t", UnresolvedTableValuedFunction("range", Literal(10) :: Nil, Seq.empty))
+        .select(star()))
+    assertEqual(
+      "select * from range(7) AS t(a)",
+      SubqueryAlias("t", UnresolvedTableValuedFunction("range", Literal(7) :: Nil, "a" :: Nil))
+        .select(star()))
   }
 
   test("inline table") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added parsing rules to support aliases in table value functions.

## How was this patch tested?
Added tests in `PlanParserSuite`.