### PR TITLE
[SPARK-20365][YARN] Remove LocalSchem when add path to ClassPath.

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1275,8 +1275,8 @@ private object Client extends Logging {
     if (sparkConf.get(SPARK_ARCHIVE).isEmpty) {
       sparkConf.get(SPARK_JARS).foreach { jars =>
         jars.filter(isLocalUri).foreach { jar =>
-          val noLocal = jar.substring(LOCAL_SCHEME.length)
-          addClasspathEntry(getClusterPath(sparkConf, noLocal), env)
+          val uri = new URI(jar)
+          addClasspathEntry(getClusterPath(sparkConf, uri.getPath), env)
         }
       }
     }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1275,7 +1275,8 @@ private object Client extends Logging {
     if (sparkConf.get(SPARK_ARCHIVE).isEmpty) {
       sparkConf.get(SPARK_JARS).foreach { jars =>
         jars.filter(isLocalUri).foreach { jar =>
-          addClasspathEntry(getClusterPath(sparkConf, jar), env)
+          val noLocal = jar.substring(LOCAL_SCHEME.length)
+          addClasspathEntry(getClusterPath(sparkConf, noLocal), env)
         }
       }
     }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1276,7 +1276,7 @@ private object Client extends Logging {
       sparkConf.get(SPARK_JARS).foreach { jars =>
         jars.filter(isLocalUri).foreach { jar =>
           val uri = new URI(jar)
-          addClasspathEntry(getClusterPath(sparkConf, uri.getPath), env)
+          addClasspathEntry(getClusterPath(sparkConf, uri.getPath()), env)
         }
       }
     }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -116,15 +116,16 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
     val cp = env("CLASSPATH").split(":|;|<CPS>")
     s"$SPARK,$USER,$ADDED".split(",").foreach({ entry =>
       val uri = new URI(entry)
-      if (LOCAL_SCHEME.equals(uri.getScheme())) {
-        cp should contain (uri.getPath())
+      if (LOCAL_SCHEME.equals(uri.getScheme)) {
+        cp should contain (uri.getPath)
       } else {
-        cp should not contain (uri.getPath())
+        cp should not contain uri.getPath
       }
     })
+    cp should not contain "local"
     cp should contain(PWD)
-    cp should contain (s"$PWD${Path.SEPARATOR}${LOCALIZED_CONF_DIR}")
-    cp should not contain (APP_JAR)
+    cp should contain (s"$PWD${Path.SEPARATOR}$LOCALIZED_CONF_DIR")
+    cp should not contain APP_JAR
   }
 
   test("Jar path propagation through SparkConf") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -122,7 +122,7 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
         cp should not contain (uri.getPath())
       }
     })
-    cp should not contain "local"
+    cp should not contain ("local")
     cp should contain(PWD)
     cp should contain (s"$PWD${Path.SEPARATOR}${LOCALIZED_CONF_DIR}")
     cp should not contain (APP_JAR)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -119,13 +119,13 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
       if (LOCAL_SCHEME.equals(uri.getScheme())) {
         cp should contain (uri.getPath())
       } else {
-        cp should not contain uri.getPath()
+        cp should not contain (uri.getPath())
       }
     })
     cp should not contain "local"
     cp should contain(PWD)
     cp should contain (s"$PWD${Path.SEPARATOR}${LOCALIZED_CONF_DIR}")
-    cp should not contain APP_JAR
+    cp should not contain (APP_JAR)
   }
 
   test("Jar path propagation through SparkConf") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -116,15 +116,15 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
     val cp = env("CLASSPATH").split(":|;|<CPS>")
     s"$SPARK,$USER,$ADDED".split(",").foreach({ entry =>
       val uri = new URI(entry)
-      if (LOCAL_SCHEME.equals(uri.getScheme)) {
-        cp should contain (uri.getPath)
+      if (LOCAL_SCHEME.equals(uri.getScheme())) {
+        cp should contain (uri.getPath())
       } else {
-        cp should not contain uri.getPath
+        cp should not contain uri.getPath()
       }
     })
     cp should not contain "local"
     cp should contain(PWD)
-    cp should contain (s"$PWD${Path.SEPARATOR}$LOCALIZED_CONF_DIR")
+    cp should contain (s"$PWD${Path.SEPARATOR}${LOCALIZED_CONF_DIR}")
     cp should not contain APP_JAR
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Spark on YARN, when configuring "spark.yarn.jars" with local jars (jars started with "local" scheme), we will get inaccurate classpath for AM and containers. This is because we don't remove "local" scheme when concatenating classpath. It is OK to run because classpath is separated with ":" and java treat "local" as a separate jar. But we could improve it to remove the scheme.

## How was this patch tested?

Updated `ClientSuite` to check "local" is not in the classpath.

cc @jerryshao
