### PR TITLE
[SPARK-21043][SQL] Add unionByName in Dataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1736,11 +1736,11 @@ class Dataset[T] private[sql](
   /**
    * Returns a new Dataset containing union of rows in this Dataset and another Dataset.
    *
-   * To do a SQL-style set union (that does deduplication of elements), use this function
-   * followed by a [[distinct]].
+   * This is different from both `UNION ALL` and `UNION DISTINCT` in SQL. To do a SQL-style set
+   * union (that does deduplication of elements), use this function followed by a [[distinct]].
    *
    * The difference between this function and [[union]] is that this function
-   * resolves columns by name:
+   * resolves columns by name (not by position):
    *
    * {{{
    *   val df1 = Seq((1, 2, 3)).toDF("col0", "col1", "col2")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1773,11 +1773,11 @@ class Dataset[T] private[sql](
     val rightOutputAttrs = rightPlan.analyzed.output
     // SchemaUtils.checkColumnNameDuplication(
     //   leftOutputAttrs.map(_.name),
-    //   "in unionByName",
+    //   "in the left attributes",
     //   sparkSession.sessionState.conf.caseSensitiveAnalysis)
     // SchemaUtils.checkColumnNameDuplication(
     //   rightOutputAttrs.map(_.name),
-    //   "in unionByName",
+    //   "in the right attributes",
     //   sparkSession.sessionState.conf.caseSensitiveAnalysis)
 
     // Builds a project list for `other` based on `logicalPlan` output names

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -21,7 +21,6 @@ import java.io.CharArrayWriter
 import java.sql.{Date, Timestamp}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
@@ -53,6 +52,7 @@ import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.streaming.DataStreamWriter
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.SchemaUtils
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.Utils
@@ -1765,14 +1765,15 @@ class Dataset[T] private[sql](
     val resolver = sparkSession.sessionState.analyzer.resolver
     val leftOutputAttrs = logicalPlan.output
     val rightOutputAttrs = other.logicalPlan.output
-    // SchemaUtils.checkColumnNameDuplication(
-    //   leftOutputAttrs.map(_.name),
-    //   "in the left attributes",
-    //   sparkSession.sessionState.conf.caseSensitiveAnalysis)
-    // SchemaUtils.checkColumnNameDuplication(
-    //   rightOutputAttrs.map(_.name),
-    //   "in the right attributes",
-    //   sparkSession.sessionState.conf.caseSensitiveAnalysis)
+
+    SchemaUtils.checkColumnNameDuplication(
+      leftOutputAttrs.map(_.name),
+      "in the left attributes",
+      sparkSession.sessionState.conf.caseSensitiveAnalysis)
+    SchemaUtils.checkColumnNameDuplication(
+      rightOutputAttrs.map(_.name),
+      "in the right attributes",
+      sparkSession.sessionState.conf.caseSensitiveAnalysis)
 
     // Builds a project list for `other` based on `logicalPlan` output names
     val rightProjectList = leftOutputAttrs.map { lattr =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1764,8 +1764,6 @@ class Dataset[T] private[sql](
     // Resolves children first to reorder output attributes in `other` by name
     val leftPlan = sparkSession.sessionState.executePlan(logicalPlan)
     val rightPlan = sparkSession.sessionState.executePlan(other.logicalPlan)
-    leftPlan.assertAnalyzed()
-    rightPlan.assertAnalyzed()
 
     // Check column name duplication
     val resolver = sparkSession.sessionState.analyzer.resolver

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -113,12 +113,12 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
 
   test("union by name") {
     // Simple case
-    val df1 = Seq((1, 2, 3)).toDF("a", "b", "c")
-    val df2 = Seq(("a", "7", "bc")).toDF("c", "a", "b")
-    val df3 = Seq((3.8, 1.2, 5.6)).toDF("b", "c", "a")
+    val df1 = Seq((1, "a", 3.0)).toDF("a", "b", "c")
+    val df2 = Seq((1.2, 2, "bc")).toDF("c", "a", "b")
+    val df3 = Seq(("def", 1.2, 3)).toDF("b", "c", "a")
     val unionDf = df1.unionByName(df2.unionByName(df3))
     checkAnswer(unionDf,
-      Row("1", "2", "3") :: Row("7", "bc", "a") :: Row("5.6", "3.8", "1.2") :: Nil
+      Row(1, "a", 3.0) :: Row(2, "bc", 1.2) :: Row(3, "def", 1.2) :: Nil
     )
 
     // Check if adjacent unions are combined into a single one

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -188,7 +188,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
           df1.unionByName(df2)
         }.getMessage
         assert(errMsg.contains("Found duplicate column(s) in the left attributes:"))
-            df1 = Seq((1, 1)).toDF("c0", "c1")
+        df1 = Seq((1, 1)).toDF("c0", "c1")
         df2 = Seq((1, 1)).toDF(c0, c1)
         errMsg = intercept[AnalysisException] {
           df1.unionByName(df2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -139,7 +139,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val errMsg2 = intercept[AnalysisException] {
       df6.unionByName(df7)
     }.getMessage
-    assert(errMsg2.contains("(a, c, d) must have the same name set with (a, b, c)"))
+    assert(errMsg2.contains("""Cannot resolve column name "b" among (a, c, d)"""))
 
     def checkCaseSensitiveTest(): Unit = {
       val df1 = Seq((1, 2, 3)).toDF("ab", "cd", "ef")
@@ -150,7 +150,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       val errMsg2 = intercept[AnalysisException] {
         checkCaseSensitiveTest()
       }.getMessage
-      assert(errMsg2.contains("(cd, ef, AB) must have the same name set with (ab, cd, ef)"))
+      assert(errMsg2.contains("""Cannot resolve column name "ab" among (cd, ef, AB)"""))
     }
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       checkCaseSensitiveTest()


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added `unionByName` in `DataSet`.
Here is how to use:
```
val df1 = Seq((1, 2, 3)).toDF("col0", "col1", "col2")
val df2 = Seq((4, 5, 6)).toDF("col1", "col2", "col0")
df1.unionByName(df2).show

// output:
// +----+----+----+
// |col0|col1|col2|
// +----+----+----+
// |   1|   2|   3|
// |   6|   4|   5|
// +----+----+----+
```

## How was this patch tested?
Added tests in `DataFrameSuite`.
