### PR TITLE
[SPARK-20783][SQL] Enhance ColumnVector to keep UnsafeArrayData for array

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -65,19 +65,15 @@ public final class ColumnarBatch {
   final Row row;
 
   public static ColumnarBatch allocate(StructType schema, MemoryMode memMode) {
-    return new ColumnarBatch(schema, DEFAULT_BATCH_SIZE, memMode, false);
+    return new ColumnarBatch(schema, DEFAULT_BATCH_SIZE, memMode);
   }
 
   public static ColumnarBatch allocate(StructType type) {
-    return new ColumnarBatch(type, DEFAULT_BATCH_SIZE, DEFAULT_MEMORY_MODE, false);
+    return new ColumnarBatch(type, DEFAULT_BATCH_SIZE, DEFAULT_MEMORY_MODE);
   }
 
   public static ColumnarBatch allocate(StructType schema, MemoryMode memMode, int maxRows) {
-    return allocate(schema, memMode, maxRows, false);
-  }
-
-  public static ColumnarBatch allocate(StructType schema, MemoryMode memMode, int maxRows, boolean useUnsafeArrayData) {
-    return new ColumnarBatch(schema, maxRows, memMode, useUnsafeArrayData);
+    return new ColumnarBatch(schema, maxRows, memMode);
   }
 
   /**
@@ -470,7 +466,7 @@ public final class ColumnarBatch {
     nullFilteredColumns.add(ordinal);
   }
 
-  private ColumnarBatch(StructType schema, int maxRows, MemoryMode memMode, boolean useUnsafeArrayData) {
+  private ColumnarBatch(StructType schema, int maxRows, MemoryMode memMode) {
     this.schema = schema;
     this.capacity = maxRows;
     this.columns = new ColumnVector[schema.size()];
@@ -479,7 +475,7 @@ public final class ColumnarBatch {
 
     for (int i = 0; i < schema.fields().length; ++i) {
       StructField field = schema.fields()[i];
-      columns[i] = ColumnVector.allocate(maxRows, field.dataType(), memMode, useUnsafeArrayData);
+      columns[i] = ColumnVector.allocate(maxRows, field.dataType(), memMode);
     }
 
     this.row = new Row(this);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -65,15 +65,19 @@ public final class ColumnarBatch {
   final Row row;
 
   public static ColumnarBatch allocate(StructType schema, MemoryMode memMode) {
-    return new ColumnarBatch(schema, DEFAULT_BATCH_SIZE, memMode);
+    return new ColumnarBatch(schema, DEFAULT_BATCH_SIZE, memMode, false);
   }
 
   public static ColumnarBatch allocate(StructType type) {
-    return new ColumnarBatch(type, DEFAULT_BATCH_SIZE, DEFAULT_MEMORY_MODE);
+    return new ColumnarBatch(type, DEFAULT_BATCH_SIZE, DEFAULT_MEMORY_MODE, false);
   }
 
   public static ColumnarBatch allocate(StructType schema, MemoryMode memMode, int maxRows) {
-    return new ColumnarBatch(schema, maxRows, memMode);
+    return allocate(schema, memMode, maxRows, false);
+  }
+
+  public static ColumnarBatch allocate(StructType schema, MemoryMode memMode, int maxRows, boolean useUnsafeArrayData) {
+    return new ColumnarBatch(schema, maxRows, memMode, useUnsafeArrayData);
   }
 
   /**
@@ -466,7 +470,7 @@ public final class ColumnarBatch {
     nullFilteredColumns.add(ordinal);
   }
 
-  private ColumnarBatch(StructType schema, int maxRows, MemoryMode memMode) {
+  private ColumnarBatch(StructType schema, int maxRows, MemoryMode memMode, boolean useUnsafeArrayData) {
     this.schema = schema;
     this.capacity = maxRows;
     this.columns = new ColumnVector[schema.size()];
@@ -475,7 +479,7 @@ public final class ColumnarBatch {
 
     for (int i = 0; i < schema.fields().length; ++i) {
       StructField field = schema.fields()[i];
-      columns[i] = ColumnVector.allocate(maxRows, field.dataType(), memMode);
+      columns[i] = ColumnVector.allocate(maxRows, field.dataType(), memMode, useUnsafeArrayData);
     }
 
     this.row = new Row(this);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.apache.spark.memory.MemoryMode;
-import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.Platform;
 
@@ -135,6 +134,9 @@ public final class OffHeapColumnVector extends ColumnVector {
   @Override
   public boolean getBoolean(int rowId) { return Platform.getByte(null, data + rowId) == 1; }
 
+  @Override
+  public void getBooleanArray(int offset, int length, boolean[] array) { throw new UnsupportedOperationException(); }
+
   //
   // APIs dealing with Bytes
   //
@@ -165,6 +167,9 @@ public final class OffHeapColumnVector extends ColumnVector {
       return (byte) dictionary.decodeToInt(dictionaryIds.getDictId(rowId));
     }
   }
+
+  @Override
+  public void getByteArray(int offset, int length, byte[] array) { throw new UnsupportedOperationException(); }
 
   //
   // APIs dealing with shorts
@@ -197,6 +202,9 @@ public final class OffHeapColumnVector extends ColumnVector {
       return (short) dictionary.decodeToInt(dictionaryIds.getDictId(rowId));
     }
   }
+
+  @Override
+  public void getShortArray(int offset, int length, short[] array) { throw new UnsupportedOperationException(); }
 
   //
   // APIs dealing with ints
@@ -256,6 +264,9 @@ public final class OffHeapColumnVector extends ColumnVector {
     return Platform.getInt(null, data + 4 * rowId);
   }
 
+  @Override
+  public void getIntArray(int offset, int length, int[] array) { throw new UnsupportedOperationException(); }
+
   //
   // APIs dealing with Longs
   //
@@ -303,6 +314,9 @@ public final class OffHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getLongArray(int offset, int length, long[] array) { throw new UnsupportedOperationException(); }
+
   //
   // APIs dealing with floats
   //
@@ -349,6 +363,8 @@ public final class OffHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getFloatArray(int offset, int length, float[] array) { throw new UnsupportedOperationException(); }
 
   //
   // APIs dealing with doubles
@@ -396,6 +412,9 @@ public final class OffHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getDoubleArray(int offset, int length, double[] array) { throw new UnsupportedOperationException(); }
+
   //
   // APIs dealing with Arrays.
   //
@@ -407,12 +426,7 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void putArray(int rowId, Object src, int offset, int length) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public UnsafeArrayData getUnsafeArray(int rowId) {
+  public void putArray(int rowId, Object src, int srcOffset, int dstOffset, int length) {
     throw new UnsupportedOperationException();
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.Platform;
 
@@ -403,6 +404,16 @@ public final class OffHeapColumnVector extends ColumnVector {
     assert(offset >= 0 && offset + length <= childColumns[0].capacity);
     Platform.putInt(null, lengthData + 4 * rowId, length);
     Platform.putInt(null, offsetData + 4 * rowId, offset);
+  }
+
+  @Override
+  public void putArray(int rowId, Object src, int offset, int length) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UnsafeArrayData getUnsafeArray(int rowId) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -24,11 +24,11 @@ import java.nio.ByteOrder
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
@@ -716,7 +716,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
 
   test("Int UnsafeArray") {
     (MemoryMode.ON_HEAP :: Nil).foreach { memMode => {
-      val column = ColumnVector.allocate(10, new ArrayType(IntegerType, true), memMode, true)
+      val column = ColumnVector.allocate(10, new ArrayType(IntegerType, true), memMode)
 
       // Populate it with arrays [0], [1, 2], [], [3, 4, 5]
       val len1 = column.putArray(0, UnsafeArrayData.fromPrimitiveArray(Array(0)))
@@ -729,10 +729,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(len3 == ((UnsafeArrayData.calculateHeaderPortionInBytes(0) + 0 * 4 + 7) / 8) * 8)
       assert(len4 == ((UnsafeArrayData.calculateHeaderPortionInBytes(3) + 3 * 4 + 7) / 8) * 8)
 
-      val a1 = column.getArray(0).asInstanceOf[UnsafeArrayData].toIntArray
-      val a2 = column.getArray(1).asInstanceOf[UnsafeArrayData].toIntArray
-      val a3 = column.getArray(2).asInstanceOf[UnsafeArrayData].toIntArray
-      val a4 = column.getArray(3).asInstanceOf[UnsafeArrayData].toIntArray
+      val a1 = column.getArray(0).toIntArray
+      val a2 = column.getArray(1).toIntArray
+      val a3 = column.getArray(2).toIntArray
+      val a4 = column.getArray(3).toIntArray
       assert(a1 === Array(0))
       assert(a2 === Array(1, 2))
       assert(a3 === Array.empty[Int])
@@ -757,7 +757,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       column.reset
       val array = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
       column.putArray(0, UnsafeArrayData.fromPrimitiveArray(array))
-      assert(column.getArray(0).asInstanceOf[UnsafeArrayData].toIntArray === array)
+      assert(column.getArray(0).toIntArray === array)
     }}
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -24,11 +24,11 @@ import java.nio.ByteOrder
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -24,11 +24,11 @@ import java.nio.ByteOrder
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -672,26 +672,30 @@ class ColumnarBatchSuite extends SparkFunSuite {
       column.putArray(2, 2, 0)
       column.putArray(3, 3, 3)
 
-      val a1 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
-      val a2 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(1)).asInstanceOf[Array[Int]]
-      val a3 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(2)).asInstanceOf[Array[Int]]
-      val a4 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(3)).asInstanceOf[Array[Int]]
+      val a1 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(0).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
+      val a2 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(1).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
+      val a3 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(2).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
+      val a4 = ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(3).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]]
       assert(a1 === Array(0))
       assert(a2 === Array(1, 2))
       assert(a3 === Array.empty[Int])
       assert(a4 === Array(3, 4, 5))
 
       // Verify the ArrayData APIs
-      assert(column.getArray(0).length == 1)
+      assert(column.getArray(0).numElements() == 1)
       assert(column.getArray(0).getInt(0) == 0)
 
-      assert(column.getArray(1).length == 2)
+      assert(column.getArray(1).numElements() == 2)
       assert(column.getArray(1).getInt(0) == 1)
       assert(column.getArray(1).getInt(1) == 2)
 
-      assert(column.getArray(2).length == 0)
+      assert(column.getArray(2).numElements() == 0)
 
-      assert(column.getArray(3).length == 3)
+      assert(column.getArray(3).numElements() == 3)
       assert(column.getArray(3).getInt(0) == 3)
       assert(column.getArray(3).getInt(1) == 4)
       assert(column.getArray(3).getInt(2) == 5)
@@ -704,8 +708,55 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(data.capacity == array.length * 2)
       data.putInts(0, array.length, array, 0)
       column.putArray(0, 0, array.length)
-      assert(ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
-        === array)
+      assert(ColumnVectorUtils.toPrimitiveJavaArray(
+        column.getArray(0).asInstanceOf[ColumnVector.Array]).asInstanceOf[Array[Int]] === array)
+    }}
+  }
+
+  test("Int UnsafeArray") {
+    (MemoryMode.ON_HEAP :: Nil).foreach { memMode => {
+      val column = ColumnVector.allocate(10, new ArrayType(IntegerType, true), memMode, true)
+
+      // Populate it with arrays [0], [1, 2], [], [3, 4, 5]
+      val len1 = column.putArray(0, UnsafeArrayData.fromPrimitiveArray(Array(0)))
+      val len2 = column.putArray(1, UnsafeArrayData.fromPrimitiveArray(Array(1, 2)))
+      val len3 = column.putArray(2, UnsafeArrayData.fromPrimitiveArray(Array.empty[Int]))
+      val len4 = column.putArray(3, UnsafeArrayData.fromPrimitiveArray(Array(3, 4, 5)))
+      // since UnsafeArrayData.fromPrimitiveArray allocates long[], size should be ceiled by 8
+      assert(len1 == ((UnsafeArrayData.calculateHeaderPortionInBytes(1) + 1 * 4 + 7) / 8) * 8)
+      assert(len2 == ((UnsafeArrayData.calculateHeaderPortionInBytes(2) + 2 * 4 + 7) / 8) * 8)
+      assert(len3 == ((UnsafeArrayData.calculateHeaderPortionInBytes(0) + 0 * 4 + 7) / 8) * 8)
+      assert(len4 == ((UnsafeArrayData.calculateHeaderPortionInBytes(3) + 3 * 4 + 7) / 8) * 8)
+
+      val a1 = column.getArray(0).asInstanceOf[UnsafeArrayData].toIntArray
+      val a2 = column.getArray(1).asInstanceOf[UnsafeArrayData].toIntArray
+      val a3 = column.getArray(2).asInstanceOf[UnsafeArrayData].toIntArray
+      val a4 = column.getArray(3).asInstanceOf[UnsafeArrayData].toIntArray
+      assert(a1 === Array(0))
+      assert(a2 === Array(1, 2))
+      assert(a3 === Array.empty[Int])
+      assert(a4 === Array(3, 4, 5))
+
+      // Verify the ArrayData APIs
+      assert(column.getArray(0).numElements() == 1)
+      assert(column.getArray(0).getInt(0) == 0)
+
+      assert(column.getArray(1).numElements() == 2)
+      assert(column.getArray(1).getInt(0) == 1)
+      assert(column.getArray(1).getInt(1) == 2)
+
+      assert(column.getArray(2).numElements() == 0)
+
+      assert(column.getArray(3).numElements() == 3)
+      assert(column.getArray(3).getInt(0) == 3)
+      assert(column.getArray(3).getInt(1) == 4)
+      assert(column.getArray(3).getInt(2) == 5)
+
+      // Add a longer array which requires resizing
+      column.reset
+      val array = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+      column.putArray(0, UnsafeArrayData.fromPrimitiveArray(array))
+      assert(column.getArray(0).asInstanceOf[UnsafeArrayData].toIntArray === array)
     }}
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -24,6 +24,7 @@ import java.nio.ByteOrder
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR enhances `ColumnVector` to keep `UnsafeArrayData` for array to use `ColumnVector` for table cache (e.g. CACHE table, DataFrame.cache). Other complex types such as Map and struct will be addressed by another PR if it is OK.

Current `ColumnVector` accepts only primitive-type Java array as an input for array. It is good to keep data from Parquet.

This PR changed or added the following APIs:

`ColumnVector ColumnVector.allocate(int capacity, DataType type, MemoryMode mode, boolean useUnsafeArrayData)`
* When the last is true, the `ColumnVector` can keep `UnsafeArrayData`. If it is false, the `ColumnVector` cannot keep `UnsafeArrayData`. 

`int ColumnVector.putArray(int rowId, ArrayData array)`
* When this `ColumnVector` was generated with `useUnsafeArrayData=true`, this method stores `UnsafeArrayData` into `ColumnVector`. Otherwise, throw an exception.

`ArrayData ColumnVector.getArray(int rowId)`
* When this `ColumnVector` was generated with `useUnsafeArrayData=true`, this method returns  `UnsafeArrayData`.

## How was this patch tested?

Update existing testsuite
