### PR TITLE
[SPARK-14659][ML] RFormula consistent with R when handling strings

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -38,21 +38,23 @@ import org.apache.spark.sql.types._
 private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
 
   /**
-   * Param for how to order categories of a FEATURE string column used by `StringIndexer`.
+   * Param for how to order categories of a string FEATURE column used by `StringIndexer`.
    * The last category after ordering is dropped when encoding strings.
-   * The options are explained using an example string: 'b', 'a', 'b', 'a', 'c', 'b'
-   * {{{
-   * +-----------------+---------------------------------------+---------------------------------+
-   * |      Option     | Category mapped to 0 by StringIndexer |  Category dropped by RFormula   |
-   * +-----------------+---------------------------------------+---------------------------------+
-   * | 'frequencyDesc' | most frequent category ('b')          | least frequent category ('c')   |
-   * | 'frequencyAsc'  | least frequent category ('c')         | most frequent category ('b')    |
-   * | 'alphabetDesc'  | first alphabetical category ('a')     | last alphabetical category ('c')|
-   * | 'alphabetAsc'   | last alphabetical category ('c')      | last alphabetical category ('a')|
-   * +-----------------+---------------------------------------+---------------------------------+
-   * }}}
+   * Supported options: 'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'.
    * The default value is 'frequencyDesc'. When the ordering is set to 'alphabetDesc', `RFormula`
    * drops the same category as R when encoding strings.
+   *
+   * The options are explained using an example `'b', 'a', 'b', 'a', 'c', 'b'`:
+   * {{{
+   * +-----------------+---------------------------------------+----------------------------------+
+   * |      Option     | Category mapped to 0 by StringIndexer |  Category dropped by RFormula    |
+   * +-----------------+---------------------------------------+----------------------------------+
+   * | 'frequencyDesc' | most frequent category ('b')          | least frequent category ('c')    |
+   * | 'frequencyAsc'  | least frequent category ('c')         | most frequent category ('b')     |
+   * | 'alphabetDesc'  | first alphabetical category ('a')     | last alphabetical category ('c') |
+   * | 'alphabetAsc'   | last alphabetical category ('c')      | first alphabetical category ('a')|
+   * +-----------------+---------------------------------------+----------------------------------+
+   * }}}
    * Note that this ordering option is NOT used for the label column. When the label column is
    * indexed, it uses the default descending frequency ordering in `StringIndexer`.
    *
@@ -60,11 +62,11 @@ private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
    */
   @Since("2.3.0")
   final val stringIndexerOrderType: Param[String] = new Param(this, "stringIndexerOrderType",
-    "How to order categories of a FEATURE string column used by StringIndexer. " +
+    "How to order categories of a string FEATURE column used by StringIndexer. " +
     "The last category after ordering is dropped when encoding strings. " +
+    s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}. " +
     "The default value is 'frequencyDesc'. When the ordering is set to 'alphabetDesc', " +
