### PR TITLE
[SPARK-20440][SparkR] Allow SparkR session and context to have delayed bindings

### DIFF
--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -155,10 +155,10 @@ sparkR.sparkContext <- function(
     # ignore error
   },
   finally = {
-    if (!is.na(sparkRjsc)) 
+    if (!is.na(sparkRjsc))
       cat(paste("Re-using existing Spark Context.",
                 "Call sparkR.session.stop() or restart R to create a new Spark Context\n"))
-  }) 
+  })
 
   jars <- processSparkJars(sparkJars)
   packages <- processSparkPackages(sparkPackages)
@@ -412,15 +412,15 @@ sparkR.session <- function(
        sparkJars, sparkPackages)
     stopifnot(exists(".sparkRjsc", envir = .sparkREnv))
   }
-  
+
   tryCatch({
-    if (exists(".sparkRsession", envir = .sparkREnv)) 
+    if (exists(".sparkRsession", envir = .sparkREnv))
       sparkSession <- get(".sparkRsession", envir = .sparkREnv)
   },
   error = function(cond) {
     # ignore error
   })
-  
+
   if (exists("sparkSession")) {
     # Apply config to Spark Context and Spark Session if already there
     # Cannot change enableHiveSupport


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow SparkR to ignore the "promise already under evaluation" error in case the user has created a delayed binding for the `.sparkRsession / .sparkRjsc` names in the `SparkR:::.sparkREnv`. 

## How was this patch tested?

Ran all unit tests - run-tests.sh
