### PR TITLE
[SPARK-18772][SQL] Avoid unnecessary conversion try for special floats in JSON 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -88,6 +88,17 @@ class JacksonParser(
     }
   }
 
+  private object SpecialDouble {
+    def unapply(value: String): Option[Double] = {
+      value.toLowerCase match {
+        case "nan" => Some(Double.NaN)
+        case "infinity" | "+infinity" | "inf" | "+inf" => Some(Double.PositiveInfinity)
+        case "-infinity" | "-inf" => Some(Double.NegativeInfinity)
+        case _ => None
+      }
+    }
+  }
+
   /**
    * Create a converter which converts the JSON documents held by the `JsonParser`
    * to a value according to a desired schema.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -126,12 +126,10 @@ class JacksonParser(
         case VALUE_STRING =>
           // Special case handling for NaN and Infinity.
           parser.getText match {
-            case "NaN" | "+NaN" | "-NaN" => Float.NaN
-            case "+INF" | "INF" | "+Infinity" | "Infinity" => Float.PositiveInfinity
-            case "-INF" | "-Infinity" => Float.NegativeInfinity
-            case other => Try(other.toFloat).getOrElse {
-              throw new RuntimeException(s"Cannot parse $other as FloatType.")
-            }
+            case "NaN" => Float.NaN
+            case "Infinity" => Float.PositiveInfinity
+            case "-Infinity" => Float.NegativeInfinity
+            case other => throw new RuntimeException(s"Cannot parse $other as FloatType.")
           }
       }
 
@@ -143,12 +141,10 @@ class JacksonParser(
         case VALUE_STRING =>
           // Special case handling for NaN and Infinity.
           parser.getText match {
-            case "NaN" | "+NaN" | "-NaN" => Double.NaN
-            case "+INF" | "INF" | "+Infinity" | "Infinity" => Double.PositiveInfinity
-            case "-INF" | "-Infinity" => Double.NegativeInfinity
-            case other => Try(other.toDouble).getOrElse {
-              throw new RuntimeException(s"Cannot parse $other as DoubleType.")
-            }
+            case "NaN" => Double.NaN
+            case "Infinity" => Double.PositiveInfinity
+            case "-Infinity" => Double.NegativeInfinity
+            case other => throw new RuntimeException(s"Cannot parse $other as DoubleType.")
           }
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1992,25 +1992,13 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
 
   test("SPARK-18772: Parse special floats correctly") {
     val jsons = Seq(
-      """{"a": "+INF"}""",
-      """{"a": "INF"}""",
-      """{"a": "-INF"}""",
       """{"a": "NaN"}""",
-      """{"a": "+NaN"}""",
-      """{"a": "-NaN"}""",
       """{"a": "Infinity"}""",
-      """{"a": "+Infinity"}""",
       """{"a": "-Infinity"}""")
 
     // positive cases
     val checks: Seq[Double => Boolean] = Seq(
-      _.isPosInfinity,
-      _.isPosInfinity,
-      _.isNegInfinity,
       _.isNaN,
-      _.isNaN,
-      _.isNaN,
-      _.isPosInfinity,
       _.isPosInfinity,
       _.isNegInfinity)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1986,6 +1986,37 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
           .collect
       }.getMessage
       assert(errMsg.startsWith("The field for corrupt records must be string type and nullable"))
+
+  test("SPARK-18772: Special floats") {
+    val records = sparkContext
+      .parallelize(
+        """{"a": "NaN"}""" ::
+          """{"a": "nAn"}""" ::
+          """{"a": "-iNf"}""" ::
+          """{"a": "inF"}""" ::
+          """{"a": "+Inf"}""" ::
+          """{"a": "-iNfInity"}""" ::
+          """{"a": "InFiNiTy"}""" ::
+          """{"a": "+InfiNitY"}""" ::
+          """{"a": "+Infi"}""" ::
+          Nil)
+
+    for (dt <- Seq(FloatType, DoubleType)) {
+      val res = spark.read
+        .schema(StructType(Seq(StructField("a", dt))))
+        .json(records)
+        .select($"a".cast(DoubleType).as[java.lang.Double])
+        .collect()
+      assert(res.length === 9)
+      assert(res(0).isNaN)
+      assert(res(1).isNaN)
+      assert(res(2).toDouble.isNegInfinity)
+      assert(res(3).toDouble.isPosInfinity)
+      assert(res(4).toDouble.isPosInfinity)
+      assert(res(5).toDouble.isNegInfinity)
+      assert(res(6).toDouble.isPosInfinity)
+      assert(res(7).toDouble.isPosInfinity)
+      assert(res(8) eq null)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.json
 import java.io.{File, StringWriter}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
+import java.util.Locale
 
 import com.fasterxml.jackson.core.JsonFactory
 import org.apache.hadoop.fs.{Path, PathFilter}
@@ -1986,37 +1987,57 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
           .collect
       }.getMessage
       assert(errMsg.startsWith("The field for corrupt records must be string type and nullable"))
+    }
+  }
 
-  test("SPARK-18772: Special floats") {
-    val records = sparkContext
-      .parallelize(
-        """{"a": "NaN"}""" ::
-          """{"a": "nAn"}""" ::
-          """{"a": "-iNf"}""" ::
-          """{"a": "inF"}""" ::
-          """{"a": "+Inf"}""" ::
-          """{"a": "-iNfInity"}""" ::
-          """{"a": "InFiNiTy"}""" ::
-          """{"a": "+InfiNitY"}""" ::
-          """{"a": "+Infi"}""" ::
-          Nil)
+  test("SPARK-18772: Parse special floats correctly") {
+    val jsons = Seq(
+      """{"a": "+INF"}""",
+      """{"a": "INF"}""",
+      """{"a": "-INF"}""",
+      """{"a": "NaN"}""",
+      """{"a": "+NaN"}""",
+      """{"a": "-NaN"}""",
+      """{"a": "Infinity"}""",
+      """{"a": "+Infinity"}""",
+      """{"a": "-Infinity"}""")
 
-    for (dt <- Seq(FloatType, DoubleType)) {
-      val res = spark.read
-        .schema(StructType(Seq(StructField("a", dt))))
-        .json(records)
-        .select($"a".cast(DoubleType).as[java.lang.Double])
-        .collect()
-      assert(res.length === 9)
-      assert(res(0).isNaN)
-      assert(res(1).isNaN)
-      assert(res(2).toDouble.isNegInfinity)
-      assert(res(3).toDouble.isPosInfinity)
-      assert(res(4).toDouble.isPosInfinity)
-      assert(res(5).toDouble.isNegInfinity)
-      assert(res(6).toDouble.isPosInfinity)
-      assert(res(7).toDouble.isPosInfinity)
-      assert(res(8) eq null)
+    // positive cases
+    val checks: Seq[Double => Boolean] = Seq(
+      _.isPosInfinity,
+      _.isPosInfinity,
+      _.isNegInfinity,
+      _.isNaN,
+      _.isNaN,
+      _.isNaN,
+      _.isPosInfinity,
+      _.isPosInfinity,
+      _.isNegInfinity)
+
+    Seq(FloatType, DoubleType).foreach { dt =>
+      jsons.zip(checks).foreach { case (json, check) =>
+        val ds = spark.read
+          .schema(StructType(Seq(StructField("a", dt))))
+          .json(Seq(json).toDS())
+          .select($"a".cast(DoubleType)).as[Double]
+        assert(check(ds.first()))
+      }
+    }
+
+    // negative cases
+    Seq(FloatType, DoubleType).foreach { dt =>
+      val lowerCasedJsons = jsons.map(_.toLowerCase(Locale.ROOT))
+      // The special floats are case-sensitive so these cases below throw exceptions.
+      lowerCasedJsons.foreach { lowerCasedJson =>
+        val e = intercept[SparkException] {
+          spark.read
+            .option("mode", "FAILFAST")
+            .schema(StructType(Seq(StructField("a", dt))))
+            .json(Seq(lowerCasedJson).toDS())
+            .collect()
+        }
+        assert(e.getMessage.contains("Cannot parse"))
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is based on  https://github.com/apache/spark/pull/16199 and extracts the valid change from https://github.com/apache/spark/pull/9759 to resolve SPARK-18772

This avoids additional conversion try with `toFloat` and `toDouble`.

For avoiding additional conversions, please refer the codes below:

**Before**

```scala
scala> import org.apache.spark.sql.types._
import org.apache.spark.sql.types._

scala> spark.read.schema(StructType(Seq(StructField("a", DoubleType)))).option("mode", "FAILFAST").json(Seq("""{"a": "nan"}""").toDS).show()
17/05/12 11:30:41 ERROR Executor: Exception in task 0.0 in stage 2.0 (TID 2)
java.lang.NumberFormatException: For input string: "nan"
...
```

**After**

```scala
scala> import org.apache.spark.sql.types._
import org.apache.spark.sql.types._

scala> spark.read.schema(StructType(Seq(StructField("a", DoubleType)))).option("mode", "FAILFAST").json(Seq("""{"a": "nan"}""").toDS).show()
17/05/12 11:44:30 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.RuntimeException: Cannot parse nan as DoubleType.
...
```

## How was this patch tested?

Unit tests added in `JsonSuite`.

Closes #16199