### PR TITLE
[SPARK-21046][SQL] simplify the array offset and length in ColumnVector

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -523,7 +523,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * size of the written array.
    */
   public void putArrayOffsetAndSize(int rowId, int offset, int size) {
-    long offsetAndSize = (offset << 32) | size;
+    long offsetAndSize = (((long) offset) << 32) | size;
     putLong(rowId, offsetAndSize);
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -522,7 +522,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * After writing array elements to the child column vector, call this method to set the offset and
    * length of the written array.
    */
-  public void arrayWriteEnd(int rowId, int offset, int length) {
+  public void putArrayOffsetAndLength(int rowId, int offset, int length) {
     putInt(2 * rowId, offset);
     putInt(2 * rowId + 1, length);
   }
@@ -563,7 +563,7 @@ public abstract class ColumnVector implements AutoCloseable {
    */
   public int putByteArray(int rowId, byte[] value, int offset, int length) {
     int result = arrayData().appendBytes(length, value, offset);
-    arrayWriteEnd(rowId, result, length);
+    putArrayOffsetAndLength(rowId, result, length);
     return result;
   }
 
@@ -829,13 +829,13 @@ public abstract class ColumnVector implements AutoCloseable {
   public final int appendByteArray(byte[] value, int offset, int length) {
     int copiedOffset = arrayData().appendBytes(length, value, offset);
     reserve(elementsAppended + 1);
-    arrayWriteEnd(elementsAppended, copiedOffset, length);
+    putArrayOffsetAndLength(elementsAppended, copiedOffset, length);
     return elementsAppended++;
   }
 
   public final int appendArray(int length) {
     reserve(elementsAppended + 1);
-    arrayWriteEnd(elementsAppended, arrayData().elementsAppended, length);
+    putArrayOffsetAndLength(elementsAppended, arrayData().elementsAppended, length);
     return elementsAppended++;
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -520,11 +520,11 @@ public abstract class ColumnVector implements AutoCloseable {
 
   /**
    * After writing array elements to the child column vector, call this method to set the offset and
-   * length of the written array.
+   * size of the written array.
    */
-  public void putArrayOffsetAndLength(int rowId, int offset, int length) {
-    putInt(2 * rowId, offset);
-    putInt(2 * rowId + 1, length);
+  public void putArrayOffsetAndSize(int rowId, int offset, int size) {
+    long offsetAndSize = (offset << 32) | size;
+    putLong(rowId, offsetAndSize);
   }
 
   /**
@@ -548,8 +548,9 @@ public abstract class ColumnVector implements AutoCloseable {
    * Returns the array at rowid.
    */
   public final Array getArray(int rowId) {
-    resultArray.offset = getInt(2 * rowId);
-    resultArray.length = getInt(2 * rowId + 1);
+    long offsetAndSize = getLong(rowId);
+    resultArray.offset = (int) (offsetAndSize >> 32);
+    resultArray.length = (int) offsetAndSize;
     return resultArray;
   }
 
@@ -563,7 +564,7 @@ public abstract class ColumnVector implements AutoCloseable {
    */
   public int putByteArray(int rowId, byte[] value, int offset, int length) {
     int result = arrayData().appendBytes(length, value, offset);
-    putArrayOffsetAndLength(rowId, result, length);
+    putArrayOffsetAndSize(rowId, result, length);
     return result;
   }
 
@@ -829,13 +830,13 @@ public abstract class ColumnVector implements AutoCloseable {
   public final int appendByteArray(byte[] value, int offset, int length) {
     int copiedOffset = arrayData().appendBytes(length, value, offset);
     reserve(elementsAppended + 1);
-    putArrayOffsetAndLength(elementsAppended, copiedOffset, length);
+    putArrayOffsetAndSize(elementsAppended, copiedOffset, length);
     return elementsAppended++;
   }
 
   public final int appendArray(int length) {
     reserve(elementsAppended + 1);
-    putArrayOffsetAndLength(elementsAppended, arrayData().elementsAppended, length);
+    putArrayOffsetAndSize(elementsAppended, arrayData().elementsAppended, length);
     return elementsAppended++;
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -34,7 +34,7 @@ public final class OffHeapColumnVector extends ColumnVector {
   // The data stored in these two allocations need to maintain binary compatible. We can
   // directly pass this buffer to external components.
   private long nulls;
-  // The actually data of this column vector will be store here. If it's an array column vector,
+  // The actually data of this column vector will be stored here. If it's an array column vector,
   // we will store the offsets and lengths here, and store the element data in child column vector.
   private long data;
 
@@ -403,7 +403,6 @@ public final class OffHeapColumnVector extends ColumnVector {
     if (this.resultArray != null) {
       // need 2 ints as offset and length for each array.
       this.data = Platform.reallocateMemory(data, oldCapacity * 8, newCapacity * 8);
-      putInt(0, 0);
     } else if (type instanceof ByteType || type instanceof BooleanType) {
       this.data = Platform.reallocateMemory(data, oldCapacity, newCapacity);
     } else if (type instanceof ShortType) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -401,7 +401,7 @@ public final class OffHeapColumnVector extends ColumnVector {
   protected void reserveInternal(int newCapacity) {
     int oldCapacity = (this.data == 0L) ? 0 : capacity;
     if (this.resultArray != null) {
-      // need 2 ints as offset and length for each array.
+      // need a long as offset and length for each array.
       this.data = Platform.reallocateMemory(data, oldCapacity * 8, newCapacity * 8);
     } else if (type instanceof ByteType || type instanceof BooleanType) {
       this.data = Platform.reallocateMemory(data, oldCapacity, newCapacity);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -36,17 +36,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   private long nulls;
   private long data;
 
-  // Set iff the type is array.
-  private long lengthData;
-  private long offsetData;
-
   protected OffHeapColumnVector(int capacity, DataType type) {
     super(capacity, type, MemoryMode.OFF_HEAP);
 
     nulls = 0;
     data = 0;
-    lengthData = 0;
-    offsetData = 0;
 
     reserveInternal(capacity);
     reset();
@@ -66,12 +60,8 @@ public final class OffHeapColumnVector extends ColumnVector {
   public void close() {
     Platform.freeMemory(nulls);
     Platform.freeMemory(data);
-    Platform.freeMemory(lengthData);
-    Platform.freeMemory(offsetData);
     nulls = 0;
     data = 0;
-    lengthData = 0;
-    offsetData = 0;
   }
 
   //
@@ -395,35 +385,6 @@ public final class OffHeapColumnVector extends ColumnVector {
     }
   }
 
-  //
-  // APIs dealing with Arrays.
-  //
-  @Override
-  public void putArray(int rowId, int offset, int length) {
-    assert(offset >= 0 && offset + length <= childColumns[0].capacity);
-    Platform.putInt(null, lengthData + 4 * rowId, length);
-    Platform.putInt(null, offsetData + 4 * rowId, offset);
-  }
-
-  @Override
-  public int getArrayLength(int rowId) {
-    return Platform.getInt(null, lengthData + 4 * rowId);
-  }
-
-  @Override
-  public int getArrayOffset(int rowId) {
-    return Platform.getInt(null, offsetData + 4 * rowId);
-  }
-
-  // APIs dealing with ByteArrays
-  @Override
-  public int putByteArray(int rowId, byte[] value, int offset, int length) {
-    int result = arrayData().appendBytes(length, value, offset);
-    Platform.putInt(null, lengthData + 4 * rowId, length);
-    Platform.putInt(null, offsetData + 4 * rowId, result);
-    return result;
-  }
-
   @Override
   public void loadBytes(ColumnVector.Array array) {
     if (array.tmpByteArray.length < array.length) array.tmpByteArray = new byte[array.length];
@@ -438,10 +399,9 @@ public final class OffHeapColumnVector extends ColumnVector {
   protected void reserveInternal(int newCapacity) {
     int oldCapacity = (this.data == 0L) ? 0 : capacity;
     if (this.resultArray != null) {
-      this.lengthData =
-          Platform.reallocateMemory(lengthData, oldCapacity * 4, newCapacity * 4);
-      this.offsetData =
-          Platform.reallocateMemory(offsetData, oldCapacity * 4, newCapacity * 4);
+      // need 2 ints as offset and length for each array.
+      this.data = Platform.reallocateMemory(data, oldCapacity * 8, newCapacity * 8);
+      putInt(0, 0);
     } else if (type instanceof ByteType || type instanceof BooleanType) {
       this.data = Platform.reallocateMemory(data, oldCapacity, newCapacity);
     } else if (type instanceof ShortType) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -34,6 +34,8 @@ public final class OffHeapColumnVector extends ColumnVector {
   // The data stored in these two allocations need to maintain binary compatible. We can
   // directly pass this buffer to external components.
   private long nulls;
+  // The actually data of this column vector will be store here. If it's an array column vector,
+  // we will store the offsets and lengths here, and store the element data in child column vector.
   private long data;
 
   protected OffHeapColumnVector(int capacity, DataType type) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -42,7 +42,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   // Array for each type. Only 1 is populated for any type.
   private byte[] byteData;
   private short[] shortData;
-  // This is not used used to store data for int column vector, but also can store offsets and
+  // This is not only used to store data for int column vector, but also can store offsets and
   // lengths for array column vector.
   private int[] intData;
   private long[] longData;
@@ -377,10 +377,9 @@ public final class OnHeapColumnVector extends ColumnVector {
       // need 2 ints as offset and length for each array.
       if (intData == null || intData.length < newCapacity * 2) {
         int[] newData = new int[newCapacity * 2];
-        if (intData != null) System.arraycopy(intData, 0, newData, 0, capacity * 2);
+        if (intData != null) System.arraycopy(intData, 0, newData, 0, intData.length);
         intData = newData;
       }
-      putInt(0, 0);
     } else if (type instanceof BooleanType) {
       if (byteData == null || byteData.length < newCapacity) {
         byte[] newData = new byte[newCapacity];

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -43,7 +43,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   private byte[] byteData;
   private short[] shortData;
   private int[] intData;
-  // This is not only used to store data for int column vector, but also can store offsets and
+  // This is not only used to store data for long column vector, but also can store offsets and
   // lengths for array column vector.
   private long[] longData;
   private float[] floatData;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -42,6 +42,8 @@ public final class OnHeapColumnVector extends ColumnVector {
   // Array for each type. Only 1 is populated for any type.
   private byte[] byteData;
   private short[] shortData;
+  // This is not used used to store data for int column vector, but also can store offsets and
+  // lengths for array column vector.
   private int[] intData;
   private long[] longData;
   private float[] floatData;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -42,9 +42,9 @@ public final class OnHeapColumnVector extends ColumnVector {
   // Array for each type. Only 1 is populated for any type.
   private byte[] byteData;
   private short[] shortData;
+  private int[] intData;
   // This is not only used to store data for int column vector, but also can store offsets and
   // lengths for array column vector.
-  private int[] intData;
   private long[] longData;
   private float[] floatData;
   private double[] doubleData;
@@ -374,11 +374,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   @Override
   protected void reserveInternal(int newCapacity) {
     if (this.resultArray != null || DecimalType.isByteArrayDecimalType(type)) {
-      // need 2 ints as offset and length for each array.
-      if (intData == null || intData.length < newCapacity * 2) {
-        int[] newData = new int[newCapacity * 2];
-        if (intData != null) System.arraycopy(intData, 0, newData, 0, intData.length);
-        intData = newData;
+      // need 1 long as offset and length for each array.
+      if (longData == null || longData.length < newCapacity) {
+        long[] newData = new long[newCapacity];
+        if (longData != null) System.arraycopy(longData, 0, newData, 0, capacity);
+        longData = newData;
       }
     } else if (type instanceof BooleanType) {
       if (byteData == null || byteData.length < newCapacity) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -631,7 +631,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(column.arrayData().elementsAppended == 17)
 
       // Put the same "ll" at offset. This should not allocate more memory in the column.
-      column.arrayWriteEnd(idx, offset, 2)
+      column.putArrayOffsetAndLength(idx, offset, 2)
       reference += "ll"
       idx += 1
       assert(column.arrayData().elementsAppended == 17)
@@ -667,10 +667,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       }
 
       // Populate it with arrays [0], [1, 2], [], [3, 4, 5]
-      column.arrayWriteEnd(0, 0, 1)
-      column.arrayWriteEnd(1, 1, 2)
-      column.arrayWriteEnd(2, 2, 0)
-      column.arrayWriteEnd(3, 3, 3)
+      column.putArrayOffsetAndLength(0, 0, 1)
+      column.putArrayOffsetAndLength(1, 1, 2)
+      column.putArrayOffsetAndLength(2, 2, 0)
+      column.putArrayOffsetAndLength(3, 3, 3)
 
       val a1 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
       val a2 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(1)).asInstanceOf[Array[Int]]
@@ -703,7 +703,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       data.reserve(array.length)
       assert(data.capacity == array.length * 2)
       data.putInts(0, array.length, array, 0)
-      column.arrayWriteEnd(0, 0, array.length)
+      column.putArrayOffsetAndLength(0, 0, array.length)
       assert(ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
         === array)
     }}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -631,7 +631,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(column.arrayData().elementsAppended == 17)
 
       // Put the same "ll" at offset. This should not allocate more memory in the column.
-      column.putArray(idx, offset, 2)
+      column.arrayWriteEnd(idx, offset, 2)
       reference += "ll"
       idx += 1
       assert(column.arrayData().elementsAppended == 17)
@@ -644,7 +644,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(column.arrayData().elementsAppended == 17 + (s + s).length)
 
       reference.zipWithIndex.foreach { v =>
-        assert(v._1.length == column.getArrayLength(v._2), "MemoryMode=" + memMode)
+        assert(v._1.length == column.getInt(v._2 * 2 + 1), "MemoryMode=" + memMode)
         assert(v._1 == column.getUTF8String(v._2).toString,
           "MemoryMode" + memMode)
       }
@@ -659,7 +659,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       val column = ColumnVector.allocate(10, new ArrayType(IntegerType, true), memMode)
 
       // Fill the underlying data with all the arrays back to back.
-      val data = column.arrayData();
+      val data = column.arrayData()
       var i = 0
       while (i < 6) {
         data.putInt(i, i)
@@ -667,10 +667,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       }
 
       // Populate it with arrays [0], [1, 2], [], [3, 4, 5]
-      column.putArray(0, 0, 1)
-      column.putArray(1, 1, 2)
-      column.putArray(2, 2, 0)
-      column.putArray(3, 3, 3)
+      column.arrayWriteEnd(0, 0, 1)
+      column.arrayWriteEnd(1, 1, 2)
+      column.arrayWriteEnd(2, 2, 0)
+      column.arrayWriteEnd(3, 3, 3)
 
       val a1 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
       val a2 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(1)).asInstanceOf[Array[Int]]
@@ -703,7 +703,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       data.reserve(array.length)
       assert(data.capacity == array.length * 2)
       data.putInts(0, array.length, array, 0)
-      column.putArray(0, 0, array.length)
+      column.arrayWriteEnd(0, 0, array.length)
       assert(ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
         === array)
     }}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -644,7 +644,8 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(column.arrayData().elementsAppended == 17 + (s + s).length)
 
       reference.zipWithIndex.foreach { v =>
-        assert(v._1.length == column.getInt(v._2 * 2 + 1), "MemoryMode=" + memMode)
+        val offsetAndLength = column.getLong(v._2)
+        assert(v._1.length == offsetAndLength.toInt, "MemoryMode=" + memMode)
         assert(v._1 == column.getUTF8String(v._2).toString,
           "MemoryMode" + memMode)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -631,7 +631,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(column.arrayData().elementsAppended == 17)
 
       // Put the same "ll" at offset. This should not allocate more memory in the column.
-      column.putArrayOffsetAndLength(idx, offset, 2)
+      column.putArrayOffsetAndSize(idx, offset, 2)
       reference += "ll"
       idx += 1
       assert(column.arrayData().elementsAppended == 17)
@@ -667,10 +667,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       }
 
       // Populate it with arrays [0], [1, 2], [], [3, 4, 5]
-      column.putArrayOffsetAndLength(0, 0, 1)
-      column.putArrayOffsetAndLength(1, 1, 2)
-      column.putArrayOffsetAndLength(2, 3, 0)
-      column.putArrayOffsetAndLength(3, 3, 3)
+      column.putArrayOffsetAndSize(0, 0, 1)
+      column.putArrayOffsetAndSize(1, 1, 2)
+      column.putArrayOffsetAndSize(2, 3, 0)
+      column.putArrayOffsetAndSize(3, 3, 3)
 
       val a1 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
       val a2 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(1)).asInstanceOf[Array[Int]]
@@ -703,7 +703,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       data.reserve(array.length)
       assert(data.capacity == array.length * 2)
       data.putInts(0, array.length, array, 0)
-      column.putArrayOffsetAndLength(0, 0, array.length)
+      column.putArrayOffsetAndSize(0, 0, array.length)
       assert(ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]
         === array)
     }}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -669,7 +669,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       // Populate it with arrays [0], [1, 2], [], [3, 4, 5]
       column.putArrayOffsetAndLength(0, 0, 1)
       column.putArrayOffsetAndLength(1, 1, 2)
-      column.putArrayOffsetAndLength(2, 2, 0)
+      column.putArrayOffsetAndLength(2, 3, 0)
       column.putArrayOffsetAndLength(3, 3, 3)
 
       val a1 = ColumnVectorUtils.toPrimitiveJavaArray(column.getArray(0)).asInstanceOf[Array[Int]]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when a `ColumnVector` stores array type elements, we will use 2 arrays for lengths and offsets and implement them individually in on-heap and off-heap column vector.

In this PR, we use one array to represent both offsets and lengths, so that we can treat it as `ColumnVector` and all the logic can go to the base class `ColumnVector`

## How was this patch tested?

existing tests.