### PR TITLE
[SPARK-18838][CORE] Introduce blocking strategy for LiveListener

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -158,6 +158,11 @@ package object config {
       .checkValue(_ > 0, "The capacity of listener bus event queue must not be negative")
       .createWithDefault(10000)
 
+  private[spark] val LISTENER_BUS_EVENT_QUEUE_DROP =
+    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.drop")
+      .booleanConf
+      .createWithDefault(true)
+
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
     .stringConf


### PR DESCRIPTION
## What changes were proposed in this pull request?
When the queue of the LiveListener is full, events are dropped in an arbitrary fashion. 
But some of them can be crucial for the good execution of the job. The job doesn t in general fail immediately, but presents incoherent state before dying.
 In this pull request:
 the queue implementation was refactored to increase  a bit the performances
 (reduce object allocation & decrease lock usage)
 A "waiting for space" strategy is introduced and can be used instead of
 the default and current "dropping" strategy.
 The new strategy even if it does not resolve the "real" problem
 (the small dequeing rate) brings a lot more stability to the jobs with a
  huge event production rate (i.e jobs with many partitions).
The EventLogListener which is the most time-consuming listener (see the attached files in the Jira issue for timings) is now asynchronous (not the default implementation, but a new version which is configurable with a simple parameter)

  ## How was this patch tested?
  Existing unit tests have been enriched to run on both strategy.
  + manual tests have been run on the cluster
