### PR TITLE
[SPARK-21005][ML] Fix VectorIndexerModel does not prepare output column field correctly.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
@@ -414,7 +414,11 @@ class VectorIndexerModel private[ml] (
             featAttr
           }
         case (origAttr: Attribute, featAttr: NumericAttribute) =>
-          origAttr.withIndex(featAttr.index.get)
+          if (origAttr.name.nonEmpty) {
+            featAttr.withName(origAttr.name.get)
+          } else {
+            featAttr
+          }
         case (origAttr: Attribute, _) =>
           origAttr
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix VectorIndexerModel does not prepare output column field correctly. Original attributes which is expected to be a continuous feature should be converted to numerical attribute to keep consistent with the documentation.

## How was this patch tested?
Add unit test.
