### PR TITLE
[SPARK-20884] Spark' masters will be both standby due to the bug of curator

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -47,9 +47,9 @@ commons-net-2.2.jar
 commons-pool-1.5.4.jar
 compress-lzf-1.0.3.jar
 core-1.1.2.jar
-curator-client-2.6.0.jar
-curator-framework-2.6.0.jar
-curator-recipes-2.6.0.jar
+curator-client-2.8.0.jar
+curator-framework-2.8.0.jar
+curator-recipes-2.8.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -47,9 +47,9 @@ commons-net-2.2.jar
 commons-pool-1.5.4.jar
 compress-lzf-1.0.3.jar
 core-1.1.2.jar
-curator-client-2.6.0.jar
-curator-framework-2.6.0.jar
-curator-recipes-2.6.0.jar
+curator-client-2.8.0.jar
+curator-framework-2.8.0.jar
+curator-recipes-2.8.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <yarn.version>${hadoop.version}</yarn.version>
     <flume.version>1.6.0</flume.version>
     <zookeeper.version>3.4.6</zookeeper.version>
-    <curator.version>2.6.0</curator.version>
+    <curator.version>2.8.0</curator.version>
     <hive.group>org.spark-project.hive</hive.group>
     <!-- Version used in Maven Hive dependency -->
     <hive.version>1.2.1.spark2</hive.version>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-20884](https://issues.apache.org/jira/browse/SPARK-20884)
I built a cluster with two masters and three workers.When there is a switch of master's state,two masters are both standby in a long period.There are some ERROR in master's logfile " ERROR CuratorFrameworkImpl: Background exception was not retry-able or retry gave up
java.lang.IllegalArgumentException: Path must start with / character
at org.apache.curator.utils.PathUtils.validatePath(PathUtils.java:53)
at org.apache.curator.utils.ZKPaths.getNodeFromPath(ZKPaths.java:56)
at org.apache.curator.framework.recipes.leader.LeaderLatch.checkLeadership(LeaderLatch.java:421)
at org.apache.curator.framework.recipes.leader.LeaderLatch.access$500(LeaderLatch.java:60)
at org.apache.curator.framework.recipes.leader.LeaderLatch$6.processResult(LeaderLatch.java:478)
at org.apache.curator.framework.imps.CuratorFrameworkImpl.sendToBackgroundCallback(CuratorFrameworkImpl.java:686)
at org.apache.curator.framework.imps.CuratorFrameworkImpl.processBackgroundOperation(CuratorFrameworkImpl.java:485)
at org.apache.curator.framework.imps.GetChildrenBuilderImpl$2.processResult(GetChildrenBuilderImpl.java:166)
at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:587)
at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:495)"
it can be related to https://issues.apache.org/jira/browse/CURATOR-168.
So I think the version of curator in spark should be 2.8.