### PR TITLE
SPARK-7856 Principal components and variance using computeSVD()

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -386,8 +386,8 @@ class RowMatrix @Since("1.0.0") (
 
     // Check matrix is standarized with mean 0
     val mean = computeColumnSummaryStatistics().mean
-    val stdMat = if (mean.toArray.sum < 0.0001) {
-      this
+    val stdMat = if (mean.toArray.sum < 1E-9) {
+      this  // If matrix is already centered in 0, then no need to standarize
     } else {
       // X' = X - µ
       def subPairs = (vPair: (Double, Double)) => vPair._1 - vPair._2

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -384,19 +384,23 @@ class RowMatrix @Since("1.0.0") (
     val n = numCols().toInt
     require(k > 0 && k <= n, s"k = $k out of range (0, n = $n]")
 
-    val Cov = computeCovariance().asBreeze.asInstanceOf[BDM[Double]]
-
-    val brzSvd.SVD(u: BDM[Double], s: BDV[Double], _) = brzSvd(Cov)
-
-    val eigenSum = s.data.sum
-    val explainedVariance = s.data.map(_ / eigenSum)
-
-    if (k == n) {
-      (Matrices.dense(n, k, u.data), Vectors.dense(explainedVariance))
+    // Check matrix is standarized with mean 0
+    val mean = computeColumnSummaryStatistics().mean
+    val stdMat = if (mean.toArray.sum < 0.0001) {
+      this
     } else {
-      (Matrices.dense(n, k, Arrays.copyOfRange(u.data, 0, n * k)),
-        Vectors.dense(Arrays.copyOfRange(explainedVariance, 0, k)))
+      // X' = X - µ
+      def subPairs = (vPair: (Double, Double)) => vPair._1 - vPair._2
+      def subMean = (v: Vector) => Vectors.dense(v.toArray.zip(mean.toArray).map(subPairs))
+      val stdData = rows.map(subMean)
+      new RowMatrix(stdData)
     }
+    val svd = stdMat.computeSVD(n, computeU = false, rCond = 0)
+    val eigenSum = svd.s.toArray.map(math.pow(_, 2)).sum
+    val explainedVariance = Vectors.dense(svd.s.toArray.slice(0, k).map(math.pow(_, 2)/eigenSum))
+    val pc = Matrices.dense(n, k, svd.V.toArray.slice(0, k*n))
+
+    (pc, explainedVariance)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current implementation of computePrincipalComponentsAndExplainedVariance in RowMatrix for tall and fat matrices usually crashes as it computes the covariance matrix locally.

Instead in this patch I used the same RowMatrix.computeSVD which is already optimized for big matrices, to compute the Principal components and Explained Variance.

It's known that if a matrix X with mean µ and covariance (X - µ)'(X - µ)
(X - µ) can be decomposed with SVD such that

(X - µ) = USV'
and
(X - µ)' = VS'U'

V and U are orthonormal, therefore V'V = I and U'U = I.
cov = (X - µ)'(X -µ) = VS'U'USV' = VS'SV'
and
cov*V = V(S'S), with V the eigenvectors of covariance and S'S contains the eigenvalues

## How was this patch tested?

This patch has been tested running the current RowMatrixSuite, mllib.PCASuite and ml.PCASuite, passing all the tests.

Also, this patch allowed to run PCA over a matrix 56k x 12k without crashing from OutOfMemory errors (not included in testing as it takes long time to execute and it's generated by a private dataset)

Please review http://spark.apache.org/contributing.html before opening a pull request.
