### PR TITLE
fix param dismatch when using makeRDD

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -103,12 +103,12 @@ object SQLDataSourceExample {
     import spark.implicits._
 
     // Create a simple DataFrame, store into a partition directory
-    val squaresDF = spark.sparkContext.makeRDD(1 to 5).map(i => (i, i * i)).toDF("value", "square")
+    val squaresDF = spark.sparkContext.makeRDD((1 to 5).map(i => (i, i * i))).toDF("value", "square")
     squaresDF.write.parquet("data/test_table/key=1")
 
     // Create another DataFrame in a new partition directory,
     // adding a new column and dropping an existing column
-    val cubesDF = spark.sparkContext.makeRDD(6 to 10).map(i => (i, i * i * i)).toDF("value", "cube")
+    val cubesDF = spark.sparkContext.makeRDD((6 to 10).map(i => (i, i * i))).toDF("value", "cube")
     cubesDF.write.parquet("data/test_table/key=2")
 
     // Read the partitioned table


### PR DESCRIPTION
when i see at : http://spark.apache.org/docs/latest/sql-programming-guide.html#schema-merging, 

```
val squaresDF = spark.sparkContext.makeRDD(1 to 5).map(i => (i, i * i)).toDF("value", "square")
squaresDF.write.parquet("data/test_table/key=1")
```

this will be error on jobs

```
[Stage 0:>                                                          (0 + 2) / 2]17/06/06 17:21:14 WARN TaskSetManager: Lost task 0.0 in stage 0.0 (TID 0, 10.235.3.133, executor 0): java.lang.ClassCastException: cannot assign instance of scala.collection.immutable.List$SerializationProxy to field org.apache.spark.rdd.RDD.org$apache$spark$rdd$RDD$$dependencies_ of type scala.collection.Seq in instance of org.apache.spark.rdd.MapPartitionsRDD
	at java.io.ObjectStreamClass$FieldReflector.setObjFieldValues(ObjectStreamClass.java:2089)
	at java.io.ObjectStreamClass.setObjFieldValues(ObjectStreamClass.java:1261)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2006)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:1924)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1801)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1351)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2000)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:1924)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1801)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1351)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:371)
	at scala.collection.immutable.List$SerializationProxy.readObject(List.scala:479)
```

should be changed to this below

```
val squaresDF = spark.sparkContext.makeRDD((1 to 5).map(i => (i, i * i))).toDF("value", "square")
squaresDF.write.parquet("data/test_table/key=1")
```
