### PR TITLE
[ SPARK-20739][CORE][TEST]Supplement the new unit tests to SparkContextSchedulerCreationSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextSchedulerCreationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSchedulerCreationSuite.scala
@@ -129,4 +129,29 @@ class SparkContextSchedulerCreationSuite
       case _ => fail()
     }
   }
+
+  test("bad-spark-url") {
+    val e = intercept[SparkException] {
+      createTaskScheduler("spark:*")
+    }
+    assert(e.getMessage.contains("spark:*"))
+  }
+
+  test("spark-localhost") {
+    val conf = new SparkConf().set("spark.default.parallelism", "16")
+    val sched = createTaskScheduler("spark://localhost:1234", "spark", conf)
+      sched.backend match {
+      case s: StandaloneSchedulerBackend => assert(s.defaultParallelism() === 16)
+      case _ => fail()
+    }
+  }
+
+  test("spark-ipaddress") {
+    val conf = new SparkConf().set("spark.default.parallelism", "16")
+    val sched = createTaskScheduler("spark://127.0.0.1:1234", "spark", conf)
+    sched.backend match {
+      case s: StandaloneSchedulerBackend => assert(s.defaultParallelism() === 16)
+      case _ => fail()
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the new unit tests to support test 'SPARK_REGEX(sparkUrl)' branch in createTaskScheduler methods.  

## How was this patch tested?

The new unit test.
