### PR TITLE
[SPARK-20541][SPARKR][SS] support awaitTermination without timeout

### DIFF
--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1510,7 +1510,7 @@ setGeneric("write.ml", function(object, path, ...) { standardGeneric("write.ml")
 
 #' @rdname awaitTermination
 #' @export
-setGeneric("awaitTermination", function(x, timeout) { standardGeneric("awaitTermination") })
+setGeneric("awaitTermination", function(x, timeout = NULL) { standardGeneric("awaitTermination") })
 
 #' @rdname isActive
 #' @export

--- a/R/pkg/R/streaming.R
+++ b/R/pkg/R/streaming.R
@@ -171,7 +171,8 @@ setMethod("isActive",
 #' @param x a StreamingQuery.
 #' @param timeout time to wait in milliseconds, if omitted, wait indefinitely until \code{stopQuery}
 #'                is called or an error has occured.
-#' @return TRUE if query has terminated within the timeout period.
+#' @return TRUE if query has terminated within the timeout period; nothing if timeout is not
+#'         specified.
 #' @rdname awaitTermination
 #' @name awaitTermination
 #' @aliases awaitTermination,StreamingQuery-method
@@ -185,7 +186,7 @@ setMethod("awaitTermination",
           signature(x = "StreamingQuery"),
           function(x, timeout = NULL) {
             if (is.null(timeout)) {
-              handledCallJMethod(x@ssq, "awaitTermination")
+              invisible(handledCallJMethod(x@ssq, "awaitTermination"))
             } else {
               handledCallJMethod(x@ssq, "awaitTermination", as.integer(timeout))
             }

--- a/R/pkg/R/streaming.R
+++ b/R/pkg/R/streaming.R
@@ -169,7 +169,8 @@ setMethod("isActive",
 #' immediately.
 #'
 #' @param x a StreamingQuery.
-#' @param timeout time to wait in milliseconds
+#' @param timeout time to wait in milliseconds, if omitted, wait indefinitely until \code{stopQuery}
+#'                is called or an error has occured.
 #' @return TRUE if query has terminated within the timeout period.
 #' @rdname awaitTermination
 #' @name awaitTermination
@@ -182,8 +183,12 @@ setMethod("isActive",
 #' @note experimental
 setMethod("awaitTermination",
           signature(x = "StreamingQuery"),
-          function(x, timeout) {
-            handledCallJMethod(x@ssq, "awaitTermination", as.integer(timeout))
+          function(x, timeout = NULL) {
+            if (is.null(timeout)) {
+              handledCallJMethod(x@ssq, "awaitTermination")
+            } else {
+              handledCallJMethod(x@ssq, "awaitTermination", as.integer(timeout))
+            }
           })
 
 #' stopQuery

--- a/R/pkg/inst/tests/testthat/test_streaming.R
+++ b/R/pkg/inst/tests/testthat/test_streaming.R
@@ -61,6 +61,7 @@ test_that("read.stream, write.stream, awaitTermination, stopQuery", {
 
   stopQuery(q)
   expect_true(awaitTermination(q, 1))
+  expect_true(awaitTermination(q))
 })
 
 test_that("print from explain, lastProgress, status, isActive", {

--- a/R/pkg/inst/tests/testthat/test_streaming.R
+++ b/R/pkg/inst/tests/testthat/test_streaming.R
@@ -61,7 +61,7 @@ test_that("read.stream, write.stream, awaitTermination, stopQuery", {
 
   stopQuery(q)
   expect_true(awaitTermination(q, 1))
-  expect_true(awaitTermination(q))
+  expect_error(awaitTermination(q), NA)
 })
 
 test_that("print from explain, lastProgress, status, isActive", {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add without param for timeout - will need this to submit a job that runs until stopped
Need this for 2.2

## How was this patch tested?

manually, unit test