### PR TITLE
[SPARK-20822][SQL] Generate code to build table cache using ColumnarBatch and to get value from ColumnVector

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -98,6 +98,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val CACHE_CODEGEN = buildConf("spark.sql.inMemoryColumnarStorage.codegen")
+    .internal()
+    .doc("When true, use generated code to build column batches for caching. This is only " +
+      "supported for basic types and improves caching performance for such types.")
+    .booleanConf
+    .createWithDefault(true)
+
   val PREFER_SORTMERGEJOIN = buildConf("spark.sql.join.preferSortMergeJoin")
     .internal()
     .doc("When true, prefer sort merge join over shuffle hash join.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -31,6 +31,8 @@ import org.apache.spark.sql.types.DataType
  */
 private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
+  val columnIndexes: Array[Int] = null
+
   val inMemoryTableScan: InMemoryTableScanExec = null
 
   override lazy val metrics = Map(
@@ -89,7 +91,8 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
     val colVars = output.indices.map(i => ctx.freshName("colInstance" + i))
     val columnAssigns = colVars.zipWithIndex.map { case (name, i) =>
       ctx.addMutableState(columnVectorClz, name, s"$name = null;")
-      s"$name = $batch.column($i);"
+      val index = if (columnIndexes == null) i else columnIndexes(i)
+      s"$name = $batch.column($index);"
     }
 
     val nextBatch = ctx.freshName("nextBatch")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -157,6 +157,7 @@ class GenerateColumnAccessor(useColumnarBatch: Boolean)
          (0 to groupedAccessorsLength - 1).map { i => s"extractors$i();" }.mkString("\n"))
       }
 
