### PR TITLE
[SPARK-20807][SQL] Add compression/decompression of column data to ColumnVector

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -284,6 +284,14 @@ public abstract class ColumnVector implements AutoCloseable {
    */
   public abstract void close();
 
+  /**
+   * Compress or decompress data for this column if possible.
+   * Note: After calling compress(), gettter/setter (e.g. getInt) do not work
+   * until decompress() will be called
+   */
+  public abstract void compress();
+  public abstract void decompress();
+
   public void reserve(int requiredCapacity) {
     if (requiredCapacity > capacity) {
       int newCapacity = (int) Math.min(MAX_CAPACITY, requiredCapacity * 2L);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -74,6 +74,14 @@ public final class OffHeapColumnVector extends ColumnVector {
     offsetData = 0;
   }
 
+  @Override
+  public void compress() {
+  }
+
+  @Override
+  public void decompress() {
+  }
+
   //
   // APIs dealing with nulls
   //

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -77,6 +77,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   public void close() {
   }
 
+  @Override
   public void compress() {
     if (compressed) return;
 
@@ -117,6 +118,7 @@ public final class OnHeapColumnVector extends ColumnVector {
     compressed = (compressedData != null) || (compressedNulls != null);
   }
 
+  @Override
   public void decompress() {
     if (!compressed) return;
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.execution.columnar.compression.ColumnVectorCompressionBuilder;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.Platform;
 
@@ -30,6 +31,10 @@ import org.apache.spark.unsafe.Platform;
  */
 public final class OnHeapColumnVector extends ColumnVector {
 
+  private boolean compressed;
+  private ColumnVectorCompressionBuilder compressionBuilder;
+  private ColumnVectorCompressionBuilder nullCompressionBuilder;
+
   private static final boolean bigEndianPlatform =
     ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
 
@@ -38,6 +43,7 @@ public final class OnHeapColumnVector extends ColumnVector {
 
   // This is faster than a boolean array and we optimize this over memory footprint.
   private byte[] nulls;
+  private byte[] compressedNulls;
 
   // Array for each type. Only 1 is populated for any type.
   private byte[] byteData;
@@ -46,6 +52,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   private long[] longData;
   private float[] floatData;
   private double[] doubleData;
+  private byte[] compressedData;
 
   // Only set if type is Array.
   private int[] arrayLengths;
@@ -68,6 +75,79 @@ public final class OnHeapColumnVector extends ColumnVector {
 
   @Override
   public void close() {
+  }
+
+  public void compress() {
+    if (compressed) return;
+
+    Object inputData =
+      (type instanceof BooleanType || type instanceof ByteType) ? byteData :
+      (type instanceof ShortType) ? shortData :
+      (type instanceof IntegerType) ? intData :
+      (type instanceof LongType) ? longData :
+      (type instanceof FloatType) ? floatData :
+      (type instanceof DoubleType) ? doubleData : null;
+    if (inputData != null) {
+      if (compressionBuilder == null) {
+        compressionBuilder = new ColumnVectorCompressionBuilder((AtomicType) type);
+      }
+      byte[] out = compressionBuilder.compress(inputData);
+      if (out != null) {
+        compressedData = out;
+        byteData = null;
+        shortData = null;
+        intData = null;
+        longData = null;
+        floatData = null;
+        doubleData = null;
+      }
+    }
+
+    if (nulls != null) {
+      if (nullCompressionBuilder == null) {
+        nullCompressionBuilder = new ColumnVectorCompressionBuilder(BooleanType$.MODULE$);
+      }
+      byte[] out = nullCompressionBuilder.compress(nulls);
+      if (out != null) {
+        compressedNulls = out;
+        nulls = null;
+      }
+    }
+
+    compressed = (compressedData != null) || (compressedNulls != null);
+  }
+
+  public void decompress() {
+    if (!compressed) return;
+
+    if (compressedData != null) {
+      Object outputData = null;
+      if (type instanceof BooleanType || type instanceof ByteType) {
+        outputData = byteData = new byte[capacity];
+      } else if (type instanceof ShortType) {
+        outputData = shortData = new short[capacity];
+      } else if (type instanceof IntegerType) {
+        outputData = intData = new int[capacity];
+      } else if (type instanceof LongType) {
+        outputData = longData = new long[capacity];
+      } else if (type instanceof FloatType) {
+        outputData = floatData = new float[capacity];
+      } else if (type instanceof DoubleType) {
+        outputData = doubleData = new double[capacity];
+      }
+      if (outputData != null) {
+        compressionBuilder.decompress(compressedData, outputData);
+        compressedData = null;
+      }
+    }
+
+    if (compressedNulls != null) {
+      nulls = new byte[capacity];
+      nullCompressionBuilder.decompress(compressedNulls, nulls);
+      compressedNulls = null;
+    }
+
+    compressed = false;
   }
 
   //

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
@@ -21,6 +21,7 @@ import java.math.{BigDecimal, BigInteger}
 import java.nio.ByteBuffer
 
 import scala.annotation.tailrec
+import scala.language.existentials
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.sql.catalyst.InternalRow

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
@@ -141,6 +141,18 @@ private[columnar] sealed abstract class ColumnType[JvmType] {
   def clone(v: JvmType): JvmType = v
 
   override def toString: String = getClass.getSimpleName.stripSuffix("$")
+
+  /**
+   * Extracts a value out of the buffer at the ArrayBuffer's current position
+   * Subclasses should override this method to avoid boxing/unboxing costs whenever possible.
+   */
+  def get(buffer: ArrayBuffer): JvmType
+
+  /**
+   * Store value of type T#InternalType into the given ArrayBuffer at the current position
+   * Subclasses should override this method to avoid boxing/unboxing costs whenever possible.
+   */
+  def put(buffer: ArrayBuffer, value: JvmType): Unit
 }
 
 private[columnar] object NULL extends ColumnType[Any] {
@@ -151,6 +163,8 @@ private[columnar] object NULL extends ColumnType[Any] {
   override def extract(buffer: ByteBuffer): Any = null
   override def setField(row: InternalRow, ordinal: Int, value: Any): Unit = row.setNullAt(ordinal)
   override def getField(row: InternalRow, ordinal: Int): Any = null
+  override def get(buffer: ArrayBuffer): Any = null
+  override def put(buffer: ArrayBuffer, value: Any): Unit = {}
 }
 
 private[columnar] abstract class NativeColumnType[T <: AtomicType](
@@ -191,6 +205,21 @@ private[columnar] object INT extends NativeColumnType(IntegerType, 4) {
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setInt(toOrdinal, from.getInt(fromOrdinal))
   }
+
+  override def get(buffer: ArrayBuffer): Int = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    val value = Platform.getInt(array, buffer.arrayOffset + buffer.pos)
+    buffer.addPos(defaultSize)
+    value
+  }
+
+  override def put(buffer: ArrayBuffer, value: Int): Unit = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    Platform.putInt(array, buffer.arrayOffset + buffer.pos, value)
+    buffer.addPos(defaultSize)
+  }
 }
 
 private[columnar] object LONG extends NativeColumnType(LongType, 8) {
@@ -218,6 +247,21 @@ private[columnar] object LONG extends NativeColumnType(LongType, 8) {
 
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setLong(toOrdinal, from.getLong(fromOrdinal))
+  }
+
+  override def get(buffer: ArrayBuffer): Long = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    val value = Platform.getLong(array, buffer.arrayOffset + buffer.pos)
+    buffer.addPos(defaultSize)
+    value
+  }
+
+  override def put(buffer: ArrayBuffer, value: Long): Unit = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    Platform.putLong(array, buffer.arrayOffset + buffer.pos, value)
+    buffer.addPos(defaultSize)
   }
 }
 
@@ -247,6 +291,14 @@ private[columnar] object FLOAT extends NativeColumnType(FloatType, 4) {
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setFloat(toOrdinal, from.getFloat(fromOrdinal))
   }
+
+  override def get(buffer: ArrayBuffer): Float = {
+    throw new UnsupportedOperationException("Float is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: Float): Unit = {
+    throw new UnsupportedOperationException("Float is not supported yet")
+  }
 }
 
 private[columnar] object DOUBLE extends NativeColumnType(DoubleType, 8) {
@@ -275,6 +327,14 @@ private[columnar] object DOUBLE extends NativeColumnType(DoubleType, 8) {
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setDouble(toOrdinal, from.getDouble(fromOrdinal))
   }
+
+  override def get(buffer: ArrayBuffer): Double = {
+    throw new UnsupportedOperationException("Double is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: Double): Unit = {
+    throw new UnsupportedOperationException("Double is not supported yet")
+  }
 }
 
 private[columnar] object BOOLEAN extends NativeColumnType(BooleanType, 1) {
@@ -300,6 +360,21 @@ private[columnar] object BOOLEAN extends NativeColumnType(BooleanType, 1) {
 
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setBoolean(toOrdinal, from.getBoolean(fromOrdinal))
+  }
+
+  override def get(buffer: ArrayBuffer): Boolean = {
+    val array = buffer.array
+    assert(buffer.pos < array.length)
+    val value = Platform.getByte(array, buffer.arrayOffset + buffer.pos)
+    buffer.addPos(defaultSize)
+    value == 1
+  }
+
+  override def put(buffer: ArrayBuffer, value: Boolean): Unit = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    Platform.putByte(array, buffer.arrayOffset + buffer.pos, if (value) 1 else 0)
+    buffer.addPos(defaultSize)
   }
 }
 
@@ -329,6 +404,21 @@ private[columnar] object BYTE extends NativeColumnType(ByteType, 1) {
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setByte(toOrdinal, from.getByte(fromOrdinal))
   }
+
+  override def get(buffer: ArrayBuffer): Byte = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    val value = Platform.getByte(array, buffer.arrayOffset + buffer.pos)
+    buffer.addPos(defaultSize)
+    value
+  }
+
+  override def put(buffer: ArrayBuffer, value: Byte): Unit = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    Platform.putByte(array, buffer.arrayOffset + buffer.pos, value)
+    buffer.addPos(defaultSize)
+  }
 }
 
 private[columnar] object SHORT extends NativeColumnType(ShortType, 2) {
@@ -356,6 +446,21 @@ private[columnar] object SHORT extends NativeColumnType(ShortType, 2) {
 
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     to.setShort(toOrdinal, from.getShort(fromOrdinal))
+  }
+
+  override def get(buffer: ArrayBuffer): Short = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    val value = Platform.getShort(array, buffer.arrayOffset + buffer.pos)
+    buffer.addPos(defaultSize)
+    value
+  }
+
+  override def put(buffer: ArrayBuffer, value: Short): Unit = {
+    val array = buffer.array
+    assert(buffer.pos < array.length * defaultSize)
+    Platform.putShort(array, buffer.arrayOffset + buffer.pos, value)
+    buffer.addPos(defaultSize)
   }
 }
 
@@ -424,6 +529,14 @@ private[columnar] object STRING
   }
 
   override def clone(v: UTF8String): UTF8String = v.clone()
