### PR TITLE
[SPARK-20595][Deploy]Parse the 'SPARK_EXECUTOR_INSTANCES' into the parsed arguments

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -189,7 +189,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       .orElse(env.get("DEPLOY_MODE"))
       .orNull
     numExecutors = Option(numExecutors)
-      .getOrElse(sparkProperties.get("spark.executor.instances").orNull)
+      .orElse(sparkProperties.get("spark.executor.instances"))
+      .orElse(env.get("SPARK_EXECUTOR_INSTANCES"))
+      .orNull
     queue = Option(queue).orElse(sparkProperties.get("spark.yarn.queue")).orNull
     keytab = Option(keytab).orElse(sparkProperties.get("spark.yarn.keytab")).orNull
     principal = Option(principal).orElse(sparkProperties.get("spark.yarn.principal")).orNull


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, when we set the parameter `SPARK_EXECUTOR_INSTANCES` in the `spark-env.sh`, it seems that the parameter doesn't parsed by Spark. So this patch parse the 'SPARK_EXECUTOR_INSTANCES' into the parsed arguments.

## How was this patch tested?

Existing tests.