### PR TITLE
[SPARK-20612][SQL][WIP] Throw exception when there is unresolvable attributes in Filter

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
@@ -83,7 +83,7 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     )).toDF("id", "items")
     val model = new FPGrowth().setMinSupport(0.7).fit(dataset)
     val prediction = model.transform(df)
-    assert(prediction.select("prediction").where("id=3").first().getSeq[String](0).isEmpty)
+    assert(prediction.where("id=3").select("prediction").first().getSeq[String](0).isEmpty)
   }
 
   test("FPGrowth prediction should not contain duplicates") {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1023,8 +1023,6 @@ class Analyzer(
    * clause.  This rule detects such queries and adds the required attributes to the original
    * projection, so that they will be available during sorting. Another projection is added to
    * remove these attributes after sorting.
-   *
-   * The HAVING clause could also used a grouping columns that is not presented in the SELECT.
    */
   object ResolveMissingReferences extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
@@ -1050,26 +1048,6 @@ class Analyzer(
           // Users will see an AnalysisException for resolution failure of missing attributes
           // in Sort
           case ae: AnalysisException => s
-        }
-
-      case f @ Filter(cond, child) if child.resolved =>
-        try {
-          val newCond = resolveExpressionRecursively(cond, child)
-          val requiredAttrs = newCond.references.filter(_.resolved)
-          val missingAttrs = requiredAttrs -- child.outputSet
-          if (missingAttrs.nonEmpty) {
-            // Add missing attributes and then project them away.
-            Project(child.output,
-              Filter(newCond, addMissingAttr(child, missingAttrs)))
-          } else if (newCond != cond) {
-            f.copy(condition = newCond)
-          } else {
-            f
-          }
-        } catch {
-          // Attempting to resolve it might fail. When this happens, return the original plan.
-          // Users will see an AnalysisException for resolution failure of missing attributes
-          case ae: AnalysisException => f
         }
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1844,4 +1844,10 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       .filter($"x1".isNotNull || !$"y".isin("a!"))
       .count
   }
+
+  test("Unresolvable attribute in Filter should throw analysis exception") {
+    val df = Seq((1, "a"), (2, "b"), (3, "c")).toDF("x", "y")
+    val e = intercept[AnalysisException](df.select("y").where("x=1"))
+    assert(e.message.contains("cannot resolve '`x`'"))
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
@@ -59,8 +59,8 @@ class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEac
     import _hc.implicits._
     val df1 = (1 to 20).map { i => (i, i) }.toDF("a", "x")
     val df2 = (1 to 100).map { i => (i, i % 10, i % 2 == 0) }.toDF("a", "b", "c")
-      .select($"a", $"b")
       .filter($"a" > 10 && $"b" > 6 && $"c")
+      .select($"a", $"b")
     val df3 = df1.join(df2, "a")
     val res = df3.collect()
     val expected = Seq((18, 18, 8)).toDF("a", "x", "b").collect()


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have a rule in `Analyzer` that adds missing attributes in a Filter into its child plan. It makes the following codes work:

    val df = Seq((1, "a"), (2, "b"), (3, "c")).toDF("x", "y")
    df.select("y").where("x=1")

It should throw an analysis exception instead of implicitly adding the missing attributes into underlying plan.

## How was this patch tested?

Jenkins tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
