### PR TITLE
[SPARK-20496][SS] Bug in KafkaWriter Looks at Unanalyzed Plans

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
@@ -47,7 +47,8 @@ private[kafka010] object KafkaWriter extends Logging {
       queryExecution: QueryExecution,
       kafkaParameters: ju.Map[String, Object],
       topic: Option[String] = None): Unit = {
-    val schema = queryExecution.logical.output
+    queryExecution.assertAnalyzed()
+    val schema = queryExecution.analyzed.output
     schema.find(_.name == TOPIC_ATTRIBUTE_NAME).getOrElse(
       if (topic == None) {
         throw new AnalysisException(s"topic option required when no " +

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
@@ -47,7 +47,6 @@ private[kafka010] object KafkaWriter extends Logging {
       queryExecution: QueryExecution,
       kafkaParameters: ju.Map[String, Object],
       topic: Option[String] = None): Unit = {
-    queryExecution.assertAnalyzed()
     val schema = queryExecution.analyzed.output
     schema.find(_.name == TOPIC_ATTRIBUTE_NAME).getOrElse(
       if (topic == None) {

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
@@ -84,7 +84,7 @@ private[kafka010] object KafkaWriter extends Logging {
       queryExecution: QueryExecution,
       kafkaParameters: ju.Map[String, Object],
       topic: Option[String] = None): Unit = {
-    val schema = queryExecution.logical.output
+    val schema = queryExecution.analyzed.output
     validateQuery(queryExecution, kafkaParameters, topic)
     SQLExecution.withNewExecutionId(sparkSession, queryExecution) {
       queryExecution.toRdd.foreachPartition { iter =>

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -118,15 +118,13 @@ class KafkaSinkSuite extends StreamTest with SharedSQLContext {
     /* No topic field or topic option */
     var writer: StreamingQuery = null
     var ex: Exception = null
-    try {
       ex = intercept[AnalysisException] {
         writer = createKafkaWriter(input.toDF())(
           withSelectExpr = "value as key", "value"
         )
         writer.processAllAvailable()
       }
-    } finally {
-    }
+    println(ex.getMessage)
     assert(ex.getMessage
       .toLowerCase(Locale.ROOT)
       .contains("can be called only on streaming"))

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -224,7 +224,7 @@ class KafkaSinkSuite extends StreamTest with SharedSQLContext {
       withTopic = Some(topic),
       withOutputMode = Some(OutputMode.Update()))(
       withSelectExpr = "'foo' as topic",
-      "CAST(value as STRING) key", "CAST(count as STRING) value")
+        "CAST(value as STRING) key", "CAST(count as STRING) value")
 
     val reader = createKafkaReader(topic)
       .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
@@ -423,11 +423,11 @@ class KafkaSinkSuite extends StreamTest with SharedSQLContext {
   }
 
   private def createKafkaWriter(
-                                 input: DataFrame,
-                                 withTopic: Option[String] = None,
-                                 withOutputMode: Option[OutputMode] = None,
-                                 withOptions: Map[String, String] = Map[String, String]())
-                               (withSelectExpr: String*): StreamingQuery = {
+      input: DataFrame,
+      withTopic: Option[String] = None,
+      withOutputMode: Option[OutputMode] = None,
+      withOptions: Map[String, String] = Map[String, String]())
+      (withSelectExpr: String*): StreamingQuery = {
     var stream: DataStreamWriter[Row] = null
     withTempDir { checkpointDir =>
       var df = input.toDF()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This now asserts that a plan has been analyzed before reading the schema.

## How was this patch tested?

Existing Tests.
- [ ] New Test Coming Soon

Please review http://spark.apache.org/contributing.html before opening a pull request.
