### PR TITLE
[SPARK-20414][MLLIB] avoid creating only 16 reducers when calling topByKey()

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/rdd/MLPairRDDFunctions.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/rdd/MLPairRDDFunctions.scala
@@ -47,7 +47,18 @@ class MLPairRDDFunctions[K: ClassTag, V: ClassTag](self: RDD[(K, V)]) extends Se
       combOp = (queue1, queue2) => {
         queue1 ++= queue2
       }
-    ).mapValues(_.toArray.sorted(ord.reverse))  // This is a min-heap, so we reverse the order.
+    ).mapValues(_.toArray.sorted(ord.reverse)) // This is a min-heap, so we reverse the order.
+  }
+
+  def topByKey(num: Int, bucketsCount: Int)(implicit ord: Ordering[V]): RDD[(K, Array[V])] = {
+    self.aggregateByKey(new BoundedPriorityQueue[V](num)(ord), bucketsCount)(
+      seqOp = (queue, item) => {
+        queue += item
+      },
+      combOp = (queue1, queue2) => {
+        queue1 ++= queue2
+      }
+    ).mapValues(_.toArray.sorted(ord.reverse)) // This is a min-heap, so we reverse the order.
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/rdd/MLPairRDDFunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/rdd/MLPairRDDFunctionsSuite.scala
@@ -22,10 +22,25 @@ import org.apache.spark.mllib.rdd.MLPairRDDFunctions._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 class MLPairRDDFunctionsSuite extends SparkFunSuite with MLlibTestSparkContext {
+  val sourceArray = Array(
+    (1, 7), (1, 3), (1, 6), (1, 1), (1, 2), (1, -1),
+    (3, 2), (3, 7), (5, 1), (3, 5)
+  )
+
   test("topByKey") {
-    val topMap = sc.parallelize(Array((1, 7), (1, 3), (1, 6), (1, 1), (1, 2), (3, 2), (3, 7), (5,
-      1), (3, 5)), 2)
+    val topMap = sc.parallelize(sourceArray, 2)
       .topByKey(5)
+      .collectAsMap()
+
+    assert(topMap.size === 3)
+    assert(topMap(1) === Array(7, 6, 3, 2, 1))
+    assert(topMap(3) === Array(7, 5, 2))
+    assert(topMap(5) === Array(1))
+  }
+
+  test("topByKeyUsingBuckets") {
+    val topMap = sc.parallelize(sourceArray, 2)
+      .topByKey(5, 10)
       .collectAsMap()
 
     assert(topMap.size === 3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

in the topByKey() call, provide a configurable partition count. without this, currently topByKey() results in only 16 reducers even if you have a 100GB input size

## How was this patch tested?
use existing unit tests


Please review http://spark.apache.org/contributing.html before opening a pull request.