+    val cachedBatchBytesCls = classOf[CachedBatchBytes].getName
     val codeBody = s"""
       import java.nio.ByteBuffer;
       import java.nio.ByteOrder;
@@ -210,7 +211,7 @@ class GenerateColumnAccessor(useColumnarBatch: Boolean)
             return false;
           }
 
-          ${classOf[CachedBatchBytes].getName} batch = (${classOf[CachedBatchBytes].getName}) input.next();
+          $cachedBatchBytesCls batch = ($cachedBatchBytesCls) input.next();
           currentRow = 0;
           numRowsInBatch = batch.getNumRows();
           for (int i = 0; i < columnIndexes.length; i ++) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GeneratedColumnarBatch.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GeneratedColumnarBatch.scala
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.columnar
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.execution.vectorized.ColumnarBatch
+import org.apache.spark.sql.types._
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.storage.StorageLevel._
+
+
+/**
+ * A helper class to expose the scala iterator to Java.
+ */
+abstract class ColumnarBatchIterator extends Iterator[ColumnarBatch]
+
+
+/**
+ * Generate code to batch [[InternalRow]]s into [[ColumnarBatch]]es.
+ */
+class GenerateColumnarBatch(
+    schema: StructType,
+    batchSize: Int,
+    storageLevel: StorageLevel)
+  extends CodeGenerator[Iterator[InternalRow], Iterator[CachedColumnarBatch]] {
+
+  protected def canonicalize(in: Iterator[InternalRow]): Iterator[InternalRow] = in
+
+  protected def bind(
+    in: Iterator[InternalRow], inputSchema: Seq[Attribute]): Iterator[InternalRow] = {
+    in
+  }
+
+  protected def create(rowIterator: Iterator[InternalRow]): Iterator[CachedColumnarBatch] = {
+    import scala.collection.JavaConverters._
+    val ctx = newCodeGenContext()
+    val columnStatsCls = classOf[ColumnStats].getName
+    val rowVar = ctx.freshName("row")
+    val batchVar = ctx.freshName("columnarBatch")
+    val rowNumVar = ctx.freshName("rowNum")
+    val numBytesVar = ctx.freshName("bytesInBatch")
+    ctx.addMutableState("long", numBytesVar, s"$numBytesVar = 0;")
+    val rowIterVar = ctx.addReferenceObj(
+      "rowIterator", rowIterator.asJava, classOf[java.util.Iterator[_]].getName)
+    val schemas = StructType(
+      schema.fields.map(s => StructField(s.name,
+        s.dataType match {
+          case udt: UserDefinedType[_] => udt.sqlType
+          case other => other
+        }, s.nullable))
+    )
+    val schemaVar = ctx.addReferenceObj("schema", schemas, classOf[StructType].getName)
+    val maxNumBytes = ColumnBuilder.MAX_BATCH_SIZE_IN_BYTE
+    val numColumns = schema.fields.length
+
+    val colStatVars = (0 to numColumns - 1).map(i => ctx.freshName("colStat" + i))
+    val colStatCode = ctx.splitExpressions(
+      (schemas.fields zip colStatVars).zipWithIndex.map {
+        case ((field, varName), i) =>
+          val columnStatsCls = field.dataType match {
+            case IntegerType => classOf[IntColumnStats].getName
+            case DoubleType => classOf[DoubleColumnStats].getName
+            case others => throw new UnsupportedOperationException(s"$others is not supported yet")
+          }
+          ctx.addMutableState(columnStatsCls, varName, "")
+          s"$varName = new $columnStatsCls(); statsArray[$i] = $varName;\n"
+      },
+      "apply",
+      Seq.empty
+    )
+
+    val populateColumnVectorsCode = ctx.splitExpressions(
+      (schemas.fields zip colStatVars).zipWithIndex.map {
+        case ((field, colStatVar), i) =>
+          GenerateColumnarBatch.putColumnCode(ctx, field.dataType, field.nullable,
+            batchVar, rowVar, rowNumVar, colStatVar, i, numBytesVar).trim + "\n"
+      },
+      "apply",
+      Seq(("InternalRow", rowVar), ("ColumnarBatch", batchVar), ("int", rowNumVar))
+    )
+
+    val code = s"""
+      import org.apache.spark.memory.MemoryMode;
+      import org.apache.spark.sql.catalyst.InternalRow;
+      import org.apache.spark.sql.execution.columnar.CachedColumnarBatch;
+      import org.apache.spark.sql.execution.columnar.GenerateColumnarBatch;
+      import org.apache.spark.sql.execution.vectorized.ColumnarBatch;
+      import org.apache.spark.sql.execution.vectorized.ColumnVector;
+
+      public GeneratedColumnarBatchIterator generate(Object[] references) {
+        return new GeneratedColumnarBatchIterator(references);
+      }
+
+      class GeneratedColumnarBatchIterator extends ${classOf[ColumnarBatchIterator].getName} {
+        private Object[] references;
+        ${ctx.declareMutableStates()}
+
+        public GeneratedColumnarBatchIterator(Object[] references) {
+          this.references = references;
+          ${ctx.initMutableStates()}
+        }
+
+        ${ctx.declareAddedFunctions()}
+
+        $columnStatsCls[] statsArray = new $columnStatsCls[$numColumns];
+        private void allocateColumnStats() {
+          ${colStatCode.trim}
+        }
+
+        @Override
+        public boolean hasNext() {
+          return $rowIterVar.hasNext();
+        }
+
+        @Override
+        public CachedColumnarBatch next() {
+          ColumnarBatch $batchVar =
+          ColumnarBatch.allocate($schemaVar, MemoryMode.ON_HEAP, $batchSize);
+          allocateColumnStats();
+          int $rowNumVar = 0;
+          $numBytesVar = 0;
+          while ($rowIterVar.hasNext() && $rowNumVar < $batchSize && $numBytesVar < $maxNumBytes) {
+            InternalRow $rowVar = (InternalRow) $rowIterVar.next();
+            $populateColumnVectorsCode
+            $rowNumVar += 1;
+          }
+          $batchVar.setNumRows($rowNumVar);
+          return CachedColumnarBatch.apply(
+            $batchVar, GenerateColumnarBatch.generateStats(statsArray));
+        }
+      }
+      """
+    val formattedCode = CodeFormatter.stripOverlappingComments(
+      new CodeAndComment(code, ctx.getPlaceHolderToComments()))
+    CodeGenerator.compile(formattedCode).generate(ctx.references.toArray)
+      .asInstanceOf[Iterator[CachedColumnarBatch]]
+  }
+}
+
+
+private[sql] object GenerateColumnarBatch {
+  def compressStorageLevel(storageLevel: StorageLevel, useCompression: Boolean): StorageLevel = {
+    if (!useCompression) return storageLevel
+    storageLevel match {
+      case MEMORY_ONLY => MEMORY_ONLY_SER
+      case MEMORY_ONLY_2 => MEMORY_ONLY_SER_2
+      case MEMORY_AND_DISK => MEMORY_AND_DISK_SER
+      case MEMORY_AND_DISK_2 => MEMORY_AND_DISK_SER_2
+      case sl => sl
+    }
+  }
+
+  def isCompress(storageLevel: StorageLevel) : Boolean = {
+    (storageLevel == MEMORY_ONLY_SER || storageLevel == MEMORY_ONLY_SER_2 ||
+      storageLevel == MEMORY_AND_DISK_SER || storageLevel == MEMORY_AND_DISK_SER_2)
+  }
+
+  private val typeToName = Map[AbstractDataType, String](
+    IntegerType -> "int",
+    DoubleType -> "double"
+  )
+
+  def putColumnCode(ctx: CodegenContext, dt: DataType, nullable: Boolean, batchVar: String,
+      rowVar: String, rowNumVar: String,
+      colStatVar: String, colNum: Int, numBytesVar: String): String = {
+    val colVar = s"$batchVar.column($colNum)"
+    val body = dt match {
+      case t if ctx.isPrimitiveType(dt) =>
+        val typeName = GenerateColumnarBatch.typeToName(dt)
+        val put = "put" + typeName.capitalize
+        val get = "get" + typeName.capitalize
+        s"""
+         $typeName val = $rowVar.$get($colNum);
+         $colVar.$put($rowNumVar, val);
+         $numBytesVar += ${dt.defaultSize};
+         $colStatVar.gatherValueStats(val);
+       """
+      case _ =>
+        throw new UnsupportedOperationException("Unsupported data type " + dt.simpleString);
+    }
+    if (nullable) {
+      s"""
+       if ($rowVar.isNullAt($colNum)) {
+         $colVar.putNull($rowNumVar);
+         $colStatVar.gatherNullStats();
+       } else {
+         ${body.trim}
+       }
+      """
+    } else {
+      s"""
+       {
+         ${body.trim}
+       }
+      """
+    }
+  }
+
+  def generateStats(columnStats: Array[ColumnStats]): InternalRow = {
+    val array = columnStats.flatMap(_.collectedStatistics)
+    InternalRow.fromSeq(array)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -27,7 +27,9 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.vectorized.ColumnarBatch
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.LongAccumulator
 
@@ -44,14 +46,36 @@ object InMemoryRelation {
 
 
 /**
- * CachedBatch is a cached batch of rows.
+ * An abstract representation of a cached batch of rows.
+ */
+private[columnar] trait CachedBatch {
+  val stats: InternalRow
+  def getNumRows(): Int
+}
+
+
+/**
+ * A cached batch of rows stored as a list of byte arrays, one for each column.
  *
  * @param numRows The total number of rows in this batch
  * @param buffers The buffers for serialized columns
  * @param stats The stat of columns
  */
-private[columnar]
-case class CachedBatch(numRows: Int, buffers: Array[Array[Byte]], stats: InternalRow)
+private[columnar] case class CachedBatchBytes(
+    numRows: Int, buffers: Array[Array[Byte]], stats: InternalRow)
+  extends CachedBatch {
+  def getNumRows(): Int = numRows
+}
+
+
+/**
+ * A cached batch of rows stored as a [[ColumnarBatch]].
+ */
+private[columnar] case class CachedColumnarBatch(columnarBatch: ColumnarBatch, stats: InternalRow)
+  extends CachedBatch {
+  def getNumRows(): Int = columnarBatch.numRows()
+}
+
 
 case class InMemoryRelation(
     output: Seq[Attribute],
@@ -63,6 +87,32 @@ case class InMemoryRelation(
     @transient var _cachedColumnBuffers: RDD[CachedBatch] = null,
     val batchStats: LongAccumulator = child.sqlContext.sparkContext.longAccumulator)
   extends logical.LeafNode with MultiInstanceRelation {
+
+  /**
+   * If true, store the input rows using [[CachedColumnarBatch]]es, which are generally faster.
+   * If false, store the input rows using [[CachedBatchBytes]].
+   */
+  private def numOfNestedFields(dataType: DataType): Int = dataType match {
+    case dt: StructType => dt.fields.map(f => numOfNestedFields(f.dataType)).sum
+    case m: MapType => numOfNestedFields(m.keyType) + numOfNestedFields(m.valueType)
+    case a: ArrayType => numOfNestedFields(a.elementType)
+    case u: UserDefinedType[_] => numOfNestedFields(u.sqlType)
+    case _ => 1
+  }
+
+  private[columnar] val useColumnarBatches: Boolean = {
+    // In the initial implementation, for ease of review
+    // support only integer and double and # of fields is less than wholeStageMaxNumFields
+    val schema = StructType.fromAttributes(child.output)
+    schema.fields.find(f => f.dataType match {
+      case IntegerType => false
+      case DoubleType => false
+      case _ => true
+    }).isEmpty &&
+    !(children.map(p => numOfNestedFields(p.schema))
+      .exists(_ > child.sqlContext.conf.wholeStageMaxNumFields)) &&
+    child.sqlContext.conf.getConf(SQLConf.CACHE_CODEGEN)
+  }
 
   override def innerChildren: Seq[SparkPlan] = Seq(child)
 
@@ -80,17 +130,33 @@ case class InMemoryRelation(
     }
   }
 
-  // If the cached column buffers were not passed in, we calculate them in the constructor.
-  // As in Spark, the actual work of caching is lazy.
-  if (_cachedColumnBuffers == null) {
-    buildBuffers()
+  /**
+   * Batch the input rows into [[CachedBatch]]es.
+   */
+  private def buildColumnBuffers: RDD[CachedBatch] = {
+    val buffers =
+      if (useColumnarBatches) {
+        buildColumnarBatches()
+      } else {
+        buildColumnBytes()
+      }
+    buffers.setName(
+      tableName.map { n => s"In-memory table $n" }
+        .getOrElse(StringUtils.abbreviate(child.toString, 1024)))
+    buffers.asInstanceOf[RDD[CachedBatch]]
   }
 
-  private def buildBuffers(): Unit = {
+  /**
+   * Batch the input rows into [[CachedBatchBytes]] built using [[ColumnBuilder]]s.
+   *
+   * This handles complex types and compression, but is more expensive than
+   * [[buildColumnarBatches]], which generates code to build the buffers.
+   */
+  private def buildColumnBytes(): RDD[CachedBatchBytes] = {
     val output = child.output
-    val cached = child.execute().mapPartitionsInternal { rowIterator =>
-      new Iterator[CachedBatch] {
-        def next(): CachedBatch = {
+    child.execute().mapPartitionsInternal { rowIterator =>
+      new Iterator[CachedBatchBytes] {
+        def next(): CachedBatchBytes = {
           val columnBuilders = output.map { attribute =>
             ColumnBuilder(attribute.dataType, batchSize, attribute.name, useCompression)
           }.toArray
@@ -125,7 +191,7 @@ case class InMemoryRelation(
 
           val stats = InternalRow.fromSeq(
             columnBuilders.flatMap(_.columnStats.collectedStatistics))
-          CachedBatch(rowCount, columnBuilders.map { builder =>
+          CachedBatchBytes(rowCount, columnBuilders.map { builder =>
             JavaUtils.bufferToArray(builder.build())
           }, stats)
         }
@@ -133,11 +199,46 @@ case class InMemoryRelation(
         def hasNext: Boolean = rowIterator.hasNext
       }
     }.persist(storageLevel)
+  }
 
-    cached.setName(
-      tableName.map(n => s"In-memory table $n")
-        .getOrElse(StringUtils.abbreviate(child.toString, 1024)))
-    _cachedColumnBuffers = cached
+  /**
+   * Batch the input rows using [[ColumnarBatch]]es.
+   *
+   * Compared with [[buildColumnBytes]], this provides a faster implementation of memory
+   * scan because both the read path and the write path are generated.
+   * However, this does not compress data for now
+   */
+  private def buildColumnarBatches(): RDD[CachedColumnarBatch] = {
+    val schema = StructType.fromAttributes(child.output)
+    val newStorageLevel = GenerateColumnarBatch.compressStorageLevel(storageLevel, useCompression)
+    child.execute().mapPartitionsInternal { rows =>
+      new GenerateColumnarBatch(schema, batchSize, newStorageLevel).generate(rows).map {
+        cachedColumnarBatch => {
+          var i = 0
+          var totalSize = 0L
+          while (i < cachedColumnarBatch.columnarBatch.numCols()) {
+            totalSize += cachedColumnarBatch.stats.getLong(4 + i * 5)
+            i += 1
+          }
+          batchStats.add(totalSize)
+          cachedColumnarBatch
+        }
+      }
+    }.persist(storageLevel)
+  }
+
+  // If the cached column buffers were not passed in, we calculate them in the constructor.
+  // As in Spark, the actual work of caching is lazy.
+  if (_cachedColumnBuffers == null) {
+    _cachedColumnBuffers = buildColumnBuffers
+  }
+
+  def recache(): Unit = {
+    if (_cachedColumnBuffers != null) {
+      _cachedColumnBuffers.unpersist()
+      _cachedColumnBuffers = null
+    }
+    _cachedColumnBuffers = buildColumnBuffers
   }
 
   def withOutput(newOutput: Seq[Attribute]): InMemoryRelation = {
@@ -158,7 +259,15 @@ case class InMemoryRelation(
         batchStats).asInstanceOf[this.type]
   }
 
-  def cachedColumnBuffers: RDD[CachedBatch] = _cachedColumnBuffers
+  /**
+   * Return lazily cached batches of rows in the original plan.
+   */
+  def cachedColumnBuffers: RDD[CachedBatch] = {
+    if (_cachedColumnBuffers == null) {
+      _cachedColumnBuffers = buildColumnBuffers
+    }
+    _cachedColumnBuffers
+  }
 
   override protected def otherCopyArgs: Seq[AnyRef] =
     Seq(_cachedColumnBuffers, batchStats)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
-import org.apache.spark.sql.execution.LeafExecNode
+import org.apache.spark.sql.execution.{ColumnarBatchScan, LeafExecNode}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.UserDefinedType
 
@@ -32,12 +32,55 @@ case class InMemoryTableScanExec(
     attributes: Seq[Attribute],
     predicates: Seq[Expression],
     @transient relation: InMemoryRelation)
-  extends LeafExecNode {
+  extends LeafExecNode with ColumnarBatchScan {
+
+  override val columnIndexes =
+    attributes.map(a => relation.output.map(o => o.exprId).indexOf(a.exprId)).toArray
+
+  override val inMemoryTableScan = this
+
+  override val supportCodegen: Boolean = relation.useColumnarBatches
 
   override def innerChildren: Seq[QueryPlan[_]] = Seq(relation) ++ super.innerChildren
 
-  override lazy val metrics = Map(
-    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    if (relation.useColumnarBatches) {
+      val schema = relation.partitionStatistics.schema
+      val schemaIndex = schema.zipWithIndex
+      val buffers = relation.cachedColumnBuffers.asInstanceOf[RDD[CachedColumnarBatch]]
+      val prunedBuffers = if (inMemoryPartitionPruningEnabled) {
+        buffers.mapPartitionsInternal { cachedColumnarBatchIterator =>
+          val partitionFilter = newPredicate(
+            partitionFilters.reduceOption(And).getOrElse(Literal(true)), schema)
+
+          // Do partition batch pruning if enabled
+          cachedColumnarBatchIterator.filter { cachedColumnarBatch =>
+            if (!partitionFilter.eval(cachedColumnarBatch.stats)) {
+              def statsString: String = schemaIndex.map {
+                case (a, i) =>
+                  val value = cachedColumnarBatch.stats.get(i, a.dataType)
+                  s"${a.name}: $value"
+              }.mkString(", ")
+              logInfo(s"Skipping partition based on stats $statsString")
+              false
+            } else {
+              true
+            }
+          }
+        }
+      } else {
+        buffers
+      }
+
+      // HACK ALERT: This is actually an RDD[CachedColumnarBatch].
+      // We're taking advantage of Scala's type erasure here to pass these batches along.
+      Seq(prunedBuffers.map(_.columnarBatch).asInstanceOf[RDD[InternalRow]])
+    } else {
+      Seq()
+    }
+  }
+
+  override protected def innerChildren: Seq[QueryPlan[_]] = Seq(relation) ++ super.innerChildren
 
   override def output: Seq[Attribute] = attributes
 
@@ -148,6 +191,7 @@ case class InMemoryTableScanExec(
     val schemaIndex = schema.zipWithIndex
     val relOutput: AttributeSeq = relation.output
     val buffers = relation.cachedColumnBuffers
+    val useColumnarBatches = relation.useColumnarBatches
 
     buffers.mapPartitionsWithIndexInternal { (index, cachedBatchIterator) =>
       val partitionFilter = newPredicate(
@@ -186,7 +230,7 @@ case class InMemoryTableScanExec(
         if (enableAccumulators) {
           readBatches.add(1)
         }
-        numOutputRows += batch.numRows
+        numOutputRows += batch.getNumRows()
         batch
       }
 
@@ -194,7 +238,8 @@ case class InMemoryTableScanExec(
         case udt: UserDefinedType[_] => udt.sqlType
         case other => other
       }.toArray
-      val columnarIterator = GenerateColumnAccessor.generate(columnTypes)
+      val columnarIterator = new GenerateColumnAccessor(useColumnarBatches)
+        .generate(columnTypes)
       columnarIterator.initialize(withMetrics, columnTypes, requestedColumnIndices.toArray)
       if (enableAccumulators && columnarIterator.hasNext) {
         readPartitions.add(1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -41,8 +41,6 @@ case class InMemoryTableScanExec(
 
   override val supportCodegen: Boolean = relation.useColumnarBatches
 
-  override def innerChildren: Seq[QueryPlan[_]] = Seq(relation) ++ super.innerChildren
-
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     if (relation.useColumnarBatches) {
       val schema = relation.partitionStatistics.schema
@@ -80,7 +78,7 @@ case class InMemoryTableScanExec(
     }
   }
 
-  override protected def innerChildren: Seq[QueryPlan[_]] = Seq(relation) ++ super.innerChildren
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(relation) ++ super.innerChildren
 
   override def output: Seq[Attribute] = attributes
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
-import org.apache.spark.sql.catalyst.expressions.AttributeSet
+import org.apache.spark.sql.catalyst.expressions.{AttributeSet, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -311,12 +311,12 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
   test("SPARK-14138: Generated SpecificColumnarIterator can exceed JVM size limit for cached DF") {
     val length1 = 3999
     val columnTypes1 = List.fill(length1)(IntegerType)
-    val columnarIterator1 = GenerateColumnAccessor.generate(columnTypes1)
+    val columnarIterator1 = new GenerateColumnAccessor(false).generate(columnTypes1)
 
     // SPARK-16664: the limit of janino is 8117
     val length2 = 8117
     val columnTypes2 = List.fill(length2)(IntegerType)
-    val columnarIterator2 = GenerateColumnAccessor.generate(columnTypes2)
+    val columnarIterator2 = new GenerateColumnAccessor(false).generate(columnTypes2)
   }
 
   test("SPARK-17549: cached table size should be correctly calculated") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR generates the following Java code
1. Build each in-memory table cache using `ColumnarBatch` with `ColumnVector` instead of using CachedBatch with `Array[Byte]`.
2. Get a value for a column in `ColumnVector without using an iterator

As the first step, for ease of review, I supported only integer and double data types with whole-stage codegen. Another PR will address an execution path without whole-stage codegen

This PR implements the follings:
1. Keep a in-memory table cache using `ColumnarBatch` with `ColumnVector`. For supporting the new and coventional cache data structure, this PR declares `CachedBatch` as trait, and declares `CachedColumnarBatch` and `CachedBatchBytes` as actual implementations.
2. Generate Java code to build a in-memory table cache.
3. Generate Java code to directly get value from `ColumnVector`.

This PR improves runtime performance by
1. build in-memory table cache by eliminating lots of virtual calls and complicated data path.
2. eliminating data copy from column-oriented storage to `InternalRow` in a `SpecificColumnarIterator` iterator.


**Options**
A ColumnVector for all primitive data types in ColumnarBatch can be compressed. Currently, there are two ways to enable compression:

1. Set true into a property `spark.sql.inMemoryColumnarStorage.compressed (default is true)`, or
2. Call `DataFrame.persist(st)`, where st is `MEMORY_ONLY_SER`, `MEMORY_ONLY_SER_2`, `MEMORY_AND_DISK_SER`, or `MEMORY_AND_DISK_SER_2`.


**an example program**
```java
val df = sparkContext.parallelize((1 to 10), 1).map(i => (i, i.toDouble)).toDF("i", "d").cache
df.filter("i < 8 and 4.0 < d").show
```

**Generated code for building a in-memory table cache**
```
/* 001 */ import scala.collection.Iterator;
/* 002 */ import org.apache.spark.sql.types.DataType;
/* 003 */ import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
/* 004 */ import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
/* 005 */ import org.apache.spark.sql.execution.columnar.MutableUnsafeRow;
/* 006 */ import org.apache.spark.sql.execution.vectorized.ColumnVector;
/* 007 */
/* 008 */ public SpecificColumnarIterator generate(Object[] references) {
/* 009 */   return new SpecificColumnarIterator(references);
/* 010 */ }
/* 011 */
/* 012 */ class SpecificColumnarIterator extends org.apache.spark.sql.execution.columnar.ColumnarIterator {
/* 013 */   private ColumnVector[] colInstances;
/* 014 */   private UnsafeRow unsafeRow = new UnsafeRow(0);
/* 015 */   private BufferHolder bufferHolder = new BufferHolder(unsafeRow);
/* 016 */   private UnsafeRowWriter rowWriter = new UnsafeRowWriter(bufferHolder, 0);
/* 017 */   private MutableUnsafeRow mutableRow = null;
/* 018 */
/* 019 */   private int rowIdx = 0;
/* 020 */   private int numRowsInBatch = 0;
/* 021 */
/* 022 */   private scala.collection.Iterator input = null;
/* 023 */   private DataType[] columnTypes = null;
/* 024 */   private int[] columnIndexes = null;
/* 025 */
/* 026 */
/* 027 */
/* 028 */   public SpecificColumnarIterator(Object[] references) {
/* 029 */
/* 030 */     this.mutableRow = new MutableUnsafeRow(rowWriter);
/* 031 */   }
/* 032 */
/* 033 */   public void initialize(Iterator input, DataType[] columnTypes, int[] columnIndexes) {
/* 034 */     this.input = input;
/* 035 */     this.columnTypes = columnTypes;
/* 036 */     this.columnIndexes = columnIndexes;
/* 037 */   }
/* 038 */
/* 039 */
/* 040 */
/* 041 */   public boolean hasNext() {
/* 042 */     if (rowIdx < numRowsInBatch) {
/* 043 */       return true;
/* 044 */     }
/* 045 */     if (!input.hasNext()) {
/* 046 */       return false;
/* 047 */     }
/* 048 */
/* 049 */     org.apache.spark.sql.execution.columnar.CachedColumnarBatch cachedBatch =
/* 050 */     (org.apache.spark.sql.execution.columnar.CachedColumnarBatch) input.next();
/* 051 */     org.apache.spark.sql.execution.vectorized.ColumnarBatch batch = cachedBatch.columnarBatch();
/* 052 */     rowIdx = 0;
/* 053 */     numRowsInBatch = cachedBatch.getNumRows();
/* 054 */     colInstances = new ColumnVector[columnIndexes.length];
/* 055 */     for (int i = 0; i < columnIndexes.length; i ++) {
/* 056 */       colInstances[i] = batch.column(columnIndexes[i]);
/* 057 */     }
/* 058 */
/* 059 */     return hasNext();
/* 060 */   }
/* 061 */
/* 062 */   public InternalRow next() {
/* 063 */     bufferHolder.reset();
/* 064 */     rowWriter.zeroOutNullBytes();
/* 065 */
/* 066 */     unsafeRow.setTotalSize(bufferHolder.totalSize());
/* 067 */     rowIdx += 1;
/* 068 */     return unsafeRow;
/* 069 */   }
/* 070 */ }
```

**Generated code by whole-stage codegen (lines 75-78 are major changes)**
```
/* 001 */ public Object generate(Object[] references) {
/* 002 */   return new GeneratedIterator(references);
/* 003 */ }
/* 004 */
/* 005 */ final class GeneratedIterator extends org.apache.spark.sql.execution.BufferedRowIterator {
/* 006 */   private Object[] references;
/* 007 */   private scala.collection.Iterator[] inputs;
/* 008 */   private boolean agg_initAgg;
/* 009 */   private boolean agg_bufIsNull;
/* 010 */   private long agg_bufValue;
/* 011 */   private scala.collection.Iterator inmemorytablescan_input;
/* 012 */   private org.apache.spark.sql.execution.metric.SQLMetric inmemorytablescan_numOutputRows;
/* 013 */   private org.apache.spark.sql.execution.metric.SQLMetric inmemorytablescan_scanTime;
/* 014 */   private long inmemorytablescan_scanTime1;
/* 015 */   private org.apache.spark.sql.execution.vectorized.ColumnarBatch inmemorytablescan_batch;
/* 016 */   private int inmemorytablescan_batchIdx;
/* 017 */   private org.apache.spark.sql.execution.vectorized.ColumnVector inmemorytablescan_colInstance0;
/* 018 */   private org.apache.spark.sql.execution.vectorized.ColumnVector inmemorytablescan_colInstance1;
/* 019 */   private UnsafeRow inmemorytablescan_result;
/* 020 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder inmemorytablescan_holder;
/* 021 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter inmemorytablescan_rowWriter;
/* 022 */   private org.apache.spark.sql.execution.metric.SQLMetric filter_numOutputRows;
/* 023 */   private UnsafeRow filter_result;
/* 024 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder filter_holder;
/* 025 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter filter_rowWriter;
/* 026 */   private org.apache.spark.sql.execution.metric.SQLMetric agg_numOutputRows;
/* 027 */   private org.apache.spark.sql.execution.metric.SQLMetric agg_aggTime;
/* 028 */   private UnsafeRow agg_result;
/* 029 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder agg_holder;
/* 030 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter agg_rowWriter;
/* 031 */
/* 032 */   public GeneratedIterator(Object[] references) {
/* 033 */     this.references = references;
/* 034 */   }
/* 035 */
/* 036 */   public void init(int index, scala.collection.Iterator[] inputs) {
/* 037 */     partitionIndex = index;
/* 038 */     this.inputs = inputs;
/* 039 */     wholestagecodegen_init_0();
/* 040 */     wholestagecodegen_init_1();
/* 041 */
/* 042 */   }
/* 043 */
/* 044 */   private void wholestagecodegen_init_0() {
/* 045 */     agg_initAgg = false;
/* 046 */
/* 047 */     inmemorytablescan_input = inputs[0];
/* 048 */     this.inmemorytablescan_numOutputRows = (org.apache.spark.sql.execution.metric.SQLMetric) references[0];
/* 049 */     this.inmemorytablescan_scanTime = (org.apache.spark.sql.execution.metric.SQLMetric) references[1];
/* 050 */     inmemorytablescan_scanTime1 = 0;
/* 051 */     inmemorytablescan_batch = null;
/* 052 */     inmemorytablescan_batchIdx = 0;
/* 053 */     inmemorytablescan_colInstance0 = null;
/* 054 */     inmemorytablescan_colInstance1 = null;
/* 055 */     inmemorytablescan_result = new UnsafeRow(2);
/* 056 */     this.inmemorytablescan_holder = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(inmemorytablescan_result, 0);
/* 057 */     this.inmemorytablescan_rowWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(inmemorytablescan_holder, 2);
/* 058 */     this.filter_numOutputRows = (org.apache.spark.sql.execution.metric.SQLMetric) references[2];
/* 059 */     filter_result = new UnsafeRow(2);
/* 060 */     this.filter_holder = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(filter_result, 0);
/* 061 */     this.filter_rowWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(filter_holder, 2);
/* 062 */
/* 063 */   }
/* 064 */
/* 065 */   private void agg_doAggregateWithoutKey() throws java.io.IOException {
/* 066 */     // initialize aggregation buffer
/* 067 */     agg_bufIsNull = false;
/* 068 */     agg_bufValue = 0L;
/* 069 */
/* 070 */     if (inmemorytablescan_batch == null) {
/* 071 */       inmemorytablescan_nextBatch();
/* 072 */     }
/* 073 */     while (inmemorytablescan_batch != null) {
/* 074 */       int inmemorytablescan_numRows = inmemorytablescan_batch.numRows();
/* 075 */       int inmemorytablescan_localEnd = inmemorytablescan_numRows - inmemorytablescan_batchIdx;
/* 076 */       for (int inmemorytablescan_localIdx = 0; inmemorytablescan_localIdx < inmemorytablescan_localEnd; inmemorytablescan_localIdx++) {
/* 077 */         int inmemorytablescan_rowIdx = inmemorytablescan_batchIdx + inmemorytablescan_localIdx;
/* 078 */         int inmemorytablescan_value = inmemorytablescan_colInstance0.getInt(inmemorytablescan_rowIdx);
/* 079 */
/* 080 */         boolean filter_isNull = false;
/* 081 */
/* 082 */         boolean filter_value = false;
/* 083 */         filter_value = inmemorytablescan_value > 4;
/* 084 */         if (!filter_value) continue;
/* 085 */         double inmemorytablescan_value1 = inmemorytablescan_colInstance1.getDouble(inmemorytablescan_rowIdx);
/* 086 */
/* 087 */         boolean filter_isNull3 = false;
/* 088 */
/* 089 */         boolean filter_value3 = false;
/* 090 */         filter_value3 = org.apache.spark.util.Utils.nanSafeCompareDoubles(inmemorytablescan_value1, 10.0D) > 0;
/* 091 */         if (!filter_value3) continue;
/* 092 */
/* 093 */         filter_numOutputRows.add(1);
/* 094 */
/* 095 */         // do aggregate
/* 096 */         // common sub-expressions
/* 097 */
/* 098 */         // evaluate aggregate function
/* 099 */         boolean agg_isNull1 = false;
/* 100 */
/* 101 */         long agg_value1 = -1L;
/* 102 */         agg_value1 = agg_bufValue + 1L;
/* 103 */         // update aggregation buffer
/* 104 */         agg_bufIsNull = false;
/* 105 */         agg_bufValue = agg_value1;
/* 106 */         // shouldStop check is eliminated
/* 107 */       }
/* 108 */       inmemorytablescan_batchIdx = inmemorytablescan_numRows;
/* 109 */       inmemorytablescan_batch = null;
/* 110 */       inmemorytablescan_nextBatch();
/* 111 */     }
/* 112 */     inmemorytablescan_scanTime.add(inmemorytablescan_scanTime1 / (1000 * 1000));
/* 113 */     inmemorytablescan_scanTime1 = 0;
/* 114 */
/* 115 */   }
/* 116 */
/* 117 */   private void inmemorytablescan_nextBatch() throws java.io.IOException {
/* 118 */     long getBatchStart = System.nanoTime();
/* 119 */     if (inmemorytablescan_input.hasNext()) {
/* 120 */       inmemorytablescan_batch = (org.apache.spark.sql.execution.vectorized.ColumnarBatch)inmemorytablescan_input.next();
/* 121 */       inmemorytablescan_numOutputRows.add(inmemorytablescan_batch.numRows());
/* 122 */       inmemorytablescan_batchIdx = 0;
/* 123 */       inmemorytablescan_colInstance0 = inmemorytablescan_batch.column(0);
/* 124 */       inmemorytablescan_colInstance1 = inmemorytablescan_batch.column(1);
/* 125 */
/* 126 */     }
/* 127 */     inmemorytablescan_scanTime1 += System.nanoTime() - getBatchStart;
/* 128 */   }
/* 129 */
/* 130 */   private void wholestagecodegen_init_1() {
/* 131 */     this.agg_numOutputRows = (org.apache.spark.sql.execution.metric.SQLMetric) references[3];
/* 132 */     this.agg_aggTime = (org.apache.spark.sql.execution.metric.SQLMetric) references[4];
/* 133 */     agg_result = new UnsafeRow(1);
/* 134 */     this.agg_holder = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(agg_result, 0);
/* 135 */     this.agg_rowWriter = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(agg_holder, 1);
/* 136 */
/* 137 */   }
/* 138 */
/* 139 */   protected void processNext() throws java.io.IOException {
/* 140 */     while (!agg_initAgg) {
/* 141 */       agg_initAgg = true;
/* 142 */       long agg_beforeAgg = System.nanoTime();
/* 143 */       agg_doAggregateWithoutKey();
/* 144 */       agg_aggTime.add((System.nanoTime() - agg_beforeAgg) / 1000000);
/* 145 */
/* 146 */       // output the result
/* 147 */
/* 148 */       agg_numOutputRows.add(1);
/* 149 */       agg_rowWriter.zeroOutNullBytes();
/* 150 */
/* 151 */       if (agg_bufIsNull) {
/* 152 */         agg_rowWriter.setNullAt(0);
/* 153 */       } else {
/* 154 */         agg_rowWriter.write(0, agg_bufValue);
/* 155 */       }
/* 156 */       append(agg_result);
/* 157 */     }
/* 158 */   }
/* 159 */ }
```

## How was this patch tested?

Add test suites for wider columns