### PR TITLE
[SPARK-20959][CORE]Add a parameter to UnsafeExternalSorter to configure filebuffersize

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -94,11 +94,12 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       RecordComparator recordComparator,
       PrefixComparator prefixComparator,
       int initialSize,
+      long fileBufferSizeBytes,
       long pageSizeBytes,
       long numElementsForSpillThreshold,
       UnsafeInMemorySorter inMemorySorter) throws IOException {
     UnsafeExternalSorter sorter = new UnsafeExternalSorter(taskMemoryManager, blockManager,
-      serializerManager, taskContext, recordComparator, prefixComparator, initialSize,
+      serializerManager, taskContext, recordComparator, prefixComparator, initialSize, fileBufferSizeBytes,
         numElementsForSpillThreshold, pageSizeBytes, inMemorySorter, false /* ignored */);
     sorter.spill(Long.MAX_VALUE, sorter);
     // The external sorter will be used to insert records, in-memory sorter is not needed.
@@ -114,12 +115,13 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       RecordComparator recordComparator,
       PrefixComparator prefixComparator,
       int initialSize,
+      long fileBufferSizeBytes,
       long pageSizeBytes,
       long numElementsForSpillThreshold,
       boolean canUseRadixSort) {
     return new UnsafeExternalSorter(taskMemoryManager, blockManager, serializerManager,
-      taskContext, recordComparator, prefixComparator, initialSize, pageSizeBytes,
-      numElementsForSpillThreshold, null, canUseRadixSort);
+      taskContext, recordComparator, prefixComparator, initialSize, fileBufferSizeBytes,
+      pageSizeBytes, numElementsForSpillThreshold, null, canUseRadixSort);
   }
 
   private UnsafeExternalSorter(
@@ -130,6 +132,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       RecordComparator recordComparator,
       PrefixComparator prefixComparator,
       int initialSize,
+      long fileBufferSizeBytes,
       long pageSizeBytes,
       long numElementsForSpillThreshold,
       @Nullable UnsafeInMemorySorter existingInMemorySorter,
@@ -143,7 +146,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     this.prefixComparator = prefixComparator;
     // Use getSizeAsKb (not bytes) to maintain backwards compatibility for units
     // this.fileBufferSizeBytes = (int) conf.getSizeAsKb("spark.shuffle.file.buffer", "32k") * 1024
-    this.fileBufferSizeBytes = 32 * 1024;
+    this.fileBufferSizeBytes = (int) fileBufferSizeBytes;
     // The spill metrics are stored in a new ShuffleWriteMetrics,
     // and then discarded (this fixes SPARK-16827).
     // TODO: Instead, separate spill metrics should be stored and reported (tracked in SPARK-3577).

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -157,6 +157,7 @@ public class UnsafeExternalSorterSuite {
       recordComparator,
       prefixComparator,
       /* initialSize */ 1024,
+      32 * 1024,
       pageSizeBytes,
       UnsafeExternalSorter.DEFAULT_NUM_ELEMENTS_FOR_SPILL_THRESHOLD,
       shouldUseRadixSort());
@@ -381,6 +382,7 @@ public class UnsafeExternalSorterSuite {
       null,
       null,
       /* initialSize */ 1024,
+      32 * 1024,
       pageSizeBytes,
       UnsafeExternalSorter.DEFAULT_NUM_ELEMENTS_FOR_SPILL_THRESHOLD,
       shouldUseRadixSort());
@@ -418,6 +420,7 @@ public class UnsafeExternalSorterSuite {
       recordComparator,
       prefixComparator,
       1024,
+      32 * 1024,
       pageSizeBytes,
       UnsafeExternalSorter.DEFAULT_NUM_ELEMENTS_FOR_SPILL_THRESHOLD,
       shouldUseRadixSort());

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -88,6 +88,7 @@ public final class UnsafeExternalRowSorter {
       prefixComparator,
       sparkEnv.conf().getInt("spark.shuffle.sort.initialBufferSize",
                              DEFAULT_INITIAL_SORT_BUFFER_SIZE),
+      sparkEnv.conf().getSizeAsKb("spark.shuffle.file.buffer", "32k") * 1024,
       pageSizeBytes,
       SparkEnv.get().conf().getLong("spark.shuffle.spill.numElementsForceSpillThreshold",
         UnsafeExternalSorter.DEFAULT_NUM_ELEMENTS_FOR_SPILL_THRESHOLD),

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
@@ -92,6 +92,7 @@ public final class UnsafeKVExternalSorter {
         prefixComparator,
         SparkEnv.get().conf().getInt("spark.shuffle.sort.initialBufferSize",
                                      UnsafeExternalRowSorter.DEFAULT_INITIAL_SORT_BUFFER_SIZE),
+        SparkEnv.get().conf().getSizeAsKb("spark.shuffle.file.buffer", "32k") * 1024,
         pageSizeBytes,
         numElementsForSpillThreshold,
         canUseRadixSort);
@@ -141,6 +142,7 @@ public final class UnsafeKVExternalSorter {
         prefixComparator,
         SparkEnv.get().conf().getInt("spark.shuffle.sort.initialBufferSize",
                                      UnsafeExternalRowSorter.DEFAULT_INITIAL_SORT_BUFFER_SIZE),
+        SparkEnv.get().conf().getSizeAsKb("spark.shuffle.file.buffer", "32k") * 1024,
         pageSizeBytes,
         numElementsForSpillThreshold,
         inMemSorter);

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -48,6 +48,7 @@ private[sql] class ExternalAppendOnlyUnsafeRowArray(
     serializerManager: SerializerManager,
     taskContext: TaskContext,
     initialSize: Int,
+    fileBufferSizeBytes: Long,
     pageSizeBytes: Long,
     numRowsSpillThreshold: Int) extends Logging {
 
@@ -58,6 +59,7 @@ private[sql] class ExternalAppendOnlyUnsafeRowArray(
       SparkEnv.get.serializerManager,
       TaskContext.get(),
       1024,
+      SparkEnv.get.conf.getSizeAsKb("spark.shuffle.file.buffer", "32k") * 1024,
       SparkEnv.get.memoryManager.pageSizeBytes,
       numRowsSpillThreshold)
   }
@@ -118,6 +120,7 @@ private[sql] class ExternalAppendOnlyUnsafeRowArray(
           null,
           null,
           initialSize,
+          fileBufferSizeBytes,
           pageSizeBytes,
           numRowsSpillThreshold,
           false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
@@ -117,6 +117,7 @@ object ExternalAppendOnlyUnsafeRowArrayBenchmark {
           null,
           null,
           1024,
+          32 * 1024,
           SparkEnv.get.memoryManager.pageSizeBytes,
           numSpillThreshold,
           false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArraySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArraySuite.scala
@@ -44,6 +44,7 @@ class ExternalAppendOnlyUnsafeRowArraySuite extends SparkFunSuite with LocalSpar
       SparkEnv.get.serializerManager,
       taskContext,
       1024,
+      32 * 1024,
       SparkEnv.get.memoryManager.pageSizeBytes,
       spillThreshold)
     try f(array) finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR Improvement with `spark.shuffle.file.buffer` configure fileBufferSizeBytes in UnsafeExternalSorter.  
when change the size of the spark.shuffle.file.buffer to test SQL algorithm.
The average performance of running 5 times is as follows
```
buffer size:   1M      64K      32K      4K
----------------------------------------------
Time           558s    513s     500s     510s
```

## How was this patch tested?

The unit test.