+
+  override def get(buffer: ArrayBuffer): UTF8String = {
+    throw new UnsupportedOperationException("UTF8String is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: UTF8String): Unit = {
+    throw new UnsupportedOperationException("UTF8String is not supported yet")
+  }
 }
 
 private[columnar] case class COMPACT_DECIMAL(precision: Int, scale: Int)
@@ -465,6 +578,14 @@ private[columnar] case class COMPACT_DECIMAL(precision: Int, scale: Int)
 
   override def copyField(from: InternalRow, fromOrdinal: Int, to: InternalRow, toOrdinal: Int) {
     setField(to, toOrdinal, getField(from, fromOrdinal))
+  }
+
+  override def get(buffer: ArrayBuffer): Decimal = {
+    throw new UnsupportedOperationException("Decimal is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: Decimal): Unit = {
+    throw new UnsupportedOperationException("Decimal is not supported yet")
   }
 }
 
@@ -509,6 +630,14 @@ private[columnar] object BINARY extends ByteArrayColumnType[Array[Byte]](16) {
     row.getBinary(ordinal).length + 4
   }
 
+  override def get(buffer: ArrayBuffer): Array[Byte] = {
+    throw new UnsupportedOperationException("Binary is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: Array[Byte]): Unit = {
+    throw new UnsupportedOperationException("Binary is not supported yet")
+  }
+
   def serialize(value: Array[Byte]): Array[Byte] = value
   def deserialize(bytes: Array[Byte]): Array[Byte] = bytes
 }
