### PR TITLE
[SPARK-20687][MLLIB] mllib.Matrices.fromBreeze may crash when converting from Breeze sparse matrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -1003,9 +1003,13 @@ object Matrices {
         // We need to truncate both arrays (rowIndices, data)
         // to the real size of the vector sm.activeSize to allow valid conversion
 
-        val truncRowIndices = sm.rowIndices.slice(0, sm.activeSize)
-        val truncData = sm.data.slice(0, sm.activeSize)
-        new SparseMatrix(sm.rows, sm.cols, sm.colPtrs, truncRowIndices, truncData)
+        if (sm.rowIndices.length > sm.activeSize) {
+          val smC = sm.copy
+          smC.compact()
+          new SparseMatrix(smC.rows, smC.cols, smC.colPtrs, smC.rowIndices, smC.data)
+        } else {
+          new SparseMatrix(sm.rows, sm.cols, sm.colPtrs, sm.rowIndices, sm.data)
+        }
       case _ =>
         throw new UnsupportedOperationException(
           s"Do not support conversion from type ${breeze.getClass.getName}.")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -993,7 +993,7 @@ object Matrices {
       case sm: BSM[Double] =>
         // There is no isTranspose flag for sparse matrices in Breeze
         val nsm = if (sm.rowIndices.length > sm.activeSize) {
-          // This sparse matrix has trainling zeros.
+          // This sparse matrix has trailing zeros.
           // Remove them by compacting the matrix.
           val csm = sm.copy
           csm.compact()

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -992,24 +992,16 @@ object Matrices {
         new DenseMatrix(dm.rows, dm.cols, dm.data, dm.isTranspose)
       case sm: BSM[Double] =>
         // There is no isTranspose flag for sparse matrices in Breeze
-
-        // Some Breeze CSCMatrices may have extra trailing zeros in
-        // .rowIndices and .data, which are added after some matrix
-        // operations for efficiency.
-        //
-        // Therefore the last element of sm.colPtrs would no longer be
-        // coherent with the size of sm.rowIndices and sm.data
-        // despite sm being a valid CSCMatrix.
-        // We need to truncate both arrays (rowIndices, data)
-        // to the real size of the vector sm.activeSize to allow valid conversion
-
-        if (sm.rowIndices.length > sm.activeSize) {
-          val smC = sm.copy
-          smC.compact()
-          new SparseMatrix(smC.rows, smC.cols, smC.colPtrs, smC.rowIndices, smC.data)
+        val nsm = if (sm.rowIndices.length > sm.activeSize) {
+          // This sparse matrix has trainling zeros.
+          // Remove them by compacting the matrix.
+          val csm = sm.copy
+          csm.compact()
+          csm
         } else {
-          new SparseMatrix(sm.rows, sm.cols, sm.colPtrs, sm.rowIndices, sm.data)
+          sm
         }
+        new SparseMatrix(nsm.rows, nsm.cols, nsm.colPtrs, nsm.rowIndices, nsm.data)
       case _ =>
         throw new UnsupportedOperationException(
           s"Do not support conversion from type ${breeze.getClass.getName}.")

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -46,25 +46,21 @@ class MatricesSuite extends SparkFunSuite {
     }
   }
 
-  test("breeze conversion bug") {
+  test("Test Breeze Conversion Bug - SPARK-20687") {
     // (2, 0, 0)
     // (2, 0, 0)
     val mat1Brz = Matrices.sparse(2, 3, Array(0, 2, 2, 2), Array(0, 1), Array(2, 2)).asBreeze
     // (2, 1E-15, 1E-15)
-    // (2, 1E-15, 1E-15
+    // (2, 1E-15, 1E-15)
     val mat2Brz = Matrices.sparse(2, 3, Array(0, 2, 4, 6), Array(0, 0, 0, 1, 1, 1), Array(2, 1E-15, 1E-15, 2, 1E-15, 1E-15)).asBreeze
-    // The following shouldn't break
-    val t01 = mat1Brz - mat1Brz
-    val t02 = mat2Brz - mat2Brz
-    val t02Brz = Matrices.fromBreeze(t02)
-    val t01Brz = Matrices.fromBreeze(t01)
-
     val t1Brz = mat1Brz - mat2Brz
     val t2Brz = mat2Brz - mat1Brz
-    // The following ones should break
+    // The following operations raise exceptions on un-patch Matrices.fromBreeze
     val t1 = Matrices.fromBreeze(t1Brz)
     val t2 = Matrices.fromBreeze(t2Brz)
-
+    // t1 == t1Brz && t2 == t2Brz
+    assert((t1.asBreeze - t1Brz).iterator.map((x) => math.abs(x._2)).sum < 1E-15)
+    assert((t2.asBreeze - t2Brz).iterator.map((x) => math.abs(x._2)).sum < 1E-15)
   }
 
   test("sparse matrix construction") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -46,6 +46,27 @@ class MatricesSuite extends SparkFunSuite {
     }
   }
 
+  test("breeze conversion bug") {
+    // (2, 0, 0)
+    // (2, 0, 0)
+    val mat1Brz = Matrices.sparse(2, 3, Array(0, 2, 2, 2), Array(0, 1), Array(2, 2)).asBreeze
+    // (2, 1E-15, 1E-15)
+    // (2, 1E-15, 1E-15
+    val mat2Brz = Matrices.sparse(2, 3, Array(0, 2, 4, 6), Array(0, 0, 0, 1, 1, 1), Array(2, 1E-15, 1E-15, 2, 1E-15, 1E-15)).asBreeze
+    // The following shouldn't break
+    val t01 = mat1Brz - mat1Brz
+    val t02 = mat2Brz - mat2Brz
+    val t02Brz = Matrices.fromBreeze(t02)
+    val t01Brz = Matrices.fromBreeze(t01)
+
+    val t1Brz = mat1Brz - mat2Brz
+    val t2Brz = mat2Brz - mat1Brz
+    // The following ones should break
+    val t1 = Matrices.fromBreeze(t1Brz)
+    val t2 = Matrices.fromBreeze(t2Brz)
+
+  }
+
   test("sparse matrix construction") {
     val m = 3
     val n = 4

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -52,7 +52,10 @@ class MatricesSuite extends SparkFunSuite {
     val mat1Brz = Matrices.sparse(2, 3, Array(0, 2, 2, 2), Array(0, 1), Array(2, 2)).asBreeze
     // (2, 1E-15, 1E-15)
     // (2, 1E-15, 1E-15)
-    val mat2Brz = Matrices.sparse(2, 3, Array(0, 2, 4, 6), Array(0, 0, 0, 1, 1, 1), Array(2, 1E-15, 1E-15, 2, 1E-15, 1E-15)).asBreeze
+    val mat2Brz = Matrices.sparse(2, 3,
+      Array(0, 2, 4, 6),
+      Array(0, 0, 0, 1, 1, 1),
+      Array(2, 1E-15, 1E-15, 2, 1E-15, 1E-15)).asBreeze
     val t1Brz = mat1Brz - mat2Brz
     val t2Brz = mat2Brz - mat1Brz
     // The following operations raise exceptions on un-patch Matrices.fromBreeze

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -46,26 +46,6 @@ class MatricesSuite extends SparkFunSuite {
     }
   }
 
-  test("Test Breeze Conversion Bug - SPARK-20687") {
-    // (2, 0, 0)
-    // (2, 0, 0)
-    val mat1Brz = Matrices.sparse(2, 3, Array(0, 2, 2, 2), Array(0, 1), Array(2, 2)).asBreeze
-    // (2, 1E-15, 1E-15)
-    // (2, 1E-15, 1E-15)
-    val mat2Brz = Matrices.sparse(2, 3,
-      Array(0, 2, 4, 6),
-      Array(0, 0, 0, 1, 1, 1),
-      Array(2, 1E-15, 1E-15, 2, 1E-15, 1E-15)).asBreeze
-    val t1Brz = mat1Brz - mat2Brz
-    val t2Brz = mat2Brz - mat1Brz
-    // The following operations raise exceptions on un-patch Matrices.fromBreeze
-    val t1 = Matrices.fromBreeze(t1Brz)
-    val t2 = Matrices.fromBreeze(t2Brz)
-    // t1 == t1Brz && t2 == t2Brz
-    assert((t1.asBreeze - t1Brz).iterator.map((x) => math.abs(x._2)).sum < 1E-15)
-    assert((t2.asBreeze - t2Brz).iterator.map((x) => math.abs(x._2)).sum < 1E-15)
-  }
-
   test("sparse matrix construction") {
     val m = 3
     val n = 4
@@ -531,6 +511,26 @@ class MatricesSuite extends SparkFunSuite {
       Array(1.0, 2, 2, 4), 3, 3, Array(0, 0, 2, 4), Array(1, 2, 1, 2))
     val sum = bm1 + bm2
     Matrices.fromBreeze(sum)
+  }
+
+  test("Test FromBreeze when Breeze.CSCMatrix.rowIndices has trailing zeros. - SPARK-20687") {
+    // (2, 0, 0)
+    // (2, 0, 0)
+    val mat1Brz = Matrices.sparse(2, 3, Array(0, 2, 2, 2), Array(0, 1), Array(2, 2)).asBreeze
+    // (2, 1E-15, 1E-15)
+    // (2, 1E-15, 1E-15)
+    val mat2Brz = Matrices.sparse(2, 3,
+      Array(0, 2, 4, 6),
+      Array(0, 0, 0, 1, 1, 1),
+      Array(2, 1E-15, 1E-15, 2, 1E-15, 1E-15)).asBreeze
+    val t1Brz = mat1Brz - mat2Brz
+    val t2Brz = mat2Brz - mat1Brz
+    // The following operations raise exceptions on un-patch Matrices.fromBreeze
+    val t1 = Matrices.fromBreeze(t1Brz)
+    val t2 = Matrices.fromBreeze(t2Brz)
+    // t1 == t1Brz && t2 == t2Brz
+    assert((t1.asBreeze - t1Brz).iterator.map((x) => math.abs(x._2)).sum < 1E-15)
+    assert((t2.asBreeze - t2Brz).iterator.map((x) => math.abs(x._2)).sum < 1E-15)
   }
 
   test("row/col iterator") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When two Breeze SparseMatrices are operated, the result matrix may contain provisional 0 values extra in rowIndices and data arrays. This causes an incoherence with the colPtrs data, but Breeze get away with this incoherence by keeping a counter of the valid data.

In spark, when this matrices are converted to SparseMatrices, Sparks relies solely on rowIndices, data, and colPtrs, but these might be incorrect because of breeze internal hacks. Therefore, we need to slice both rowIndices and data, using their counter of active data

This method is at least called by BlockMatrix when performing distributed block operations, causing exceptions on valid operations.

See http://stackoverflow.com/questions/33528555/error-thrown-when-using-blockmatrix-add

## How was this patch tested?

Added a test to MatricesSuite that verifies that the conversions are valid and that code doesn't crash. Originally the same code would crash on Spark.

Bugfix for https://issues.apache.org/jira/browse/SPARK-20687