### PR TITLE
[SPARK-20899][PySpark] PySpark supports stringIndexerOrderType in RFormula

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -3032,18 +3032,6 @@ class RFormula(JavaEstimator, HasFeaturesCol, HasLabelCol, JavaMLReadable, JavaM
     ...
     >>> str(loadedModel)
     'RFormulaModel(ResolvedRFormula(label=y, terms=[x,s], hasIntercept=true)) (uid=...)'
-    >>> rf = RFormula(formula="y ~ x + s", stringIndexerOrderType="alphabetDesc")
-    >>> rf.getStringIndexerOrderType()
-    'alphabetDesc'
-    >>> rf.fit(df).transform(df).show()
-    +---+---+---+---------+-----+
-    |  y|  x|  s| features|label|
-    +---+---+---+---------+-----+
-    |1.0|1.0|  a|[1.0,0.0]|  1.0|
-    |0.0|2.0|  b|[2.0,1.0]|  0.0|
-    |0.0|0.0|  a|(2,[],[])|  0.0|
-    +---+---+---+---------+-----+
-    ...
 
     .. versionadded:: 1.5.0
     """

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -3032,6 +3032,18 @@ class RFormula(JavaEstimator, HasFeaturesCol, HasLabelCol, JavaMLReadable, JavaM
     ...
     >>> str(loadedModel)
     'RFormulaModel(ResolvedRFormula(label=y, terms=[x,s], hasIntercept=true)) (uid=...)'
+    >>> rf = RFormula(formula="y ~ x + s", stringIndexerOrderType="alphabetDesc")
+    >>> rf.getStringIndexerOrderType()
+    'alphabetDesc'
+    >>> rf.fit(df).transform(df).show()
+    +---+---+---+---------+-----+
+    |  y|  x|  s| features|label|
+    +---+---+---+---------+-----+
+    |1.0|1.0|  a|[1.0,0.0]|  1.0|
+    |0.0|2.0|  b|[2.0,1.0]|  0.0|
+    |0.0|0.0|  a|(2,[],[])|  0.0|
+    +---+---+---+---------+-----+
+    ...
 
     .. versionadded:: 1.5.0
     """
@@ -3043,26 +3055,35 @@ class RFormula(JavaEstimator, HasFeaturesCol, HasLabelCol, JavaMLReadable, JavaM
                             "Force to index label whether it is numeric or string",
                             typeConverter=TypeConverters.toBoolean)
 
+    stringIndexerOrderType = Param(Params._dummy(), "stringIndexerOrderType",
+                                   "How to order categories of a string FEATURE column used by " +
+                                   "StringIndexer. The last category after ordering is dropped " +
+                                   "when encoding strings. Supported options: frequencyDesc, " +
+                                   "frequencyAsc, alphabetDesc, alphabetAsc. The default value " +
+                                   "is frequencyDesc. When the ordering is set to alphabetDesc, " +
+                                   "RFormula drops the same category as R when encoding strings.",
+                                   typeConverter=TypeConverters.toString)
+
     @keyword_only
     def __init__(self, formula=None, featuresCol="features", labelCol="label",
-                 forceIndexLabel=False):
+                 forceIndexLabel=False, stringIndexerOrderType="frequencyDesc"):
         """
         __init__(self, formula=None, featuresCol="features", labelCol="label", \
-                 forceIndexLabel=False)
+                 forceIndexLabel=False, stringIndexerOrderType="frequencyDesc")
         """
         super(RFormula, self).__init__()
         self._java_obj = self._new_java_obj("org.apache.spark.ml.feature.RFormula", self.uid)
-        self._setDefault(forceIndexLabel=False)
+        self._setDefault(forceIndexLabel=False, stringIndexerOrderType="frequencyDesc")
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
     @since("1.5.0")
     def setParams(self, formula=None, featuresCol="features", labelCol="label",
-                  forceIndexLabel=False):
+                  forceIndexLabel=False, stringIndexerOrderType="frequencyDesc"):
         """
         setParams(self, formula=None, featuresCol="features", labelCol="label", \
-                  forceIndexLabel=False)
+                  forceIndexLabel=False, stringIndexerOrderType="frequencyDesc")
         Sets params for RFormula.
         """
         kwargs = self._input_kwargs
