### PR TITLE
Failing test for parquet predicate pushdown on columns with dots

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -536,4 +536,18 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
       // scalastyle:on nonascii
     }
   }
+
+  test("predicate pushdown for columns with a '.' in them") {
+    withTempPath { dir =>
+      import testImplicits._
+
+      val path = dir.getCanonicalPath
+      Seq("apple", null).toDF("col.dots").write.parquet(path)
+
+      assert(spark.read.parquet(path).count() == 2)
+      assert(spark.read.parquet(path).where("`col.dots` IS NULL").count() == 1)
+      assert(spark.read.parquet(path).where("`col.dots` IS NOT NULL").count() == 1)
+    }
+
+  }
 }


### PR DESCRIPTION
// checking against Jenkins to make sure this is still live on master