### PR TITLE
[SPARK-20399][SQL] Add a config to fallback string literal parsing consistent with old sql parser behavior

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -73,7 +73,7 @@ class SessionCatalog(
       functionRegistry,
       conf,
       new Configuration(),
-      CatalystSqlParser,
+      new CatalystSqlParser(conf),
       DummyFunctionResourceLoader)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -87,11 +87,11 @@ abstract class StringRegexExpression extends BinaryExpression
         any other character.
 
         Since Spark 2.0, string literals are unescaped in our SQL parser. For example, in order
-        to match a Tab character "\t", the pattern should be "\\t".
+        to match "\abc", the pattern should be "\\abc".
 
         When SQL config 'spark.sql.parser.escapedStringLiterals' is enabled, it fallbacks
         to Spark 1.6 behavior regarding string literal parsing. For example, if the config is
-        enabled, the pattern to match a Tab character should be "\t".
+        enabled, the pattern to match "\abc" should be "\abc".
 
     Examples:
       > SELECT '%SystemDrive%\Users\John' _FUNC_ '\%SystemDrive\%\\Users%'
@@ -158,11 +158,11 @@ case class Like(left: Expression, right: Expression) extends StringRegexExpressi
       regexp - a string expression. The pattern string should be a Java regular expression.
 
         Since Spark 2.0, string literals (including regex patterns) are unescaped in our SQL parser.
-        For example, if to match "abc\td", a regular expression for `regexp` can be "^abc\\\\td$".
+        For example, if to match "\abc", a regular expression for `regexp` can be "^\\abc$".
 
         There is a SQL config 'spark.sql.parser.escapedStringLiterals' that can be used to fallback
         to the Spark 1.6 behavior regarding string literal parsing. For example, if the config is
-        enabled, the `regexp` that can match "abc\td" is "^abc\\t$".
+        enabled, the `regexp` that can match "\abc" is "^\abc$".
 
     Examples:
       When spark.sql.parser.escapedStringLiterals is disabled (default).

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -158,18 +158,18 @@ case class Like(left: Expression, right: Expression) extends StringRegexExpressi
       regexp - a string expression. The pattern string should be a Java regular expression.
 
         Since Spark 2.0, string literals (including regex patterns) are unescaped in our SQL parser.
-        For example, if the `str` parameter is "abc\td", the `regexp` can match it is:
-        "^abc\\\\td$".
+        For example, if to match "abc\td", a regular expression for `regexp` can be "^abc\\\\td$".
+
+        There is a SQL config 'spark.sql.parser.escapedStringLiterals' that can be used to fallback
+        to the Spark 1.6 behavior regarding string literal parsing. For example, if the config is
+        enabled, the `regexp` that can match "abc\td" is "^abc\\t$".
 
     Examples:
+      When spark.sql.parser.escapedStringLiterals is disabled (default).
       > SELECT '%SystemDrive%\Users\John' _FUNC_ '%SystemDrive%\\Users.*'
       true
 
-        There is a SQL config 'spark.sql.parser.escapedStringLiterals' can be used to fallback
-        to Spark 1.6 behavior regarding string literal parsing. For example, if the config is
-        enabled, the `regexp` can match "abc\td" is "^abc\\t$".
-
-    Examples (spark.sql.parser.escapedStringLiterals is enabled):
+      When spark.sql.parser.escapedStringLiterals is enabled.
       > SELECT '%SystemDrive%\Users\John' _FUNC_ '%SystemDrive%\Users.*'
       true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -158,7 +158,7 @@ case class Like(left: Expression, right: Expression) extends StringRegexExpressi
       regexp - a string expression. The pattern string should be a Java regular expression.
 
         Since Spark 2.0, string literals (including regex patterns) are unescaped in our SQL parser.
