### PR TITLE
[SPARK-20379][core] Allow reading SSL-related passwords from the environment.

### DIFF
--- a/core/src/test/scala/org/apache/spark/SSLOptionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SSLOptionsSuite.scala
@@ -22,6 +22,8 @@ import javax.net.ssl.SSLContext
 
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.spark.util.SparkConfWithEnv
+
 class SSLOptionsSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   test("test resolving property file as spark conf ") {
@@ -131,6 +133,20 @@ class SSLOptionsSuite extends SparkFunSuite with BeforeAndAfterAll {
     assert(opts.keyPassword === Some("password"))
     assert(opts.protocol === Some("SSLv3"))
     assert(opts.enabledAlgorithms === Set("ABC", "DEF"))
+  }
+
+  test("read passwords from environment") {
+    val key = "spark.ssl.ui.keyStorePassword"
+    val env = Map("SPARK_SSL_UI_KEYSTOREPASSWORD" -> "passFromEnv")
+    val conf = new SparkConfWithEnv(env)
+    conf.set(key, "passFromConf")
+
+    val key2 = "spark.ssl.trustStorePassword"
+    conf.set(key2, "pass2FromConf")
+
+    assert(SSLOptions.getFromEnv(conf, key) === Some("passFromEnv"))
+    assert(SSLOptions.getFromEnv(conf, key2) === Some("pass2FromConf"))
+    assert(SSLOptions.getFromEnv(conf, "spark.ssl.keyStorePassword") === None)
   }
 
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1925,6 +1925,10 @@ Apart from these, the following properties are also available, and may be useful
     </tr>
 </table>
 
+All password-related SSL options can also be set using environment variables, which take precedence
+over the configuration when both are set. The names of the environment variables match the name of
+the configuration key, with all capital letters and periods replaced with underscores. So, for
+example, <code>spark.ssl.keyStorePassword</code> becomes <code>SPARK_SSL_KEYSTOREPASSWORD</code>.
 
 ### Spark SQL
 


### PR DESCRIPTION
In some deployments, admins are reluctant to have passwords written to plain
text files in the same fs as the file they're protecting (e.g. the SSL key
store). Using the environment to propagate these passwords is more secure,
since in that situation the password is not written to disk.

Tested with new unit test.