### PR TITLE
[DOCS][MINOR] Add missing since to SparkR repeat_string note.

### DIFF
--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -3796,7 +3796,7 @@ setMethod("split_string",
 #' # This is equivalent to the following SQL expression
 #' first(selectExpr(df, "repeat(value, 3)"))
 #' }
-#' @note repeat_string 2.3.0
+#' @note repeat_string since 2.3.0
 setMethod("repeat_string",
           signature(x = "Column", n = "numeric"),
           function(x, n) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace

    @note repeat_string 2.3.0

with 
  
    @note repeat_string since 2.3.0

## How was this patch tested?

`create-docs.sh`