-    "RFormula drops the same category as R when encoding strings." +
-    s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}.",
+    "RFormula drops the same category as R when encoding strings.",
     ParamValidators.inArray(StringIndexer.supportedStringOrderType))
 
   /** @group getParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -41,13 +41,16 @@ private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
    * Param for how to order categories of a FEATURE string column used by `StringIndexer`.
    * The last category after ordering is dropped when encoding strings.
    * The options are explained using an example string: 'b', 'a', 'b', 'a', 'c', 'b'
-   * |
-   * | Option | Category mapped to 0 by StringIndexer |  Category dropped by RFormula
-   * | 'frequencyDesc' | most frequent category ('b') | least frequent category ('c')
-   * | 'frequencyAsc' | least frequent category ('c') | most frequent category ('b')
-   * | 'alphabetDesc' | first alphabetical category ('a') | last alphabetical category ('c')
-   * | 'alphabetAsc' | last alphabetical category ('c') | last alphabetical category ('a')
-   * |
+   * {{{
+   * +-----------------+---------------------------------------+---------------------------------+
+   * |      Option     | Category mapped to 0 by StringIndexer |  Category dropped by RFormula   |
+   * +-----------------+---------------------------------------+---------------------------------+
+   * | 'frequencyDesc' | most frequent category ('b')          | least frequent category ('c')   |
+   * | 'frequencyAsc'  | least frequent category ('c')         | most frequent category ('b')    |
+   * | 'alphabetDesc'  | first alphabetical category ('a')     | last alphabetical category ('c')|
+   * | 'alphabetAsc'   | last alphabetical category ('c')      | last alphabetical category ('a')|
+   * +-----------------+---------------------------------------+---------------------------------+
+   * }}}
    * The default value is 'frequencyDesc'. When the ordering is set to 'alphabetDesc', `RFormula`
    * drops the same category as R when encoding strings.
    * Note that this ordering option is NOT used for the label column. When the label column is

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -46,6 +46,8 @@ private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
    *   - 'alphabetDesc': descending alphabetical order
    *   - 'alphabetAsc': ascending alphabetical order
    * Default is 'frequencyDesc'.
+   * When the ordering is set to 'alphabetDesc', `RFormula` drops the same category as R
+   * when encoding strings.
    *
    * @group param
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -26,8 +26,7 @@ import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.{Estimator, Model, Pipeline, PipelineModel, PipelineStage, Transformer}
 import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.VectorUDT
-import org.apache.spark.ml.param._
-import org.apache.spark.ml.param.{BooleanParam, Param, ParamMap}
+import org.apache.spark.ml.param.{BooleanParam, Param, ParamMap, ParamValidators}
 import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasLabelCol}
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -51,7 +51,7 @@ private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
    */
   @Since("2.3.0")
   final val stringOrderType: Param[String] = new Param(this, "stringOrderType",
-    "how to order labels of string column. " +
+    "How to order labels of string column. " +
     "The first label after ordering is assigned an index of 0. " +
     s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}.",
     ParamValidators.inArray(StringIndexer.supportedStringOrderType))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -38,22 +38,22 @@ import org.apache.spark.sql.types._
 private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
 
   /**
-    * Param for how to order labels of string column. The first label after ordering is assigned
-    * an index of 0.
-    * Options are:
-    *   - 'frequencyDesc': descending order by label frequency (most frequent label assigned 0)
-    *   - 'frequencyAsc': ascending order by label frequency (least frequent label assigned 0)
-    *   - 'alphabetDesc': descending alphabetical order
-    *   - 'alphabetAsc': ascending alphabetical order
-    * Default is 'frequencyDesc'.
-    *
-    * @group param
-    */
+   * Param for how to order labels of string column. The first label after ordering is assigned
+   * an index of 0.
+   * Options are:
+   *   - 'frequencyDesc': descending order by label frequency (most frequent label assigned 0)
+   *   - 'frequencyAsc': ascending order by label frequency (least frequent label assigned 0)
+   *   - 'alphabetDesc': descending alphabetical order
+   *   - 'alphabetAsc': ascending alphabetical order
+   * Default is 'frequencyDesc'.
+   *
+   * @group param
+   */
   @Since("2.3.0")
   final val stringOrderType: Param[String] = new Param(this, "stringOrderType",
     "how to order labels of string column. " +
-      "The first label after ordering is assigned an index of 0. " +
-      s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}.",
+    "The first label after ordering is assigned an index of 0. " +
+    s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}.",
     ParamValidators.inArray(StringIndexer.supportedStringOrderType))
 
   /** @group getParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -51,8 +51,8 @@ private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
    * +-----------------+---------------------------------------+----------------------------------+
    * | 'frequencyDesc' | most frequent category ('b')          | least frequent category ('c')    |
    * | 'frequencyAsc'  | least frequent category ('c')         | most frequent category ('b')     |
-   * | 'alphabetDesc'  | first alphabetical category ('a')     | last alphabetical category ('c') |
-   * | 'alphabetAsc'   | last alphabetical category ('c')      | first alphabetical category ('a')|
+   * | 'alphabetDesc'  | last alphabetical category ('c')      | first alphabetical category ('a')|
+   * | 'alphabetAsc'   | first alphabetical category ('a')     | last alphabetical category ('c') |
    * +-----------------+---------------------------------------+----------------------------------+
    * }}}
    * Note that this ordering option is NOT used for the label column. When the label column is

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -47,7 +47,7 @@ private[feature] trait StringIndexerBase extends Params with HasInputCol with Ha
    * @group param
    */
   @Since("1.6.0")
