### PR TITLE
[SPARK-20806][DEPLOY] Launcher: redundant check for Spark lib dir

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -335,22 +335,17 @@ class CommandBuilderUtils {
    */
   static String findJarsDir(String sparkHome, String scalaVersion, boolean failIfNotFound) {
     // TODO: change to the correct directory once the assembly build is changed.
-    File libdir;
-    if (new File(sparkHome, "jars").isDirectory()) {
-      libdir = new File(sparkHome, "jars");
-      checkState(!failIfNotFound || libdir.isDirectory(),
-        "Library directory '%s' does not exist.",
-        libdir.getAbsolutePath());
-    } else {
+    File libdir = new File(sparkHome, "jars");
+    if (!libdir.isDirectory()) {
       libdir = new File(sparkHome, String.format("assembly/target/scala-%s/jars", scalaVersion));
       if (!libdir.isDirectory()) {
         checkState(!failIfNotFound,
           "Library directory '%s' does not exist; make sure Spark is built.",
           libdir.getAbsolutePath());
-        libdir = null;
+        return null;
       }
     }
-    return libdir != null ? libdir.getAbsolutePath() : null;
+    return libdir.getAbsolutePath();
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove redundant check for libdir in CommandBuilderUtils

## How was this patch tested?

Existing tests
