### PR TITLE
[SPARK-20933][SQL]when the input parameter is float type，the ’round ’ or  ‘bround’ function can't work well

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1058,7 +1058,7 @@ abstract class RoundBase(child: Expression, scale: Expression,
         if (f.isNaN || f.isInfinite) {
           f
         } else {
-          BigDecimal(f.toDouble).setScale(_scale, mode).toFloat
+          BigDecimal(f.toString).setScale(_scale, mode).toFloat
         }
       case DoubleType =>
         val d = input1.asInstanceOf[Double]
@@ -1119,7 +1119,7 @@ abstract class RoundBase(child: Expression, scale: Expression,
           if (Float.isNaN(${ce.value}) || Float.isInfinite(${ce.value})) {
             ${ev.value} = ${ce.value};
           } else {
-            ${ev.value} = java.math.BigDecimal.valueOf(${ce.value}).
+            ${ev.value} = new java.math.BigDecimal(Float.toString(${ce.value})).
               setScale(${_scale}, java.math.BigDecimal.${modeStr}).floatValue();
           }"""
       case DoubleType => // if child eval to NaN or Infinity, just return it.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -541,9 +541,13 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val intPi: Int = 314159265
     val longPi: Long = 31415926535897932L
     val bdPi: BigDecimal = BigDecimal(31415927L, 7)
+    val floatPi: Float = 3.1415f
 
     val doubleResults: Seq[Double] = Seq(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 3.1, 3.14, 3.142,
       3.1416, 3.14159, 3.141593)
+
+    val floatResults: Seq[Float] = Seq(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 3.0f, 3.1f, 3.14f,
+      3.142f, 3.1415f, 3.1415f, 3.1415f)
 
     val shortResults: Seq[Short] = Seq[Short](0, 0, 30000, 31000, 31400, 31420) ++
       Seq.fill[Short](7)(31415)
@@ -563,10 +567,12 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(Round(shortPi, scale), shortResults(i), EmptyRow)
       checkEvaluation(Round(intPi, scale), intResults(i), EmptyRow)
       checkEvaluation(Round(longPi, scale), longResults(i), EmptyRow)
+      checkEvaluation(Round(floatPi, scale), floatResults(i), EmptyRow)
       checkEvaluation(BRound(doublePi, scale), doubleResults(i), EmptyRow)
       checkEvaluation(BRound(shortPi, scale), shortResults(i), EmptyRow)
       checkEvaluation(BRound(intPi, scale), intResultsB(i), EmptyRow)
       checkEvaluation(BRound(longPi, scale), longResults(i), EmptyRow)
+      checkEvaluation(BRound(floatPi, scale), floatResults(i), EmptyRow)
     }
 
     val bdResults: Seq[BigDecimal] = Seq(BigDecimal(3.0), BigDecimal(3.1), BigDecimal(3.14),


### PR DESCRIPTION
## What changes were proposed in this pull request?
spark-sql>select round(cast(3.1415 as float), 3);
spark-sql>3.141
For this case, the result we expected is 3.142

spark-sql>select bround(cast(3.1415 as float), 3);
spark-sql>3.141
For this case, the result we expected is 3.142

Because `Float` is converted to `Double` or `BigDecimal` directly,which will change its pricision.
If converting float into string can solve this problem.
## How was this patch tested?
add unit test
