### PR TITLE
[Spark-11968][ML][MLLIB]Optimize MLLIB ALS recommendForAll

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -288,27 +288,27 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
       val output = new Array[(Int, (Int, Double))](m * n)
       var j = 0
       srcIter.foreach { case (srcId, srcFactor) =>
-          val pq = new BoundedPriorityQueue[(Int, Double)](n)(Ordering.by(_._2))
-          dstIter.foreach { case (dstId, dstFactor) =>
-              /**
-               * The below code is equivalent to
-               * val score = blas.ddot(rank, srcFactor, 1, dstFactor, 1)
-               */
-              var score: Double = 0
-              var k = 0
-              while (k < rank) {
-                score += srcFactor(k) * dstFactor(k)
-                k += 1
-              }
-              pq += ((dstId, score))
+        val pq = new BoundedPriorityQueue[(Int, Double)](n)(Ordering.by(_._2))
+        dstIter.foreach { case (dstId, dstFactor) =>
+          /**
+           * The below code is equivalent to
+           * val score = blas.ddot(rank, srcFactor, 1, dstFactor, 1)
+           */
+          var score: Double = 0
+          var k = 0
+          while (k < rank) {
+            score += srcFactor(k) * dstFactor(k)
+            k += 1
           }
-          val pqIter = pq.iterator
-          var i = 0
-          while (i < n) {
-            output(j + i) = (srcId, pqIter.next())
-            i += 1
-          }
-          j += n
+          pq += ((dstId, score))
+        }
+        val pqIter = pq.iterator
+        var i = 0
+        while (i < n) {
+          output(j + i) = (srcId, pqIter.next())
+          i += 1
+        }
+        j += n
       }
       output.toSeq
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.mllib.recommendation
 
-import breeze.linalg.min
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus
 import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import java.io.IOException
@@ -279,7 +278,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
     val ratings = srcBlocks.cartesian(dstBlocks).flatMap {
       case (users, items) =>
       val m = users.size
-      val n = min(items.size, num)
+      val n = math.min(items.size, num)
       val output = new Array[(Int, (Int, Double))](m * n)
       var j = 0
       users.foreach (user => {

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -280,7 +280,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
     /**
      * Use dot to replace blas 3 gemm is the key approach to improve efficiency.
      * By this change, we can get the topK elements of each block to reduce the GC time.
-     * Comparing with BLAS.dot, hand writing dot is high efficiency.
+     * Comparing with BLAS.dot, hand-written dot is high efficiency.
      */
     val ratings = srcBlocks.cartesian(dstBlocks).flatMap { case (srcIter, dstIter) =>
       val m = srcIter.size


### PR DESCRIPTION
## What changes were proposed in this pull request?

The recommendForAll of MLLIB ALS is very slow.
GC is a key problem of the current method.
The task use the following code to keep temp result:
val output = new Array[(Int, (Int, Double))](m*n)
m = n = 4096 (default value, no method to set)
so output is about 4k * 4k * (4 + 4 + 8) = 256M. This is a large memory and cause serious GC problem, and it is frequently OOM.

Actually, we don't need to save all the temp result. Support we recommend topK (topK is about 10, or 20) product for each user, we only need 4k * topK * (4 + 4 + 8) memory to save the temp result.

The Test Environment:
3 workers: each work 10 core, each work 30G memory, each work 1 executor.
The Data: User 480,000, and Item 17,000

BlockSize:     1024  2048  4096  8192
Old method:  245s  332s  488s  OOM
This solution: 121s  118s   117s  120s



## How was this patch tested?
The existing UT.
