### PR TITLE
[SPARK-21064][Core][Test] Fix the default value bug in NettyBlockTran…

### DIFF
--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
@@ -80,7 +80,8 @@ class NettyBlockTransferServiceSuite
   private def verifyServicePort(expectedPort: Int, actualPort: Int): Unit = {
     actualPort should be >= expectedPort
     // avoid testing equality in case of simultaneous tests
-    actualPort should be <= (expectedPort + 10)
+    // the default value for `spark.port.maxRetries` is 100 in test
+    actualPort should be <= (expectedPort + 100)
   }
 
   private def createService(port: Int): NettyBlockTransferService = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the default value bug in NettyBlockTransferServiceSuite.
The defalut value for `spark.port.maxRetries` is 100, but we use the 10
in the suite file, we change 10 to 100.

## How was this patch tested?
No Test