### PR TITLE
[SPARK-21023][Submit] Ignore to load default properties file is not a…

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -20,6 +20,7 @@ package org.apache.spark.launcher;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -272,20 +273,26 @@ abstract class AbstractCommandBuilder {
   }
 
   /**
-   * Loads the configuration file for the application, if it exists. This is either the
-   * user-specified properties file, or the spark-defaults.conf file under the Spark configuration
-   * directory.
+   * Loads the configuration file for the application, if it exists.
+   * The KV pair in user-specified properties file will overwrite the one
+   * in spark-defaults.conf file under the Spark configuration directory.
    */
   private Properties loadPropertiesFile() throws IOException {
     Properties props = new Properties();
-    File propsFile;
+    File propsFile = new File(getConfDir(), DEFAULT_PROPERTIES_FILE);
+    loadPropertiesFileInternal(props, propsFile);
+
     if (propertiesFile != null) {
       propsFile = new File(propertiesFile);
       checkArgument(propsFile.isFile(), "Invalid properties file '%s'.", propertiesFile);
-    } else {
-      propsFile = new File(getConfDir(), DEFAULT_PROPERTIES_FILE);
     }
+    loadPropertiesFileInternal(props, propsFile);
 
+    return props;
+  }
+
+  private void loadPropertiesFileInternal(Properties props, File propsFile)
+      throws FileNotFoundException, IOException {
     if (propsFile.isFile()) {
       FileInputStream fd = null;
       try {
@@ -304,8 +311,6 @@ abstract class AbstractCommandBuilder {
         }
       }
     }
-
-    return props;
   }
 
   private String getConfDir() {


### PR DESCRIPTION
… good choice from the perspective of system

## What changes were proposed in this pull request?

The default properties file spark-defaults.conf shouldn't be ignore to load even though the submit arg --properties-file is set. The reasons are very easy to see:

1. Infrastructure team need continually update the spark-defaults.conf when they want set something as default for entire cluster as a tuning purpose.
2. Application developer only want to override the parameters they really want rather than others they even doesn't know (Set by infrastructure team).
3. The purpose of using --properties-file from most of application developers is to avoid setting dozens of --conf k=v. But if spark-defaults.conf is ignored, the behaviour becomes unexpected finally.

For example:
Current implement
Default configuration file:

> spark.A="foo"
> spark.B="foo"
> spark.D="foo"
> spark.E="foo"
> spark.F="foo"

Use-special file:

> spark.A="bar"
> spark.C="bar"
> spark.D="foo"

The result:

> spark.A="bar"
> spark.C="bar"
> spark.D="foo"


Expected right implement
The result:

> spark.A="bar"
> spark.B="foo"
> spark.C="bar"
> spark.D="foo"
> spark.E="foo"
> spark.F="foo"


## How was this patch tested?

Modify the UT of SparkSubmitCommandBuilderSuite.java
