### PR TITLE
[SPARK-20952] ParquetFileFormat should forward TaskContext to its forkjoinpool

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -481,8 +481,10 @@ object ParquetFileFormat extends Logging {
     val parFiles = partFiles.par
     val pool = ThreadUtils.newForkJoinPool("readingParquetFooters", 8)
     parFiles.tasksupport = new ForkJoinTaskSupport(pool)
+    val tc = TaskContext.get()
     try {
       parFiles.flatMap { currentFile =>
+        TaskContext.setTaskContext(tc)
         try {
           // Skips row group information since we only need the schema.
           // ParquetFileReader.readFooter throws RuntimeException, instead of IOException,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make TaskContext reference an InheritableTheadLocal so thread pools spun up inside tasks have access to the reference

## How was this patch tested?

Added tests