### PR TITLE
[SPARK-21073] Support map_keys and map_values functions in DataSet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1007,6 +1007,24 @@ object functions {
   def map(cols: Column*): Column = withExpr { CreateMap(cols.map(_.expr)) }
 
   /**
+   * Returns the keys from map as a array.
+   *
+   * @group collection_funcs
+   */
+  def map_keys(column: Column): Column = withExpr {
+    MapKeys(column.expr)
+  }
+
+  /**
+   * Returns the values from map as a array.
+   *
+   * @group collection_funcs
+   */
+  def map_values(column: Column): Column = withExpr {
+    MapValues(column.expr)
+  }
+
+  /**
    * Marks a DataFrame as small enough for use in broadcast joins.
    *
    * The following example marks the right DataFrame for broadcast hash join using `joinKey`.

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollectionFunctionsSuit.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollectionFunctionsSuit.scala
@@ -1,0 +1,26 @@
+package org.apache.spark.sql
+
+import org.apache.spark.sql.test.SharedSQLContext
+
+import org.apache.spark.sql.functions._
+
+class CollectionFunctionsSuit extends QueryTest with SharedSQLContext {
+
+  import testImplicits._
+
+  test("functions map_keys") {
+    val df = Seq(("1", 1), ("2", 2), ("3", 3)).toDF("col0", "col1")
+    val mapDF = df.select(map($"col0", $"col1").as("column0"))
+    checkAnswer(
+      mapDF.select(map_keys($"column0")),
+      Seq(Row(Array("1")), Row(Array("2")), Row(Array("3"))))
+  }
+
+  test("function map_values") {
+    val df = Seq(("1", 1), ("2", 2), ("3", 3)).toDF("col0", "col1")
+    val mapDF = df.select(map($"col0", $"col1").as("column0"))
+    checkAnswer(
+      mapDF.select(map_values($"column0")),
+      Seq(Row(Array(1)), Row(Array(2)), Row(Array(3))))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `map_keys` function to get keys from a MapType field and `map_values` function to get values from a MapType field.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
