### PR TITLE
[SPARK-11373] [CORE] Add metrics to the FsHistoryProvider

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -21,7 +21,9 @@ import java.util.zip.ZipOutputStream
 
 import scala.xml.Node
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkFirehoseListener}
+import org.apache.spark.metrics.source.Source
+import org.apache.spark.scheduler._
 import org.apache.spark.ui.SparkUI
 
 private[spark] case class ApplicationAttemptInfo(
@@ -100,6 +102,15 @@ private[history] abstract class ApplicationHistoryProvider {
   }
 
   /**
+   * Bind to the History Server: threads should be started here; exceptions may be raised
+   * if the history provider cannot be started.
+   * @return the metric information for registration
+   */
+  def start(): Option[Source] = {
+    None
+  }
+
+  /**
    * Returns a list of applications available for the history server to show.
    *
    * @return List of all know applications.
@@ -145,4 +156,16 @@ private[history] abstract class ApplicationHistoryProvider {
    * @return html text to display when the application list is empty
    */
   def getEmptyListingHtml(): Seq[Node] = Seq.empty
+}
+
+/**
+ * A simple counter of events.
+ * There is no concurrency support here: all events must come in sequentially.
+ */
+private[history] class EventCountListener extends SparkFirehoseListener {
+  var eventCount = 0L
+
+  override def onEvent(event: SparkListenerEvent): Unit = {
+    eventCount += 1
+  }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -102,9 +102,7 @@ private[history] abstract class ApplicationHistoryProvider {
   }
 
   /**
-   * Bind to the History Server: threads should be started here; exceptions may be raised
-   * if the history provider cannot be started.
-   * @return the metric information for registration
+   * @return None
    */
   def start(): Option[Source] = {
     None

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -170,9 +170,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   }
 
   /**
-   * Start the provider: threads should be started here; exceptions may be raised
-   * if the history provider cannot be started.
-   * @return the metric information for registration
+   * @return the metrics for this provider.
    */
   override def start(): Option[Source] = {
     super.start()

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryMetricSource.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryMetricSource.scala
@@ -57,7 +57,7 @@ private[history] abstract class HistoryMetricSource(val prefix: String) extends 
    */
   override def toString: String = {
     val sb = new StringBuilder(s"Metrics for $sourceName:\n")
-    def robustAppend(s : => Long) = {
+    def robustAppend[T](s : => T) = {
       try {
         sb.append(s)
       } catch {
@@ -69,18 +69,13 @@ private[history] abstract class HistoryMetricSource(val prefix: String) extends 
     sb.append("  Counters\n")
 
     metricRegistry.getCounters.asScala.foreach { case (name, counter) =>
-        sb.append("    ").append(name).append(" = ")
-            .append(counter.getCount).append('\n')
+      sb.append("    ").append(name).append(" = ")
+        .append(counter.getCount).append('\n')
     }
     sb.append("  Gauges\n")
     metricRegistry.getGauges.asScala.foreach { case (name, gauge) =>
       sb.append("    ").append(name).append(" = ")
-      try {
-        sb.append(gauge.getValue)
-      } catch {
-        case e: Exception =>
-          sb.append(s"(exception: $e)")
-      }
+      robustAppend(gauge.getValue)
       sb.append('\n')
     }
     sb.toString()

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryMetricSource.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryMetricSource.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.history
+
+import scala.collection.JavaConverters._
+
+import com.codahale.metrics.{Counter, Gauge, Metric, MetricFilter, MetricRegistry, Timer}
+
+import org.apache.spark.metrics.source.Source
+import org.apache.spark.util.Clock
+
+/**
+ * An abstract implementation of the metrics [[Source]] trait with some common operations for
+ * retrieving entries; the `toString()` operation dumps all counters and gauges.
+ */
+private[history] abstract class HistoryMetricSource(val prefix: String) extends Source {
+
+  override val metricRegistry = new MetricRegistry()
+
+  /**
+   * Register a sequence of metrics
+   * @param metrics sequence of metrics to register
+   */
+  def register(metrics: Seq[(String, Metric)]): Unit = {
+    metrics.foreach { case (name, metric) =>
+      metricRegistry.register(fullname(name), metric)
+    }
+  }
+
+  /**
+   * Create the full name of a metric by prepending the prefix to the name
+   * @param name short name
+   * @return the full name to use in registration
+   */
+  def fullname(name: String): String = {
+    MetricRegistry.name(prefix, name)
+  }
+
+  /**
+   * Dump the counters and gauges.
+   * @return a string for logging and diagnostics -not for parsing by machines.
+   */
+  override def toString: String = {
+    val sb = new StringBuilder(s"Metrics for $sourceName:\n")
+    def robustAppend(s : => Long) = {
+      try {
+        sb.append(s)
+      } catch {
+        case e: Exception =>
+          sb.append(s"(exception: $e)")
+      }
+    }
+
+    sb.append("  Counters\n")
+
+    metricRegistry.getCounters.asScala.foreach { case (name, counter) =>
+        sb.append("    ").append(name).append(" = ")
+            .append(counter.getCount).append('\n')
+    }
+    sb.append("  Gauges\n")
+    metricRegistry.getGauges.asScala.foreach { case (name, gauge) =>
+      sb.append("    ").append(name).append(" = ")
+      try {
+        sb.append(gauge.getValue)
+      } catch {
+        case e: Exception =>
+          sb.append(s"(exception: $e)")
+      }
+      sb.append('\n')
+    }
+    sb.toString()
+  }
+
+  /**
+   * Get a named counter.
+   * @param counterName name of the counter
+   * @return the counter, if found
+   */
+  def getCounter(counterName: String): Option[Counter] = {
+    val full = fullname(counterName)
+    Option(metricRegistry.getCounters(new MetricByName(full)).get(full))
+  }
+
+  /**
+   * Get a gauge of an unknown numeric type.
+   * @param gaugeName name of the gauge
+   * @return gauge, if found
+   */
+  def getGauge(gaugeName: String): Option[Gauge[_]] = {
+    val full = fullname(gaugeName)
+    Option(metricRegistry.getGauges(new MetricByName(full)).get(full))
+  }
+
+  /**
+   * Get a Long gauge.
+   * @param gaugeName name of the gauge
+   * @return gauge, if found
+   * @throws ClassCastException if the gauge is found but of the wrong type
+   */
+  def getLongGauge(gaugeName: String): Option[Gauge[Long]] = {
+    getGauge(gaugeName).asInstanceOf[Option[Gauge[Long]]]
+  }
+
+  /**
+   * Get a timer.
+   * @param timerName name of the timer
+   * @return the timer, if found.
+   */
+  def getTimer(timerName: String): Option[Timer] = {
+    val full = fullname(timerName)
+    Option(metricRegistry.getTimers(new MetricByName(full)).get(full))
+  }
+
+  /**
+   * A filter for metrics by name; include the prefix in the name.
+   * @param fullname full name of metric
+   */
+  private class MetricByName(fullname: String) extends MetricFilter {
+    def matches(metricName: String, metric: Metric): Boolean = metricName == fullname
+  }
+}
+
+/**
+ * A Long gauge from a lambda expression; the expression is evaluated
+ * whenever the metrics are queried.
+ * @param expression expression which generates the value.
+ */
+private[history] class LambdaLongGauge(expression: (() => Long)) extends Gauge[Long] {
+  override def getValue: Long = expression()
+}
+
+/**
+ * A timestamp is a gauge which is set to a point in time
+ * as measured in millseconds since the epoch began.
+ */
+private[history] class TimestampGauge(clock: Clock) extends Gauge[Long] {
+  var time = 0L
+
+  /** Current value. */
+  override def getValue: Long = time
+
+  /** Set a new value. */
+  def setValue(t: Long): Unit = {
+    time = t
+  }
+
+  /** Set to the current system time. */
+  def touch(): Unit = {
+    setValue(clock.getTimeMillis())
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -70,6 +70,10 @@ class HistoryServer(
 
   private[history] var metricsRegistry = metricsSystem.getMetricRegistry
 
+  def cacheMetrics(): CacheMetrics = {
+   appCache.metrics
+  }
+
   private val loaderServlet = new HttpServlet {
     protected override def doGet(req: HttpServletRequest, res: HttpServletResponse): Unit = {
       // Parse the URI created by getAttemptURI(). It contains an app ID and an optional

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -30,6 +30,8 @@ import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
+import org.apache.spark.metrics.MetricsSystem
+import org.apache.spark.metrics.source.Source
 import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationInfo, ApplicationsListResource, UIRoot}
 import org.apache.spark.ui.{SparkUI, UIUtils, WebUI}
 import org.apache.spark.ui.JettyUtils._
@@ -62,6 +64,11 @@ class HistoryServer(
 
   // application
   private val appCache = new ApplicationCache(this, retainedApplications, new SystemClock())
+
+  private[history] val metricsSystem = MetricsSystem.createMetricsSystem("history",
+    conf, securityManager)
+
+  private[history] var metricsRegistry = metricsSystem.getMetricRegistry
 
   // and its metrics, for testing as well as monitoring
   val cacheMetrics = appCache.metrics
@@ -110,6 +117,14 @@ class HistoryServer(
     appCache.getSparkUI(appKey)
   }
 
+  val historyMetrics = new HistoryMetrics(this, "history.server")
+
+  /**
+   * Provider metrics are None until the provider is started, and only after that
+   * point if the provider returns any.
+   */
+  var providerMetrics: Option[Source] = None
+
   initialize()
 
   /**
@@ -131,15 +146,52 @@ class HistoryServer(
     attachHandler(contextHandler)
   }
 
-  /** Bind to the HTTP server behind this web interface. */
+  /**
+   * Startup Actions.
+   * 1. Call `start()` on the provider (and maybe get some metrics back).
+   * 2. Start the metrics.
+   * 3. Bind to the HTTP server behind this web interface.
+   */
   override def bind() {
+    providerMetrics = provider.start()
+    startMetrics()
     super.bind()
   }
 
-  /** Stop the server and close the file system. */
+  /**
+   * Start up the metrics.
+   * This includes registering any metrics defined in `providerMetrics`; the provider
+   * needs its `start()` method to be invoked to get these metric *prior to this method
+   * being invoked*.
+   */
+  private def startMetrics(): Unit = {
+    // hook up metrics
+    metricsSystem.registerSource(historyMetrics)
+    metricsSystem.registerSource(appCache.metrics)
+    providerMetrics.foreach(metricsSystem.registerSource)
+    metricsSystem.start()
+    metricsSystem.getServletHandlers.foreach(attachHandler)
+  }
+
+  /**
+   * Stop the server.
+   * And:
+   * 1. Stop the application cache.
+   * 2. Stop the history provider.
+   * 3. Stop the metrics system.
+   */
   override def stop() {
-    super.stop()
-    provider.stop()
+    Utils.tryLog {
+      super.stop()
+    }
+    Utils.tryLog {
+      if (provider != null) {
+        provider.stop()
+      }
+    }
+    Utils.tryLog {
+      metricsSystem.stop()
+    }
     appCache.stop()
   }
 
@@ -247,6 +299,15 @@ class HistoryServer(
       | cache = $appCache
     """.stripMargin
   }
+}
+
+/**
+ * History system metrics independent of providers go in here.
+ * @param owner owning instance
+ */
+private[history] class HistoryMetrics(val owner: HistoryServer, prefix: String)
+    extends HistoryMetricSource(prefix) {
+  override val sourceName = "history"
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -211,6 +211,8 @@ private[spark] class MetricsSystem private (
       }
     }
   }
+
+  private[spark] def getMetricRegistry(): MetricRegistry = registry
 }
 
 private[spark] object MetricsSystem {

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -66,9 +66,29 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
     new File(logPath)
   }
 
+  /**
+   * Create and configure a new history provider.
+   * @return a filesystem history provider ready for use
+   */
+  private def createHistoryProvider(): FsHistoryProvider = {
+    val provider = new FsHistoryProvider(createTestConf())
+    provider.start()
+    provider
+  }
+
+  /**
+   * Create and configure a new history provider.
+   * @return a filesystem history provider ready for use
+   */
+  private def createHistoryProvider(clock: Clock): FsHistoryProvider = {
+    val provider = new FsHistoryProvider(createTestConf(), clock)
+    provider.start()
+    provider
+  }
+
   test("Parse application logs") {
     val clock = new ManualClock(12345678)
-    val provider = new FsHistoryProvider(createTestConf(), clock)
+    val provider = createHistoryProvider(clock)
 
     // Write a new-style application log.
     val newAppComplete = newLogFile("new1", None, inProgress = false)
@@ -142,6 +162,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
       }
     }
     val provider = new TestFsHistoryProvider
+    provider.start()
 
     val logFile1 = newLogFile("new1", None, inProgress = false)
     writeFile(logFile1, true, None,
@@ -163,7 +184,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("history file is renamed from inprogress to completed") {
-    val provider = new FsHistoryProvider(createTestConf())
+    val provider = createHistoryProvider()
 
     val logFile1 = newLogFile("app1", None, inProgress = true)
     writeFile(logFile1, true, None,
@@ -197,7 +218,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("SPARK-5582: empty log directory") {
-    val provider = new FsHistoryProvider(createTestConf())
+    val provider = createHistoryProvider()
 
     val logFile1 = newLogFile("app1", None, inProgress = true)
     writeFile(logFile1, true, None,
@@ -213,7 +234,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("apps with multiple attempts with order") {
-    val provider = new FsHistoryProvider(createTestConf())
+    val provider = createHistoryProvider()
 
     val attempt1 = newLogFile("app1", Some("attempt1"), inProgress = true)
     writeFile(attempt1, true, None,
@@ -358,7 +379,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("Event log copy") {
-    val provider = new FsHistoryProvider(createTestConf())
+    val provider = createHistoryProvider()
     val logs = (1 to 2).map { i =>
       val log = newLogFile("downloadApp1", Some(s"attempt$i"), inProgress = false)
       writeFile(log, true, None,
@@ -393,7 +414,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
   }
 
   test("SPARK-8372: new logs with no app ID are ignored") {
-    val provider = new FsHistoryProvider(createTestConf())
+    val provider = createHistoryProvider()
 
     // Write a new log file without an app id, to make sure it's ignored.
     val logFile1 = newLogFile("app1", None, inProgress = true)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryMetricSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryMetricSourceSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.history
+
+import scala.collection.JavaConverters._
+
+import com.codahale.metrics.{Counter, Timer}
+import org.scalatest.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.util.ManualClock
+
+class HistoryMetricSourceSuite extends SparkFunSuite with Matchers {
+
+  test("LambdaLongGauge") {
+    assert(3L === new LambdaLongGauge(() => 3L).getValue)
+  }
+
+  test("TimestampGauge lifecycle") {
+    val clock = new ManualClock(1)
+    val ts = new TimestampGauge(clock)
+    assert (0L === ts.getValue)
+    ts.touch()
+    assert (1L === ts.getValue)
+    clock.setTime(1000)
+    assert (1L === ts.getValue)
+    ts.touch()
+    assert (1000 === ts.getValue)
+  }
+
+  test("HistoryMetricSource registration and lookup") {
+    val threeGauge = new LambdaLongGauge(() => 3L)
+    val clock = new ManualClock(1)
+    val ts = new TimestampGauge(clock)
+    val timer = new Timer
+    val counter = new Counter()
+    val source = new TestMetricSource
+    source.register(Seq(
+      ("three", threeGauge),
+      ("timestamp", ts),
+      ("timer", timer),
+      ("counter", counter)))
+    logInfo(source.toString)
+
+    val registry = source.metricRegistry
+    val counters = registry.getCounters.asScala
+    counters.size should be (1)
+    assert(counter === counters("t.counter"))
+    assert(counter === source.getCounter("counter").get)
+
+    val gauges = registry.getGauges.asScala
+    gauges.size should be(2)
+
+    assert(ts === source.getLongGauge("timestamp").get)
+    assert(threeGauge === source.getLongGauge("three").get)
+    assert(timer === source.getTimer("timer").get)
+
+  }
+
+  test("Handle failing Gauge.getValue in toString()") {
+    var zero = 0L
+    val trouble = new LambdaLongGauge(() => 1L/zero)
+    intercept[ArithmeticException](trouble.getValue)
+    val source = new TestMetricSource
+    source.register(Seq(("trouble", trouble)))
+    val s = source.toString
+    logInfo(s)
+    s should include("ArithmeticException")
+  }
+
+  private class TestMetricSource extends HistoryMetricSource("t") {
+    override def sourceName: String = "TestMetricSource"
+  }
+}

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -26,7 +26,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletRequestWrapper, HttpSe
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import com.codahale.metrics.Counter
+import com.codahale.metrics.{Counter, Gauge}
 import com.google.common.io.{ByteStreams, Files}
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
@@ -43,6 +43,7 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatest.selenium.WebBrowser
 
 import org.apache.spark._
+import org.apache.spark.metrics.source.Source
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.ui.jobs.UIData.JobUIData
 import org.apache.spark.util.{ResetSystemProperties, Utils}
@@ -419,15 +420,33 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     server.initialize()
     server.bind()
     val port = server.boundPort
-    val metrics = server.cacheMetrics
+    val cacheMetrics = server.cacheMetrics
+    val historyMetrics = server.historyMetrics
+    val providerMetrics = server.providerMetrics.get.asInstanceOf[HistoryMetricSource]
 
-    // assert that a metric has a value; if not dump the whole metrics instance
-    def assertMetric(name: String, counter: Counter, expected: Long): Unit = {
-      val actual = counter.getCount
-      if (actual != expected) {
+    // assert that a metric counter evaluates as expected; if not dump the whole metrics instance
+    def assertCounterEvaluates(
+        source: Source,
+        name: String,
+        counter: Counter,
+        evaluation: (Long => Boolean)): Unit = {
+      val value = counter.getCount
+      if (!evaluation(value)) {
         // this is here because Scalatest loses stack depth
-        fail(s"Wrong $name value - expected $expected but got $actual" +
-            s" in metrics\n$metrics")
+        fail(s"Wrong $name value: $value in metrics\n$source")
+      }
+    }
+
+    // assert that a long metric gauge evaluates as expected; if not dump the whole metrics instance
+    def assertGaugeEvaluates(
+        source: Source,
+        name: String,
+        gauge: Gauge[Long],
+        evaluation: (Long => Boolean)): Unit = {
+      val value = gauge.getValue
+      if (!evaluation(value)) {
+        // this is here because Scalatest loses stack depth
+        fail(s"Wrong $name value: $value in metrics\n$source")
       }
     }
 
@@ -441,7 +460,10 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       new URL(s"http://localhost:$port/api/v1/applications/$appId$suffix")
     }
 
-    val historyServerRoot = new URL(s"http://localhost:$port/")
+    // check that a dynamically calculated average returns 0 and not a division by zero error.
+    val replayTime = "appui.event.replay.time"
+    assertGaugeEvaluates(providerMetrics, replayTime,
+      providerMetrics.getLongGauge(replayTime).get, _ == 0)
 
     // start initial job
     val d = sc.parallelize(1 to 10)
@@ -516,7 +538,8 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     getNumJobs("") should be (1)
     getNumJobs("/jobs") should be (1)
     getNumJobsRestful() should be (1)
-    assert(metrics.lookupCount.getCount > 1, s"lookup count too low in $metrics")
+    assertCounterEvaluates(cacheMetrics, "lookup count",
+      cacheMetrics.lookupCount, _ > 1)
 
     // dump state before the next bit of test, which is where update
     // checking really gets stressed
@@ -563,6 +586,24 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     listApplications(false) should not contain(appId)
 
     assert(jobcount === getNumJobs("/jobs"))
+
+    // print out the metrics. This forces a run through all the counters and gauges
+    // the evaluation is done outside the log statement to guarantee that the evaluation
+    // always takes place
+    val metricsDump = s"$historyMetrics\n$providerMetrics\n$cacheMetrics"
+    logInfo(s"Metrics:\n$metricsDump")
+    // make some assertions about internal state of providers via the metrics
+    val loadcount = "appui.load.count"
+    assert(metricsDump.contains(loadcount),
+      s"No $loadcount in metrics dump <$metricsDump>")
+    assertCounterEvaluates(providerMetrics, loadcount,
+      providerMetrics.getCounter(loadcount).get, _ > 0)
+    assertGaugeEvaluates(providerMetrics, replayTime,
+      providerMetrics.getLongGauge(replayTime).get, _ > 0)
+
+    val evictionCount = cacheMetrics.fullname("eviction.count")
+    assert(metricsDump.contains(evictionCount),
+      s"No $evictionCount in metrics dump <$metricsDump>")
 
     // no need to retain the test dir now the tests complete
     logDir.deleteOnExit()

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -598,8 +598,6 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       s"No $loadcount in metrics dump <$metricsDump>")
     assertCounterEvaluates(providerMetrics, loadcount,
       providerMetrics.getCounter(loadcount).get, _ > 0)
-    assertGaugeEvaluates(providerMetrics, replayTime,
-      providerMetrics.getLongGauge(replayTime).get, _ > 0)
 
     val evictionCount = cacheMetrics.fullname("eviction.count")
     assert(metricsDump.contains(evictionCount),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds metrics to the history server, with the `FsHistoryProvider` metering its operation count and time spent in activities.

The `HistoryServer` sets up the codahale metrics for the Web under metrics/ with metrics/metrics behind metrics, metrics/health any health probes and metrics/threads a thread dump. There's currently no attempt to  hook up JMX, etc. The Web servlets are the ones tests can easily hit and don't need infrastructure, so are the good initial first step.

It then instantiated the configured `ApplicationHistoryProvider` implementation, now invoking the `start(): Option[Source]` method. If this method
returns an instance of `org.apache.spark.metrics.source.Source`, then it will 

```
  def start(): Option[Source] = {
    None
  }
```

Part of the patch for `HistoryServerSuite` removes the call to `HistoryServer.initialize()` in the `before` clause. That was a duplicate call, one which hit the re-entrancy tests on the provider and registry. As well as cutting it, `HistoryServer.initialize()` has been made idempotent. That should not be needed -but it will eliminate the problem arising again.


## How was this patch tested?

- New test suite `HistoryMetricSourceSuite` to verify low level metrics, in particular ability to wire up a lambda expression to a Coda Hale probe.
- The test suite `FsHistoryProviderSuite` queries the FsHistoryProvider metrics within the existing tests, alongside the existing probes of the `ApplicationCache` metrics. this not only adds coverage of the metrics, it allows the metrics to be used within assertions on the behaviour of the History provider.

