### PR TITLE
[SPARK-20779][Examples]The ASF header placed in an incorrect location in some files.

### DIFF
--- a/examples/src/main/python/parquet_inputformat.py
+++ b/examples/src/main/python/parquet_inputformat.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import print_function
 
 import sys
 

--- a/examples/src/main/python/pi.py
+++ b/examples/src/main/python/pi.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import print_function
 
 import sys
 from random import random


### PR DESCRIPTION
## What changes were proposed in this pull request?

The license is not at the top in some files. and it will be best if we update these places of the ASF header to be consistent with other files.

## How was this patch tested?

manual tests