@@ -528,6 +657,14 @@ private[columnar] case class LARGE_DECIMAL(precision: Int, scale: Int)
 
   override def actualSize(row: InternalRow, ordinal: Int): Int = {
     4 + getField(row, ordinal).toJavaBigDecimal.unscaledValue().bitLength() / 8 + 1
+  }
+
+  override def get(buffer: ArrayBuffer): Decimal = {
+    throw new UnsupportedOperationException("Decimal is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: Decimal): Unit = {
+    throw new UnsupportedOperationException("Decimal is not supported yet")
   }
 
   override def serialize(value: Decimal): Array[Byte] = {
@@ -563,6 +700,14 @@ private[columnar] case class STRUCT(dataType: StructType)
 
   override def actualSize(row: InternalRow, ordinal: Int): Int = {
     4 + getField(row, ordinal).getSizeInBytes
+  }
+
+  override def get(buffer: ArrayBuffer): UnsafeRow = {
+    throw new UnsupportedOperationException("Struct is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: UnsafeRow): Unit = {
+    throw new UnsupportedOperationException("Struct is not supported yet")
   }
 
   override def append(value: UnsafeRow, buffer: ByteBuffer): Unit = {
@@ -604,6 +749,14 @@ private[columnar] case class ARRAY(dataType: ArrayType)
     4 + unsafeArray.getSizeInBytes
   }
 
+  override def get(buffer: ArrayBuffer): UnsafeArrayData = {
+    throw new UnsupportedOperationException("Array is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: UnsafeArrayData): Unit = {
+    throw new UnsupportedOperationException("Array is not supported yet")
+  }
+
   override def append(value: UnsafeArrayData, buffer: ByteBuffer): Unit = {
     buffer.putInt(value.getSizeInBytes)
     value.writeTo(buffer)
@@ -641,6 +794,14 @@ private[columnar] case class MAP(dataType: MapType)
   override def actualSize(row: InternalRow, ordinal: Int): Int = {
     val unsafeMap = getField(row, ordinal)
     4 + unsafeMap.getSizeInBytes
+  }
+
+  override def get(buffer: ArrayBuffer): UnsafeMapData = {
+    throw new UnsupportedOperationException("Map is not supported yet")
+  }
+
+  override def put(buffer: ArrayBuffer, value: UnsafeMapData): Unit = {
+    throw new UnsupportedOperationException("Map is not supported yet")
   }
 
   override def append(value: UnsafeMapData, buffer: ByteBuffer): Unit = {
@@ -686,5 +847,54 @@ private[columnar] object ColumnType {
       case other =>
         throw new Exception(s"Unsupported type: $other")
     }
+  }
+}
+
+case class ArrayBuffer(array: Array[_]) {
+  val (arrayOffset, elementSize) = array match {
+    case _: Array[Boolean] => (Platform.BOOLEAN_ARRAY_OFFSET, 1)
+    case _: Array[Byte] => (Platform.BYTE_ARRAY_OFFSET, 1)
+    case _: Array[Short] => (Platform.SHORT_ARRAY_OFFSET, 2)
+    case _: Array[Int] => (Platform.INT_ARRAY_OFFSET, 4)
+    case _: Array[Long] => (Platform.LONG_ARRAY_OFFSET, 8)
+    case _: Array[Float] => (Platform.FLOAT_ARRAY_OFFSET, 4)
+    case _: Array[Double] => (Platform.DOUBLE_ARRAY_OFFSET, 8)
+    case other => throw new UnsupportedOperationException(s"unsupported type: $other")
+  }
+
+  private var _pos: Int = 0
+
+  def pos(): Int = { _pos }
+
+  def addPos(value: Int): Unit = { _pos += value }
+
+  def remaining(): Int = { array.length * elementSize - _pos}
+
+  def hasRemaining(): Boolean = { remaining > 0 }
+
+  def getInt(): Int = {
+    assert(_pos < array.length * elementSize)
+    val value = Platform.getInt(array, arrayOffset + _pos)
+    _pos += 4
+    value
+  }
+
+  def getLong(): Long = {
+    assert(_pos < array.length * elementSize)
+    val value = Platform.getLong(array, arrayOffset + _pos)
+    _pos += 8
+    value
+  }
+
+  def putInt(value: Int): Unit = {
+    assert(_pos < array.length * elementSize)
+    Platform.putInt(array, arrayOffset + _pos, value)
+    _pos += 4
+  }
+
+  def putLong(value: Long): Unit = {
+    assert(_pos < array.length * elementSize)
+    Platform.putLong(array, arrayOffset + _pos, value)
+    _pos += 8
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
@@ -20,11 +20,13 @@ package org.apache.spark.sql.execution.columnar.compression
 import java.nio.{ByteBuffer, ByteOrder}
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.columnar.{ColumnType, NativeColumnType}
+import org.apache.spark.sql.execution.columnar.{ArrayBuffer, ColumnType, NativeColumnType}
 import org.apache.spark.sql.types.AtomicType
 
 private[columnar] trait Encoder[T <: AtomicType] {
   def gatherCompressibilityStats(row: InternalRow, ordinal: Int): Unit = {}
+
+  def gatherCompressibilityStats(in: ArrayBuffer): Unit = { }
 
   def compressedSize: Int
 
@@ -35,12 +37,16 @@ private[columnar] trait Encoder[T <: AtomicType] {
   }
 
   def compress(from: ByteBuffer, to: ByteBuffer): ByteBuffer
+
+  def compress(from: ArrayBuffer, to: ArrayBuffer): Unit
 }
 
 private[columnar] trait Decoder[T <: AtomicType] {
   def next(row: InternalRow, ordinal: Int): Unit
 
   def hasNext: Boolean
+
+  def decompress(values: ArrayBuffer): Unit
 }
 
 private[columnar] trait CompressionScheme {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/RunLengthEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/RunLengthEncodingSuite.scala
@@ -17,11 +17,13 @@
 
 package org.apache.spark.sql.execution.columnar.compression
 
+import java.nio.ByteBuffer
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
-import org.apache.spark.sql.types.AtomicType
+import org.apache.spark.sql.types._
 
 class RunLengthEncodingSuite extends SparkFunSuite {
   testRunLengthEncoding(new NoopColumnStats, BOOLEAN)
@@ -108,6 +110,97 @@ class RunLengthEncodingSuite extends SparkFunSuite {
     }
 
     test(s"$RunLengthEncoding with $typeName: single long run") {
+      skeleton(1, Seq(0 -> 1000))
+    }
+  }
+
+  testRunLengthEncoding(BooleanType, BOOLEAN)
+  testRunLengthEncoding(ByteType, BYTE)
+  testRunLengthEncoding(ShortType, SHORT)
+  testRunLengthEncoding(IntegerType, INT)
+  testRunLengthEncoding(LongType, LONG)
+
+  def testRunLengthEncoding[T <: AtomicType](
+      dataType: DataType,
+      columnType: NativeColumnType[T]) {
+
+    def generateArray(dataType: DataType, length: Int): Array[T#InternalType] = {
+      (dataType match {
+        case BooleanType => new Array[Boolean](length)
+        case ByteType => new Array[Byte](length)
+        case ShortType => new Array[Short](length)
+        case IntegerType => new Array[Int](length)
+        case LongType => new Array[Long](length)
+        case other => throw new UnsupportedOperationException(s"Unsupported type: $other")
+      }).asInstanceOf[Array[T#InternalType]]
+    }
+
+    val typeName = columnType.getClass.getSimpleName.stripSuffix("$")
+
+    def skeleton(uniqueValueCount: Int, inputRuns: Seq[(Int, Int)]) {
+      // -------------
+      // Tests encoder
+      // -------------
+
+      val (values, rows) = makeUniqueValuesAndSingleValueRows(columnType, uniqueValueCount)
+      val inputSeq = inputRuns.flatMap { case (index, run) =>
+        Seq.fill(run)(index)
+      }
+      val inputArray = generateArray(dataType, inputSeq.length)
+      inputSeq.zipWithIndex.foreach { case (i, index) => inputArray(index) = values(i) }
+
+      val encoder = RunLengthEncoding.encoder(columnType)
+      encoder.gatherCompressibilityStats(ArrayBuffer(inputArray))
+
+      val size = encoder.compressedSize
+      val compressedArray = new Array[Byte](4 + size)
+      encoder.compress(ArrayBuffer(inputArray), ArrayBuffer(compressedArray))
+      val buffer = ArrayBuffer(compressedArray)
+
+      // Compression scheme ID + compressed contents
+      val compressedSize = 4 + inputRuns.map { _ =>
+        // 4 extra bytes each run for run length
+        columnType.actualSize(null, 0) + 4
+      }.sum
+
+      // 4 extra bytes for compression scheme type ID
+      assertResult(compressedSize, "Wrong buffer capacity")(compressedArray.length)
+
+      // Skips column header
+      assertResult(RunLengthEncoding.typeId, "Wrong compression scheme ID")(buffer.getInt())
+
+      inputRuns.foreach { case (index, run) =>
+        assertResult(values(index), "Wrong column element value")(columnType.get(buffer))
+        assertResult(run, "Wrong run length")(buffer.getInt())
+      }
+
+      // -------------
+      // Tests decoder
+      // -------------
+      val outputArray = generateArray(dataType, inputArray.length)
+      val decoder = RunLengthEncoding.decoder(ByteBuffer.wrap(compressedArray), columnType)
+      decoder.decompress(ArrayBuffer(outputArray))
+
+      if (inputArray.nonEmpty) {
+        inputArray.zipWithIndex.foreach { case (value, i) =>
+          assertResult(value, "Wrong decoded value")(outputArray(i))
+        }
+      }
+    }
+
+    test(s"$RunLengthEncoding Batch with $typeName: empty column") {
+      skeleton(0, Seq.empty)
+    }
+
+    test(s"$RunLengthEncoding Batch with $typeName: simple case") {
+      skeleton(2, Seq(0 -> 2, 1 -> 2))
+    }
+
+    test(s"$RunLengthEncoding Batch with $typeName: run length == 1") {
+      skeleton(2, Seq(0 -> 1, 1 -> 1))
+    }
+
+    test(s"$RunLengthEncoding Batch with $typeName: single long run") {
       skeleton(1, Seq(0 -> 1000))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1078,7 +1078,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
     }
   }
 
-  private def getPrivateValue(column : OnHeapColumnVector, fieldName : String) : Any = {
+  private def getPrivateValue(column : ColumnVector, fieldName : String) : Any = {
     val cls = classOf[OnHeapColumnVector]
     val field = cls.getDeclaredField(fieldName)
     field.setAccessible(true)
@@ -1086,19 +1086,18 @@ class ColumnarBatchSuite extends SparkFunSuite {
   }
 
   def performCompressDecompress(column: ColumnVector, dataFieldName: String): Unit = {
-    val unsafeColumn = column.asInstanceOf[OnHeapColumnVector]
-    unsafeColumn.compress()
-    assert(getPrivateValue(unsafeColumn, "compressed").asInstanceOf[Boolean])
-    assert((getPrivateValue(unsafeColumn, dataFieldName) == null))
-    assert((getPrivateValue(unsafeColumn, "compressedData") != null))
-    assert((getPrivateValue(unsafeColumn, "nulls") == null))
-    assert((getPrivateValue(unsafeColumn, "compressedNulls") != null))
-    unsafeColumn.decompress()
-    assert(getPrivateValue(unsafeColumn, "compressed").asInstanceOf[Boolean] == false)
-    assert((getPrivateValue(unsafeColumn, dataFieldName) != null))
-    assert((getPrivateValue(unsafeColumn, "compressedData") == null))
-    assert((getPrivateValue(unsafeColumn, "nulls") != null))
-    assert((getPrivateValue(unsafeColumn, "compressedNulls") == null))
+    column.compress()
+    assert(getPrivateValue(column, "compressed").asInstanceOf[Boolean])
+    assert((getPrivateValue(column, dataFieldName) == null))
+    assert((getPrivateValue(column, "compressedData") != null))
+    assert((getPrivateValue(column, "nulls") == null))
+    assert((getPrivateValue(column, "compressedNulls") != null))
+    column.decompress()
+    assert(getPrivateValue(column, "compressed").asInstanceOf[Boolean] == false)
+    assert((getPrivateValue(column, dataFieldName) != null))
+    assert((getPrivateValue(column, "compressedData") == null))
+    assert((getPrivateValue(column, "nulls") != null))
+    assert((getPrivateValue(column, "compressedNulls") == null))
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds compression/decompression of column data to `ColumnVector`. 
While current `CachedBatch` can compress column data by using of multiple compression schemes, `ColumnVector` cannot compress column data. The compression is mandatory for table cache.

At first, this PR enables the following schemes. Another JIRA will support compression schemes.
1. `RunLengthEncoding` for boolean/byte/short/int/long
2. `BooleanBitSet` for boolean. 

At high level view, when `ColumnVector.compress()` is called, compression is performed from an array for primitive data type to byte array in `ColumnVector`. When `ColumnVector.decompress()` is called, decompression is performed from the byte array to the array for primitive data type to byte array in `ColumnVector`. `ArrayBuffer` is used for accessing data during compression or decompression.


This PR added and changed the following APIs:

`ArrayBuffer`
* This new class is similar to `java.io.ByteBuffer`. `ArrayBuffer` class can wrap an array for any primitive data type such as `Array[Int]` or `Array[Long]`. This class manages current position to be accessed.

`ColumnType.get(buffer: ArrayBuffer): jvmType, ColumnType.put(buffer: ArrayBuffer)`
* These APIs gets a primitive value from the current position or puts a primitive value into the current position at the given `ArrayBuffer`. 

`Encoder.gatherCompressibilityStats(in: ArrayBuffer)`
* This API calculates uncompressed and compressed size by using a given compression method.

`Encoder.compress(from: ArrayBuffer, to: ArrayBuffer): Unit`
* This API compresses data in `from` and stores compressed data to `to`. `to` has to have an byte array with enough size for compressed data.

`Decoder.decompress(values: ArrayBuffer): Unit`
* This API decompresses data in `Decoder` by providing its constructor and stores uncompressed data to `values`. `to` has to have an byte array with enough size for uncompressed data.

## How was this patch tested?

Added new test suites