### PR TITLE
[SPARK-20456][Docs] Add examples for functions collection for pyspark

### DIFF
--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -1602,16 +1602,10 @@ setMethod("sumDistinct",
           })
 
 #' @details
-#' \code{tan}: Computes the tangent of the given value.
+#' \code{tan}: Computes the tangent of the given value. Units in radians.
 #'
-#' Computes the tangent of the given value. Units in radians.
-#'
-#' @param x Column to compute on.
-#'
-#' @rdname tan
-#' @name tan
-#' @family math functions
-#' @aliases tan,Column-method
+#' @rdname column_math_functions
+#' @aliases tan tan,Column-method
 #' @export
 #' @note tan since 1.5.0
 setMethod("tan",

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -600,8 +600,9 @@ setMethod("covar_pop", signature(col1 = "characterOrColumn", col2 = "characterOr
             column(jc)
           })
 
-#' @details
-#' \code{cos}: Computes the cosine of the given value.
+#' cos
+#'
+#' Computes the cosine of the given value. Units in radians.
 #'
 #' @rdname column_math_functions
 #' @aliases cos cos,Column-method
@@ -1396,8 +1397,9 @@ setMethod("signum",
             column(jc)
           })
 
-#' @details
-#' \code{sign}: Alias for \code{signum}.
+#' sin
+#'
+#' Computes the sine of the given value. Units in radians
 #'
 #' @rdname column_math_functions
 #' @aliases sign sign,Column-method
