### PR TITLE
[SPARK-20574][ML] Allow Bucketizer to handle non-Double numeric column

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -116,7 +116,7 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
       Bucketizer.binarySearchForBuckets($(splits), feature, keepInvalid)
     }
 
-    val newCol = bucketizer(filteredDataset($(inputCol)))
+    val newCol = bucketizer(filteredDataset($(inputCol)).cast(DoubleType))
     val newField = prepOutputField(filteredDataset.schema)
     filteredDataset.withColumn($(outputCol), newCol, newField.metadata)
   }
@@ -130,7 +130,7 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    SchemaUtils.checkColumnType(schema, $(inputCol), DoubleType)
+    SchemaUtils.checkNumericType(schema, $(inputCol))
     SchemaUtils.appendColumn(schema, prepOutputField(schema))
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -166,7 +166,7 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
     testDefaultReadWrite(t)
   }
 
-  test("Bucket non-double features") {
+  test("Bucket non-double numeric features") {
     val splits = Array(-3.0, 0.0, 3.0)
     val data = Array(-2.0, -1.0, 0.0, 1.0, 2.0)
     val expectedBuckets = Array(0.0, 0.0, 1.0, 1.0, 1.0)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -162,6 +162,24 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setSplits(Array(0.1, 0.8, 0.9))
     testDefaultReadWrite(t)
   }
+
+  test("Bucket non-double features") {
+    val splits = Array(-3.0, 0.0, 3.0)
+    val validData: Array[Int] = Array(-2, -1, 0, 1, 2)
+    val expectedBuckets = Array(0.0, 0.0, 0.0, 1.0, 1.0)
+    val dataFrame: DataFrame = validData.zip(expectedBuckets).toSeq.toDF("feature", "expected")
+
+    val bucketizer: Bucketizer = new Bucketizer()
+      .setInputCol("feature")
+      .setOutputCol("result")
+      .setSplits(splits)
+
+    bucketizer.transform(dataFrame).select("result", "expected").collect().foreach {
+      case Row(x: Double, y: Double) =>
+        assert(x === y,
+          s"The feature value is not correct after bucketing.  Expected $y but found $x")
+    }
+  }
 }
 
 private object BucketizerSuite extends SparkFunSuite {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
-
 class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 
   import testImplicits._
@@ -166,7 +165,7 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
     testDefaultReadWrite(t)
   }
 
-  test("Bucket non-double numeric features") {
+  test("Bucket numeric features") {
     val splits = Array(-3.0, 0.0, 3.0)
     val data = Array(-2.0, -1.0, 0.0, 1.0, 2.0)
     val expectedBuckets = Array(0.0, 0.0, 1.0, 1.0, 1.0)
@@ -177,12 +176,13 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setOutputCol("result")
       .setSplits(splits)
 
-    val types = Seq(ShortType, IntegerType, LongType, FloatType)
+    val types = Seq(ShortType, IntegerType, LongType, FloatType, DoubleType,
+      ByteType, DecimalType(10, 0))
     for (mType <- types) {
       val df = dataFrame.withColumn("feature", col("feature").cast(mType))
       bucketizer.transform(df).select("result", "expected").collect().foreach {
         case Row(x: Double, y: Double) =>
-          assert(x === y, "The feature value is not correct after bucketing in type " +
+          assert(x === y, "The result is not correct after bucketing in type " +
             mType.toString + ". " + s"Expected $y but found $x.")
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bucketizer currently requires input column to be Double, but the logic should work on any numeric data types. Many practical problems have integer/float data types, and it could get very tedious to manually cast them into Double before calling bucketizer. This PR extends bucketizer to handle all numeric types.  

## How was this patch tested?
New test.