### PR TITLE
[MINOR][BUILD] Fix lint-java breaks.

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -54,6 +54,8 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
   extends RDD[(T, U)](sc, Nil)
   with Serializable {
 
+  logInfo("-------------> In Cartesian RDD initialize")
+
   val numPartitionsInRdd2 = rdd2.partitions.length
 
   override def getPartitions: Array[Partition] = {
@@ -72,6 +74,7 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
   }
 
   override def compute(split: Partition, context: TaskContext): Iterator[(T, U)] = {
+    logInfo("-------------------> In Cartesian compute method")
     val currSplit = split.asInstanceOf[CartesianPartition]
     for (x <- rdd1.iterator(currSplit.s1, context);
          y <- getOrCacheBlock(rdd2, currSplit.s2, context, StorageLevel.MEMORY_AND_DISK))

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -83,6 +83,7 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
       partition: Partition,
       context: TaskContext,
       level: StorageLevel): Iterator[U] = {
+    logInfo("--------------> in getOrCacheBlock")
     val blockId = RDDBlockId(rdd.id, partition.index)
     var readCachedBlock = true
     // This method is called on executors, so we need call SparkEnv.get instead of sc.env.
@@ -107,21 +108,21 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
         new InterruptibleIterator(context, iter.asInstanceOf[Iterator[U]])
     }
 
-    context.addTaskCompletionListener(new TaskCompletionListener{
-      override def onTaskCompletion(context: TaskContext): Unit = {
-        if (!readCachedBlock) {
-          SparkEnv.get.blockManager.removeBlock(blockId, false)
-        }
-      }
-    })
-
-    context.addTaskFailureListener(new TaskFailureListener{
-      override def onTaskFailure(context: TaskContext, error: Throwable): Unit = {
-        if (!readCachedBlock) {
-          SparkEnv.get.blockManager.removeBlock(blockId, false)
-        }
-      }
-    })
+//    context.addTaskCompletionListener(new TaskCompletionListener{
+//      override def onTaskCompletion(context: TaskContext): Unit = {
+//        if (!readCachedBlock) {
+//          SparkEnv.get.blockManager.removeBlock(blockId, false)
+//        }
+//      }
+//    })
+//
+//    context.addTaskFailureListener(new TaskFailureListener{
+//      override def onTaskFailure(context: TaskContext, error: Throwable): Unit = {
+//        if (!readCachedBlock) {
+//          SparkEnv.get.blockManager.removeBlock(blockId, false)
+//        }
+//      }
+//    })
 
     iterator
   }

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -78,6 +78,14 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
       yield (x, y)
   }
 
