### PR TITLE
[SPARK-20787][PYTHON] PySpark can't handle datetimes before 1900 

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -188,7 +188,7 @@ class TimestampType(AtomicType):
     def toInternal(self, dt):
         if dt is not None:
             seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
-                       else time.mktime(dt.timetuple()))
+                       else calendar.timegm(dt.timetuple()))
             return int(seconds) * 1000000 + dt.microsecond
 
     def fromInternal(self, ts):


### PR DESCRIPTION
`time.mktime` can't handle dates from 1899-100, according to the documentation by design. `calendar.timegm` is equivalent in shared cases, but can handle those years.

## What changes were proposed in this pull request?

Change `time.mktime` for the more able `calendar.timegm` to adress cases like:
```python
import datetime as dt
sqlContext.createDataFrame(sc.parallelize([[dt.datetime(1899,12,31)]])).count()
```
failing due to internal conversion failure when there is no timezone information in the time object. In the case there is information, `calendar` was used instead.

## How was this patch tested?

The existing test cases should cover this change, since it should not change any existing functionality.

This PR is original work from me and I license this work to the Spark project