### PR TITLE
[SPARK-20848][SQL] Shutdown the pool after reading parquet files

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -26,22 +26,6 @@ import org.apache.spark.sql.test.SharedSQLContext
 
 class ParquetFileFormatSuite extends QueryTest with ParquetTest with SharedSQLContext {
 
-  test("Number of threads doesn't grow extremely after parquet file reading") {
-    withTempDir { dir =>
-      val file = dir.toString + "/file"
-      spark.range(1).toDF("a").coalesce(1).write.parquet(file)
-      spark.read.parquet(file)
-      val numThreadBefore = Thread.activeCount
-      (1 to 100).map { _ =>
-        spark.read.parquet(file)
-      }
-      val numThreadAfter = Thread.activeCount
-      // Hard to test a correct thread number,
-      // but it shouldn't increase more than a reasonable number.
-      assert(numThreadAfter - numThreadBefore < 20)
-    }
-  }
-
   test("read parquet footers in parallel") {
     def testReadFooters(ignoreCorruptFiles: Boolean): Unit = {
       withTempDir { dir =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

From JIRA: On each call to spark.read.parquet, a new ForkJoinPool is created. One of the threads in the pool is kept in the WAITING state, and never stopped, which leads to unbounded growth in number of threads.

We should shutdown the pool after reading parquet files.

## How was this patch tested?

Added a test to ParquetFileFormatSuite.

Please review http://spark.apache.org/contributing.html before opening a pull request.