### PR TITLE
[SPARK-20465][CORE] Throws a proper exception when any temp directory could not be got

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -740,9 +740,13 @@ private[spark] object Utils extends Logging {
    * always return a single directory.
    */
   def getLocalDir(conf: SparkConf): String = {
-    getOrCreateLocalRootDirs(conf).headOption.getOrElse {
-      val dirPaths = getConfiguredLocalDirs(conf)
-      throw new IOException(s"Failed to get a temp directory under [${dirPaths.mkString(",")}].")
+    val localRootDirs = getOrCreateLocalRootDirs(conf)
+    if (localRootDirs.nonEmpty) {
+      localRootDirs(0)
+    } else {
+      val configuredLocalDirs = getConfiguredLocalDirs(conf)
+      throw new IOException(
+        s"Failed to get a temp directory under [${configuredLocalDirs.mkString(",")}].")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -740,7 +740,10 @@ private[spark] object Utils extends Logging {
    * always return a single directory.
    */
   def getLocalDir(conf: SparkConf): String = {
-    getOrCreateLocalRootDirs(conf)(0)
+    getOrCreateLocalRootDirs(conf).headOption.getOrElse {
+      val dirPaths = getConfiguredLocalDirs(conf)
+      throw new IOException(s"Failed to get a temp directory under [${dirPaths.mkString(",")}].")
+    }
   }
 
   private[spark] def isRunningInYarnContainer(conf: SparkConf): Boolean = {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -740,10 +740,7 @@ private[spark] object Utils extends Logging {
    * always return a single directory.
    */
   def getLocalDir(conf: SparkConf): String = {
-    val localRootDirs = getOrCreateLocalRootDirs(conf)
-    if (localRootDirs.nonEmpty) {
-      localRootDirs(0)
-    } else {
+    getOrCreateLocalRootDirs(conf).headOption.getOrElse {
       val configuredLocalDirs = getConfiguredLocalDirs(conf)
       throw new IOException(
         s"Failed to get a temp directory under [${configuredLocalDirs.mkString(",")}].")

--- a/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
@@ -33,6 +33,10 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
     Utils.clearLocalRootDirs()
   }
 
+  after {
+    Utils.clearLocalRootDirs()
+  }
+
   test("Utils.getLocalDir() returns a valid directory, even if some local dirs are missing") {
     // Regression test for SPARK-2974
     assert(!new File("/NONEXISTENT_PATH").exists())

--- a/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.storage
 
-import java.io.File
+import java.io.{File, IOException}
 
 import org.scalatest.BeforeAndAfter
 
@@ -51,4 +51,14 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
     assert(new File(Utils.getLocalDir(conf)).exists())
   }
 
+  test("Utils.getLocalDir() throws an exception if any temporary directory cannot be retrieved") {
+    assert(!new File("/NONEXISTENT_DIR_ONE").exists())
+    assert(!new File("/NONEXISTENT_DIR_TWO").exists())
+    val conf = new SparkConf().set("spark.local.dir", "/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO")
+    val message = intercept[IOException] {
+      Utils.getLocalDir(conf)
+    }.getMessage
+    assert(message ===
+      "Failed to get a temp directory under [/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO].")
+  }
 }

--- a/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
@@ -35,7 +35,7 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
 
   test("Utils.getLocalDir() returns a valid directory, even if some local dirs are missing") {
     // Regression test for SPARK-2974
-    assert(!new File("/NONEXISTENT_DIR").exists())
+    assert(!new File("/NONEXISTENT_PATH").exists())
     val conf = new SparkConf(false)
       .set("spark.local.dir", s"/NONEXISTENT_PATH,${System.getProperty("java.io.tmpdir")}")
     assert(new File(Utils.getLocalDir(conf)).exists())
@@ -43,7 +43,7 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
 
   test("SPARK_LOCAL_DIRS override also affects driver") {
     // Regression test for SPARK-2975
-    assert(!new File("/NONEXISTENT_DIR").exists())
+    assert(!new File("/NONEXISTENT_PATH").exists())
     // spark.local.dir only contains invalid directories, but that's not a problem since
     // SPARK_LOCAL_DIRS will override it on both the driver and workers:
     val conf = new SparkConfWithEnv(Map("SPARK_LOCAL_DIRS" -> System.getProperty("java.io.tmpdir")))
@@ -52,8 +52,8 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("Utils.getLocalDir() throws an exception if any temporary directory cannot be retrieved") {
-    assert(!new File("/NONEXISTENT_DIR_ONE").exists())
-    assert(!new File("/NONEXISTENT_DIR_TWO").exists())
+    assert(!new File("/NONEXISTENT_PATH_ONE").exists())
+    assert(!new File("/NONEXISTENT_PATH_TWO").exists())
     val conf = new SparkConf(false)
       .set("spark.local.dir", "/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO")
     val message = intercept[IOException] {

--- a/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
@@ -54,7 +54,8 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
   test("Utils.getLocalDir() throws an exception if any temporary directory cannot be retrieved") {
     assert(!new File("/NONEXISTENT_DIR_ONE").exists())
     assert(!new File("/NONEXISTENT_DIR_TWO").exists())
-    val conf = new SparkConf().set("spark.local.dir", "/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO")
+    val conf = new SparkConf(false)
+      .set("spark.local.dir", "/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO")
     val message = intercept[IOException] {
       Utils.getLocalDir(conf)
     }.getMessage

--- a/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
@@ -52,14 +52,16 @@ class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("Utils.getLocalDir() throws an exception if any temporary directory cannot be retrieved") {
-    assert(!new File("/NONEXISTENT_PATH_ONE").exists())
-    assert(!new File("/NONEXISTENT_PATH_TWO").exists())
-    val conf = new SparkConf(false)
-      .set("spark.local.dir", "/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO")
+    val path1 = "/NONEXISTENT_PATH_ONE"
+    val path2 = "/NONEXISTENT_PATH_TWO"
+    assert(!new File(path1).exists())
+    assert(!new File(path2).exists())
+    val conf = new SparkConf(false).set("spark.local.dir", s"$path1,$path2")
     val message = intercept[IOException] {
       Utils.getLocalDir(conf)
     }.getMessage
-    assert(message ===
-      "Failed to get a temp directory under [/NONEXISTENT_PATH_ONE,/NONEXISTENT_PATH_TWO].")
+    // If any temporary directory could not be retrieved under the given paths above, it should
+    // throw an exception with the message that includes the paths.
+    assert(message.contains(s"$path1,$path2"))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to throw an exception with better message rather than `ArrayIndexOutOfBoundsException` when temp directories could not be created.

Running the commands below:

```bash
./bin/spark-shell --conf spark.local.dir=/NONEXISTENT_DIR_ONE,/NONEXISTENT_DIR_TWO
```

produces ...

**Before**

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        ...
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
        ...
```

**After**

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        ...
Caused by: java.io.IOException: Failed to get a temp directory under [/NONEXISTENT_DIR_ONE,/NONEXISTENT_DIR_TWO].
        ...
```

## How was this patch tested?

Unit tests in `LocalDirsSuite.scala`.
