### PR TITLE
[SPARK-20999][CORE][DAG]No failure Stages, no log 'DAGScheduler: failed: Set()' output

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -769,7 +769,9 @@ class DAGScheduler(
     logTrace(s"Checking if any dependencies of $parent are now runnable")
     logTrace("running: " + runningStages)
     logTrace("waiting: " + waitingStages)
-    logTrace("failed: " + failedStages)
+    if (!failedStages.isEmpty) {
+      logTrace("failed: " + failedStages)
+    }
     val childStages = waitingStages.filter(_.parents.contains(parent)).toArray
     waitingStages --= childStages
     for (stage <- childStages.sortBy(_.firstJobId)) {
@@ -1232,7 +1234,9 @@ class DAGScheduler(
               logInfo("looking for newly runnable stages")
               logInfo("running: " + runningStages)
               logInfo("waiting: " + waitingStages)
-              logInfo("failed: " + failedStages)
+              if (!failedStages.isEmpty) {
+                logInfo("failed: " + failedStages)
+              }
 
               // We supply true to increment the epoch number here in case this is a
               // recomputation of the map outputs. In that case, some nodes may have cached


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the output of the spark log information:

```
INFO DAGScheduler: looking for newly runnable stages
INFO DAGScheduler: running: Set(ShuffleMapStage 14)
INFO DAGScheduler: waiting: Set(ResultStage 15)
INFO DAGScheduler: failed: Set()
```

If there is no failure stage, `"INFO DAGScheduler: failed: Set()"` is not must be to output in the log information.

## How was this patch tested?

Existing the unit test.
