### PR TITLE
[Web UI] Remove no need loop in JobProgressListener

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -202,12 +202,12 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
     }
     jobIdToData(jobStart.jobId) = jobData
     activeJobs(jobStart.jobId) = jobData
-    for (stageId <- jobStart.stageIds) {
-      stageIdToActiveJobIds.getOrElseUpdate(stageId, new HashSet[StageId]).add(jobStart.jobId)
-    }
+
     // If there's no information for a stage, store the StageInfo received from the scheduler
     // so that we can display stage descriptions for pending stages:
     for (stageInfo <- jobStart.stageInfos) {
+      stageIdToActiveJobIds.getOrElseUpdate(stageInfo.stageId, new HashSet[StageId]).add(jobStart.jobId)
+
       stageIdToInfo.getOrElseUpdate(stageInfo.stageId, stageInfo)
       stageIdToData.getOrElseUpdate((stageInfo.stageId, stageInfo.attemptId), new StageUIData)
     }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -206,7 +206,8 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
     // If there's no information for a stage, store the StageInfo received from the scheduler
     // so that we can display stage descriptions for pending stages:
     for (stageInfo <- jobStart.stageInfos) {
-      stageIdToActiveJobIds.getOrElseUpdate(stageInfo.stageId, new HashSet[StageId]).add(jobStart.jobId)
+      stageIdToActiveJobIds.getOrElseUpdate(stageInfo.stageId, 
+        new HashSet[StageId]).add(jobStart.jobId)
 
       stageIdToInfo.getOrElseUpdate(stageInfo.stageId, stageInfo)
       stageIdToData.getOrElseUpdate((stageInfo.stageId, stageInfo.attemptId), new StageUIData)


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found it's unnecessary to use the same loop twice, so changed them into one. It's a little change...

## How was this patch tested?

`./build/mvn -P... -Dtest=none -DwildcardSuites=org.apache.spark.ui.jobs.JobProgressListenerSuite test`