### PR TITLE
[DOCS][SPARKR] Use verbose names for family annotations in functions.R

### DIFF
--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -24,7 +24,7 @@ NULL
 #' If the parameter is a \linkS4class{Column}, it is returned unchanged.
 #'
 #' @param x a literal value or a Column.
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname lit
 #' @name lit
 #' @export
@@ -52,7 +52,7 @@ setMethod("lit", signature("ANY"),
 #'
 #' @rdname abs
 #' @name abs
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @export
 #' @examples \dontrun{abs(df$c)}
 #' @aliases abs,Column-method
@@ -73,7 +73,7 @@ setMethod("abs",
 #'
 #' @rdname acos
 #' @name acos
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @examples \dontrun{acos(df$c)}
 #' @aliases acos,Column-method
@@ -113,7 +113,7 @@ setMethod("approxCountDistinct",
 #'
 #' @rdname ascii
 #' @name ascii
-#' @family String functions
+#' @family string functions
 #' @export
 #' @aliases ascii,Column-method
 #' @examples \dontrun{\dontrun{ascii(df$c)}}
@@ -134,7 +134,7 @@ setMethod("ascii",
 #'
 #' @rdname asin
 #' @name asin
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases asin,Column-method
 #' @examples \dontrun{asin(df$c)}
@@ -154,7 +154,7 @@ setMethod("asin",
 #'
 #' @rdname atan
 #' @name atan
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases atan,Column-method
 #' @examples \dontrun{atan(df$c)}
@@ -172,7 +172,7 @@ setMethod("atan",
 #'
 #' @rdname avg
 #' @name avg
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @export
 #' @aliases avg,Column-method
 #' @examples \dontrun{avg(df$c)}
@@ -193,7 +193,7 @@ setMethod("avg",
 #'
 #' @rdname base64
 #' @name base64
-#' @family String functions
+#' @family string functions
 #' @export
 #' @aliases base64,Column-method
 #' @examples \dontrun{base64(df$c)}
@@ -214,7 +214,7 @@ setMethod("base64",
 #'
 #' @rdname bin
 #' @name bin
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases bin,Column-method
 #' @examples \dontrun{bin(df$c)}
@@ -234,7 +234,7 @@ setMethod("bin",
 #'
 #' @rdname bitwiseNOT
 #' @name bitwiseNOT
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @export
 #' @aliases bitwiseNOT,Column-method
 #' @examples \dontrun{bitwiseNOT(df$c)}
@@ -254,7 +254,7 @@ setMethod("bitwiseNOT",
 #'
 #' @rdname cbrt
 #' @name cbrt
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases cbrt,Column-method
 #' @examples \dontrun{cbrt(df$c)}
@@ -274,7 +274,7 @@ setMethod("cbrt",
 #'
 #' @rdname ceil
 #' @name ceil
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases ceil,Column-method
 #' @examples \dontrun{ceil(df$c)}
@@ -292,7 +292,7 @@ setMethod("ceil",
 #'
 #' @rdname coalesce
 #' @name coalesce
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @export
 #' @aliases coalesce,Column-method
 #' @examples \dontrun{coalesce(df$c, df$d, df$e)}
@@ -324,7 +324,7 @@ col <- function(x) {
 #'
 #' @rdname column
 #' @name column
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @export
 #' @aliases column,character-method
 #' @examples \dontrun{column("name")}
@@ -342,7 +342,7 @@ setMethod("column",
 #'
 #' @rdname corr
 #' @name corr
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases corr,Column-method
 #' @examples \dontrun{corr(df$c, df$d)}
@@ -360,7 +360,7 @@ setMethod("corr", signature(x = "Column"),
 #'
 #' @rdname cov
 #' @name cov
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases cov,characterOrColumn-method
 #' @examples
@@ -404,7 +404,7 @@ setMethod("covar_samp", signature(col1 = "characterOrColumn", col2 = "characterO
 #'
 #' @rdname covar_pop
 #' @name covar_pop
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @aliases covar_pop,characterOrColumn,characterOrColumn-method
 #' @examples
@@ -432,7 +432,7 @@ setMethod("covar_pop", signature(col1 = "characterOrColumn", col2 = "characterOr
 #'
 #' @rdname cos
 #' @name cos
-#' @family Math functions
+#' @family math functions
 #' @aliases cos,Column-method
 #' @export
 #' @examples \dontrun{cos(df$c)}
@@ -452,7 +452,7 @@ setMethod("cos",
 #'
 #' @rdname cosh
 #' @name cosh
-#' @family Math functions
+#' @family math functions
 #' @aliases cosh,Column-method
 #' @export
 #' @examples \dontrun{cosh(df$c)}
@@ -471,7 +471,7 @@ setMethod("cosh",
 #'
 #' @rdname count
 #' @name count
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases count,Column-method
 #' @export
 #' @examples \dontrun{count(df$c)}
@@ -492,7 +492,7 @@ setMethod("count",
 #'
 #' @rdname crc32
 #' @name crc32
-#' @family Misc functions
+#' @family misc functions
 #' @aliases crc32,Column-method
 #' @export
 #' @examples \dontrun{crc32(df$c)}
@@ -513,7 +513,7 @@ setMethod("crc32",
 #'
 #' @rdname hash
 #' @name hash
-#' @family Misc functions
+#' @family misc functions
 #' @aliases hash,Column-method
 #' @export
 #' @examples \dontrun{hash(df$c)}
@@ -537,7 +537,7 @@ setMethod("hash",
 #'
 #' @rdname dayofmonth
 #' @name dayofmonth
-#' @family Date time functions
+#' @family date time functions
 #' @aliases dayofmonth,Column-method
 #' @export
 #' @examples \dontrun{dayofmonth(df$c)}
@@ -557,7 +557,7 @@ setMethod("dayofmonth",
 #'
 #' @rdname dayofyear
 #' @name dayofyear
-#' @family Date time functions
+#' @family date time functions
 #' @aliases dayofyear,Column-method
 #' @export
 #' @examples \dontrun{dayofyear(df$c)}
@@ -579,7 +579,7 @@ setMethod("dayofyear",
 #'
 #' @rdname decode
 #' @name decode
-#' @family String functions
+#' @family string functions
 #' @aliases decode,Column,character-method
 #' @export
 #' @examples \dontrun{decode(df$c, "UTF-8")}
@@ -601,7 +601,7 @@ setMethod("decode",
 #'
 #' @rdname encode
 #' @name encode
-#' @family String functions
+#' @family string functions
 #' @aliases encode,Column,character-method
 #' @export
 #' @examples \dontrun{encode(df$c, "UTF-8")}
@@ -621,7 +621,7 @@ setMethod("encode",
 #'
 #' @rdname exp
 #' @name exp
-#' @family Math functions
+#' @family math functions
 #' @aliases exp,Column-method
 #' @export
 #' @examples \dontrun{exp(df$c)}
@@ -642,7 +642,7 @@ setMethod("exp",
 #' @rdname expm1
 #' @name expm1
 #' @aliases expm1,Column-method
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @examples \dontrun{expm1(df$c)}
 #' @note expm1 since 1.5.0
@@ -662,7 +662,7 @@ setMethod("expm1",
 #' @rdname factorial
 #' @name factorial
 #' @aliases factorial,Column-method
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @examples \dontrun{factorial(df$c)}
 #' @note factorial since 1.5.0
@@ -686,7 +686,7 @@ setMethod("factorial",
 #' @rdname first
 #' @name first
 #' @aliases first,characterOrColumn-method
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @export
 #' @examples
 #' \dontrun{
@@ -715,7 +715,7 @@ setMethod("first",
 #' @rdname floor
 #' @name floor
 #' @aliases floor,Column-method
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @examples \dontrun{floor(df$c)}
 #' @note floor since 1.5.0
@@ -734,7 +734,7 @@ setMethod("floor",
 #'
 #' @rdname hex
 #' @name hex
-#' @family Math functions
+#' @family math functions
 #' @aliases hex,Column-method
 #' @export
 #' @examples \dontrun{hex(df$c)}
@@ -755,7 +755,7 @@ setMethod("hex",
 #' @rdname hour
 #' @name hour
 #' @aliases hour,Column-method
-#' @family Date time functions
+#' @family date time functions
 #' @export
 #' @examples \dontrun{hour(df$c)}
 #' @note hour since 1.5.0
@@ -777,7 +777,7 @@ setMethod("hour",
 #'
 #' @rdname initcap
 #' @name initcap
-#' @family String functions
+#' @family string functions
 #' @aliases initcap,Column-method
 #' @export
 #' @examples \dontrun{initcap(df$c)}
@@ -797,7 +797,7 @@ setMethod("initcap",
 #'
 #' @rdname is.nan
 #' @name is.nan
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @aliases is.nan,Column-method
 #' @export
 #' @examples
@@ -832,7 +832,7 @@ setMethod("isnan",
 #' @rdname kurtosis
 #' @name kurtosis
 #' @aliases kurtosis,Column-method
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @export
 #' @examples \dontrun{kurtosis(df$c)}
 #' @note kurtosis since 1.6.0
@@ -858,7 +858,7 @@ setMethod("kurtosis",
 #' @rdname last
 #' @name last
 #' @aliases last,characterOrColumn-method
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @export
 #' @examples
 #' \dontrun{
@@ -889,7 +889,7 @@ setMethod("last",
 #' @rdname last_day
 #' @name last_day
 #' @aliases last_day,Column-method
-#' @family Date time functions
+#' @family date time functions
 #' @export
 #' @examples \dontrun{last_day(df$c)}
 #' @note last_day since 1.5.0
@@ -909,7 +909,7 @@ setMethod("last_day",
 #' @rdname length
 #' @name length
 #' @aliases length,Column-method
-#' @family String functions
+#' @family string functions
 #' @export
 #' @examples \dontrun{length(df$c)}
 #' @note length since 1.5.0
@@ -929,7 +929,7 @@ setMethod("length",
 #' @rdname log
 #' @name log
 #' @aliases log,Column-method
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @examples \dontrun{log(df$c)}
 #' @note log since 1.5.0
@@ -948,7 +948,7 @@ setMethod("log",
 #'
 #' @rdname log10
 #' @name log10
-#' @family Math functions
+#' @family math functions
 #' @aliases log10,Column-method
 #' @export
 #' @examples \dontrun{log10(df$c)}
@@ -968,7 +968,7 @@ setMethod("log10",
 #'
 #' @rdname log1p
 #' @name log1p
-#' @family Math functions
+#' @family math functions
 #' @aliases log1p,Column-method
 #' @export
 #' @examples \dontrun{log1p(df$c)}
@@ -988,7 +988,7 @@ setMethod("log1p",
 #'
 #' @rdname log2
 #' @name log2
-#' @family Math functions
+#' @family math functions
 #' @aliases log2,Column-method
 #' @export
 #' @examples \dontrun{log2(df$c)}
@@ -1008,7 +1008,7 @@ setMethod("log2",
 #'
 #' @rdname lower
 #' @name lower
-#' @family String functions
+#' @family string functions
 #' @aliases lower,Column-method
 #' @export
 #' @examples \dontrun{lower(df$c)}
@@ -1028,7 +1028,7 @@ setMethod("lower",
 #'
 #' @rdname ltrim
 #' @name ltrim
-#' @family String functions
+#' @family string functions
 #' @aliases ltrim,Column-method
 #' @export
 #' @examples \dontrun{ltrim(df$c)}
@@ -1048,7 +1048,7 @@ setMethod("ltrim",
 #'
 #' @rdname max
 #' @name max
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases max,Column-method
 #' @export
 #' @examples \dontrun{max(df$c)}
@@ -1069,7 +1069,7 @@ setMethod("max",
 #'
 #' @rdname md5
 #' @name md5
-#' @family Misc functions
+#' @family misc functions
 #' @aliases md5,Column-method
 #' @export
 #' @examples \dontrun{md5(df$c)}
@@ -1090,7 +1090,7 @@ setMethod("md5",
 #'
 #' @rdname mean
 #' @name mean
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases mean,Column-method
 #' @export
 #' @examples \dontrun{mean(df$c)}
@@ -1111,7 +1111,7 @@ setMethod("mean",
 #' @rdname min
 #' @name min
 #' @aliases min,Column-method
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @export
 #' @examples \dontrun{min(df$c)}
 #' @note min since 1.5.0
@@ -1131,7 +1131,7 @@ setMethod("min",
 #' @rdname minute
 #' @name minute
 #' @aliases minute,Column-method
-#' @family Date time functions
+#' @family date time functions
 #' @export
 #' @examples \dontrun{minute(df$c)}
 #' @note minute since 1.5.0
@@ -1160,7 +1160,7 @@ setMethod("minute",
 #' @rdname monotonically_increasing_id
 #' @aliases monotonically_increasing_id,missing-method
 #' @name monotonically_increasing_id
-#' @family Misc functions
+#' @family misc functions
 #' @export
 #' @examples \dontrun{select(df, monotonically_increasing_id())}
 setMethod("monotonically_increasing_id",
@@ -1179,7 +1179,7 @@ setMethod("monotonically_increasing_id",
 #' @rdname month
 #' @name month
 #' @aliases month,Column-method
-#' @family Date time functions
+#' @family date time functions
 #' @export
 #' @examples \dontrun{month(df$c)}
 #' @note month since 1.5.0
@@ -1198,7 +1198,7 @@ setMethod("month",
 #'
 #' @rdname negate
 #' @name negate
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @aliases negate,Column-method
 #' @export
 #' @examples \dontrun{negate(df$c)}
@@ -1218,7 +1218,7 @@ setMethod("negate",
 #'
 #' @rdname quarter
 #' @name quarter
-#' @family Date time functions
+#' @family date time functions
 #' @aliases quarter,Column-method
 #' @export
 #' @examples \dontrun{quarter(df$c)}
@@ -1238,7 +1238,7 @@ setMethod("quarter",
 #'
 #' @rdname reverse
 #' @name reverse
-#' @family String functions
+#' @family string functions
 #' @aliases reverse,Column-method
 #' @export
 #' @examples \dontrun{reverse(df$c)}
@@ -1259,7 +1259,7 @@ setMethod("reverse",
 #'
 #' @rdname rint
 #' @name rint
-#' @family Math functions
+#' @family math functions
 #' @aliases rint,Column-method
 #' @export
 #' @examples \dontrun{rint(df$c)}
@@ -1279,7 +1279,7 @@ setMethod("rint",
 #'
 #' @rdname round
 #' @name round
-#' @family Math functions
+#' @family math functions
 #' @aliases round,Column-method
 #' @export
 #' @examples \dontrun{round(df$c)}
@@ -1305,7 +1305,7 @@ setMethod("round",
 #' @param ... further arguments to be passed to or from other methods.
 #' @rdname bround
 #' @name bround
-#' @family Math functions
+#' @family math functions
 #' @aliases bround,Column-method
 #' @export
 #' @examples \dontrun{bround(df$c, 0)}
@@ -1326,7 +1326,7 @@ setMethod("bround",
 #'
 #' @rdname rtrim
 #' @name rtrim
-#' @family String functions
+#' @family string functions
 #' @aliases rtrim,Column-method
 #' @export
 #' @examples \dontrun{rtrim(df$c)}
@@ -1346,7 +1346,7 @@ setMethod("rtrim",
 #' @param na.rm currently not used.
 #' @rdname sd
 #' @name sd
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases sd,Column-method
 #' @seealso \link{stddev_pop}, \link{stddev_samp}
 #' @export
@@ -1372,7 +1372,7 @@ setMethod("sd",
 #'
 #' @rdname second
 #' @name second
-#' @family Date time functions
+#' @family date time functions
 #' @aliases second,Column-method
 #' @export
 #' @examples \dontrun{second(df$c)}
@@ -1393,7 +1393,7 @@ setMethod("second",
 #'
 #' @rdname sha1
 #' @name sha1
-#' @family Misc functions
+#' @family misc functions
 #' @aliases sha1,Column-method
 #' @export
 #' @examples \dontrun{sha1(df$c)}
@@ -1414,7 +1414,7 @@ setMethod("sha1",
 #' @rdname sign
 #' @name signum
 #' @aliases signum,Column-method
-#' @family Math functions
+#' @family math functions
 #' @export
 #' @examples \dontrun{signum(df$c)}
 #' @note signum since 1.5.0
@@ -1433,7 +1433,7 @@ setMethod("signum",
 #'
 #' @rdname sin
 #' @name sin
-#' @family Math functions
+#' @family math functions
 #' @aliases sin,Column-method
 #' @export
 #' @examples \dontrun{sin(df$c)}
@@ -1453,7 +1453,7 @@ setMethod("sin",
 #'
 #' @rdname sinh
 #' @name sinh
-#' @family Math functions
+#' @family math functions
 #' @aliases sinh,Column-method
 #' @export
 #' @examples \dontrun{sinh(df$c)}
@@ -1473,7 +1473,7 @@ setMethod("sinh",
 #'
 #' @rdname skewness
 #' @name skewness
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases skewness,Column-method
 #' @export
 #' @examples \dontrun{skewness(df$c)}
@@ -1493,7 +1493,7 @@ setMethod("skewness",
 #'
 #' @rdname soundex
 #' @name soundex
-#' @family String functions
+#' @family string functions
 #' @aliases soundex,Column-method
 #' @export
 #' @examples \dontrun{soundex(df$c)}
@@ -1546,7 +1546,7 @@ setMethod("stddev",
 #'
 #' @rdname stddev_pop
 #' @name stddev_pop
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases stddev_pop,Column-method
 #' @seealso \link{sd}, \link{stddev_samp}
 #' @export
@@ -1567,7 +1567,7 @@ setMethod("stddev_pop",
 #'
 #' @rdname stddev_samp
 #' @name stddev_samp
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases stddev_samp,Column-method
 #' @seealso \link{stddev_pop}, \link{sd}
 #' @export
@@ -1589,7 +1589,7 @@ setMethod("stddev_samp",
 #'
 #' @rdname struct
 #' @name struct
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @aliases struct,characterOrColumn-method
 #' @export
 #' @examples
@@ -1618,7 +1618,7 @@ setMethod("struct",
 #'
 #' @rdname sqrt
 #' @name sqrt
-#' @family Math functions
+#' @family math functions
 #' @aliases sqrt,Column-method
 #' @export
 #' @examples \dontrun{sqrt(df$c)}
@@ -1638,7 +1638,7 @@ setMethod("sqrt",
 #'
 #' @rdname sum
 #' @name sum
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases sum,Column-method
 #' @export
 #' @examples \dontrun{sum(df$c)}
@@ -1658,7 +1658,7 @@ setMethod("sum",
 #'
 #' @rdname sumDistinct
 #' @name sumDistinct
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases sumDistinct,Column-method
 #' @export
 #' @examples \dontrun{sumDistinct(df$c)}
@@ -1678,7 +1678,7 @@ setMethod("sumDistinct",
 #'
 #' @rdname tan
 #' @name tan
-#' @family Math functions
+#' @family math functions
 #' @aliases tan,Column-method
 #' @export
 #' @examples \dontrun{tan(df$c)}
@@ -1698,7 +1698,7 @@ setMethod("tan",
 #'
 #' @rdname tanh
 #' @name tanh
-#' @family Math functions
+#' @family math functions
 #' @aliases tanh,Column-method
 #' @export
 #' @examples \dontrun{tanh(df$c)}
@@ -1718,7 +1718,7 @@ setMethod("tanh",
 #'
 #' @rdname toDegrees
 #' @name toDegrees
-#' @family Math functions
+#' @family math functions
 #' @aliases toDegrees,Column-method
 #' @export
 #' @examples \dontrun{toDegrees(df$c)}
@@ -1738,7 +1738,7 @@ setMethod("toDegrees",
 #'
 #' @rdname toRadians
 #' @name toRadians
-#' @family Math functions
+#' @family math functions
 #' @aliases toRadians,Column-method
 #' @export
 #' @examples \dontrun{toRadians(df$c)}
@@ -1764,7 +1764,7 @@ setMethod("toRadians",
 #'
 #' @rdname to_date
 #' @name to_date
-#' @family Date time functions
+#' @family date time functions
 #' @aliases to_date,Column,missing-method
 #' @export
 #' @examples
@@ -1782,7 +1782,7 @@ setMethod("to_date",
 
 #' @rdname to_date
 #' @name to_date
-#' @family Date time functions
+#' @family date time functions
 #' @aliases to_date,Column,character-method
 #' @export
 #' @note to_date(Column, character) since 2.2.0
@@ -1802,7 +1802,7 @@ setMethod("to_date",
 #' @param ... additional named properties to control how it is converted, accepts the same options
 #'            as the JSON data source.
 #'
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname to_json
 #' @name to_json
 #' @aliases to_json,Column-method
@@ -1839,7 +1839,7 @@ setMethod("to_json", signature(x = "Column"),
 #'
 #' @rdname to_timestamp
 #' @name to_timestamp
-#' @family Date time functions
+#' @family date time functions
 #' @aliases to_timestamp,Column,missing-method
 #' @export
 #' @examples
@@ -1857,7 +1857,7 @@ setMethod("to_timestamp",
 
 #' @rdname to_timestamp
 #' @name to_timestamp
-#' @family Date time functions
+#' @family date time functions
 #' @aliases to_timestamp,Column,character-method
 #' @export
 #' @note to_timestamp(Column, character) since 2.2.0
@@ -1876,7 +1876,7 @@ setMethod("to_timestamp",
 #'
 #' @rdname trim
 #' @name trim
-#' @family String functions
+#' @family string functions
 #' @aliases trim,Column-method
 #' @export
 #' @examples \dontrun{trim(df$c)}
@@ -1897,7 +1897,7 @@ setMethod("trim",
 #'
 #' @rdname unbase64
 #' @name unbase64
-#' @family String functions
+#' @family string functions
 #' @aliases unbase64,Column-method
 #' @export
 #' @examples \dontrun{unbase64(df$c)}
@@ -1918,7 +1918,7 @@ setMethod("unbase64",
 #'
 #' @rdname unhex
 #' @name unhex
-#' @family Math functions
+#' @family math functions
 #' @aliases unhex,Column-method
 #' @export
 #' @examples \dontrun{unhex(df$c)}
@@ -1938,7 +1938,7 @@ setMethod("unhex",
 #'
 #' @rdname upper
 #' @name upper
-#' @family String functions
+#' @family string functions
 #' @aliases upper,Column-method
 #' @export
 #' @examples \dontrun{upper(df$c)}
@@ -1958,7 +1958,7 @@ setMethod("upper",
 #' @param y,na.rm,use currently not used.
 #' @rdname var
 #' @name var
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases var,Column-method
 #' @seealso \link{var_pop}, \link{var_samp}
 #' @export
@@ -1995,7 +1995,7 @@ setMethod("variance",
 #'
 #' @rdname var_pop
 #' @name var_pop
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases var_pop,Column-method
 #' @seealso \link{var}, \link{var_samp}
 #' @export
@@ -2017,7 +2017,7 @@ setMethod("var_pop",
 #' @rdname var_samp
 #' @name var_samp
 #' @aliases var_samp,Column-method
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @seealso \link{var_pop}, \link{var}
 #' @export
 #' @examples \dontrun{var_samp(df$c)}
@@ -2038,7 +2038,7 @@ setMethod("var_samp",
 #' @rdname weekofyear
 #' @name weekofyear
 #' @aliases weekofyear,Column-method
-#' @family Date time functions
+#' @family date time functions
 #' @export
 #' @examples \dontrun{weekofyear(df$c)}
 #' @note weekofyear since 1.5.0
@@ -2057,7 +2057,7 @@ setMethod("weekofyear",
 #'
 #' @rdname year
 #' @name year
-#' @family Date time functions
+#' @family date time functions
 #' @aliases year,Column-method
 #' @export
 #' @examples \dontrun{year(df$c)}
@@ -2079,7 +2079,7 @@ setMethod("year",
 #'
 #' @rdname atan2
 #' @name atan2
-#' @family Math functions
+#' @family math functions
 #' @aliases atan2,Column-method
 #' @export
 #' @examples \dontrun{atan2(df$c, x)}
@@ -2103,7 +2103,7 @@ setMethod("atan2", signature(y = "Column"),
 #' @rdname datediff
 #' @name datediff
 #' @aliases datediff,Column-method
-#' @family Date time functions
+#' @family date time functions
 #' @export
 #' @examples \dontrun{datediff(df$c, x)}
 #' @note datediff since 1.5.0
@@ -2125,7 +2125,7 @@ setMethod("datediff", signature(y = "Column"),
 #'
 #' @rdname hypot
 #' @name hypot
-#' @family Math functions
+#' @family math functions
 #' @aliases hypot,Column-method
 #' @export
 #' @examples \dontrun{hypot(df$c, x)}
@@ -2148,7 +2148,7 @@ setMethod("hypot", signature(y = "Column"),
 #'
 #' @rdname levenshtein
 #' @name levenshtein
-#' @family String functions
+#' @family string functions
 #' @aliases levenshtein,Column-method
 #' @export
 #' @examples \dontrun{levenshtein(df$c, x)}
@@ -2171,7 +2171,7 @@ setMethod("levenshtein", signature(y = "Column"),
 #'
 #' @rdname months_between
 #' @name months_between
-#' @family Date time functions
+#' @family date time functions
 #' @aliases months_between,Column-method
 #' @export
 #' @examples \dontrun{months_between(df$c, x)}
@@ -2195,7 +2195,7 @@ setMethod("months_between", signature(y = "Column"),
 #'
 #' @rdname nanvl
 #' @name nanvl
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @aliases nanvl,Column-method
 #' @export
 #' @examples \dontrun{nanvl(df$c, x)}
@@ -2219,7 +2219,7 @@ setMethod("nanvl", signature(y = "Column"),
 #' @rdname pmod
 #' @name pmod
 #' @docType methods
-#' @family Math functions
+#' @family math functions
 #' @aliases pmod,Column-method
 #' @export
 #' @examples \dontrun{pmod(df$c, x)}
@@ -2257,7 +2257,7 @@ setMethod("approxCountDistinct",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @rdname countDistinct
 #' @name countDistinct
 #' @aliases countDistinct,Column-method
@@ -2285,7 +2285,7 @@ setMethod("countDistinct",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family String functions
+#' @family string functions
 #' @rdname concat
 #' @name concat
 #' @aliases concat,Column-method
@@ -2311,7 +2311,7 @@ setMethod("concat",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname greatest
 #' @name greatest
 #' @aliases greatest,Column-method
@@ -2338,7 +2338,7 @@ setMethod("greatest",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname least
 #' @aliases least,Column-method
 #' @name least
@@ -2422,7 +2422,7 @@ setMethod("n", signature(x = "Column"),
 #' @param y Column to compute on.
 #' @param x date format specification.
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname date_format
 #' @name date_format
 #' @aliases date_format,Column,character-method
@@ -2447,7 +2447,7 @@ setMethod("date_format", signature(y = "Column", x = "character"),
 #' @param ... additional named properties to control how the json is parsed, accepts the same
 #'            options as the JSON data source.
 #'
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname from_json
 #' @name from_json
 #' @aliases from_json,Column,structType-method
@@ -2482,7 +2482,7 @@ setMethod("from_json", signature(x = "Column", schema = "structType"),
 #' @param y Column to compute on.
 #' @param x time zone to use.
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname from_utc_timestamp
 #' @name from_utc_timestamp
 #' @aliases from_utc_timestamp,Column,character-method
@@ -2505,7 +2505,7 @@ setMethod("from_utc_timestamp", signature(y = "Column", x = "character"),
 #'
 #' @param y column to check
 #' @param x substring to check
-#' @family String functions
+#' @family string functions
 #' @aliases instr,Column,character-method
 #' @rdname instr
 #' @name instr
@@ -2532,7 +2532,7 @@ setMethod("instr", signature(y = "Column", x = "character"),
 #' @param y Column to compute on.
 #' @param x Day of the week string.
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname next_day
 #' @name next_day
 #' @aliases next_day,Column,character-method
@@ -2557,7 +2557,7 @@ setMethod("next_day", signature(y = "Column", x = "character"),
 #' @param y Column to compute on
 #' @param x timezone to use
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname to_utc_timestamp
 #' @name to_utc_timestamp
 #' @aliases to_utc_timestamp,Column,character-method
@@ -2578,7 +2578,7 @@ setMethod("to_utc_timestamp", signature(y = "Column", x = "character"),
 #' @param x Number of months to add
 #'
 #' @name add_months
-#' @family Date time functions
+#' @family date time functions
 #' @rdname add_months
 #' @aliases add_months,Column,numeric-method
 #' @export
@@ -2597,7 +2597,7 @@ setMethod("add_months", signature(y = "Column", x = "numeric"),
 #' @param y Column to compute on
 #' @param x Number of days to add
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname date_add
 #' @name date_add
 #' @aliases date_add,Column,numeric-method
@@ -2617,7 +2617,7 @@ setMethod("date_add", signature(y = "Column", x = "numeric"),
 #' @param y Column to compute on
 #' @param x Number of days to substract
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname date_sub
 #' @name date_sub
 #' @aliases date_sub,Column,numeric-method
@@ -2640,7 +2640,7 @@ setMethod("date_sub", signature(y = "Column", x = "numeric"),
 #'
 #' @param y column to format
 #' @param x number of decimal place to format to
-#' @family String functions
+#' @family string functions
 #' @rdname format_number
 #' @name format_number
 #' @aliases format_number,Column,numeric-method
@@ -2662,7 +2662,7 @@ setMethod("format_number", signature(y = "Column", x = "numeric"),
 #'
 #' @param y column to compute SHA-2 on.
 #' @param x one of 224, 256, 384, or 512.
-#' @family Misc functions
+#' @family misc functions
 #' @rdname sha2
 #' @name sha2
 #' @aliases sha2,Column,numeric-method
@@ -2683,7 +2683,7 @@ setMethod("sha2", signature(y = "Column", x = "numeric"),
 #' @param y column to compute on.
 #' @param x number of bits to shift.
 #'
-#' @family Math functions
+#' @family math functions
 #' @rdname shiftLeft
 #' @name shiftLeft
 #' @aliases shiftLeft,Column,numeric-method
@@ -2706,7 +2706,7 @@ setMethod("shiftLeft", signature(y = "Column", x = "numeric"),
 #' @param y column to compute on.
 #' @param x number of bits to shift.
 #'
-#' @family Math functions
+#' @family math functions
 #' @rdname shiftRight
 #' @name shiftRight
 #' @aliases shiftRight,Column,numeric-method
@@ -2729,7 +2729,7 @@ setMethod("shiftRight", signature(y = "Column", x = "numeric"),
 #' @param y column to compute on.
 #' @param x number of bits to shift.
 #'
-#' @family Math functions
+#' @family math functions
 #' @rdname shiftRightUnsigned
 #' @name shiftRightUnsigned
 #' @aliases shiftRightUnsigned,Column,numeric-method
@@ -2753,7 +2753,7 @@ setMethod("shiftRightUnsigned", signature(y = "Column", x = "numeric"),
 #' @param sep separator to use.
 #' @param ... other columns to concatenate.
 #'
-#' @family String functions
+#' @family string functions
 #' @rdname concat_ws
 #' @name concat_ws
 #' @aliases concat_ws,character,Column-method
@@ -2775,7 +2775,7 @@ setMethod("concat_ws", signature(sep = "character", x = "Column"),
 #' @param fromBase base to convert from.
 #' @param toBase base to convert to.
 #'
-#' @family Math functions
+#' @family math functions
 #' @rdname conv
 #' @aliases conv,Column,numeric,numeric-method
 #' @name conv
@@ -2798,7 +2798,7 @@ setMethod("conv", signature(x = "Column", fromBase = "numeric", toBase = "numeri
 #' SparkDataFrame.selectExpr
 #'
 #' @param x an expression character object to be parsed.
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname expr
 #' @aliases expr,character-method
 #' @name expr
@@ -2818,7 +2818,7 @@ setMethod("expr", signature(x = "character"),
 #' @param format a character object of format strings.
 #' @param x a Column.
 #' @param ... additional Column(s).
-#' @family String functions
+#' @family string functions
 #' @rdname format_string
 #' @name format_string
 #' @aliases format_string,character,Column-method
@@ -2845,7 +2845,7 @@ setMethod("format_string", signature(format = "character", x = "Column"),
 #'               \href{http://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html}{
 #'               Customizing Formats} for available options.
 #' @param ... further arguments to be passed to or from other methods.
-#' @family Date time functions
+#' @family date time functions
 #' @rdname from_unixtime
 #' @name from_unixtime
 #' @aliases from_unixtime,Column-method
@@ -2890,7 +2890,7 @@ setMethod("from_unixtime", signature(x = "Column"),
 #' @param ... further arguments to be passed to or from other methods.
 #' @return An output column of struct called 'window' by default with the nested columns 'start'
 #'         and 'end'.
-#' @family Date time functions
+#' @family date time functions
 #' @rdname window
 #' @name window
 #' @aliases window,Column-method
@@ -2946,7 +2946,7 @@ setMethod("window", signature(x = "Column"),
 #' @param str a Column where matches are sought for each entry.
 #' @param pos start position of search.
 #' @param ... further arguments to be passed to or from other methods.
-#' @family String functions
+#' @family string functions
 #' @rdname locate
 #' @aliases locate,character,Column-method
 #' @name locate
@@ -2968,7 +2968,7 @@ setMethod("locate", signature(substr = "character", str = "Column"),
 #' @param x the string Column to be left-padded.
 #' @param len maximum length of each output result.
 #' @param pad a character string to be padded with.
-#' @family String functions
+#' @family string functions
 #' @rdname lpad
 #' @aliases lpad,Column,numeric,character-method
 #' @name lpad
@@ -2989,7 +2989,7 @@ setMethod("lpad", signature(x = "Column", len = "numeric", pad = "character"),
 #' from U[0.0, 1.0].
 #'
 #' @param seed a random seed. Can be missing.
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname rand
 #' @name rand
 #' @aliases rand,missing-method
@@ -3019,7 +3019,7 @@ setMethod("rand", signature(seed = "numeric"),
 #' the standard normal distribution.
 #'
 #' @param seed a random seed. Can be missing.
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname randn
 #' @name randn
 #' @aliases randn,missing-method
@@ -3051,7 +3051,7 @@ setMethod("randn", signature(seed = "numeric"),
 #' @param x a string Column.
 #' @param pattern a regular expression.
 #' @param idx a group index.
-#' @family String functions
+#' @family string functions
 #' @rdname regexp_extract
 #' @name regexp_extract
 #' @aliases regexp_extract,Column,character,numeric-method
@@ -3074,7 +3074,7 @@ setMethod("regexp_extract",
 #' @param x a string Column.
 #' @param pattern a regular expression.
 #' @param replacement a character string that a matched \code{pattern} is replaced with.
-#' @family String functions
+#' @family string functions
 #' @rdname regexp_replace
 #' @name regexp_replace
 #' @aliases regexp_replace,Column,character,character-method
@@ -3097,7 +3097,7 @@ setMethod("regexp_replace",
 #' @param x the string Column to be right-padded.
 #' @param len maximum length of each output result.
 #' @param pad a character string to be padded with.
-#' @family String functions
+#' @family string functions
 #' @rdname rpad
 #' @name rpad
 #' @aliases rpad,Column,numeric,character-method
@@ -3124,7 +3124,7 @@ setMethod("rpad", signature(x = "Column", len = "numeric", pad = "character"),
 #' @param count number of occurrences of \code{delim} before the substring is returned.
 #'              A positive number means counting from the left, while negative means
 #'              counting from the right.
-#' @family String functions
+#' @family string functions
 #' @rdname substring_index
 #' @aliases substring_index,Column,character,numeric-method
 #' @name substring_index
@@ -3156,7 +3156,7 @@ setMethod("substring_index",
 #' @param replaceString a target string where each \code{matchingString} character will
 #'                      be replaced by the character in \code{replaceString}
 #'                      at the same location, if any.
-#' @family String functions
+#' @family string functions
 #' @rdname translate
 #' @name translate
 #' @aliases translate,Column,character,character-method
@@ -3175,7 +3175,7 @@ setMethod("translate",
 #'
 #' Gets current Unix timestamp in seconds.
 #'
-#' @family Date time functions
+#' @family date time functions
 #' @rdname unix_timestamp
 #' @name unix_timestamp
 #' @aliases unix_timestamp,missing,missing-method
@@ -3225,7 +3225,7 @@ setMethod("unix_timestamp", signature(x = "Column", format = "character"),
 #'
 #' @param condition the condition to test on. Must be a Column expression.
 #' @param value result expression.
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname when
 #' @name when
 #' @aliases when,Column-method
@@ -3249,7 +3249,7 @@ setMethod("when", signature(condition = "Column", value = "ANY"),
 #' @param test a Column expression that describes the condition.
 #' @param yes return values for \code{TRUE} elements of test.
 #' @param no return values for \code{FALSE} elements of test.
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname ifelse
 #' @name ifelse
 #' @aliases ifelse,Column-method
@@ -3287,7 +3287,7 @@ setMethod("ifelse",
 #'
 #' @rdname cume_dist
 #' @name cume_dist
-#' @family Window functions
+#' @family window functions
 #' @aliases cume_dist,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3316,7 +3316,7 @@ setMethod("cume_dist",
 #'
 #' @rdname dense_rank
 #' @name dense_rank
-#' @family Window functions
+#' @family window functions
 #' @aliases dense_rank,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3348,7 +3348,7 @@ setMethod("dense_rank",
 #' @rdname lag
 #' @name lag
 #' @aliases lag,characterOrColumn-method
-#' @family Window functions
+#' @family window functions
 #' @export
 #' @examples \dontrun{
 #'   df <- createDataFrame(mtcars)
@@ -3390,7 +3390,7 @@ setMethod("lag",
 #'
 #' @rdname lead
 #' @name lead
-#' @family Window functions
+#' @family window functions
 #' @aliases lead,characterOrColumn,numeric-method
 #' @export
 #' @examples \dontrun{
@@ -3430,7 +3430,7 @@ setMethod("lead",
 #' @rdname ntile
 #' @name ntile
 #' @aliases ntile,numeric-method
-#' @family Window functions
+#' @family window functions
 #' @export
 #' @examples \dontrun{
 #'   df <- createDataFrame(mtcars)
@@ -3461,7 +3461,7 @@ setMethod("ntile",
 #'
 #' @rdname percent_rank
 #' @name percent_rank
-#' @family Window functions
+#' @family window functions
 #' @aliases percent_rank,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3491,7 +3491,7 @@ setMethod("percent_rank",
 #'
 #' @rdname rank
 #' @name rank
-#' @family Window functions
+#' @family window functions
 #' @aliases rank,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3529,7 +3529,7 @@ setMethod("rank",
 #' @rdname row_number
 #' @name row_number
 #' @aliases row_number,missing-method
-#' @family Window functions
+#' @family window functions
 #' @export
 #' @examples \dontrun{
 #'   df <- createDataFrame(mtcars)
@@ -3555,7 +3555,7 @@ setMethod("row_number",
 #' @rdname array_contains
 #' @aliases array_contains,Column-method
 #' @name array_contains
-#' @family Collection functions
+#' @family collection functions
 #' @export
 #' @examples \dontrun{array_contains(df$c, 1)}
 #' @note array_contains since 1.6.0
@@ -3574,7 +3574,7 @@ setMethod("array_contains",
 #'
 #' @rdname explode
 #' @name explode
-#' @family Collection functions
+#' @family collection functions
 #' @aliases explode,Column-method
 #' @export
 #' @examples \dontrun{explode(df$c)}
@@ -3595,7 +3595,7 @@ setMethod("explode",
 #' @rdname size
 #' @name size
 #' @aliases size,Column-method
-#' @family Collection functions
+#' @family collection functions
 #' @export
 #' @examples \dontrun{size(df$c)}
 #' @note size since 1.5.0
@@ -3618,7 +3618,7 @@ setMethod("size",
 #' @rdname sort_array
 #' @name sort_array
 #' @aliases sort_array,Column-method
-#' @family Collection functions
+#' @family collection functions
 #' @export
 #' @examples
 #' \dontrun{
@@ -3641,7 +3641,7 @@ setMethod("sort_array",
 #'
 #' @rdname posexplode
 #' @name posexplode
-#' @family Collection functions
+#' @family collection functions
 #' @aliases posexplode,Column-method
 #' @export
 #' @examples \dontrun{posexplode(df$c)}
@@ -3660,7 +3660,7 @@ setMethod("posexplode",
 #' @param x Column to compute on
 #' @param ... additional Column(s).
 #'
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname create_array
 #' @name create_array
 #' @aliases create_array,Column-method
@@ -3688,7 +3688,7 @@ setMethod("create_array",
 #' @param x Column to compute on
 #' @param ... additional Column(s).
 #'
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @rdname create_map
 #' @name create_map
 #' @aliases create_map,Column-method
@@ -3714,7 +3714,7 @@ setMethod("create_map",
 #'
 #' @rdname collect_list
 #' @name collect_list
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases collect_list,Column-method
 #' @export
 #' @examples \dontrun{collect_list(df$x)}
@@ -3734,7 +3734,7 @@ setMethod("collect_list",
 #'
 #' @rdname collect_set
 #' @name collect_set
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases collect_set,Column-method
 #' @export
 #' @examples \dontrun{collect_set(df$x)}
@@ -3756,7 +3756,7 @@ setMethod("collect_set",
 #' @param pattern Java regular expression
 #'
 #' @rdname split_string
-#' @family String functions
+#' @family string functions
 #' @aliases split_string,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3785,7 +3785,7 @@ setMethod("split_string",
 #' @param n Number of repetitions
 #'
 #' @rdname repeat_string
-#' @family String functions
+#' @family string functions
 #' @aliases repeat_string,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3814,7 +3814,7 @@ setMethod("repeat_string",
 #'
 #' @rdname explode_outer
 #' @name explode_outer
-#' @family Collection functions
+#' @family collection functions
 #' @aliases explode_outer,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3842,7 +3842,7 @@ setMethod("explode_outer",
 #'
 #' @rdname posexplode_outer
 #' @name posexplode_outer
-#' @family Collection functions
+#' @family collection functions
 #' @aliases posexplode_outer,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3871,7 +3871,7 @@ setMethod("posexplode_outer",
 #' @rdname not
 #' @name not
 #' @aliases not,Column-method
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @export
 #' @examples \dontrun{
 #' df <- createDataFrame(data.frame(
@@ -3903,7 +3903,7 @@ setMethod("not",
 #'
 #' @rdname grouping_bit
 #' @name grouping_bit
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases grouping_bit,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3944,7 +3944,7 @@ setMethod("grouping_bit",
 #'
 #' @rdname grouping_id
 #' @name grouping_id
-#' @family Aggregate functions
+#' @family aggregate functions
 #' @aliases grouping_id,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3982,7 +3982,7 @@ setMethod("grouping_id",
 #'
 #' @rdname input_file_name
 #' @name input_file_name
-#' @family Non-aggregate functions
+#' @family non-aggregate functions
 #' @aliases input_file_name,missing-method
 #' @export
 #' @examples \dontrun{

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -24,7 +24,7 @@ NULL
 #' If the parameter is a \linkS4class{Column}, it is returned unchanged.
 #'
 #' @param x a literal value or a Column.
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname lit
 #' @name lit
 #' @export
@@ -52,7 +52,7 @@ setMethod("lit", signature("ANY"),
 #'
 #' @rdname abs
 #' @name abs
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @export
 #' @examples \dontrun{abs(df$c)}
 #' @aliases abs,Column-method
@@ -73,7 +73,7 @@ setMethod("abs",
 #'
 #' @rdname acos
 #' @name acos
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @examples \dontrun{acos(df$c)}
 #' @aliases acos,Column-method
@@ -113,7 +113,7 @@ setMethod("approxCountDistinct",
 #'
 #' @rdname ascii
 #' @name ascii
-#' @family string_funcs
+#' @family String functions
 #' @export
 #' @aliases ascii,Column-method
 #' @examples \dontrun{\dontrun{ascii(df$c)}}
@@ -134,7 +134,7 @@ setMethod("ascii",
 #'
 #' @rdname asin
 #' @name asin
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases asin,Column-method
 #' @examples \dontrun{asin(df$c)}
@@ -154,7 +154,7 @@ setMethod("asin",
 #'
 #' @rdname atan
 #' @name atan
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases atan,Column-method
 #' @examples \dontrun{atan(df$c)}
@@ -172,7 +172,7 @@ setMethod("atan",
 #'
 #' @rdname avg
 #' @name avg
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @export
 #' @aliases avg,Column-method
 #' @examples \dontrun{avg(df$c)}
@@ -193,7 +193,7 @@ setMethod("avg",
 #'
 #' @rdname base64
 #' @name base64
-#' @family string_funcs
+#' @family String functions
 #' @export
 #' @aliases base64,Column-method
 #' @examples \dontrun{base64(df$c)}
@@ -214,7 +214,7 @@ setMethod("base64",
 #'
 #' @rdname bin
 #' @name bin
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases bin,Column-method
 #' @examples \dontrun{bin(df$c)}
@@ -234,7 +234,7 @@ setMethod("bin",
 #'
 #' @rdname bitwiseNOT
 #' @name bitwiseNOT
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @export
 #' @aliases bitwiseNOT,Column-method
 #' @examples \dontrun{bitwiseNOT(df$c)}
@@ -254,7 +254,7 @@ setMethod("bitwiseNOT",
 #'
 #' @rdname cbrt
 #' @name cbrt
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases cbrt,Column-method
 #' @examples \dontrun{cbrt(df$c)}
@@ -274,7 +274,7 @@ setMethod("cbrt",
 #'
 #' @rdname ceil
 #' @name ceil
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases ceil,Column-method
 #' @examples \dontrun{ceil(df$c)}
@@ -292,7 +292,7 @@ setMethod("ceil",
 #'
 #' @rdname coalesce
 #' @name coalesce
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @export
 #' @aliases coalesce,Column-method
 #' @examples \dontrun{coalesce(df$c, df$d, df$e)}
@@ -324,7 +324,7 @@ col <- function(x) {
 #'
 #' @rdname column
 #' @name column
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @export
 #' @aliases column,character-method
 #' @examples \dontrun{column("name")}
@@ -342,7 +342,7 @@ setMethod("column",
 #'
 #' @rdname corr
 #' @name corr
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases corr,Column-method
 #' @examples \dontrun{corr(df$c, df$d)}
@@ -360,7 +360,7 @@ setMethod("corr", signature(x = "Column"),
 #'
 #' @rdname cov
 #' @name cov
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases cov,characterOrColumn-method
 #' @examples
@@ -404,7 +404,7 @@ setMethod("covar_samp", signature(col1 = "characterOrColumn", col2 = "characterO
 #'
 #' @rdname covar_pop
 #' @name covar_pop
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @aliases covar_pop,characterOrColumn,characterOrColumn-method
 #' @examples
@@ -432,7 +432,7 @@ setMethod("covar_pop", signature(col1 = "characterOrColumn", col2 = "characterOr
 #'
 #' @rdname cos
 #' @name cos
-#' @family math_funcs
+#' @family Math functions
 #' @aliases cos,Column-method
 #' @export
 #' @examples \dontrun{cos(df$c)}
@@ -452,7 +452,7 @@ setMethod("cos",
 #'
 #' @rdname cosh
 #' @name cosh
-#' @family math_funcs
+#' @family Math functions
 #' @aliases cosh,Column-method
 #' @export
 #' @examples \dontrun{cosh(df$c)}
@@ -471,7 +471,7 @@ setMethod("cosh",
 #'
 #' @rdname count
 #' @name count
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases count,Column-method
 #' @export
 #' @examples \dontrun{count(df$c)}
@@ -492,7 +492,7 @@ setMethod("count",
 #'
 #' @rdname crc32
 #' @name crc32
-#' @family misc_funcs
+#' @family Misc functions
 #' @aliases crc32,Column-method
 #' @export
 #' @examples \dontrun{crc32(df$c)}
@@ -513,7 +513,7 @@ setMethod("crc32",
 #'
 #' @rdname hash
 #' @name hash
-#' @family misc_funcs
+#' @family Misc functions
 #' @aliases hash,Column-method
 #' @export
 #' @examples \dontrun{hash(df$c)}
@@ -537,7 +537,7 @@ setMethod("hash",
 #'
 #' @rdname dayofmonth
 #' @name dayofmonth
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases dayofmonth,Column-method
 #' @export
 #' @examples \dontrun{dayofmonth(df$c)}
@@ -557,7 +557,7 @@ setMethod("dayofmonth",
 #'
 #' @rdname dayofyear
 #' @name dayofyear
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases dayofyear,Column-method
 #' @export
 #' @examples \dontrun{dayofyear(df$c)}
@@ -579,7 +579,7 @@ setMethod("dayofyear",
 #'
 #' @rdname decode
 #' @name decode
-#' @family string_funcs
+#' @family String functions
 #' @aliases decode,Column,character-method
 #' @export
 #' @examples \dontrun{decode(df$c, "UTF-8")}
@@ -601,7 +601,7 @@ setMethod("decode",
 #'
 #' @rdname encode
 #' @name encode
-#' @family string_funcs
+#' @family String functions
 #' @aliases encode,Column,character-method
 #' @export
 #' @examples \dontrun{encode(df$c, "UTF-8")}
@@ -621,7 +621,7 @@ setMethod("encode",
 #'
 #' @rdname exp
 #' @name exp
-#' @family math_funcs
+#' @family Math functions
 #' @aliases exp,Column-method
 #' @export
 #' @examples \dontrun{exp(df$c)}
@@ -642,7 +642,7 @@ setMethod("exp",
 #' @rdname expm1
 #' @name expm1
 #' @aliases expm1,Column-method
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @examples \dontrun{expm1(df$c)}
 #' @note expm1 since 1.5.0
@@ -662,7 +662,7 @@ setMethod("expm1",
 #' @rdname factorial
 #' @name factorial
 #' @aliases factorial,Column-method
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @examples \dontrun{factorial(df$c)}
 #' @note factorial since 1.5.0
@@ -686,7 +686,7 @@ setMethod("factorial",
 #' @rdname first
 #' @name first
 #' @aliases first,characterOrColumn-method
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @export
 #' @examples
 #' \dontrun{
@@ -715,7 +715,7 @@ setMethod("first",
 #' @rdname floor
 #' @name floor
 #' @aliases floor,Column-method
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @examples \dontrun{floor(df$c)}
 #' @note floor since 1.5.0
@@ -734,7 +734,7 @@ setMethod("floor",
 #'
 #' @rdname hex
 #' @name hex
-#' @family math_funcs
+#' @family Math functions
 #' @aliases hex,Column-method
 #' @export
 #' @examples \dontrun{hex(df$c)}
@@ -755,7 +755,7 @@ setMethod("hex",
 #' @rdname hour
 #' @name hour
 #' @aliases hour,Column-method
-#' @family datetime_funcs
+#' @family Date time functions
 #' @export
 #' @examples \dontrun{hour(df$c)}
 #' @note hour since 1.5.0
@@ -777,7 +777,7 @@ setMethod("hour",
 #'
 #' @rdname initcap
 #' @name initcap
-#' @family string_funcs
+#' @family String functions
 #' @aliases initcap,Column-method
 #' @export
 #' @examples \dontrun{initcap(df$c)}
@@ -797,7 +797,7 @@ setMethod("initcap",
 #'
 #' @rdname is.nan
 #' @name is.nan
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @aliases is.nan,Column-method
 #' @export
 #' @examples
@@ -832,7 +832,7 @@ setMethod("isnan",
 #' @rdname kurtosis
 #' @name kurtosis
 #' @aliases kurtosis,Column-method
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @export
 #' @examples \dontrun{kurtosis(df$c)}
 #' @note kurtosis since 1.6.0
@@ -858,7 +858,7 @@ setMethod("kurtosis",
 #' @rdname last
 #' @name last
 #' @aliases last,characterOrColumn-method
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @export
 #' @examples
 #' \dontrun{
@@ -889,7 +889,7 @@ setMethod("last",
 #' @rdname last_day
 #' @name last_day
 #' @aliases last_day,Column-method
-#' @family datetime_funcs
+#' @family Date time functions
 #' @export
 #' @examples \dontrun{last_day(df$c)}
 #' @note last_day since 1.5.0
@@ -909,7 +909,7 @@ setMethod("last_day",
 #' @rdname length
 #' @name length
 #' @aliases length,Column-method
-#' @family string_funcs
+#' @family String functions
 #' @export
 #' @examples \dontrun{length(df$c)}
 #' @note length since 1.5.0
@@ -929,7 +929,7 @@ setMethod("length",
 #' @rdname log
 #' @name log
 #' @aliases log,Column-method
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @examples \dontrun{log(df$c)}
 #' @note log since 1.5.0
@@ -948,7 +948,7 @@ setMethod("log",
 #'
 #' @rdname log10
 #' @name log10
-#' @family math_funcs
+#' @family Math functions
 #' @aliases log10,Column-method
 #' @export
 #' @examples \dontrun{log10(df$c)}
@@ -968,7 +968,7 @@ setMethod("log10",
 #'
 #' @rdname log1p
 #' @name log1p
-#' @family math_funcs
+#' @family Math functions
 #' @aliases log1p,Column-method
 #' @export
 #' @examples \dontrun{log1p(df$c)}
@@ -988,7 +988,7 @@ setMethod("log1p",
 #'
 #' @rdname log2
 #' @name log2
-#' @family math_funcs
+#' @family Math functions
 #' @aliases log2,Column-method
 #' @export
 #' @examples \dontrun{log2(df$c)}
@@ -1008,7 +1008,7 @@ setMethod("log2",
 #'
 #' @rdname lower
 #' @name lower
-#' @family string_funcs
+#' @family String functions
 #' @aliases lower,Column-method
 #' @export
 #' @examples \dontrun{lower(df$c)}
@@ -1028,7 +1028,7 @@ setMethod("lower",
 #'
 #' @rdname ltrim
 #' @name ltrim
-#' @family string_funcs
+#' @family String functions
 #' @aliases ltrim,Column-method
 #' @export
 #' @examples \dontrun{ltrim(df$c)}
@@ -1048,7 +1048,7 @@ setMethod("ltrim",
 #'
 #' @rdname max
 #' @name max
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases max,Column-method
 #' @export
 #' @examples \dontrun{max(df$c)}
@@ -1069,7 +1069,7 @@ setMethod("max",
 #'
 #' @rdname md5
 #' @name md5
-#' @family misc_funcs
+#' @family Misc functions
 #' @aliases md5,Column-method
 #' @export
 #' @examples \dontrun{md5(df$c)}
@@ -1090,7 +1090,7 @@ setMethod("md5",
 #'
 #' @rdname mean
 #' @name mean
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases mean,Column-method
 #' @export
 #' @examples \dontrun{mean(df$c)}
@@ -1111,7 +1111,7 @@ setMethod("mean",
 #' @rdname min
 #' @name min
 #' @aliases min,Column-method
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @export
 #' @examples \dontrun{min(df$c)}
 #' @note min since 1.5.0
@@ -1131,7 +1131,7 @@ setMethod("min",
 #' @rdname minute
 #' @name minute
 #' @aliases minute,Column-method
-#' @family datetime_funcs
+#' @family Date time functions
 #' @export
 #' @examples \dontrun{minute(df$c)}
 #' @note minute since 1.5.0
@@ -1160,7 +1160,7 @@ setMethod("minute",
 #' @rdname monotonically_increasing_id
 #' @aliases monotonically_increasing_id,missing-method
 #' @name monotonically_increasing_id
-#' @family misc_funcs
+#' @family Misc functions
 #' @export
 #' @examples \dontrun{select(df, monotonically_increasing_id())}
 setMethod("monotonically_increasing_id",
@@ -1179,7 +1179,7 @@ setMethod("monotonically_increasing_id",
 #' @rdname month
 #' @name month
 #' @aliases month,Column-method
-#' @family datetime_funcs
+#' @family Date time functions
 #' @export
 #' @examples \dontrun{month(df$c)}
 #' @note month since 1.5.0
@@ -1198,7 +1198,7 @@ setMethod("month",
 #'
 #' @rdname negate
 #' @name negate
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @aliases negate,Column-method
 #' @export
 #' @examples \dontrun{negate(df$c)}
@@ -1218,7 +1218,7 @@ setMethod("negate",
 #'
 #' @rdname quarter
 #' @name quarter
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases quarter,Column-method
 #' @export
 #' @examples \dontrun{quarter(df$c)}
@@ -1238,7 +1238,7 @@ setMethod("quarter",
 #'
 #' @rdname reverse
 #' @name reverse
-#' @family string_funcs
+#' @family String functions
 #' @aliases reverse,Column-method
 #' @export
 #' @examples \dontrun{reverse(df$c)}
@@ -1259,7 +1259,7 @@ setMethod("reverse",
 #'
 #' @rdname rint
 #' @name rint
-#' @family math_funcs
+#' @family Math functions
 #' @aliases rint,Column-method
 #' @export
 #' @examples \dontrun{rint(df$c)}
@@ -1279,7 +1279,7 @@ setMethod("rint",
 #'
 #' @rdname round
 #' @name round
-#' @family math_funcs
+#' @family Math functions
 #' @aliases round,Column-method
 #' @export
 #' @examples \dontrun{round(df$c)}
@@ -1305,7 +1305,7 @@ setMethod("round",
 #' @param ... further arguments to be passed to or from other methods.
 #' @rdname bround
 #' @name bround
-#' @family math_funcs
+#' @family Math functions
 #' @aliases bround,Column-method
 #' @export
 #' @examples \dontrun{bround(df$c, 0)}
@@ -1326,7 +1326,7 @@ setMethod("bround",
 #'
 #' @rdname rtrim
 #' @name rtrim
-#' @family string_funcs
+#' @family String functions
 #' @aliases rtrim,Column-method
 #' @export
 #' @examples \dontrun{rtrim(df$c)}
@@ -1346,7 +1346,7 @@ setMethod("rtrim",
 #' @param na.rm currently not used.
 #' @rdname sd
 #' @name sd
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases sd,Column-method
 #' @seealso \link{stddev_pop}, \link{stddev_samp}
 #' @export
@@ -1372,7 +1372,7 @@ setMethod("sd",
 #'
 #' @rdname second
 #' @name second
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases second,Column-method
 #' @export
 #' @examples \dontrun{second(df$c)}
@@ -1393,7 +1393,7 @@ setMethod("second",
 #'
 #' @rdname sha1
 #' @name sha1
-#' @family misc_funcs
+#' @family Misc functions
 #' @aliases sha1,Column-method
 #' @export
 #' @examples \dontrun{sha1(df$c)}
@@ -1414,7 +1414,7 @@ setMethod("sha1",
 #' @rdname sign
 #' @name signum
 #' @aliases signum,Column-method
-#' @family math_funcs
+#' @family Math functions
 #' @export
 #' @examples \dontrun{signum(df$c)}
 #' @note signum since 1.5.0
@@ -1433,7 +1433,7 @@ setMethod("signum",
 #'
 #' @rdname sin
 #' @name sin
-#' @family math_funcs
+#' @family Math functions
 #' @aliases sin,Column-method
 #' @export
 #' @examples \dontrun{sin(df$c)}
@@ -1453,7 +1453,7 @@ setMethod("sin",
 #'
 #' @rdname sinh
 #' @name sinh
-#' @family math_funcs
+#' @family Math functions
 #' @aliases sinh,Column-method
 #' @export
 #' @examples \dontrun{sinh(df$c)}
@@ -1473,7 +1473,7 @@ setMethod("sinh",
 #'
 #' @rdname skewness
 #' @name skewness
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases skewness,Column-method
 #' @export
 #' @examples \dontrun{skewness(df$c)}
@@ -1493,7 +1493,7 @@ setMethod("skewness",
 #'
 #' @rdname soundex
 #' @name soundex
-#' @family string_funcs
+#' @family String functions
 #' @aliases soundex,Column-method
 #' @export
 #' @examples \dontrun{soundex(df$c)}
@@ -1546,7 +1546,7 @@ setMethod("stddev",
 #'
 #' @rdname stddev_pop
 #' @name stddev_pop
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases stddev_pop,Column-method
 #' @seealso \link{sd}, \link{stddev_samp}
 #' @export
@@ -1567,7 +1567,7 @@ setMethod("stddev_pop",
 #'
 #' @rdname stddev_samp
 #' @name stddev_samp
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases stddev_samp,Column-method
 #' @seealso \link{stddev_pop}, \link{sd}
 #' @export
@@ -1589,7 +1589,7 @@ setMethod("stddev_samp",
 #'
 #' @rdname struct
 #' @name struct
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @aliases struct,characterOrColumn-method
 #' @export
 #' @examples
@@ -1618,7 +1618,7 @@ setMethod("struct",
 #'
 #' @rdname sqrt
 #' @name sqrt
-#' @family math_funcs
+#' @family Math functions
 #' @aliases sqrt,Column-method
 #' @export
 #' @examples \dontrun{sqrt(df$c)}
@@ -1638,7 +1638,7 @@ setMethod("sqrt",
 #'
 #' @rdname sum
 #' @name sum
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases sum,Column-method
 #' @export
 #' @examples \dontrun{sum(df$c)}
@@ -1658,7 +1658,7 @@ setMethod("sum",
 #'
 #' @rdname sumDistinct
 #' @name sumDistinct
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases sumDistinct,Column-method
 #' @export
 #' @examples \dontrun{sumDistinct(df$c)}
@@ -1678,7 +1678,7 @@ setMethod("sumDistinct",
 #'
 #' @rdname tan
 #' @name tan
-#' @family math_funcs
+#' @family Math functions
 #' @aliases tan,Column-method
 #' @export
 #' @examples \dontrun{tan(df$c)}
@@ -1698,7 +1698,7 @@ setMethod("tan",
 #'
 #' @rdname tanh
 #' @name tanh
-#' @family math_funcs
+#' @family Math functions
 #' @aliases tanh,Column-method
 #' @export
 #' @examples \dontrun{tanh(df$c)}
@@ -1718,7 +1718,7 @@ setMethod("tanh",
 #'
 #' @rdname toDegrees
 #' @name toDegrees
-#' @family math_funcs
+#' @family Math functions
 #' @aliases toDegrees,Column-method
 #' @export
 #' @examples \dontrun{toDegrees(df$c)}
@@ -1738,7 +1738,7 @@ setMethod("toDegrees",
 #'
 #' @rdname toRadians
 #' @name toRadians
-#' @family math_funcs
+#' @family Math functions
 #' @aliases toRadians,Column-method
 #' @export
 #' @examples \dontrun{toRadians(df$c)}
@@ -1764,7 +1764,7 @@ setMethod("toRadians",
 #'
 #' @rdname to_date
 #' @name to_date
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases to_date,Column,missing-method
 #' @export
 #' @examples
@@ -1782,7 +1782,7 @@ setMethod("to_date",
 
 #' @rdname to_date
 #' @name to_date
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases to_date,Column,character-method
 #' @export
 #' @note to_date(Column, character) since 2.2.0
@@ -1802,7 +1802,7 @@ setMethod("to_date",
 #' @param ... additional named properties to control how it is converted, accepts the same options
 #'            as the JSON data source.
 #'
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname to_json
 #' @name to_json
 #' @aliases to_json,Column-method
@@ -1839,7 +1839,7 @@ setMethod("to_json", signature(x = "Column"),
 #'
 #' @rdname to_timestamp
 #' @name to_timestamp
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases to_timestamp,Column,missing-method
 #' @export
 #' @examples
@@ -1857,7 +1857,7 @@ setMethod("to_timestamp",
 
 #' @rdname to_timestamp
 #' @name to_timestamp
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases to_timestamp,Column,character-method
 #' @export
 #' @note to_timestamp(Column, character) since 2.2.0
@@ -1876,7 +1876,7 @@ setMethod("to_timestamp",
 #'
 #' @rdname trim
 #' @name trim
-#' @family string_funcs
+#' @family String functions
 #' @aliases trim,Column-method
 #' @export
 #' @examples \dontrun{trim(df$c)}
@@ -1897,7 +1897,7 @@ setMethod("trim",
 #'
 #' @rdname unbase64
 #' @name unbase64
-#' @family string_funcs
+#' @family String functions
 #' @aliases unbase64,Column-method
 #' @export
 #' @examples \dontrun{unbase64(df$c)}
@@ -1918,7 +1918,7 @@ setMethod("unbase64",
 #'
 #' @rdname unhex
 #' @name unhex
-#' @family math_funcs
+#' @family Math functions
 #' @aliases unhex,Column-method
 #' @export
 #' @examples \dontrun{unhex(df$c)}
@@ -1938,7 +1938,7 @@ setMethod("unhex",
 #'
 #' @rdname upper
 #' @name upper
-#' @family string_funcs
+#' @family String functions
 #' @aliases upper,Column-method
 #' @export
 #' @examples \dontrun{upper(df$c)}
@@ -1958,7 +1958,7 @@ setMethod("upper",
 #' @param y,na.rm,use currently not used.
 #' @rdname var
 #' @name var
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases var,Column-method
 #' @seealso \link{var_pop}, \link{var_samp}
 #' @export
@@ -1995,7 +1995,7 @@ setMethod("variance",
 #'
 #' @rdname var_pop
 #' @name var_pop
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases var_pop,Column-method
 #' @seealso \link{var}, \link{var_samp}
 #' @export
@@ -2017,7 +2017,7 @@ setMethod("var_pop",
 #' @rdname var_samp
 #' @name var_samp
 #' @aliases var_samp,Column-method
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @seealso \link{var_pop}, \link{var}
 #' @export
 #' @examples \dontrun{var_samp(df$c)}
@@ -2038,7 +2038,7 @@ setMethod("var_samp",
 #' @rdname weekofyear
 #' @name weekofyear
 #' @aliases weekofyear,Column-method
-#' @family datetime_funcs
+#' @family Date time functions
 #' @export
 #' @examples \dontrun{weekofyear(df$c)}
 #' @note weekofyear since 1.5.0
@@ -2057,7 +2057,7 @@ setMethod("weekofyear",
 #'
 #' @rdname year
 #' @name year
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases year,Column-method
 #' @export
 #' @examples \dontrun{year(df$c)}
@@ -2079,7 +2079,7 @@ setMethod("year",
 #'
 #' @rdname atan2
 #' @name atan2
-#' @family math_funcs
+#' @family Math functions
 #' @aliases atan2,Column-method
 #' @export
 #' @examples \dontrun{atan2(df$c, x)}
@@ -2103,7 +2103,7 @@ setMethod("atan2", signature(y = "Column"),
 #' @rdname datediff
 #' @name datediff
 #' @aliases datediff,Column-method
-#' @family datetime_funcs
+#' @family Date time functions
 #' @export
 #' @examples \dontrun{datediff(df$c, x)}
 #' @note datediff since 1.5.0
@@ -2125,7 +2125,7 @@ setMethod("datediff", signature(y = "Column"),
 #'
 #' @rdname hypot
 #' @name hypot
-#' @family math_funcs
+#' @family Math functions
 #' @aliases hypot,Column-method
 #' @export
 #' @examples \dontrun{hypot(df$c, x)}
@@ -2148,7 +2148,7 @@ setMethod("hypot", signature(y = "Column"),
 #'
 #' @rdname levenshtein
 #' @name levenshtein
-#' @family string_funcs
+#' @family String functions
 #' @aliases levenshtein,Column-method
 #' @export
 #' @examples \dontrun{levenshtein(df$c, x)}
@@ -2171,7 +2171,7 @@ setMethod("levenshtein", signature(y = "Column"),
 #'
 #' @rdname months_between
 #' @name months_between
-#' @family datetime_funcs
+#' @family Date time functions
 #' @aliases months_between,Column-method
 #' @export
 #' @examples \dontrun{months_between(df$c, x)}
@@ -2195,7 +2195,7 @@ setMethod("months_between", signature(y = "Column"),
 #'
 #' @rdname nanvl
 #' @name nanvl
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @aliases nanvl,Column-method
 #' @export
 #' @examples \dontrun{nanvl(df$c, x)}
@@ -2219,7 +2219,7 @@ setMethod("nanvl", signature(y = "Column"),
 #' @rdname pmod
 #' @name pmod
 #' @docType methods
-#' @family math_funcs
+#' @family Math functions
 #' @aliases pmod,Column-method
 #' @export
 #' @examples \dontrun{pmod(df$c, x)}
@@ -2257,7 +2257,7 @@ setMethod("approxCountDistinct",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @rdname countDistinct
 #' @name countDistinct
 #' @aliases countDistinct,Column-method
@@ -2285,7 +2285,7 @@ setMethod("countDistinct",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family string_funcs
+#' @family String functions
 #' @rdname concat
 #' @name concat
 #' @aliases concat,Column-method
@@ -2311,7 +2311,7 @@ setMethod("concat",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname greatest
 #' @name greatest
 #' @aliases greatest,Column-method
@@ -2338,7 +2338,7 @@ setMethod("greatest",
 #' @param x Column to compute on
 #' @param ... other columns
 #'
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname least
 #' @aliases least,Column-method
 #' @name least
@@ -2422,7 +2422,7 @@ setMethod("n", signature(x = "Column"),
 #' @param y Column to compute on.
 #' @param x date format specification.
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname date_format
 #' @name date_format
 #' @aliases date_format,Column,character-method
@@ -2447,7 +2447,7 @@ setMethod("date_format", signature(y = "Column", x = "character"),
 #' @param ... additional named properties to control how the json is parsed, accepts the same
 #'            options as the JSON data source.
 #'
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname from_json
 #' @name from_json
 #' @aliases from_json,Column,structType-method
@@ -2482,7 +2482,7 @@ setMethod("from_json", signature(x = "Column", schema = "structType"),
 #' @param y Column to compute on.
 #' @param x time zone to use.
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname from_utc_timestamp
 #' @name from_utc_timestamp
 #' @aliases from_utc_timestamp,Column,character-method
@@ -2505,7 +2505,7 @@ setMethod("from_utc_timestamp", signature(y = "Column", x = "character"),
 #'
 #' @param y column to check
 #' @param x substring to check
-#' @family string_funcs
+#' @family String functions
 #' @aliases instr,Column,character-method
 #' @rdname instr
 #' @name instr
@@ -2532,7 +2532,7 @@ setMethod("instr", signature(y = "Column", x = "character"),
 #' @param y Column to compute on.
 #' @param x Day of the week string.
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname next_day
 #' @name next_day
 #' @aliases next_day,Column,character-method
@@ -2557,7 +2557,7 @@ setMethod("next_day", signature(y = "Column", x = "character"),
 #' @param y Column to compute on
 #' @param x timezone to use
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname to_utc_timestamp
 #' @name to_utc_timestamp
 #' @aliases to_utc_timestamp,Column,character-method
@@ -2578,7 +2578,7 @@ setMethod("to_utc_timestamp", signature(y = "Column", x = "character"),
 #' @param x Number of months to add
 #'
 #' @name add_months
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname add_months
 #' @aliases add_months,Column,numeric-method
 #' @export
@@ -2597,7 +2597,7 @@ setMethod("add_months", signature(y = "Column", x = "numeric"),
 #' @param y Column to compute on
 #' @param x Number of days to add
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname date_add
 #' @name date_add
 #' @aliases date_add,Column,numeric-method
@@ -2617,7 +2617,7 @@ setMethod("date_add", signature(y = "Column", x = "numeric"),
 #' @param y Column to compute on
 #' @param x Number of days to substract
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname date_sub
 #' @name date_sub
 #' @aliases date_sub,Column,numeric-method
@@ -2640,7 +2640,7 @@ setMethod("date_sub", signature(y = "Column", x = "numeric"),
 #'
 #' @param y column to format
 #' @param x number of decimal place to format to
-#' @family string_funcs
+#' @family String functions
 #' @rdname format_number
 #' @name format_number
 #' @aliases format_number,Column,numeric-method
@@ -2662,7 +2662,7 @@ setMethod("format_number", signature(y = "Column", x = "numeric"),
 #'
 #' @param y column to compute SHA-2 on.
 #' @param x one of 224, 256, 384, or 512.
-#' @family misc_funcs
+#' @family Misc functions
 #' @rdname sha2
 #' @name sha2
 #' @aliases sha2,Column,numeric-method
@@ -2683,7 +2683,7 @@ setMethod("sha2", signature(y = "Column", x = "numeric"),
 #' @param y column to compute on.
 #' @param x number of bits to shift.
 #'
-#' @family math_funcs
+#' @family Math functions
 #' @rdname shiftLeft
 #' @name shiftLeft
 #' @aliases shiftLeft,Column,numeric-method
@@ -2706,7 +2706,7 @@ setMethod("shiftLeft", signature(y = "Column", x = "numeric"),
 #' @param y column to compute on.
 #' @param x number of bits to shift.
 #'
-#' @family math_funcs
+#' @family Math functions
 #' @rdname shiftRight
 #' @name shiftRight
 #' @aliases shiftRight,Column,numeric-method
@@ -2729,7 +2729,7 @@ setMethod("shiftRight", signature(y = "Column", x = "numeric"),
 #' @param y column to compute on.
 #' @param x number of bits to shift.
 #'
-#' @family math_funcs
+#' @family Math functions
 #' @rdname shiftRightUnsigned
 #' @name shiftRightUnsigned
 #' @aliases shiftRightUnsigned,Column,numeric-method
@@ -2753,7 +2753,7 @@ setMethod("shiftRightUnsigned", signature(y = "Column", x = "numeric"),
 #' @param sep separator to use.
 #' @param ... other columns to concatenate.
 #'
-#' @family string_funcs
+#' @family String functions
 #' @rdname concat_ws
 #' @name concat_ws
 #' @aliases concat_ws,character,Column-method
@@ -2775,7 +2775,7 @@ setMethod("concat_ws", signature(sep = "character", x = "Column"),
 #' @param fromBase base to convert from.
 #' @param toBase base to convert to.
 #'
-#' @family math_funcs
+#' @family Math functions
 #' @rdname conv
 #' @aliases conv,Column,numeric,numeric-method
 #' @name conv
@@ -2798,7 +2798,7 @@ setMethod("conv", signature(x = "Column", fromBase = "numeric", toBase = "numeri
 #' SparkDataFrame.selectExpr
 #'
 #' @param x an expression character object to be parsed.
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname expr
 #' @aliases expr,character-method
 #' @name expr
@@ -2818,7 +2818,7 @@ setMethod("expr", signature(x = "character"),
 #' @param format a character object of format strings.
 #' @param x a Column.
 #' @param ... additional Column(s).
-#' @family string_funcs
+#' @family String functions
 #' @rdname format_string
 #' @name format_string
 #' @aliases format_string,character,Column-method
@@ -2845,7 +2845,7 @@ setMethod("format_string", signature(format = "character", x = "Column"),
 #'               \href{http://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html}{
 #'               Customizing Formats} for available options.
 #' @param ... further arguments to be passed to or from other methods.
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname from_unixtime
 #' @name from_unixtime
 #' @aliases from_unixtime,Column-method
@@ -2890,7 +2890,7 @@ setMethod("from_unixtime", signature(x = "Column"),
 #' @param ... further arguments to be passed to or from other methods.
 #' @return An output column of struct called 'window' by default with the nested columns 'start'
 #'         and 'end'.
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname window
 #' @name window
 #' @aliases window,Column-method
@@ -2946,7 +2946,7 @@ setMethod("window", signature(x = "Column"),
 #' @param str a Column where matches are sought for each entry.
 #' @param pos start position of search.
 #' @param ... further arguments to be passed to or from other methods.
-#' @family string_funcs
+#' @family String functions
 #' @rdname locate
 #' @aliases locate,character,Column-method
 #' @name locate
@@ -2968,7 +2968,7 @@ setMethod("locate", signature(substr = "character", str = "Column"),
 #' @param x the string Column to be left-padded.
 #' @param len maximum length of each output result.
 #' @param pad a character string to be padded with.
-#' @family string_funcs
+#' @family String functions
 #' @rdname lpad
 #' @aliases lpad,Column,numeric,character-method
 #' @name lpad
@@ -2989,7 +2989,7 @@ setMethod("lpad", signature(x = "Column", len = "numeric", pad = "character"),
 #' from U[0.0, 1.0].
 #'
 #' @param seed a random seed. Can be missing.
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname rand
 #' @name rand
 #' @aliases rand,missing-method
@@ -3019,7 +3019,7 @@ setMethod("rand", signature(seed = "numeric"),
 #' the standard normal distribution.
 #'
 #' @param seed a random seed. Can be missing.
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname randn
 #' @name randn
 #' @aliases randn,missing-method
@@ -3051,7 +3051,7 @@ setMethod("randn", signature(seed = "numeric"),
 #' @param x a string Column.
 #' @param pattern a regular expression.
 #' @param idx a group index.
-#' @family string_funcs
+#' @family String functions
 #' @rdname regexp_extract
 #' @name regexp_extract
 #' @aliases regexp_extract,Column,character,numeric-method
@@ -3074,7 +3074,7 @@ setMethod("regexp_extract",
 #' @param x a string Column.
 #' @param pattern a regular expression.
 #' @param replacement a character string that a matched \code{pattern} is replaced with.
-#' @family string_funcs
+#' @family String functions
 #' @rdname regexp_replace
 #' @name regexp_replace
 #' @aliases regexp_replace,Column,character,character-method
@@ -3097,7 +3097,7 @@ setMethod("regexp_replace",
 #' @param x the string Column to be right-padded.
 #' @param len maximum length of each output result.
 #' @param pad a character string to be padded with.
-#' @family string_funcs
+#' @family String functions
 #' @rdname rpad
 #' @name rpad
 #' @aliases rpad,Column,numeric,character-method
@@ -3124,7 +3124,7 @@ setMethod("rpad", signature(x = "Column", len = "numeric", pad = "character"),
 #' @param count number of occurrences of \code{delim} before the substring is returned.
 #'              A positive number means counting from the left, while negative means
 #'              counting from the right.
-#' @family string_funcs
+#' @family String functions
 #' @rdname substring_index
 #' @aliases substring_index,Column,character,numeric-method
 #' @name substring_index
@@ -3156,7 +3156,7 @@ setMethod("substring_index",
 #' @param replaceString a target string where each \code{matchingString} character will
 #'                      be replaced by the character in \code{replaceString}
 #'                      at the same location, if any.
-#' @family string_funcs
+#' @family String functions
 #' @rdname translate
 #' @name translate
 #' @aliases translate,Column,character,character-method
@@ -3175,7 +3175,7 @@ setMethod("translate",
 #'
 #' Gets current Unix timestamp in seconds.
 #'
-#' @family datetime_funcs
+#' @family Date time functions
 #' @rdname unix_timestamp
 #' @name unix_timestamp
 #' @aliases unix_timestamp,missing,missing-method
@@ -3225,7 +3225,7 @@ setMethod("unix_timestamp", signature(x = "Column", format = "character"),
 #'
 #' @param condition the condition to test on. Must be a Column expression.
 #' @param value result expression.
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname when
 #' @name when
 #' @aliases when,Column-method
@@ -3249,7 +3249,7 @@ setMethod("when", signature(condition = "Column", value = "ANY"),
 #' @param test a Column expression that describes the condition.
 #' @param yes return values for \code{TRUE} elements of test.
 #' @param no return values for \code{FALSE} elements of test.
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname ifelse
 #' @name ifelse
 #' @aliases ifelse,Column-method
@@ -3287,7 +3287,7 @@ setMethod("ifelse",
 #'
 #' @rdname cume_dist
 #' @name cume_dist
-#' @family window_funcs
+#' @family Window functions
 #' @aliases cume_dist,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3316,7 +3316,7 @@ setMethod("cume_dist",
 #'
 #' @rdname dense_rank
 #' @name dense_rank
-#' @family window_funcs
+#' @family Window functions
 #' @aliases dense_rank,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3348,7 +3348,7 @@ setMethod("dense_rank",
 #' @rdname lag
 #' @name lag
 #' @aliases lag,characterOrColumn-method
-#' @family window_funcs
+#' @family Window functions
 #' @export
 #' @examples \dontrun{
 #'   df <- createDataFrame(mtcars)
@@ -3390,7 +3390,7 @@ setMethod("lag",
 #'
 #' @rdname lead
 #' @name lead
-#' @family window_funcs
+#' @family Window functions
 #' @aliases lead,characterOrColumn,numeric-method
 #' @export
 #' @examples \dontrun{
@@ -3430,7 +3430,7 @@ setMethod("lead",
 #' @rdname ntile
 #' @name ntile
 #' @aliases ntile,numeric-method
-#' @family window_funcs
+#' @family Window functions
 #' @export
 #' @examples \dontrun{
 #'   df <- createDataFrame(mtcars)
@@ -3461,7 +3461,7 @@ setMethod("ntile",
 #'
 #' @rdname percent_rank
 #' @name percent_rank
-#' @family window_funcs
+#' @family Window functions
 #' @aliases percent_rank,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3491,7 +3491,7 @@ setMethod("percent_rank",
 #'
 #' @rdname rank
 #' @name rank
-#' @family window_funcs
+#' @family Window functions
 #' @aliases rank,missing-method
 #' @export
 #' @examples \dontrun{
@@ -3529,7 +3529,7 @@ setMethod("rank",
 #' @rdname row_number
 #' @name row_number
 #' @aliases row_number,missing-method
-#' @family window_funcs
+#' @family Window functions
 #' @export
 #' @examples \dontrun{
 #'   df <- createDataFrame(mtcars)
@@ -3555,7 +3555,7 @@ setMethod("row_number",
 #' @rdname array_contains
 #' @aliases array_contains,Column-method
 #' @name array_contains
-#' @family collection_funcs
+#' @family Collection functions
 #' @export
 #' @examples \dontrun{array_contains(df$c, 1)}
 #' @note array_contains since 1.6.0
@@ -3574,7 +3574,7 @@ setMethod("array_contains",
 #'
 #' @rdname explode
 #' @name explode
-#' @family collection_funcs
+#' @family Collection functions
 #' @aliases explode,Column-method
 #' @export
 #' @examples \dontrun{explode(df$c)}
@@ -3595,7 +3595,7 @@ setMethod("explode",
 #' @rdname size
 #' @name size
 #' @aliases size,Column-method
-#' @family collection_funcs
+#' @family Collection functions
 #' @export
 #' @examples \dontrun{size(df$c)}
 #' @note size since 1.5.0
@@ -3618,7 +3618,7 @@ setMethod("size",
 #' @rdname sort_array
 #' @name sort_array
 #' @aliases sort_array,Column-method
-#' @family collection_funcs
+#' @family Collection functions
 #' @export
 #' @examples
 #' \dontrun{
@@ -3641,7 +3641,7 @@ setMethod("sort_array",
 #'
 #' @rdname posexplode
 #' @name posexplode
-#' @family collection_funcs
+#' @family Collection functions
 #' @aliases posexplode,Column-method
 #' @export
 #' @examples \dontrun{posexplode(df$c)}
@@ -3660,7 +3660,7 @@ setMethod("posexplode",
 #' @param x Column to compute on
 #' @param ... additional Column(s).
 #'
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname create_array
 #' @name create_array
 #' @aliases create_array,Column-method
@@ -3688,7 +3688,7 @@ setMethod("create_array",
 #' @param x Column to compute on
 #' @param ... additional Column(s).
 #'
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @rdname create_map
 #' @name create_map
 #' @aliases create_map,Column-method
@@ -3714,7 +3714,7 @@ setMethod("create_map",
 #'
 #' @rdname collect_list
 #' @name collect_list
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases collect_list,Column-method
 #' @export
 #' @examples \dontrun{collect_list(df$x)}
@@ -3734,7 +3734,7 @@ setMethod("collect_list",
 #'
 #' @rdname collect_set
 #' @name collect_set
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases collect_set,Column-method
 #' @export
 #' @examples \dontrun{collect_set(df$x)}
@@ -3756,7 +3756,7 @@ setMethod("collect_set",
 #' @param pattern Java regular expression
 #'
 #' @rdname split_string
-#' @family string_funcs
+#' @family String functions
 #' @aliases split_string,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3785,7 +3785,7 @@ setMethod("split_string",
 #' @param n Number of repetitions
 #'
 #' @rdname repeat_string
-#' @family string_funcs
+#' @family String functions
 #' @aliases repeat_string,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3814,7 +3814,7 @@ setMethod("repeat_string",
 #'
 #' @rdname explode_outer
 #' @name explode_outer
-#' @family collection_funcs
+#' @family Collection functions
 #' @aliases explode_outer,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3842,7 +3842,7 @@ setMethod("explode_outer",
 #'
 #' @rdname posexplode_outer
 #' @name posexplode_outer
-#' @family collection_funcs
+#' @family Collection functions
 #' @aliases posexplode_outer,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3871,7 +3871,7 @@ setMethod("posexplode_outer",
 #' @rdname not
 #' @name not
 #' @aliases not,Column-method
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @export
 #' @examples \dontrun{
 #' df <- createDataFrame(data.frame(
@@ -3903,7 +3903,7 @@ setMethod("not",
 #'
 #' @rdname grouping_bit
 #' @name grouping_bit
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases grouping_bit,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3944,7 +3944,7 @@ setMethod("grouping_bit",
 #'
 #' @rdname grouping_id
 #' @name grouping_id
-#' @family agg_funcs
+#' @family Aggregate functions
 #' @aliases grouping_id,Column-method
 #' @export
 #' @examples \dontrun{
@@ -3982,7 +3982,7 @@ setMethod("grouping_id",
 #'
 #' @rdname input_file_name
 #' @name input_file_name
-#' @family normal_funcs
+#' @family Non-aggregate functions
 #' @aliases input_file_name,missing-method
 #' @export
 #' @examples \dontrun{


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Change current short annotations (same as Scala `@group`) to verbose names (same as Scala `@groupname`). 

    Before:

    ![image](https://cloud.githubusercontent.com/assets/1554276/26033909/9a98b596-38b4-11e7-961e-15fd9ea7440d.png)

    After:
    ![image](https://cloud.githubusercontent.com/assets/1554276/26033903/727a9944-38b4-11e7-8873-b09c553f4ec3.png)


- Add missing `@family` annotations.

## How was this patch tested?

`check-cran.R` (skipping tests), manual inspection.
