### PR TITLE
[SPARK-20689][PYSPARK] python doctest leaking bucketed table

### DIFF
--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -678,6 +678,7 @@ test_that("jsonRDD() on a RDD with json string", {
 
 test_that("test tableNames and tables", {
   count <- count(listTables())
+  expect_equal(count, 0)
 
   df <- read.json(jsonPath)
   createOrReplaceTempView(df, "table1")

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -678,7 +678,6 @@ test_that("jsonRDD() on a RDD with json string", {
 
 test_that("test tableNames and tables", {
   count <- count(listTables())
-  expect_equal(count, 0)
 
   df <- read.json(jsonPath)
   createOrReplaceTempView(df, "table1")

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -575,7 +575,7 @@ class DataFrameWriter(OptionUtils):
         .. note:: Applicable for file-based data sources in combination with
                   :py:meth:`DataFrameWriter.saveAsTable`.
 
-        >>> (df.write.format('parquet')
+        >>> (df.write.format('parquet')  # doctest: +SKIP
         ...     .bucketBy(100, 'year', 'month')
         ...     .mode("overwrite")
         ...     .saveAsTable('bucketed_table'))
@@ -602,7 +602,7 @@ class DataFrameWriter(OptionUtils):
         :param col: a name of a column, or a list of names.
         :param cols: additional names (optional). If `col` is a list it should be empty.
 
-        >>> (df.write.format('parquet')
+        >>> (df.write.format('parquet')  # doctest: +SKIP
         ...     .bucketBy(100, 'year', 'month')
         ...     .sortBy('day')
         ...     .mode("overwrite")


### PR DESCRIPTION
## What changes were proposed in this pull request?

It turns out pyspark doctest is calling saveAsTable without ever dropping them. Since we have separate python tests for bucketed table, and there is no checking of results, there is really no need to run the doctest, other than leaving it as an example in the generated doc

## How was this patch tested?

Jenkins