### PR TITLE
[SPARK-21056][SQL] Use at most one spark job to list files in InMemoryFileIndex

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -188,7 +188,7 @@ object InMemoryFileIndex extends Logging {
       .parallelize(serializedPaths, numParallelism)
       .mapPartitions { pathStrings =>
         val hadoopConf = serializableConfiguration.value
-        val paths = pathStrings.map(new Path(_)).toSeq
+        val paths = pathStrings.map(new Path(_)).toIndexedSeq
         listLeafFiles(paths, hadoopConf, filter, None).iterator
       }.map { case (path, statuses) =>
       val serializableStatuses = statuses.map { status =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes `InMemoryFileIndex.listLeafFiles` behaviour to launch at most one spark job to list leaf files.

##JIRA 
https://issues.apache.org/jira/browse/SPARK-21056

Given partitioned file relation (e.g. parquet):
```root/a=../b=../c=..```
InMemoryFileIndex.listLeafFiles runs numberOfPartitions(a) times numberOfPartitions(b) spark jobs sequentially to list leaf files, if both numberOfPartitions(a) and numberOfPartitions(b) are below `spark.sql.sources.parallelPartitionDiscovery.threshold` and numberOfPartitions(c) is above `spark.sql.sources.parallelPartitionDiscovery.threshold`

Since the jobs are run sequentially, the overhead of the jobs dominates and the file listing operation can become significantly slower than listing the files from the driver.
I propose that InMemoryFileIndex.listLeafFiles should launch at most one spark job for listing leaf files.


## How was this patch tested?

Adapted existing tests to match expected behaviour.

