### PR TITLE
[SPARK-20711][ML] Fix incorrect min/max for NaN value in MultivariateOnlineSummarizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -249,7 +249,8 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
+      if (nnz(i) == 0L) currMax(i) = Double.NaN
+      else if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
       i += 1
     }
     Vectors.dense(currMax)
@@ -265,7 +266,8 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
+      if (nnz(i) == 0L) currMax(i) = Double.NaN
+      else if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
       i += 1
     }
     Vectors.dense(currMin)

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -266,7 +266,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (nnz(i) == 0L) currMax(i) = Double.NaN
+      if (nnz(i) == 0L) currMin(i) = Double.NaN
       else if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
       i += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -252,6 +252,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
       if (nnz(i) < totalCnt) {
         if (currMax(i) < 0.0) currMax(i) = 0.0
       } else if (currMax(i) < currMin(i)) {
+        currMin(i) = Double.NaN
         currMax(i) = Double.NaN
       }
       i += 1
@@ -273,6 +274,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
         if (currMin(i) > 0.0) currMin(i) = 0.0
       } else if (currMax(i) < currMin(i)) {
         currMin(i) = Double.NaN
+        currMax(i) = Double.NaN
       }
       i += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -97,12 +97,8 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
     val localCurrMin = currMin
     instance.foreachActive { (index, value) =>
       if (value != 0.0) {
-        if (localCurrMax(index) < value) {
-          localCurrMax(index) = value
-        }
-        if (localCurrMin(index) > value) {
-          localCurrMin(index) = value
-        }
+        localCurrMax(index) = math.max(localCurrMax(index), value)
+        localCurrMin(index) = math.min(localCurrMin(index), value)
 
         val prevMean = localCurrMean(index)
         val diff = value - prevMean
@@ -249,12 +245,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (nnz(i) < totalCnt) {
-        if (currMax(i) < 0.0) currMax(i) = 0.0
-      } else if (currMax(i) < currMin(i)) {
-        currMin(i) = Double.NaN
-        currMax(i) = Double.NaN
-      }
+      if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
       i += 1
     }
     Vectors.dense(currMax)
@@ -270,12 +261,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (nnz(i) < totalCnt) {
-        if (currMin(i) > 0.0) currMin(i) = 0.0
-      } else if (currMax(i) < currMin(i)) {
-        currMin(i) = Double.NaN
-        currMax(i) = Double.NaN
-      }
+      if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
       i += 1
     }
     Vectors.dense(currMin)

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -249,7 +249,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (nnz(i) == 0L) currMax(i) = Double.NaN
+      if (currMax(i) < currMin(i)) currMax(i) = Double.NaN
       else if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
       i += 1
     }
@@ -266,7 +266,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (nnz(i) == 0L) currMin(i) = Double.NaN
+      if (currMax(i) < currMin(i)) currMin(i) = Double.NaN
       else if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
       i += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -249,8 +249,11 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (currMax(i) < currMin(i)) currMax(i) = Double.NaN
-      else if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
+      if (nnz(i) < totalCnt) {
+        if (currMax(i) < 0.0) currMax(i) = 0.0
+      } else if (currMax(i) < currMin(i)) {
+        currMax(i) = Double.NaN
+      }
       i += 1
     }
     Vectors.dense(currMax)
@@ -266,8 +269,11 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
 
     var i = 0
     while (i < n) {
-      if (currMax(i) < currMin(i)) currMin(i) = Double.NaN
-      else if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
+      if (nnz(i) < totalCnt) {
+        if (currMin(i) > 0.0) currMin(i) = 0.0
+      } else if (currMax(i) < currMin(i)) {
+        currMin(i) = Double.NaN
+      }
       i += 1
     }
     Vectors.dense(currMin)

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
@@ -271,12 +271,17 @@ class MultivariateOnlineSummarizerSuite extends SparkFunSuite {
     assert(summarizer3.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
   }
 
-  test("test min/max with identical NaN feature") {
+  test("test min/max with NaN feature") {
     val summarizer = new MultivariateOnlineSummarizer()
       .add(Vectors.dense(Double.NaN, -10.0))
       .add(Vectors.dense(Double.NaN, 0.0))
+      .add(Vectors.dense(Double.NaN, Double.NaN))
 
-    assert(summarizer.min(0).isNaN)
-    assert(summarizer.max(0).isNaN)
+    val minVec = summarizer.min
+    val maxVec = summarizer.max
+    assert(minVec(0).isNaN)
+    assert(minVec(1).isNaN)
+    assert(maxVec(0).isNaN)
+    assert(maxVec(1).isNaN)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
@@ -270,4 +270,13 @@ class MultivariateOnlineSummarizerSuite extends SparkFunSuite {
     assert(summarizer3.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer3.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
   }
+
+  test("test min/max with identical NaN feature") {
+    val summarizer = new MultivariateOnlineSummarizer()
+      .add(Vectors.dense(Double.NaN, -10.0))
+      .add(Vectors.dense(Double.NaN, 0.0))
+
+    assert(summarizer.min(0).isNaN)
+    assert(summarizer.max(0).isNaN)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
current impl will ignore `NaN` in computation of `min\max`
Moreover, if one column only conatins `NaN`, `Double.MaxValue` will be returned for `min`, and `Double.MinValue` for `max`.
This PR fix this issue and return `Double.NaN` min/max for columns conatining `Double.NaN`
## How was this patch tested?
added tests