### PR TITLE
[SPARK-20915][SQL] Make lpad/rpad with empty pad string same as MySQL.

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -688,28 +688,36 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    *   ('hi', 1, '??') =&gt; 'h'
    */
   public UTF8String rpad(int len, UTF8String pad) {
-    int spaces = len - this.numChars(); // number of char need to pad
-    if (spaces <= 0 || pad.numBytes() == 0) {
-      // no padding at all, return the substring of the current string
-      return substring(0, len);
+    if (len < 0) {
+      return null;
+    } else if (len == 0) {
+      return EMPTY_UTF8;
     } else {
-      int padChars = pad.numChars();
-      int count = spaces / padChars; // how many padding string needed
-      // the partial string of the padding
-      UTF8String remain = pad.substring(0, spaces - padChars * count);
+      int spaces = len - this.numChars(); // number of char need to pad
+      if (spaces > 0 && pad.numBytes() == 0) {
+        return null;
+      } else if (spaces <= 0) {
+        // no padding at all, return the substring of the current string
+        return substring(0, len);
+      } else {
+        int padChars = pad.numChars();
+        int count = spaces / padChars; // how many padding string needed
+        // the partial string of the padding
+        UTF8String remain = pad.substring(0, spaces - padChars * count);
 
-      byte[] data = new byte[this.numBytes + pad.numBytes * count + remain.numBytes];
-      copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET, this.numBytes);
-      int offset = this.numBytes;
-      int idx = 0;
-      while (idx < count) {
-        copyMemory(pad.base, pad.offset, data, BYTE_ARRAY_OFFSET + offset, pad.numBytes);
-        ++ idx;
-        offset += pad.numBytes;
+        byte[] data = new byte[this.numBytes + pad.numBytes * count + remain.numBytes];
+        copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET, this.numBytes);
+        int offset = this.numBytes;
+        int idx = 0;
+        while (idx < count) {
+          copyMemory(pad.base, pad.offset, data, BYTE_ARRAY_OFFSET + offset, pad.numBytes);
+          ++idx;
+          offset += pad.numBytes;
+        }
+        copyMemory(remain.base, remain.offset, data, BYTE_ARRAY_OFFSET + offset, remain.numBytes);
+
+        return UTF8String.fromBytes(data);
       }
-      copyMemory(remain.base, remain.offset, data, BYTE_ARRAY_OFFSET + offset, remain.numBytes);
-
-      return UTF8String.fromBytes(data);
     }
   }
 
@@ -720,30 +728,38 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    *   ('hi', 1, '??') =&gt; 'h'
    */
   public UTF8String lpad(int len, UTF8String pad) {
-    int spaces = len - this.numChars(); // number of char need to pad
-    if (spaces <= 0 || pad.numBytes() == 0) {
-      // no padding at all, return the substring of the current string
-      return substring(0, len);
+    if(len < 0) {
+      return null;
+    } else if (len == 0) {
+      return EMPTY_UTF8;
     } else {
-      int padChars = pad.numChars();
-      int count = spaces / padChars; // how many padding string needed
-      // the partial string of the padding
-      UTF8String remain = pad.substring(0, spaces - padChars * count);
+      int spaces = len - this.numChars(); // number of char need to pad
+      if (spaces > 0 && pad.numBytes() == 0) {
+        return null;
+      } else if (spaces <= 0) {
+        // no padding at all, return the substring of the current string
+        return substring(0, len);
+      } else {
+        int padChars = pad.numChars();
+        int count = spaces / padChars; // how many padding string needed
+        // the partial string of the padding
+        UTF8String remain = pad.substring(0, spaces - padChars * count);
 
-      byte[] data = new byte[this.numBytes + pad.numBytes * count + remain.numBytes];
+        byte[] data = new byte[this.numBytes + pad.numBytes * count + remain.numBytes];
 
-      int offset = 0;
-      int idx = 0;
-      while (idx < count) {
-        copyMemory(pad.base, pad.offset, data, BYTE_ARRAY_OFFSET + offset, pad.numBytes);
-        ++ idx;
-        offset += pad.numBytes;
+        int offset = 0;
+        int idx = 0;
+        while (idx < count) {
+          copyMemory(pad.base, pad.offset, data, BYTE_ARRAY_OFFSET + offset, pad.numBytes);
+          ++ idx;
+          offset += pad.numBytes;
+        }
+        copyMemory(remain.base, remain.offset, data, BYTE_ARRAY_OFFSET + offset, remain.numBytes);
+        offset += remain.numBytes;
+        copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET + offset, numBytes());
+
+        return UTF8String.fromBytes(data);
       }
-      copyMemory(remain.base, remain.offset, data, BYTE_ARRAY_OFFSET + offset, remain.numBytes);
-      offset += remain.numBytes;
-      copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET + offset, numBytes());
-
-      return UTF8String.fromBytes(data);
     }
   }
 

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -352,17 +352,40 @@ public class UTF8StringSuite {
       fromString("数据砖头孙行者孙行者孙行"),
       fromString("数据砖头").rpad(12, fromString("孙行者")));
 
