### PR TITLE
[SPARK-20590] Map default input data source formats to inlined classes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -483,35 +483,42 @@ case class DataSource(
 
 object DataSource {
 
-  /** A map to maintain backward compatibility in case we move data sources around. */
-  private val backwardCompatibilityMap: Map[String, String] = {
-    val jdbc = classOf[JdbcRelationProvider].getCanonicalName
-    val json = classOf[JsonFileFormat].getCanonicalName
-    val parquet = classOf[ParquetFileFormat].getCanonicalName
-    val csv = classOf[CSVFileFormat].getCanonicalName
-    val libsvm = "org.apache.spark.ml.source.libsvm.LibSVMFileFormat"
-    val orc = "org.apache.spark.sql.hive.orc.OrcFileFormat"
+  private val jdbc = classOf[JdbcRelationProvider].getCanonicalName
+  private val json = classOf[JsonFileFormat].getCanonicalName
+  private val parquet = classOf[ParquetFileFormat].getCanonicalName
+  private val csv = classOf[CSVFileFormat].getCanonicalName
+  private val libsvm = "org.apache.spark.ml.source.libsvm.LibSVMFileFormat"
+  private val orc = "org.apache.spark.sql.hive.orc.OrcFileFormat"
 
-    Map(
-      "org.apache.spark.sql.jdbc" -> jdbc,
-      "org.apache.spark.sql.jdbc.DefaultSource" -> jdbc,
-      "org.apache.spark.sql.execution.datasources.jdbc.DefaultSource" -> jdbc,
-      "org.apache.spark.sql.execution.datasources.jdbc" -> jdbc,
-      "org.apache.spark.sql.json" -> json,
-      "org.apache.spark.sql.json.DefaultSource" -> json,
-      "org.apache.spark.sql.execution.datasources.json" -> json,
-      "org.apache.spark.sql.execution.datasources.json.DefaultSource" -> json,
-      "org.apache.spark.sql.parquet" -> parquet,
-      "org.apache.spark.sql.parquet.DefaultSource" -> parquet,
-      "org.apache.spark.sql.execution.datasources.parquet" -> parquet,
-      "org.apache.spark.sql.execution.datasources.parquet.DefaultSource" -> parquet,
-      "org.apache.spark.sql.hive.orc.DefaultSource" -> orc,
-      "org.apache.spark.sql.hive.orc" -> orc,
-      "org.apache.spark.ml.source.libsvm.DefaultSource" -> libsvm,
-      "org.apache.spark.ml.source.libsvm" -> libsvm,
-      "com.databricks.spark.csv" -> csv
-    )
-  }
+  /** A map to maintain backward compatibility in case we move data sources around. */
+  private val backwardCompatibilityMap: Map[String, String] = Map(
+    "org.apache.spark.sql.jdbc" -> jdbc,
+    "org.apache.spark.sql.jdbc.DefaultSource" -> jdbc,
+    "org.apache.spark.sql.execution.datasources.jdbc.DefaultSource" -> jdbc,
+    "org.apache.spark.sql.execution.datasources.jdbc" -> jdbc,
+    "org.apache.spark.sql.json" -> json,
+    "org.apache.spark.sql.json.DefaultSource" -> json,
+    "org.apache.spark.sql.execution.datasources.json" -> json,
+    "org.apache.spark.sql.execution.datasources.json.DefaultSource" -> json,
+    "org.apache.spark.sql.parquet" -> parquet,
+    "org.apache.spark.sql.parquet.DefaultSource" -> parquet,
+    "org.apache.spark.sql.execution.datasources.parquet" -> parquet,
+    "org.apache.spark.sql.execution.datasources.parquet.DefaultSource" -> parquet,
+    "org.apache.spark.sql.hive.orc.DefaultSource" -> orc,
+    "org.apache.spark.sql.hive.orc" -> orc,
+    "org.apache.spark.ml.source.libsvm.DefaultSource" -> libsvm,
+    "org.apache.spark.ml.source.libsvm" -> libsvm,
+    "com.databricks.spark.csv" -> csv
+  )
+
+  private val builtinShortNamesMap: Map[String, String] = Map(
+    "jdbc" -> jdbc,
+    "json" -> json,
+    "parquet" -> parquet,
+    "csv" -> csv,
+    "libsvm" -> libsvm,
+    "orc" -> orc
+  )
 
   /**
    * Class that were removed in Spark 2.0. Used to detect incompatibility libraries for Spark 2.0.
@@ -523,7 +530,8 @@ object DataSource {
 
   /** Given a provider name, look up the data source class definition. */
   def lookupDataSource(provider: String): Class[_] = {
-    val provider1 = backwardCompatibilityMap.getOrElse(provider, provider)
+    val provider1 = builtinShortNamesMap.getOrElse(provider,
+      backwardCompatibilityMap.getOrElse(provider, provider))
     val provider2 = s"$provider1.DefaultSource"
     val loader = Utils.getContextOrSparkClassLoader
     val serviceLoader = ServiceLoader.load(classOf[DataSourceRegister], loader)


### PR DESCRIPTION
## What changes were proposed in this pull request?

One of the common usability problems around reading data in spark (particularly CSV) is that there can often be a conflict between different readers in the classpath.

As an example, if someone launches a 2.x spark shell with the spark-csv package in the classpath, Spark currently fails in an extremely unfriendly way (see https://github.com/databricks/spark-csv/issues/367):

```scala
./bin/spark-shell --packages com.databricks:spark-csv_2.11:1.5.0
scala> val df = spark.read.csv("/foo/bar.csv")
java.lang.RuntimeException: Multiple sources found for csv (org.apache.spark.sql.execution.datasources.csv.CSVFileFormat, com.databricks.spark.csv.DefaultSource15), please specify the fully qualified class name.
  at scala.sys.package$.error(package.scala:27)
  at org.apache.spark.sql.execution.datasources.DataSource$.lookupDataSource(DataSource.scala:574)
  at org.apache.spark.sql.execution.datasources.DataSource.providingClass$lzycompute(DataSource.scala:85)
  at org.apache.spark.sql.execution.datasources.DataSource.providingClass(DataSource.scala:85)
  at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:295)
  at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:178)
  at org.apache.spark.sql.DataFrameReader.csv(DataFrameReader.scala:533)
  at org.apache.spark.sql.DataFrameReader.csv(DataFrameReader.scala:412)
  ... 48 elided
```

This patch proposes a simple way of fixing this error by always mapping default input data source formats to inlined classes (that exist in Spark):

```scala
./bin/spark-shell --packages com.databricks:spark-csv_2.11:1.5.0
scala> val df = spark.read.csv("/foo/bar.csv")
df: org.apache.spark.sql.DataFrame = [_c0: string]
```

## How was this patch tested?

Existing Tests