### PR TITLE
[SPARK-21062] There are some minor mistakes in log

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -293,7 +293,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   override def getConfig(): Map[String, String] = {
     val safeMode = if (isFsInSafeMode()) {
-      Map("HDFS State" -> "In safe mode, application logs not available.")
+      Map("HDFS State" -> "In safe mode, application logs are not available.")
     } else {
       Map()
     }

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -197,7 +197,7 @@ object KafkaUtils {
     }
     val badRanges = KafkaCluster.checkErrors(result)
     if (!badRanges.isEmpty) {
-      throw new SparkException("Offsets not available on leader: " + badRanges.mkString(","))
+      throw new SparkException("Offsets are not available on leader: " + badRanges.mkString(","))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/StarJoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/StarJoinReorderSuite.scala
@@ -298,7 +298,7 @@ class StarJoinReorderSuite extends PlanTest with StatsEstimationTestBase {
     assertEqualPlans(query, expected)
   }
 
-  test("Test 5: Table stats not available for some of the joined tables") {
+  test("Test 5: Table stats are not available for some of the joined tables") {
     // Star join:
     //   (=)  (=)
     // d1 - f1 - d2


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21062](https://issues.apache.org/jira/browse/SPARK-21062)
There are some minor mistakes in log.For example,"Offsets not available on leader" should be "Offsets are not available on leader" in kafkautils.