### PR TITLE
[SPARK-20364][SQL] Support Parquet predicate pushdown on columns with dots

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -243,7 +243,8 @@ private[parquet] object ParquetFilters {
  * Note that, this is a hacky workaround to allow dots in column names. Currently, column APIs
  * in Parquet's `FilterApi` only allows dot-separated names so here we resemble those columns
  * but only allow single column path that allows dots in the names as we don't currently push
- * down filters with nested fields.
+ * down filters with nested fields. The functions in this object are based on
+ * the codes in `org.apache.parquet.filter2.predicate`.
  */
 private[parquet] object ParquetColumns {
   def intColumn(columnPath: String): Column[Integer] with SupportsLtGt = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.parquet.filter2.predicate._
-import org.apache.parquet.filter2.predicate.FilterApi._
+import org.apache.parquet.filter2.predicate.Operators.{Column, SupportsEqNotEq, SupportsLtGt}
+import org.apache.parquet.hadoop.metadata.ColumnPath
 import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.sql.sources
@@ -28,6 +29,8 @@ import org.apache.spark.sql.types._
  * Some utility function to convert Spark data source filters to Parquet filters.
  */
 private[parquet] object ParquetFilters {
+
+  import ParquetColumns._
 
   private val makeEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
     case BooleanType =>
@@ -233,5 +236,41 @@ private[parquet] object ParquetFilters {
 
       case _ => None
     }
+  }
+}
+
+/**
+ * Note that, this is a hacky workaround to allow dots in column names. Currently, column APIs
+ * in Parquet's `FilterApi` only allows dot-separated names so here we resemble those columns
+ * but only allow single column path that allows dots in the names as we don't currently push
+ * down filters with nested fields.
+ */
+private[parquet] object ParquetColumns {
+  def intColumn(columnPath: String): Column[Integer] with SupportsLtGt = {
+    new Column[Integer] (ColumnPath.get(columnPath), classOf[Integer]) with SupportsLtGt
+  }
+
+  def longColumn(columnPath: String): Column[java.lang.Long] with SupportsLtGt = {
+    new Column[java.lang.Long] (
+      ColumnPath.get(columnPath), classOf[java.lang.Long]) with SupportsLtGt
+  }
+
+  def floatColumn(columnPath: String): Column[java.lang.Float] with SupportsLtGt = {
+    new Column[java.lang.Float] (
+      ColumnPath.get(columnPath), classOf[java.lang.Float]) with SupportsLtGt
+  }
+
+  def doubleColumn(columnPath: String): Column[java.lang.Double] with SupportsLtGt = {
+    new Column[java.lang.Double] (
+      ColumnPath.get(columnPath), classOf[java.lang.Double]) with SupportsLtGt
+  }
+
+  def booleanColumn(columnPath: String): Column[java.lang.Boolean] with SupportsEqNotEq = {
+    new Column[java.lang.Boolean] (
+      ColumnPath.get(columnPath), classOf[java.lang.Boolean]) with SupportsEqNotEq
+  }
+
+  def binaryColumn(columnPath: String): Column[Binary] with SupportsLtGt = {
+    new Column[Binary] (ColumnPath.get(columnPath), classOf[Binary]) with SupportsLtGt
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -487,7 +487,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     }
   }
 
-  test("no filter puwhdown for nested field access") {
+  test("no filter pushdown for nested field access") {
     val table = createTable(
       files = Seq("file1" -> 1),
       format = classOf[TestFileFormatWithNestedSchema].getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -487,6 +487,20 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     }
   }
 
+  test("no filter puwhdown for nested field access") {
+    val table = createTable(
+      files = Seq("file1" -> 1),
+      format = classOf[TestFileFormatWithNestedSchema].getName)
+
+    checkScan(table.where("a1 = 1"))(_ => ())
+    // Check `a1` access pushes the predicate.
+    checkDataFilters(Set(IsNotNull("a1"), EqualTo("a1", 1)))
+
+    checkScan(table.where("a2.c1 = 1"))(_ => ())
+    // Check `a2.c1` access does not pushes the predicate.
+    checkDataFilters(Set(IsNotNull("a2")))
+  }
+
   // Helpers for checking the arguments passed to the FileFormat.
 
   protected val checkPartitionSchema =
@@ -537,7 +551,8 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
    */
   def createTable(
       files: Seq[(String, Int)],
-      buckets: Int = 0): DataFrame = {
+      buckets: Int = 0,
+      format: String = classOf[TestFileFormat].getName): DataFrame = {
     val tempDir = Utils.createTempDir()
     files.foreach {
       case (name, size) =>
@@ -547,7 +562,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     }
 
     val df = spark.read
-      .format(classOf[TestFileFormat].getName)
+      .format(format)
       .load(tempDir.getCanonicalPath)
 
     if (buckets > 0) {
@@ -632,6 +647,22 @@ class TestFileFormat extends TextBasedFileFormat {
   }
 }
 
+/**
+ * A test [[FileFormat]] that records the arguments passed to buildReader, and returns nothing.
+ * Unlike the one above, this one has a nested schema.
+ */
+class TestFileFormatWithNestedSchema extends TestFileFormat {
+  override def inferSchema(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      files: Seq[FileStatus]): Option[StructType] =
+    Some(StructType(Nil)
+      .add("a1", IntegerType)
+      .add("a2",
+         StructType(Nil)
+           .add("c1", IntegerType)
+           .add("c2", IntegerType)))
+}
 
 class LocalityTestFileSystem extends RawLocalFileSystem {
   private val invocations = new AtomicInteger(0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -497,7 +497,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     checkDataFilters(Set(IsNotNull("a1"), EqualTo("a1", 1)))
 
     checkScan(table.where("a2.c1 = 1"))(_ => ())
-    // Check `a2.c1` access does not pushes the predicate.
+    // Check `a2.c1` access does not push the predicate.
     checkDataFilters(Set(IsNotNull("a2")))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 import java.nio.charset.StandardCharsets
 
 import org.apache.parquet.filter2.predicate.{FilterPredicate, Operators}
-import org.apache.parquet.filter2.predicate.FilterApi._
+import org.apache.parquet.filter2.predicate.FilterApi.{and, gt, lt}
 import org.apache.parquet.filter2.predicate.Operators.{Column => _, _}
 
 import org.apache.spark.sql._
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetColumns.{doubleColumn, intColumn}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
@@ -536,6 +537,45 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
       assert(spark.read.parquet(path).where("name < 'é'").count() == 1)
       assert(spark.read.parquet(path).where("name <= 'é'").count() == 2)
       // scalastyle:on nonascii
+    }
+  }
+
+  test("SPARK-20364: Predicate pushdown for columns with a '.' in them") {
+    import testImplicits._
+
+    Seq(true, false).foreach { vectorized =>
+      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorized.toString) {
+        withTempPath { path =>
+          Seq(Some(1), None).toDF("col.dots").write.parquet(path.getAbsolutePath)
+          assert(spark.read.parquet(path.getAbsolutePath).where("`col.dots` > 0").count() == 1)
+        }
+
+        withTempPath { path =>
+          Seq(Some(1L), None).toDF("col.dots").write.parquet(path.getAbsolutePath)
+          assert(spark.read.parquet(path.getAbsolutePath).where("`col.dots` >= 1L").count() == 1)
+        }
+
+        withTempPath { path =>
+          Seq(Some(1.0F), None).toDF("col.dots").write.parquet(path.getAbsolutePath)
+          assert(spark.read.parquet(path.getAbsolutePath).where("`col.dots` < 2.0").count() == 1)
+        }
+
+        withTempPath { path =>
+          Seq(Some(1.0D), None).toDF("col.dots").write.parquet(path.getAbsolutePath)
+          assert(spark.read.parquet(path.getAbsolutePath).where("`col.dots` <= 1.0D").count() == 1)
+        }
+
+        withTempPath { path =>
+          Seq(true, false).toDF("col.dots").write.parquet(path.getAbsolutePath)
+          assert(spark.read.parquet(path.getAbsolutePath).where("`col.dots` == true").count() == 1)
+        }
+
+        withTempPath { path =>
+          Seq("apple", null).toDF("col.dots").write.parquet(path.getAbsolutePath)
+          assert(
+            spark.read.parquet(path.getAbsolutePath).where("`col.dots` IS NOT NULL").count() == 1)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if there are dots in the column name, predicate pushdown seems being failed in Parquet.

**With dots**

```scala
val path = "/tmp/abcde"
Seq(Some(1), None).toDF("col.dots").write.parquet(path)
spark.read.parquet(path).where("`col.dots` IS NOT NULL").show()
```

```
+--------+
|col.dots|
+--------+
+--------+
```

**Without dots**

```scala
val path = "/tmp/abcde"
Seq(Some(1), None).toDF("coldots").write.parquet(path)
spark.read.parquet(path).where("`coldots` IS NOT NULL").show()
```

```
+-------+
|coldots|
+-------+
|      1|
+-------+
```

It seems dot in the column names via `FilterApi` tries to separate the field name with dot (`ColumnPath` with multiple column paths) whereas the actual column name is `col.dots`. (See [FilterApi.java#L71](https://github.com/apache/parquet-mr/blob/apache-parquet-1.8.2/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/FilterApi.java#L71) and it calls [ColumnPath.java#L44](https://github.com/apache/parquet-mr/blob/apache-parquet-1.8.2/parquet-common/src/main/java/org/apache/parquet/hadoop/metadata/ColumnPath.java#L44)).

I just tried to come up with ways to resolve it and I came up with two as below (as I could not find 
 a way to set dots as are):

 - One is simply to don't push down filters when there are dots in column names so that it reads all and filters in Spark-side.

 - The other way creates Spark's `FilterApi` for those columns (it seems final) to get always use single column path it in Spark-side (this seems hacky) as we are not pushing down nested columns currently. So, it looks we can get a field name via `ColumnPath.get` not `ColumnPath.fromDotString` in this way.

This PR proposes the latter way because I think we need to be sure on that it passes the tests.

**After**

```scala
val path = "/tmp/abcde"
Seq(Some(1), None).toDF("col.dots").write.parquet(path)
spark.read.parquet(path).where("`col.dots` IS NOT NULL").show()
```

```
+--------+
|col.dots|
+--------+
|       1|
+--------+
```


## How was this patch tested?

Existing tests should cover this. Some tests were added in `ParquetFilterSuite.scala`. Manually, I ran related tests and Jenkins tests will cover this.
