### PR TITLE
[MINOR][TEST]The unit test cases of "UnifiedMemoryManagerSuite" run failed

### DIFF
--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -42,6 +42,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       maxOffHeapExecutionMemory: Long): UnifiedMemoryManager = {
     val conf = new SparkConf()
       .set("spark.memory.fraction", "1")
+      .set("spark.testing", "true")
       .set("spark.testing.memory", maxOnHeapExecutionMemory.toString)
       .set("spark.memory.offHeap.size", maxOffHeapExecutionMemory.toString)
       .set("spark.memory.storageFraction", storageFraction.toString)
@@ -259,6 +260,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set("spark.memory.fraction", "1")
       .set("spark.memory.storageFraction", "0")
       .set("spark.testing.memory", "1000")
+      .set("spark.testing", "true")
     val mm = UnifiedMemoryManager(conf, numCores = 2)
     val ms = makeMemoryStore(mm)
     val memoryMode = MemoryMode.ON_HEAP
@@ -285,6 +287,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set("spark.memory.fraction", "1")
       .set("spark.memory.storageFraction", "0")
       .set("spark.testing.memory", "1000")
+      .set("spark.testing", "true")
     val mm = UnifiedMemoryManager(conf, numCores = 2)
     makeBadMemoryStore(mm)
     val memoryMode = MemoryMode.ON_HEAP


### PR DESCRIPTION
## What changes were proposed in this pull request?
OS:  Windows 7
When running `UnifiedMemoryManagerSuite`,  the following exception occurred:
`System memory 1000 must be at least 471859200. Please increase heap size using the --driver-memory option or spark.driver.memory in Spark configuration.
java.lang.IllegalArgumentException: System memory 1000 must be at least 471859200. Please increase heap size using the --driver-memory option or spark.driver.memory in Spark configuration.`

## How was this patch tested?
unit test
