### PR TITLE
[SPARK-20833]  it seems to be a part of Android TimSort class rather than a port of .. in the first line of TimSort.java comments

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/TimSort.java
+++ b/core/src/main/java/org/apache/spark/util/collection/TimSort.java
@@ -38,7 +38,7 @@ package org.apache.spark.util.collection;
 import java.util.Comparator;
 
 /**
- * A port of the Android TimSort class, which utilizes a "stable, adaptive, iterative mergesort."
+ * A part of the Android TimSort class, which utilizes a "stable, adaptive, iterative mergesort."
  * See the method comment on sort() for more details.
  *
  * This has been kept in Java with the original style in order to match very closely with the


### PR DESCRIPTION
## What changes were proposed in this pull request?

modify TimSort comments 
it seems to be a part of Android TimSort class rather than a port of .. in the first line of TimSort.java comments


## How was this patch tested?

no test

Please review http://spark.apache.org/contributing.html before opening a pull request.
