### PR TITLE
[SPARK-20633][SQL] FileFormatWriter wrap the FetchFailedException which breaks job's failover

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -262,8 +262,8 @@ object FileFormatWriter extends Logging {
     } catch {
       case e: FetchFailedException =>
         throw e
-      case _ =>
-        throw new SparkException("Task failed while writing rows.", e)
+      case t: Throwable =>
+        throw new SparkException("Task failed while writing rows.", t)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -31,6 +31,7 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
+import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, ExternalCatalogUtils}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -259,8 +260,10 @@ object FileFormatWriter extends Logging {
         }
       })
     } catch {
-      case t: Throwable =>
-        throw new SparkException("Task failed while writing rows", t)
+      case e: FetchFailedException =>
+        throw e
+      case _ =>
+        throw new SparkException("Task failed while writing rows.", e)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Handle the fetch failed exception separately in FileFormatWriter.

## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