@@ -3095,6 +3116,20 @@ class RFormula(JavaEstimator, HasFeaturesCol, HasLabelCol, JavaMLReadable, JavaM
         Gets the value of :py:attr:`forceIndexLabel`.
         """
         return self.getOrDefault(self.forceIndexLabel)
+
+    @since("2.3.0")
+    def setStringIndexerOrderType(self, value):
+        """
+        Sets the value of :py:attr:`stringIndexerOrderType`.
+        """
+        return self._set(stringIndexerOrderType=value)
+
+    @since("2.3.0")
+    def getStringIndexerOrderType(self):
+        """
+        Gets the value of :py:attr:`stringIndexerOrderType` or its default value 'frequencyDesc'.
+        """
+        return self.getOrDefault(self.stringIndexerOrderType)
 
     def _create_model(self, java_model):
         return RFormulaModel(java_model)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -3056,7 +3056,7 @@ class RFormula(JavaEstimator, HasFeaturesCol, HasLabelCol, JavaMLReadable, JavaM
                             typeConverter=TypeConverters.toBoolean)
 
     stringIndexerOrderType = Param(Params._dummy(), "stringIndexerOrderType",
-                                   "How to order categories of a string FEATURE column used by " +
+                                   "How to order categories of a string feature column used by " +
                                    "StringIndexer. The last category after ordering is dropped " +
                                    "when encoding strings. Supported options: frequencyDesc, " +
                                    "frequencyAsc, alphabetDesc, alphabetAsc. The default value " +

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -538,6 +538,19 @@ class FeatureTests(SparkSessionTestCase):
         transformedDF2 = model2.transform(df)
         self.assertEqual(transformedDF2.head().label, 0.0)
 
+    def test_rformula_string_indexer_order_type(self):
+        df = self.spark.createDataFrame([
+            (1.0, 1.0, "a"),
+            (0.0, 2.0, "b"),
+            (1.0, 0.0, "a")], ["y", "x", "s"])
+        rf = RFormula(formula="y ~ x + s", stringIndexerOrderType="alphabetDesc")
+        self.assertEqual(rf.getStringIndexerOrderType(), 'alphabetDesc')
+        transformedDF = rf.fit(df).transform(df)
+        observed = transformedDF.select("features").collect()
+        expected = [[1.0, 0.0], [2.0, 1.0], [0.0, 0.0]]
+        for i in range(0, len(expected)):
+            self.assertTrue((observed[i]["features"].toArray() == expected[i]).all())
+
 
 class HasInducedError(Params):
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -549,7 +549,7 @@ class FeatureTests(SparkSessionTestCase):
         observed = transformedDF.select("features").collect()
         expected = [[1.0, 0.0], [2.0, 1.0], [0.0, 0.0]]
         for i in range(0, len(expected)):
-            self.assertTrue((observed[i]["features"].toArray() == expected[i]).all())
+            self.assertTrue(all(observed[i]["features"].toArray() == expected[i]))
 
 
 class HasInducedError(Params):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -61,9 +61,9 @@ else:
 from pyspark import keyword_only
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
-from pyspark.rdd import RDD
 from pyspark.files import SparkFiles
 from pyspark.ml.feature import RFormula
+from pyspark.rdd import RDD
 from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, PickleSerializer, \
     CloudPickleSerializer, CompressedSerializer, UTF8Deserializer, NoOpSerializer, \
     PairDeserializer, CartesianDeserializer, AutoBatchedSerializer, AutoSerializer, \
@@ -2207,20 +2207,20 @@ class KeywordOnlyTests(unittest.TestCase):
         self.assertEqual(b._x, 2)
 
 
-class SparkMLTests(unittest.TestCase):
+class SparkMLTests(ReusedPySparkTestCase):
 
     def test_rformula(self):
-        df = spark.createDataFrame([
-             (1.0, 1.0, "a"),
-             (0.0, 2.0, "b"),
-             (0.0, 0.0, "a")
-        ], ["y", "x", "s"])
+        df = self.sc.parallelize([
+            (1.0, 1.0, "a"),
+            (0.0, 2.0, "b"),
+            (0.0, 0.0, "a")
+        ]).toDF(["y", "x", "s"])
         rf = RFormula(formula="y ~ x + s", stringIndexerOrderType="alphabetDesc")
         self.assertEqual(rf.getStringIndexerOrderType(), 'alphabetDesc')
 
         result = rf.fit(df).transform(df)
         observed = result.select("features").collect()
-        expected = [[1.0, 0.0], [2.0, 1.0], [0.0,0.0]]
+        expected = [[1.0, 0.0], [2.0, 1.0], [0.0, 0.0]]
         for i in range(0, len(expected)):
             self.assertEqual(observed[i]["features"].toArray(), expected[i])
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -63,6 +63,7 @@ from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.rdd import RDD
 from pyspark.files import SparkFiles
+from pyspark.ml.feature import RFormula
 from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, PickleSerializer, \
     CloudPickleSerializer, CompressedSerializer, UTF8Deserializer, NoOpSerializer, \
     PairDeserializer, CartesianDeserializer, AutoBatchedSerializer, AutoSerializer, \
@@ -2204,6 +2205,24 @@ class KeywordOnlyTests(unittest.TestCase):
         a.set(x=1, other=b, other_x=2)
         self.assertEqual(a._x, 1)
         self.assertEqual(b._x, 2)
+
+
+class SparkMLTests(unittest.TestCase):
+
+    def test_rformula(self):
+        df = spark.createDataFrame([
+             (1.0, 1.0, "a"),
+             (0.0, 2.0, "b"),
+             (0.0, 0.0, "a")
+        ], ["y", "x", "s"])
+        rf = RFormula(formula="y ~ x + s", stringIndexerOrderType="alphabetDesc")
+        self.assertEqual(rf.getStringIndexerOrderType(), 'alphabetDesc')
+
+        result = rf.fit(df).transform(df)
+        observed = result.select("features").collect()
+        expected = [[1.0, 0.0], [2.0, 1.0], [0.0,0.0]]
+        for i in range(0, len(expected)):
+            self.assertEqual(observed[i]["features"].toArray(), expected[i])
 
 
 @unittest.skipIf(not _have_scipy, "SciPy not installed")

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -61,9 +61,8 @@ else:
 from pyspark import keyword_only
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
-from pyspark.files import SparkFiles
-from pyspark.ml.feature import RFormula
 from pyspark.rdd import RDD
+from pyspark.files import SparkFiles
 from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, PickleSerializer, \
     CloudPickleSerializer, CompressedSerializer, UTF8Deserializer, NoOpSerializer, \
     PairDeserializer, CartesianDeserializer, AutoBatchedSerializer, AutoSerializer, \
@@ -2205,24 +2204,6 @@ class KeywordOnlyTests(unittest.TestCase):
         a.set(x=1, other=b, other_x=2)
         self.assertEqual(a._x, 1)
         self.assertEqual(b._x, 2)
-
-
-class SparkMLTests(ReusedPySparkTestCase):
-
-    def test_rformula(self):
-        df = self.sc.parallelize([
-            (1.0, 1.0, "a"),
-            (0.0, 2.0, "b"),
-            (0.0, 0.0, "a")
-        ]).toDF(["y", "x", "s"])
-        rf = RFormula(formula="y ~ x + s", stringIndexerOrderType="alphabetDesc")
-        self.assertEqual(rf.getStringIndexerOrderType(), 'alphabetDesc')
-
-        result = rf.fit(df).transform(df)
-        observed = result.select("features").collect()
-        expected = [[1.0, 0.0], [2.0, 1.0], [0.0, 0.0]]
-        for i in range(0, len(expected)):
-            self.assertEqual(observed[i]["features"].toArray(), expected[i])
 
 
 @unittest.skipIf(not _have_scipy, "SciPy not installed")


### PR DESCRIPTION
## What changes were proposed in this pull request?

PySpark supports stringIndexerOrderType in RFormula as in #17967. 

## How was this patch tested?
docstring test