-        For example, if to match "\abc", a regular expression for `regexp` can be "^\\abc$".
+        For example, to match "\abc", a regular expression for `regexp` can be "^\\abc$".
 
         There is a SQL config 'spark.sql.parser.escapedStringLiterals' that can be used to fallback
         to the Spark 1.6 behavior regarding string literal parsing. For example, if the config is

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -144,7 +144,31 @@ case class Like(left: Expression, right: Expression) extends StringRegexExpressi
 }
 
 @ExpressionDescription(
-  usage = "str _FUNC_ regexp - Returns true if `str` matches `regexp`, or false otherwise.")
+  usage = "str _FUNC_ regexp - Returns true if `str` matches `regexp`, or false otherwise.",
+  extended = """
+    Arguments:
+      str - a string expression
+      regexp - a string expression. The pattern string should be a Java regular expression.
+
+        Since Spark 2.0, string literals (including regex patterns) are unescaped in our SQL parser.
+        For example, if the `str` parameter is "abc\td", the `regexp` can match it is:
+        "^abc\\\\td$".
+
+    Examples:
+      > SELECT '%SystemDrive%\Users\John' _FUNC_ '%SystemDrive%\\Users.*'
+      true
+
+        There is a SQL config 'spark.sql.parser.escapedStringLiterals' can be used to fallback
+        to Spark 1.6 behavior regarding string literal parsing. For example, if the config is
+        enabled, the `regexp` can match "abc\td" is "^abc\\t$".
+
+    Examples (spark.sql.parser.escapedStringLiterals is enabled):
+      > SELECT '%SystemDrive%\Users\John' _FUNC_ '%SystemDrive%\Users.*'
+      true
+
+    See also:
+      Use LIKE to match with simple string pattern.
+""")
 case class RLike(left: Expression, right: Expression) extends StringRegexExpression {
 
   override def escape(v: String): String = v

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -86,6 +86,13 @@ abstract class StringRegexExpression extends BinaryExpression
         escape character, the following character is matched literally. It is invalid to escape
         any other character.
 
+        Since Spark 2.0, string literals are unescaped in our SQL parser. For example, in order
+        to match a Tab character "\t", the pattern should be "\\t".
+
+        When SQL config 'spark.sql.parser.escapedStringLiterals' is enabled, it fallbacks
+        to Spark 1.6 behavior regarding string literal parsing. For example, if the config is
+        enabled, the pattern to match a Tab character should be "\t".
+
     Examples:
       > SELECT '%SystemDrive%\Users\John' _FUNC_ '\%SystemDrive\%\\Users%'
       true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.random.RandomSampler
@@ -44,8 +45,10 @@ import org.apache.spark.util.random.RandomSampler
  * The AstBuilder converts an ANTLR4 ParseTree into a catalyst Expression, LogicalPlan or
  * TableIdentifier.
  */
-class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
+class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging {
   import ParserUtils._
+
+  def this() = this(new SQLConf())
 
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
@@ -1406,7 +1409,11 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with Logging {
    * Special characters can be escaped by using Hive/C-style escaping.
    */
   private def createString(ctx: StringLiteralContext): String = {
-    ctx.STRING().asScala.map(string).mkString
+    if (conf.noUnescapedStringLiteral) {
+      ctx.STRING().asScala.map(stringWithoutUnescape).mkString
+    } else {
+      ctx.STRING().asScala.map(string).mkString
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1409,7 +1409,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
    * Special characters can be escaped by using Hive/C-style escaping.
    */
   private def createString(ctx: StringLiteralContext): String = {
-    if (conf.noUnescapedStringLiteral) {
+    if (conf.escapedStringLiterals) {
       ctx.STRING().asScala.map(stringWithoutUnescape).mkString
     } else {
       ctx.STRING().asScala.map(string).mkString

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
@@ -120,8 +121,13 @@ abstract class AbstractSqlParser extends ParserInterface with Logging {
 /**
  * Concrete SQL parser for Catalyst-only SQL statements.
  */
+class CatalystSqlParser(conf: SQLConf) extends AbstractSqlParser {
+  val astBuilder = new AstBuilder(conf)
+}
+
+/** For test-only. */
 object CatalystSqlParser extends AbstractSqlParser {
-  val astBuilder = new AstBuilder
+  val astBuilder = new AstBuilder(new SQLConf())
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -70,6 +70,7 @@ object ParserUtils {
 
   /** Convert a string node into a string without unescaping. */
   def stringWithoutUnescape(node: TerminalNode): String = {
+    // STRING parser rule forces that the input always has quotes at the starting and ending.
     node.getText.slice(1, node.getText.size - 1)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -68,6 +68,11 @@ object ParserUtils {
   /** Convert a string node into a string. */
   def string(node: TerminalNode): String = unescapeSQLString(node.getText)
 
+  /** Convert a string node into a string without unescaping. */
+  def stringWithoutUnescape(node: TerminalNode): String = {
+    node.getText.slice(1, node.getText.size - 1)
+  }
+
   /** Get the origin (line and position) of the token. */
   def position(token: Token): Origin = {
     val opt = Option(token)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -196,6 +196,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val NO_UNESCAPED_SQL_STRING = buildConf("spark.sql.noUnescapedStringLiteral")
+    .internal()
+    .doc("Since Spark 2.0, we use unescaped SQL string for string literals including regex. " +
+      "It is different than 1.6 behavior. Enabling this config can use no unescaped SQL string " +
+      "literals and mitigate migration problem.")
+    .booleanConf
+    .createWithDefault(false)
+
   val PARQUET_SCHEMA_MERGING_ENABLED = buildConf("spark.sql.parquet.mergeSchema")
     .doc("When true, the Parquet data source merges schemas collected from all data files, " +
          "otherwise the schema is picked from the summary file or a random data file " +
@@ -910,6 +918,8 @@ class SQLConf extends Serializable with Logging {
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
+
+  def noUnescapedStringLiteral: Boolean = getConf(NO_UNESCAPED_SQL_STRING)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -198,7 +198,7 @@ object SQLConf {
 
   val ESCAPED_STRING_LITERALS = buildConf("spark.sql.parser.escapedStringLiterals")
     .internal()
-    .doc("When true, string literals (including regex patterns) remains escaped in our SQL " +
+    .doc("When true, string literals (including regex patterns) remain escaped in our SQL " +
       "parser. The default is false since Spark 2.0. Setting it to true can restore the behavior " +
       "prior to Spark 2.0.")
     .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -196,11 +196,11 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
-  val NO_UNESCAPED_SQL_STRING = buildConf("spark.sql.noUnescapedStringLiteral")
+  val ESCAPED_STRING_LITERALS = buildConf("spark.sql.parser.escapedStringLiterals")
     .internal()
-    .doc("Since Spark 2.0, we use unescaped SQL string for string literals including regex. " +
-      "It is different than 1.6 behavior. Enabling this config can use no unescaped SQL string " +
-      "literals and mitigate migration problem.")
+    .doc("When true, string literals (including regex patterns) remains escaped in our SQL " +
+      "parser. The default is false since Spark 2.0. Setting it to true can restore the behavior " +
+      "prior to Spark 2.0.")
     .booleanConf
     .createWithDefault(false)
 
@@ -919,7 +919,7 @@ class SQLConf extends Serializable with Logging {
 
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
 
-  def noUnescapedStringLiteral: Boolean = getConf(NO_UNESCAPED_SQL_STRING)
+  def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -483,7 +483,7 @@ class ExpressionParserSuite extends PlanTest {
     // Escaped characters.
     assertEqual("'\0'", "\u0000", parser) // ASCII NUL (X'00')
 
-    // Note: Single quote follows 1.6 parsing behavior when NO_UNESCAPED_SQL_STRING is enabled.
+    // Note: Single quote follows 1.6 parsing behavior when ESCAPED_STRING_LITERALS is enabled.
     val e = intercept[ParseException](parser.parseExpression("'\''"))
     assert(e.message.contains("extraneous input '''"))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -166,9 +166,9 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("a not regexp 'pattern%'", !('a rlike "pattern%"))
   }
 
-  test("like expressions with NO_UNESCAPED_SQL_STRING") {
+  test("like expressions with ESCAPED_STRING_LITERALS = true") {
     val conf = new SQLConf()
-    conf.setConfString("spark.sql.noUnescapedStringLiteral", "true")
+    conf.setConfString("spark.sql.parser.escapedStringLiterals", "true")
     val parser = new CatalystSqlParser(conf)
     assertEqual("a rlike '^\\x20[\\x20-\\x23]+$'", 'a rlike "^\\x20[\\x20-\\x23]+$", parser)
     assertEqual("a rlike 'pattern\\\\'", 'a rlike "pattern\\\\", parser)
@@ -462,9 +462,9 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("'\\u0057\\u006F\\u0072\\u006C\\u0064\\u0020\\u003A\\u0029'", "World :)")
   }
 
-  test("strings with NO_UNESCAPED_SQL_STRING") {
+  test("strings with ESCAPED_STRING_LITERALS = true") {
     val conf = new SQLConf()
-    conf.setConfString("spark.sql.noUnescapedStringLiteral", "true")
+    conf.setConfString("spark.sql.parser.escapedStringLiterals", "true")
     val parser = new CatalystSqlParser(conf)
 
     // Single Strings.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -52,7 +52,7 @@ class SparkSqlParser(conf: SQLConf) extends AbstractSqlParser {
 /**
  * Builder that converts an ANTLR ParseTree into a LogicalPlan/Expression/TableIdentifier.
  */
-class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
+class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   import org.apache.spark.sql.catalyst.parser.ParserUtils._
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1170,7 +1170,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDataset(ds, WithMapInOption(Some(Map(1 -> 1))))
   }
 
-  test("do not unescaped regex pattern string") {
+  test("SPARK-20399: do not unescaped regex pattern when ESCAPED_STRING_LITERALS is enabled") {
     withSQLConf(SQLConf.ESCAPED_STRING_LITERALS.key -> "true") {
       val data = Seq("\u0020\u0021\u0023", "abc")
       val df = data.toDF()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1171,7 +1171,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("do not unescaped regex pattern string") {
-    withSQLConf(SQLConf.NO_UNESCAPED_SQL_STRING.key -> "true") {
+    withSQLConf(SQLConf.ESCAPED_STRING_LITERALS.key -> "true") {
       val data = Seq("\u0020\u0021\u0023", "abc")
       val df = data.toDF()
       val rlike1 = df.filter("value rlike '^\\x20[\\x20-\\x23]+$'")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new SQL parser is introduced into Spark 2.0. All string literals are unescaped in parser. Seems it bring an issue regarding the regex pattern string.

The following codes can reproduce it:

    val data = Seq("\u0020\u0021\u0023", "abc")
    val df = data.toDF()

    // 1st usage: works in 1.6
    // Let parser parse pattern string
    val rlike1 = df.filter("value rlike '^\\x20[\\x20-\\x23]+$'")
    // 2nd usage: works in 1.6, 2.x
    // Call Column.rlike so the pattern string is a literal which doesn't go through parser
    val rlike2 = df.filter($"value".rlike("^\\x20[\\x20-\\x23]+$"))

    // In 2.x, we need add backslashes to make regex pattern parsed correctly
    val rlike3 = df.filter("value rlike '^\\\\x20[\\\\x20-\\\\x23]+$'")

Follow the discussion in #17736, this patch adds a config to fallback to 1.6 string literal parsing and mitigate migration issue.

## How was this patch tested?

Jenkins tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
