### PR TITLE
[SPARK-20413] Add new query hint NO_COLLAPSE.

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -468,7 +468,7 @@ def nanvl(col1, col2):
 
 @since(2.2)
 def no_collapse(df):
-    """Marks a DataFrame as small enough for use in broadcast joins."""
+    """Marks a DataFrame as non-collapsible."""
 
     sc = SparkContext._active_spark_context
     return DataFrame(sc._jvm.functions.no_collapse(df._jdf), df.sql_ctx)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -466,6 +466,14 @@ def nanvl(col1, col2):
     return Column(sc._jvm.functions.nanvl(_to_java_column(col1), _to_java_column(col2)))
 
 
+@since(2.2)
+def no_collapse(df):
+    """Marks a DataFrame as small enough for use in broadcast joins."""
+
+    sc = SparkContext._active_spark_context
+    return DataFrame(sc._jvm.functions.no_collapse(df._jdf), df.sql_ctx)
+
+
 @since(1.4)
 def rand(seed=None):
     """Generates a random column with independent and identically distributed (i.i.d.) samples

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -387,6 +387,13 @@ case class BroadcastHint(child: LogicalPlan) extends UnaryNode {
 }
 
 /**
+ * A hint for the optimizer that we should not merge two projections.
+ */
+case class NoCollapseHint(child: LogicalPlan) extends UnaryNode {
+  override def output: Seq[Attribute] = child.output
+}
+
+/**
  * A general hint for the child. This node will be eliminated post analysis.
  * A pair of (name, parameters).
  */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -537,5 +537,10 @@ class PlanParserSuite extends PlanTest {
     comparePlans(
       parsePlan("SELECT /*+ MAPJOIN(t) */ a from t where true group by a order by a"),
       Hint("MAPJOIN", Seq("t"), table("t").where(Literal(true)).groupBy('a)('a)).orderBy('a.asc))
+
+    comparePlans(
+      parsePlan("SELECT a FROM (SELECT /*+ NO_COLLAPSE */ * FROM t) t1"),
+      SubqueryAlias("t1", Hint("NO_COLLAPSE", Seq.empty, table("t").select(star())))
+        .select('a))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -537,10 +537,5 @@ class PlanParserSuite extends PlanTest {
     comparePlans(
       parsePlan("SELECT /*+ MAPJOIN(t) */ a from t where true group by a order by a"),
       Hint("MAPJOIN", Seq("t"), table("t").where(Literal(true)).groupBy('a)('a)).orderBy('a.asc))
-
-    comparePlans(
-      parsePlan("SELECT a FROM (SELECT /*+ NO_COLLAPSE */ * FROM t) t1"),
-      SubqueryAlias("t1", Hint("NO_COLLAPSE", Seq.empty, table("t").select(star())))
-        .select('a))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -433,6 +433,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case r: LogicalRDD =>
         RDDScanExec(r.output, r.rdd, "ExistingRDD", r.outputPartitioning, r.outputOrdering) :: Nil
       case BroadcastHint(child) => planLater(child) :: Nil
+      case NoCollapseHint(child) => planLater(child) :: Nil
       case _ => Nil
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -19,9 +19,10 @@ package org.apache.spark.sql
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
-import scala.reflect.runtime.universe.{TypeTag, typeTag}
+import scala.reflect.runtime.universe.{typeTag, TypeTag}
 import scala.util.Try
 import scala.util.control.NonFatal
+
 import org.apache.spark.annotation.{Experimental, InterfaceStability}
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.analysis.{Star, UnresolvedFunction}
@@ -1006,33 +1007,33 @@ object functions {
   def map(cols: Column*): Column = withExpr { CreateMap(cols.map(_.expr)) }
 
   /**
-    * Marks a DataFrame as small enough for use in broadcast joins.
-    *
-    * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
-    * {{{
-    *   // left and right are DataFrames
-    *   left.join(broadcast(right), "joinKey")
-    * }}}
-    *
-    * @group normal_funcs
-    * @since 1.5.0
-    */
+   * Marks a DataFrame as small enough for use in broadcast joins.
+   *
+   * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
+   * {{{
+   *   // left and right are DataFrames
+   *   left.join(broadcast(right), "joinKey")
+   * }}}
+   *
+   * @group normal_funcs
+   * @since 1.5.0
+   */
   def broadcast[T](df: Dataset[T]): Dataset[T] = {
     Dataset[T](df.sparkSession, BroadcastHint(df.logicalPlan))(df.exprEnc)
   }
 
   /**
-    * Marks a DataFrame as small enough for use in broadcast joins.
-    *
-    * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
-    * {{{
-    *   // left and right are DataFrames
-    *   left.join(broadcast(right), "joinKey")
-    * }}}
-    *
-    * @group normal_funcs
-    * @since 1.5.0
-    */
+   * Marks a DataFrame as non-collapsible.
+   *
+   * For example:
+   * {{{
+    *  df1 = no_collapse(df.select((df.col("qty") * lit(10).alias("c1")))
+   *   df2 = df1.select(col("c1") + lit(1)), col("c1") + lit(2)))
+   * }}}
+   *
+   * @group normal_funcs
+   * @since 2.2.0
+   */
   def no_collapse[T](df: Dataset[T]): Dataset[T] = {
     Dataset[T](df.sparkSession, NoCollapseHint(df.logicalPlan))(df.exprEnc)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -19,17 +19,16 @@ package org.apache.spark.sql
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
-import scala.reflect.runtime.universe.{typeTag, TypeTag}
+import scala.reflect.runtime.universe.{TypeTag, typeTag}
 import scala.util.Try
 import scala.util.control.NonFatal
-
 import org.apache.spark.annotation.{Experimental, InterfaceStability}
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.analysis.{Star, UnresolvedFunction}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.plans.logical.BroadcastHint
+import org.apache.spark.sql.catalyst.plans.logical.{BroadcastHint, NoCollapseHint}
 import org.apache.spark.sql.execution.SparkSqlParser
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.internal.SQLConf
@@ -1007,19 +1006,35 @@ object functions {
   def map(cols: Column*): Column = withExpr { CreateMap(cols.map(_.expr)) }
 
   /**
-   * Marks a DataFrame as small enough for use in broadcast joins.
-   *
-   * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
-   * {{{
-   *   // left and right are DataFrames
-   *   left.join(broadcast(right), "joinKey")
-   * }}}
-   *
-   * @group normal_funcs
-   * @since 1.5.0
-   */
+    * Marks a DataFrame as small enough for use in broadcast joins.
+    *
+    * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
+    * {{{
+    *   // left and right are DataFrames
+    *   left.join(broadcast(right), "joinKey")
+    * }}}
+    *
+    * @group normal_funcs
+    * @since 1.5.0
+    */
   def broadcast[T](df: Dataset[T]): Dataset[T] = {
     Dataset[T](df.sparkSession, BroadcastHint(df.logicalPlan))(df.exprEnc)
+  }
+
+  /**
+    * Marks a DataFrame as small enough for use in broadcast joins.
+    *
+    * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
+    * {{{
+    *   // left and right are DataFrames
+    *   left.join(broadcast(right), "joinKey")
+    * }}}
+    *
+    * @group normal_funcs
+    * @since 1.5.0
+    */
+  def no_collapse[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession, NoCollapseHint(df.logicalPlan))(df.exprEnc)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes adding a new query hint called NO_COLLAPSE that can be used to prevent adjacent projections from being collapsed.

## How was this patch tested?

Test using unit tests, integration tests and manual tests.