### PR TITLE
[SPARK-20836][LAUNCHER] DRIVER_EXTRA_JAVA_OPTIONS is needed only when use…

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -241,17 +241,16 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     }
     addOptionString(cmd, System.getenv("SPARK_SUBMIT_OPTS"));
 
-    // We don't want the client to specify Xmx. These have to be set by their corresponding
-    // memory flag --driver-memory or configuration entry spark.driver.memory
-    String driverExtraJavaOptions = config.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS);
-    if (!isEmpty(driverExtraJavaOptions) && driverExtraJavaOptions.contains("Xmx")) {
-      String msg = String.format("Not allowed to specify max heap(Xmx) memory settings through " +
-                   "java options (was %s). Use the corresponding --driver-memory or " +
-                   "spark.driver.memory configuration instead.", driverExtraJavaOptions);
-      throw new IllegalArgumentException(msg);
-    }
-
     if (isClientMode) {
+      // We don't want the client to specify Xmx. These have to be set by their corresponding
+      // memory flag --driver-memory or configuration entry spark.driver.memory
+      String driverExtraJavaOptions = config.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS);
+      if (!isEmpty(driverExtraJavaOptions) && driverExtraJavaOptions.contains("Xmx")) {
+        String msg = String.format("Not allowed to specify max heap(Xmx) memory settings through " +
+                     "java options (was %s). Use the corresponding --driver-memory or " +
+                     "spark.driver.memory configuration instead.", driverExtraJavaOptions);
+        throw new IllegalArgumentException(msg);
+      }
       // Figuring out where the memory value come from is a little tricky due to precedence.
       // Precedence is observed in the following order:
       // - explicit configuration (setConf()), which also covers --driver-memory cli argument.


### PR DESCRIPTION
…rDeployMode is 'client'. If userDeployMode is not 'client', the launcher shouldn't care about DRIVER_EXTRA_JAVA_OPTIONS, nor should it exit abnormally because DRIVER_EXTRA_JAVA_OPTIONS contains Xmx configuration.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
