### PR TITLE
[SPARK-18406][CORE] Race between end-of-task and completion iterator read lock release

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
@@ -46,5 +46,5 @@ trait BlockDataManager {
   /**
    * Release locks acquired by [[putBlockData()]] and [[getBlockData()]].
    */
-  def releaseLock(blockId: BlockId): Unit
+  def releaseLock(blockId: BlockId, taskAttemptId: Option[Long]): Unit
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -718,16 +718,12 @@ private[spark] class BlockManager(
   }
 
   /**
-   * Release a lock on the given block.
-   */
-  def releaseLock(blockId: BlockId): Unit = releaseLock(blockId, taskAttemptId = None)
-
-  /**
    * Release a lock on the given block with explicit TID.
-   * This method should be used in case we can't get the correct TID from TaskContext, for example,
-   * the input iterator of a cached RDD iterates to the end in a child thread.
+   * The param `taskAttemptId` should be passed in case we can't get the correct TID from
+   * TaskContext, for example, the input iterator of a cached RDD iterates to the end in a child
+   * thread.
    */
-  def releaseLock(blockId: BlockId, taskAttemptId: Option[Long]): Unit = {
+  def releaseLock(blockId: BlockId, taskAttemptId: Option[Long] = None): Unit = {
     blockInfoManager.unlock(blockId, taskAttemptId)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a TaskContext is not propagated properly to all child threads for the task, just like the reported cases in this issue, we fail to get to TID from TaskContext and that causes unable to release the lock and assertion failures. To resolve this, we have to explicitly pass the TID value to the `unlock` method.

## How was this patch tested?

Add new failing regression test case in `RDDSuite`.