### PR TITLE
[SPARK-20562][MESOS] Support for declining offers under Unavailability.

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -516,6 +516,15 @@ See the [configuration page](configuration.html) for information on Spark config
     Fetcher Cache</a>
   </td>
 </tr>
+<tr>
+  <td><code>spark.mesos.unavailabilityThreshold</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    Minimum threshold in MilliSeconds to accept offers that have unavailability period
+    set. Accepts offers iff the the current time plus threshold is less than the 
+    start of Unavailability period.
+  </td>
+</tr>
 </table>
 
 # Troubleshooting and Debugging

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -303,6 +303,23 @@ trait MesosSchedulerUtils extends Logging {
   }
 
   /**
+   * Ensure that an offer is accepted only if the start of the
+   * unavailability period is after the minimum configured threshold
+   */
+  def matchesUnavailabilityRequirements(
+    threshold: Long,
+    offer: Offer): Boolean = {
+
+    val currentTime = System.currentTimeMillis()
+    if (offer.hasUnavailability) {
+      val unavailabilityStart = offer.getUnavailability.getStart.getNanoseconds / 1000000
+      unavailabilityStart > currentTime + threshold
+    } else {
+      true
+    }
+  }
+
+  /**
    * Parses the attributes constraints provided to spark and build a matching data struct:
    *  Map[<attribute-name>, Set[values-to-match]]
    *  The constraints are specified as ';' separated key-value pairs where keys and values


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support Mesos Maintenance by making the Spark Scheduler decline offers that might go under maintenance when a task is running on it.

Added a configurable threshold which is the users estimate of how long a task would take up an offer for, and then decide whether the Scheduler can schedule a task on that offer or not.

## How was this patch tested?

Unit tests that ensure that offers with unavailability set are appropriately handled.

Please review http://spark.apache.org/contributing.html before opening a pull request.
