### PR TITLE
[SPARK-20552][SQL][PYTHON] Add isNotDistinctFrom/isDistinctFrom for column APIs in Scala and Python

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -224,7 +224,39 @@ class Column(object):
        https://spark.apache.org/docs/latest/sql-programming-guide.html#nan-semantics
     .. versionadded:: 2.3.0
     """
+    _isNotDistinctFrom_doc = _eqNullSafe_doc.replace("eqNullSafe", "isNotDistinctFrom")
+    _isDistinctFrom_doc = """
+    Inequality test that is safe for null values.
+
+    :param other: a value or :class:`Column`
+
+    >>> from pyspark.sql import Row
+    >>> df1 = spark.createDataFrame([
+    ...     Row(id=1, value='foo'),
+    ...     Row(id=2, value=None)
+    ... ])
+    >>> df1.select(
+    ...     df1['value'] != 'foo',
+    ...     df1['value'].isDistinctFrom('foo'),
+    ...     df1['value'].isDistinctFrom(None)
+    ... ).show()
+    +-------------------+---------------------+----------------------+
+    |(NOT (value = foo))|(NOT (value <=> foo))|(NOT (value <=> NULL))|
+    +-------------------+---------------------+----------------------+
+    |              false|                false|                  true|
+    |               null|                 true|                 false|
+    +-------------------+---------------------+----------------------+
+
+    .. note:: Unlike Pandas, PySpark doesn't consider NaN values to be NULL.
+       See the `NaN Semantics`_ for details.
+    .. _NaN Semantics:
+       https://spark.apache.org/docs/latest/sql-programming-guide.html#nan-semantics
+    .. versionadded:: 2.3.0
+    """
+
     eqNullSafe = _bin_op("eqNullSafe", _eqNullSafe_doc)
+    isNotDistinctFrom = _bin_op("isNotDistinctFrom", _isNotDistinctFrom_doc)
+    isDistinctFrom = _bin_op("isDistinctFrom", _isDistinctFrom_doc)
 
     # `and`, `or`, `not` cannot be overloaded in Python,
     # so use bitwise operators as boolean operators

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -475,6 +475,22 @@ class Column(val expr: Expression) extends Logging {
   def eqNullSafe(other: Any): Column = this <=> other
 
   /**
+   * Equality test that is safe for null values.
+   *
+   * @group java_expr_ops
+   * @since 2.3.0
+   */
+  def isNotDistinctFrom(other: Any): Column = eqNullSafe(other)
+
+  /**
+   * Inequality test that is safe for null values.
+   *
+   * @group java_expr_ops
+   * @since 2.3.0
+   */
+  def isDistinctFrom(other: Any): Column = withExpr { Not(EqualNullSafe(expr, lit(other).expr)) }
+
+  /**
    * Evaluates a list of conditions and returns one of multiple possible result expressions.
    * If otherwise is not defined at the end, null is returned for unmatched conditions.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -39,6 +39,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       StructType(Seq(StructField("a", BooleanType), StructField("b", BooleanType))))
   }
 
+  private val nullData = Seq(
+    (Some(1), Some(1)), (Some(1), Some(2)), (Some(1), None), (None, None)).toDF("a", "b")
+
   test("column names with space") {
     val df = Seq((1, "a")).toDF("name with space", "name.with.dot")
 
@@ -284,23 +287,6 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
 
   test("<=>") {
     checkAnswer(
-      testData2.filter($"a" === 1),
-      testData2.collect().toSeq.filter(r => r.getInt(0) == 1))
-
-    checkAnswer(
-      testData2.filter($"a" === $"b"),
-      testData2.collect().toSeq.filter(r => r.getInt(0) == r.getInt(1)))
-  }
-
-  test("=!=") {
-    val nullData = spark.createDataFrame(sparkContext.parallelize(
-      Row(1, 1) ::
-      Row(1, 2) ::
-      Row(1, null) ::
-      Row(null, null) :: Nil),
-      StructType(Seq(StructField("a", IntegerType), StructField("b", IntegerType))))
-
-    checkAnswer(
       nullData.filter($"b" <=> 1),
       Row(1, 1) :: Nil)
 
@@ -321,7 +307,34 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       nullData2.filter($"a" <=> null),
       Row(null) :: Nil)
+  }
 
+  test("eqNullSafe and isNotDistinctFrom") {
+    checkAnswer(
+      nullData.filter($"b" <=> null),
+      nullData.filter($"b".eqNullSafe(null)))
+
+    checkAnswer(
+      nullData.filter($"b" <=> null),
+      nullData.filter($"b".isNotDistinctFrom(null)))
+  }
+
+  test("isDistinctFrom") {
+    checkAnswer(
+      nullData.filter(!($"b" <=> null)),
+      nullData.filter($"b".isDistinctFrom(null)))
+  }
+
+  test("=!=") {
+    checkAnswer(
+      nullData.filter($"b" =!= 1),
+      Row(1, 2) :: Nil)
+
+    checkAnswer(nullData.filter($"b" =!= null), Nil)
+
+    checkAnswer(
+      nullData.filter($"a" =!= $"b"),
+      Row(1, 2) :: Nil)
   }
 
   test(">") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -39,7 +39,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       StructType(Seq(StructField("a", BooleanType), StructField("b", BooleanType))))
   }
 
-  private val nullData = Seq(
+  private lazy val nullData = Seq(
     (Some(1), Some(1)), (Some(1), Some(2)), (Some(1), None), (None, None)).toDF("a", "b")
 
   test("column names with space") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add both `isNotDistinctFrom` and `isDistinctFrom` to both Scala and Python column APIs.

`IS [NOT] DISTINCT FROM` syntax is now supported in favour of https://github.com/apache/spark/pull/17764

Adding a Python API was initially suggested in that PR but that PR turned to SQL syntax change only. Per https://github.com/apache/spark/pull/17764#discussion_r114048387 I assume we want this.

## How was this patch tested?

Doctests for Python and unit tests in `ColumnExpressionSuite`.
