### PR TITLE
[SPARK-20835][Core]It should exit directly when the --total-executor-cores parameter is setted less than 0 when submit a application

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -214,7 +214,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         case _ =>
           SparkSubmit.printErrorAndExit(
             s"Cannot load main class from JAR $primaryResource with URI $uriScheme. " +
-              "Please specify a class through --class.")
+             "Please specify a class through --class.")
       }
     }
 
@@ -638,8 +638,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       // Get the output and discard any unnecessary lines from it.
       Source.fromString(new String(out.toByteArray(), StandardCharsets.UTF_8)).getLines
         .filter { line =>
-        !line.startsWith("log4j") && !line.startsWith("usage")
-      }
+         !line.startsWith("log4j") && !line.startsWith("usage")
+       }
         .mkString("\n")
     } finally {
       System.setSecurityManager(currentSm)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -214,7 +214,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         case _ =>
           SparkSubmit.printErrorAndExit(
             s"Cannot load main class from JAR $primaryResource with URI $uriScheme. " +
-            "Please specify a class through --class.")
+              "Please specify a class through --class.")
       }
     }
 
@@ -255,10 +255,12 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (mainClass == null && SparkSubmit.isUserJar(primaryResource)) {
       SparkSubmit.printErrorAndExit("No main class set in JAR; please specify one with --class")
     }
-    if (driverMemory != null && Try(JavaUtils.byteStringAsBytes(driverMemory)).getOrElse(-1L) <= 0) {
+    if (driverMemory != null
+        && Try(JavaUtils.byteStringAsBytes(driverMemory)).getOrElse(-1L) <= 0) {
       SparkSubmit.printErrorAndExit("Driver Memory must be a positive number")
     }
-    if (executorMemory != null && Try(JavaUtils.byteStringAsBytes(executorMemory)).getOrElse(-1L) <= 0) {
+    if (executorMemory != null
+        && Try(JavaUtils.byteStringAsBytes(executorMemory)).getOrElse(-1L) <= 0) {
       SparkSubmit.printErrorAndExit("Executor Memory cores must be a positive number")
     }
     if (executorCores != null && Try(executorCores.toInt).getOrElse(-1) <= 0) {
@@ -638,8 +640,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       // Get the output and discard any unnecessary lines from it.
       Source.fromString(new String(out.toByteArray(), StandardCharsets.UTF_8)).getLines
         .filter { line =>
-          !line.startsWith("log4j") && !line.startsWith("usage")
-        }
+        !line.startsWith("log4j") && !line.startsWith("usage")
+      }
         .mkString("\n")
     } finally {
       System.setSecurityManager(currentSm)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -214,7 +214,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         case _ =>
           SparkSubmit.printErrorAndExit(
             s"Cannot load main class from JAR $primaryResource with URI $uriScheme. " +
-              "Please specify a class through --class.")
+            "Please specify a class through --class.")
       }
     }
 
@@ -640,8 +640,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       // Get the output and discard any unnecessary lines from it.
       Source.fromString(new String(out.toByteArray(), StandardCharsets.UTF_8)).getLines
         .filter { line =>
-        !line.startsWith("log4j") && !line.startsWith("usage")
-      }
+          !line.startsWith("log4j") && !line.startsWith("usage")
+        }
         .mkString("\n")
     } finally {
       System.setSecurityManager(currentSm)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -31,8 +31,9 @@ import scala.util.Try
 
 import org.apache.spark.deploy.SparkSubmitAction._
 import org.apache.spark.launcher.SparkSubmitArgumentsParser
-import org.apache.spark.util.Utils
 import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.util.Utils
+
 
 /**
  * Parses and encapsulates arguments from the spark-submit script.

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -214,7 +214,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         case _ =>
           SparkSubmit.printErrorAndExit(
             s"Cannot load main class from JAR $primaryResource with URI $uriScheme. " +
-             "Please specify a class through --class.")
+            "Please specify a class through --class.")
       }
     }
 
@@ -638,8 +638,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       // Get the output and discard any unnecessary lines from it.
       Source.fromString(new String(out.toByteArray(), StandardCharsets.UTF_8)).getLines
         .filter { line =>
-         !line.startsWith("log4j") && !line.startsWith("usage")
-       }
+          !line.startsWith("log4j") && !line.startsWith("usage")
+        }
         .mkString("\n")
     } finally {
       System.setSecurityManager(currentSm)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -27,6 +27,7 @@ import java.util.jar.JarFile
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.io.Source
+import scala.util.Try
 
 import org.apache.spark.deploy.SparkSubmitAction._
 import org.apache.spark.launcher.SparkSubmitArgumentsParser
@@ -252,6 +253,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     }
     if (mainClass == null && SparkSubmit.isUserJar(primaryResource)) {
       SparkSubmit.printErrorAndExit("No main class set in JAR; please specify one with --class")
+    }
+    if (totalExecutorCores != null && Try(totalExecutorCores.toInt).getOrElse(-1) <= 0) {
+      SparkSubmit.printErrorAndExit("Total executor cores must be a positive number")
     }
     if (pyFiles != null && !isPython) {
       SparkSubmit.printErrorAndExit("--py-files given but primary resource is not a Python script")


### PR DESCRIPTION
## What changes were proposed in this pull request?
In my test, the submitted app running with out an error when the --total-executor-cores less than 0
and given the warnings:
"2017-05-22 17:19:36,319 WARN org.apache.spark.scheduler.TaskSchedulerImpl: Initial job has not accepted any resources; check your cluster UI to ensure that workers are registered and have sufficient resources";

It should exit directly when the --total-executor-cores parameter is setted less than 0 when submit a application
(Please fill in changes proposed in this fix)

## How was this patch tested?
Run the ut tests
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
