### PR TITLE
[SPARK-20013][SQL]merge renameTable to alterTable in ExternalCatalog

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -92,17 +92,18 @@ abstract class ExternalCatalog {
 
   def dropTable(db: String, table: String, ignoreIfNotExists: Boolean, purge: Boolean): Unit
 
-  def renameTable(db: String, oldName: String, newName: String): Unit
-
   /**
    * Alter a table whose database and name match the ones specified in `tableDefinition`, assuming
    * the table exists. Note that, even though we can specify database in `tableDefinition`, it's
    * used to identify the table, not to alter the table's database, which is not allowed.
    *
+   * If `newNameTable` is defined and its table name is not equal to the table name of
+   * `tableDefinition`,it will just rename the table.
+   *
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
    */
-  def alterTable(tableDefinition: CatalogTable): Unit
+  def alterTable(tableDefinition: CatalogTable, newNameTable: Option[CatalogTable] = None): Unit
 
   /**
    * Alter the schema of a table identified by the provided database and table name. The new schema


### PR DESCRIPTION
## What changes were proposed in this pull request?

merge renameTable to alterTable in ExternalCatalog has some reasons:

In Hive, we rename a Table by alterTable
Currently when we create / rename a managed table, we should get the defaultTablePath for them in ExternalCatalog, then we have two defaultTablePath logic in its two subclass HiveExternalCatalog and InMemoryCatalog, additionally there is also a defaultTablePath in SessionCatalog, so till now we have three defaultTablePath in three classes.
we'd better to unify them up to SessionCatalog
To unify them, we should move some logic from ExternalCatalog to SessionCatalog, renameTable is one of this.

while limit to the simple parameters in renameTable
```
  def renameTable(db: String, oldName: String, newName: String): Unit
```
even if we move the defaultTablePath logic to SessionCatalog, we can not pass it to renameTable.

So we can merge the renameTable to alterTable, and rename it in alterTable.


## How was this patch tested?

delete some tests in ExternalCatalogSuite which already existed in SessionCatalogSuite,
and move some other tests in ExternalCatalogSuite which does not exist in SessionCatalogSuite