### PR TITLE
[SPARK-20787][PYTHON] PySpark can't handle datetimes before 1900

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1568,6 +1568,18 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(first['date'], epoch)
         self.assertEqual(first['lit_date'], epoch)
 
+    # regression test for SPARK-20787
+    def test_datetype_accepts_calendar_dates(self):
+        df1 = self.spark.createDataFrame(self.sc.parallelize([[datetime.datetime(1899,12,31)]]))
+        df2 = self.spark.createDataFrame(self.sc.parallelize([[datetime.datetime(100,1,1)]]))
+        try:
+            counted1 = df1.count()
+            counted2 = df2.count()
+            self.assertEqual(counted1, 1)
+            self.assertEqual(counted2, 1)
+        except Exception:
+            self.fail("Internal conversion should handle years 100-1899")
+
     def test_decimal(self):
         from decimal import Decimal
         schema = StructType([StructField("decimal", DecimalType(10, 5))])

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1570,8 +1570,8 @@ class SQLTests(ReusedPySparkTestCase):
 
     # regression test for SPARK-20787
     def test_datetype_accepts_calendar_dates(self):
-        df1 = self.spark.createDataFrame(self.sc.parallelize([[datetime.datetime(1899,12,31)]]))
-        df2 = self.spark.createDataFrame(self.sc.parallelize([[datetime.datetime(100,1,1)]]))
+        df1 = self.spark.createDataFrame(self.sc.parallelize([[datetime.datetime(1899, 12, 31)]]))
+        df2 = self.spark.createDataFrame(self.sc.parallelize([[datetime.datetime(100, 1, 1)]]))
         try:
             counted1 = df1.count()
             counted2 = df2.count()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -189,7 +189,7 @@ class TimestampType(AtomicType):
         if dt is not None:
             seconds = calendar.timegm(dt.utctimetuple())
             # Avoiding the invalid range of years (100-1899) for mktime in Python < 3
-            if dt.year not in range(100, 1900):
+            if dt.year > 1899 or dt.year <= 100:
                 seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
                            else time.mktime(dt.timetuple()))
             return int(seconds) * 1000000 + dt.microsecond

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -187,11 +187,12 @@ class TimestampType(AtomicType):
 
     def toInternal(self, dt):
         if dt is not None:
-            seconds = calendar.timegm(dt.utctimetuple())
             # Avoiding the invalid range of years (100-1899) for mktime in Python < 3
             if dt.year > 1899 or dt.year <= 100:
                 seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
                            else time.mktime(dt.timetuple()))
+            else:
+                seconds = calendar.timegm(dt.utctimetuple())
             return int(seconds) * 1000000 + dt.microsecond
 
     def fromInternal(self, ts):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -188,7 +188,7 @@ class TimestampType(AtomicType):
     def toInternal(self, dt):
         if dt is not None:
             seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
-                       else time.mktime(dt.timetuple()))
+                       else calendar.timegm(dt.timetuple()))
             return int(seconds) * 1000000 + dt.microsecond
 
     def fromInternal(self, ts):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -188,7 +188,7 @@ class TimestampType(AtomicType):
     def toInternal(self, dt):
         if dt is not None:
             # Avoiding the invalid range of years (100-1899) for mktime in Python < 3
-            if dt.year > 1899 or dt.year <= 100:
+            if dt.year > 1899 or dt.year < 100:
                 seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
                            else time.mktime(dt.timetuple()))
             else:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -187,8 +187,11 @@ class TimestampType(AtomicType):
 
     def toInternal(self, dt):
         if dt is not None:
-            seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
-                       else calendar.timegm(dt.timetuple()))
+            seconds = calendar.timegm(dt.utctimetuple())
+            # Avoiding the invalid range of years (100-1899) for mktime in Python < 3
+            if dt.year not in range(100, 1900):
+                seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
+                           else time.mktime(dt.timetuple()))
             return int(seconds) * 1000000 + dt.microsecond
 
     def fromInternal(self, ts):


### PR DESCRIPTION
`time.mktime` can't handle dates from 1899-100, according to the documentation by design. `calendar.timegm` is equivalent in shared cases, but can handle those years.

## What changes were proposed in this pull request?

Change `time.mktime` for the more able `calendar.timegm` to adress cases like:
```python
import datetime as dt
sqlContext.createDataFrame(sc.parallelize([[dt.datetime(1899,12,31)]])).count()
```
failing due to internal conversion failure when there is no timezone information in the time object. In the case there is information, `calendar` was used instead.

## How was this patch tested?

The existing test cases cover this change, since it does not change any existing functionality. Added a test to confirm it working in the problematic range.

This PR is original work from me and I license this work to the Spark project