### PR TITLE
[SPARK-20608] allow standby namenodes in spark.yarn.access.namenodes

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/HadoopFSCredentialProvider.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/HadoopFSCredentialProvider.scala
@@ -56,9 +56,9 @@ private[security] class HadoopFSCredentialProvider
         dstFs.addDelegationTokens(tokenRenewer, tmpCreds)
       } catch {
         case e: StandbyException =>
-          logWarning(s"Namenode ${dst} is in state standby", e)
+          logWarning(s"Can't get token from ${dst} for it is in state standby", e)
         case e: RemoteException =>
-          logWarning(s"Namenode ${dst} is in state standby", e)
+          logWarning(s"Can't get token from ${dst}", e)
       }
     }
 
@@ -95,9 +95,9 @@ private[security] class HadoopFSCredentialProvider
           dstFs.addDelegationTokens(renewer, creds)
         } catch {
           case e: StandbyException =>
-            logWarning(s"Namenode ${dst} is in state standby", e)
+            logWarning(s"Can't get token from ${dst} for it is in state standby", e)
           case e: RemoteException =>
-            logWarning(s"Namenode ${dst} is in state standby", e)
+            logWarning(s"Can't get token from ${dst}", e)
         }
       }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/HadoopFSCredentialProvider.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/security/HadoopFSCredentialProvider.scala
@@ -22,8 +22,7 @@ import scala.util.Try
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.hadoop.ipc.RemoteException
-import org.apache.hadoop.ipc.StandbyException
+import org.apache.hadoop.ipc.{RemoteException, StandbyException}
 import org.apache.hadoop.mapred.Master
 import org.apache.hadoop.security.Credentials
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier


### PR DESCRIPTION
Related Jira:
https://issues.apache.org/jira/browse/SPARK-20608

Descriptions:
See PR (in branch-2.1): https://github.com/apache/spark/pull/17870/
