### PR TITLE
[DOCS] Fix a typo in Encoder.clsTag

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
@@ -78,7 +78,7 @@ trait Encoder[T] extends Serializable {
   def schema: StructType
 
   /**
-   * A ClassTag that can be used to construct and Array to contain a collection of `T`.
+   * A ClassTag that can be used to construct an Array to contain a collection of `T`.
    */
   def clsTag: ClassTag[T]
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes a typo: `and` -> `an`

## How was this patch tested?

Not at all.
