### PR TITLE
[SPARK-20633][SQL] FileFormatWriter should not wrap FetchFailedException

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -262,8 +262,8 @@ object FileFormatWriter extends Logging {
     } catch {
       case e: FetchFailedException =>
         throw e
-      case _ =>
-        throw new SparkException("Task failed while writing rows.", e)
+      case t: Throwable =>
+        throw new SparkException("Task failed while writing rows.", t)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -31,6 +31,7 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
+import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, ExternalCatalogUtils}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -259,8 +260,10 @@ object FileFormatWriter extends Logging {
         }
       })
     } catch {
-      case t: Throwable =>
-        throw new SparkException("Task failed while writing rows", t)
+      case e: FetchFailedException =>
+        throw e
+      case _ =>
+        throw new SparkException("Task failed while writing rows.", e)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Explicitly handle the FetchFailedException in FileFormatWriter, so it does not get wrapped.

Note that this is no longer strictly necessary after SPARK-19276, but it improves error messages and also will help avoid others stumbling across this in the future.

## How was this patch tested?

Existing unit tests.


Closes https://github.com/apache/spark/pull/17893