### PR TITLE
[SPARK-20917][ML][SparkR] SparkR supports string encoding consistent with R

### DIFF
--- a/R/pkg/R/mllib_regression.R
+++ b/R/pkg/R/mllib_regression.R
@@ -443,6 +443,12 @@ setMethod("write.ml", signature(object = "IsotonicRegressionModel", path = "char
 #' @param aggregationDepth The depth for treeAggregate (greater than or equal to 2). If the dimensions of features
 #'                         or the number of partitions are large, this param could be adjusted to a larger size.
 #'                         This is an expert parameter. Default value should be good for most cases.
+#' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
+#'                               decide the base level of a string feature as the last category after
+#'                               ordering is dropped when encoding strings. Supported options are
+#'                               'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'.
+#'                               The default value is 'frequencyDesc'. When the ordering is set to
+#'                               'alphabetDesc', this drops the same category as R when encoding strings.
 #' @param ... additional arguments passed to the method.
 #' @return \code{spark.survreg} returns a fitted AFT survival regression model.
 #' @rdname spark.survreg
@@ -468,10 +474,11 @@ setMethod("write.ml", signature(object = "IsotonicRegressionModel", path = "char
 #' }
 #' @note spark.survreg since 2.0.0
 setMethod("spark.survreg", signature(data = "SparkDataFrame", formula = "formula"),
-          function(data, formula, aggregationDepth = 2) {
+          function(data, formula, aggregationDepth = 2, stringIndexerOrderType = "frequencyDesc") {
             formula <- paste(deparse(formula), collapse = "")
             jobj <- callJStatic("org.apache.spark.ml.r.AFTSurvivalRegressionWrapper",
-                                "fit", formula, data@sdf, as.integer(aggregationDepth))
+                                "fit", formula, data@sdf, as.integer(aggregationDepth),
+                                as.character(stringIndexerOrderType))
             new("AFTSurvivalRegressionModel", jobj = jobj)
           })
 

--- a/R/pkg/R/mllib_regression.R
+++ b/R/pkg/R/mllib_regression.R
@@ -73,9 +73,9 @@ setClass("IsotonicRegressionModel", representation(jobj = "jobj"))
 #' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
 #'                               decide the base level of a string feature as the last category after
 #'                               ordering is dropped when encoding strings. Supported options are
-#'                               'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'.
-#'                               The default value is 'frequencyDesc'. When the ordering is set to
-#'                               'alphabetDesc', this drops the same category as R when encoding strings.
+#'                               "frequencyDesc", "frequencyAsc", "alphabetDes", and "alphabetAsc".
+#'                               The default value is "frequencyDesc". When the ordering is set to
+#'                               "alphabetDesc", this drops the same category as R when encoding strings.
 #' @param ... additional arguments passed to the method.
 #' @aliases spark.glm,SparkDataFrame,formula-method
 #' @return \code{spark.glm} returns a fitted generalized linear model.
@@ -187,9 +187,9 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 #' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
 #'                               decide the base level of a string feature as the last category after
 #'                               ordering is dropped when encoding strings. Supported options are
-#'                               'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'.
-#'                               The default value is 'frequencyDesc'. When the ordering is set to
-#'                               'alphabetDesc', this drops the same category as R when encoding strings.
+#'                               "frequencyDesc", "frequencyAsc", "alphabetDes", and "alphabetAsc".
+#'                               The default value is "frequencyDesc". When the ordering is set to
+#'                               "alphabetDesc", this drops the same category as R when encoding strings.
 #' @return \code{glm} returns a fitted generalized linear model.
 #' @rdname glm
 #' @export
@@ -446,9 +446,9 @@ setMethod("write.ml", signature(object = "IsotonicRegressionModel", path = "char
 #' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
 #'                               decide the base level of a string feature as the last category after
 #'                               ordering is dropped when encoding strings. Supported options are
-#'                               'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'.
-#'                               The default value is 'frequencyDesc'. When the ordering is set to
-#'                               'alphabetDesc', this drops the same category as R when encoding strings.
+#'                               "frequencyDesc", "frequencyAsc", "alphabetDes", and "alphabetAsc".
+#'                               The default value is "frequencyDesc". When the ordering is set to
+#'                               "alphabetDesc", this drops the same category as R when encoding strings.
 #' @param ... additional arguments passed to the method.
 #' @return \code{spark.survreg} returns a fitted AFT survival regression model.
 #' @rdname spark.survreg

--- a/R/pkg/R/mllib_regression.R
+++ b/R/pkg/R/mllib_regression.R
@@ -164,7 +164,7 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
                                 "fit", formula, data@sdf, tolower(family$family), family$link,
                                 tol, as.integer(maxIter), weightCol, regParam,
                                 as.double(var.power), as.double(link.power),
-                                as.character(stringIndexerOrderType))
+                                stringIndexerOrderType)
             new("GeneralizedLinearRegressionModel", jobj = jobj)
           })
 
@@ -210,7 +210,6 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "SparkDat
                    var.power = 0.0, link.power = 1.0 - var.power,
                    stringIndexerOrderType = c("frequencyDesc", "frequencyAsc",
                                               "alphabetDesc", "alphabetAsc")) {
-            stringIndexerOrderType <- match.arg(stringIndexerOrderType)
             spark.glm(data, formula, family, tol = epsilon, maxIter = maxit, weightCol = weightCol,
                       var.power = var.power, link.power = link.power,
                       stringIndexerOrderType = stringIndexerOrderType)
@@ -485,7 +484,7 @@ setMethod("spark.survreg", signature(data = "SparkDataFrame", formula = "formula
             formula <- paste(deparse(formula), collapse = "")
             jobj <- callJStatic("org.apache.spark.ml.r.AFTSurvivalRegressionWrapper",
                                 "fit", formula, data@sdf, as.integer(aggregationDepth),
-                                as.character(stringIndexerOrderType))
+                                stringIndexerOrderType)
             new("AFTSurvivalRegressionModel", jobj = jobj)
           })
 

--- a/R/pkg/R/mllib_regression.R
+++ b/R/pkg/R/mllib_regression.R
@@ -73,7 +73,7 @@ setClass("IsotonicRegressionModel", representation(jobj = "jobj"))
 #' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
 #'                               decide the base level of a string feature as the last category after
 #'                               ordering is dropped when encoding strings. Supported options are
-#'                               "frequencyDesc", "frequencyAsc", "alphabetDes", and "alphabetAsc".
+#'                               "frequencyDesc", "frequencyAsc", "alphabetDesc", and "alphabetAsc".
 #'                               The default value is "frequencyDesc". When the ordering is set to
 #'                               "alphabetDesc", this drops the same category as R when encoding strings.
 #' @param ... additional arguments passed to the method.
@@ -126,8 +126,10 @@ setClass("IsotonicRegressionModel", representation(jobj = "jobj"))
 setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
           function(data, formula, family = gaussian, tol = 1e-6, maxIter = 25, weightCol = NULL,
                    regParam = 0.0, var.power = 0.0, link.power = 1.0 - var.power,
-                   stringIndexerOrderType = "frequencyDesc") {
+                   stringIndexerOrderType = c("frequencyDesc", "frequencyAsc",
+                                              "alphabetDesc", "alphabetAsc")) {
 
+            stringIndexerOrderType <- match.arg(stringIndexerOrderType)
             if (is.character(family)) {
               # Handle when family = "tweedie"
               if (tolower(family) == "tweedie") {
@@ -187,7 +189,7 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 #' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
 #'                               decide the base level of a string feature as the last category after
 #'                               ordering is dropped when encoding strings. Supported options are
-#'                               "frequencyDesc", "frequencyAsc", "alphabetDes", and "alphabetAsc".
+#'                               "frequencyDesc", "frequencyAsc", "alphabetDesc", and "alphabetAsc".
 #'                               The default value is "frequencyDesc". When the ordering is set to
 #'                               "alphabetDesc", this drops the same category as R when encoding strings.
 #' @return \code{glm} returns a fitted generalized linear model.
@@ -206,7 +208,9 @@ setMethod("spark.glm", signature(data = "SparkDataFrame", formula = "formula"),
 setMethod("glm", signature(formula = "formula", family = "ANY", data = "SparkDataFrame"),
           function(formula, family = gaussian, data, epsilon = 1e-6, maxit = 25, weightCol = NULL,
                    var.power = 0.0, link.power = 1.0 - var.power,
-                   stringIndexerOrderType = "frequencyDesc") {
+                   stringIndexerOrderType = c("frequencyDesc", "frequencyAsc",
+                                              "alphabetDesc", "alphabetAsc")) {
+            stringIndexerOrderType <- match.arg(stringIndexerOrderType)
             spark.glm(data, formula, family, tol = epsilon, maxIter = maxit, weightCol = weightCol,
                       var.power = var.power, link.power = link.power,
                       stringIndexerOrderType = stringIndexerOrderType)
@@ -446,7 +450,7 @@ setMethod("write.ml", signature(object = "IsotonicRegressionModel", path = "char
 #' @param stringIndexerOrderType how to order categories of a string feature column. This is used to
 #'                               decide the base level of a string feature as the last category after
 #'                               ordering is dropped when encoding strings. Supported options are
-#'                               "frequencyDesc", "frequencyAsc", "alphabetDes", and "alphabetAsc".
+#'                               "frequencyDesc", "frequencyAsc", "alphabetDesc", and "alphabetAsc".
 #'                               The default value is "frequencyDesc". When the ordering is set to
 #'                               "alphabetDesc", this drops the same category as R when encoding strings.
 #' @param ... additional arguments passed to the method.
@@ -474,7 +478,9 @@ setMethod("write.ml", signature(object = "IsotonicRegressionModel", path = "char
 #' }
 #' @note spark.survreg since 2.0.0
 setMethod("spark.survreg", signature(data = "SparkDataFrame", formula = "formula"),
-          function(data, formula, aggregationDepth = 2, stringIndexerOrderType = "frequencyDesc") {
+          function(data, formula, aggregationDepth = 2,
+                   stringIndexerOrderType = c("frequencyDesc", "frequencyAsc",
+                                              "alphabetDesc", "alphabetAsc")) {
             formula <- paste(deparse(formula), collapse = "")
             jobj <- callJStatic("org.apache.spark.ml.r.AFTSurvivalRegressionWrapper",
                                 "fit", formula, data@sdf, as.integer(aggregationDepth),

--- a/R/pkg/R/mllib_regression.R
+++ b/R/pkg/R/mllib_regression.R
@@ -481,6 +481,7 @@ setMethod("spark.survreg", signature(data = "SparkDataFrame", formula = "formula
           function(data, formula, aggregationDepth = 2,
                    stringIndexerOrderType = c("frequencyDesc", "frequencyAsc",
                                               "alphabetDesc", "alphabetAsc")) {
+            stringIndexerOrderType <- match.arg(stringIndexerOrderType)
             formula <- paste(deparse(formula), collapse = "")
             jobj <- callJStatic("org.apache.spark.ml.r.AFTSurvivalRegressionWrapper",
                                 "fit", formula, data@sdf, as.integer(aggregationDepth),

--- a/R/pkg/tests/fulltests/test_mllib_regression.R
+++ b/R/pkg/tests/fulltests/test_mllib_regression.R
@@ -368,8 +368,6 @@ test_that("glm save/load", {
 })
 
 test_that("spark.glm and glm with string encoding", {
-  skip_on_cran()
-
   t <- as.data.frame(Titanic, stringsAsFactors = FALSE)
   df <- createDataFrame(t)
 

--- a/R/pkg/tests/fulltests/test_mllib_regression.R
+++ b/R/pkg/tests/fulltests/test_mllib_regression.R
@@ -368,6 +368,8 @@ test_that("glm save/load", {
 })
 
 test_that("spark.glm and glm with string encoding", {
+  skip_on_cran()
+
   t <- as.data.frame(Titanic, stringsAsFactors = FALSE)
   df <- createDataFrame(t)
 

--- a/R/pkg/tests/fulltests/test_mllib_regression.R
+++ b/R/pkg/tests/fulltests/test_mllib_regression.R
@@ -510,8 +510,8 @@ test_that("spark.survreg", {
     rData <- as.data.frame(rData)
     rData$sex2 <- c("female", "male")[rData$sex + 1]
     df <- createDataFrame(rData)
-
-    rModel <- survreg(Surv(time, status) ~ x + sex2, rData)
+    expect_error(
+      rModel <- survival::survreg(survival::Surv(time, status) ~ x + sex2, rData), NA)
     rCoefs <- as.numeric(summary(rModel)$table[, 1])
     model <- spark.survreg(df, Surv(time, status) ~ x + sex2)
     coefs <- as.vector(summary(model)$coefficients[, 1])

--- a/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
@@ -85,11 +85,13 @@ private[r] object AFTSurvivalRegressionWrapper extends MLReadable[AFTSurvivalReg
   def fit(
       formula: String,
       data: DataFrame,
-      aggregationDepth: Int): AFTSurvivalRegressionWrapper = {
+      aggregationDepth: Int,
+      stringIndexerOrderType: String): AFTSurvivalRegressionWrapper = {
 
     val (rewritedFormula, censorCol) = formulaRewrite(formula)
 
     val rFormula = new RFormula().setFormula(rewritedFormula)
+      .setStringIndexerOrderType(stringIndexerOrderType)
     RWrapperUtils.checkDataColumns(rFormula, data)
     val rFormulaModel = rFormula.fit(data)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -64,7 +64,7 @@ private[r] class GeneralizedLinearRegressionWrapper private (
 
 private[r] object GeneralizedLinearRegressionWrapper
   extends MLReadable[GeneralizedLinearRegressionWrapper] {
-
+  // scalastyle:off
   def fit(
       formula: String,
       data: DataFrame,
@@ -75,8 +75,11 @@ private[r] object GeneralizedLinearRegressionWrapper
       weightCol: String,
       regParam: Double,
       variancePower: Double,
-      linkPower: Double): GeneralizedLinearRegressionWrapper = {
+      linkPower: Double,
+      stringIndexerOrderType: String): GeneralizedLinearRegressionWrapper = {
+  // scalastyle:on
     val rFormula = new RFormula().setFormula(formula)
+      .setStringIndexerOrderType(stringIndexerOrderType)
     checkDataColumns(rFormula, data)
     val rFormulaModel = rFormula.fit(data)
     // get labels and feature names from output schema

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GeneralizedLinearRegressionWrapper.scala
@@ -64,6 +64,7 @@ private[r] class GeneralizedLinearRegressionWrapper private (
 
 private[r] object GeneralizedLinearRegressionWrapper
   extends MLReadable[GeneralizedLinearRegressionWrapper] {
+
   // scalastyle:off
   def fit(
       formula: String,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `stringIndexerOrderType` to `spark.glm` and `spark.survreg` to support string encoding that is consistent with default R. 

## How was this patch tested?
new tests 