### PR TITLE
[SPARK-20919][SS] Simplificaiton of CachedKafkaConsumer using guava cache.

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaConsumerPool.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaConsumerPool.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010
+
+import java.util
+
+import scala.collection.concurrent.TrieMap
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+
+private[kafka010] object KafkaConsumerPool extends Logging {
+
+  private lazy val map = TrieMap[String, CachedKafkaConsumer]()
+  private lazy val capacity = SparkEnv.get.conf.getInt("spark.sql.kafkaConsumerPool.capacity", 64)
+
+  def borrowConsumer(topic: String, partition: Int, kafkaParams: util.Map[String, Object],
+      reuseConsumer: Boolean): CachedKafkaConsumer = synchronized {
+    val groupId = kafkaParams.get(ConsumerConfig.GROUP_ID_CONFIG).asInstanceOf[String]
+    assert(groupId != null)
+    map.remove(topic + partition + groupId).getOrElse {
+      CachedKafkaConsumer.createConsumer(topic, partition, kafkaParams, reuseConsumer)
+    }
+  }
+
+  def returnConsumer(cachedKafkaConsumer: CachedKafkaConsumer): Unit = synchronized {
+    val partition = cachedKafkaConsumer.topicPartition.partition()
+    val reuseConsumer = cachedKafkaConsumer.reuseConsumer
+    val groupId = cachedKafkaConsumer.groupId
+    val topic = cachedKafkaConsumer.topicPartition.topic()
+    if (reuseConsumer && map.size < capacity) {
+      if (map.contains(topic + partition + groupId)) {
+        // Ideally, this should never happen.
+        map.remove(topic + partition + groupId).foreach(_.close())
+        logWarning(s"""consumer for same partition already exists, closing previously stored
+            consumer for topic-partition: ${cachedKafkaConsumer.topicPartition},
+           $cachedKafkaConsumer""")
+      }
+      map.put(topic + partition + groupId, cachedKafkaConsumer)
+    } else {
+      if (reuseConsumer) {
+        logWarning(s"Consumer pool has reached it's max capacity, closing consumer:" +
+          s" $cachedKafkaConsumer")
+      }
+      cachedKafkaConsumer.close()
+    }
+  }
+
+  // For testing.
+  def close(): Unit = synchronized {
+    map.values.foreach(_.close())
+    map.clear()
+  }
+}

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousReader.scala
@@ -189,7 +189,7 @@ class KafkaContinuousDataReader(
     failOnDataLoss: Boolean) extends ContinuousDataReader[UnsafeRow] {
   private val topic = topicPartition.topic
   private val kafkaPartition = topicPartition.partition
-  private val consumer = CachedKafkaConsumer.createUncached(topic, kafkaPartition, kafkaParams)
+  private val consumer = KafkaConsumerPool.borrowConsumer(topic, kafkaPartition, kafkaParams, true)
 
   private val sharedRow = new UnsafeRow(7)
   private val bufferHolder = new BufferHolder(sharedRow)
@@ -255,6 +255,6 @@ class KafkaContinuousDataReader(
   }
 
   override def close(): Unit = {
-    consumer.close()
+    KafkaConsumerPool.returnConsumer(consumer)
   }
 }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceSuite.scala
@@ -29,7 +29,7 @@ import scala.util.Random
 
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
-import org.scalatest.concurrent.Eventually._
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.SpanSugar._
 
@@ -46,7 +46,7 @@ import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.test.{SharedSQLContext, TestSparkSession}
 import org.apache.spark.util.Utils
 
-abstract class KafkaSourceTest extends StreamTest with SharedSQLContext {
+abstract class KafkaSourceTest extends StreamTest with SharedSQLContext with BeforeAndAfterEach {
 
   protected var testUtils: KafkaTestUtils = _
 
@@ -66,6 +66,10 @@ abstract class KafkaSourceTest extends StreamTest with SharedSQLContext {
       testUtils = null
     }
     super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    KafkaConsumerPool.close()
   }
 
   protected def makeSureGetOffsetCalled = AssertOnQuery { q =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

On the lines of SPARK-19968, guava cache can be used to simplify the code in CachedKafkaConsumer as well. With an additional feature of automatic cleanup of a consumer unused for a configurable time.

## How was this patch tested?

Existing tests.