### PR TITLE
[SPARK-20875] Spark should print the log when the directory has been deleted

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1004,7 +1004,7 @@ private[spark] object Utils extends Logging {
           for (child <- listFilesSafely(file)) {
             try {
               deleteRecursively(child)
-              logTrace(file.getAbsolutePath + s" has been deleted")
+              logTrace(file.getAbsolutePath + " has been deleted")
             } catch {
               // In case of multiple exceptions, only last one will be thrown
               case ioe: IOException => savedIOException = ioe

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1016,7 +1016,7 @@ private[spark] object Utils extends Logging {
         }
       } finally {
         if (file.delete()) {
-            logTrace(s"${file.getAbsolutePath} has been deleted")
+          logTrace(s"${file.getAbsolutePath} has been deleted")
         } else {
           // Delete can also fail if the file simply did not exist
           if (file.exists()) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1004,7 +1004,6 @@ private[spark] object Utils extends Logging {
           for (child <- listFilesSafely(file)) {
             try {
               deleteRecursively(child)
-              logTrace(s"${file.getAbsolutePath} has been deleted")
             } catch {
               // In case of multiple exceptions, only last one will be thrown
               case ioe: IOException => savedIOException = ioe
@@ -1016,7 +1015,9 @@ private[spark] object Utils extends Logging {
           ShutdownHookManager.removeShutdownDeleteDir(file)
         }
       } finally {
-        if (!file.delete()) {
+        if (file.delete()) {
+            logTrace(s"${file.getAbsolutePath} has been deleted")
+        } else {
           // Delete can also fail if the file simply did not exist
           if (file.exists()) {
             throw new IOException("Failed to delete: " + file.getAbsolutePath)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1004,7 +1004,7 @@ private[spark] object Utils extends Logging {
           for (child <- listFilesSafely(file)) {
             try {
               deleteRecursively(child)
-              logInfo(file.getAbsolutePath + s" has been deleted")
+              logTrace(file.getAbsolutePath + s" has been deleted")
             } catch {
               // In case of multiple exceptions, only last one will be thrown
               case ioe: IOException => savedIOException = ioe

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1004,7 +1004,7 @@ private[spark] object Utils extends Logging {
           for (child <- listFilesSafely(file)) {
             try {
               deleteRecursively(child)
-              logTrace(file.getAbsolutePath + " has been deleted")
+              logTrace(s"${file.getAbsolutePath} has been deleted")
             } catch {
               // In case of multiple exceptions, only last one will be thrown
               case ioe: IOException => savedIOException = ioe

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1004,6 +1004,7 @@ private[spark] object Utils extends Logging {
           for (child <- listFilesSafely(file)) {
             try {
               deleteRecursively(child)
+              logInfo(file.getAbsolutePath + s" has been deleted")
             } catch {
               // In case of multiple exceptions, only last one will be thrown
               case ioe: IOException => savedIOException = ioe


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-20875](https://issues.apache.org/jira/browse/SPARK-20875)
When the "deleteRecursively" method is invoked,spark doesn't print any log if the path was deleted.For example,spark only print "Removing directory" when the worker began cleaning spark.work.dir,but didn't print any log about "the path has been delete".So, I can't judge whether the path was deleted form the worker's logfile,If there is any accidents about Linux.