### PR TITLE
[SPARK-20399][SQL] Can't use same regex pattern between 1.6 and 2.x due to unescaped sql string in parser

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -532,7 +532,9 @@ predicate
     : NOT? kind=BETWEEN lower=valueExpression AND upper=valueExpression
     | NOT? kind=IN '(' expression (',' expression)* ')'
     | NOT? kind=IN '(' query ')'
-    | NOT? kind=(RLIKE | LIKE) pattern=valueExpression
+    | NOT? kind=LIKE pattern=valueExpression
+    | NOT? kind=RLIKE regex=regexString
+    | NOT? kind=RLIKE pattern=valueExpression
     | IS NOT? kind=NULL
     ;
 
@@ -574,6 +576,10 @@ constant
     | number                                                                                   #numericLiteral
     | booleanValue                                                                             #booleanLiteral
     | STRING+                                                                                  #stringLiteral
+    ;
+
+regexString
+    : STRING+                                                                                  #regexPattern
     ;
 
 comparisonOperator

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -954,7 +954,11 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
       case SqlBaseParser.LIKE =>
         invertIfNotDefined(Like(e, expression(ctx.pattern)))
       case SqlBaseParser.RLIKE =>
-        invertIfNotDefined(RLike(e, expression(ctx.pattern)))
+        if (ctx.pattern != null) {
+          invertIfNotDefined(RLike(e, expression(ctx.pattern)))
+        } else {
+          invertIfNotDefined(RLike(e, expression(ctx.regex)))
+        }
       case SqlBaseParser.NULL if ctx.NOT != null =>
         IsNotNull(e)
       case SqlBaseParser.NULL =>
@@ -1396,6 +1400,10 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
    */
   override def visitStringLiteral(ctx: StringLiteralContext): Literal = withOrigin(ctx) {
     Literal(createString(ctx))
+  }
+
+  override def visitRegexPattern(ctx: RegexPatternContext): Literal = withOrigin(ctx) {
+    Literal(ctx.STRING().asScala.map(regexString).mkString)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -69,7 +69,9 @@ object ParserUtils {
   def string(node: TerminalNode): String = unescapeSQLString(node.getText)
 
   /** Convert a string node to a regex string. */
-  def regexString(node: TerminalNode): String = unescapeSQLString(node.getText, isRegex = true)
+  def regexString(node: TerminalNode): String = {
+    node.getText.slice(1, node.getText.size - 1)
+  }
 
   /** Get the origin (line and position) of the token. */
   def position(token: Token): Origin = {
@@ -100,7 +102,7 @@ object ParserUtils {
   }
 
   /** Unescape baskslash-escaped string enclosed by quotes. */
-  def unescapeSQLString(b: String, isRegex: Boolean = false): String = {
+  def unescapeSQLString(b: String): String = {
     var enclosure: Character = null
     val sb = new StringBuilder(b.length())
 
@@ -132,7 +134,7 @@ object ParserUtils {
         }
       } else if (enclosure == currentChar) {
         enclosure = null
-      } else if (currentChar == '\\' && !isRegex) {
+      } else if (currentChar == '\\') {
 
         if ((i + 6 < strLength) && b.charAt(i + 1) == 'u') {
           // \u0000 style character literals.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -68,6 +68,9 @@ object ParserUtils {
   /** Convert a string node into a string. */
   def string(node: TerminalNode): String = unescapeSQLString(node.getText)
 
+  /** Convert a string node to a regex string. */
+  def regexString(node: TerminalNode): String = unescapeSQLString(node.getText, isRegex = true)
+
   /** Get the origin (line and position) of the token. */
   def position(token: Token): Origin = {
     val opt = Option(token)
@@ -97,7 +100,7 @@ object ParserUtils {
   }
 
   /** Unescape baskslash-escaped string enclosed by quotes. */
-  def unescapeSQLString(b: String): String = {
+  def unescapeSQLString(b: String, isRegex: Boolean = false): String = {
     var enclosure: Character = null
     val sb = new StringBuilder(b.length())
 
@@ -129,7 +132,7 @@ object ParserUtils {
         }
       } else if (enclosure == currentChar) {
         enclosure = null
-      } else if (currentChar == '\\') {
+      } else if (currentChar == '\\' && !isRegex) {
 
         if ((i + 6 < strLength) && b.charAt(i + 1) == 'u') {
           // \u0000 style character literals.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -158,6 +158,11 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("a not rlike 'pattern%'", !('a rlike "pattern%"))
     assertEqual("a regexp 'pattern%'", 'a rlike "pattern%")
     assertEqual("a not regexp 'pattern%'", !('a rlike "pattern%"))
+
+    assertEqual("a rlike '^\\x20[\\x20-\\x23]+$'", 'a rlike "^\\x20[\\x20-\\x23]+$")
+    assertEqual("a rlike 'pattern\\\\'", 'a rlike "pattern\\\\")
+    assertEqual("a rlike 'pattern\\t\\n'", 'a rlike "pattern\\t\\n")
+    intercept("a rlike 'pattern\\'", "mismatched input")
   }
 
   test("is null expressions") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new SQL parser is introduced into Spark 2.0. Seems it bring an issue regarding the regex pattern string.

The following codes can reproduce it:

    val data = Seq("\u0020\u0021\u0023", "abc")
    val df = data.toDF()

    // 1st usage: works in 1.6
    // Let parser parse pattern string
    val rlike1 = df.filter("value rlike '^\\x20[\\x20-\\x23]+$'")
    // 2nd usage: works in 1.6, 2.x
    // Call Column.rlike so the pattern string is a literal which doesn't go through parser
    val rlike2 = df.filter($"value".rlike("^\\x20[\\x20-\\x23]+$"))

    // In 2.x, we need add backslashes to make regex pattern parsed correctly
    val rlike3 = df.filter("value rlike '^\\\\x20[\\\\x20-\\\\x23]+$'")

Due to unescaping SQL String in parser, the first usage working in 1.6 can't work in 2.0. To make it work, we need to add additional backslashes.

It is quite weird that we can't use the same regex pattern string in the 2 usages. We should not do unescaping on regex pattern string.

## How was this patch tested?

Jenkins tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
