### PR TITLE
[SPARK-21054] [SQL] Reset Command support reset specific property.

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -160,7 +160,7 @@ statement
     | op=(ADD | LIST) identifier .*?                                   #manageResource
     | SET ROLE .*?                                                     #failNativeCommand
     | SET .*?                                                          #setConfiguration
-    | RESET                                                            #resetConfiguration
+    | RESET .*?                                                        #resetConfiguration
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -82,17 +82,13 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    * Example SQL :
    * {{{
    *   RESET;
-   *   RESET key;
+   *   RESET `special#$!`;
    * }}}
    */
   override def visitResetConfiguration(
       ctx: ResetConfigurationContext): LogicalPlan = withOrigin(ctx) {
     val raw = remainder(ctx.RESET.getSymbol)
-    if (raw.nonEmpty) {
-      ResetCommand(Some(raw.trim))
-    } else {
-      ResetCommand(None)
-    }
+    if (raw.nonEmpty) ResetCommand(Some(raw.trim)) else ResetCommand(None)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -86,7 +86,12 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    */
   override def visitResetConfiguration(
       ctx: ResetConfigurationContext): LogicalPlan = withOrigin(ctx) {
-    ResetCommand
+    val raw = remainder(ctx.RESET.getSymbol)
+    if (raw.nonEmpty) {
+      ResetCommand(Some(raw.trim))
+    } else {
+      ResetCommand(None)
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -82,6 +82,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    * Example SQL :
    * {{{
    *   RESET;
+   *   RESET key;
    * }}}
    */
   override def visitResetConfiguration(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -82,7 +82,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    * Example SQL :
    * {{{
    *   RESET;
-   *   RESET `special#$!`;
+   *   RESET key;
    * }}}
    */
   override def visitResetConfiguration(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -151,6 +151,7 @@ object SetCommand {
  * {{{
  *   reset;
  *   reset key;
+ *   reset key1 key2 ...;
  * }}}
  */
 case class ResetCommand(key: Option[String]) extends RunnableCommand with Logging {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -149,8 +149,8 @@ object SetCommand {
 /**
  * This command is for resetting SQLConf to the default values. Command that runs
  * {{{
- *   reset key;
  *   reset;
+ *   reset key;
  * }}}
  */
 case class ResetCommand(key: Option[String]) extends RunnableCommand with Logging {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -155,24 +155,14 @@ object SetCommand {
  */
 case class ResetCommand(key: Option[String]) extends RunnableCommand with Logging {
 
-  private val runFunc: (SparkSession => Unit) = key match {
-
-    case None =>
-      val runFunc = (sparkSession: SparkSession) => {
-        sparkSession.sessionState.conf.clear()
-      }
-      runFunc
-
-    // (In Hive, "RESET key" clear a specific property.)
-    case Some(key) =>
-      val runFunc = (sparkSession: SparkSession) => {
-        sparkSession.conf.unset(key)
-      }
-      runFunc
-  }
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    runFunc(sparkSession)
+    key match {
+      case None =>
+        sparkSession.sessionState.conf.clear()
+      // "RESET key" clear a specific property.
+      case Some(key) =>
+        sparkSession.conf.unset(key)
+    }
     Seq.empty[Row]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -161,7 +161,8 @@ case class ResetCommand(key: Option[String]) extends RunnableCommand with Loggin
         sparkSession.sessionState.conf.clear()
       // "RESET key" clear a specific property.
       case Some(key) =>
-        sparkSession.conf.unset(key)
+        key.split("\\s+")
+          .foreach(confName => if (!confName.isEmpty) sparkSession.conf.unset(confName))
     }
     Seq.empty[Row]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -163,10 +163,10 @@ case class ResetCommand(key: Option[String]) extends RunnableCommand with Loggin
       }
       runFunc
 
-    // (In Hive, "UNSET key" clear a sepecific properties.)
+    // (In Hive, "RESET key" clear a specific property.)
     case Some(key) =>
       val runFunc = (sparkSession: SparkSession) => {
-        sparkSession.sessionState.conf.unsetConf(key)
+        sparkSession.conf.unset(key)
       }
       runFunc
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -294,11 +294,16 @@ class SparkSqlParserSuite extends PlanTest {
   test("pipeline concatenation") {
     val concat = Concat(
       Concat(UnresolvedAttribute("a") :: UnresolvedAttribute("b") :: Nil) ::
-      UnresolvedAttribute("c") ::
-      Nil
+        UnresolvedAttribute("c") ::
+        Nil
     )
     assertEqual(
       "SELECT a || b || c FROM t",
       Project(UnresolvedAlias(concat) :: Nil, UnresolvedRelation(TableIdentifier("t"))))
+  }
+
+  test("reset") {
+    assertEqual("reset", ResetCommand(None))
+    assertEqual("reset spark.test.property", ResetCommand(Some("spark.test.property")))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -294,8 +294,8 @@ class SparkSqlParserSuite extends PlanTest {
   test("pipeline concatenation") {
     val concat = Concat(
       Concat(UnresolvedAttribute("a") :: UnresolvedAttribute("b") :: Nil) ::
-        UnresolvedAttribute("c") ::
-        Nil
+      UnresolvedAttribute("c") ::
+      Nil
     )
     assertEqual(
       "SELECT a || b || c FROM t",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -305,5 +305,6 @@ class SparkSqlParserSuite extends PlanTest {
   test("reset") {
     assertEqual("reset", ResetCommand(None))
     assertEqual("reset spark.test.property", ResetCommand(Some("spark.test.property")))
+    assertEqual("reset #$a!", ResetCommand(Some("#$a!")))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -305,6 +305,6 @@ class SparkSqlParserSuite extends PlanTest {
   test("reset") {
     assertEqual("reset", ResetCommand(None))
     assertEqual("reset spark.test.property", ResetCommand(Some("spark.test.property")))
-    assertEqual("reset #$a!", ResetCommand(Some("#$a!")))
+    assertEqual("reset #$a!  !a$# \t ", ResetCommand(Some("#$a!  !a$#")))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -115,7 +115,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset ${SQLConf.GROUP_BY_ORDINAL.key}").foreach { resetCmd =>
-    test("reset - public conf") {
+    test(s"reset - public conf $resetCmd") {
       spark.sessionState.conf.clear()
       val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
       try {
@@ -133,7 +133,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}").foreach { resetCmd =>
-    test("reset - internal conf") {
+    test(s"reset - internal conf $resetCmd") {
       spark.sessionState.conf.clear()
       val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
       try {
@@ -151,7 +151,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset $testKey").foreach { resetCmd =>
-    test("reset - user-defined conf") {
+    test(s"reset - user-defined conf $resetCmd") {
       spark.sessionState.conf.clear()
       try {
         assert(spark.conf.getOption(testKey).isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -114,97 +114,55 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("reset - public conf") {
-    spark.sessionState.conf.clear()
-    val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
-    try {
-      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
-      sql(s"set ${SQLConf.GROUP_BY_ORDINAL.key}=false")
-      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === false)
-      assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 1)
-      sql(s"reset")
-      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
-      assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 0)
-    } finally {
-      sql(s"set ${SQLConf.GROUP_BY_ORDINAL}=$original")
+  Seq("reset", s"reset ${SQLConf.GROUP_BY_ORDINAL.key}").foreach { resetCmd =>
+    test("reset - public conf") {
+      spark.sessionState.conf.clear()
+      val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
+      try {
+        assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
+        sql(s"set ${SQLConf.GROUP_BY_ORDINAL.key}=false")
+        assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === false)
+        assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 1)
+        sql(resetCmd)
+        assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
+        assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 0)
+      } finally {
+        sql(s"set ${SQLConf.GROUP_BY_ORDINAL}=$original")
+      }
     }
   }
 
-  test("reset specific property - public conf") {
-    spark.sessionState.conf.clear()
-    val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
-    try {
-      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
-      sql(s"set ${SQLConf.GROUP_BY_ORDINAL.key}=false")
-      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === false)
-      assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 1)
-      sql(s"reset ${SQLConf.GROUP_BY_ORDINAL.key}")
-      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
-      assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 0)
-    } finally {
-      sql(s"set ${SQLConf.GROUP_BY_ORDINAL}=$original")
+  Seq("reset", s"reset ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}").foreach { resetCmd =>
+    test("reset - internal conf") {
+      spark.sessionState.conf.clear()
+      val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
+      try {
+        assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
+        sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}=10")
+        assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 10)
+        assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 1)
+        sql(resetCmd)
+        assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
+        assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 0)
+      } finally {
+        sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS}=$original")
+      }
     }
   }
 
-  test("reset - internal conf") {
-    spark.sessionState.conf.clear()
-    val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
-    try {
-      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
-      sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}=10")
-      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 10)
-      assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 1)
-      sql(s"reset")
-      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
-      assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 0)
-    } finally {
-      sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS}=$original")
-    }
-  }
-
-  test("reset specific property - internal conf") {
-    spark.sessionState.conf.clear()
-    val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
-    try {
-      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
-      sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}=10")
-      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 10)
-      assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 1)
-      sql(s"reset ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}")
-      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
-      assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 0)
-    } finally {
-      sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS}=$original")
-    }
-  }
-
-  test("reset - user-defined conf") {
-    spark.sessionState.conf.clear()
-    val userDefinedConf = "x.y.z.reset"
-    try {
-      assert(spark.conf.getOption(userDefinedConf).isEmpty)
-      sql(s"set $userDefinedConf=false")
-      assert(spark.conf.get(userDefinedConf) === "false")
-      assert(sql(s"set").where(s"key = '$userDefinedConf'").count() == 1)
-      sql(s"reset")
-      assert(spark.conf.getOption(userDefinedConf).isEmpty)
-    } finally {
-      spark.conf.unset(userDefinedConf)
-    }
-  }
-
-  test("reset specific property - user-defined conf") {
-    spark.sessionState.conf.clear()
-    val userDefinedConf = "x.y.z.reset"
-    try {
-      assert(spark.conf.getOption(userDefinedConf).isEmpty)
-      sql(s"set $userDefinedConf=false")
-      assert(spark.conf.get(userDefinedConf) === "false")
-      assert(sql(s"set").where(s"key = '$userDefinedConf'").count() == 1)
-      sql(s"reset $userDefinedConf")
-      assert(spark.conf.getOption(userDefinedConf).isEmpty)
-    } finally {
-      spark.conf.unset(userDefinedConf)
+  Seq("reset", s"reset $testKey").foreach { resetCmd =>
+    test("reset - user-defined conf") {
+      spark.sessionState.conf.clear()
+      try {
+        assert(spark.conf.getOption(testKey).isEmpty)
+        sql(s"set $testKey=false")
+        assert(spark.conf.get(testKey) === "false")
+        assert(sql(s"set").where(s"key = '$testKey'").count() == 1)
+        sql(resetCmd)
+        assert(spark.conf.getOption(testKey).isEmpty)
+      } finally {
+        spark.conf.unset(testKey)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -130,6 +130,22 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("reset specific property - public conf") {
+    spark.sessionState.conf.clear()
+    val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
+    try {
+      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
+      sql(s"set ${SQLConf.GROUP_BY_ORDINAL.key}=false")
+      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === false)
+      assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 1)
+      sql(s"reset ${SQLConf.GROUP_BY_ORDINAL.key}")
+      assert(spark.conf.get(SQLConf.GROUP_BY_ORDINAL) === true)
+      assert(sql(s"set").where(s"key = '${SQLConf.GROUP_BY_ORDINAL.key}'").count() == 0)
+    } finally {
+      sql(s"set ${SQLConf.GROUP_BY_ORDINAL}=$original")
+    }
+  }
+
   test("reset - internal conf") {
     spark.sessionState.conf.clear()
     val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
@@ -146,6 +162,22 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("reset specific property - internal conf") {
+    spark.sessionState.conf.clear()
+    val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
+    try {
+      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
+      sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}=10")
+      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 10)
+      assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 1)
+      sql(s"reset ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}")
+      assert(spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS) === 100)
+      assert(sql(s"set").where(s"key = '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}'").count() == 0)
+    } finally {
+      sql(s"set ${SQLConf.OPTIMIZER_MAX_ITERATIONS}=$original")
+    }
+  }
+
   test("reset - user-defined conf") {
     spark.sessionState.conf.clear()
     val userDefinedConf = "x.y.z.reset"
@@ -155,6 +187,21 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
       assert(spark.conf.get(userDefinedConf) === "false")
       assert(sql(s"set").where(s"key = '$userDefinedConf'").count() == 1)
       sql(s"reset")
+      assert(spark.conf.getOption(userDefinedConf).isEmpty)
+    } finally {
+      spark.conf.unset(userDefinedConf)
+    }
+  }
+
+  test("reset specific property - user-defined conf") {
+    spark.sessionState.conf.clear()
+    val userDefinedConf = "x.y.z.reset"
+    try {
+      assert(spark.conf.getOption(userDefinedConf).isEmpty)
+      sql(s"set $userDefinedConf=false")
+      assert(spark.conf.get(userDefinedConf) === "false")
+      assert(sql(s"set").where(s"key = '$userDefinedConf'").count() == 1)
+      sql(s"reset $userDefinedConf")
       assert(spark.conf.getOption(userDefinedConf).isEmpty)
     } finally {
       spark.conf.unset(userDefinedConf)

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -115,7 +115,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset ${SQLConf.GROUP_BY_ORDINAL.key}").foreach { resetCmd =>
-    test(s"reset - public conf $resetCmd") {
+    test(s"$resetCmd - public conf") {
       spark.sessionState.conf.clear()
       val original = spark.conf.get(SQLConf.GROUP_BY_ORDINAL)
       try {
@@ -133,7 +133,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset ${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}").foreach { resetCmd =>
-    test(s"reset - internal conf $resetCmd") {
+    test(s"$resetCmd - internal conf") {
       spark.sessionState.conf.clear()
       val original = spark.conf.get(SQLConf.OPTIMIZER_MAX_ITERATIONS)
       try {
@@ -151,7 +151,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset $testKey").foreach { resetCmd =>
-    test(s"reset - user-defined conf $resetCmd") {
+    test(s"$resetCmd - user-defined conf") {
       spark.sessionState.conf.clear()
       try {
         assert(spark.conf.getOption(testKey).isEmpty)
@@ -167,7 +167,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   Seq("reset", s"reset ${testKey}1 \t ${testKey}2 \t ").foreach { resetCmd =>
-    test(s"reset - multiple conf $resetCmd") {
+    test(s"$resetCmd - multiple conf") {
       spark.sessionState.conf.clear()
       val key1 = testKey + "1"
       val key2 = testKey + "2"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reset Command support reset specific property to default value like `reset spark.test.property`.

Hive 2.1.1 ([HIVE-14418](https://issues.apache.org/jira/browse/HIVE-14418)) support Reset Command for specific property like `reset spark.test.property`, which will throw error in SparkSQL.

Compatibility will lower the cost for transferring SQL in production from Hive to SparkSQL.


## How was this patch tested?

Add unit tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
