### PR TITLE
[SPARK-20900][YARN] Catch IllegalArgumentException thrown by new Path in ApplicationMaster

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -534,10 +534,12 @@ private[spark] class ApplicationMaster(
     try {
       val preserveFiles = sparkConf.get(PRESERVE_STAGING_FILES)
       if (!preserveFiles) {
-        stagingDirPath = new Path(System.getenv("SPARK_YARN_STAGING_DIR"))
-        if (stagingDirPath == null) {
-          logError("Staging directory is null")
-          return
+        try {
+          stagingDirPath = new Path(System.getenv("SPARK_YARN_STAGING_DIR"))
+        } catch {
+          case e: IllegalArgumentException =>
+            logError("Staging directory is null")
+            return
         }
         logInfo("Deleting staging directory " + stagingDirPath)
         fs.delete(stagingDirPath, true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Catch `IllegalArgumentException` which might be thrown if `SPARK_YARN_STAGING_DIR` is not set or empty.

## How was this patch tested?

Manually tested by running `ApplicationMaster` with `SPARK_YARN_STAGING_DIR` unset.