### PR TITLE
[SPARK-21015] Check field name is not null and empty in GenericRowWit…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -183,7 +183,11 @@ class GenericRowWithSchema(values: Array[Any], override val schema: StructType)
   /** No-arg constructor for serialization. */
   protected def this() = this(null, null)
 
-  override def fieldIndex(name: String): Int = schema.fieldIndex(name)
+  override def fieldIndex(name: String): Int = if (name == null || name.length() == 0) {
+    throw new IllegalArgumentException(s"""Field "$name" should not null or empty.""")
+  } else {
+    schema.fieldIndex(name)
+  }
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we get field index from row with schema , we shoule make sure the field name is not null and empty .
