### PR TITLE
[SPARK-20594][SQL]The staging directory should be a child directory starts with "." to avoid being deleted if we set hive.exec.stagingdir under the table directory.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -222,7 +222,7 @@ case class InsertIntoHiveTable(
     val externalCatalog = sparkSession.sharedState.externalCatalog
     val hiveVersion = externalCatalog.asInstanceOf[HiveExternalCatalog].client.version
     val hadoopConf = sessionState.newHadoopConf()
-    val stagingDir = hadoopConf.get("hive.exec.stagingdir", ".hive-staging")
+    val stagingDir = hadoopConf.get("hive.exec.stagingdir", ".hive-staging") + "/.hive-staging"
     val scratchDir = hadoopConf.get("hive.exec.scratchdir", "/tmp/hive")
 
     val hiveQlTable = HiveClientImpl.toHiveTable(table)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -107,11 +107,11 @@ case class InsertIntoHiveTable(
     // SPARK-20594: This is a walk-around fix to resolve a Hive bug. Hive requires that the
     // staging directory needs to avoid being deleted when users set hive.exec.stagingdir
     // under the table directory.
-    if (FileUtils.isSubDir(new Path(stagingPathName), inputPath, fs)
-      && !stagingPathName.stripPrefix(inputPathName).stripPrefix(File.separator).startsWith(".")) {
+    if (FileUtils.isSubDir(new Path(stagingPathName), inputPath, fs) &&
+      !stagingPathName.stripPrefix(inputPathName).stripPrefix(File.separator).startsWith(".")) {
       logDebug(s"The staging dir '$stagingPathName' should be a child directory starts " +
-        s"with '.' to avoid being deleted if we set hive.exec.stagingdir under the table " +
-        s"directory.")
+        "with '.' to avoid being deleted if we set hive.exec.stagingdir under the table " +
+        "directory.")
       stagingPathName = new Path(inputPathName, ".hive-staging").toString
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -23,12 +23,14 @@ import java.text.SimpleDateFormat
 import java.util.{Date, Locale, Random}
 
 import scala.util.control.NonFatal
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.common.FileUtils
 import org.apache.hadoop.hive.ql.exec.TaskRunner
 import org.apache.hadoop.hive.ql.ErrorMsg
 import org.apache.hadoop.hive.ql.plan.TableDesc
+
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -104,8 +104,9 @@ case class InsertIntoHiveTable(
         inputPathName.substring(0, inputPathName.indexOf(stagingDir) + stagingDir.length)
       }
 
-    // SPARK-20594: The staging directory should be a child directory starts with "." to avoid
-    // being deleted if we set hive.exec.stagingdir under the table directory.
+    // SPARK-20594: This is a walk-around fix to resolve a Hive bug. Hive requires that the
+    // staging directory needs to avoid being deleted when users set hive.exec.stagingdir
+    // under the table directory.
     if (FileUtils.isSubDir(new Path(stagingPathName), inputPath, fs)
       && !stagingPathName.stripPrefix(inputPathName).stripPrefix(File.separator).startsWith(".")) {
       logDebug(s"The staging dir '$stagingPathName' should be a child directory starts " +

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -17,20 +17,18 @@
 
 package org.apache.spark.sql.hive.execution
 
-import java.io.IOException
+import java.io.{File, IOException}
 import java.net.URI
 import java.text.SimpleDateFormat
 import java.util.{Date, Locale, Random}
 
 import scala.util.control.NonFatal
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.common.FileUtils
 import org.apache.hadoop.hive.ql.exec.TaskRunner
 import org.apache.hadoop.hive.ql.ErrorMsg
 import org.apache.hadoop.hive.ql.plan.TableDesc
-
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -107,7 +105,7 @@ case class InsertIntoHiveTable(
     // SPARK-20594: The staging directory should be a child directory starts with "." to avoid
     // being deleted if we set hive.exec.stagingdir under the table directory.
     if (FileUtils.isSubDir(new Path(stagingPathName), inputPath, fs)
-      && !stagingPathName.stripPrefix(inputPathName).startsWith(".")) {
+      && !stagingPathName.stripPrefix(inputPathName).stripPrefix(File.separator).startsWith(".")) {
       logDebug(s"The staging dir '$stagingPathName' should be a child directory starts " +
         s"with '.' to avoid being deleted if we set hive.exec.stagingdir under the table " +
         s"directory.")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -500,7 +500,7 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
       |staging directory needs to avoid being deleted when users set hive.exec.stagingdir
       |under the table directory.""".stripMargin) {
 
-    withTable("test_table", "test_table1") {
+    withTable("test_table") {
       spark.range(1).write.saveAsTable("test_table")
 
       // Make sure the table has also been updated.
@@ -509,19 +509,19 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
         Row(0)
       )
 
-      sql("CREATE TABLE test_table1 (key int)")
-
       // Set hive.exec.stagingdir under the table directory without start with ".".
       sql("set hive.exec.stagingdir=./test")
 
       // Now overwrite.
-      sql("INSERT OVERWRITE TABLE test_table1 SELECT * FROM test_table")
+      sql("INSERT OVERWRITE TABLE test_table SELECT 1")
 
       // Make sure the table has also been updated.
       checkAnswer(
-        sql("SELECT * FROM test_table1"),
-        Row(0)
+        sql("SELECT * FROM test_table"),
+        Row(1)
       )
+
+      sql("reset")
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -495,44 +495,33 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
       }
   }
 
-  private def dropTables(tableNames: String*): Unit = {
-    tableNames.foreach { name =>
-      sql(s"DROP TABLE IF EXISTS $name")
-    }
-  }
-
   test(
-    """SPARK-20594: The staging directory should be appended with ".hive-staging"
-      |to avoid being deleted if we set hive.exec.stagingdir under the table directory
-      |without start with "."""".stripMargin) {
+    """SPARK-20594: This is a walk-around fix to resolve a Hive bug. Hive requires that the
+      |staging directory needs to avoid being deleted when users set hive.exec.stagingdir
+      |under the table directory.""".stripMargin) {
 
-    dropTables("test_table", "test_table1")
+    withTable("test_table", "test_table1") {
+      spark.range(1).write.saveAsTable("test_table")
 
-    sql("CREATE TABLE test_table (key int, value string)")
+      // Make sure the table has also been updated.
+      checkAnswer(
+        sql("SELECT * FROM test_table"),
+        Row(0)
+      )
 
-    // Add some data.
-    testData.write.mode(SaveMode.Append).insertInto("test_table")
+      sql("CREATE TABLE test_table1 (key int)")
 
-    // Make sure the table has also been updated.
-    checkAnswer(
-      sql("SELECT * FROM test_table"),
-      testData.collect().toSeq
-    )
+      // Set hive.exec.stagingdir under the table directory without start with ".".
+      sql("set hive.exec.stagingdir=./test")
 
-    sql("CREATE TABLE test_table1 (key int, value string)")
+      // Now overwrite.
+      sql("INSERT OVERWRITE TABLE test_table1 SELECT * FROM test_table")
 
-    // Set hive.exec.stagingdir under the table directory without start with ".".
-    sql("set hive.exec.stagingdir=./test")
-
-    // Now overwrite.
-    sql("INSERT OVERWRITE TABLE test_table1 SELECT * FROM test_table")
-
-    // Make sure the table has also been updated.
-    checkAnswer(
-      sql("SELECT * FROM test_table1"),
-      testData.collect().toSeq
-    )
-
-    dropTables("test_table", "test_table1")
+      // Make sure the table has also been updated.
+      checkAnswer(
+        sql("SELECT * FROM test_table1"),
+        Row(0)
+      )
+    }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -495,12 +495,7 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
       }
   }
 
-  /**
-    * Drop named tables if they exist
-    *
-    * @param tableNames tables to drop
-    */
-  def dropTables(tableNames: String*): Unit = {
+  private def dropTables(tableNames: String*): Unit = {
     tableNames.foreach { name =>
       sql(s"DROP TABLE IF EXISTS $name")
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -501,13 +501,8 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
       |under the table directory.""".stripMargin) {
 
     withTable("test_table") {
-      spark.range(1).write.saveAsTable("test_table")
 
-      // Make sure the table has also been updated.
-      checkAnswer(
-        sql("SELECT * FROM test_table"),
-        Row(0)
-      )
+      sql("CREATE TABLE test_table (key int)")
 
       // Set hive.exec.stagingdir under the table directory without start with ".".
       sql("set hive.exec.stagingdir=./test")


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-20594

## What changes were proposed in this pull request?

The staging directory should be a child directory starts with "." to avoid being deleted before moving staging directory to table directory if we set hive.exec.stagingdir under the table directory.

## How was this patch tested?

Added unit tests
