### PR TITLE
[SPARK-20494] Implement UDF array_unique in Spark with codegen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -361,6 +361,7 @@ object FunctionRegistry {
     // collection functions
     expression[CreateArray]("array"),
     expression[ArrayContains]("array_contains"),
+    expression[ArrayUnique]("array_unique"),
     expression[CreateMap]("map"),
     expression[CreateNamedStruct]("named_struct"),
     expression[MapKeys]("map_keys"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
@@ -163,4 +163,8 @@ abstract class ArrayData extends SpecializedGetters with Serializable {
       i += 1
     }
   }
+
+  def distinct(elementType: DataType): Array[AnyRef] = {
+    toObjectArray(elementType).distinct
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -105,4 +105,18 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(ArrayContains(a3, Literal("")), null)
     checkEvaluation(ArrayContains(a3, Literal.create(null, StringType)), null)
   }
+
+  test("Array Unique") {
+    val a0 = Literal.create(Seq(2, 1, 3, 4, 1, 2, 6), ArrayType(IntegerType))
+    val a1 = Literal.create(Seq[Integer](), ArrayType(IntegerType))
+    val a2 = Literal.create(Seq("b", "a", "c", "b", "a", "d"), ArrayType(StringType))
+    val a3 = Literal.create(Seq("b", null, "a"), ArrayType(StringType))
+    val a4 = Literal.create(Seq(null, null), ArrayType(NullType))
+
+    checkEvaluation(ArrayUnique(a0), Seq(2, 1, 3, 4, 6))
+    checkEvaluation(ArrayUnique(a1), Seq())
+    checkEvaluation(ArrayUnique(a2), Seq("b", "a", "c", "d"))
+    checkEvaluation(ArrayUnique(a3), Seq("b", null, "a"))
+    checkEvaluation(ArrayUnique(a4), Seq(null))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add UDF array_unique which return a new array with all the duplicated elements in the original array removed.

## How was this patch tested?
Added various unittests in collectionExpressionsSuite.scala and also in spark-shell, created tables with columns of array type and inserted values with duplicated array elements, ran queries with UDF and verified the results.

