### PR TITLE
[SPARK-20390][SQL] Respect deterministic in AttributeReference

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/source/libsvm/LibSVMRelation.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/source/libsvm/LibSVMRelation.scala
@@ -166,7 +166,7 @@ private[libsvm] class LibSVMFileFormat extends TextBasedFileFormat with DataSour
 
       val converter = RowEncoder(dataSchema)
       val fullOutput = dataSchema.map { f =>
-        AttributeReference(f.name, f.dataType, f.nullable, f.metadata)()
+        AttributeReference(f.name, f.dataType, f.nullable, metadata = f.metadata)()
       }
       val requiredOutput = fullOutput.filter { a =>
         requiredSchema.fieldNames.contains(a.name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -384,8 +384,9 @@ trait CheckAnalysis extends PredicateHelper {
               "is " + mapCol.dataType.simpleString)
 
           case o if o.expressions.exists(!_.deterministic) &&
-            !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] &&
-            !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] =>
+              !o.isInstanceOf[LocalRelation] && !o.isInstanceOf[DeserializeToObject] &&
+              !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] && !o.isInstanceOf[Aggregate] &&
+              !o.isInstanceOf[Window] =>
             // The rule above is used to check Aggregate operator.
             failAnalysis(
               s"""nondeterministic expressions are only allowed in

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -164,7 +164,7 @@ case class Alias(child: Expression, name: String)(
 
   override def toAttribute: Attribute = {
     if (resolved) {
-      AttributeReference(name, child.dataType, child.nullable, metadata)(
+      AttributeReference(name, child.dataType, child.nullable, child.deterministic, metadata)(
         exprId, qualifier, isGenerated)
     } else {
       UnresolvedAttribute(name)
@@ -213,6 +213,7 @@ case class AttributeReference(
     name: String,
     dataType: DataType,
     nullable: Boolean = true,
+    override val deterministic: Boolean = true,
     override val metadata: Metadata = Metadata.empty)(
     val exprId: ExprId = NamedExpression.newExprId,
     val qualifier: Option[String] = None,
@@ -253,7 +254,7 @@ case class AttributeReference(
   }
 
   override def newInstance(): AttributeReference =
-    AttributeReference(name, dataType, nullable, metadata)(
+    AttributeReference(name, dataType, nullable, deterministic, metadata)(
       qualifier = qualifier, isGenerated = isGenerated)
 
   /**
@@ -263,7 +264,8 @@ case class AttributeReference(
     if (nullable == newNullability) {
       this
     } else {
-      AttributeReference(name, dataType, newNullability, metadata)(exprId, qualifier, isGenerated)
+      AttributeReference(name, dataType, newNullability, deterministic, metadata)(
+        exprId, qualifier, isGenerated)
     }
   }
 
@@ -271,7 +273,8 @@ case class AttributeReference(
     if (name == newName) {
       this
     } else {
-      AttributeReference(newName, dataType, nullable, metadata)(exprId, qualifier, isGenerated)
+      AttributeReference(newName, dataType, nullable, deterministic, metadata)(
+        exprId, qualifier, isGenerated)
     }
   }
 
@@ -282,7 +285,8 @@ case class AttributeReference(
     if (newQualifier == qualifier) {
       this
     } else {
-      AttributeReference(name, dataType, nullable, metadata)(exprId, newQualifier, isGenerated)
+      AttributeReference(name, dataType, nullable, deterministic, metadata)(
+        exprId, newQualifier, isGenerated)
     }
   }
 
@@ -290,12 +294,14 @@ case class AttributeReference(
     if (exprId == newExprId) {
       this
     } else {
-      AttributeReference(name, dataType, nullable, metadata)(newExprId, qualifier, isGenerated)
+      AttributeReference(name, dataType, nullable, deterministic, metadata)(
+        newExprId, qualifier, isGenerated)
     }
   }
 
   override def withMetadata(newMetadata: Metadata): Attribute = {
-    AttributeReference(name, dataType, nullable, newMetadata)(exprId, qualifier, isGenerated)
+    AttributeReference(name, dataType, nullable, deterministic, newMetadata)(
+      exprId, qualifier, isGenerated)
   }
 
   override protected final def otherCopyArgs: Seq[AnyRef] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -297,7 +297,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
   }
 
   protected[sql] def toAttributes: Seq[AttributeReference] =
-    map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+    map(f => AttributeReference(f.name, f.dataType, f.nullable, metadata = f.metadata)())
 
   def treeString: String = {
     val builder = new StringBuilder

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -409,7 +409,7 @@ class ExpressionEncoderSuite extends PlanTest with AnalysisTest {
 
         val encodedData = try {
           row.toSeq(encoder.schema).zip(schema).map {
-            case (a: ArrayData, AttributeReference(_, ArrayType(et, _), _, _)) =>
+            case (a: ArrayData, AttributeReference(_, ArrayType(et, _), _, _, _)) =>
               a.toArray[Any](et).toSeq
             case (other, _) =>
               other

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -20,13 +20,11 @@ package org.apache.spark.sql.execution.command
 import java.io.File
 import java.net.URI
 import java.nio.file.FileSystems
-import java.util.Date
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 import scala.util.Try
 
-import org.apache.commons.lang3.StringEscapeUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
@@ -506,11 +504,11 @@ case class DescribeTableCommand(
   override val output: Seq[Attribute] = Seq(
     // Column names are based on Hive.
     AttributeReference("col_name", StringType, nullable = false,
-      new MetadataBuilder().putString("comment", "name of the column").build())(),
+      metadata = new MetadataBuilder().putString("comment", "name of the column").build())(),
     AttributeReference("data_type", StringType, nullable = false,
-      new MetadataBuilder().putString("comment", "data type of the column").build())(),
+      metadata = new MetadataBuilder().putString("comment", "data type of the column").build())(),
     AttributeReference("comment", StringType, nullable = true,
-      new MetadataBuilder().putString("comment", "comment of the column").build())()
+      metadata = new MetadataBuilder().putString("comment", "comment of the column").build())()
   )
 
   override def run(sparkSession: SparkSession): Seq[Row] = {

--- a/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
@@ -137,14 +137,10 @@ GROUP BY position 3 is an aggregate function, and aggregate functions are not al
 -- !query 13
 select a, rand(0), sum(b) from data group by a, 2
 -- !query 13 schema
-struct<a:int,rand(0):double,sum(b):bigint>
+struct<>
 -- !query 13 output
-1	0.4048454303385226	2
-1	0.8446490682263027	1
-2	0.5871875724155838	1
-2	0.8865128837019473	2
-3	0.742083829230211	1
-3	0.9179913208300406	2
+org.apache.spark.sql.AnalysisException
+nondeterministic expression `_nondeterministic` should not appear in grouping expression.;
 
 
 -- !query 14


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr respected the `deterministic` properties of query plans in `AttributeReference`.
Only deterministic expressions can exist in grouping keys though, non-deterministic one could exist there in some cases. This is because `AttributeReference` does not respect `deterministic` properties in query plans. A example is as follows;

```
scala> val df = sql("""select rand(0), count(1) group by 1""")
df: org.apache.spark.sql.DataFrame = [rand(0): double, count(1): bigint]

scala> df.explain(true)
== Parsed Logical Plan ==
'Aggregate [1], [unresolvedalias('rand(0), None), unresolvedalias('count(1), None)]
+- OneRowRelation$

== Analyzed Logical Plan ==
rand(0): double, count(1): bigint
Aggregate [_nondeterministic#92], [_nondeterministic#92 AS rand(0)#90, count(1) AS count(1)#91L]
+- Project [rand(0) AS _nondeterministic#92]
   +- OneRowRelation$

== Optimized Logical Plan ==
Aggregate [_nondeterministic#92], [_nondeterministic#92 AS rand(0)#90, count(1) AS count(1)#91L]
+- Project [rand(0) AS _nondeterministic#92]
   +- OneRowRelation$

== Physical Plan ==
*HashAggregate(keys=[_nondeterministic#92], functions=[count(1)], output=[rand(0)#90, count(1)#91L])
+- Exchange hashpartitioning(_nondeterministic#92, 200)
   +- *HashAggregate(keys=[_nondeterministic#92], functions=[partial_count(1)], output=[_nondeterministic#92, count#94L])
      +- *Project [rand(0) AS _nondeterministic#92]
         +- Scan OneRowRelation[]

scala> df.show
+------------------+--------+
|           rand(0)|count(1)|
+------------------+--------+
|0.8446490682263027|       1|
+------------------+--------+
```

## How was this patch tested?
Existing tests