### PR TITLE
[SPARK-20778][SQL] Implement array_intersect function.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -363,6 +363,7 @@ object FunctionRegistry {
     // collection functions
     expression[CreateArray]("array"),
     expression[ArrayContains]("array_contains"),
+    expression[ArrayIntersect]("array_intersect"),
     expression[CreateMap]("map"),
     expression[CreateNamedStruct]("named_struct"),
     expression[MapKeys]("map_keys"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -105,4 +105,117 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(ArrayContains(a3, Literal("")), null)
     checkEvaluation(ArrayContains(a3, Literal.create(null, StringType)), null)
   }
+
+  test("Array intersects") {
+    val a0 = Literal.create(1, IntegerType)
+    val a1 = Literal.create(2, IntegerType)
+    val a2 = Literal.create(3, IntegerType)
+    val a3 = Literal.create(4, IntegerType)
+
+    val b0 = Literal.create(1L, LongType)
+    val b2 = Literal.create(3L, LongType)
+
+    val c0 = Literal.create(1.0, DoubleType)
+    val d0 = Literal.create("1", StringType)
+
+    val nullLiteral = Literal.create(null)
+
+    checkEvaluation(ArrayIntersect(Seq(nullLiteral)), null)
+
+    checkEvaluation(ArrayIntersect(Seq(CreateArray(Seq()))), Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1)), CreateArray(Seq(a2)), CreateArray(Seq(a3)))), Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1)), CreateArray(Seq(a0)))), Seq(1))
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1)), CreateArray(Seq(a0)), CreateArray(Seq(a0)))), Seq(1))
+
+    checkEvaluation(ArrayIntersect(Seq(ArrayIntersect(Seq(CreateArray(
+      Seq(a0, a1)), CreateArray(Seq(a2)))), CreateArray(Seq(a0)))), Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(CreateArray(Seq(a0, a1)),
+      CreateArray(Seq(Cast(b0, IntegerType), Cast(b2, IntegerType))))), Seq(1))
+
+    checkEvaluation(ArrayIntersect(
+      Seq(CreateArray(Seq(a0, a0, a1, a3)), CreateArray(Seq(a0, a2, a3, a3)),
+        CreateArray(Seq(a0, a1, a3)))), Seq(1, 1, 4))
+
+    checkEvaluation(ArrayIntersect(Seq(nullLiteral, CreateArray(Seq(a0, a2, a3, a3)),
+      CreateArray(Seq(a0, a1, a3)))), null)
+
+    checkEvaluation(ArrayIntersect(Seq(CreateArray(Seq(a0, a1)), CreateArray(Seq(a0)))), Seq(1))
+
+    checkEvaluation(If(LessThan(Rand(0L), c0), a0, a0), 1)
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a0, a1, a3)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a2, a3, a3)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a2, a3)))), Seq(1, 1, 4))
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a1)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0))))), Seq(1))
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a1)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), d0, d0))))), Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1)), CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0))))), Seq(1))
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1)), CreateArray(Seq(If(LessThan(Rand(0L), c0), d0, d0))))), Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a1)), CreateArray(Seq(a0)))), Seq(1))
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1, a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a1, a2)),
+      CreateArray(Seq(a0, a1, a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a2)))),
+      Seq(1, 3))
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(d0, Cast(a1, StringType), Cast(a2, StringType))),
+      CreateArray(Seq(a1, a2)))),
+      Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(a0, a1, a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a1, a2)),
+      CreateArray(Seq(a0, a1, a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), d0, d0), Cast(a2, StringType))))),
+      Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(
+      nullLiteral,
+      CreateArray(Seq(a0, a1, a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), d0, d0))))),
+      null)
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), nullLiteral, nullLiteral))),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), a0, a0), a2)),
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), d0, d0))))),
+      Seq())
+
+    checkEvaluation(ArrayIntersect(Seq(CreateArray(Seq(a0, a1)), nullLiteral)), null)
+
+    checkEvaluation(ArrayIntersect(Seq(nullLiteral, CreateArray(Seq(a0, a1)))), null)
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), nullLiteral, nullLiteral))),
+      nullLiteral, nullLiteral, CreateArray(Seq(a0)))), null)
+
+    checkEvaluation(ArrayIntersect(Seq(
+      CreateArray(Seq(If(LessThan(Rand(0L), c0), nullLiteral, nullLiteral))),
+      CreateArray(Seq(a0, a1)),
+      CreateArray(Seq(a0)))),
+      Seq())
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -163,6 +163,7 @@ trait ExpressionEvalHelper extends GeneratorDrivenPropertyChecks {
           Alias(expression, s"Optimized($expression)2")() :: Nil),
       expression)
 
+    plan.initialize(0)
     val unsafeRow = plan(inputRow)
     val input = if (inputRow == EmptyRow) "" else s", input: $inputRow"
 


### PR DESCRIPTION
Implement array_intersect UDF for intersecting first array with set of arrays.

## What changes were proposed in this pull request?

Implement a function array_intersect that computes the intersection of first array and remaining arrays.  Similar to hive implementation of array intersect.

## How was this patch tested?

Added unit tests to validate eval and code gen logic.
Performed testing using spark-shell with similar tests to hive array intersect.
