### PR TITLE
[SPARK-20797][MLLIB]fix LocalLDAModel.save() bug.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -33,6 +33,7 @@ import org.apache.spark.mllib.util.{Loader, Saveable}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.util.BoundedPriorityQueue
+import org.apache.spark.util.Utils
 
 /**
  * Latent Dirichlet Allocation (LDA) model.
@@ -475,7 +476,7 @@ object LocalLDAModel extends Loader[LocalLDAModel] {
       // We only calculate the array size, considering an
       // average string size of 15 bytes, the formula is:
       // (floatSize * vectorSize + 15) * numWords
-      val approxSize = (4L * topicsMatrix.numRows + 15) * k
+      val approxSize = (4L * k + 15) * topicsMatrix.numRows
       val nPartitions = ((approxSize / bufferSize) + 1).toInt
       spark.createDataFrame(topics).repartition(nPartitions).write.parquet(Loader.dataPath(path))
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

LocalLDAModel's model save function has a bug: 

please see: https://issues.apache.org/jira/browse/SPARK-20797

add some code like word2vec's save method (repartition), to avoid this bug.

## How was this patch tested?

it's hard to test. need large data to train with online LDA method.