### PR TITLE
[SPARK-19753][CORE] Un-register all shuffle output on a host in case of slave lost or fetch failure

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -151,6 +151,14 @@ package object config {
       .createOptional
   // End blacklist confs
 
+  private[spark] val UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE =
+    ConfigBuilder("spark.files.fetchFailure.unRegisterOutputOnHost")
+      .doc("Whether to un-register all the outputs on the host in condition that we receive " +
+        " a FetchFailure. This is set default to false, which means, we only un-register the " +
+        " outputs related to the exact executor(instead of the host) on a FetchFailure.")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val LISTENER_BUS_EVENT_QUEUE_CAPACITY =
     ConfigBuilder("spark.scheduler.listenerbus.eventqueue.capacity")
       .withAlternative("spark.scheduler.listenerbus.eventqueue.size")

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1410,8 +1410,7 @@ class DAGScheduler(
         clearCacheLocs()
       }
     } else {
-      logDebug("Additional executor lost message for " + execId +
-        "(epoch " + currentEpoch + ")")
+      logDebug("Additional executor lost message for %s (epoch %d)".format(execId, currentEpoch))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1334,8 +1334,14 @@ class DAGScheduler(
 
           // TODO: mark the executor as failed only if there were lots of fetch failures on it
           if (bmAddress != null) {
-            handleExecutorLost(bmAddress.executorId, fileLost = false, hostLost = true,
-              Some(bmAddress.host), Some(task.epoch))
+            if (!env.blockManager.externalShuffleServiceEnabled) {
+              handleExecutorLost(bmAddress.executorId, fileLost = false, hostLost = true,
+                Some(bmAddress.host), Some(task.epoch))
+            }
+            else {
+              handleExecutorLost(bmAddress.executorId, fileLost = true, hostLost = false,
+                Some(bmAddress.host),Some(task.epoch))
+            }
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -149,7 +149,6 @@ class DAGScheduler(
    */
   private[scheduler] val shuffleIdToMapStage = new HashMap[Int, ShuffleMapStage]
   private[scheduler] val jobIdToActiveJob = new HashMap[Int, ActiveJob]
-  private[scheduler] val execIdToHost = new HashMap[String, String]
 
   // Stages we need to run whose parents aren't done
   private[scheduler] val waitingStages = new HashSet[Stage]
@@ -549,10 +548,8 @@ class DAGScheduler(
    * @param callSite where in the user program this job was called
    * @param resultHandler callback to pass each result to
    * @param properties scheduler properties to attach to this job, e.g. fair scheduler pool name
-   *
    * @return a JobWaiter object that can be used to block until the job finishes executing
    *         or can be used to cancel the job.
-   *
    * @throws IllegalArgumentException when partitions ids are illegal
    */
   def submitJob[T, U](
@@ -1337,7 +1334,8 @@ class DAGScheduler(
 
           // TODO: mark the executor as failed only if there were lots of fetch failures on it
           if (bmAddress != null) {
-            handleExecutorLost(bmAddress.executorId, slaveLost = true, Some(task.epoch))
+            handleExecutorLost(bmAddress.executorId, fileLost = false, hostLost = true,
+              Some(bmAddress.host), Some(task.epoch))
           }
         }
 
@@ -1371,7 +1369,9 @@ class DAGScheduler(
    */
   private[scheduler] def handleExecutorLost(
       execId: String,
-      slaveLost: Boolean,
+      fileLost: Boolean,
+      hostLost: Boolean = false,
+      maybeHost: Option[String] = None,
       maybeEpoch: Option[Long] = None) {
     val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
     if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
@@ -1396,7 +1396,6 @@ class DAGScheduler(
       logInfo("Host added was in lost list earlier: " + host)
       failedEpoch -= execId
     }
-    execIdToHost.put(execId, host)
   }
 
   private[scheduler] def handleStageCancellation(stageId: Int, reason: Option[String]) {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1377,8 +1377,7 @@ class DAGScheduler(
       execId: String,
       fileLost: Boolean) {
     removeExecutorAndUnregisterOutputOnExecutor(execId,
-      // There will not be any file loss if external shuffle service is enabled
-      fileLost && !env.blockManager.externalShuffleServiceEnabled, None)
+      fileLost || !env.blockManager.externalShuffleServiceEnabled, None)
   }
 
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -188,10 +188,12 @@ class DAGScheduler(
   private val disallowStageRetryForTest = sc.getConf.getBoolean("spark.test.noStageRetry", false)
 
   /**
-   * If enabled, fetch failure will cause all the output on that host to be unregistered.
+   * Whether to unregister all the outputs on the host in condition that we receive a FetchFailure,
+   * this is set default to false, which means, we only unregister the outputs related to the exact
+   * executor(instead of the host) on a FetchFailure.
    */
   private[scheduler] val unRegisterOutputOnHostOnFetchFailure =
-    sc.getConf.getBoolean("spark.files.fetchFailure.unRegisterOutputOnHost", true)
+    sc.getConf.getBoolean("spark.files.fetchFailure.unRegisterOutputOnHost", false)
 
   /**
    * Number of consecutive stage attempts allowed before a stage is aborted.
@@ -557,6 +559,7 @@ class DAGScheduler(
    *
    * @return a JobWaiter object that can be used to block until the job finishes executing
    *         or can be used to cancel the job.
+   *
    * @throws IllegalArgumentException when partitions ids are illegal
    */
   def submitJob[T, U](

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -188,13 +188,13 @@ class DAGScheduler(
   private val disallowStageRetryForTest = sc.getConf.getBoolean("spark.test.noStageRetry", false)
 
   /**
-   * Number of consecutive stage attempts allowed before a stage is aborted.
+   * If enabled, fetch failure will cause all the output on that host to be unregistered.
    */
   private[scheduler] val unRegisterOutputOnHostOnFetchFailure =
-    sc.getConf.getBoolean("spark.fetch.failure.unRegister.output.on.host", true)
+    sc.getConf.getBoolean("spark.files.fetchFailure.unRegisterOutputOnHost", true)
 
   /**
-   *
+   * Number of consecutive stage attempts allowed before a stage is aborted.
    */
   private[scheduler] val maxConsecutiveStageAttempts =
     sc.getConf.getInt("spark.stage.maxConsecutiveAttempts",

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1339,7 +1339,7 @@ class DAGScheduler(
               // assume all shuffle data on the node is bad.
               Some(bmAddress.host)
             } else {
-              // Deregister shuffle data just for one executor (we don't have any
+              // Unregister shuffle data just for one executor (we don't have any
               // reason to believe shuffle data has been lost for the entire host).
               None
             }
@@ -1385,10 +1385,10 @@ class DAGScheduler(
     // if the cluster manager explicitly tells us that the entire worker was lost, then
     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
     // from a Standalone cluster, where the shuffle service lives in the Worker.)
-    val filesLost = workerLost || !env.blockManager.externalShuffleServiceEnabled
+    val fileLost = workerLost || !env.blockManager.externalShuffleServiceEnabled
     removeExecutorAndUnregisterOutputs(
       execId = execId,
-      fileLost = filesLost,
+      fileLost = fileLost,
       hostToUnregisterOutputs = None,
       maybeEpoch = None)
   }
@@ -1704,8 +1704,7 @@ private[scheduler] class DAGSchedulerEventProcessLoop(dagScheduler: DAGScheduler
 
     case ExecutorLost(execId, reason) =>
       val workerLost = reason match {
-        case SlaveLost(_, true) =>
-          true
+        case SlaveLost(_, true) => true
         case _ => false
       }
       dagScheduler.handleExecutorLost(execId, workerLost)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1334,14 +1334,20 @@ class DAGScheduler(
 
           // TODO: mark the executor as failed only if there were lots of fetch failures on it
           if (bmAddress != null) {
-            if (env.blockManager.externalShuffleServiceEnabled) {
-              removeExecutorAndUnregisterOutputOnHost(bmAddress.executorId,
-                bmAddress.host, Some(task.epoch))
+            val hostToUnregisterOutputs = if (env.blockManager.externalShuffleServiceEnabled) {
+              // We had a fetch failure with the external shuffle service, so we
+              // assume all shuffle data on the node is bad.
+              Some(bmAddress.host)
+            } else {
+              // Deregister shuffle data just for one executor (we don't have any
+              // reason to believe shuffle data has been lost for the entire host).
+              None
             }
-            else {
-              removeExecutorAndUnregisterOutputOnExecutor(bmAddress.executorId,
-                true, Some(task.epoch))
-            }
+            removeExecutorAndUnregisterOutputs(
+              execId = bmAddress.executorId,
+              fileLost = true,
+              hostToUnregisterOutputs = hostToUnregisterOutputs,
+              maybeEpoch = Some(task.epoch))
           }
         }
 
@@ -1375,16 +1381,23 @@ class DAGScheduler(
    */
   private[scheduler] def handleExecutorLost(
       execId: String,
-      fileLost: Boolean) {
-    removeExecutorAndUnregisterOutputOnExecutor(execId,
-      fileLost || !env.blockManager.externalShuffleServiceEnabled, None)
+      workerLost: Boolean): Unit = {
+    // if the cluster manager explicitly tells us that the entire worker was lost, then
+    // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
+    // from a Standalone cluster, where the shuffle service lives in the Worker.)
+    val filesLost = workerLost || !env.blockManager.externalShuffleServiceEnabled
+    removeExecutorAndUnregisterOutputs(
+      execId = execId,
+      fileLost = filesLost,
+      hostToUnregisterOutputs = None,
+      maybeEpoch = None)
   }
 
-
-  private[scheduler] def removeExecutorAndUnregisterOutputOnExecutor(
+  private def removeExecutorAndUnregisterOutputs(
       execId: String,
       fileLost: Boolean,
-      maybeEpoch: Option[Long] = None) {
+      hostToUnregisterOutputs: Option[String],
+      maybeEpoch: Option[Long] = None): Unit = {
     val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
     if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
       failedEpoch(execId) = currentEpoch
@@ -1396,33 +1409,6 @@ class DAGScheduler(
         mapOutputTracker.removeOutputsOnExecutor(execId)
         clearCacheLocs()
       }
-    } else {
-      logDebug("Additional executor lost message for " + execId +
-        "(epoch " + currentEpoch + ")")
-    }
-  }
-
-  private[scheduler] def removeExecutorAndUnregisterOutputOnHost(
-      execId: String,
-      host: String,
-      maybeEpoch: Option[Long] = None) {
-    val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
-    if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
-      failedEpoch(execId) = currentEpoch
-      logInfo("Executor lost: %s (epoch %d)".format(execId, currentEpoch))
-      blockManagerMaster.removeExecutor(execId)
-      for ((shuffleId, stage) <- shuffleIdToMapStage) {
-        logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))
-        stage.removeOutputsOnHost(host)
-        mapOutputTracker.registerMapOutputs(
-          shuffleId,
-          stage.outputLocInMapOutputTrackerFormat(),
-          changeEpoch = true)
-      }
-      if (shuffleIdToMapStage.isEmpty) {
-        mapOutputTracker.incrementEpoch()
-      }
-      clearCacheLocs()
     } else {
       logDebug("Additional executor lost message for " + execId +
         "(epoch " + currentEpoch + ")")
@@ -1718,11 +1704,12 @@ private[scheduler] class DAGSchedulerEventProcessLoop(dagScheduler: DAGScheduler
       dagScheduler.handleExecutorAdded(execId, host)
 
     case ExecutorLost(execId, reason) =>
-      val filesLost = reason match {
-        case SlaveLost(_, true) => true
+      val workerLost = reason match {
+        case SlaveLost(_, true) =>
+          true
         case _ => false
       }
-      dagScheduler.handleExecutorLost(execId, filesLost)
+      dagScheduler.handleExecutorLost(execId, workerLost)
 
     case BeginEvent(task, taskInfo) =>
       dagScheduler.handleBeginEvent(task, taskInfo)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1340,7 +1340,7 @@ class DAGScheduler(
             }
             else {
               handleExecutorLost(bmAddress.executorId, fileLost = true, hostLost = false,
-                Some(bmAddress.host),Some(task.epoch))
+                Some(bmAddress.host), Some(task.epoch))
             }
           }
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -426,6 +426,7 @@ private[spark] class TaskSchedulerImpl private[scheduler](
             }
           case None =>
             logError(
+
               ("Ignoring update with state %s for TID %s because its task set is gone (this is " +
                 "likely the result of receiving duplicate task finished status updates) or its " +
                 "executor has been marked as failed.")

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -426,7 +426,6 @@ private[spark] class TaskSchedulerImpl private[scheduler](
             }
           case None =>
             logError(
-
               ("Ignoring update with state %s for TID %s because its task set is gone (this is " +
                 "likely the result of receiving duplicate task finished status updates) or its " +
                 "executor has been marked as failed.")

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -445,8 +445,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
         null)
     ))
 
-    // Here is the main assertion -- make sure that we de-register the map outputs for both map stage
-    // from both executors on hostA
+    // Here is the main assertion -- make sure that we de-register
+    // the map outputs for both map stage from both executors on hostA
     val mapStatus1 = mapOutputTracker.mapStatuses.get(0).get
     assert(mapStatus1.count(_ != null) === 1)
     assert(mapStatus1(2).location.executorId === "exec-hostB")

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -414,6 +414,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
       (Success, makeMapStatus("hostA", 1)),
       (Success, makeMapStatus("hostA", 1)),
       (Success, makeMapStatus("hostB", 1))))
+    scheduler.handleExecutorLost("exec-hostA1", fileLost = false, hostLost = true, Some("hostA"))
     runEvent(ExecutorLost("exec-hostA1", SlaveLost("", true)))
     val mapStatus = mapOutputTracker.mapStatuses.get(0).get.filter(_!= null)
     assert(mapStatus.size === 1)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -406,10 +406,10 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
     runEvent(ExecutorAdded("exec-hostA2", "hostA"))
     runEvent(ExecutorAdded("exec-hostB", "hostB"))
     val firstRDD = new MyRDD(sc, 3, Nil)
-    val firstShuffleDep = new ShuffleDependency(firstRDD, new HashPartitioner(2))
+    val firstShuffleDep = new ShuffleDependency(firstRDD, new HashPartitioner(3))
     val firstShuffleId = firstShuffleDep.shuffleId
     val shuffleMapRdd = new MyRDD(sc, 3, List(firstShuffleDep))
-    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
+    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(3))
     val reduceRdd = new MyRDD(sc, 1, List(shuffleDep))
     submit(reduceRdd, Array(0))
     // map stage1 completes successfully, with one task on each executor

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -401,6 +401,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with Timeou
     afterEach()
     val conf = new SparkConf()
     conf.set("spark.shuffle.service.enabled", "true")
+    conf.set("spark.files.fetchFailure.unRegisterOutputOnHost", "true")
     init(conf)
     runEvent(ExecutorAdded("exec-hostA1", "hostA"))
     runEvent(ExecutorAdded("exec-hostA2", "hostA"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, when we detect fetch failure, we only remove the shuffle files produced by the executor, while the host itself might be down and all the shuffle files are not accessible. In case we are running multiple executors on a host, any host going down currently results in multiple fetch failures and multiple retries of the stage, which is very inefficient. If we remove all the shuffle files on that host, on first fetch failure, we can rerun all the tasks on that host in a single stage retry.

## How was this patch tested?

Unit testing and also ran a job on the cluster and made sure multiple retries are gone.

