### PR TITLE
[SPARK-20550][SPARKR] R wrapper for Dataset.alias

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3744,7 +3744,7 @@ setMethod("hint",
             stopifnot(all(sapply(parameters, is.character)))
             jdf <- callJMethod(x@sdf, "hint", name, parameters)
             dataFrame(jdf)
-		  })
+          })
 
 #' alias
 #'

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3744,4 +3744,30 @@ setMethod("hint",
             stopifnot(all(sapply(parameters, is.character)))
             jdf <- callJMethod(x@sdf, "hint", name, parameters)
             dataFrame(jdf)
+		  })
+
+#' alias
+#'
+#' Returns a new SparkDataFrame with an alias set.
+#'
+#' @param object a SparkDataFrame
+#' @param data new name to use
+#' @return SparkDataFrame
+#' @aliases alias,SparkDataFrame-method
+#' @rdname alias
+#' @name alias
+#' @examples \dontrun{
+#' df <- alias(createDataFrame(mtcars), "mtcars")
+#' avg_mpg <- alias(agg(groupBy(df, df$cyl), avg(df$mpg)), "avg_mpg")
+#'
+#' head(select(df, column("mtcars.mpg")))
+#' head(join(df, avg_mpg, column("mtcars.cyl") == column("avg_mpg.cyl")))
+#' }
+#' @note alias since 2.3.0
+setMethod("alias",
+          signature(object = "SparkDataFrame"),
+          function(object, data) {
+            stopifnot(is.character(data))
+            sdf <- callJMethod(object@sdf, "alias", data)
+            dataFrame(sdf)
           })

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3751,7 +3751,8 @@ setMethod("hint",
 #' @aliases alias,SparkDataFrame-method
 #' @rdname alias
 #' @name alias
-#' @examples \dontrun{
+#' @examples
+#' \dontrun{
 #' df <- alias(createDataFrame(mtcars), "mtcars")
 #' avg_mpg <- alias(agg(groupBy(df, df$cyl), avg(df$mpg)), "avg_mpg")
 #'

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3759,7 +3759,7 @@ setMethod("hint",
 #' head(select(df, column("mtcars.mpg")))
 #' head(join(df, avg_mpg, column("mtcars.cyl") == column("avg_mpg.cyl")))
 #' }
-#' @note alias since 2.3.0
+#' @note alias(SparkDataFrame) since 2.3.0
 setMethod("alias",
           signature(object = "SparkDataFrame"),
           function(object, data) {

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3748,7 +3748,6 @@ setMethod("hint",
 
 #' alias
 #'
-#' @return SparkDataFrame
 #' @aliases alias,SparkDataFrame-method
 #' @rdname alias
 #' @name alias

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3752,6 +3752,7 @@ setMethod("hint",
 #' @family SparkDataFrame functions
 #' @rdname alias
 #' @name alias
+#' @export
 #' @examples
 #' \dontrun{
 #' df <- alias(createDataFrame(mtcars), "mtcars")

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3749,6 +3749,7 @@ setMethod("hint",
 #' alias
 #'
 #' @aliases alias,SparkDataFrame-method
+#' @family SparkDataFrame functions
 #' @rdname alias
 #' @name alias
 #' @examples

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -3748,10 +3748,6 @@ setMethod("hint",
 
 #' alias
 #'
-#' Returns a new SparkDataFrame with an alias set.
-#'
-#' @param object a SparkDataFrame
-#' @param data new name to use
 #' @return SparkDataFrame
 #' @aliases alias,SparkDataFrame-method
 #' @rdname alias

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -132,9 +132,9 @@ createMethods()
 
 #' alias
 #'
-#' Set a new name for a column
+#' Set a new name for an object
 #'
-#' @param object Column to rename
+#' @param object object to rename
 #' @param data new name to use
 #'
 #' @rdname alias

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -142,6 +142,13 @@ createMethods()
 #' @aliases alias,Column-method
 #' @family colum_func
 #' @export
+#' @examples \dontrun{
+#' df <- createDataFrame(iris)
+#'
+#' head(select(
+#'   df, alias(df$Sepal_Length, "slength"), alias(df$Petal_Length, "plength")
+#' ))
+#' }
 #' @note alias since 1.4.0
 setMethod("alias",
           signature(object = "Column"),

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -132,7 +132,7 @@ createMethods()
 
 #' alias
 #'
-#' Set a new name for an object
+#' Set a new name for an object. Equivalent to SQL "AS" keyword.
 #'
 #' @param object x a Column or a SparkDataFrame
 #' @param data new name to use

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -134,7 +134,7 @@ createMethods()
 #'
 #' Set a new name for an object
 #'
-#' @param object object to rename
+#' @param object x a Column or a SparkDataFrame
 #' @param data new name to use
 #'
 #' @rdname alias

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -149,7 +149,7 @@ createMethods()
 #'   df, alias(df$Sepal_Length, "slength"), alias(df$Petal_Length, "plength")
 #' ))
 #' }
-#' @note alias since 1.4.0
+#' @note alias(Column) since 1.4.0
 setMethod("alias",
           signature(object = "Column"),
           function(object, data) {

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -130,13 +130,6 @@ createMethods <- function() {
 
 createMethods()
 
-#' alias
-#'
-#' Set a new name for an object. Equivalent to SQL "AS" keyword.
-#'
-#' @param object x a Column or a SparkDataFrame
-#' @param data new name to use
-#'
 #' @rdname alias
 #' @name alias
 #' @aliases alias,Column-method

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -389,7 +389,7 @@ setGeneric("agg", function (x, ...) { standardGeneric("agg") })
 
 #' alias
 #'
-#' Set a new name for a Column or a SparkDataFrame. Equivalent to SQL "AS" keyword.
+#' Returns a new SparkDataFrame or Column with an alias set. Equivalent to SQL "AS" keyword.
 #'
 #' @name alias
 #' @rdname alias

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -387,6 +387,16 @@ setGeneric("value", function(bcast) { standardGeneric("value") })
 #' @export
 setGeneric("agg", function (x, ...) { standardGeneric("agg") })
 
+#' alias
+#'
+#' Set a new name for a Column or a SparkDataFrame. Equivalent to SQL "AS" keyword.
+#'
+#' @name alias
+#' @rdname alias
+#' @param object x a Column or a SparkDataFrame
+#' @param data new name to use
+NULL
+
 #' @rdname arrange
 #' @export
 setGeneric("arrange", function(x, col, ...) { standardGeneric("arrange") })

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -389,13 +389,13 @@ setGeneric("agg", function (x, ...) { standardGeneric("agg") })
 
 #' alias
 #'
-#' Returns a new SparkDataFrame or Column with an alias set. Equivalent to SQL "AS" keyword.
+#' Returns a new SparkDataFrame or a Column with an alias set. Equivalent to SQL "AS" keyword.
 #'
 #' @name alias
 #' @rdname alias
-#' @param object x a Column or a SparkDataFrame
+#' @param object x a SparkDataFrame or a Column
 #' @param data new name to use
-#' @return a Column or a SparkDataFrame
+#' @return a SparkDataFrame or a Column
 NULL
 
 #' @rdname arrange

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -395,6 +395,7 @@ setGeneric("agg", function (x, ...) { standardGeneric("agg") })
 #' @rdname alias
 #' @param object x a Column or a SparkDataFrame
 #' @param data new name to use
+#' @return a Column or a SparkDataFrame
 NULL
 
 #' @rdname arrange

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1229,6 +1229,10 @@ test_that("select with column", {
   expect_equal(columns(select(df5, column("table.name"))), "name")
   expect_equal(columns(select(df5, "table.name")), "name")
 
+  # Test that stats::alias is not masked
+  expect_is(alias(aov(yield ~ block + N*P*K, npk)), "listof")
+
+
   expect_error(select(df, c("name", "age"), "name"),
                 "To select multiple columns, use a character vector or list for col")
 })

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2352,6 +2352,15 @@ test_that("mutate(), transform(), rename() and names()", {
   detach(airquality)
 })
 
+test("alias on SparkDataFrame", {
+  df <- alias(read.df(jsonPath, "json"), "table")
+
+  actual <- sort(collect(select(df, column("table.name")))$name)
+  expected <- c("Andy", "Justin", "Michael")
+
+  expect_equal(actual, expected)
+})
+
 test_that("read/write ORC files", {
   skip_on_cran()
 

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1230,7 +1230,7 @@ test_that("select with column", {
   expect_equal(columns(select(df5, "table.name")), "name")
 
   # Test that stats::alias is not masked
-  expect_is(alias(aov(yield ~ block + N*P*K, npk)), "listof")
+  expect_is(alias(aov(yield ~ block + N * P * K, npk)), "listof")
 
 
   expect_error(select(df, c("name", "age"), "name"),

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -2352,7 +2352,7 @@ test_that("mutate(), transform(), rename() and names()", {
   detach(airquality)
 })
 
-test("alias on SparkDataFrame", {
+test_that("alias on SparkDataFrame", {
   df <- alias(read.df(jsonPath, "json"), "table")
 
   actual <- sort(collect(select(df, column("table.name")))$name)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1223,6 +1223,12 @@ test_that("select with column", {
   expect_equal(columns(df4), c("name", "age"))
   expect_equal(count(df4), 3)
 
+  # Test select with alias
+  df5 <- alias(df, "table")
+
+  expect_equal(columns(select(df5, column("table.name"))), "name")
+  expect_equal(columns(select(df5, "table.name")), "name")
+
   expect_error(select(df, c("name", "age"), "name"),
                 "To select multiple columns, use a character vector or list for col")
 })
@@ -2350,15 +2356,6 @@ test_that("mutate(), transform(), rename() and names()", {
   expect_equal(nrow(result), 153)
   expect_equal(ncol(result), 2)
   detach(airquality)
-})
-
-test_that("alias on SparkDataFrame", {
-  df <- alias(read.df(jsonPath, "json"), "table")
-
-  actual <- sort(collect(select(df, column("table.name")))$name)
-  expected <- c("Andy", "Justin", "Michael")
-
-  expect_equal(actual, expected)
 })
 
 test_that("read/write ORC files", {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add SparkR wrapper for `Dataset.alias`.
- Adjust roxygen annotations for `functions.alias` (including example usage).

## How was this patch tested?

Unit tests, `check_cran.sh`.
