### PR TITLE
[SPARK-20834][SQL]TypeCoercion:loss of precision when widening long and float,or int and float

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -89,7 +89,14 @@ object TypeCoercion {
     case (t1: DecimalType, t2: IntegralType) if t1.isWiderThan(t2) =>
       Some(t1)
 
+    case (_: IntegerType, _: FloatType) | (_: FloatType, _: IntegerType) =>
+      Some(DoubleType)
+    // This situation can only do our best
+    case (_: FloatType, _: LongType) | (_: LongType, _: FloatType) =>
+      Some(DoubleType)
+
     // Promote numeric types to the highest of the two
+    // loss of precision when widening long and double
     case (t1: NumericType, t2: NumericType)
         if !t1.isInstanceOf[DecimalType] && !t2.isInstanceOf[DecimalType] =>
       val index = numericPrecedence.lastIndexWhere(t => t == t1 || t == t2)


### PR DESCRIPTION
## What changes were proposed in this pull request?
spark-sql>select if(true, 123456789, cast(1.23 as float));
spark-sql>1.23456792E8

For this case, the result is not we expected, it lost precision.
 So ,i think these  rules can improve: between `IntegerType` and `FloatType`,   or `LongType` and `FloatType`

## How was this patch tested?
unit test cases
Also tested in spark-sql:
spark-sql>select if(true, 123456789, cast(1.23 as float));
spark-sql>1.23456789E8