@@ -1603,8 +1605,14 @@ setMethod("sumDistinct",
 #' @details
 #' \code{tan}: Computes the tangent of the given value.
 #'
-#' @rdname column_math_functions
-#' @aliases tan tan,Column-method
+#' Computes the tangent of the given value. Units in radians.
+#'
+#' @param x Column to compute on.
+#'
+#' @rdname tan
+#' @name tan
+#' @family math functions
+#' @aliases tan,Column-method
 #' @export
 #' @note tan since 1.5.0
 setMethod("tan",
@@ -1902,8 +1910,16 @@ setMethod("year",
 #' \code{atan2}: Returns the angle theta from the conversion of rectangular coordinates
 #' (x, y) to polar coordinates (r, theta).
 #'
-#' @rdname column_math_functions
-#' @aliases atan2 atan2,Column-method
+#' Returns the angle theta from the conversion of rectangular coordinates (x, y) to
+#' polar coordinates (r, theta). Units in radians.
+#
+#' @param x Column to compute on.
+#' @param y Column to compute on.
+#'
+#' @rdname atan2
+#' @name atan2
+#' @family math functions
+#' @aliases atan2,Column-method
 #' @export
 #' @note atan2 since 1.5.0
 setMethod("atan2", signature(y = "Column"),

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -337,8 +337,12 @@ setMethod("asin",
             column(jc)
           })
 
-#' @details
-#' \code{atan}: Computes the tangent inverse of the given value.
+#' atan
+#'
+#' Computes the tangent inverse of the given value; the returned angle is in the range
+#' -pi/2 through pi/2
+#'
+#' @param x Column to compute on.
 #'
 #' @rdname column_math_functions
 #' @export

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -339,7 +339,7 @@ setMethod("asin",
 
 #' @details
 #' \code{atan}: Computes the tangent inverse of the given value; the returned angle is in the range
-#' -pi/2 through pi/2
+#' -pi/2 through pi/2.
 #'
 #' @rdname column_math_functions
 #' @export
@@ -1902,7 +1902,7 @@ setMethod("year",
 #' @details
 #' \code{atan2}: Returns the angle theta from the conversion of rectangular coordinates
 #' (x, y) to polar coordinates (r, theta). Units in radians.
-#
+#'
 #' @rdname column_math_functions
 #' @aliases atan2 atan2,Column-method
 #' @export

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -1398,7 +1398,7 @@ setMethod("signum",
           })
 
 #' @details
-#' \code{sign}: Alias for \code{signum}. 
+#' \code{sign}: Alias for \code{signum}.
 #'
 #' @rdname column_math_functions
 #' @aliases sign sign,Column-method

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -337,12 +337,9 @@ setMethod("asin",
             column(jc)
           })
 
-#' atan
-#'
-#' Computes the tangent inverse of the given value; the returned angle is in the range
+#' @details
+#' \code{atan}: Computes the tangent inverse of the given value; the returned angle is in the range
 #' -pi/2 through pi/2
-#'
-#' @param x Column to compute on.
 #'
 #' @rdname column_math_functions
 #' @export
@@ -604,9 +601,8 @@ setMethod("covar_pop", signature(col1 = "characterOrColumn", col2 = "characterOr
             column(jc)
           })
 
-#' cos
-#'
-#' Computes the cosine of the given value. Units in radians.
+#' @details
+#' \code{cos}: Computes the cosine of the given value. Units in radians.
 #'
 #' @rdname column_math_functions
 #' @aliases cos cos,Column-method
@@ -1401,9 +1397,8 @@ setMethod("signum",
             column(jc)
           })
 
-#' sin
-#'
-#' Computes the sine of the given value. Units in radians
+#' @details
+#' \code{sign}: Alias for \code{signum}. 
 #'
 #' @rdname column_math_functions
 #' @aliases sign sign,Column-method
@@ -1415,7 +1410,7 @@ setMethod("sign", signature(x = "Column"),
           })
 
 #' @details
-#' \code{sin}: Computes the sine of the given value.
+#' \code{sin}: Computes the sine of the given value. Units in radians.
 #'
 #' @rdname column_math_functions
 #' @aliases sin sin,Column-method
@@ -1912,18 +1907,10 @@ setMethod("year",
 
 #' @details
 #' \code{atan2}: Returns the angle theta from the conversion of rectangular coordinates
-#' (x, y) to polar coordinates (r, theta).
-#'
-#' Returns the angle theta from the conversion of rectangular coordinates (x, y) to
-#' polar coordinates (r, theta). Units in radians.
+#' (x, y) to polar coordinates (r, theta). Units in radians.
 #
-#' @param x Column to compute on.
-#' @param y Column to compute on.
-#'
-#' @rdname atan2
-#' @name atan2
-#' @family math functions
-#' @aliases atan2,Column-method
+#' @rdname column_math_functions
+#' @aliases atan2 atan2,Column-method
 #' @export
 #' @note atan2 since 1.5.0
 setMethod("atan2", signature(y = "Column"),

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -67,9 +67,16 @@ def _create_window_function(name, doc=''):
     _.__doc__ = 'Window function: ' + doc
     return _
 
+_lit_doc = """
+    Creates a :class:`Column` of literal value. Supports basic types like :class:`IntegerType`,
+    :class:`FloatType`, :class:`BooleanType`, and :class:`StringType`
 
+    >>> df.withColumn('height', lit(5) ).withColumn('spark_user', lit(True) ).collect()
+    [Row(age=2, name=u'Alice', height=5, spark_user=True),
+     Row(age=5, name=u'Bob', height=5, spark_user=True)]
+    """
 _functions = {
-    'lit': 'Creates a :class:`Column` of literal value.',
+    'lit': _lit_doc,
     'col': 'Returns a :class:`Column` based on the given column name.',
     'column': 'Returns a :class:`Column` based on the given column name.',
     'asc': 'Returns a sort expression based on the ascending order of the given column name.',
@@ -92,14 +99,14 @@ _functions = {
 _functions_1_4 = {
     # unary math functions
     'acos': 'Computes the cosine inverse of the given value; the returned angle is in the range' +
-            '0.0 through pi.',
+            '0.0 through pi. Units in radians.',
     'asin': 'Computes the sine inverse of the given value; the returned angle is in the range' +
-            '-pi/2 through pi/2.',
-    'atan': 'Computes the tangent inverse of the given value.',
+            '-pi/2 through pi/2. Units in radians.',
+    'atan': 'Computes the tangent inverse of the given value. Units in radians.',
     'cbrt': 'Computes the cube-root of the given value.',
     'ceil': 'Computes the ceiling of the given value.',
-    'cos': 'Computes the cosine of the given value.',
-    'cosh': 'Computes the hyperbolic cosine of the given value.',
+    'cos': 'Computes the cosine of the given value. Units in radians.',
+    'cosh': 'Computes the hyperbolic cosine of the given value. Units in radians.',
     'exp': 'Computes the exponential of the given value.',
     'expm1': 'Computes the exponential of the given value minus one.',
     'floor': 'Computes the floor of the given value.',
@@ -109,15 +116,29 @@ _functions_1_4 = {
     'rint': 'Returns the double value that is closest in value to the argument and' +
             ' is equal to a mathematical integer.',
     'signum': 'Computes the signum of the given value.',
-    'sin': 'Computes the sine of the given value.',
-    'sinh': 'Computes the hyperbolic sine of the given value.',
-    'tan': 'Computes the tangent of the given value.',
-    'tanh': 'Computes the hyperbolic tangent of the given value.',
-    'toDegrees': '.. note:: Deprecated in 2.1, use degrees instead.',
-    'toRadians': '.. note:: Deprecated in 2.1, use radians instead.',
+    'sin': 'Computes the sine of the given value. Units in radians',
+    'sinh': 'Computes the hyperbolic sine of the given value. Units in radians.',
+    'tan': 'Computes the tangent of the given value. Units in radians.',
+    'tanh': 'Computes the hyperbolic tangent of the given value. Units in radians.',
+    'toDegrees': '.. note:: Deprecated in 2.1, use :func:`degrees` instead.',
+    'toRadians': '.. note:: Deprecated in 2.1, use :func:`radians` instead.',
     'bitwiseNOT': 'Computes bitwise not.',
 }
 
+_collect_list_doc = """
+    Aggregate function: returns a list of objects with duplicates.
+
+    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5),('Alice', 99)], ('name', 'age'))
+    >>> df2.agg(collect_list('name')).collect()
+    [Row(collect_list(name)=[u'Alice', u'Bob', u'Alice'])]
+    """
+_collect_set_doc = """
+    Aggregate function: returns a set of objects with duplicate elements eliminated.
+
+    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5),('Alice', 99)], ('name', 'age'))
+    >>> df2.agg(collect_set('name')).collect()
+    [Row(collect_set(name)=[u'Bob', u'Alice'])]
+    """
 _functions_1_6 = {
     # unary math functions
     'stddev': 'Aggregate function: returns the unbiased sample standard deviation of' +
@@ -131,9 +152,8 @@ _functions_1_6 = {
     'var_pop':  'Aggregate function: returns the population variance of the values in a group.',
     'skewness': 'Aggregate function: returns the skewness of the values in a group.',
     'kurtosis': 'Aggregate function: returns the kurtosis of the values in a group.',
-    'collect_list': 'Aggregate function: returns a list of objects with duplicates.',
-    'collect_set': 'Aggregate function: returns a set of objects with duplicate elements' +
-                   ' eliminated.',
+    'collect_list': _collect_list_doc,
+    'collect_set': _collect_set_doc
 }
 
 _functions_2_1 = {
@@ -147,7 +167,7 @@ _functions_2_1 = {
 # math functions that take two arguments as input
 _binary_mathfunctions = {
     'atan2': 'Returns the angle theta from the conversion of rectangular coordinates (x, y) to' +
-             'polar coordinates (r, theta).',
+             'polar coordinates (r, theta). Units in radians.',
     'hypot': 'Computes ``sqrt(a^2 + b^2)`` without intermediate overflow or underflow.',
     'pow': 'Returns the value of the first argument raised to the power of the second argument.',
 }
@@ -200,17 +220,20 @@ del _name, _doc
 @since(1.3)
 def approxCountDistinct(col, rsd=None):
     """
-    .. note:: Deprecated in 2.1, use approx_count_distinct instead.
+    .. note:: Deprecated in 2.1, use :func:`approx_count_distinct instead`.
     """
     return approx_count_distinct(col, rsd)
 
 
 @since(2.1)
 def approx_count_distinct(col, rsd=None):
-    """Returns a new :class:`Column` for approximate distinct count of ``col``.
+    """Returns a new :class:`Column` for approximate distinct count of column ``col``.
 
-    >>> df.agg(approx_count_distinct(df.age).alias('c')).collect()
-    [Row(c=2)]
+    :param rsd: Residual (float). The approximate count will be within this fraction of the true
+    count. For rsd < 0.01, it is more efficient to use :func:`countDistinct`
+
+    >>> df.agg(approx_count_distinct(df.age).alias('distinct_ages')).collect()
+    [Row(distinct_ages=2)]
     """
     sc = SparkContext._active_spark_context
     if rsd is None:
@@ -391,7 +414,7 @@ def input_file_name():
 
 @since(1.6)
 def isnan(col):
-    """An expression that returns true iff the column is NaN.
+    """An expression that returns true if the column is NaN.
 
     >>> df = spark.createDataFrame([(1.0, float('nan')), (float('nan'), 2.0)], ("a", "b"))
     >>> df.select(isnan("a").alias("r1"), isnan(df.a).alias("r2")).collect()
@@ -403,7 +426,7 @@ def isnan(col):
 
 @since(1.6)
 def isnull(col):
-    """An expression that returns true iff the column is null.
+    """An expression that returns true if the column is null.
 
     >>> df = spark.createDataFrame([(1, None), (None, 2)], ("a", "b"))
     >>> df.select(isnull("a").alias("r1"), isnull(df.a).alias("r2")).collect()
@@ -450,7 +473,7 @@ def monotonically_increasing_id():
 def nanvl(col1, col2):
     """Returns col1 if it is not NaN, or col2 if col1 is NaN.
 
-    Both inputs should be floating point columns (DoubleType or FloatType).
+    Both inputs should be floating point columns (:class:`DoubleType` or FloatType).
 
     >>> df = spark.createDataFrame([(1.0, float('nan')), (float('nan'), 2.0)], ("a", "b"))
     >>> df.select(nanvl("a", "b").alias("r1"), nanvl(df.a, df.b).alias("r2")).collect()
@@ -464,6 +487,10 @@ def nanvl(col1, col2):
 def rand(seed=None):
     """Generates a random column with independent and identically distributed (i.i.d.) samples
     from U[0.0, 1.0].
+
+    >>> df.withColumn('rand',rand(seed=42) * 3).collect()
+    [Row(age=2, name=u'Alice', rand=1.1568609015300986),
+     Row(age=5, name=u'Bob', rand=1.403379671529166)]
     """
     sc = SparkContext._active_spark_context
     if seed is not None:
@@ -477,6 +504,10 @@ def rand(seed=None):
 def randn(seed=None):
     """Generates a column with independent and identically distributed (i.i.d.) samples from
     the standard normal distribution.
+
+    >>> df.withColumn('randn',randn(seed=42) ).collect()
+    [Row(age=2, name=u'Alice', randn=-0.7556247885860078),
+    Row(age=5, name=u'Bob', randn=-0.0861619008451133)]
     """
     sc = SparkContext._active_spark_context
     if seed is not None:
@@ -595,7 +626,7 @@ def struct(*cols):
 def greatest(*cols):
     """
     Returns the greatest value of the list of column names, skipping null values.
-    This function takes at least 2 parameters. It will return null iff all parameters are null.
+    This function takes at least 2 parameters. It will return null if all parameters are null.
 
     >>> df = spark.createDataFrame([(1, 4, 3)], ['a', 'b', 'c'])
     >>> df.select(greatest(df.a, df.b, df.c).alias("greatest")).collect()
@@ -611,7 +642,7 @@ def greatest(*cols):
 def least(*cols):
     """
     Returns the least value of the list of column names, skipping null values.
-    This function takes at least 2 parameters. It will return null iff all parameters are null.
+    This function takes at least 2 parameters. It will return null if all parameters are null.
 
     >>> df = spark.createDataFrame([(1, 4, 3)], ['a', 'b', 'c'])
     >>> df.select(least(df.a, df.b, df.c).alias("least")).collect()
@@ -760,7 +791,7 @@ def ntile(n):
 @since(1.5)
 def current_date():
     """
-    Returns the current date as a date column.
+    Returns the current date as a :class:`DateType` column.
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.current_date())
@@ -768,7 +799,7 @@ def current_date():
 
 def current_timestamp():
     """
-    Returns the current timestamp as a timestamp column.
+    Returns the current timestamp as a :class:`TimestampType`column.
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.current_timestamp())
@@ -787,8 +818,8 @@ def date_format(date, format):
     .. note:: Use when ever possible specialized functions like `year`. These benefit from a
         specialized implementation.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(date_format('a', 'MM/dd/yyy').alias('date')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(date_format('time', 'MM/dd/yyy').alias('date')).collect()
     [Row(date=u'04/08/2015')]
     """
     sc = SparkContext._active_spark_context
@@ -800,8 +831,8 @@ def year(col):
     """
     Extract the year of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(year('a').alias('year')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(year('time').alias('year')).collect()
     [Row(year=2015)]
     """
     sc = SparkContext._active_spark_context
@@ -813,8 +844,8 @@ def quarter(col):
     """
     Extract the quarter of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(quarter('a').alias('quarter')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(quarter('time').alias('quarter')).collect()
     [Row(quarter=2)]
     """
     sc = SparkContext._active_spark_context
@@ -826,8 +857,8 @@ def month(col):
     """
     Extract the month of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(month('a').alias('month')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(month('time').alias('month')).collect()
     [Row(month=4)]
    """
     sc = SparkContext._active_spark_context
@@ -839,8 +870,8 @@ def dayofmonth(col):
     """
     Extract the day of the month of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(dayofmonth('a').alias('day')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(dayofmonth('time').alias('day')).collect()
     [Row(day=8)]
     """
     sc = SparkContext._active_spark_context
@@ -852,8 +883,8 @@ def dayofyear(col):
     """
     Extract the day of the year of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(dayofyear('a').alias('day')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(dayofyear('time').alias('day')).collect()
     [Row(day=98)]
     """
     sc = SparkContext._active_spark_context
@@ -865,8 +896,8 @@ def hour(col):
     """
     Extract the hours of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['a'])
-    >>> df.select(hour('a').alias('hour')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['time'])
+    >>> df.select(hour('time').alias('hour')).collect()
     [Row(hour=13)]
     """
     sc = SparkContext._active_spark_context
@@ -878,8 +909,8 @@ def minute(col):
     """
     Extract the minutes of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['a'])
-    >>> df.select(minute('a').alias('minute')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['time'])
+    >>> df.select(minute('time').alias('minute')).collect()
     [Row(minute=8)]
     """
     sc = SparkContext._active_spark_context
@@ -891,8 +922,8 @@ def second(col):
     """
     Extract the seconds of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['a'])
-    >>> df.select(second('a').alias('second')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['time'])
+    >>> df.select(second('time').alias('second')).collect()
     [Row(second=15)]
     """
     sc = SparkContext._active_spark_context
@@ -904,8 +935,8 @@ def weekofyear(col):
     """
     Extract the week number of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['a'])
-    >>> df.select(weekofyear(df.a).alias('week')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
+    >>> df.select(weekofyear(df.time).alias('week')).collect()
     [Row(week=15)]
     """
     sc = SparkContext._active_spark_context
@@ -917,9 +948,9 @@ def date_add(start, days):
     """
     Returns the date that is `days` days after `start`
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['d'])
-    >>> df.select(date_add(df.d, 1).alias('d')).collect()
-    [Row(d=datetime.date(2015, 4, 9))]
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['date'])
+    >>> df.select(date_add(df.date, 1).alias('next_date')).collect()
+    [Row(next_date=datetime.date(2015, 4, 9))]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.date_add(_to_java_column(start), days))
@@ -930,9 +961,9 @@ def date_sub(start, days):
     """
     Returns the date that is `days` days before `start`
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['d'])
-    >>> df.select(date_sub(df.d, 1).alias('d')).collect()
-    [Row(d=datetime.date(2015, 4, 7))]
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['date'])
+    >>> df.select(date_sub(df.date, 1).alias('prev_date')).collect()
+    [Row(prev_date=datetime.date(2015, 4, 7))]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.date_sub(_to_java_column(start), days))
@@ -956,9 +987,9 @@ def add_months(start, months):
     """
     Returns the date that is `months` months after `start`
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['d'])
-    >>> df.select(add_months(df.d, 1).alias('d')).collect()
-    [Row(d=datetime.date(2015, 5, 8))]
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['date'])
+    >>> df.select(add_months(df.date, 1).alias('next_month')).collect()
+    [Row(next_month=datetime.date(2015, 5, 8))]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.add_months(_to_java_column(start), months))
@@ -969,8 +1000,8 @@ def months_between(date1, date2):
     """
     Returns the number of months between date1 and date2.
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00', '1996-10-30')], ['t', 'd'])
-    >>> df.select(months_between(df.t, df.d).alias('months')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00', '1996-10-30')], ['date1', 'date2'])
+    >>> df.select(months_between(df.date1, df.date2).alias('months')).collect()
     [Row(months=3.9495967...)]
     """
     sc = SparkContext._active_spark_context
@@ -986,12 +1017,12 @@ def to_date(col, format=None):
     By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
     is omitted (equivalent to ``col.cast("date")``).
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(to_date(df.t).alias('date')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
+    >>> df.select(to_date(df.time).alias('date')).collect()
     [Row(date=datetime.date(1997, 2, 28))]
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(to_date(df.t, 'yyyy-MM-dd HH:mm:ss').alias('date')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
+    >>> df.select(to_date(df.time, 'yyyy-MM-dd HH:mm:ss').alias('date')).collect()
     [Row(date=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
@@ -1011,12 +1042,12 @@ def to_timestamp(col, format=None):
     By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
     is omitted (equivalent to ``col.cast("timestamp")``).
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(to_timestamp(df.t).alias('dt')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['date'])
+    >>> df.select(to_timestamp(df.date).alias('dt')).collect()
     [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(to_timestamp(df.t, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['date'])
+    >>> df.select(to_timestamp(df.date, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
     [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
     """
     sc = SparkContext._active_spark_context
@@ -1052,8 +1083,8 @@ def next_day(date, dayOfWeek):
     Day of the week parameter is case insensitive, and accepts:
         "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun".
 
-    >>> df = spark.createDataFrame([('2015-07-27',)], ['d'])
-    >>> df.select(next_day(df.d, 'Sun').alias('date')).collect()
+    >>> df = spark.createDataFrame([('2015-07-27',)], ['time'])
+    >>> df.select(next_day(df.time, 'Sun').alias('date')).collect()
     [Row(date=datetime.date(2015, 8, 2))]
     """
     sc = SparkContext._active_spark_context
@@ -1079,6 +1110,10 @@ def from_unixtime(timestamp, format="yyyy-MM-dd HH:mm:ss"):
     Converts the number of seconds from unix epoch (1970-01-01 00:00:00 UTC) to a string
     representing the timestamp of that moment in the current system time zone in the given
     format.
+
+    >>> time_df = spark.createDataFrame([(1428476400, )], ['unix_time'])
+    >>> time_df.select(from_unixtime('unix_time').alias('ts') ).collect()
+    [Row(ts=u'2015-04-08 00:00:00')]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.from_unixtime(_to_java_column(timestamp), format))
@@ -1092,6 +1127,10 @@ def unix_timestamp(timestamp=None, format='yyyy-MM-dd HH:mm:ss'):
     locale, return null if fail.
 
     if `timestamp` is None, then it returns current timestamp.
+
+    >>> time_df = spark.createDataFrame([('2015-04-08',)], ['date'])
+    >>> time_df.select(unix_timestamp('date', 'yyyy-MM-dd').alias('unix_time')).collect()
+    [Row(unix_time=1428476400)]
     """
     sc = SparkContext._active_spark_context
     if timestamp is None:
@@ -1105,9 +1144,9 @@ def from_utc_timestamp(timestamp, tz):
     Given a timestamp, which corresponds to a certain time of day in UTC, returns another timestamp
     that corresponds to the same time of day in the given timezone.
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(from_utc_timestamp(df.t, "PST").alias('t')).collect()
-    [Row(t=datetime.datetime(1997, 2, 28, 2, 30))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
+    >>> df.select(from_utc_timestamp(df.time, "PST").alias('local_time')).collect()
+    [Row(local_time=datetime.datetime(1997, 2, 28, 2, 30))]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.from_utc_timestamp(_to_java_column(timestamp), tz))
@@ -1116,12 +1155,12 @@ def from_utc_timestamp(timestamp, tz):
 @since(1.5)
 def to_utc_timestamp(timestamp, tz):
     """
-    Given a timestamp, which corresponds to a certain time of day in the given timezone, returns
-    another timestamp that corresponds to the same time of day in UTC.
+    Given a `timestamp`, which corresponds to a time of day in the timezone `tz`,
+    returns another timestamp that corresponds to the same time of day in UTC.
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(to_utc_timestamp(df.t, "PST").alias('t')).collect()
-    [Row(t=datetime.datetime(1997, 2, 28, 18, 30))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
+    >>> df.select(to_utc_timestamp(df.time, "PST").alias('utc_time')).collect()
+    [Row(utc_time=datetime.datetime(1997, 2, 28, 18, 30))]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.to_utc_timestamp(_to_java_column(timestamp), tz))
@@ -1250,15 +1289,33 @@ def hash(*cols):
 
 # ---------------------- String/Binary functions ------------------------------
 
+_lower_doc = """
+    Converts a string column to lower case.
+
+    >>> df.select(lower(df.name) ).collect()
+    [Row(lower(name)=u'alice'), Row(lower(name)=u'bob')]
+    """
+_upper_doc = """
+    Converts a string column to upper case.
+
+    >>> df.select(upper(df.name) ).collect()
+    [Row(upper(name)=u'ALICE'), Row(upper(name)=u'BOB')]
+    """
+_reverse_doc = """
+    Reverses the string column and returns it as a new string column.
+
+    >>> df.select(reverse(df.name) ).collect()
+    [Row(reverse(name)=u'ecilA'), Row(reverse(name)=u'boB')]
+    """
 _string_functions = {
     'ascii': 'Computes the numeric value of the first character of the string column.',
     'base64': 'Computes the BASE64 encoding of a binary column and returns it as a string column.',
     'unbase64': 'Decodes a BASE64 encoded string column and returns it as a binary column.',
     'initcap': 'Returns a new string column by converting the first letter of each word to ' +
                'uppercase. Words are delimited by whitespace.',
-    'lower': 'Converts a string column to lower case.',
-    'upper': 'Converts a string column to upper case.',
-    'reverse': 'Reverses the string column and returns it as a new string column.',
+    'lower': _lower_doc,
+    'upper': _upper_doc,
+    'reverse': _reverse_doc,
     'ltrim': 'Trim the spaces from left end for the specified string value.',
     'rtrim': 'Trim the spaces from right end for the specified string value.',
     'trim': 'Trim the spaces from both ends for the specified string column.',
@@ -2095,7 +2152,7 @@ def _test():
     sc = spark.sparkContext
     globs['sc'] = sc
     globs['spark'] = spark
-    globs['df'] = sc.parallelize([Row(name='Alice', age=2), Row(name='Bob', age=5)]).toDF()
+    globs['df'] = spark.createDataFrame([Row(name='Alice', age=2), Row(name='Bob', age=5)])
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.functions, globs=globs,
         optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -631,7 +631,7 @@ def struct(*cols):
 def greatest(*cols):
     """
     Returns the greatest value of the list of column names, skipping null values.
-    This function takes at least 2 parameters. It will return null if all parameters are null.
+    This function takes at least 2 parameters. It will return null iff all parameters are null.
 
     >>> df = spark.createDataFrame([(1, 4, 3)], ['a', 'b', 'c'])
     >>> df.select(greatest(df.a, df.b, df.c).alias("greatest")).collect()
@@ -647,7 +647,7 @@ def greatest(*cols):
 def least(*cols):
     """
     Returns the least value of the list of column names, skipping null values.
-    This function takes at least 2 parameters. It will return null if all parameters are null.
+    This function takes at least 2 parameters. It will return null iff all parameters are null.
 
     >>> df = spark.createDataFrame([(1, 4, 3)], ['a', 'b', 'c'])
     >>> df.select(least(df.a, df.b, df.c).alias("least")).collect()
@@ -1052,7 +1052,7 @@ def to_timestamp(col, format=None):
     [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
 
     >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
-    >>> df.select(to_timestamp(df.ts, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
+    >>> df.select(to_timestamp(df.t, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
     [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
     """
     sc = SparkContext._active_spark_context
@@ -1303,7 +1303,7 @@ _string_functions = {
                'uppercase. Words are delimited by whitespace.',
     'lower': 'Converts a string column to lower case.',
     'upper': 'Converts a string column to upper case.',
-    'reverse': 'Reverses a column and returns it as a new string column.',
+    'reverse': 'Reverses a string column and returns it as a new string column.',
     'ltrim': 'Trim the spaces from left end for the specified string value.',
     'rtrim': 'Trim the spaces from right end for the specified string value.',
     'trim': 'Trim the spaces from both ends for the specified string column.',

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -70,7 +70,7 @@ def _create_window_function(name, doc=''):
 _lit_doc = """
     Creates a :class:`Column` of literal value.
 
-    >>> df.withColumn('height', lit(5) ).withColumn('spark_user', lit(True) ).collect()
+    >>> df.withColumn('height', lit(5)).withColumn('spark_user', lit(True)).collect()
     [Row(age=2, name=u'Alice', height=5, spark_user=True),
      Row(age=5, name=u'Bob', height=5, spark_user=True)]
     """
@@ -98,16 +98,17 @@ _functions = {
 _functions_1_4 = {
     # unary math functions
     'acos': 'Computes the cosine inverse of the given value; the returned angle is in the range' +
-            '0.0 through pi.\n\n:param col: float column, units in radians.',
-    'asin': """Computes the sine inverse of the given value; the returned angle is in the range
-            -pi/2 through pi/2.
-
-            :param col: float column, units in radians.""",
-    'atan': 'Computes the tangent inverse of the given value. Units in radians.',
+            '0.0 through pi.',
+    'asin': 'Computes the sine inverse of the given value; the returned angle is in the range' +
+            '-pi/2 through pi/2.',
+    'atan': 'Computes the tangent inverse of the given value; the returned angle is in the range' +
+            '-pi/2 through pi/2',
     'cbrt': 'Computes the cube-root of the given value.',
     'ceil': 'Computes the ceiling of the given value.',
-    'cos': 'Computes the cosine of the given value. Units in radians.',
-    'cosh': 'Computes the hyperbolic cosine of the given value. Units in radians.',
+    'cos': """Computes the cosine of the given value.
+
+           :param col: :class:`DoubleType` column, units in radians.""",
+    'cosh': 'Computes the hyperbolic cosine of the given value.',
     'exp': 'Computes the exponential of the given value.',
     'expm1': 'Computes the exponential of the given value minus one.',
     'floor': 'Computes the floor of the given value.',
@@ -117,10 +118,14 @@ _functions_1_4 = {
     'rint': 'Returns the double value that is closest in value to the argument and' +
             ' is equal to a mathematical integer.',
     'signum': 'Computes the signum of the given value.',
-    'sin': 'Computes the sine of the given value. Units in radians',
-    'sinh': 'Computes the hyperbolic sine of the given value. Units in radians.',
-    'tan': 'Computes the tangent of the given value. Units in radians.',
-    'tanh': 'Computes the hyperbolic tangent of the given value. Units in radians.',
+    'sin': """Computes the sine of the given value.
+
+           :param col: :class:`DoubleType` column, units in radians.""",
+    'sinh': 'Computes the hyperbolic sine of the given value.',
+    'tan': """Computes the tangent of the given value.
+
+           :param col: :class:`DoubleType` column, units in radians.""",
+    'tanh': 'Computes the hyperbolic tangent of the given value.',
     'toDegrees': '.. note:: Deprecated in 2.1, use :func:`degrees` instead.',
     'toRadians': '.. note:: Deprecated in 2.1, use :func:`radians` instead.',
     'bitwiseNOT': 'Computes bitwise not.',
@@ -129,14 +134,14 @@ _functions_1_4 = {
 _collect_list_doc = """
     Aggregate function: returns a list of objects with duplicates.
 
-    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5),('Alice', 99)], ('name', 'age'))
+    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
     >>> df2.agg(collect_list('name')).collect()
     [Row(collect_list(name)=[u'Alice', u'Bob', u'Alice'])]
     """
 _collect_set_doc = """
     Aggregate function: returns a set of objects with duplicate elements eliminated.
 
-    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5),('Alice', 99)], ('name', 'age'))
+    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
     >>> df2.agg(collect_set('name')).collect()
     [Row(collect_set(name)=[u'Bob', u'Alice'])]
     """
@@ -227,11 +232,11 @@ def approxCountDistinct(col, rsd=None):
 
 
 @since(2.1)
-def approx_count_distinct(col, rsd=None):
-    """Returns a new :class:`Column` for approximate distinct count of column `col`.
+def approx_count_distinct(col, rsd=0.05):
+    """Aggregate function. Returns a new :class:`Column` for approximate distinct count of column `col`.
 
-    :param rsd: Residual (float). The approximate count will be within this fraction of the true
-        count. For rsd < 0.01, it is more efficient to use :func:`countDistinct`
+    :param rsd: maximum estimation error allowed (default = 0.05). For rsd < 0.01, it is more
+    efficient to use :func:`countDistinct`
 
     >>> df.agg(approx_count_distinct(df.age).alias('distinct_ages')).collect()
     [Row(distinct_ages=2)]
@@ -487,7 +492,7 @@ def rand(seed=None):
     """Generates a random column with independent and identically distributed (i.i.d.) samples
     from U[0.0, 1.0].
 
-    >>> df.withColumn('rand',rand(seed=42) * 3).collect()
+    >>> df.withColumn('rand', rand(seed=42) * 3).collect()
     [Row(age=2, name=u'Alice', rand=1.1568609015300986),
      Row(age=5, name=u'Bob', rand=1.403379671529166)]
     """
@@ -505,7 +510,7 @@ def randn(seed=None):
     """Generates a column with independent and identically distributed (i.i.d.) samples from
     the standard normal distribution.
 
-    >>> df.withColumn('randn',randn(seed=42) ).collect()
+    >>> df.withColumn('randn', randn(seed=42) ).collect()
     [Row(age=2, name=u'Alice', randn=-0.7556247885860078),
     Row(age=5, name=u'Bob', randn=-0.0861619008451133)]
     """
@@ -1293,19 +1298,19 @@ def hash(*cols):
 _lower_doc = """
     Converts a string column to lower case.
 
-    >>> df.select(lower(df.name) ).collect()
+    >>> df.select(lower(df.name)).collect()
     [Row(lower(name)=u'alice'), Row(lower(name)=u'bob')]
     """
 _upper_doc = """
     Converts a string column to upper case.
 
-    >>> df.select(upper(df.name) ).collect()
+    >>> df.select(upper(df.name)).collect()
     [Row(upper(name)=u'ALICE'), Row(upper(name)=u'BOB')]
     """
 _reverse_doc = """
     Reverses the string column and returns it as a new string column.
 
-    >>> df.select(reverse(df.name) ).collect()
+    >>> df.select(reverse(df.name)).collect()
     [Row(reverse(name)=u'ecilA'), Row(reverse(name)=u'boB')]
     """
 _string_functions = {

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -71,8 +71,8 @@ _lit_doc = """
     Creates a :class:`Column` of literal value.
 
     >>> df.withColumn('height', lit(5)).withColumn('spark_user', lit(True)).collect()
-    [Row(age=2, name=u'Alice', height=5, spark_user=True),
-     Row(age=5, name=u'Bob', height=5, spark_user=True)]
+    [Row(age=2, name='Alice', height=5, spark_user=True),
+     Row(age=5, name='Bob', height=5, spark_user=True)]
     """
 _functions = {
     'lit': _lit_doc,
@@ -209,7 +209,7 @@ _window_functions = {
 }
 
 for _name, _doc in _functions.items():
-    globals()[_name] = since(1.3)(ignore_unicode_prefix(_create_function(_name, _doc)))
+    globals()[_name] = since(1.3)(_create_function(_name, _doc))
 for _name, _doc in _functions_1_4.items():
     globals()[_name] = since(1.4)(_create_function(_name, _doc))
 for _name, _doc in _binary_mathfunctions.items():
@@ -217,7 +217,7 @@ for _name, _doc in _binary_mathfunctions.items():
 for _name, _doc in _window_functions.items():
     globals()[_name] = since(1.6)(_create_window_function(_name, _doc))
 for _name, _doc in _functions_1_6.items():
-    globals()[_name] = since(1.6)(ignore_unicode_prefix(_create_function(_name, _doc)))
+    globals()[_name] = since(1.6)(_create_function(_name, _doc))
 for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
 del _name, _doc
@@ -236,7 +236,7 @@ def approx_count_distinct(col, rsd=0.05):
     """Aggregate function. Returns a new :class:`Column` for approximate distinct count of column `col`.
 
     :param rsd: maximum estimation error allowed (default = 0.05). For rsd < 0.01, it is more
-    efficient to use :func:`countDistinct`
+        efficient to use :func:`countDistinct`
 
     >>> df.agg(approx_count_distinct(df.age).alias('distinct_ages')).collect()
     [Row(distinct_ages=2)]
@@ -1022,13 +1022,13 @@ def to_date(col, format=None):
     By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
     is omitted (equivalent to ``col.cast("date")``).
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
-    >>> df.select(to_date(df.ts).alias('dt')).collect()
-    [Row(dt=datetime.date(1997, 2, 28))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
+    >>> df.select(to_date(df.t).alias('date')).collect()
+    [Row(date=datetime.date(1997, 2, 28))]
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
-    >>> df.select(to_date(df.ts, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
-    [Row(dt=datetime.date(1997, 2, 28))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
+    >>> df.select(to_date(df.t, 'yyyy-MM-dd HH:mm:ss').alias('date')).collect()
+    [Row(date=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
     if format is None:
@@ -1047,13 +1047,13 @@ def to_timestamp(col, format=None):
     By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
     is omitted (equivalent to ``col.cast("timestamp")``).
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['dt'])
-    >>> df.select(to_timestamp(df.dt).alias('ts')).collect()
-    [Row(ts=datetime.datetime(1997, 2, 28, 10, 30))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
+    >>> df.select(to_timestamp(df.t).alias('dt')).collect()
+    [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['dt'])
-    >>> df.select(to_timestamp(df.dt, 'yyyy-MM-dd HH:mm:ss').alias('ts')).collect()
-    [Row(ts=datetime.datetime(1997, 2, 28, 10, 30))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
+    >>> df.select(to_timestamp(df.ts, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
+    [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
     """
     sc = SparkContext._active_spark_context
     if format is None:
@@ -1088,8 +1088,8 @@ def next_day(date, dayOfWeek):
     Day of the week parameter is case insensitive, and accepts:
         "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun".
 
-    >>> df = spark.createDataFrame([('2015-07-27',)], ['dt'])
-    >>> df.select(next_day(df.dt, 'Sun').alias('date')).collect()
+    >>> df = spark.createDataFrame([('2015-07-27',)], ['d'])
+    >>> df.select(next_day(df.d, 'Sun').alias('date')).collect()
     [Row(date=datetime.date(2015, 8, 2))]
     """
     sc = SparkContext._active_spark_context
@@ -1101,8 +1101,8 @@ def last_day(date):
     """
     Returns the last day of the month which the given date belongs to.
 
-    >>> df = spark.createDataFrame([('1997-02-10',)], ['dt'])
-    >>> df.select(last_day(df.dt).alias('date')).collect()
+    >>> df = spark.createDataFrame([('1997-02-10',)], ['d'])
+    >>> df.select(last_day(df.d).alias('date')).collect()
     [Row(date=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
@@ -1295,33 +1295,15 @@ def hash(*cols):
 
 # ---------------------- String/Binary functions ------------------------------
 
-_lower_doc = """
-    Converts a string column to lower case.
-
-    >>> df.select(lower(df.name)).collect()
-    [Row(lower(name)=u'alice'), Row(lower(name)=u'bob')]
-    """
-_upper_doc = """
-    Converts a string column to upper case.
-
-    >>> df.select(upper(df.name)).collect()
-    [Row(upper(name)=u'ALICE'), Row(upper(name)=u'BOB')]
-    """
-_reverse_doc = """
-    Reverses the string column and returns it as a new string column.
-
-    >>> df.select(reverse(df.name)).collect()
-    [Row(reverse(name)=u'ecilA'), Row(reverse(name)=u'boB')]
-    """
 _string_functions = {
     'ascii': 'Computes the numeric value of the first character of the string column.',
     'base64': 'Computes the BASE64 encoding of a binary column and returns it as a string column.',
     'unbase64': 'Decodes a BASE64 encoded string column and returns it as a binary column.',
     'initcap': 'Returns a new string column by converting the first letter of each word to ' +
                'uppercase. Words are delimited by whitespace.',
-    'lower': _lower_doc,
-    'upper': _upper_doc,
-    'reverse': _reverse_doc,
+    'lower': 'Converts a string column to lower case.',
+    'upper': 'Converts a string column to upper case.',
+    'reverse': 'Reverses a column and returns it as a new string column.',
     'ltrim': 'Trim the spaces from left end for the specified string value.',
     'rtrim': 'Trim the spaces from right end for the specified string value.',
     'trim': 'Trim the spaces from both ends for the specified string column.',
@@ -1329,7 +1311,7 @@ _string_functions = {
 
 
 for _name, _doc in _string_functions.items():
-    globals()[_name] = since(1.5)(ignore_unicode_prefix(_create_function(_name, _doc)))
+    globals()[_name] = since(1.5)(_create_function(_name, _doc))
 del _name, _doc
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -71,8 +71,8 @@ _lit_doc = """
     Creates a :class:`Column` of literal value.
 
     >>> df.withColumn('height', lit(5)).withColumn('spark_user', lit(True)).collect()
-    [Row(age=2, name='Alice', height=5, spark_user=True),
-     Row(age=5, name='Bob', height=5, spark_user=True)]
+    [Row(age=2, name=u'Alice', height=5, spark_user=True),
+     Row(age=5, name=u'Bob', height=5, spark_user=True)]
     """
 _functions = {
     'lit': _lit_doc,

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -134,14 +134,14 @@ _functions_1_4 = {
 _collect_list_doc = """
     Aggregate function: returns a list of objects with duplicates.
 
-    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
+    >>> df2 = spark.createDataFrame([(u'Alice', 2), (u'Bob', 5), (u'Alice', 99)], ('name', 'age'))
     >>> df2.agg(collect_list('name')).collect()
     [Row(collect_list(name)=[u'Alice', u'Bob', u'Alice'])]
     """
 _collect_set_doc = """
     Aggregate function: returns a set of objects with duplicate elements eliminated.
 
-    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
+    >>> df2 = spark.createDataFrame([(u'Alice', 2), (u'Bob', 5), (u'Alice', 99)], ('name', 'age'))
     >>> df2.agg(collect_set('name')).collect()
     [Row(collect_set(name)=[u'Bob', u'Alice'])]
     """
@@ -209,7 +209,7 @@ _window_functions = {
 }
 
 for _name, _doc in _functions.items():
-    globals()[_name] = since(1.3)(_create_function(_name, _doc))
+    globals()[_name] = since(1.3)(ignore_unicode_prefix(_create_function(_name, _doc)))
 for _name, _doc in _functions_1_4.items():
     globals()[_name] = since(1.4)(_create_function(_name, _doc))
 for _name, _doc in _binary_mathfunctions.items():
@@ -217,7 +217,7 @@ for _name, _doc in _binary_mathfunctions.items():
 for _name, _doc in _window_functions.items():
     globals()[_name] = since(1.6)(_create_window_function(_name, _doc))
 for _name, _doc in _functions_1_6.items():
-    globals()[_name] = since(1.6)(_create_function(_name, _doc))
+    globals()[_name] = since(1.6)(ignore_unicode_prefix(_create_function(_name, _doc)))
 for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
 del _name, _doc

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -232,7 +232,7 @@ def approxCountDistinct(col, rsd=None):
 
 @since(2.1)
 def approx_count_distinct(col, rsd=None):
-    """Aggregate function. Returns a new :class:`Column` for approximate distinct count of column `col`.
+    """Aggregate function: returns a new :class:`Column` for approximate distinct count of column `col`.
 
     :param rsd: maximum estimation error allowed (default = 0.05). For rsd < 0.01, it is more
         efficient to use :func:`countDistinct`
@@ -309,7 +309,7 @@ def corr(col1, col2):
 
 @since(2.0)
 def covar_pop(col1, col2):
-    """Returns a new :class:`Column` for the population covariance of `col1` and `col2`.
+    """Returns a new :class:`Column` for the population covariance of ``col1`` and ``col2``.
 
     >>> a = [1] * 10
     >>> b = [1] * 10
@@ -509,7 +509,7 @@ def randn(seed=None):
     """Generates a column with independent and identically distributed (i.i.d.) samples from
     the standard normal distribution.
 
-    >>> df.withColumn('randn', randn(seed=42) ).collect()
+    >>> df.withColumn('randn', randn(seed=42)).collect()
     [Row(age=2, name=u'Alice', randn=-0.7556247885860078),
     Row(age=5, name=u'Bob', randn=-0.0861619008451133)]
     """
@@ -1116,7 +1116,7 @@ def from_unixtime(timestamp, format="yyyy-MM-dd HH:mm:ss"):
     representing the timestamp of that moment in the current system time zone in the given
     format.
 
-    >>> time_df = spark.createDataFrame([(1428476400, )], ['unix_time'])
+    >>> time_df = spark.createDataFrame([(1428476400,)], ['unix_time'])
     >>> time_df.select(from_unixtime('unix_time').alias('ts')).collect()
     [Row(ts=u'2015-04-08 00:00:00')]
     """
@@ -1160,7 +1160,7 @@ def from_utc_timestamp(timestamp, tz):
 @since(1.5)
 def to_utc_timestamp(timestamp, tz):
     """
-    Given a `timestamp`, which corresponds to a time of day in the timezone `tz`,
+    Given a timestamp, which corresponds to a time of day in the timezone `tz`,
     returns another timestamp that corresponds to the same time of day in UTC.
 
     >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
@@ -1302,7 +1302,7 @@ _string_functions = {
                'uppercase. Words are delimited by whitespace.',
     'lower': 'Converts a string column to lower case.',
     'upper': 'Converts a string column to upper case.',
-    'reverse': 'Reverses a string column and returns it as a new string column.',
+    'reverse': 'Reverses the string column and returns it as a new string column.',
     'ltrim': 'Trim the spaces from left end for the specified string value.',
     'rtrim': 'Trim the spaces from right end for the specified string value.',
     'trim': 'Trim the spaces from both ends for the specified string column.',

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -98,9 +98,11 @@ _functions = {
 _functions_1_4 = {
     # unary math functions
     'acos': 'Computes the cosine inverse of the given value; the returned angle is in the range' +
-            '0.0 through pi. Units in radians.',
-    'asin': 'Computes the sine inverse of the given value; the returned angle is in the range' +
-            '-pi/2 through pi/2. Units in radians.',
+            '0.0 through pi.\n\n:param col: float column, units in radians.',
+    'asin': """Computes the sine inverse of the given value; the returned angle is in the range
+            -pi/2 through pi/2.
+
+            :param col: float column, units in radians.""",
     'atan': 'Computes the tangent inverse of the given value. Units in radians.',
     'cbrt': 'Computes the cube-root of the given value.',
     'ceil': 'Computes the ceiling of the given value.',
@@ -208,9 +210,9 @@ for _name, _doc in _functions_1_4.items():
 for _name, _doc in _binary_mathfunctions.items():
     globals()[_name] = since(1.4)(_create_binary_mathfunction(_name, _doc))
 for _name, _doc in _window_functions.items():
-    globals()[_name] = since(1.6)(ignore_unicode_prefix(_create_window_function(_name, _doc)))
+    globals()[_name] = since(1.6)(_create_window_function(_name, _doc))
 for _name, _doc in _functions_1_6.items():
-    globals()[_name] = since(1.6)(_create_function(_name, _doc))
+    globals()[_name] = since(1.6)(ignore_unicode_prefix(_create_function(_name, _doc)))
 for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
 del _name, _doc
@@ -226,7 +228,7 @@ def approxCountDistinct(col, rsd=None):
 
 @since(2.1)
 def approx_count_distinct(col, rsd=None):
-    """Returns a new :class:`Column` for approximate distinct count of column ``col``.
+    """Returns a new :class:`Column` for approximate distinct count of column `col`.
 
     :param rsd: Residual (float). The approximate count will be within this fraction of the true
         count. For rsd < 0.01, it is more efficient to use :func:`countDistinct`
@@ -289,8 +291,7 @@ def coalesce(*cols):
 
 @since(1.6)
 def corr(col1, col2):
-    """Returns a new :class:`Column` for the Pearson Correlation Coefficient for ``col1``
-    and ``col2``.
+    """Returns a new :class:`Column` for the Pearson Correlation Coefficient for `col1` and `col2`.
 
     >>> a = range(20)
     >>> b = [2 * x for x in range(20)]
@@ -304,8 +305,7 @@ def corr(col1, col2):
 
 @since(2.0)
 def covar_pop(col1, col2):
-    """Returns a new :class:`Column` for the population covariance of ``col1``
-    and ``col2``.
+    """Returns a new :class:`Column` for the population covariance of `col1` and `col2`.
 
     >>> a = [1] * 10
     >>> b = [1] * 10
@@ -319,8 +319,7 @@ def covar_pop(col1, col2):
 
 @since(2.0)
 def covar_samp(col1, col2):
-    """Returns a new :class:`Column` for the sample covariance of ``col1``
-    and ``col2``.
+    """Returns a new :class:`Column` for the sample covariance of `col1` and `col2`.
 
     >>> a = [1] * 10
     >>> b = [1] * 10
@@ -334,7 +333,7 @@ def covar_samp(col1, col2):
 
 @since(1.3)
 def countDistinct(col, *cols):
-    """Returns a new :class:`Column` for distinct count of ``col`` or ``cols``.
+    """Returns a new :class:`Column` for distinct count of `col` or `cols`.
 
     >>> df.agg(countDistinct(df.age, df.name).alias('c')).collect()
     [Row(c=2)]
@@ -413,7 +412,7 @@ def input_file_name():
 
 @since(1.6)
 def isnan(col):
-    """An expression that returns true if the column is NaN.
+    """An expression that returns true iff the column is NaN.
 
     >>> df = spark.createDataFrame([(1.0, float('nan')), (float('nan'), 2.0)], ("a", "b"))
     >>> df.select(isnan("a").alias("r1"), isnan(df.a).alias("r2")).collect()
@@ -425,7 +424,7 @@ def isnan(col):
 
 @since(1.6)
 def isnull(col):
-    """An expression that returns true if the column is null.
+    """An expression that returns true iff the column is null.
 
     >>> df = spark.createDataFrame([(1, None), (None, 2)], ("a", "b"))
     >>> df.select(isnull("a").alias("r1"), isnull(df.a).alias("r2")).collect()
@@ -482,6 +481,7 @@ def nanvl(col1, col2):
     return Column(sc._jvm.functions.nanvl(_to_java_column(col1), _to_java_column(col2)))
 
 
+@ignore_unicode_prefix
 @since(1.4)
 def rand(seed=None):
     """Generates a random column with independent and identically distributed (i.i.d.) samples
@@ -499,6 +499,7 @@ def rand(seed=None):
     return Column(jc)
 
 
+@ignore_unicode_prefix
 @since(1.4)
 def randn(seed=None):
     """Generates a column with independent and identically distributed (i.i.d.) samples from
@@ -1103,6 +1104,7 @@ def last_day(date):
     return Column(sc._jvm.functions.last_day(_to_java_column(date)))
 
 
+@ignore_unicode_prefix
 @since(1.5)
 def from_unixtime(timestamp, format="yyyy-MM-dd HH:mm:ss"):
     """

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -323,7 +323,7 @@ def covar_pop(col1, col2):
 
 @since(2.0)
 def covar_samp(col1, col2):
-    """Returns a new :class:`Column` for the sample covariance of `col1` and `col2`.
+    """Returns a new :class:`Column` for the sample covariance of ``col1`` and ``col2``.
 
     >>> a = [1] * 10
     >>> b = [1] * 10

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -134,14 +134,14 @@ _functions_1_4 = {
 _collect_list_doc = """
     Aggregate function: returns a list of objects with duplicates.
 
-    >>> df2 = spark.createDataFrame([(u'Alice', 2), (u'Bob', 5), (u'Alice', 99)], ('name', 'age'))
+    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
     >>> df2.agg(collect_list('name')).collect()
     [Row(collect_list(name)=[u'Alice', u'Bob', u'Alice'])]
     """
 _collect_set_doc = """
     Aggregate function: returns a set of objects with duplicate elements eliminated.
 
-    >>> df2 = spark.createDataFrame([(u'Alice', 2), (u'Bob', 5), (u'Alice', 99)], ('name', 'age'))
+    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
     >>> df2.agg(collect_set('name')).collect()
     [Row(collect_set(name)=[u'Bob', u'Alice'])]
     """

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -68,8 +68,7 @@ def _create_window_function(name, doc=''):
     return _
 
 _lit_doc = """
-    Creates a :class:`Column` of literal value. Supports basic types like :class:`IntegerType`,
-    :class:`FloatType`, :class:`BooleanType`, and :class:`StringType`
+    Creates a :class:`Column` of literal value.
 
     >>> df.withColumn('height', lit(5) ).withColumn('spark_user', lit(True) ).collect()
     [Row(age=2, name=u'Alice', height=5, spark_user=True),
@@ -203,13 +202,13 @@ _window_functions = {
 }
 
 for _name, _doc in _functions.items():
-    globals()[_name] = since(1.3)(_create_function(_name, _doc))
+    globals()[_name] = since(1.3)(ignore_unicode_prefix(_create_function(_name, _doc)))
 for _name, _doc in _functions_1_4.items():
     globals()[_name] = since(1.4)(_create_function(_name, _doc))
 for _name, _doc in _binary_mathfunctions.items():
     globals()[_name] = since(1.4)(_create_binary_mathfunction(_name, _doc))
 for _name, _doc in _window_functions.items():
-    globals()[_name] = since(1.6)(_create_window_function(_name, _doc))
+    globals()[_name] = since(1.6)(ignore_unicode_prefix(_create_window_function(_name, _doc)))
 for _name, _doc in _functions_1_6.items():
     globals()[_name] = since(1.6)(_create_function(_name, _doc))
 for _name, _doc in _functions_2_1.items():
@@ -220,7 +219,7 @@ del _name, _doc
 @since(1.3)
 def approxCountDistinct(col, rsd=None):
     """
-    .. note:: Deprecated in 2.1, use :func:`approx_count_distinct instead`.
+    .. note:: Deprecated in 2.1, use :func:`approx_count_distinct` instead.
     """
     return approx_count_distinct(col, rsd)
 
@@ -230,7 +229,7 @@ def approx_count_distinct(col, rsd=None):
     """Returns a new :class:`Column` for approximate distinct count of column ``col``.
 
     :param rsd: Residual (float). The approximate count will be within this fraction of the true
-    count. For rsd < 0.01, it is more efficient to use :func:`countDistinct`
+        count. For rsd < 0.01, it is more efficient to use :func:`countDistinct`
 
     >>> df.agg(approx_count_distinct(df.age).alias('distinct_ages')).collect()
     [Row(distinct_ages=2)]
@@ -473,7 +472,7 @@ def monotonically_increasing_id():
 def nanvl(col1, col2):
     """Returns col1 if it is not NaN, or col2 if col1 is NaN.
 
-    Both inputs should be floating point columns (:class:`DoubleType` or FloatType).
+    Both inputs should be floating point columns (:class:`DoubleType` or :class:`FloatType`).
 
     >>> df = spark.createDataFrame([(1.0, float('nan')), (float('nan'), 2.0)], ("a", "b"))
     >>> df.select(nanvl("a", "b").alias("r1"), nanvl(df.a, df.b).alias("r2")).collect()
@@ -799,7 +798,7 @@ def current_date():
 
 def current_timestamp():
     """
-    Returns the current timestamp as a :class:`TimestampType`column.
+    Returns the current timestamp as a :class:`TimestampType` column.
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.current_timestamp())
@@ -818,9 +817,9 @@ def date_format(date, format):
     .. note:: Use when ever possible specialized functions like `year`. These benefit from a
         specialized implementation.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(date_format('time', 'MM/dd/yyy').alias('date')).collect()
-    [Row(date=u'04/08/2015')]
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(date_format('dt', 'MM/dd/yyy').alias('dt2')).collect()
+    [Row(dt2=u'04/08/2015')]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.date_format(_to_java_column(date), format))
@@ -831,8 +830,8 @@ def year(col):
     """
     Extract the year of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(year('time').alias('year')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(year('dt').alias('year')).collect()
     [Row(year=2015)]
     """
     sc = SparkContext._active_spark_context
@@ -844,8 +843,8 @@ def quarter(col):
     """
     Extract the quarter of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(quarter('time').alias('quarter')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(quarter('dt').alias('quarter')).collect()
     [Row(quarter=2)]
     """
     sc = SparkContext._active_spark_context
@@ -857,8 +856,8 @@ def month(col):
     """
     Extract the month of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(month('time').alias('month')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(month('dt').alias('month')).collect()
     [Row(month=4)]
    """
     sc = SparkContext._active_spark_context
@@ -870,8 +869,8 @@ def dayofmonth(col):
     """
     Extract the day of the month of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(dayofmonth('time').alias('day')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(dayofmonth('dt').alias('day')).collect()
     [Row(day=8)]
     """
     sc = SparkContext._active_spark_context
@@ -883,8 +882,8 @@ def dayofyear(col):
     """
     Extract the day of the year of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(dayofyear('time').alias('day')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(dayofyear('dt').alias('day')).collect()
     [Row(day=98)]
     """
     sc = SparkContext._active_spark_context
@@ -896,8 +895,8 @@ def hour(col):
     """
     Extract the hours of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['time'])
-    >>> df.select(hour('time').alias('hour')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['ts'])
+    >>> df.select(hour('ts').alias('hour')).collect()
     [Row(hour=13)]
     """
     sc = SparkContext._active_spark_context
@@ -909,8 +908,8 @@ def minute(col):
     """
     Extract the minutes of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['time'])
-    >>> df.select(minute('time').alias('minute')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['ts'])
+    >>> df.select(minute('ts').alias('minute')).collect()
     [Row(minute=8)]
     """
     sc = SparkContext._active_spark_context
@@ -922,8 +921,8 @@ def second(col):
     """
     Extract the seconds of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['time'])
-    >>> df.select(second('time').alias('second')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08 13:08:15',)], ['ts'])
+    >>> df.select(second('ts').alias('second')).collect()
     [Row(second=15)]
     """
     sc = SparkContext._active_spark_context
@@ -935,8 +934,8 @@ def weekofyear(col):
     """
     Extract the week number of a given date as integer.
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['time'])
-    >>> df.select(weekofyear(df.time).alias('week')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(weekofyear(df.dt).alias('week')).collect()
     [Row(week=15)]
     """
     sc = SparkContext._active_spark_context
@@ -948,8 +947,8 @@ def date_add(start, days):
     """
     Returns the date that is `days` days after `start`
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['date'])
-    >>> df.select(date_add(df.date, 1).alias('next_date')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(date_add(df.dt, 1).alias('next_date')).collect()
     [Row(next_date=datetime.date(2015, 4, 9))]
     """
     sc = SparkContext._active_spark_context
@@ -961,8 +960,8 @@ def date_sub(start, days):
     """
     Returns the date that is `days` days before `start`
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['date'])
-    >>> df.select(date_sub(df.date, 1).alias('prev_date')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(date_sub(df.dt, 1).alias('prev_date')).collect()
     [Row(prev_date=datetime.date(2015, 4, 7))]
     """
     sc = SparkContext._active_spark_context
@@ -987,8 +986,8 @@ def add_months(start, months):
     """
     Returns the date that is `months` months after `start`
 
-    >>> df = spark.createDataFrame([('2015-04-08',)], ['date'])
-    >>> df.select(add_months(df.date, 1).alias('next_month')).collect()
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(add_months(df.dt, 1).alias('next_month')).collect()
     [Row(next_month=datetime.date(2015, 5, 8))]
     """
     sc = SparkContext._active_spark_context
@@ -1017,13 +1016,13 @@ def to_date(col, format=None):
     By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
     is omitted (equivalent to ``col.cast("date")``).
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
-    >>> df.select(to_date(df.time).alias('date')).collect()
-    [Row(date=datetime.date(1997, 2, 28))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
+    >>> df.select(to_date(df.ts).alias('dt')).collect()
+    [Row(dt=datetime.date(1997, 2, 28))]
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
-    >>> df.select(to_date(df.time, 'yyyy-MM-dd HH:mm:ss').alias('date')).collect()
-    [Row(date=datetime.date(1997, 2, 28))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
+    >>> df.select(to_date(df.ts, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
+    [Row(dt=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
     if format is None:
@@ -1042,13 +1041,13 @@ def to_timestamp(col, format=None):
     By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
     is omitted (equivalent to ``col.cast("timestamp")``).
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['date'])
-    >>> df.select(to_timestamp(df.date).alias('dt')).collect()
-    [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['dt'])
+    >>> df.select(to_timestamp(df.dt).alias('ts')).collect()
+    [Row(ts=datetime.datetime(1997, 2, 28, 10, 30))]
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['date'])
-    >>> df.select(to_timestamp(df.date, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
-    [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['dt'])
+    >>> df.select(to_timestamp(df.dt, 'yyyy-MM-dd HH:mm:ss').alias('ts')).collect()
+    [Row(ts=datetime.datetime(1997, 2, 28, 10, 30))]
     """
     sc = SparkContext._active_spark_context
     if format is None:
@@ -1083,8 +1082,8 @@ def next_day(date, dayOfWeek):
     Day of the week parameter is case insensitive, and accepts:
         "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun".
 
-    >>> df = spark.createDataFrame([('2015-07-27',)], ['time'])
-    >>> df.select(next_day(df.time, 'Sun').alias('date')).collect()
+    >>> df = spark.createDataFrame([('2015-07-27',)], ['dt'])
+    >>> df.select(next_day(df.dt, 'Sun').alias('date')).collect()
     [Row(date=datetime.date(2015, 8, 2))]
     """
     sc = SparkContext._active_spark_context
@@ -1096,8 +1095,8 @@ def last_day(date):
     """
     Returns the last day of the month which the given date belongs to.
 
-    >>> df = spark.createDataFrame([('1997-02-10',)], ['d'])
-    >>> df.select(last_day(df.d).alias('date')).collect()
+    >>> df = spark.createDataFrame([('1997-02-10',)], ['dt'])
+    >>> df.select(last_day(df.dt).alias('date')).collect()
     [Row(date=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
@@ -1128,8 +1127,8 @@ def unix_timestamp(timestamp=None, format='yyyy-MM-dd HH:mm:ss'):
 
     if `timestamp` is None, then it returns current timestamp.
 
-    >>> time_df = spark.createDataFrame([('2015-04-08',)], ['date'])
-    >>> time_df.select(unix_timestamp('date', 'yyyy-MM-dd').alias('unix_time')).collect()
+    >>> time_df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> time_df.select(unix_timestamp('dt', 'yyyy-MM-dd').alias('unix_time')).collect()
     [Row(unix_time=1428476400)]
     """
     sc = SparkContext._active_spark_context
@@ -1144,8 +1143,8 @@ def from_utc_timestamp(timestamp, tz):
     Given a timestamp, which corresponds to a certain time of day in UTC, returns another timestamp
     that corresponds to the same time of day in the given timezone.
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
-    >>> df.select(from_utc_timestamp(df.time, "PST").alias('local_time')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
+    >>> df.select(from_utc_timestamp(df.ts, "PST").alias('local_time')).collect()
     [Row(local_time=datetime.datetime(1997, 2, 28, 2, 30))]
     """
     sc = SparkContext._active_spark_context
@@ -1158,8 +1157,8 @@ def to_utc_timestamp(timestamp, tz):
     Given a `timestamp`, which corresponds to a time of day in the timezone `tz`,
     returns another timestamp that corresponds to the same time of day in UTC.
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['time'])
-    >>> df.select(to_utc_timestamp(df.time, "PST").alias('utc_time')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
+    >>> df.select(to_utc_timestamp(df.ts, "PST").alias('utc_time')).collect()
     [Row(utc_time=datetime.datetime(1997, 2, 28, 18, 30))]
     """
     sc = SparkContext._active_spark_context
@@ -1323,7 +1322,7 @@ _string_functions = {
 
 
 for _name, _doc in _string_functions.items():
-    globals()[_name] = since(1.5)(_create_function(_name, _doc))
+    globals()[_name] = since(1.5)(ignore_unicode_prefix(_create_function(_name, _doc)))
 del _name, _doc
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -70,9 +70,8 @@ def _create_window_function(name, doc=''):
 _lit_doc = """
     Creates a :class:`Column` of literal value.
 
-    >>> df.withColumn('height', lit(5)).withColumn('spark_user', lit(True)).collect()
-    [Row(age=2, name=u'Alice', height=5, spark_user=True),
-     Row(age=5, name=u'Bob', height=5, spark_user=True)]
+    >>> df.select(lit(5).alias('height')).withColumn('spark_user', lit(True)).take(1)
+    [Row(height=5, spark_user=True)]
     """
 _functions = {
     'lit': _lit_doc,
@@ -134,16 +133,16 @@ _functions_1_4 = {
 _collect_list_doc = """
     Aggregate function: returns a list of objects with duplicates.
 
-    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
-    >>> df2.agg(collect_list('name')).collect()
-    [Row(collect_list(name)=[u'Alice', u'Bob', u'Alice'])]
+    >>> df2 = spark.createDataFrame([(2,), (5,), (5,)], ('age',))
+    >>> df2.agg(collect_list('age')).collect()
+    [Row(collect_list(age)=[2, 5, 5])]
     """
 _collect_set_doc = """
     Aggregate function: returns a set of objects with duplicate elements eliminated.
 
-    >>> df2 = spark.createDataFrame([('Alice', 2), ('Bob', 5), ('Alice', 99)], ('name', 'age'))
-    >>> df2.agg(collect_set('name')).collect()
-    [Row(collect_set(name)=[u'Bob', u'Alice'])]
+    >>> df2 = spark.createDataFrame([(2,), (5,), (5,)], ('age',))
+    >>> df2.agg(collect_set('age')).collect()
+    [Row(collect_set(age)=[5, 2])]
     """
 _functions_1_6 = {
     # unary math functions
@@ -209,7 +208,7 @@ _window_functions = {
 }
 
 for _name, _doc in _functions.items():
-    globals()[_name] = since(1.3)(ignore_unicode_prefix(_create_function(_name, _doc)))
+    globals()[_name] = since(1.3)(_create_function(_name, _doc))
 for _name, _doc in _functions_1_4.items():
     globals()[_name] = since(1.4)(_create_function(_name, _doc))
 for _name, _doc in _binary_mathfunctions.items():
@@ -217,7 +216,7 @@ for _name, _doc in _binary_mathfunctions.items():
 for _name, _doc in _window_functions.items():
     globals()[_name] = since(1.6)(_create_window_function(_name, _doc))
 for _name, _doc in _functions_1_6.items():
-    globals()[_name] = since(1.6)(ignore_unicode_prefix(_create_function(_name, _doc)))
+    globals()[_name] = since(1.6)(_create_function(_name, _doc))
 for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
 del _name, _doc
@@ -232,7 +231,7 @@ def approxCountDistinct(col, rsd=None):
 
 
 @since(2.1)
-def approx_count_distinct(col, rsd=0.05):
+def approx_count_distinct(col, rsd=None):
     """Aggregate function. Returns a new :class:`Column` for approximate distinct count of column `col`.
 
     :param rsd: maximum estimation error allowed (default = 0.05). For rsd < 0.01, it is more
@@ -296,7 +295,7 @@ def coalesce(*cols):
 
 @since(1.6)
 def corr(col1, col2):
-    """Returns a new :class:`Column` for the Pearson Correlation Coefficient for `col1` and `col2`.
+    """Returns a new :class:`Column` for the Pearson Correlation Coefficient for ``col1`` and ``col2``.
 
     >>> a = range(20)
     >>> b = [2 * x for x in range(20)]
@@ -338,7 +337,7 @@ def covar_samp(col1, col2):
 
 @since(1.3)
 def countDistinct(col, *cols):
-    """Returns a new :class:`Column` for distinct count of `col` or `cols`.
+    """Returns a new :class:`Column` for distinct count of ``col`` or ``cols``.
 
     >>> df.agg(countDistinct(df.age, df.name).alias('c')).collect()
     [Row(c=2)]
@@ -824,8 +823,8 @@ def date_format(date, format):
         specialized implementation.
 
     >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
-    >>> df.select(date_format('dt', 'MM/dd/yyy').alias('dt2')).collect()
-    [Row(dt2=u'04/08/2015')]
+    >>> df.select(date_format('dt', 'MM/dd/yyy').alias('date')).collect()
+    [Row(date=u'04/08/2015')]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.date_format(_to_java_column(date), format))
@@ -1118,7 +1117,7 @@ def from_unixtime(timestamp, format="yyyy-MM-dd HH:mm:ss"):
     format.
 
     >>> time_df = spark.createDataFrame([(1428476400, )], ['unix_time'])
-    >>> time_df.select(from_unixtime('unix_time').alias('ts') ).collect()
+    >>> time_df.select(from_unixtime('unix_time').alias('ts')).collect()
     [Row(ts=u'2015-04-08 00:00:00')]
     """
     sc = SparkContext._active_spark_context
@@ -1150,8 +1149,8 @@ def from_utc_timestamp(timestamp, tz):
     Given a timestamp, which corresponds to a certain time of day in UTC, returns another timestamp
     that corresponds to the same time of day in the given timezone.
 
-    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
-    >>> df.select(from_utc_timestamp(df.ts, "PST").alias('local_time')).collect()
+    >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['t'])
+    >>> df.select(from_utc_timestamp(df.t, "PST").alias('local_time')).collect()
     [Row(local_time=datetime.datetime(1997, 2, 28, 2, 30))]
     """
     sc = SparkContext._active_spark_context

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1160,8 +1160,8 @@ def from_utc_timestamp(timestamp, tz):
 @since(1.5)
 def to_utc_timestamp(timestamp, tz):
     """
-    Given a timestamp, which corresponds to a time of day in the timezone `tz`,
-    returns another timestamp that corresponds to the same time of day in UTC.
+    Given a timestamp, which corresponds to a certain time of day in the given timezone, returns
+    another timestamp that corresponds to the same time of day in UTC.
 
     >>> df = spark.createDataFrame([('1997-02-28 10:30:00',)], ['ts'])
     >>> df.select(to_utc_timestamp(df.ts, "PST").alias('utc_time')).collect()

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1322,7 +1322,8 @@ object functions {
   def asin(columnName: String): Column = asin(Column(columnName))
 
   /**
-   * Computes the tangent inverse of the given value.
+   * Computes the tangent inverse of the given column; the returned angle is in the range
+   * -pi/2 through pi/2
    *
    * @group math_funcs
    * @since 1.4.0
@@ -1330,7 +1331,8 @@ object functions {
   def atan(e: Column): Column = withExpr { Atan(e.expr) }
 
   /**
-   * Computes the tangent inverse of the given column.
+   * Computes the tangent inverse of the given column; the returned angle is in the range
+   * -pi/2 through pi/2
    *
    * @group math_funcs
    * @since 1.4.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1339,7 +1339,7 @@ object functions {
 
   /**
    * Returns the angle theta from the conversion of rectangular coordinates (x, y) to
-   * polar coordinates (r, theta).
+   * polar coordinates (r, theta). Units in radians.
    *
    * @group math_funcs
    * @since 1.4.0
@@ -1471,7 +1471,7 @@ object functions {
   }
 
   /**
-   * Computes the cosine of the given value.
+   * Computes the cosine of the given value. Units in radians.
    *
    * @group math_funcs
    * @since 1.4.0
@@ -1944,7 +1944,7 @@ object functions {
   def signum(columnName: String): Column = signum(Column(columnName))
 
   /**
-   * Computes the sine of the given value.
+   * Computes the sine of the given value. Units in radians.
    *
    * @group math_funcs
    * @since 1.4.0
@@ -1976,7 +1976,7 @@ object functions {
   def sinh(columnName: String): Column = sinh(Column(columnName))
 
   /**
-   * Computes the tangent of the given value.
+   * Computes the tangent of the given value. Units in radians.
    *
    * @group math_funcs
    * @since 1.4.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds documentation to many functions in pyspark.sql.functions.py:
`upper`, `lower`, `reverse`, `unix_timestamp`, `from_unixtime`, `rand`, `randn`, `collect_list`, `collect_set`, `lit`
Add units to the trigonometry functions.
Renames columns in datetime examples to be more informative.
Adds links between some functions.

## How was this patch tested?

`./dev/lint-python`
`python python/pyspark/sql/functions.py`
`./python/run-tests.py --module pyspark-sql`