### PR TITLE
[SPARK-20408][SQL] Get the glob path in parallel to reduce resolve relation time

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -100,18 +100,22 @@ class SparkHadoopUtilSuite extends SparkFunSuite with Matchers with LocalSparkCo
       val fs = FileSystem.getLocal(new Configuration())
 
       // test partial match
-      sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-000[1-5]/*")) should be(Seq(
-        s"file:${rootDir}/dir-0001/*",
-        s"file:${rootDir}/dir-0002/*",
-        s"file:${rootDir}/dir-0003/*",
-        s"file:${rootDir}/dir-0004/*",
-        s"file:${rootDir}/dir-0005/*"))
+      sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-000[1-5]/*"))
+        .sortWith(_.compareTo(_) < 0) should be(Seq(
+          s"file:${rootDir}/dir-0001/*",
+          s"file:${rootDir}/dir-0002/*",
+          s"file:${rootDir}/dir-0003/*",
+          s"file:${rootDir}/dir-0004/*",
+          s"file:${rootDir}/dir-0005/*"))
+
       // test wild cast on the leaf files
       sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-0001/*")) should be(Seq(
         s"${rootDir}/dir-0001/*"))
+
       // test path is not globPath
       sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-0001/part-0001")) should be(Seq(
         s"${rootDir}/dir-0001/part-0001"))
+
       // test the wrong wild cast
       sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/000[1-5]/*")) should be(
         Seq.empty[String])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -596,6 +596,15 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val PARALLEL_GET_GLOBBED_PATH_PARALLELISM =
+    buildConf("spark.sql.sources.parallelGetGlobbedPath.parallelism")
+      .doc("The number of threads to get a collection of path in parallel. Set the " +
+        "number to avoid generating too many threads.")
+      .intConf
+      .checkValue(parallel => parallel >= 0, "The maximum number of threads allowed for getting " +
+        "globbed paths at driver side must not be negative")
+      .createWithDefault(32)
+
   // Whether to automatically resolve ambiguity in join conditions for self-joins.
   // See SPARK-6231.
   val DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY =
@@ -1350,6 +1359,9 @@ class SQLConf extends Serializable with Logging {
 
   def parallelPartitionDiscoveryParallelism: Int =
     getConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_PARALLELISM)
+
+  def parallelGetGlobbedPathParallelism: Int =
+    getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_PARALLELISM)
 
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -690,9 +690,9 @@ object DataSource extends Logging {
   }
 
   /**
-    * Return all paths represented by the wildcard string.
-    * Follow [[InMemoryFileIndex]].bulkListLeafFile and reuse the conf.
-    */
+   * Return all paths represented by the wildcard string.
+   * Follow [[InMemoryFileIndex]].bulkListLeafFile and reuse the conf.
+   */
   private def getGlobbedPaths(
       sparkSession: SparkSession,
       fs: FileSystem,


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change the work of getting glob path in parallel, which can make complex wildcard path more quickly, the mainly changes in details:
1.Add new function `getGlobbedPaths` in DataSource, return all paths represented by the wildcard, follow the logic of `InMemoryFileIndex.bulkListLeafFiles` and reuse the config.
2.Add new function `expandGlobPath ` in SparkHadoopUtil, to expand the first dir represented by the wildcard

## How was this patch tested?
Existing UT.