+  /**
+   * Try to get the block from the local, if not local, then get from the remote and cache it in
+   * local.
+   *
+   * Because the Block may be used by another task in the same executor, so when the task is
+   * complete, we try to remove the block in a non-blocking manner, otherwise it will be marked
+   * as removable.
+    */
   private def getOrCacheBlock(
       rdd: RDD[U],
       partition: Partition,

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -110,7 +110,7 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
     def removeBlock(blockId: BlockId,
         readCachedBlock: Boolean): Unit = {
       if (!readCachedBlock) {
-        SparkEnv.get.blockManager.removeBlock(blockId, true, false)
+        SparkEnv.get.blockManager.removeBlock(blockId, true)
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -109,8 +109,9 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
 
     def removeBlock(blockId: BlockId,
         readCachedBlock: Boolean): Unit = {
-      if (!readCachedBlock) {
-        SparkEnv.get.blockManager.removeBlock(blockId, true)
+      val blockManager = SparkEnv.get.blockManager
+      if (!readCachedBlock || blockManager.isRemovable(blockId)) {
+        blockManager.removeOrMarkAsRemovable(blockId, true)
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -672,7 +672,6 @@ abstract class RDD[T: ClassTag](
    * elements (a, b) where a is in `this` and b is in `other`.
    */
   def cartesian[U: ClassTag](other: RDD[U]): RDD[(T, U)] = withScope {
-    logInfo("---------------> In cartesian method")
     new CartesianRDD(sc, this, other)
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -672,6 +672,7 @@ abstract class RDD[T: ClassTag](
    * elements (a, b) where a is in `this` and b is in `other`.
    */
   def cartesian[U: ClassTag](other: RDD[U]): RDD[(T, U)] = withScope {
+    logInfo("---------------> In cartesian method")
     new CartesianRDD(sc, this, other)
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -679,7 +679,7 @@ private[spark] class BlockManager(
   }
 
   def get[T: ClassTag](blockId: BlockId): Option[BlockResult] = {
-    getAndCache(blockId, false, StorageLevel.NONE)
+    getOrCacheRemote(blockId, false, StorageLevel.NONE)
   }
 
   /**
@@ -689,7 +689,7 @@ private[spark] class BlockManager(
    * any locks if the block was fetched from a remote block manager. The read lock will
    * automatically be freed once the result's `data` iterator is fully consumed.
    */
-  def getAndCache[T: ClassTag](
+  def getOrCacheRemote[T: ClassTag](
       blockId: BlockId,
       cacheRemote: Boolean,
       storageLevel: StorageLevel): Option[BlockResult] = {
@@ -756,7 +756,7 @@ private[spark] class BlockManager(
       cacheRemote: Boolean = false): Either[BlockResult, Iterator[T]] = {
     // Attempt to read the block from local or remote storage. If it's present, then we don't need
     // to go through the local-get-or-put path.
-    getAndCache[T](blockId, cacheRemote, level)(classTag) match {
+    getOrCacheRemote[T](blockId, cacheRemote, level)(classTag) match {
       case Some(block) =>
         return Left(block)
       case _ =>

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -756,6 +756,7 @@ private[spark] class BlockManager(
       classTag: ClassTag[T],
       makeIterator: () => Iterator[T],
       cacheRemote: Boolean = false): Either[BlockResult, Iterator[T]] = {
+    logInfo("--------------> In getOrElseUpdate")
     // Attempt to read the block from local or remote storage. If it's present, then we don't need
     // to go through the local-get-or-put path.
     getOrCacheRemote[T](blockId, cacheRemote, level)(classTag) match {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -703,9 +703,9 @@ private[spark] class BlockManager(
     remote match {
       case Some(blockResult) =>
         logInfo(s"Found block $blockId remotely")
-        logInfo("------------------->" + cacheRemote)
+        logInfo(s"-------------------> (${blockId.name})")
         if (cacheRemote) {
-          logInfo("-------------------> in cacheRemote ")
+          logInfo(s"-------------------> in cacheRemote (${blockId.name})")
           putIterator(blockId, blockResult.data, storageLevel)
           logInfo(s"Cache bock $blockId fetched from remotely")
         }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -707,7 +707,7 @@ private[spark] class BlockManager(
           logInfo(s"Cache bock $blockId fetched from remotely")
         }
         return remote
-      case None => _
+      case None =>
     }
 
     None

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1448,14 +1448,10 @@ private[spark] class BlockManager(
 
   /**
    * Remove a block from both memory and disk.
-   * @param blocking if true (default), this call will block until the lock is acquired. If false,
-   *                 this call will return immediately if the lock acquisition fails.
    */
-  def removeBlock(blockId: BlockId,
-      tellMaster: Boolean = true,
-      blocking: Boolean = true): Unit = {
+  def removeBlock(blockId: BlockId, tellMaster: Boolean = true): Unit = {
     logDebug(s"Removing block $blockId")
-    blockInfoManager.lockForWriting(blockId, blocking) match {
+    blockInfoManager.lockForWriting(blockId) match {
       case None =>
         // The block has already been removed; do nothing.
         logWarning(s"Asked to remove block $blockId, which does not exist")

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -699,15 +699,17 @@ private[spark] class BlockManager(
       return local
     }
     val remote = getRemoteValues[T](blockId)
-    if (cacheRemote) {
-      remote.foreach{ blockResult =>
-        putIterator(blockId, blockResult.data, storageLevel)
-      }
+    remote match {
+      case Some(blockResult) =>
+        logInfo(s"Found block $blockId remotely")
+        if (cacheRemote) {
+          putIterator(blockId, blockResult.data, storageLevel)
+          logInfo(s"Cache bock $blockId fetched from remotely")
+        }
+        return remote
+      case None => _
     }
-    if (remote.isDefined) {
-      logInfo(s"Found block $blockId remotely")
-      return remote
-    }
+
     None
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -702,7 +702,9 @@ private[spark] class BlockManager(
     remote match {
       case Some(blockResult) =>
         logInfo(s"Found block $blockId remotely")
+        logInfo("------------------->" + cacheRemote)
         if (cacheRemote) {
+          logInfo("-------------------> in cacheRemote ")
           putIterator(blockId, blockResult.data, storageLevel)
           logInfo(s"Cache bock $blockId fetched from remotely")
         }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -679,6 +679,7 @@ private[spark] class BlockManager(
   }
 
   def get[T: ClassTag](blockId: BlockId): Option[BlockResult] = {
+    logInfo("-------------> get")
     getOrCacheRemote(blockId, false, StorageLevel.NONE)
   }
 
@@ -758,7 +759,7 @@ private[spark] class BlockManager(
       classTag: ClassTag[T],
       makeIterator: () => Iterator[T],
       cacheRemote: Boolean = false): Either[BlockResult, Iterator[T]] = {
-    logInfo("--------------> In getOrElseUpdate")
+    logInfo("--------------> In getOrElseUpdate, cacheRemote: " + cacheRemote)
     // Attempt to read the block from local or remote storage. If it's present, then we don't need
     // to go through the local-get-or-put path.
     getOrCacheRemote[T](blockId, cacheRemote, level)(classTag) match {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -20,6 +20,7 @@ package org.apache.spark.storage
 import java.io._
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
+import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.mutable
 import scala.collection.mutable.HashMap
@@ -201,6 +202,9 @@ private[spark] class BlockManager(
   private var lastPeerFetchTime = 0L
 
   private var blockReplicationPolicy: BlockReplicationPolicy = _
+
+  // Record the removable block.
+  private lazy val removableBlocks = ConcurrentHashMap.newKeySet[BlockId]()
 
   /**
    * Initializes the BlockManager with the given appId. This is not performed in the constructor as
@@ -1475,6 +1479,39 @@ private[spark] class BlockManager(
     blockInfoManager.removeBlock(blockId)
     if (tellMaster) {
       reportBlockStatus(blockId, BlockStatus.empty)
+    }
+  }
+
+  /**
+   * Whether the block is removable.
+   */
+  def isRemovable(blockId: BlockId): Boolean = {
+    removableBlocks.contains(blockId)
+  }
+
+  /**
+   * Try to remove the block without blocking. Mark it as removable if it is use.
+   */
+  def removeOrMarkAsRemovable(blockId: BlockId, tellMaster: Boolean = true): Unit = {
+    blockInfoManager.lockForWriting(blockId, false) match {
+      case None =>
+        blockInfoManager.synchronized {
+          blockInfoManager.get(blockId) match {
+            case None =>
+              // The block has already been removed; do nothing.
+              logWarning(s"Asked to remove block $blockId, which does not exist")
+              removableBlocks.remove(blockId)
+            case Some(_) =>
+              // The block is in use, mark it as removable.
+              logDebug(s"Marking block $blockId as removable")
+              removableBlocks.add(blockId)
+          }
+        }
+      case Some(info) =>
+        logDebug(s"Removing block $blockId")
+        removableBlocks.remove(blockId)
+        removeBlockInternal(blockId, tellMaster = tellMaster && info.tellMaster)
+        addUpdatedBlockStatusToTaskMetrics(blockId, BlockStatus.empty)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.storage
 
 import java.nio.ByteBuffer
+import java.util.Properties
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
@@ -25,13 +26,11 @@ import scala.concurrent.Future
 import scala.language.implicitConversions
 import scala.language.postfixOps
 import scala.reflect.ClassTag
-
 import org.mockito.{Matchers => mc}
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest._
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.Timeouts._
-
 import org.apache.spark._
 import org.apache.spark.broadcast.BroadcastManager
 import org.apache.spark.executor.DataReadMethod
@@ -99,6 +98,16 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     memManager.setMemoryStore(blockManager.memoryStore)
     blockManager.initialize("app-id")
     blockManager
+  }
+
+  private def withTaskId[T](taskAttemptId: Long)(block: => T): T = {
+    try {
+      TaskContext.setTaskContext(
+        new TaskContextImpl(0, 0, taskAttemptId, 0, null, new Properties, null))
+      block
+    } finally {
+      TaskContext.unset()
+    }
   }
 
   override def beforeEach(): Unit = {
@@ -1253,6 +1262,77 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     assert(master.getLocations("item").nonEmpty)
     assert(store2.getRemoteBytes("item").isEmpty)
     assert(master.getLocations("item").isEmpty)
+  }
+
+  test("cache block fetch remotely") {
+    store = makeBlockManager(8000, "executor1")
+    store2 = makeBlockManager(8000, "executor2")
+    val arr = new Array[Byte](4000)
+    store.putSingle("block1", arr, StorageLevel.MEMORY_AND_DISK, true)
+    assert(store.getSingleAndReleaseLock("block1").isDefined, "block1 was not in store")
+
+    // default not cache the remotely block
+    store2.getOrCacheRemote("block1")
+    assert(!store2.getLocalAndReleaseLock("block1").isDefined,
+      "block1 should not be cached by store2")
+
+    // cache remotely block
+    store2.getOrCacheRemote("block1", true, Some(StorageLevel.MEMORY_AND_DISK))
+    assert(store2.getLocalAndReleaseLock("block1").isDefined,
+      "block1 should be cached by store2")
+    assert(master.getLocations("block1").size == 2,
+      "master did not report 2 locations for block1")
+  }
+
+  test("remote block with blocking") {
+    store = makeBlockManager(8000, "executor1")
+    val arr = new Array[Byte](4000)
+    store.putSingle("block", arr, StorageLevel.MEMORY_AND_DISK, true)
+    withTaskId(0) {
+      store.get("block")
+    }
+    val future = Future {
+      withTaskId(1) {
+        store.removeBlock("block")
+        master.getLocations("block").isEmpty
+      }
+    }
+    Thread.sleep(300)
+    assert(store.getStatus("block").isDefined, "block was not in store")
+    withTaskId(0) {
+      store.releaseLock("block")
+    }
+    assert(ThreadUtils.awaitResult(future, 1.seconds))
+  }
+
+  test("remote block without blocking") {
+    store = makeBlockManager(8000, "executor1")
+    val arr = new Array[Byte](4000)
+    store.putSingle("block", arr, StorageLevel.MEMORY_AND_DISK, true)
+    withTaskId(0) {
+      // lock the block with read lock
+      store.get("block")
+    }
+    val future = Future {
+      withTaskId(1) {
+        store.removeOrMarkAsRemovable("block")
+        store.isRemovable("block")
+      }
+    }
+    Thread.sleep(300)
+    assert(store.getStatus("block").isDefined, "block should not be removed")
+    assert(ThreadUtils.awaitResult(future, 1.seconds), "block should be marked as removable")
+    withTaskId(0) {
+      store.releaseLock("block")
+    }
+    val future1 = Future {
+      withTaskId(1) {
+        store.removeOrMarkAsRemovable("block")
+        !store.isRemovable("block")
+      }
+    }
+    assert(ThreadUtils.awaitResult(future1, 1.seconds), "block should not be marked as removable")
+    assert(master.getLocations("block").isEmpty, "block should be removed")
   }
 
   class MockBlockTransferService(val maxFailures: Int) extends BlockTransferService {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to fix the lint-breaks as below:
```
[ERROR] src/main/java/org/apache/spark/unsafe/Platform.java:[51] (regexp) RegexpSingleline: No trailing whitespace allowed.
[ERROR] src/main/scala/org/apache/spark/sql/streaming/Trigger.java:[45,25] (naming) MethodName: Method name 'ProcessingTime' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9_]*$'.
[ERROR] src/main/scala/org/apache/spark/sql/streaming/Trigger.java:[62,25] (naming) MethodName: Method name 'ProcessingTime' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9_]*$'.
[ERROR] src/main/scala/org/apache/spark/sql/streaming/Trigger.java:[78,25] (naming) MethodName: Method name 'ProcessingTime' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9_]*$'.
[ERROR] src/main/scala/org/apache/spark/sql/streaming/Trigger.java:[92,25] (naming) MethodName: Method name 'ProcessingTime' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9_]*$'.
[ERROR] src/main/scala/org/apache/spark/sql/streaming/Trigger.java:[102,25] (naming) MethodName: Method name 'Once' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9_]*$'.
[ERROR] src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisInputDStreamBuilderSuite.java:[28,8] (imports) UnusedImports: Unused import - org.apache.spark.streaming.api.java.JavaDStream.
```

after:
```
dev/lint-java
Checkstyle checks passed.
```
[Test Result][https://travis-ci.org/ConeyLiu/spark/jobs/229666169]

## How was this patch tested?

Travis CI.
