### PR TITLE
[SPARK-20672][SS] Keep the `isStreaming` property in triggerLogicalPlan in Structured Streaming

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
@@ -104,7 +104,7 @@ abstract class KafkaSourceTest extends StreamTest with SharedSQLContext {
         "Cannot add data when there is no query for finding the active kafka source")
 
       val sources = query.get.logicalPlan.collect {
-        case StreamingExecutionRelation(source, _) if source.isInstanceOf[KafkaSource] =>
+        case StreamingSourceRelation(source, _) if source.isInstanceOf[KafkaSource] =>
           source.asInstanceOf[KafkaSource]
       }
       if (sources.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -319,8 +319,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case s: StreamingRelation =>
         StreamingRelationExec(s.sourceName, s.output) :: Nil
-      case s: StreamingExecutionRelation =>
+      case s: StreamingSourceRelation =>
         StreamingRelationExec(s.toString, s.output) :: Nil
+      case StreamingRelationWrapper(child) =>
+        StreamingRelationWrapperExec(planLater(child)) :: Nil
       case _ => Nil
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -149,7 +149,7 @@ class StreamExecution(
       "logicalPlan must be initialized in StreamExecutionThread " +
         s"but the current thread was ${Thread.currentThread}")
     var nextSourceId = 0L
-    val toExecutionRelationMap = MutableMap[StreamingRelation, StreamingExecutionRelation]()
+    val toExecutionRelationMap = MutableMap[StreamingRelation, StreamingSourceRelation]()
     val _logicalPlan = analyzedPlan.transform {
       case streamingRelation@StreamingRelation(dataSource, _, output) =>
         toExecutionRelationMap.getOrElseUpdate(streamingRelation, {
@@ -159,10 +159,10 @@ class StreamExecution(
           nextSourceId += 1
           // We still need to use the previous `output` instead of `source.schema` as attributes in
           // "df.logicalPlan" has already used attributes of the previous `output`.
-          StreamingExecutionRelation(source, output)
+          StreamingSourceRelation(source, output)
         })
     }
-    sources = _logicalPlan.collect { case s: StreamingExecutionRelation => s.source }
+    sources = _logicalPlan.collect { case s: StreamingSourceRelation => s.source }
     uniqueSources = sources.distinct
     _logicalPlan
   }
@@ -615,16 +615,16 @@ class StreamExecution(
     var replacements = new ArrayBuffer[(Attribute, Attribute)]
     // Replace sources in the logical plan with data that has arrived since the last batch.
     val withNewSources = logicalPlan transform {
-      case StreamingExecutionRelation(source, output) =>
+      case StreamingSourceRelation(source, output) =>
         newData.get(source).map { data =>
           val newPlan = data.logicalPlan
           assert(output.size == newPlan.output.size,
             s"Invalid batch: ${Utils.truncatedString(output, ",")} != " +
             s"${Utils.truncatedString(newPlan.output, ",")}")
           replacements ++= output.zip(newPlan.output)
-          newPlan
+          StreamingRelationWrapper(newPlan)
         }.getOrElse {
-          LocalRelation(output)
+          StreamingRelationWrapper(LocalRelation(output))
         }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
@@ -53,6 +53,10 @@ case class StreamingSourceRelation(source: Source, output: Seq[Attribute]) exten
   override def toString: String = source.toString
 }
 
+/**
+ * A dummy physical plan for [[StreamingRelation]] to support
+ * [[org.apache.spark.sql.Dataset.explain]]
+ */
 case class StreamingRelationExec(sourceName: String, output: Seq[Attribute]) extends LeafExecNode {
   override def toString: String = sourceName
   override protected def doExecute(): RDD[InternalRow] = {
@@ -65,10 +69,6 @@ case class StreamingRelationWrapper(child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = child.output
 }
 
-/**
- * A dummy physical plan for [[StreamingRelation]] to support
- * [[org.apache.spark.sql.Dataset.explain]]
- */
 case class StreamingRelationWrapperExec(child: SparkPlan)
   extends UnaryExecNode {
   override protected def doExecute(): RDD[InternalRow] = child.execute()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.execution.streaming
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LeafNode
-import org.apache.spark.sql.execution.LeafExecNode
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, UnaryNode}
+import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.datasources.DataSource
 
 object StreamingRelation {
@@ -35,7 +35,7 @@ object StreamingRelation {
  * Used to link a streaming [[DataSource]] into a
  * [[org.apache.spark.sql.catalyst.plans.logical.LogicalPlan]]. This is only used for creating
  * a streaming [[org.apache.spark.sql.DataFrame]] from [[org.apache.spark.sql.DataFrameReader]].
- * It should be used to create [[Source]] and converted to [[StreamingExecutionRelation]] when
+ * It should be used to create [[Source]] and converted to [[StreamingSourceRelation]] when
  * passing to [[StreamExecution]] to run a query.
  */
 case class StreamingRelation(dataSource: DataSource, sourceName: String, output: Seq[Attribute])
@@ -48,15 +48,11 @@ case class StreamingRelation(dataSource: DataSource, sourceName: String, output:
  * Used to link a streaming [[Source]] of data into a
  * [[org.apache.spark.sql.catalyst.plans.logical.LogicalPlan]].
  */
-case class StreamingExecutionRelation(source: Source, output: Seq[Attribute]) extends LeafNode {
+case class StreamingSourceRelation(source: Source, output: Seq[Attribute]) extends LeafNode {
   override def isStreaming: Boolean = true
   override def toString: String = source.toString
 }
 
-/**
- * A dummy physical plan for [[StreamingRelation]] to support
- * [[org.apache.spark.sql.Dataset.explain]]
- */
 case class StreamingRelationExec(sourceName: String, output: Seq[Attribute]) extends LeafExecNode {
   override def toString: String = sourceName
   override protected def doExecute(): RDD[InternalRow] = {
@@ -64,8 +60,24 @@ case class StreamingRelationExec(sourceName: String, output: Seq[Attribute]) ext
   }
 }
 
-object StreamingExecutionRelation {
-  def apply(source: Source): StreamingExecutionRelation = {
-    StreamingExecutionRelation(source, source.schema.toAttributes)
+case class StreamingRelationWrapper(child: LogicalPlan) extends UnaryNode {
+  override def isStreaming: Boolean = true
+  override def output: Seq[Attribute] = child.output
+}
+
+/**
+ * A dummy physical plan for [[StreamingRelation]] to support
+ * [[org.apache.spark.sql.Dataset.explain]]
+ */
+case class StreamingRelationWrapperExec(child: SparkPlan)
+  extends UnaryExecNode {
+  override protected def doExecute(): RDD[InternalRow] = child.execute()
+
+  override def output: Seq[Attribute] = child.output
+}
+
+object StreamingSourceRelation {
+  def apply(source: Source): StreamingSourceRelation = {
+    StreamingSourceRelation(source, source.schema.toAttributes)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
@@ -50,7 +50,7 @@ object MemoryStream {
 case class MemoryStream[A : Encoder](id: Int, sqlContext: SQLContext)
     extends Source with Logging {
   protected val encoder = encoderFor[A]
-  protected val logicalPlan = StreamingExecutionRelation(this)
+  protected val logicalPlan = StreamingSourceRelation(this)
   protected val output = logicalPlan.output
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -134,7 +134,7 @@ abstract class FileStreamSourceTest
 
   protected def getSourcesFromStreamingQuery(query: StreamExecution): Seq[FileStreamSource] = {
     query.logicalPlan.collect {
-      case StreamingExecutionRelation(source, _) if source.isInstanceOf[FileStreamSource] =>
+      case StreamingSourceRelation(source, _) if source.isInstanceOf[FileStreamSource] =>
         source.asInstanceOf[FileStreamSource]
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -160,7 +160,7 @@ class StreamSuite extends StreamTest {
       val executionRelations =
         query
           .logicalPlan
-          .collect { case ser: StreamingExecutionRelation => ser }
+          .collect { case ser: StreamingSourceRelation => ser }
       assert(executionRelations.size === 2)
       assert(executionRelations.distinct.size === 1)
     } finally {
@@ -332,7 +332,7 @@ class StreamSuite extends StreamTest {
 
         override def stop(): Unit = {}
       }
-      val df = Dataset[Int](sqlContext.sparkSession, StreamingExecutionRelation(source))
+      val df = Dataset[Int](sqlContext.sparkSession, StreamingSourceRelation(source))
       testStream(df)(
         // `ExpectFailure(isFatalError = true)` verifies two things:
         // - Fatal errors can be propagated to `StreamingQuery.exception` and

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -504,7 +504,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with Timeouts {
 
               def findSourceIndex(plan: LogicalPlan): Option[Int] = {
                 plan
-                  .collect { case StreamingExecutionRelation(s, _) => s }
+                  .collect { case StreamingSourceRelation(s, _) => s }
                   .zipWithIndex
                   .find(_._1 == source)
                   .map(_._2)
@@ -537,7 +537,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with Timeouts {
             // Get the map of source index to the current source objects
             val indexToSource = currentStream
               .logicalPlan
-              .collect { case StreamingExecutionRelation(s, _) => s }
+              .collect { case StreamingSourceRelation(s, _) => s }
               .zipWithIndex
               .map(_.swap)
               .toMap

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -304,7 +304,7 @@ class StreamingQueryManagerSuite extends StreamTest with BeforeAndAfter {
       if (withError) {
         logDebug(s"Terminating query ${queryToStop.name} with error")
         queryToStop.asInstanceOf[StreamingQueryWrapper].streamingQuery.logicalPlan.collect {
-          case StreamingExecutionRelation(source, _) =>
+          case StreamingSourceRelation(source, _) =>
             source.asInstanceOf[MemoryStream[Int]].addData(0)
         }
       } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -623,7 +623,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       override def getBatch(start: Option[Offset], end: Offset): DataFrame = triggerDF
       override def stop(): Unit = {}
     }
-    StreamingExecutionRelation(source)
+    StreamingSourceRelation(source)
   }
 
   /** Returns the query progress at the end of the first trigger of streaming DF */


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Structured Streaming, the "isStreaming" property will be eliminated in each triggerLogicalPlan. Then, some rules will be applied to this triggerLogicalPlan mistakenly. So, we should refactor existing code to better execute batch query and ss query.

Like in #17896, we will eliminate `EventTimeWatermark` in any batch query. If we add this rule into `Analyzer.batches`, we will eliminate the `EventTimeWatermark` in triggerLogicalPlan mistakenly, as it is also a `batch query` in current implementation.

## How was this patch tested?

existing ut.
