### PR TITLE
[SPARK-21072][SQL] TreeNode.mapChildren should only apply to the children node.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -351,10 +351,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
             } else {
               arg2
             }
-            
+
             if (!(newChild1 fastEquals arg1) || !(newChild2 fastEquals arg2)) {
               changed = true
-              (newChild1, newChild2)
+              (newChild1.asInstanceOf[BaseType], newChild2.asInstanceOf[BaseType])
             } else {
               tuple
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -343,18 +343,18 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
             val newChild1 = if (containsChild(arg1)) {
               f(arg1.asInstanceOf[BaseType])
             } else {
-              arg1
+              arg1.asInstanceOf[BaseType]
             }
 
             val newChild2 = if (containsChild(arg2)) {
               f(arg2.asInstanceOf[BaseType])
             } else {
-              arg2
+              arg2.asInstanceOf[BaseType]
             }
 
             if (!(newChild1 fastEquals arg1) || !(newChild2 fastEquals arg2)) {
               changed = true
-              (newChild1.asInstanceOf[BaseType], newChild2.asInstanceOf[BaseType])
+              (newChild1, newChild2)
             } else {
               tuple
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -340,8 +340,18 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
               arg
             }
           case tuple@(arg1: TreeNode[_], arg2: TreeNode[_]) =>
-            val newChild1 = f(arg1.asInstanceOf[BaseType])
-            val newChild2 = f(arg2.asInstanceOf[BaseType])
+            val newChild1 = if (containsChild(arg1)) {
+              f(arg1.asInstanceOf[BaseType])
+            } else {
+              arg1
+            }
+
+            val newChild2 = if (containsChild(arg2)) {
+              f(arg2.asInstanceOf[BaseType])
+            } else {
+              arg2
+            }
+            
             if (!(newChild1 fastEquals arg1) || !(newChild2 fastEquals arg2)) {
               changed = true
               (newChild1, newChild2)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -161,7 +161,7 @@ class TreeNodeSuite extends SparkFunSuite {
     val toZero: PartialFunction[Expression, Expression] = { case Literal(_, _) => Literal(0) }
     val expect = SeqTupleExpression(Seq((Literal(0), Literal(0))), nonChildren)
 
-    val actual = before mapChildren  toZero
+    val actual = before mapChildren toZero
     assert(actual === expect)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -54,7 +54,7 @@ case class ComplexPlan(exprs: Seq[Seq[Expression]])
   override def output: Seq[Attribute] = Nil
 }
 
-case class ExpressionInMap(map: Map[String, Expression]) extends Expression with Unevaluable {
+case class ExpressionInMap(map: Map[String, Expression]) extends Unevaluable {
   override def children: Seq[Expression] = map.values.toSeq
   override def nullable: Boolean = true
   override def dataType: NullType = NullType
@@ -62,7 +62,7 @@ case class ExpressionInMap(map: Map[String, Expression]) extends Expression with
 }
 
 case class SeqTupleExpression(sons: Seq[(Expression, Expression)],
-    nonSons: Seq[(Expression, Expression)]) extends Expression with Unevaluable {
+    nonSons: Seq[(Expression, Expression)]) extends Unevaluable {
   override def children: Seq[Expression] = sons.flatMap(t => Iterator(t._1, t._2))
   override def nullable: Boolean = true
   override def dataType: NullType = NullType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -62,7 +62,7 @@ case class ExpressionInMap(map: Map[String, Expression]) extends Expression with
 }
 
 case class SeqTupleExpression(sons: Seq[(Expression, Expression)],
-    notsons: Seq[(Expression, Expression)]) extends Expression with Unevaluable {
+    nonSons: Seq[(Expression, Expression)]) extends Expression with Unevaluable {
   override def children: Seq[Expression] = sons.flatMap(t => Iterator(t._1, t._2))
   override def nullable: Boolean = true
   override def dataType: NullType = NullType
@@ -156,18 +156,12 @@ class TreeNodeSuite extends SparkFunSuite {
 
   test("mapChildren should only works on children") {
     val children = Seq((Literal(1), Literal(2)))
-    val notChildren = Seq((Literal(3), Literal(4)))
-    val before = SeqTupleExpression(children, notChildren)
+    val nonChildren = Seq((Literal(3), Literal(4)))
+    val before = SeqTupleExpression(children, nonChildren)
     val toZero: PartialFunction[Expression, Expression] = { case Literal(_, _) => Literal(0) }
-    val expect = SeqTupleExpression(Seq((Literal(0), Literal(0))), notChildren)
+    val expect = SeqTupleExpression(Seq((Literal(0), Literal(0))), nonChildren)
 
-    var actual = before transformDown toZero
-    assert(actual === expect)
-
-    actual = before transformUp toZero
-    assert(actual === expect)
-
-    actual = before transform toZero
+    val actual = before mapChildren  toZero
     assert(actual === expect)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just as the function name and comments of `TreeNode.mapChildren` mentioned, the function should be apply to all currently node children. So, the follow code should judge whether it is the children node.

https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala#L342

## How was this patch tested?

Existing tests.
