### PR TITLE
[SPARK-20944][SHUFFLE] Move shouldBypassMergeSort from SortShuffleWriter to SortShuffleManager

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -102,16 +102,3 @@ private[spark] class SortShuffleWriter[K, V, C](
     }
   }
 }
-
-private[spark] object SortShuffleWriter {
-  def shouldBypassMergeSort(conf: SparkConf, dep: ShuffleDependency[_, _, _]): Boolean = {
-    // We cannot bypass sorting if we need to do map-side aggregation.
-    if (dep.mapSideCombine) {
-      require(dep.aggregator.isDefined, "Map-side combine without Aggregator specified!")
-      false
-    } else {
-      val bypassMergeThreshold: Int = conf.getInt("spark.shuffle.sort.bypassMergeThreshold", 200)
-      dep.partitioner.numPartitions <= bypassMergeThreshold
-    }
-  }
-}


### PR DESCRIPTION
## What changes were proposed in this pull request?
 There exists three `ShuffleWriter ` implementations, we first use the helper method `SortShuffleWriter#shouldBypassMergeSort` to determine whether a shuffle should use `BypassMergeSort` path，and then use another helper method `SortShuffleManager#canUseSerializedShuffle` for deciding `UnsafeShuffleWriter` path. From view of code structure consistency，method `shouldBypassMergeSort` should not belong to `SortShuffleWriter`，it should be included in `BypassMergeSortShuffleWriter` or `SortShuffleManager`, and better for the later one to put the two helper methods together. 

## How was this patch tested?


