### PR TITLE
[SPARK-21017][sql]Move the length getter before the while to improve performance

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
@@ -142,7 +142,8 @@ class HiveOutputWriter(
 
   override def write(row: InternalRow): Unit = {
     var i = 0
-    while (i < fieldOIs.length) {
+    val fieldOIsLength = fieldOIs.length
+    while (i < fieldOIsLength) {
       outputData(i) = if (row.isNullAt(i)) null else wrappers(i)(row.get(i, dataTypes(i)))
       i += 1
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In my test, the cost of the while in the write function of HiveOutputWriter class have improved from 48ms to 40ms for a table of 500 rows and 100 columns when putting the length getter before the while 

## How was this patch tested?
Run the UT test


