### PR TITLE
[SPARK-20912][SQL] Allow column name in map functions.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1007,6 +1007,17 @@ object functions {
   def map(cols: Column*): Column = withExpr { CreateMap(cols.map(_.expr)) }
 
   /**
+   * Creates a new map column. The input columns must be grouped as key-value pairs, e.g.
+   * (key1, value1, key2, value2, ...). The key columns must all have the same data type, and can't
+   * be null. The value columns must all have the same data type.
+   *
+   * @group normal_funcs
+   * @since 2.3
+   */
+  @scala.annotation.varargs
+  def map(colName: String, colNames: String*): Column = map((colName +: colNames).map(col) : _*)
+
+  /**
    * Marks a DataFrame as small enough for use in broadcast joins.
    *
    * The following example marks the right DataFrame for broadcast hash join using `joinKey`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1015,7 +1015,9 @@ object functions {
    * @since 2.3
    */
   @scala.annotation.varargs
-  def map(colName: String, colNames: String*): Column = map((colName +: colNames).map(col) : _*)
+  def map(colName: String, colNames: String*): Column = {
+    map((colName +: colNames).map(col) : _*)
+  }
 
   /**
    * Marks a DataFrame as small enough for use in broadcast joins.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -53,6 +53,15 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     assert(row.getSeq[Int](0) === Seq(0, 2))
   }
 
+  test("map with column name") {
+    val df = Seq(1 -> "a").toDF("a", "b")
+    val row = df.select(map("a", "b")).first()
+
+    val expectedType = MapType(IntegerType, StringType, valueContainsNull = true)
+    assert(row.schema(0).dataType === expectedType)
+    assert(row.getMap[Int, String](0) === Map(1 -> "a"))
+  }
+
   test("map with column expressions") {
     val df = Seq(1 -> "a").toDF("a", "b")
     val row = df.select(map($"a" + 1, $"b")).first()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`map` function only accepts Column values only. It'd be very helpful to have a variant that accepts String for columns just like what `array` or `struct`.

## How was this patch tested?

Added a test in `DataFrameFunctionsSuite`.

cc @maropu