### PR TITLE
[SPARK-21045][PYSPARK] Fixed executor blocked because of traceback.format_exc throw UnicodeDecodeError

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -178,7 +178,7 @@ def main(infile, outfile):
     except Exception:
         try:
             write_int(SpecialLengths.PYTHON_EXCEPTION_THROWN, outfile)
-            write_with_length(traceback.format_exc().encode("utf-8"), outfile)
+            write_with_length(traceback.format_exc(), outfile)
         except IOError:
             # JVM close the socket
             pass


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove encode utf8 to traceback.format_exc()

## How was this patch tested?
We can run in pyspark:
    spark = SparkSession.builder.master('local').getOrCreate()
    rdd = spark.sparkContext.parallelize(['中']).map(lambda x: x.encode("utf8"))
    rdd.count()

Before fixed this bug, this program will be blocked. 
After fixed this bug, this program will throw exception expected.