-  val handleInvalid: Param[String] = new Param[String](this, "handleInvalid", "how to handle " +
+  val handleInvalid: Param[String] = new Param[String](this, "handleInvalid", "How to handle " +
     "invalid data (unseen labels or NULL values). " +
     "Options are 'skip' (filter out rows with invalid data), error (throw an error), " +
     "or 'keep' (put invalid data in a special additional bucket, at index numLabels).",
@@ -73,7 +73,7 @@ private[feature] trait StringIndexerBase extends Params with HasInputCol with Ha
    */
   @Since("2.3.0")
   final val stringOrderType: Param[String] = new Param(this, "stringOrderType",
-    "how to order labels of string column. " +
+    "How to order labels of string column. " +
     "The first label after ordering is assigned an index of 0. " +
     s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}.",
     ParamValidators.inArray(StringIndexer.supportedStringOrderType))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -166,7 +166,6 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
       val model = formula.setStringOrderType(orderType).fit(original)
       val result = model.transform(original)
       val resultSchema = model.transformSchema(original.schema)
-
       assert(result.schema.toString == resultSchema.toString)
       assert(result.collect() === expected(idx).collect())
       idx += 1
@@ -177,33 +176,34 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     /*
      R code:
 
-     df <- list(list(1, "foo", 4), list(2, "bar", 4), list(3, "bar", 5), list(4, "aaz", 5))
-     df <- do.call(rbind, lapply(df, as.data.frame, col.names = c("id", "a", "b")))
+     df <- data.frame(id = c(1, 2, 3, 4),
+                  a = c("foo", "bar", "bar", "aaz"),
+                  b = c(4, 4, 5, 5))
      model.matrix(id ~ a + b, df)[, -1]
 
-     abar aaaz b
-      0    0   4
+     abar afoo b
+      0    1   4
       1    0   4
       1    0   5
-      0    1   5
+      0    0   5
     */
     val original = Seq((1, "foo", 4), (2, "bar", 4), (3, "bar", 5), (4, "aaz", 5))
       .toDF("id", "a", "b")
     val formula = new RFormula().setFormula("id ~ a + b")
-      .setStringOrderType(StringIndexer.alphabetAsc)
+      .setStringOrderType(StringIndexer.alphabetDesc)
 
     /*
      Note that the category dropped after encoding is the same between R and Spark
-     (i.e., "foo" is treated as the reference level).
+     (i.e., "aaz" is treated as the reference level).
      However, the column order is still different:
-     R renders the columns in descending alphabetical order ("bar", "aaz"), while
-     RFormula renders the columns in ascending alphabetical order ("aaz", "bar").
+     R renders the columns in ascending alphabetical order ("bar", "foo"), while
+     RFormula renders the columns in descending alphabetical order ("foo", "bar").
     */
     val expected = Seq(
-      (1, "foo", 4, Vectors.dense(0.0, 0.0, 4.0), 1.0),
+      (1, "foo", 4, Vectors.dense(1.0, 0.0, 4.0), 1.0),
       (2, "bar", 4, Vectors.dense(0.0, 1.0, 4.0), 2.0),
       (3, "bar", 5, Vectors.dense(0.0, 1.0, 5.0), 3.0),
-      (4, "aaz", 5, Vectors.dense(1.0, 0.0, 5.0), 4.0)
+      (4, "aaz", 5, Vectors.dense(0.0, 0.0, 5.0), 4.0)
     ).toDF("id", "a", "b", "features", "label")
 
     val model = formula.fit(original)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -129,7 +129,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     assert(result.collect() === expected.collect())
   }
 
-  test("encodes string terms with string order type") {
+  test("encodes string terms with string indexer order type") {
     val formula = new RFormula().setFormula("id ~ a + b")
     val original = Seq((1, "foo", 4), (2, "bar", 4), (3, "bar", 5), (4, "aaz", 5))
       .toDF("id", "a", "b")
@@ -163,7 +163,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
 
     var idx = 0
     for (orderType <- StringIndexer.supportedStringOrderType) {
-      val model = formula.setStringOrderType(orderType).fit(original)
+      val model = formula.setStringIndexerOrderType(orderType).fit(original)
       val result = model.transform(original)
       val resultSchema = model.transformSchema(original.schema)
       assert(result.schema.toString == resultSchema.toString)
@@ -190,7 +190,7 @@ class RFormulaSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     val original = Seq((1, "foo", 4), (2, "bar", 4), (3, "bar", 5), (4, "aaz", 5))
       .toDF("id", "a", "b")
     val formula = new RFormula().setFormula("id ~ a + b")
-      .setStringOrderType(StringIndexer.alphabetDesc)
+      .setStringIndexerOrderType(StringIndexer.alphabetDesc)
 
     /*
      Note that the category dropped after encoding is the same between R and Spark


### PR DESCRIPTION
## What changes were proposed in this pull request?
When handling strings, the category dropped by RFormula and R are different:
- RFormula drops the least frequent level 
- R drops the first level after ascending alphabetical ordering

This PR supports different string ordering types in StringIndexer #17879 so that RFormula can drop the same level as R when handling strings using`stringOrderType = "alphabetDesc"`. 

## How was this patch tested?
new tests 