### PR TITLE
[SPARK-20467] sbt-launch-lib.bash has lacked the ASF header.

### DIFF
--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
-#
 
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # A library to simplify using the SBT launcher from other packages.
 # Note: This should be used by tools like giter8/conscript etc.
 


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-20467](https://issues.apache.org/jira/browse/SPARK-20467)
When I use this script,I found sbt-launch-lib.bash lack the ASF header.It doesn't be permitted by Apache Foundation according to apache license 2.0.
