### PR TITLE
[SPARK-20498][PYSPARK][ML] Expose getMaxDepth for ensemble tree model in PySpark

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -862,6 +862,8 @@ class RandomForestClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPred
     >>> model_path = temp_path + "/rfc_model"
     >>> model.save(model_path)
     >>> model2 = RandomForestClassificationModel.load(model_path)
+    >>> model.getMaxDepth() == model2.getMaxDepth()
+    True
     >>> model.featureImportances == model2.featureImportances
     True
 
@@ -997,6 +999,8 @@ class GBTClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol
     >>> model_path = temp_path + "gbtc_model"
     >>> model.save(model_path)
     >>> model2 = GBTClassificationModel.load(model_path)
+    >>> model.getMaxDepth() == model2.getMaxDepth()
+    True
     >>> model.featureImportances == model2.featureImportances
     True
     >>> model.treeWeights == model2.treeWeights

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -786,6 +786,12 @@ class TreeEnsembleModel(JavaModel):
         return self._call_java("getNumTrees")
 
     @property
+    @since("2.3.0")
+    def getMaxDepth(self):
+        """Maximum depth of the tree (>= 0)."""
+        return self._call_java("getMaxDepth")
+
+    @property
     @since("1.5.0")
     def treeWeights(self):
         """Return the weights for each tree"""

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -883,6 +883,8 @@ class RandomForestRegressor(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredi
     >>> model_path = temp_path + "/rfr_model"
     >>> model.save(model_path)
     >>> model2 = RandomForestRegressionModel.load(model_path)
+    >>> model.getMaxDepth() == model2.getMaxDepth()
+    True
     >>> model.featureImportances == model2.featureImportances
     True
 
@@ -1002,6 +1004,8 @@ class GBTRegressor(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol,
     >>> model_path = temp_path + "gbtr_model"
     >>> model.save(model_path)
     >>> model2 = GBTRegressionModel.load(model_path)
+    >>> model.getMaxDepth() == model2.getMaxDepth()
+    True
     >>> model.featureImportances == model2.featureImportances
     True
     >>> model.treeWeights == model2.treeWeights


### PR DESCRIPTION
## What changes were proposed in this pull request?

add `getMaxDepth` method for ensemble tree models:
+ `RandomForestClassifierModel`
+ `RandomForestRegressionModel`
+ `GBTClassificationModel`
+ `GBTRegressionModel`


## How was this patch tested?

+ [x] pass all unit tests.
+ [x] add new doctest.

