### PR TITLE
[SPARK-20587][ML] Improve performance of ML ALS recommendForAll

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -417,9 +417,9 @@ class ALSModel private[ml] (
           while (i < n) {
             val (dstId, score) = pqIter.next()
             output(j + i) = (srcId, dstId, score)
-            i +=1
+            i += 1
           }
-          j +=1
+          j += n
         }
         output.toSeq
       }


### PR DESCRIPTION
This PR is a `DataFrame` version of #17742 for [SPARK-11968](https://issues.apache.org/jira/browse/SPARK-11968), for improving the performance of `recommendAll` methods.

## How was this patch tested?

Existing unit tests.