-    assertEquals(EMPTY_UTF8, fromString("数据砖头").lpad(-10, fromString("孙行者")));
-    assertEquals(EMPTY_UTF8, fromString("数据砖头").lpad(-10, EMPTY_UTF8));
-    assertEquals(fromString("数据砖头"), fromString("数据砖头").lpad(5, EMPTY_UTF8));
+    assertEquals(null, fromString("数据砖头").lpad(-10, fromString("孙行者")));
+    assertEquals(null, fromString("数据砖头").lpad(-10, EMPTY_UTF8));
+    assertEquals(null, fromString("数据砖头").lpad(5, EMPTY_UTF8));
     assertEquals(fromString("数据砖"), fromString("数据砖头").lpad(3, EMPTY_UTF8));
-    assertEquals(EMPTY_UTF8, EMPTY_UTF8.lpad(3, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.lpad(3, EMPTY_UTF8));
 
-    assertEquals(EMPTY_UTF8, fromString("数据砖头").rpad(-10, fromString("孙行者")));
-    assertEquals(EMPTY_UTF8, fromString("数据砖头").rpad(-10, EMPTY_UTF8));
-    assertEquals(fromString("数据砖头"), fromString("数据砖头").rpad(5, EMPTY_UTF8));
+    assertEquals(null, fromString("hello").lpad(-2, EMPTY_UTF8));
+    assertEquals(null, fromString("hello").lpad(-1, EMPTY_UTF8));
+    assertEquals(EMPTY_UTF8, fromString("hello").lpad(0, EMPTY_UTF8));
+    assertEquals(fromString("h"), fromString("hello").lpad(1, EMPTY_UTF8));
+    assertEquals(fromString("hel"), fromString("hello").lpad(3, EMPTY_UTF8));
+    assertEquals(fromString("hello"), fromString("hello").lpad(5, EMPTY_UTF8));
+    assertEquals(null, fromString("hello").lpad(6, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.lpad(-1, EMPTY_UTF8));
+    assertEquals(EMPTY_UTF8, EMPTY_UTF8.lpad(0, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.lpad(1, EMPTY_UTF8));
+
+    assertEquals(null, fromString("数据砖头").rpad(-10, fromString("孙行者")));
+    assertEquals(null, fromString("数据砖头").rpad(-10, EMPTY_UTF8));
+    assertEquals(null, fromString("数据砖头").rpad(5, EMPTY_UTF8));
     assertEquals(fromString("数据砖"), fromString("数据砖头").rpad(3, EMPTY_UTF8));
-    assertEquals(EMPTY_UTF8, EMPTY_UTF8.rpad(3, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.rpad(3, EMPTY_UTF8));
+
+    assertEquals(null, fromString("hello").rpad(-2, EMPTY_UTF8));
+    assertEquals(null, fromString("hello").rpad(-1, EMPTY_UTF8));
+    assertEquals(EMPTY_UTF8, fromString("hello").rpad(0, EMPTY_UTF8));
+    assertEquals(fromString("h"), fromString("hello").rpad(1, EMPTY_UTF8));
+    assertEquals(fromString("hel"), fromString("hello").rpad(3, EMPTY_UTF8));
+    assertEquals(fromString("hello"), fromString("hello").rpad(5, EMPTY_UTF8));
+    assertEquals(null, fromString("hello").rpad(6, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.rpad(-1, EMPTY_UTF8));
+    assertEquals(EMPTY_UTF8, EMPTY_UTF8.rpad(0, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.rpad(1, EMPTY_UTF8));
+
   }
 
   @Test

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -358,6 +358,15 @@ public class UTF8StringSuite {
     assertEquals(fromString("数据砖"), fromString("数据砖头").lpad(3, EMPTY_UTF8));
     assertEquals(null, EMPTY_UTF8.lpad(3, EMPTY_UTF8));
 
+    assertEquals(null, fromString("数据砖头").rpad(-10, fromString("孙行者")));
+    assertEquals(null, fromString("数据砖头").rpad(-10, EMPTY_UTF8));
+    assertEquals(null, fromString("数据砖头").rpad(5, EMPTY_UTF8));
+    assertEquals(fromString("数据砖"), fromString("数据砖头").rpad(3, EMPTY_UTF8));
+    assertEquals(null, EMPTY_UTF8.rpad(3, EMPTY_UTF8));
+  }
+
+  @Test
+  public void padWithEmptyPad() {
     assertEquals(null, fromString("hello").lpad(-2, EMPTY_UTF8));
     assertEquals(null, fromString("hello").lpad(-1, EMPTY_UTF8));
     assertEquals(EMPTY_UTF8, fromString("hello").lpad(0, EMPTY_UTF8));
@@ -369,12 +378,6 @@ public class UTF8StringSuite {
     assertEquals(EMPTY_UTF8, EMPTY_UTF8.lpad(0, EMPTY_UTF8));
     assertEquals(null, EMPTY_UTF8.lpad(1, EMPTY_UTF8));
 
-    assertEquals(null, fromString("数据砖头").rpad(-10, fromString("孙行者")));
-    assertEquals(null, fromString("数据砖头").rpad(-10, EMPTY_UTF8));
-    assertEquals(null, fromString("数据砖头").rpad(5, EMPTY_UTF8));
-    assertEquals(fromString("数据砖"), fromString("数据砖头").rpad(3, EMPTY_UTF8));
-    assertEquals(null, EMPTY_UTF8.rpad(3, EMPTY_UTF8));
-
     assertEquals(null, fromString("hello").rpad(-2, EMPTY_UTF8));
     assertEquals(null, fromString("hello").rpad(-1, EMPTY_UTF8));
     assertEquals(EMPTY_UTF8, fromString("hello").rpad(0, EMPTY_UTF8));
@@ -385,7 +388,6 @@ public class UTF8StringSuite {
     assertEquals(null, EMPTY_UTF8.rpad(-1, EMPTY_UTF8));
     assertEquals(EMPTY_UTF8, EMPTY_UTF8.rpad(0, EMPTY_UTF8));
     assertEquals(null, EMPTY_UTF8.rpad(1, EMPTY_UTF8));
-
   }
 
   @Test

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/UTF8StringPropertyCheckSuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/UTF8StringPropertyCheckSuite.scala
@@ -162,17 +162,25 @@ class UTF8StringPropertyCheckSuite extends FunSuite with GeneratorDrivenProperty
 
   test("lpad, rpad") {
     def padding(origin: String, pad: String, length: Int, isLPad: Boolean): String = {
-      if (length <= 0) return ""
-      if (length <= origin.length) {
-        if (length <= 0) "" else origin.substring(0, length)
+      if (length < 0) {
+        null
+      } else if (length == 0) {
+        ""
       } else {
-        if (pad.length == 0) return origin
-        val toPad = length - origin.length
-        val partPad = if (toPad % pad.length == 0) "" else pad.substring(0, toPad % pad.length)
-        if (isLPad) {
-          pad * (toPad / pad.length) + partPad + origin
+        val spaces = length - origin.length
+        if (spaces > 0 && pad.isEmpty) {
+          null
+        } else if (spaces <= 0) {
+          origin.substring(0, length)
         } else {
-          origin + pad * (toPad / pad.length) + partPad
+          if (pad.length == 0) return origin
+          val toPad = length - origin.length
+          val partPad = if (toPad % pad.length == 0) "" else pad.substring(0, toPad % pad.length)
+          if (isLPad) {
+            pad * (toPad / pad.length) + partPad + origin
+          } else {
+            origin + pad * (toPad / pad.length) + partPad
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark SQL `rpad/lpad` with empty pad string:
```sql
spark-sql> select rpad('hello', -2, ''), rpad('hello', -1, '') , rpad('hello', 0, ''), rpad('hello', 1, ''), rpad('hello', 3, ''), rpad('hello', 5, ''), rpad('hello', 6, '');
			h	hel	hello	hello
spark-sql> select lpad('hello', -2, ''), lpad('hello', -1, '') , lpad('hello', 0, ''), lpad('hello', 1, ''), lpad('hello', 3, ''), lpad('hello', 5, ''), lpad('hello', 6, '');
			h	hel	hello	hello
spark-sql>
```
but the MySQL result:
```sql
mysql> select rpad('hello', -2, ''), rpad('hello', -1, '') , rpad('hello', 0, ''), rpad('hello', 1, ''), rpad('hello', 3, ''), rpad('hello', 5, ''), rpad('hello', 6, '') from dual;
+-----------------------+-----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
| rpad('hello', -2, '') | rpad('hello', -1, '') | rpad('hello', 0, '') | rpad('hello', 1, '') | rpad('hello', 3, '') | rpad('hello', 5, '') | rpad('hello', 6, '') |
+-----------------------+-----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
| NULL                  | NULL                  |                      | h                    | hel                  | hello                | NULL                 |
+-----------------------+-----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
1 row in set (0.00 sec)

mysql> select lpad('hello', -2, ''), lpad('hello', -1, '') , lpad('hello', 0, ''), lpad('hello', 1, ''), lpad('hello', 3, ''), lpad('hello', 5, ''), lpad('hello', 6, '')  from dual;
+-----------------------+-----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
| lpad('hello', -2, '') | lpad('hello', -1, '') | lpad('hello', 0, '') | lpad('hello', 1, '') | lpad('hello', 3, '') | lpad('hello', 5, '') | lpad('hello', 6, '') |
+-----------------------+-----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
| NULL                  | NULL                  |                      | h                    | hel                  | hello                | NULL                 |
+-----------------------+-----------------------+----------------------+----------------------+----------------------+----------------------+----------------------+
1 row in set (0.01 sec)
```

This PR fix this issue, after this PR:
```sql
spark-sql> select rpad('hello', -2, ''), rpad('hello', -1, '') , rpad('hello', 0, ''), rpad('hello', 1, ''), rpad('hello', 3, ''), rpad('hello', 5, ''), rpad('hello', 6, '');
NULL	NULL		h	hel	hello	NULL
spark-sql> select lpad('hello', -2, ''), lpad('hello', -1, '') , lpad('hello', 0, ''), lpad('hello', 1, ''), lpad('hello', 3, ''), lpad('hello', 5, ''), lpad('hello', 6, '');
NULL	NULL		h	hel	hello	NULL
spark-sql> 

```

## How was this patch tested?

unit tests