### PR TITLE
[SPARK-21004]remove the never used declaration in function warnDeprec…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -349,7 +349,6 @@ class SparkContext(config: SparkConf) extends Logging {
   }
 
   private def warnDeprecatedVersions(): Unit = {
-    val javaVersion = System.getProperty("java.version").split("[+.\\-]+", 3)
     if (scala.util.Properties.releaseVersion.exists(_.startsWith("2.10"))) {
       logWarning("Support for Scala 2.10 is deprecated as of Spark 2.1.0")
     }


### PR DESCRIPTION
JIRA Issue:https://issues.apache.org/jira/browse/SPARK-21004



the function {warnDeprecatedVersions} of class SparkContext, the declaration of
val javaVersion = System.getProperty("java.version").split("[+.\\-]+", 3)
is never used in this function.
