### PR TITLE
[SPARK-20463] Add support for IS [NOT] DISTINCT FROM.

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -364,6 +364,22 @@ class Column(object):
     isNull = ignore_unicode_prefix(_unary_op("isNull", _isNull_doc))
     isNotNull = ignore_unicode_prefix(_unary_op("isNotNull", _isNotNull_doc))
 
+    def isNotDistinctFrom(self, col):
+        """
+        A boolean expression that evaluates to true if this expression equals the given expression
+        or both expressions have a value of null.
+
+        :param col: other expression to compare too
+        
+        >>> data = [(10, 20), (30, 30), (40, None), (None, None)]
+        >>> df2 = sc.parallelize(data).toDF("c1", "c2")
+        >>> df2.where(df2["c1"].isNotDistinctFrom(df2["c2"]).collect())
+        [Row(c1=30, c2=30), Row(c1=None, c2=None)]        
+        """
+        jc = col._jc if isinstance(col, Column) else col
+        njc = getattr(self._jc, "eqNullSafe")(jc)
+        return Column(njc)
+
     @since(1.3)
     def alias(self, *alias, **kwargs):
         """

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -364,22 +364,6 @@ class Column(object):
     isNull = ignore_unicode_prefix(_unary_op("isNull", _isNull_doc))
     isNotNull = ignore_unicode_prefix(_unary_op("isNotNull", _isNotNull_doc))
 
-    def isNotDistinctFrom(self, col):
-        """
-        A boolean expression that evaluates to true if this expression equals the given expression
-        or both expressions have a value of null.
-
-        :param col: other expression to compare too
-        
-        >>> data = [(10, 20), (30, 30), (40, None), (None, None)]
-        >>> df2 = sc.parallelize(data).toDF("c1", "c2")
-        >>> df2.where(df2["c1"].isNotDistinctFrom(df2["c2"]).collect())
-        [Row(c1=30, c2=30), Row(c1=None, c2=None)]        
-        """
-        jc = col._jc if isinstance(col, Column) else col
-        njc = getattr(self._jc, "eqNullSafe")(jc)
-        return Column(njc)
-
     @since(1.3)
     def alias(self, *alias, **kwargs):
         """

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -534,6 +534,7 @@ predicate
     | NOT? kind=IN '(' query ')'
     | NOT? kind=(RLIKE | LIKE) pattern=valueExpression
     | IS NOT? kind=NULL
+    | IS NOT? kind=DISTINCT FROM right=valueExpression
     ;
 
 valueExpression

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -962,6 +962,11 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
         IsNotNull(e)
       case SqlBaseParser.NULL =>
         IsNull(e)
+      case SqlBaseParser.DISTINCT =>
+        ctx.NOT match {
+          case null => Not(EqualTo(e, expression(ctx.right)))
+          case not => EqualNullSafe(e, expression(ctx.right))
+        }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -935,6 +935,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
    * - (NOT) LIKE
    * - (NOT) RLIKE
    * - IS (NOT) NULL.
+   * - IS (NOT) DISTINCT FROM
    */
   private def withPredicate(e: Expression, ctx: PredicateContext): Expression = withOrigin(ctx) {
     // Invert a predicate if it has a valid NOT clause.
@@ -962,11 +963,10 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
         IsNotNull(e)
       case SqlBaseParser.NULL =>
         IsNull(e)
+      case SqlBaseParser.DISTINCT if ctx.NOT != null =>
+        EqualNullSafe(e, expression(ctx.right))
       case SqlBaseParser.DISTINCT =>
-        ctx.NOT match {
-          case null => Not(EqualTo(e, expression(ctx.right)))
-          case not => EqualNullSafe(e, expression(ctx.right))
-        }
+        Not(EqualNullSafe(e, expression(ctx.right)))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -167,6 +167,11 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("a = b is not null", ('a === 'b).isNotNull)
   }
 
+  test("is distinct expressions") {
+    assertEqual("a is distinct from b", !('a === 'b))
+    assertEqual("a is not distinct from b", 'a <=> 'b)
+  }
+
   test("binary arithmetic expressions") {
     // Simple operations
     assertEqual("a * b", 'a * 'b)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -168,7 +168,7 @@ class ExpressionParserSuite extends PlanTest {
   }
 
   test("is distinct expressions") {
-    assertEqual("a is distinct from b", !('a === 'b))
+    assertEqual("a is distinct from b", !('a <=> 'b))
     assertEqual("a is not distinct from b", 'a <=> 'b)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support for the SQL standard distinct predicate to SPARK SQL.

```
<expression> IS [NOT] DISTINCT FROM <expression>
```

## How was this patch tested?

Tested using unit tests, integration tests, manual tests.