### PR TITLE
[SPARK-21024][SQL] CSV parse mode handles Univocity parser exceptions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
@@ -25,7 +25,6 @@ import java.util.Locale
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import com.univocity.parsers.common.TextParsingException
 import com.univocity.parsers.csv.CsvParser
 
 import org.apache.spark.internal.Logging

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1174,4 +1174,27 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
         }
       }
   }
+
+  test("SPARK-21024 CSV parser mode controls parser exceptions") {
+    withTempPath { path =>
+      Seq("0,1", "0,1,2,3").toDF().write.text(path.getAbsolutePath)
+
+      val msg = intercept[SparkException] {
+        spark.read.format("csv")
+          .schema("a INT, b INT")
+          .option("maxColumns", "3")
+          .option("mode", "FAILFAST")
+          .load(path.getAbsolutePath)
+          .collect
+      }.getMessage
+      assert(msg.contains("Number of columns processed may have exceeded limit of 3 columns."))
+
+      val df = spark.read.format("csv")
+        .schema(s"a INT, b INT")
+        .option("maxColumns", "2")
+        .option("mode", "PERMISSIVE")
+        .load(path.getAbsolutePath)
+      checkAnswer(df, Row(0, 1) :: Row(null, null) :: Nil)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr fixed code to handle Univocity parser exceptions by CSV parse modes.
The current master cannot skip the illegal records that Univocity parsers:
```
scala> Seq("0,1", "0,1,2,3").toDF().write.text("/Users/maropu/Desktop/data")
scala> val df = spark.read.format("csv").schema("a int, b int").option("maxColumns", "3").load("/Users/maropu/Desktop/data")
scala> df.show

com.univocity.parsers.common.TextParsingException: java.lang.ArrayIndexOutOfBoundsException - 3
Hint: Number of columns processed may have exceeded limit of 3 columns. Use settings.setMaxColumns(int) to define the maximum number of columns your input can have
Ensure your configuration is correct, with delimiters, quotes and escape sequences that match the input format you are trying to parse
Parser Configuration: CsvParserSettings:
        Auto configuration enabled=true
        Autodetect column delimiter=false
        Autodetect quotes=false
        Column reordering enabled=true
        Empty value=null
        Escape unquoted values=false
        ...

at com.univocity.parsers.common.AbstractParser.handleException(AbstractParser.java:339)
at com.univocity.parsers.common.AbstractParser.handleEOF(AbstractParser.java:195)
at com.univocity.parsers.common.AbstractParser.parseLine(AbstractParser.java:544)
at org.apache.spark.sql.execution.datasources.csv.UnivocityParser.parse(UnivocityParser.scala:191)
at org.apache.spark.sql.execution.datasources.csv.UnivocityParser$$anonfun$5.apply(UnivocityParser.scala:308)
at org.apache.spark.sql.execution.datasources.csv.UnivocityParser$$anonfun$5.apply(UnivocityParser.scala:308)
at org.apache.spark.sql.execution.datasources.FailureSafeParser.parse(FailureSafeParser.scala:60)
at org.apache.spark.sql.execution.datasources.csv.UnivocityParser$$anonfun$parseIterator$1.apply(UnivocityParser.scala:312)
at org.apache.spark.sql.execution.datasources.csv.UnivocityParser$$anonfun$parseIterator$1.apply(UnivocityParser.scala:312)
at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
...
```

## How was this patch tested?
Added tests in `CSVSuite`.