### PR TITLE
[MINOR][SQL][PYSPARK] Allow user to specify numSlices in SparkSession.createDataFrame

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -245,7 +245,8 @@ class SQLContext(object):
 
     @since(1.3)
     @ignore_unicode_prefix
-    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True, numSlices=None):
+    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True,
+                        numSlices=None):
         """
         Creates a :class:`DataFrame` from an :class:`RDD`, a list or a :class:`pandas.DataFrame`.
 
@@ -276,7 +277,7 @@ class SQLContext(object):
             We can also use ``int`` as a short name for :class:`pyspark.sql.types.IntegerType`.
         :param samplingRatio: the sample ratio of rows used for inferring
         :param verifySchema: verify data types of every row against schema.
-        :param numSlices: specify as :class:`int` the number of slices (partitions) to distribute 
+        :param numSlices: specify as :class:`int` the number of slices (partitions) to distribute
             ``data`` across. Applies to ``data`` of :class:`list` or :class:`pandas.DataFrame`.
             Defaults to `self.sparkContext.defaultParallelism`.
         :return: :class:`DataFrame`
@@ -337,7 +338,8 @@ class SQLContext(object):
             ...
         Py4JJavaError: ...
         """
-        return self.sparkSession.createDataFrame(data, schema, samplingRatio, verifySchema, numSlices)
+        return self.sparkSession.createDataFrame(data, schema, samplingRatio, verifySchema, 
+                                                 numSlices)
 
     @since(1.3)
     def registerDataFrameAsTable(self, df, tableName):

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -245,7 +245,7 @@ class SQLContext(object):
 
     @since(1.3)
     @ignore_unicode_prefix
-    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True):
+    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True, numSlices=None):
         """
         Creates a :class:`DataFrame` from an :class:`RDD`, a list or a :class:`pandas.DataFrame`.
 
@@ -276,6 +276,9 @@ class SQLContext(object):
             We can also use ``int`` as a short name for :class:`pyspark.sql.types.IntegerType`.
         :param samplingRatio: the sample ratio of rows used for inferring
         :param verifySchema: verify data types of every row against schema.
+        :param numSlices: specify as :class:`int` the number of slices (partitions) to distribute 
+            ``data`` across. Applies to ``data`` of :class:`list` or :class:`pandas.DataFrame`.
+            Defaults to `self.sparkContext.defaultParallelism`.
         :return: :class:`DataFrame`
 
         .. versionchanged:: 2.0
@@ -334,7 +337,7 @@ class SQLContext(object):
             ...
         Py4JJavaError: ...
         """
-        return self.sparkSession.createDataFrame(data, schema, samplingRatio, verifySchema)
+        return self.sparkSession.createDataFrame(data, schema, samplingRatio, verifySchema, numSlices)
 
     @since(1.3)
     def registerDataFrameAsTable(self, df, tableName):

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -338,7 +338,7 @@ class SQLContext(object):
             ...
         Py4JJavaError: ...
         """
-        return self.sparkSession.createDataFrame(data, schema, samplingRatio, verifySchema, 
+        return self.sparkSession.createDataFrame(data, schema, samplingRatio, verifySchema,
                                                  numSlices)
 
     @since(1.3)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -416,7 +416,8 @@ class SparkSession(object):
 
     @since(2.0)
     @ignore_unicode_prefix
-    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True, numSlices=None):
+    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True,
+                        numSlices=None):
         """
         Creates a :class:`DataFrame` from an :class:`RDD`, a list or a :class:`pandas.DataFrame`.
 
@@ -446,7 +447,7 @@ class SparkSession(object):
             ``int`` as a short name for ``IntegerType``.
         :param samplingRatio: the sample ratio of rows used for inferring
         :param verifySchema: verify data types of every row against schema.
-        :param numSlices: specify as :class:`int` the number of slices (partitions) to distribute 
+        :param numSlices: specify as :class:`int` the number of slices (partitions) to distribute
             ``data`` across. Applies to ``data`` of :class:`list` or :class:`pandas.DataFrame`.
             Defaults to `self.sparkContext.defaultParallelism`.
         :return: :class:`DataFrame`

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -388,7 +388,7 @@ class SparkSession(object):
         rdd = rdd.map(schema.toInternal)
         return rdd, schema
 
-    def _createFromLocal(self, data, schema):
+    def _createFromLocal(self, data, schema, numSlices=None):
         """
         Create an RDD for DataFrame from a list or pandas.DataFrame, returns
         the RDD and schema.
@@ -412,11 +412,11 @@ class SparkSession(object):
 
         # convert python objects to sql data
         data = [schema.toInternal(row) for row in data]
-        return self._sc.parallelize(data), schema
+        return self._sc.parallelize(data, numSlices=numSlices), schema
 
     @since(2.0)
     @ignore_unicode_prefix
-    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True):
+    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True, numSlices=None):
         """
         Creates a :class:`DataFrame` from an :class:`RDD`, a list or a :class:`pandas.DataFrame`.
 
@@ -446,6 +446,9 @@ class SparkSession(object):
             ``int`` as a short name for ``IntegerType``.
         :param samplingRatio: the sample ratio of rows used for inferring
         :param verifySchema: verify data types of every row against schema.
+        :param numSlices: specify as :class:`int` the number of slices (partitions) to distribute 
+            ``data`` across. Applies to ``data`` of :class:`list` or :class:`pandas.DataFrame`.
+            Defaults to `self.sparkContext.defaultParallelism`.
         :return: :class:`DataFrame`
 
         .. versionchanged:: 2.1
@@ -534,7 +537,8 @@ class SparkSession(object):
         if isinstance(data, RDD):
             rdd, schema = self._createFromRDD(data.map(prepare), schema, samplingRatio)
         else:
-            rdd, schema = self._createFromLocal(map(prepare, data), schema)
+            rdd, schema = self._createFromLocal(map(prepare, data), schema, numSlices=numSlices)
+
         jrdd = self._jvm.SerDeUtil.toJavaArray(rdd._to_java_object_rdd())
         jdf = self._jsparkSession.applySchemaToPythonRDD(jrdd.rdd(), schema.json())
         df = DataFrame(jdf, self._wrapped)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In my experience, pushing `pandas.DataFrame`s to `pyspark.DataFrame`s will very quickly run up against size issues. These can usually be remedied by changing configuration parameters (e.g., `spark.rpc.message.maxSize`), but it is much more convenient to change the level of parallelization used during `RDD` creation. This option is available in `sparkContext.broadcast`. This pull request exposes it to `sparkSession.createDataFrame`. 

## How was this patch tested?

I have been using a patch implementing this change for a while. I'm only exposing a keyword argument used by an underlying function to the user.
