### PR TITLE
[SPARK-20996][YARN] Better handling AM reattempt based on exit code in yarn mode

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -318,9 +318,10 @@ To use a custom metrics.properties for the application master and executors, upd
 </tr>
 <tr>
   <td><code>spark.yarn.maxAppAttempts</code></td>
-  <td><code>yarn.resourcemanager.am.max-attempts</code> in YARN</td>
+  <td><code>1</code></td>
   <td>
-  The maximum number of attempts that will be made to submit the application.
+  The maximum number of attempts that will be made to submit the application. Default value is 1,
+  which means there's no another attempt when application fails.
   It should be no larger than the global number of max attempts in the YARN configuration.
   </td>
 </tr>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -218,11 +218,7 @@ private[spark] class Client(
     sparkConf.get(APPLICATION_TAGS).foreach { tags =>
       appContext.setApplicationTags(new java.util.HashSet[String](tags.asJava))
     }
-    sparkConf.get(MAX_APP_ATTEMPTS) match {
-      case Some(v) => appContext.setMaxAppAttempts(v)
-      case None => logDebug(s"${MAX_APP_ATTEMPTS.key} is not set. " +
-          "Cluster's default value will be used.")
-    }
+    appContext.setMaxAppAttempts(sparkConf.get(MAX_APP_ATTEMPTS))
 
     sparkConf.get(AM_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS).foreach { interval =>
       appContext.setAttemptFailuresValidityInterval(interval)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -108,12 +108,13 @@ private[spark] class YarnRMClient extends Logging {
 
   /** Returns the maximum number of attempts to register the AM. */
   def getMaxRegAttempts(sparkConf: SparkConf, yarnConf: YarnConfiguration): Int = {
-    val sparkMaxAttempts = sparkConf.get(MAX_APP_ATTEMPTS).map(_.toInt)
+    val sparkMaxAttempts = sparkConf.get(MAX_APP_ATTEMPTS)
     val yarnMaxAttempts = yarnConf.getInt(
       YarnConfiguration.RM_AM_MAX_ATTEMPTS, YarnConfiguration.DEFAULT_RM_AM_MAX_ATTEMPTS)
-    sparkMaxAttempts match {
-      case Some(x) => if (x <= yarnMaxAttempts) x else yarnMaxAttempts
-      case None => yarnMaxAttempts
+    if (sparkMaxAttempts < yarnMaxAttempts) {
+      sparkMaxAttempts
+    } else {
+      yarnMaxAttempts
     }
   }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -50,7 +50,7 @@ package object config {
   private[spark] val MAX_APP_ATTEMPTS = ConfigBuilder("spark.yarn.maxAppAttempts")
     .doc("Maximum number of AM attempts before failing the app.")
     .intConf
-    .createOptional
+    .createWithDefault(1)
 
   private[spark] val USER_CLASS_PATH_FIRST = ConfigBuilder("spark.yarn.user.classpath.first")
     .doc("Whether to place user jars in front of Spark's classpath.")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Yarn provides max attempt configuration for applications running on it, application has the chance to retry itself when failed. In the current Spark code, no matter which failure AM occurred and if the failure doesn't reach to the max attempt, RM will restart AM, this is not reasonable for some cases if this issue is coming from AM itself, like user code failure, OOM, Spark issue, executor failures, in large chance the reattempt of AM will meet this issue again. Only when AM is failed due to external issue like crash, process kill, NM failure, then AM should retry again.

So here propose to improve this reattempt mechanism to only retry when it meets external issues.

## How was this patch tested?

Manual verification.
