### PR TITLE
[SPARK-20951][SQL] Built-in SQL Function FormatNumber validate input value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckSuccess, TypeCheckFailure}
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckSuccess, TypeCheckFailure}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
@@ -1510,6 +1511,21 @@ case class FormatNumber(x: Expression, d: Expression)
   override def dataType: DataType = StringType
   override def nullable: Boolean = true
   override def inputTypes: Seq[AbstractDataType] = Seq(NumericType, IntegerType)
+
+  @transient
+  private lazy val decimal = d.eval().asInstanceOf[Int]
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    // Validate the inputTypes
+    val defaultCheck = super.checkInputDataTypes()
+    if (defaultCheck.isFailure) {
+      defaultCheck
+    } else if (decimal < 0) {
+      TypeCheckFailure(s"Argument 2 of function FORMAT_NUMBER must be >= 0, but got ${decimal}.")
+    } else {
+      TypeCheckSuccess
+    }
+  }
 
   // Associated with the pattern, for the last d value, and we will update the
   // pattern (DecimalFormat) once the new coming d value differ with the last one.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckFailure
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
 
@@ -582,13 +583,16 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(FormatNumber(Literal(12831273.23481d), Literal(3)), "12,831,273.235")
     checkEvaluation(FormatNumber(Literal(12831273.83421d), Literal(0)), "12,831,274")
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal(3)), "123,123,324,123.000")
-    checkEvaluation(FormatNumber(Literal(123123324123L), Literal(-1)), null)
     checkEvaluation(
       FormatNumber(
         Literal(Decimal(123123324123L) * Decimal(123123.21234d)), Literal(4)),
       "15,159,339,180,002,773.2778")
     checkEvaluation(FormatNumber(Literal.create(null, IntegerType), Literal(3)), null)
     assert(FormatNumber(Literal.create(null, NullType), Literal(3)).resolved === false)
+
+    val decimal = -4
+    assert(FormatNumber(Literal(123123324123L), Literal(decimal)).checkInputDataTypes() ==
+      TypeCheckFailure(s"Argument 2 of function FORMAT_NUMBER must be >= 0, but got ${decimal}."))
   }
 
   test("find in set") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SQL Function `FormatNumber` should validate input value, if `argument 2 < 0` throw `TypeCheckFailure` same as Hive's way . after this pr:
```:sql
spark-sql> select format_number(12332.123456, -4);
Error in query: cannot resolve 'format_number(12332.123456BD, -4)' due to data type mismatch: Argument 2 of function FORMAT_NUMBER must be >= 0, but -4 was found; line 1 pos 7;
'Project [unresolvedalias(format_number(12332.123456, -4), None)]
+- OneRowRelation$

spark-sql> 
```

## How was this patch tested?

unit tests