### PR TITLE
[SPARK-20464][SS] Add a job group and description for streaming queries and fix cancellation of running jobs using the job group

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -446,7 +446,7 @@ private[spark] object UIUtils extends Logging {
       val xml = XML.loadString(s"""<span class="description-input">$desc</span>""")
 
       // Verify that this has only anchors and span (we are wrapping in span)
-      val allowedNodeLabels = Set("a", "span")
+      val allowedNodeLabels = Set("a", "span", "br")
       val illegalNodes = xml \\ "_"  filterNot { case node: Node =>
         allowedNodeLabels.contains(node.label)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -482,7 +482,6 @@ class StreamExecution(
       case None => // We are starting this stream for the first time.
         logInfo(s"Starting new streaming query.")
         currentBatchId = 0
-        sparkSession.sparkContext.setJobDescription(getBatchDescriptionString)
         constructNextBatch()
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -835,7 +835,7 @@ class StreamExecution(
   private def getBatchDescriptionString: String = {
     val batchDescription = if (currentBatchId < 0) "init" else currentBatchId.toString
     Option(name).map(_ + " ").getOrElse("") +
-      s"[batch = $batchDescription, id = $id, runId = $runId]"
+      s"[batch = $batchDescription,<br/>id = $id,<br/>runId = $runId]"
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -590,6 +590,8 @@ class StreamExecution(
    * @param sparkSessionToRunBatch Isolated [[SparkSession]] to run this batch with.
    */
   private def runBatch(sparkSessionToRunBatch: SparkSession): Unit = {
+    sparkSession.sparkContext.setJobGroup(runId.toString, getBatchDescriptionString)
+
     // Request unprocessed data from all sources.
     newData = reportTimeTaken("getBatch") {
       availableOffsets.flatMap {
@@ -825,6 +827,9 @@ class StreamExecution(
     }
   }
 
+  private def getBatchDescriptionString: String = {
+    Option(name).map(_ + " ").getOrElse("") + s"[batch = $currentBatchId, id = $id, runId = $runId]"
+  }
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -834,8 +834,8 @@ class StreamExecution(
 
   private def getBatchDescriptionString: String = {
     val batchDescription = if (currentBatchId < 0) "init" else currentBatchId.toString
-    Option(name).map(_ + " ").getOrElse("") +
-      s"[batch = $batchDescription,<br/>id = $id,<br/>runId = $runId]"
+    Option(name).map(_ + "<br/>").getOrElse("") +
+      s"id = $id<br/>runId = $runId<br/>batch = $batchDescription"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -534,7 +534,7 @@ class StreamSuite extends StreamTest {
   test("batch id is updated correctly in the job description") {
     val queryName = "memStream"
     @volatile var jobDescription: String = null
-    def assertContainsNameAndBatch(batch: Integer): Unit = {
+    def assertDescContainsQueryNameAnd(batch: Integer): Unit = {
       // wait for listener event to be processed
       spark.sparkContext.listenerBus.waitUntilEmpty(streamingTimeout.toMillis)
       assert(jobDescription.contains(queryName) && jobDescription.contains(s"batch = $batch"))
@@ -557,13 +557,14 @@ class StreamSuite extends StreamTest {
 
     input.addData(1)
     query.processAllAvailable()
-    assertContainsNameAndBatch(batch = 0)
+    assertDescContainsQueryNameAnd(batch = 0)
     input.addData(2, 3)
     query.processAllAvailable()
-    assertContainsNameAndBatch(batch = 1)
+    assertDescContainsQueryNameAnd(batch = 1)
     input.addData(4)
     query.processAllAvailable()
-    assertContainsNameAndBatch(batch = 2)
+    assertDescContainsQueryNameAnd(batch = 2)
+    query.stop()
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Job group: adding a job group is required to properly cancel running jobs related to a query.
Description: the new description makes it easier to group the batches of a query by sorting by name in the Spark Jobs UI.

## How was this patch tested?

- Unit tests
- UI screenshot

  - Order by job id:
![screen shot 2017-04-27 at 5 10 09 pm](https://cloud.githubusercontent.com/assets/7865120/25509468/15452274-2b6e-11e7-87ba-d929816688cf.png)


  - Order by description:
![screen shot 2017-04-27 at 5 10 22 pm](https://cloud.githubusercontent.com/assets/7865120/25509474/1c298512-2b6e-11e7-99b8-fef1ef7665c1.png)

  - Order by job id (no query name):
![screen shot 2017-04-27 at 5 21 33 pm](https://cloud.githubusercontent.com/assets/7865120/25509482/28c96dc8-2b6e-11e7-8df0-9d3cdbb05e36.png)

  - Order by description (no query name):
![screen shot 2017-04-27 at 5 21 44 pm](https://cloud.githubusercontent.com/assets/7865120/25509489/37674742-2b6e-11e7-9357-b5c38ec16ac4.png)
