### PR TITLE
[SPARK-12717][PYSPARK] Resolving race condition with pyspark broadcasts when using multiple threads

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -28,7 +28,7 @@ import random
 import socket
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
-from threading import Thread
+from threading import Thread, Lock
 from collections import defaultdict
 from itertools import chain
 from functools import reduce
@@ -55,6 +55,9 @@ from pyspark.traceback_utils import SCCallSiteSync
 
 __all__ = ["RDD"]
 
+# Lock which will make sure that dependend broadcast variables are pickled along
+# with their PythonRDD wrapped function when using multple threads(SPARK-12717).
+_lock = Lock()
 
 def portable_hash(x):
     """
@@ -2451,10 +2454,12 @@ class PipelinedRDD(RDD):
         else:
             profiler = None
 
-        wrapped_func = _wrap_function(self.ctx, self.func, self._prev_jrdd_deserializer,
-                                      self._jrdd_deserializer, profiler)
-        python_rdd = self.ctx._jvm.PythonRDD(self._prev_jrdd.rdd(), wrapped_func,
-                                             self.preservesPartitioning)
+        with _lock:
+            wrapped_func = _wrap_function(self.ctx, self.func,
+                    self._prev_jrdd_deserializer, self._jrdd_deserializer, profiler)
+            python_rdd = self.ctx._jvm.PythonRDD(self._prev_jrdd.rdd(), wrapped_func,
+                    self.preservesPartitioning)
+
         self._jrdd_val = python_rdd.asJavaRDD()
 
         if profiler:


### PR DESCRIPTION

## What changes were proposed in this pull request?

In pyspark when multiple threads are used, broadcast variables are pickled with wrong PythonRDD wrap functions which leads to the following exception(Because of the race condition between the threads on java side with py4j).

16/01/08 17:10:20 ERROR Executor: Exception in task 0.0 in stage 9.0 (TID 9)
org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/Network/Servers/mother.adverplex.com/Volumes/homeland/Users/walker/.spark/spark-1.6.0-bin-hadoop2.6/python/lib/pyspark.zip/pyspark/worker.py", line 98, in main
    command = pickleSer._read_with_length(infile)
  File "/Network/Servers/mother.adverplex.com/Volumes/homeland/Users/walker/.spark/spark-1.6.0-bin-hadoop2.6/python/lib/pyspark.zip/pyspark/serializers.py", line 164, in _read_with_length
    return self.loads(obj)
  File "/Network/Servers/mother.adverplex.com/Volumes/homeland/Users/walker/.spark/spark-1.6.0-bin-hadoop2.6/python/lib/pyspark.zip/pyspark/serializers.py", line 422, in loads
    return pickle.loads(obj)
  File "/Network/Servers/mother.adverplex.com/Volumes/homeland/Users/walker/.spark/spark-1.6.0-bin-hadoop2.6/python/lib/pyspark.zip/pyspark/broadcast.py", line 39, in _from_id
    raise Exception("Broadcast variable '%s' not loaded!" % bid)
Exception: (Exception("Broadcast variable '6' not loaded!",), <function _from_id at 0xce7a28>, (6L,))

	at org.apache.spark.api.python.PythonRunner$$anon$1.read(PythonRDD.scala:166)
	at org.apache.spark.api.python.PythonRunner$$anon$1.<init>(PythonRDD.scala:207)
	at org.apache.spark.api.python.PythonRunner.compute(PythonRDD.scala:125)
	at org.apache.spark.api.python.PythonRDD.compute(PythonRDD.scala:70)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:306)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:270)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:66)
	at org.apache.spark.scheduler.Task.run(Task.scala:89)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:213)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)

This change will fix the race condition by making sure that broadcast variables are pickled with same pythonRDD function.

## How was this patch tested?
1) Reproduced the issue mentioned in SPARK-12717, following the instructions specified in jira
2) Make sure that issue is fixed with the changes.

Please review http://spark.apache.org/contributing.html before opening a pull request.
