### PR TITLE
[Spark-20771][SQL] Make weekofyear more intuitive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -358,7 +358,6 @@ object FunctionRegistry {
     expression[TruncDate]("trunc"),
     expression[UnixTimestamp]("unix_timestamp"),
     expression[WeekOfYear]("weekofyear"),
-    expression[WeekOfYearISO8601]("weekofyear_iso8601"),
     expression[Year]("year"),
     expression[TimeWindow]("window"),
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -358,6 +358,7 @@ object FunctionRegistry {
     expression[TruncDate]("trunc"),
     expression[UnixTimestamp]("unix_timestamp"),
     expression[WeekOfYear]("weekofyear"),
+    expression[WeekOfYearISO8601]("weekofyear_iso8601"),
     expression[Year]("year"),
     expression[TimeWindow]("window"),
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -404,7 +404,7 @@ case class DayOfMonth(child: Expression) extends UnaryExpression with ImplicitCa
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(date[, format[, firstDayOfWeek]) - Returns the week of the year of the given date. Defaults to ISO 8601 standard: weeks start on Monday, and week 1 is defined as the first week in the new year that contains a thursday. Start of week can be overriden, and the week first week can be defined as the week that contains the first day of the new year by setting it to 'gregorian'.",
+  usage = "_FUNC_(date[, format[, firstDayOfWeek]) - Returns the week of the year of the given date. Defaults to ISO 8601 standard: weeks start on Monday, and week 1 is defined as the first week in the new year that contains more than half of the days (Thursday in a Monday to Sunday week). Start of week can be overriden, and the week first week can be defined as the week that contains the first day of the new year by setting it to 'gregorian'.",
   extended = """
     Examples:
       > SELECT _FUNC_('2011-01-01');

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -404,24 +404,38 @@ case class DayOfMonth(child: Expression) extends UnaryExpression with ImplicitCa
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(date) - Returns the week of the year of the given date according to the ISO 8601 standard",
+  usage = "_FUNC_(date[, format]) - Returns the week of the year of the given date. Defaults to ISO 8601 standard, but can be gregorian specific",
   extended = """
     Examples:
       > SELECT _FUNC_('2008-02-20');
        8
+      > SELECT _FUNC_('2017-01-01', 'gregorian');
+       1
+      > SELECT _FUNC_('2017-01-01', 'iso');
+       52
+      > SELECT _FUNC_('2017-01-01');
+       52
   """)
 // scalastyle:on line.size.limit
-case class WeekOfYearISO8601(child: Expression) extends
+case class WeekOfYear(child: Expression, format: Expression) extends
   UnaryExpression with ImplicitCastInputTypes {
+
+  def this(child: Expression) = {
+    this(child, Literal("iso"))
+  }
 
   override def inputTypes: Seq[AbstractDataType] = Seq(DateType)
 
   override def dataType: DataType = IntegerType
 
+  @transient private lazy val minimalDays = {
+    if ("gregorian".equalsIgnoreCase(format.toString)) 1 else 4
+  }
+
   @transient private lazy val c = {
     val c = Calendar.getInstance(DateTimeUtils.getTimeZone("UTC"))
     c.setFirstDayOfWeek(Calendar.MONDAY)
-    c.setMinimalDaysInFirstWeek(4)
+    c.setMinimalDaysInFirstWeek(minimalDays)
     c
   }
 
@@ -439,51 +453,7 @@ case class WeekOfYearISO8601(child: Expression) extends
         s"""
           $c = $cal.getInstance($dtu.getTimeZone("UTC"));
           $c.setFirstDayOfWeek($cal.MONDAY);
-          $c.setMinimalDaysInFirstWeek(4);
-         """)
-      s"""
-        $c.setTimeInMillis($time * 1000L * 3600L * 24L);
-        ${ev.value} = $c.get($cal.WEEK_OF_YEAR);
-      """
-    })
-  }
-}
-
-// scalastyle:off line.size.limit
-@ExpressionDescription(
-  usage = "_FUNC_(date) - Returns the week of the year of the given date, where the first day of the year is always in week 1",
-  extended = """
-    Examples:
-      > SELECT _FUNC_('2017-01-01');
-       1
-             """)
-// scalastyle:on line.size.limit
-case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCastInputTypes {
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(DateType)
-
-  override def dataType: DataType = IntegerType
-
-  @transient private lazy val c = {
-    val c = Calendar.getInstance(DateTimeUtils.getTimeZone("UTC"))
-    c.setMinimalDaysInFirstWeek(1)
-    c
-  }
-
-  override protected def nullSafeEval(date: Any): Any = {
-    c.setTimeInMillis(date.asInstanceOf[Int] * 1000L * 3600L * 24L)
-    c.get(Calendar.WEEK_OF_YEAR)
-  }
-
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    nullSafeCodeGen(ctx, ev, time => {
-      val cal = classOf[Calendar].getName
-      val c = ctx.freshName("cal")
-      val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
-      ctx.addMutableState(cal, c,
-        s"""
-          $c = $cal.getInstance($dtu.getTimeZone("UTC"));
-          $c.setMinimalDaysInFirstWeek(1);
+          $c.setMinimalDaysInFirstWeek($minimalDays);
          """)
       s"""
         $c.setTimeInMillis($time * 1000L * 3600L * 24L);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -455,7 +455,7 @@ case class WeekOfYearISO8601(child: Expression) extends
   extended = """
     Examples:
       > SELECT _FUNC_('2017-01-01');
-       8
+       1
              """)
 // scalastyle:on line.size.limit
 case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCastInputTypes {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -197,23 +197,28 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("WeekOfYear") {
-    checkEvaluation(WeekOfYear(Literal.create(null, DateType), Literal("iso")), null)
-    checkEvaluation(WeekOfYear(Literal(d), Literal(false)), 15)
-    checkEvaluation(WeekOfYear(Cast(Literal(ts), DateType, gmtId), Literal("iso")), 45)
-    checkEvaluation(
-      WeekOfYear(Cast(Literal(sdfDate.format(d)), DateType, gmtId), Literal("iso")), 15)
-    checkEvaluation(
-      WeekOfYear(Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime)), Literal("iso")), 40)
-    checkEvaluation(
-      WeekOfYear(Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime)), Literal("iso")), 40)
-
-    checkEvaluation(
-      WeekOfYear(Cast(Literal("2017-01-01"), DateType, gmtId), Literal("iso")), 52)
-    checkEvaluation(
-      WeekOfYear(Cast(Literal("2017-01-01"), DateType, gmtId), Literal("gregorian")), 1)
+    checkEvaluation(WeekOfYear(
+      Literal.create(null, DateType), Literal("iso"), Literal("monday")), null)
+    checkEvaluation(WeekOfYear(Literal(d), Literal("iso"), Literal("monday")), 15)
+    checkEvaluation(WeekOfYear(
+      Cast(Literal(ts), DateType, gmtId), Literal("iso"), Literal("monday")), 45)
+    checkEvaluation(WeekOfYear(
+      Cast(Literal(sdfDate.format(d)), DateType, gmtId), Literal("iso"), Literal("monday")), 15)
+    checkEvaluation(WeekOfYear(
+      Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime)),
+      Literal("iso"), Literal("monday")), 40)
+    checkEvaluation(WeekOfYear(
+      Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime)),
+      Literal("iso"), Literal("monday")), 40)
+    checkEvaluation(WeekOfYear(
+      Cast(Literal("2011-01-01"), DateType, gmtId), Literal("iso"), Literal("monday")), 52)
+    checkEvaluation(WeekOfYear(
+      Cast(Literal("2011-01-01"), DateType, gmtId), Literal("gregorian"), Literal("monday")), 1)
+    checkEvaluation(WeekOfYear(
+      Cast(Literal("2011-01-01"), DateType, gmtId), Literal("iso"), Literal("sunday")), 52)
 
     checkConsistencyBetweenInterpretedAndCodegen(
-      (child: Expression) => WeekOfYear(child, Literal(true)), DateType)
+      (child: Expression) => WeekOfYear(child, Literal("iso"), Literal("monday")), DateType)
 
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -196,29 +196,25 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("WeekOfYearISO8601") {
-    checkEvaluation(WeekOfYearISO8601(Literal.create(null, DateType)), null)
-    checkEvaluation(WeekOfYearISO8601(Literal(d)), 15)
-    checkEvaluation(WeekOfYearISO8601(Cast(Literal(sdfDate.format(d)), DateType, gmtId)), 15)
-    checkEvaluation(WeekOfYearISO8601(Cast(Literal(ts), DateType, gmtId)), 45)
-    checkEvaluation(WeekOfYearISO8601(Cast(Literal("2017-01-01"), DateType, gmtId)), 52)
-    checkEvaluation(WeekOfYearISO8601(Cast(Literal("2011-05-06"), DateType, gmtId)), 18)
-    checkEvaluation(
-      WeekOfYearISO8601(Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime))), 40)
-    checkEvaluation(
-      WeekOfYearISO8601(Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime))), 40)
-    checkConsistencyBetweenInterpretedAndCodegen(WeekOfYearISO8601, DateType)
-  }
-
   test("WeekOfYear") {
-    checkEvaluation(WeekOfYear(Literal.create(null, DateType)), null)
-    checkEvaluation(WeekOfYear(Literal(d)), 15)
-    checkEvaluation(WeekOfYear(Cast(Literal(sdfDate.format(d)), DateType, gmtId)), 15)
-    checkEvaluation(WeekOfYear(Cast(Literal(ts), DateType, gmtId)), 45)
-    checkEvaluation(WeekOfYear(Cast(Literal("2017-01-01"), DateType, gmtId)), 1)
-    checkEvaluation(WeekOfYear(Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime))), 40)
-    checkEvaluation(WeekOfYear(Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime))), 40)
-    checkConsistencyBetweenInterpretedAndCodegen(WeekOfYear, DateType)
+    checkEvaluation(WeekOfYear(Literal.create(null, DateType), Literal("iso")), null)
+    checkEvaluation(WeekOfYear(Literal(d), Literal(false)), 15)
+    checkEvaluation(WeekOfYear(Cast(Literal(ts), DateType, gmtId), Literal("iso")), 45)
+    checkEvaluation(
+      WeekOfYear(Cast(Literal(sdfDate.format(d)), DateType, gmtId), Literal("iso")), 15)
+    checkEvaluation(
+      WeekOfYear(Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime)), Literal("iso")), 40)
+    checkEvaluation(
+      WeekOfYear(Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime)), Literal("iso")), 40)
+
+    checkEvaluation(
+      WeekOfYear(Cast(Literal("2017-01-01"), DateType, gmtId), Literal("iso")), 52)
+    checkEvaluation(
+      WeekOfYear(Cast(Literal("2017-01-01"), DateType, gmtId), Literal("gregorian")), 1)
+
+    checkConsistencyBetweenInterpretedAndCodegen(
+      (child: Expression) => WeekOfYear(child, Literal(true)), DateType)
+
   }
 
   test("DateFormat") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -196,12 +196,26 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("WeekOfYearISO8601") {
+    checkEvaluation(WeekOfYearISO8601(Literal.create(null, DateType)), null)
+    checkEvaluation(WeekOfYearISO8601(Literal(d)), 15)
+    checkEvaluation(WeekOfYearISO8601(Cast(Literal(sdfDate.format(d)), DateType, gmtId)), 15)
+    checkEvaluation(WeekOfYearISO8601(Cast(Literal(ts), DateType, gmtId)), 45)
+    checkEvaluation(WeekOfYearISO8601(Cast(Literal("2017-01-01"), DateType, gmtId)), 52)
+    checkEvaluation(WeekOfYearISO8601(Cast(Literal("2011-05-06"), DateType, gmtId)), 18)
+    checkEvaluation(
+      WeekOfYearISO8601(Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime))), 40)
+    checkEvaluation(
+      WeekOfYearISO8601(Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime))), 40)
+    checkConsistencyBetweenInterpretedAndCodegen(WeekOfYearISO8601, DateType)
+  }
+
   test("WeekOfYear") {
     checkEvaluation(WeekOfYear(Literal.create(null, DateType)), null)
     checkEvaluation(WeekOfYear(Literal(d)), 15)
     checkEvaluation(WeekOfYear(Cast(Literal(sdfDate.format(d)), DateType, gmtId)), 15)
     checkEvaluation(WeekOfYear(Cast(Literal(ts), DateType, gmtId)), 45)
-    checkEvaluation(WeekOfYear(Cast(Literal("2011-05-06"), DateType, gmtId)), 18)
+    checkEvaluation(WeekOfYear(Cast(Literal("2017-01-01"), DateType, gmtId)), 1)
     checkEvaluation(WeekOfYear(Literal(new Date(sdf.parse("1582-10-15 13:10:15").getTime))), 40)
     checkEvaluation(WeekOfYear(Literal(new Date(sdf.parse("1582-10-04 13:10:15").getTime))), 40)
     checkConsistencyBetweenInterpretedAndCodegen(WeekOfYear, DateType)


### PR DESCRIPTION
## What changes were proposed in this pull request?
The current implementation of weekofyear implements ISO8601, which results in the following unintuitive behaviour: 

weekofyear("2017-01-01") returns 52 

In MySQL, this would return 1 (https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_weekofyear), although it could return 52 if specified specifically (https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_week).

I therefore think instead of only changing the behavior as specified in the JIRA, it would be better to support both. Hence  I've added an additional function.

## How was this patch tested?
Added some unit tests

