### PR TITLE
[SPARK-20619][ML] StringIndexer supports multiple ways to order label

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -122,7 +122,7 @@ class StringIndexer @Since("1.4.0") (
   /** @group setParam */
   @Since("2.2.0")
   def setStringOrderType(value: String): this.type = set(stringOrderType, value)
-  setDefault(stringOrderType, "freq_desc")
+  setDefault(stringOrderType, StringIndexer.FREQ_DESC)
 
   /** @group setParam */
   @Since("1.4.0")
@@ -138,11 +138,11 @@ class StringIndexer @Since("1.4.0") (
     val values = dataset.na.drop(Array($(inputCol)))
       .select(col($(inputCol)).cast(StringType))
       .rdd.map(_.getString(0))
-    val labels = $(stringOrderType) match {
-      case "freq_desc" => values.countByValue().toSeq.sortBy(-_._2).map(_._1).toArray
-      case "freq_asc" => values.countByValue().toSeq.sortBy(_._2).map(_._1).toArray
-      case "alphabet_desc" => values.distinct.collect.sortWith(_ > _)
-      case "alphabet_asc" => values.distinct.collect.sortWith(_ < _)
+    val labels = $(stringOrderType).toLowerCase match {
+      case StringIndexer.FREQ_DESC => values.countByValue().toSeq.sortBy(-_._2).map(_._1).toArray
+      case StringIndexer.FREQ_ASC => values.countByValue().toSeq.sortBy(_._2).map(_._1).toArray
+      case StringIndexer.ALPHABET_DESC => values.distinct.collect.sortWith(_ > _)
+      case StringIndexer.ALPHABET_ASC => values.distinct.collect.sortWith(_ < _)
     }
     copyValues(new StringIndexerModel(uid, labels).setParent(this))
   }
@@ -163,8 +163,12 @@ object StringIndexer extends DefaultParamsReadable[StringIndexer] {
   private[feature] val KEEP_INVALID: String = "keep"
   private[feature] val supportedHandleInvalids: Array[String] =
     Array(SKIP_INVALID, ERROR_INVALID, KEEP_INVALID)
+  private[feature] val FREQ_DESC: String = "freq_desc"
+  private[feature] val FREQ_ASC: String = "freq_asc"
+  private[feature] val ALPHABET_DESC: String = "alphabet_desc"
+  private[feature] val ALPHABET_ASC: String = "alphabet_asc"
   private[feature] val supportedStringOrderType: Array[String] =
-    Array("freq_desc", "freq_asc", "alphabet_desc", "alphabet_asc")
+    Array(FREQ_DESC, FREQ_ASC, ALPHABET_DESC, ALPHABET_ASC)
 
   @Since("1.6.0")
   override def load(path: String): StringIndexer = super.load(path)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -124,7 +124,7 @@ class StringIndexer @Since("1.4.0") (
   def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
 
   /** @group setParam */
-  @Since("2.2.0")
+  @Since("2.3.0")
   def setStringOrderType(value: String): this.type = set(stringOrderType, value)
   setDefault(stringOrderType, StringIndexer.FREQ_DESC)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.feature
 
-import java.util.Locale
-
 import scala.language.existentials
 
 import org.apache.hadoop.fs.Path

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ml.feature
 import java.util.Locale
 
 import scala.language.existentials
+
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkException


### PR DESCRIPTION
## What changes were proposed in this pull request?

StringIndexer maps labels to numbers according to the descending order of label frequency. Other types of ordering (e.g., alphabetical) may be needed in feature ETL.  For example, the ordering will affect the result in one-hot encoding and RFormula. 

This PR proposes to support other ordering methods and we add a parameter `stringOrderType` that supports the following four options:
- 'frequencyDesc': descending order by label frequency (most frequent label assigned 0)
- 'frequencyAsc': ascending order by label frequency (least frequent label assigned 0)
- 'alphabetDesc': descending alphabetical order
- 'alphabetAsc': ascending alphabetical order

The default is still descending order of label frequency, so there should be no impact to existing programs.

## How was this patch tested?
new test 