### PR TITLE
[SPARK-20694][DOCS][SQL] Document DataFrameWriter partitionBy, bucketBy and sortBy in SQL guide

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -687,7 +687,7 @@ CLUSTERED BY(name) SORTED BY (favorite_numbers) INTO 42 BUCKETS;
 `partitionBy` creates a directory structure as described in the [Partition Discovery](#partition-discovery) section.
 Thus, it has limited applicability to columns with high cardinality. In contrast 
  `bucketBy` distributes
-data across fixed number of buckets and can be used when a number of unique values is unbounded.
+data across a fixed number of buckets and can be used when a number of unique values is unbounded.
 
 ## Parquet Files
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -600,6 +600,21 @@ Bucketing and sorting is applicable only to persistent tables:
 {% include_example write_sorting_and_bucketing python/sql/datasource.py %}
 </div>
 
+<div data-lang="sql"  markdown="1">
+
+{% highlight sql %}
+
+CREATE TABLE users_bucketed_by_name(
+  name STRING,
+  favorite_color STRING,
+  favorite_NUMBERS array<integer>
+) USING parquet 
+CLUSTERED BY(name) INTO 42 BUCKETS;
+
+{% endhighlight %}
+
+</div>
+
 </div>
 
 while partitioning can be used with both `save` and `saveAsTable`:
@@ -648,6 +663,22 @@ It is possible to use both partitions and buckets for a single table:
 
 <div data-lang="python"  markdown="1">
 {% include_example write_partition_and_bucket python/sql/datasource.py %}
+</div>
+
+<div data-lang="sql"  markdown="1">
+
+{% highlight sql %}
+
+CREATE TABLE users_bucketed_and_partitioned(
+  name STRING,
+  favorite_color STRING,
+  favorite_NUMBERS array<integer>
+) USING parquet 
+PARTITIONED BY (favorite_color)
+CLUSTERED BY(name) INTO 42 BUCKETS;
+
+{% endhighlight %}
+
 </div>
 
 </div>

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -581,6 +581,46 @@ Starting from Spark 2.1, persistent datasource tables have per-partition metadat
 
 Note that partition information is not gathered by default when creating external datasource tables (those with a `path` option). To sync the partition information in the metastore, you can invoke `MSCK REPAIR TABLE`.
 
+### Bucketing, Sorting and Partitioning
+
+For file-based data source it is also possible to bucket and and sort or partition the output. 
+Bucketing and sorting is applicable only to persistent tables:
+
+<div class="codetabs">
+
+<div data-lang="scala"  markdown="1">
+{% include_example write_sorting_and_bucketing scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% include_example write_sorting_and_bucketing java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java %}
+</div>
+
+<div data-lang="python"  markdown="1">
+{% include_example write_sorting_and_bucketing python/sql/datasource.py %}
+</div>
+
+</div>
+
+while partitioning can be used with both `save` and `saveAsTable`:
+
+
+<div class="codetabs">
+
+<div data-lang="scala"  markdown="1">
+{% include_example write_partitioning scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% include_example write_partitioning java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java %}
+</div>
+
+<div data-lang="python"  markdown="1">
+{% include_example write_partitioning python/sql/datasource.py %}
+</div>
+
+</div>
+
 ## Parquet Files
 
 [Parquet](http://parquet.io) is a columnar format that is supported by many other data processing systems.

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -621,6 +621,24 @@ while partitioning can be used with both `save` and `saveAsTable`:
 
 </div>
 
+It is possible to use both partitions and buckets for a single table:
+
+<div class="codetabs">
+
+<div data-lang="scala"  markdown="1">
+{% include_example write_partition_and_bucket scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% include_example write_partition_and_bucket java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java %}
+</div>
+
+<div data-lang="python"  markdown="1">
+{% include_example write_partition_and_bucket python/sql/datasource.py %}
+</div>
+
+</div>
+
 ## Parquet Files
 
 [Parquet](http://parquet.io) is a columnar format that is supported by many other data processing systems.

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -640,8 +640,9 @@ while partitioning can be used with both `save` and `saveAsTable`:
 
 CREATE TABLE users_by_favorite_color(
   name STRING, 
+  favorite_color STRING,
   favorite_NUMBERS array<integer>
-) PARTITIONED BY(favorite_color STRING);
+) USING csv PARTITIONED BY(favorite_color);
 
 {% endhighlight %}
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -583,8 +583,8 @@ Note that partition information is not gathered by default when creating externa
 
 ### Bucketing, Sorting and Partitioning
 
-For file-based data source it is also possible to bucket and sort or partition the output. 
-Bucketing and sorting is applicable only to persistent tables:
+For file-based data source, it is also possible to bucket and sort or partition the output. 
+Bucketing and sorting are applicable only to persistent tables:
 
 <div class="codetabs">
 
@@ -617,7 +617,7 @@ CLUSTERED BY(name) INTO 42 BUCKETS;
 
 </div>
 
-while partitioning can be used with both `save` and `saveAsTable`:
+while partitioning can be used with both `save` and `saveAsTable` when using the Dataset APIs.
 
 
 <div class="codetabs">
@@ -650,7 +650,7 @@ CREATE TABLE users_by_favorite_color(
 
 </div>
 
-It is possible to use both partitions and buckets for a single table:
+It is possible to use both partitioning and bucketing for a single table:
 
 <div class="codetabs">
 
@@ -685,8 +685,9 @@ CLUSTERED BY(name) INTO 42 BUCKETS;
 </div>
 
 `partitionBy` creates a directory structure as described in the [Partition Discovery](#partition-discovery) section.
-Because of that it has limited applicability to columns with high cardinality. In contrast `bucketBy` distributes
-data across fixed number of buckets and can be used if a number of unique values is unbounded.
+Thus, it has limited applicability to columns with high cardinality. In contrast 
+ `bucketBy` distributes
+data across fixed number of buckets and can be used when a number of unique values is unbounded.
 
 ## Parquet Files
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -639,6 +639,10 @@ It is possible to use both partitions and buckets for a single table:
 
 </div>
 
+`partitionBy` creates a directory structure as described in the [Partition Discovery](#partition-discovery) section.
+Because of that it has limited applicability to columns with high cardinality. In contrast `bucketBy` distributes
+data across fixed number of buckets and can be used if a number of unique values is unbounded.
+
 ## Parquet Files
 
 [Parquet](http://parquet.io) is a columnar format that is supported by many other data processing systems.

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -583,7 +583,7 @@ Note that partition information is not gathered by default when creating externa
 
 ### Bucketing, Sorting and Partitioning
 
-For file-based data source it is also possible to bucket and and sort or partition the output. 
+For file-based data source it is also possible to bucket and sort or partition the output. 
 Bucketing and sorting is applicable only to persistent tables:
 
 <div class="codetabs">

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -619,6 +619,19 @@ while partitioning can be used with both `save` and `saveAsTable`:
 {% include_example write_partitioning python/sql/datasource.py %}
 </div>
 
+<div data-lang="sql"  markdown="1">
+
+{% highlight sql %}
+
+CREATE TABLE users_by_favorite_color(
+  name STRING, 
+  favorite_NUMBERS array<integer>
+) PARTITIONED BY(favorite_color STRING);
+
+{% endhighlight %}
+
+</div>
+
 </div>
 
 It is possible to use both partitions and buckets for a single table:

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -607,7 +607,7 @@ Bucketing and sorting are applicable only to persistent tables:
 CREATE TABLE users_bucketed_by_name(
   name STRING,
   favorite_color STRING,
-  favorite_NUMBERS array<integer>
+  favorite_numbers array<integer>
 ) USING parquet 
 CLUSTERED BY(name) INTO 42 BUCKETS;
 
@@ -641,7 +641,7 @@ while partitioning can be used with both `save` and `saveAsTable` when using the
 CREATE TABLE users_by_favorite_color(
   name STRING, 
   favorite_color STRING,
-  favorite_NUMBERS array<integer>
+  favorite_numbers array<integer>
 ) USING csv PARTITIONED BY(favorite_color);
 
 {% endhighlight %}

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -673,10 +673,10 @@ It is possible to use both partitioning and bucketing for a single table:
 CREATE TABLE users_bucketed_and_partitioned(
   name STRING,
   favorite_color STRING,
-  favorite_NUMBERS array<integer>
+  favorite_numbers array<integer>
 ) USING parquet 
 PARTITIONED BY (favorite_color)
-CLUSTERED BY(name) INTO 42 BUCKETS;
+CLUSTERED BY(name) SORTED BY (favorite_numbers) INTO 42 BUCKETS;
 
 {% endhighlight %}
 

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -120,6 +120,14 @@ public class JavaSQLDataSourceExample {
     Dataset<Row> sqlDF =
       spark.sql("SELECT * FROM parquet.`examples/src/main/resources/users.parquet`");
     // $example off:direct_sql$
+    // $example on:write_sorting_and_bucketing$
+    peopleDF.write().bucketBy(42, "name").sortBy("age").saveAsTable("people_bucketed");
+    // $example off:write_sorting_and_bucketing$
+    // $example on:write_partitioning$
+    usersDF.write().partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet");
+    // $example off:write_partitioning$
+
+    spark.sql("DROP TABLE IF EXISTS people_bucketed");
   }
 
   private static void runBasicParquetExample(SparkSession spark) {

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -135,6 +135,7 @@ public class JavaSQLDataSourceExample {
     // $example off:write_partition_and_bucket$
 
     spark.sql("DROP TABLE IF EXISTS people_bucketed");
+    spark.sql("DROP TABLE IF EXISTS people_partitioned_bucketed");
   }
 
   private static void runBasicParquetExample(SparkSession spark) {

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -126,6 +126,13 @@ public class JavaSQLDataSourceExample {
     // $example on:write_partitioning$
     usersDF.write().partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet");
     // $example off:write_partitioning$
+    // $example on:write_partition_and_bucket$
+    peopleDF
+      .write()
+      .partitionBy("favorite_color")
+      .bucketBy(42, "name")
+      .saveAsTable("people_partitioned_bucketed");
+    // $example off:write_partition_and_bucket$
 
     spark.sql("DROP TABLE IF EXISTS people_bucketed");
   }

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -39,6 +39,17 @@ def basic_datasource_example(spark):
     df.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
     # $example off:write_partitioning$
 
+    # $example on:write_partition_and_bucket$
+    df = spark.read.parquet("examples/src/main/resources/users.parquet")
+    (df
+        .write
+        .partitionBy("favorite_color")
+        .bucketBy(42, "name")
+        .saveAsTable("people_partitioned_bucketed"))
+    # $example off:write_partition_and_bucket$
+
+    spark.sql("DROP TABLE IF EXISTS people_partitioned_bucketed")
+
     # $example on:manual_load_options$
     df = spark.read.load("examples/src/main/resources/people.json", format="json")
     df.select("name", "age").write.save("namesAndAges.parquet", format="parquet")

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -35,10 +35,20 @@ def basic_datasource_example(spark):
     df.select("name", "favorite_color").write.save("namesAndFavColors.parquet")
     # $example off:generic_load_save_functions$
 
+    # $example on:write_partitioning$
+    df.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
+    # $example off:write_partitioning$
+
     # $example on:manual_load_options$
     df = spark.read.load("examples/src/main/resources/people.json", format="json")
     df.select("name", "age").write.save("namesAndAges.parquet", format="parquet")
     # $example off:manual_load_options$
+
+    # $example on:write_sorting_and_bucketing$
+    df.write.bucketBy(42, "name").sortBy("age").saveAsTable("people_bucketed")
+    # $example off:write_sorting_and_bucketing$
+
+    spark.sql("DROP TABLE IF EXISTS people_bucketed")
 
     # $example on:direct_sql$
     df = spark.sql("SELECT * FROM parquet.`examples/src/main/resources/users.parquet`")

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -64,6 +64,7 @@ def basic_datasource_example(spark):
     spark.sql("DROP TABLE IF EXISTS people_bucketed")
     spark.sql("DROP TABLE IF EXISTS people_partitioned_bucketed")
 
+
 def parquet_example(spark):
     # $example on:basic_parquet_example$
     peopleDF = spark.read.json("examples/src/main/resources/people.json")

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -48,8 +48,6 @@ def basic_datasource_example(spark):
         .saveAsTable("people_partitioned_bucketed"))
     # $example off:write_partition_and_bucket$
 
-    spark.sql("DROP TABLE IF EXISTS people_partitioned_bucketed")
-
     # $example on:manual_load_options$
     df = spark.read.load("examples/src/main/resources/people.json", format="json")
     df.select("name", "age").write.save("namesAndAges.parquet", format="parquet")
@@ -59,12 +57,12 @@ def basic_datasource_example(spark):
     df.write.bucketBy(42, "name").sortBy("age").saveAsTable("people_bucketed")
     # $example off:write_sorting_and_bucketing$
 
-    spark.sql("DROP TABLE IF EXISTS people_bucketed")
-
     # $example on:direct_sql$
     df = spark.sql("SELECT * FROM parquet.`examples/src/main/resources/users.parquet`")
     # $example off:direct_sql$
 
+    spark.sql("DROP TABLE IF EXISTS people_bucketed")
+    spark.sql("DROP TABLE IF EXISTS people_partitioned_bucketed")
 
 def parquet_example(spark):
     # $example on:basic_parquet_example$

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -58,7 +58,7 @@ object SQLDataSourceExample {
     // $example on:write_partitioning$
     usersDF.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
     // $example off:write_partitioning$
-    //$example on:write_partition_and_bucket$
+    // $example on:write_partition_and_bucket$
     peopleDF
       .write
       .partitionBy("favorite_color")

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -52,6 +52,14 @@ object SQLDataSourceExample {
     // $example on:direct_sql$
     val sqlDF = spark.sql("SELECT * FROM parquet.`examples/src/main/resources/users.parquet`")
     // $example off:direct_sql$
+    // $example on:write_sorting_and_bucketing$
+    peopleDF.write.bucketBy(42, "name").sortBy("age").saveAsTable("people_bucketed")
+    // $example off:write_sorting_and_bucketing$
+    // $example on:write_partitioning$
+    usersDF.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
+    // $example on:write_partitioning$
+
+    spark.sql("DROP TABLE IF EXISTS people_bucketed")
   }
 
   private def runBasicParquetExample(spark: SparkSession): Unit = {

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -67,6 +67,7 @@ object SQLDataSourceExample {
     // $example off:write_partition_and_bucket$
 
     spark.sql("DROP TABLE IF EXISTS people_bucketed")
+    spark.sql("DROP TABLE IF EXISTS people_partitioned_bucketed")
   }
 
   private def runBasicParquetExample(spark: SparkSession): Unit = {

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -57,7 +57,7 @@ object SQLDataSourceExample {
     // $example off:write_sorting_and_bucketing$
     // $example on:write_partitioning$
     usersDF.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
-    // $example on:write_partitioning$
+    // $example off:write_partitioning$
 
     spark.sql("DROP TABLE IF EXISTS people_bucketed")
   }

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -58,6 +58,13 @@ object SQLDataSourceExample {
     // $example on:write_partitioning$
     usersDF.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
     // $example off:write_partitioning$
+    //$example on:write_partition_and_bucket$
+    peopleDF
+      .write
+      .partitionBy("favorite_color")
+      .bucketBy(42, "name")
+      .saveAsTable("people_partitioned_bucketed")
+    // $example off:write_partition_and_bucket$
 
     spark.sql("DROP TABLE IF EXISTS people_bucketed")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add Scala, Python and Java examples for `partitionBy`, `sortBy` and `bucketBy`.
- Add _Bucketing, Sorting and Partitioning_ section to SQL Programming Guide
- Remove bucketing from Unsupported Hive Functionalities.

## How was this patch tested?

Manual tests, docs build.
