### PR TITLE
[SPARK-20816][CORE] MetricsConfig doen't trim the properties file cau…

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -58,7 +58,7 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
     val prefix = "spark.metrics.conf."
     conf.getAll.foreach {
       case (k, v) if k.startsWith(prefix) =>
-        properties.setProperty(k.substring(prefix.length()), v)
+        properties.setProperty(k.substring(prefix.length()).trim(), v.trim())
       case _ =>
     }
 
@@ -78,7 +78,7 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
       val defaultSubProperties = perInstanceSubProperties(DEFAULT_PREFIX).asScala
       for ((instance, prop) <- perInstanceSubProperties if (instance != DEFAULT_PREFIX);
            (k, v) <- defaultSubProperties if (prop.get(k) == null)) {
-        prop.put(k, v)
+        prop.put(k.trim(), v.trim())
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsConfigSuite.scala
@@ -159,6 +159,20 @@ class MetricsConfigSuite extends SparkFunSuite with BeforeAndAfter {
     assert(servletProps.size() === 2)
   }
 
+  test("MetricsConfig with properties with spaces") {
+    val sparkConf = new SparkConf(loadDefaults = false)
+    setMetricsProperty(sparkConf, "*.sink.console.class",
+      " org.apache.spark.metrics.sink.ConsoleSink ")
+    setMetricsProperty(sparkConf, "*.sink.console.period", "10   ")
+    val conf = new MetricsConfig(sparkConf)
+    conf.initialize()
+
+    val property = conf.getInstance("random")
+    assert(property.getProperty("sink.console.class") ===
+      "org.apache.spark.metrics.sink.ConsoleSink")
+    assert(property.getProperty("sink.console.period") === "10")
+  }
+
   private def setMetricsProperty(conf: SparkConf, name: String, value: String): Unit = {
     conf.set(s"spark.metrics.conf.$name", value)
   }


### PR DESCRIPTION
…se the exception very confused

## What changes were proposed in this pull request?

Spark Metrics System use a **Properties File** to load the configurations but doesn't trim the keys and values. It might cause the exception very confused if the property is a class name. 
For example below, you must do not notice there is a space at the line end.

> *.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink

 
Unfortunately, the **ClassNotFoundException** throwing from Driver also doesn't tell me what happens and confuses me because I am sure the related jar is in the CLASSPATH.

> 17/05/20 12:47:04 ERROR SparkContext: Error initializing SparkContext.
> java.lang.ClassNotFoundException: org.apache.spark.metrics.sink.GangliaSink           
> 	at scala.reflect.internal.util.AbstractFileClassLoader.findClass(AbstractFileClassLoader.scala:62)

As a reference, I check the code of Log4j, a classic **Properties** using library. It do the trim when load the properties. See org.apache.log4j.filter.PropertyFilter.java

```
private Hashtable parseProperties(String props) {
	Hashtable hashTable = new Hashtable();
	StringTokenizer pairs = new StringTokenizer(props, ",");
	while (pairs.hasMoreTokens()) {
		StringTokenizer entry = new StringTokenizer(pairs.nextToken(), "=");
		hashTable.put(entry.nextElement().toString().trim(), entry.nextElement().toString().trim());
	}
	return hashTable;
}
```

## How was this patch tested?

Add unit tests

Also can test manually by setting metrics.properties file
(Replace "_" with " ")

> *.sink.csv.class=\_org.apache.spark.metrics.sink.CsvSink\_

