### PR TITLE
[SPARK-19462] fix bug in Exchange--pass in a tmp "newPartitioning" in "prepareShuffleDependency"

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
@@ -160,7 +160,8 @@ case class Exchange(
    * the partitioning scheme defined in `newPartitioning`. Those partitions of
    * the returned ShuffleDependency will be the input of shuffle.
    */
-  private[sql] def prepareShuffleDependency(): ShuffleDependency[Int, InternalRow, InternalRow] = {
+  private[sql] def prepareShuffleDependency(newPartitioning: Partitioning): ShuffleDependency[Int,
+    InternalRow, InternalRow] = {
     val rdd = child.execute()
     val part: Partitioner = newPartitioning match {
       case RoundRobinPartitioning(numPartitions) => new HashPartitioner(numPartitions)
@@ -251,7 +252,7 @@ case class Exchange(
         assert(shuffleRDD.partitions.length == newPartitioning.numPartitions)
         shuffleRDD
       case None =>
-        val shuffleDependency = prepareShuffleDependency()
+        val shuffleDependency = prepareShuffleDependency(newPartitioning)
         preparePostShuffleRDD(shuffleDependency)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExchangeCoordinator.scala
@@ -207,7 +207,7 @@ private[sql] class ExchangeCoordinator(
       var i = 0
       while (i < numExchanges) {
         val exchange = exchanges(i)
-        val shuffleDependency = exchange.prepareShuffleDependency()
+        val shuffleDependency = exchange.prepareShuffleDependency(exchange.newPartitioning)
         shuffleDependencies += shuffleDependency
         if (shuffleDependency.rdd.partitions.length != 0) {
           // submitMapStage does not accept RDD with 0 partition.


### PR DESCRIPTION
When `spark.sql.adaptive.enabled` is true, any rerunning of ancestors of `ShuffledRowRDD` will fail. It can be triggered by `FetchFailed` or killing some executors, which can lead to rerunning of the tasks. This is because the `newPartitioning` is set to be `UnknownPartitioning` after the post shuffleRDD is prepared. 
This pr proposes pass in a tmp "newPartitioning" in "prepareShuffleDependency". Thus we can rerun the ancestor tasks.