### PR TITLE
[SPARK-17237][SQL][FOLLOWUP][WIP] Add a qualifier in pretty expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -137,6 +137,9 @@ package object util {
   // Replaces attributes, string literals, complex type extractors with their pretty form so that
   // generated column names don't contain back-ticks or double-quotes.
   def usePrettyExpression(e: Expression): Expression = e transform {
+    case ar: AttributeReference =>
+      val nameMayHaveQualifier = s"${ar.qualifier.map(_ + ".").getOrElse("")}${ar.name}"
+      PrettyAttribute(nameMayHaveQualifier, ar.dataType)
     case a: Attribute => new PrettyAttribute(a)
     case Literal(s: UTF8String, StringType) => PrettyAttribute(s.toString, StringType)
     case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)

--- a/sql/core/src/test/resources/sql-tests/results/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/array.sql.out
@@ -25,7 +25,7 @@ two	[21,22,23]	[[211,212,213],[221,222,223]]
 -- !query 2
 select a, b[0], b[0] + b[1] from data
 -- !query 2 schema
-struct<a:string,b[0]:int,(b[0] + b[1]):int>
+struct<a:string,data.b[0]:int,(data.b[0] + data.b[1]):int>
 -- !query 2 output
 one	11	23
 two	21	43
@@ -34,7 +34,7 @@ two	21	43
 -- !query 3
 select a, c[0][0] + c[0][0 + 1] from data
 -- !query 3 schema
-struct<a:string,(c[0][0] + c[0][(0 + 1)]):int>
+struct<a:string,(data.c[0][0] + data.c[0][(0 + 1)]):int>
 -- !query 3 output
 one	223
 two	423
@@ -92,7 +92,7 @@ select
   array_contains(timestamp_array, timestamp '2016-11-15 20:54:00.000'), array_contains(timestamp_array, timestamp '2016-01-01 20:54:00.000')
 from primitive_arrays
 -- !query 6 schema
-struct<array_contains(boolean_array, true):boolean,array_contains(boolean_array, false):boolean,array_contains(tinyint_array, 2):boolean,array_contains(tinyint_array, 0):boolean,array_contains(smallint_array, 2):boolean,array_contains(smallint_array, 0):boolean,array_contains(int_array, 2):boolean,array_contains(int_array, 0):boolean,array_contains(bigint_array, 2):boolean,array_contains(bigint_array, 0):boolean,array_contains(decimal_array, 9223372036854775809):boolean,array_contains(decimal_array, CAST(1 AS DECIMAL(19,0))):boolean,array_contains(double_array, 2.0):boolean,array_contains(double_array, 0.0):boolean,array_contains(float_array, CAST(2.0 AS FLOAT)):boolean,array_contains(float_array, CAST(0.0 AS FLOAT)):boolean,array_contains(date_array, DATE '2016-03-14'):boolean,array_contains(date_array, DATE '2016-01-01'):boolean,array_contains(timestamp_array, TIMESTAMP('2016-11-15 20:54:00.0')):boolean,array_contains(timestamp_array, TIMESTAMP('2016-01-01 20:54:00.0')):boolean>
+struct<array_contains(primitive_arrays.boolean_array, true):boolean,array_contains(primitive_arrays.boolean_array, false):boolean,array_contains(primitive_arrays.tinyint_array, 2):boolean,array_contains(primitive_arrays.tinyint_array, 0):boolean,array_contains(primitive_arrays.smallint_array, 2):boolean,array_contains(primitive_arrays.smallint_array, 0):boolean,array_contains(primitive_arrays.int_array, 2):boolean,array_contains(primitive_arrays.int_array, 0):boolean,array_contains(primitive_arrays.bigint_array, 2):boolean,array_contains(primitive_arrays.bigint_array, 0):boolean,array_contains(primitive_arrays.decimal_array, 9223372036854775809):boolean,array_contains(primitive_arrays.decimal_array, CAST(1 AS DECIMAL(19,0))):boolean,array_contains(primitive_arrays.double_array, 2.0):boolean,array_contains(primitive_arrays.double_array, 0.0):boolean,array_contains(primitive_arrays.float_array, CAST(2.0 AS FLOAT)):boolean,array_contains(primitive_arrays.float_array, CAST(0.0 AS FLOAT)):boolean,array_contains(primitive_arrays.date_array, DATE '2016-03-14'):boolean,array_contains(primitive_arrays.date_array, DATE '2016-01-01'):boolean,array_contains(primitive_arrays.timestamp_array, TIMESTAMP('2016-11-15 20:54:00.0')):boolean,array_contains(primitive_arrays.timestamp_array, TIMESTAMP('2016-01-01 20:54:00.0')):boolean>
 -- !query 6 output
 true	false	true	false	true	false	true	false	true	false	true	false	true	false	true	false	true	false	true	false
 
@@ -100,7 +100,7 @@ true	false	true	false	true	false	true	false	true	false	true	false	true	false	tru
 -- !query 7
 select array_contains(b, 11), array_contains(c, array(111, 112, 113)) from data
 -- !query 7 schema
-struct<array_contains(b, 11):boolean,array_contains(c, array(111, 112, 113)):boolean>
+struct<array_contains(data.b, 11):boolean,array_contains(data.c, array(111, 112, 113)):boolean>
 -- !query 7 output
 false	false
 true	true
@@ -120,7 +120,7 @@ select
   sort_array(timestamp_array)
 from primitive_arrays
 -- !query 8 schema
-struct<sort_array(boolean_array, true):array<boolean>,sort_array(tinyint_array, true):array<tinyint>,sort_array(smallint_array, true):array<smallint>,sort_array(int_array, true):array<int>,sort_array(bigint_array, true):array<bigint>,sort_array(decimal_array, true):array<decimal(19,0)>,sort_array(double_array, true):array<double>,sort_array(float_array, true):array<float>,sort_array(date_array, true):array<date>,sort_array(timestamp_array, true):array<timestamp>>
+struct<sort_array(primitive_arrays.boolean_array, true):array<boolean>,sort_array(primitive_arrays.tinyint_array, true):array<tinyint>,sort_array(primitive_arrays.smallint_array, true):array<smallint>,sort_array(primitive_arrays.int_array, true):array<int>,sort_array(primitive_arrays.bigint_array, true):array<bigint>,sort_array(primitive_arrays.decimal_array, true):array<decimal(19,0)>,sort_array(primitive_arrays.double_array, true):array<double>,sort_array(primitive_arrays.float_array, true):array<float>,sort_array(primitive_arrays.date_array, true):array<date>,sort_array(primitive_arrays.timestamp_array, true):array<timestamp>>
 -- !query 8 output
 [true]	[1,2]	[1,2]	[1,2]	[1,2]	[9223372036854775808,9223372036854775809]	[1.0,2.0]	[1.0,2.0]	[2016-03-13,2016-03-14]	[2016-11-12 20:54:00.0,2016-11-15 20:54:00.0]
 
@@ -157,6 +157,6 @@ select
   size(timestamp_array)
 from primitive_arrays
 -- !query 11 schema
-struct<size(boolean_array):int,size(tinyint_array):int,size(smallint_array):int,size(int_array):int,size(bigint_array):int,size(decimal_array):int,size(double_array):int,size(float_array):int,size(date_array):int,size(timestamp_array):int>
+struct<size(primitive_arrays.boolean_array):int,size(primitive_arrays.tinyint_array):int,size(primitive_arrays.smallint_array):int,size(primitive_arrays.int_array):int,size(primitive_arrays.bigint_array):int,size(primitive_arrays.decimal_array):int,size(primitive_arrays.double_array):int,size(primitive_arrays.float_array):int,size(primitive_arrays.date_array):int,size(primitive_arrays.timestamp_array):int>
 -- !query 11 output
 1	2	2	2	2	2	2	2	2	2

--- a/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
@@ -15,7 +15,7 @@ struct<>
 -- !query 1
 SELECT a + b, b, SUM(a - b) FROM testData GROUP BY a + b, b WITH CUBE
 -- !query 1 schema
-struct<(a + b):int,b:int,sum((a - b)):bigint>
+struct<(testdata.a + testdata.b):int,b:int,sum((testdata.a - testdata.b)):bigint>
 -- !query 1 output
 2	1	0
 2	NULL	0
@@ -35,7 +35,7 @@ NULL	NULL	3
 -- !query 2
 SELECT a, b, SUM(b) FROM testData GROUP BY a, b WITH CUBE
 -- !query 2 schema
-struct<a:int,b:int,sum(b):bigint>
+struct<a:int,b:int,sum(testdata.b):bigint>
 -- !query 2 output
 1	1	1
 1	2	2
@@ -54,7 +54,7 @@ NULL	NULL	9
 -- !query 3
 SELECT a + b, b, SUM(a - b) FROM testData GROUP BY a + b, b WITH ROLLUP
 -- !query 3 schema
-struct<(a + b):int,b:int,sum((a - b)):bigint>
+struct<(testdata.a + testdata.b):int,b:int,sum((testdata.a - testdata.b)):bigint>
 -- !query 3 output
 2	1	0
 2	NULL	0
@@ -72,7 +72,7 @@ NULL	NULL	3
 -- !query 4
 SELECT a, b, SUM(b) FROM testData GROUP BY a, b WITH ROLLUP
 -- !query 4 schema
-struct<a:int,b:int,sum(b):bigint>
+struct<a:int,b:int,sum(testdata.b):bigint>
 -- !query 4 output
 1	1	1
 1	2	2
@@ -99,7 +99,7 @@ struct<>
 -- !query 6
 SELECT course, year, SUM(earnings) FROM courseSales GROUP BY ROLLUP(course, year) ORDER BY course, year
 -- !query 6 schema
-struct<course:string,year:int,sum(earnings):bigint>
+struct<course:string,year:int,sum(coursesales.earnings):bigint>
 -- !query 6 output
 NULL	NULL	113000
 Java	NULL	50000
@@ -113,7 +113,7 @@ dotNET	2013	48000
 -- !query 7
 SELECT course, year, SUM(earnings) FROM courseSales GROUP BY CUBE(course, year) ORDER BY course, year
 -- !query 7 schema
-struct<course:string,year:int,sum(earnings):bigint>
+struct<course:string,year:int,sum(coursesales.earnings):bigint>
 -- !query 7 output
 NULL	NULL	113000
 NULL	2012	35000
@@ -129,7 +129,7 @@ dotNET	2013	48000
 -- !query 8
 SELECT course, year, SUM(earnings) FROM courseSales GROUP BY course, year GROUPING SETS(course, year)
 -- !query 8 schema
-struct<course:string,year:int,sum(earnings):bigint>
+struct<course:string,year:int,sum(coursesales.earnings):bigint>
 -- !query 8 output
 Java	NULL	50000
 NULL	2012	35000
@@ -140,7 +140,7 @@ dotNET	NULL	63000
 -- !query 9
 SELECT course, year, SUM(earnings) FROM courseSales GROUP BY course, year GROUPING SETS(course)
 -- !query 9 schema
-struct<course:string,year:int,sum(earnings):bigint>
+struct<course:string,year:int,sum(coursesales.earnings):bigint>
 -- !query 9 output
 Java	NULL	50000
 dotNET	NULL	63000
@@ -149,7 +149,7 @@ dotNET	NULL	63000
 -- !query 10
 SELECT course, year, SUM(earnings) FROM courseSales GROUP BY course, year GROUPING SETS(year)
 -- !query 10 schema
-struct<course:string,year:int,sum(earnings):bigint>
+struct<course:string,year:int,sum(coursesales.earnings):bigint>
 -- !query 10 output
 NULL	2012	35000
 NULL	2013	78000
@@ -175,7 +175,7 @@ dotNET	63000
 SELECT course, SUM(earnings) AS sum, GROUPING_ID(course, earnings) FROM courseSales
 GROUP BY course, earnings GROUPING SETS((), (course), (course, earnings)) ORDER BY course, sum
 -- !query 12 schema
-struct<course:string,sum:bigint,grouping_id(course, earnings):int>
+struct<course:string,sum:bigint,grouping_id(coursesales.course, coursesales.earnings):int>
 -- !query 12 output
 NULL	113000	3
 Java	20000	0
@@ -191,7 +191,7 @@ dotNET	63000	1
 SELECT course, year, GROUPING(course), GROUPING(year), GROUPING_ID(course, year) FROM courseSales
 GROUP BY CUBE(course, year)
 -- !query 13 schema
-struct<course:string,year:int,grouping(course):tinyint,grouping(year):tinyint,grouping_id(course, year):int>
+struct<course:string,year:int,grouping(coursesales.course):tinyint,grouping(coursesales.year):tinyint,grouping_id(coursesales.course, coursesales.year):int>
 -- !query 13 output
 Java	2012	0	0	0
 Java	2013	0	0	0
@@ -273,7 +273,7 @@ grouping__id is deprecated; use grouping_id() instead;
 SELECT course, year, GROUPING(course), GROUPING(year) FROM courseSales GROUP BY CUBE(course, year)
 ORDER BY GROUPING(course), GROUPING(year), course, year
 -- !query 21 schema
-struct<course:string,year:int,grouping(course):tinyint,grouping(year):tinyint>
+struct<course:string,year:int,grouping(coursesales.course):tinyint,grouping(coursesales.year):tinyint>
 -- !query 21 output
 Java	2012	0	0
 Java	2013	0	0
@@ -290,7 +290,7 @@ NULL	NULL	1	1
 SELECT course, year, GROUPING_ID(course, year) FROM courseSales GROUP BY CUBE(course, year)
 ORDER BY GROUPING(course), GROUPING(year), course, year
 -- !query 22 schema
-struct<course:string,year:int,grouping_id(course, year):int>
+struct<course:string,year:int,grouping_id(coursesales.course, coursesales.year):int>
 -- !query 22 output
 Java	2012	0
 Java	2013	0
@@ -333,7 +333,7 @@ grouping__id is deprecated; use grouping_id() instead;
 -- !query 26
 SELECT a + b AS k1, b AS k2, SUM(a - b) FROM testData GROUP BY CUBE(k1, k2)
 -- !query 26 schema
-struct<k1:int,k2:int,sum((a - b)):bigint>
+struct<k1:int,k2:int,sum((testdata.a - testdata.b)):bigint>
 -- !query 26 output
 2	1	0
 2	NULL	0
@@ -353,7 +353,7 @@ NULL	NULL	3
 -- !query 27
 SELECT a + b AS k, b, SUM(a - b) FROM testData GROUP BY ROLLUP(k, b)
 -- !query 27 schema
-struct<k:int,b:int,sum((a - b)):bigint>
+struct<k:int,b:int,sum((testdata.a - testdata.b)):bigint>
 -- !query 27 output
 2	1	0
 2	NULL	0
@@ -371,7 +371,7 @@ NULL	NULL	3
 -- !query 28
 SELECT a + b, b AS k, SUM(a - b) FROM testData GROUP BY a + b, k GROUPING SETS(k)
 -- !query 28 schema
-struct<(a + b):int,k:int,sum((a - b)):bigint>
+struct<(testdata.a + testdata.b):int,k:int,sum((testdata.a - testdata.b)):bigint>
 -- !query 28 output
 NULL	1	3
 NULL	2	0

--- a/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
@@ -20,7 +20,7 @@ struct<>
 -- !query 1
 select a, sum(b) from data group by 1
 -- !query 1 schema
-struct<a:int,sum(b):bigint>
+struct<a:int,sum(data.b):bigint>
 -- !query 1 output
 1	3
 2	3
@@ -30,7 +30,7 @@ struct<a:int,sum(b):bigint>
 -- !query 2
 select 1, 2, sum(b) from data group by 1, 2
 -- !query 2 schema
-struct<1:int,2:int,sum(b):bigint>
+struct<1:int,2:int,sum(data.b):bigint>
 -- !query 2 output
 1	2	9
 
@@ -38,7 +38,7 @@ struct<1:int,2:int,sum(b):bigint>
 -- !query 3
 select a, 1, sum(b) from data group by a, 1
 -- !query 3 schema
-struct<a:int,1:int,sum(b):bigint>
+struct<a:int,1:int,sum(data.b):bigint>
 -- !query 3 output
 1	1	3
 2	1	3
@@ -48,7 +48,7 @@ struct<a:int,1:int,sum(b):bigint>
 -- !query 4
 select a, 1, sum(b) from data group by 1, 2
 -- !query 4 schema
-struct<a:int,1:int,sum(b):bigint>
+struct<a:int,1:int,sum(data.b):bigint>
 -- !query 4 output
 1	1	3
 2	1	3
@@ -58,7 +58,7 @@ struct<a:int,1:int,sum(b):bigint>
 -- !query 5
 select a, b + 2, count(2) from data group by a, 2
 -- !query 5 schema
-struct<a:int,(b + 2):int,count(2):bigint>
+struct<a:int,(data.b + 2):int,count(2):bigint>
 -- !query 5 output
 1	3	1
 1	4	1
@@ -84,7 +84,7 @@ struct<aa:int,bb:int,count(2):bigint>
 -- !query 7
 select sum(b) from data group by 1 + 0
 -- !query 7 schema
-struct<sum(b):bigint>
+struct<sum(data.b):bigint>
 -- !query 7 output
 9
 
@@ -137,7 +137,7 @@ aggregate functions are not allowed in GROUP BY, but found (sum(CAST(data.`b` AS
 -- !query 13
 select a, rand(0), sum(b) from data group by a, 2
 -- !query 13 schema
-struct<a:int,rand(0):double,sum(b):bigint>
+struct<a:int,rand(0):double,sum(data.b):bigint>
 -- !query 13 output
 1	0.4048454303385226	2
 1	0.8446490682263027	1
@@ -159,7 +159,7 @@ Star (*) is not allowed in select list when GROUP BY ordinal position is used;
 -- !query 15
 select a, count(a) from (select 1 as a) tmp group by 1 order by 1
 -- !query 15 schema
-struct<a:int,count(a):bigint>
+struct<a:int,count(tmp.a):bigint>
 -- !query 15 output
 1	1
 
@@ -167,7 +167,7 @@ struct<a:int,count(a):bigint>
 -- !query 16
 select count(a), a from (select 1 as a) tmp group by 2 having a > 0
 -- !query 16 schema
-struct<count(a):bigint,a:int>
+struct<count(tmp.a):bigint,a:int>
 -- !query 16 output
 1	1
 
@@ -175,7 +175,7 @@ struct<count(a):bigint,a:int>
 -- !query 17
 select a, a AS k, count(b) from data group by k, 1
 -- !query 17 schema
-struct<a:int,k:int,count(b):bigint>
+struct<a:int,k:int,count(data.b):bigint>
 -- !query 17 output
 1	1	2
 2	2	2
@@ -193,6 +193,6 @@ spark.sql.groupByOrdinal	false
 -- !query 19
 select sum(b) from data group by -1
 -- !query 19 schema
-struct<sum(b):bigint>
+struct<sum(data.b):bigint>
 -- !query 19 output
 9

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -18,13 +18,13 @@ SELECT a, COUNT(b) FROM testData
 struct<>
 -- !query 1 output
 org.apache.spark.sql.AnalysisException
-grouping expressions sequence is empty, and 'testdata.`a`' is not an aggregate function. Wrap '(count(testdata.`b`) AS `count(b)`)' in windowing function(s) or wrap 'testdata.`a`' in first() (or first_value) if you don't care which value you get.;
+grouping expressions sequence is empty, and 'testdata.`a`' is not an aggregate function. Wrap '(count(testdata.`b`) AS `count(testdata.b)`)' in windowing function(s) or wrap 'testdata.`a`' in first() (or first_value) if you don't care which value you get.;
 
 
 -- !query 2
 SELECT COUNT(a), COUNT(b) FROM testData
 -- !query 2 schema
-struct<count(a):bigint,count(b):bigint>
+struct<count(testdata.a):bigint,count(testdata.b):bigint>
 -- !query 2 output
 7	7
 
@@ -32,7 +32,7 @@ struct<count(a):bigint,count(b):bigint>
 -- !query 3
 SELECT a, COUNT(b) FROM testData GROUP BY a
 -- !query 3 schema
-struct<a:int,count(b):bigint>
+struct<a:int,count(testdata.b):bigint>
 -- !query 3 output
 1	2
 2	2
@@ -52,7 +52,7 @@ expression 'testdata.`a`' is neither present in the group by, nor is it an aggre
 -- !query 5
 SELECT COUNT(a), COUNT(b) FROM testData GROUP BY a
 -- !query 5 schema
-struct<count(a):bigint,count(b):bigint>
+struct<count(testdata.a):bigint,count(testdata.b):bigint>
 -- !query 5 output
 0	1
 2	2
@@ -63,7 +63,7 @@ struct<count(a):bigint,count(b):bigint>
 -- !query 6
 SELECT 'foo', COUNT(a) FROM testData GROUP BY 1
 -- !query 6 schema
-struct<foo:string,count(a):bigint>
+struct<foo:string,count(testdata.a):bigint>
 -- !query 6 output
 foo	7
 
@@ -79,7 +79,7 @@ struct<foo:string>
 -- !query 8
 SELECT 'foo', APPROX_COUNT_DISTINCT(a) FROM testData WHERE a = 0 GROUP BY 1
 -- !query 8 schema
-struct<foo:string,approx_count_distinct(a):bigint>
+struct<foo:string,approx_count_distinct(testdata.a):bigint>
 -- !query 8 output
 
 
@@ -87,7 +87,7 @@ struct<foo:string,approx_count_distinct(a):bigint>
 -- !query 9
 SELECT 'foo', MAX(STRUCT(a)) FROM testData WHERE a = 0 GROUP BY 1
 -- !query 9 schema
-struct<foo:string,max(named_struct(a, a)):struct<a:int>>
+struct<foo:string,max(named_struct(a, testdata.a)):struct<a:int>>
 -- !query 9 output
 
 
@@ -95,7 +95,7 @@ struct<foo:string,max(named_struct(a, a)):struct<a:int>>
 -- !query 10
 SELECT a + b, COUNT(b) FROM testData GROUP BY a + b
 -- !query 10 schema
-struct<(a + b):int,count(b):bigint>
+struct<(testdata.a + testdata.b):int,count(testdata.b):bigint>
 -- !query 10 output
 2	1
 3	2
@@ -116,7 +116,7 @@ expression 'testdata.`a`' is neither present in the group by, nor is it an aggre
 -- !query 12
 SELECT a + 1 + 1, COUNT(b) FROM testData GROUP BY a + 1
 -- !query 12 schema
-struct<((a + 1) + 1):int,count(b):bigint>
+struct<((testdata.a + 1) + 1):int,count(testdata.b):bigint>
 -- !query 12 output
 3	2
 4	2
@@ -128,7 +128,7 @@ NULL	1
 SELECT SKEWNESS(a), KURTOSIS(a), MIN(a), MAX(a), AVG(a), VARIANCE(a), STDDEV(a), SUM(a), COUNT(a)
 FROM testData
 -- !query 13 schema
-struct<skewness(CAST(a AS DOUBLE)):double,kurtosis(CAST(a AS DOUBLE)):double,min(a):int,max(a):int,avg(a):double,var_samp(CAST(a AS DOUBLE)):double,stddev_samp(CAST(a AS DOUBLE)):double,sum(a):bigint,count(a):bigint>
+struct<skewness(CAST(testdata.a AS DOUBLE)):double,kurtosis(CAST(testdata.a AS DOUBLE)):double,min(testdata.a):int,max(testdata.a):int,avg(testdata.a):double,var_samp(CAST(testdata.a AS DOUBLE)):double,stddev_samp(CAST(testdata.a AS DOUBLE)):double,sum(testdata.a):bigint,count(testdata.a):bigint>
 -- !query 13 output
 -0.2723801058145729	-1.5069204152249134	1	3	2.142857142857143	0.8095238095238094	0.8997354108424372	15	7
 
@@ -136,7 +136,7 @@ struct<skewness(CAST(a AS DOUBLE)):double,kurtosis(CAST(a AS DOUBLE)):double,min
 -- !query 14
 SELECT COUNT(DISTINCT b), COUNT(DISTINCT b, c) FROM (SELECT 1 AS a, 2 AS b, 3 AS c) t GROUP BY a
 -- !query 14 schema
-struct<count(DISTINCT b):bigint,count(DISTINCT b, c):bigint>
+struct<count(DISTINCT t.b):bigint,count(DISTINCT t.b, t.c):bigint>
 -- !query 14 output
 1	1
 
@@ -144,7 +144,7 @@ struct<count(DISTINCT b):bigint,count(DISTINCT b, c):bigint>
 -- !query 15
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k
 -- !query 15 schema
-struct<k:int,count(b):bigint>
+struct<k:int,count(testdata.b):bigint>
 -- !query 15 output
 1	2
 2	2
@@ -155,7 +155,7 @@ NULL	1
 -- !query 16
 SELECT a AS k, COUNT(b) FROM testData GROUP BY k HAVING k > 1
 -- !query 16 schema
-struct<k:int,count(b):bigint>
+struct<k:int,count(testdata.b):bigint>
 -- !query 16 output
 2	2
 3	2

--- a/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
@@ -17,7 +17,7 @@ struct<>
 -- !query 1
 SELECT a, b, c, count(d) FROM grouping GROUP BY a, b, c GROUPING SETS (())
 -- !query 1 schema
-struct<a:string,b:string,c:string,count(d):bigint>
+struct<a:string,b:string,c:string,count(grouping.d):bigint>
 -- !query 1 output
 NULL	NULL	NULL	3
 
@@ -25,7 +25,7 @@ NULL	NULL	NULL	3
 -- !query 2
 SELECT a, b, c, count(d) FROM grouping GROUP BY a, b, c GROUPING SETS ((a))
 -- !query 2 schema
-struct<a:string,b:string,c:string,count(d):bigint>
+struct<a:string,b:string,c:string,count(grouping.d):bigint>
 -- !query 2 output
 1	NULL	NULL	1
 4	NULL	NULL	1
@@ -35,7 +35,7 @@ struct<a:string,b:string,c:string,count(d):bigint>
 -- !query 3
 SELECT a, b, c, count(d) FROM grouping GROUP BY a, b, c GROUPING SETS ((c))
 -- !query 3 schema
-struct<a:string,b:string,c:string,count(d):bigint>
+struct<a:string,b:string,c:string,count(grouping.d):bigint>
 -- !query 3 output
 NULL	NULL	3	1
 NULL	NULL	6	1

--- a/sql/core/src/test/resources/sql-tests/results/having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/having.sql.out
@@ -18,7 +18,7 @@ struct<>
 -- !query 1
 SELECT k, sum(v) FROM hav GROUP BY k HAVING sum(v) > 2
 -- !query 1 schema
-struct<k:string,sum(v):bigint>
+struct<k:string,sum(hav.v):bigint>
 -- !query 1 output
 one	6
 three	3
@@ -27,7 +27,7 @@ three	3
 -- !query 2
 SELECT count(k) FROM hav GROUP BY v + 1 HAVING v + 1 = 2
 -- !query 2 schema
-struct<count(k):bigint>
+struct<count(hav.k):bigint>
 -- !query 2 output
 1
 
@@ -35,7 +35,7 @@ struct<count(k):bigint>
 -- !query 3
 SELECT MIN(t.v) FROM (SELECT * FROM hav WHERE v > 0) t HAVING(COUNT(1) > 0)
 -- !query 3 schema
-struct<min(v):int>
+struct<min(t.v):int>
 -- !query 3 output
 1
 
@@ -43,7 +43,7 @@ struct<min(v):int>
 -- !query 4
 SELECT a + b FROM VALUES (1L, 2), (3L, 4) AS T(a, b) GROUP BY a + b HAVING a + b > 1
 -- !query 4 schema
-struct<(a + CAST(b AS BIGINT)):bigint>
+struct<(T.a + CAST(T.b AS BIGINT)):bigint>
 -- !query 4 output
 3
 7

--- a/sql/core/src/test/resources/sql-tests/results/operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/operators.sql.out
@@ -37,7 +37,7 @@ struct<6.8:decimal(2,1)>
 -- !query 4
 select -key, +key from testdata where key = 2
 -- !query 4 schema
-struct<(- key):int,key:int>
+struct<(- testdata.key):int,key:int>
 -- !query 4 output
 -2	2
 
@@ -45,7 +45,7 @@ struct<(- key):int,key:int>
 -- !query 5
 select -(key + 1), - key + 1, +(key + 5) from testdata where key = 1
 -- !query 5 schema
-struct<(- (key + 1)):int,((- key) + 1):int,(key + 5):int>
+struct<(- (testdata.key + 1)):int,((- testdata.key) + 1):int,(testdata.key + 5):int>
 -- !query 5 output
 -2	0	6
 
@@ -53,7 +53,7 @@ struct<(- (key + 1)):int,((- key) + 1):int,(key + 5):int>
 -- !query 6
 select -max(key), +max(key) from testdata
 -- !query 6 schema
-struct<(- max(key)):int,max(key):int>
+struct<(- max(testdata.key)):int,max(testdata.key):int>
 -- !query 6 output
 -100	100
 
@@ -69,7 +69,7 @@ struct<(- -10):int>
 -- !query 8
 select + (-key) from testdata where key = 32
 -- !query 8 schema
-struct<(- key):int>
+struct<(- testdata.key):int>
 -- !query 8 output
 -32
 
@@ -77,7 +77,7 @@ struct<(- key):int>
 -- !query 9
 select - (+max(key)) from testdata
 -- !query 9 schema
-struct<(- max(key)):int>
+struct<(- max(testdata.key)):int>
 -- !query 9 output
 -100
 
@@ -109,7 +109,7 @@ struct<100:int>
 -- !query 13
 select - - max(key) from testdata
 -- !query 13 schema
-struct<(- (- max(key))):int>
+struct<(- (- max(testdata.key))):int>
 -- !query 13 output
 100
 
@@ -117,7 +117,7 @@ struct<(- (- max(key))):int>
 -- !query 14
 select + - key from testdata where key = 33
 -- !query 14 schema
-struct<(- key):int>
+struct<(- testdata.key):int>
 -- !query 14 output
 -33
 

--- a/sql/core/src/test/resources/sql-tests/results/outer-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/outer-join.sql.out
@@ -34,7 +34,7 @@ GROUP BY GREATEST(COALESCE(t2.int_col1, 109), COALESCE(t1.int_col1, -449)),
 HAVING (SUM(COALESCE(t1.int_col1, t2.int_col0)))
             > ((COALESCE(t1.int_col1, t2.int_col0)) * 2)
 -- !query 2 schema
-struct<sum(coalesce(int_col1, int_col0)):bigint,(coalesce(int_col1, int_col0) * 2):int>
+struct<sum(coalesce(t1.int_col1, t2.int_col0)):bigint,(coalesce(t1.int_col1, t2.int_col0) * 2):int>
 -- !query 2 output
 -367	-734
 -507	-1014

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-aggregate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-aggregate.sql.out
@@ -62,7 +62,7 @@ WHERE  EXISTS (SELECT state
                WHERE  dept.dept_id = emp.dept_id) 
 GROUP  BY dept_id
 -- !query 3 schema
-struct<dept_id:int,avg(salary):double,sum(salary):double>
+struct<dept_id:int,avg(emp.salary):double,sum(emp.salary):double>
 -- !query 3 output
 10	133.33333333333334	400.0
 20	300.0	300.0
@@ -132,7 +132,7 @@ WHERE  NOT EXISTS (SELECT state
                    WHERE  dept.dept_id = emp.dept_id) 
 GROUP  BY dept_id
 -- !query 7 schema
-struct<dept_id:int,avg(salary):double,sum(salary):double>
+struct<dept_id:int,avg(emp.salary):double,sum(emp.salary):double>
 -- !query 7 output
 100	400.0	800.0
 NULL	400.0	400.0

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-cte.sql.out
@@ -160,7 +160,7 @@ WHERE  EXISTS (SELECT dept_id,
                HAVING count(*) > 1) 
 GROUP  BY emp_name
 -- !query 6 schema
-struct<emp_name:string,sum(bonus_amt):double>
+struct<emp_name:string,sum(bonus.bonus_amt):double>
 -- !query 6 output
 emp 1	30.0
 emp 2	400.0
@@ -190,7 +190,7 @@ WHERE  NOT EXISTS (SELECT dept_id,
                    HAVING count(*) < 1) 
 GROUP  BY emp_name
 -- !query 7 schema
-struct<emp_name:string,sum(bonus_amt):double>
+struct<emp_name:string,sum(bonus.bonus_amt):double>
 -- !query 7 output
 emp 1	30.0
 emp 2	400.0

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-having.sql.out
@@ -104,7 +104,7 @@ WHERE  EXISTS (SELECT dept_id,
                               WHERE  bonus_amt < Min(p.salary))) 
 GROUP  BY gp.dept_id
 -- !query 5 schema
-struct<dept_id:int,max(salary):double>
+struct<dept_id:int,max(gp.salary):double>
 -- !query 5 output
 10	200.0
 100	400.0

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-joins-and-set-ops.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-joins-and-set-ops.sql.out
@@ -200,7 +200,7 @@ WHERE  EXISTS (SELECT emp_name,
                  ORDER  BY emp_name)
 GROUP  BY emp_name
 -- !query 10 schema
-struct<emp_name:string,sum(bonus_amt):double>
+struct<emp_name:string,sum(bonus.bonus_amt):double>
 -- !query 10 output
 emp 1	30.0
 
@@ -220,7 +220,7 @@ WHERE  NOT EXISTS (SELECT emp_name,
                    ORDER  BY emp_name) 
 GROUP  BY emp_name
 -- !query 11 schema
-struct<emp_name:string,sum(bonus_amt):double>
+struct<emp_name:string,sum(bonus.bonus_amt):double>
 -- !query 11 output
 emp 2	400.0
 emp 3	300.0

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-group-by.sql.out
@@ -74,7 +74,7 @@ WHERE  t1a IN (SELECT t2a
                FROM   t2)
 GROUP  BY t1a
 -- !query 3 schema
-struct<t1a:string,avg(t1b):double>
+struct<t1a:string,avg(t1.t1b):double>
 -- !query 3 output
 t1b	8.0
 t1c	8.0
@@ -91,7 +91,7 @@ WHERE  t1b IN (SELECT t2b
 GROUP  BY t1a,
           t1d
 -- !query 4 schema
-struct<t1a:string,max(t1b):smallint>
+struct<t1a:string,max(t1.t1b):smallint>
 -- !query 4 output
 t1b	8
 
@@ -125,7 +125,7 @@ WHERE  t1c IN (SELECT t2c
 GROUP  BY t1a,
           t1c
 -- !query 6 schema
-struct<t1a:string,sum(DISTINCT t1b):bigint>
+struct<t1a:string,sum(DISTINCT t1.t1b):bigint>
 -- !query 6 output
 t1b	8
 t1c	8
@@ -144,7 +144,7 @@ WHERE  t1c IN (SELECT t2c
 GROUP  BY t1a,
           t1c
 -- !query 7 schema
-struct<t1a:string,sum(DISTINCT t1b):bigint>
+struct<t1a:string,sum(DISTINCT t1.t1b):bigint>
 -- !query 7 output
 t1b	8
 
@@ -160,7 +160,7 @@ GROUP  BY t1a,
           t1c
 HAVING t1a = "t1b"
 -- !query 8 schema
-struct<t1a:string,count(DISTINCT t1b):bigint>
+struct<t1a:string,count(DISTINCT t1.t1b):bigint>
 -- !query 8 output
 t1b	1
 
@@ -209,7 +209,7 @@ WHERE  t1b IN (SELECT Min(t2b)
                       AND t1c = t2c
                GROUP  BY t2a)
 -- !query 11 schema
-struct<count(DISTINCT t1a, t1b, t1c, t1d, t1e, t1f, t1g, t1h, t1i):bigint>
+struct<count(DISTINCT t1.t1a, t1.t1b, t1.t1c, t1.t1d, t1.t1e, t1.t1f, t1.t1g, t1.t1h, t1.t1i):bigint>
 -- !query 11 output
 1
 
@@ -263,7 +263,7 @@ WHERE  t1c IN (SELECT Min(t2c)
                GROUP  BY t2a)
 GROUP  BY t1a
 -- !query 14 schema
-struct<t1a:string,min(t1b):smallint>
+struct<t1a:string,min(t1.t1b):smallint>
 -- !query 14 output
 t1b	8
 t1c	8
@@ -283,7 +283,7 @@ WHERE  t1c IN (SELECT Min(t2c)
 GROUP  BY t1a,
           t1d
 -- !query 15 schema
-struct<t1a:string,min(t1b):smallint>
+struct<t1a:string,min(t1.t1b):smallint>
 -- !query 15 output
 t1b	8
 t1c	8
@@ -305,7 +305,7 @@ WHERE  t1c IN (SELECT Min(t2c)
                    GROUP  BY t3d)
 GROUP  BY t1a
 -- !query 16 schema
-struct<t1a:string,min(t1b):smallint>
+struct<t1a:string,min(t1.t1b):smallint>
 -- !query 16 output
 t1b	8
 t1c	8
@@ -325,7 +325,7 @@ WHERE  t1c IN (SELECT Min(t2c)
                    GROUP  BY t3d)
 GROUP  BY t1a
 -- !query 17 schema
-struct<t1a:string,min(t1b):smallint>
+struct<t1a:string,min(t1.t1b):smallint>
 -- !query 17 output
 t1a	16
 t1b	8
@@ -350,7 +350,7 @@ WHERE  t1c IN (SELECT Min(t2c)
 GROUP  BY t1a
 HAVING Min(t1b) IS NOT NULL
 -- !query 18 schema
-struct<t1a:string,min(t1b):smallint>
+struct<t1a:string,min(t1.t1b):smallint>
 -- !query 18 output
 t1a	16
 t1b	8

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-having.sql.out
@@ -141,7 +141,7 @@ WHERE  t1c IN (SELECT t2c
 GROUP  BY t1b
 HAVING t1b >= 8
 -- !query 7 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 7 output
 2	8
 
@@ -159,7 +159,7 @@ HAVING t1a IN (SELECT t2a
                               WHERE  t2c = t3c)
                )
 -- !query 8 schema
-struct<t1a:string,max(t1b):smallint>
+struct<t1a:string,max(t1.t1b):smallint>
 -- !query 8 output
 val1b	8
 
@@ -176,7 +176,7 @@ WHERE  t1a NOT IN (SELECT t2a
 GROUP BY t1a, t1c
 HAVING Min(t1d) > t1c
 -- !query 9 schema
-struct<t1a:string,t1c:int,min(t1d):bigint>
+struct<t1a:string,t1c:int,min(t1.t1d):bigint>
 -- !query 9 output
 val1a	8	10
 val1b	16	19
@@ -211,7 +211,7 @@ HAVING t1a NOT IN (SELECT t2a
                    FROM   t2
                    WHERE  t2b > 3)
 -- !query 11 schema
-struct<t1a:string,max(t1b):smallint>
+struct<t1a:string,max(t1.t1b):smallint>
 -- !query 11 output
 val1a	16
 val1d	10

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-joins.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-joins.sql.out
@@ -104,7 +104,7 @@ GROUP BY  t1a,
           t3c
 ORDER BY  t1a DESC, t3b DESC
 -- !query 4 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint,t3a:string,t3b:smallint,t3c:int>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint,t3a:string,t3b:smallint,t3c:int>
 -- !query 4 output
 1	10	val3b	8	NULL
 1	10	val1b	8	16
@@ -130,7 +130,7 @@ AND        t1a = t3a
 GROUP BY   t1a
 ORDER BY   t1a
 -- !query 5 schema
-struct<count(DISTINCT t1a):bigint>
+struct<count(DISTINCT t1.t1a):bigint>
 -- !query 5 output
 1
 
@@ -182,7 +182,7 @@ GROUP BY   t1a,
 HAVING     t1b > 8
 ORDER BY   t1a
 -- !query 7 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 7 output
 1	10
 
@@ -200,7 +200,7 @@ WHERE    t1a IN
 GROUP BY t1a
 ORDER BY t1a
 -- !query 8 schema
-struct<count(DISTINCT t1a):bigint>
+struct<count(DISTINCT t1.t1a):bigint>
 -- !query 8 output
 1
 1
@@ -225,7 +225,7 @@ OR       t1a IN
 GROUP BY t1b
 HAVING   t1b > 6
 -- !query 9 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 9 output
 1	10
 1	8
@@ -250,7 +250,7 @@ AND      t1h IN
 GROUP BY t1b
 HAVING t1b > 8
 -- !query 10 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 10 output
 1	10
 
@@ -281,7 +281,7 @@ AND       t1b IN
 GROUP BY t1b
 HAVING   t1b > 8
 -- !query 11 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 11 output
 1	10
 
@@ -315,7 +315,7 @@ AND        t1a = t2a
 GROUP BY   t1b
 ORDER BY   t1b DESC
 -- !query 12 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 12 output
 1	8
 
@@ -346,7 +346,7 @@ Group By t1a, t1b, t1c, t2a, t2b, t2c
 HAVING t2c IS NOT NULL
 ORDER By t2b DESC nulls last
 -- !query 13 schema
-struct<t1a:string,t1b:smallint,t1c:int,count(DISTINCT t2a):bigint,t2b:smallint,t2c:int>
+struct<t1a:string,t1b:smallint,t1c:int,count(DISTINCT t2.t2a):bigint,t2b:smallint,t2c:int>
 -- !query 13 output
 val1b	8	16	1	10	12
 val1b	8	16	1	8	16

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
@@ -109,7 +109,7 @@ GROUP  BY t1b
 ORDER  BY t1b DESC NULLS FIRST
 LIMIT  1
 -- !query 5 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 5 output
 1	NULL
 
@@ -142,6 +142,6 @@ GROUP  BY t1b
 ORDER BY t1b NULLS last
 LIMIT  1
 -- !query 7 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 7 output
 1	6

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-order-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-order-by.sql.out
@@ -118,7 +118,7 @@ WHERE  t1b IN (SELECT t2b
                WHERE  t1a = t2a)
 ORDER  BY Count(DISTINCT( t1a ))
 -- !query 6 schema
-struct<count(DISTINCT t1a):bigint>
+struct<count(DISTINCT t1.t1a):bigint>
 -- !query 6 output
 1
 
@@ -263,7 +263,7 @@ GROUP  BY t1a,
           t1h
 ORDER BY t1a
 -- !query 14 schema
-struct<t1a:string,count(DISTINCT t1b):bigint>
+struct<t1a:string,count(DISTINCT t1.t1b):bigint>
 -- !query 14 output
 val1b	1
 
@@ -297,7 +297,7 @@ WHERE  t1b NOT IN (SELECT Min(t2b)
                    ORDER  BY t2c DESC nulls last)
 GROUP  BY t1a
 -- !query 16 schema
-struct<t1a:string,sum(DISTINCT t1b):bigint>
+struct<t1a:string,sum(DISTINCT t1.t1b):bigint>
 -- !query 16 output
 val1a	22
 val1c	8
@@ -318,7 +318,7 @@ GROUP  BY t1a,
           t1b
 ORDER  BY t1b DESC nulls last
 -- !query 17 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint>
 -- !query 17 output
 1	16
 1	10

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-set-operations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-set-operations.sql.out
@@ -116,7 +116,7 @@ GROUP  BY t2a,
           t2i
 ORDER  BY t2d DESC
 -- !query 4 schema
-struct<t2a:string,t2b:smallint,t2d:bigint,count(DISTINCT t2h):bigint,t2i:date>
+struct<t2a:string,t2b:smallint,t2d:bigint,count(DISTINCT t3.t2h):bigint,t2i:date>
 -- !query 4 output
 val1b	8	119	1	2015-05-04
 val1b	8	19	1	2014-07-04
@@ -164,7 +164,7 @@ WHERE  t1a IN (SELECT t3a
                WHERE  t3d = t1d)
 GROUP BY t1a, t1b, t1c
 -- !query 5 schema
-struct<t2a:string,t2b:smallint,t2c:int,min(t2d):bigint>
+struct<t2a:string,t2b:smallint,t2c:int,min(t2.t2d):bigint>
 -- !query 5 output
 val1b	10	12	19
 val1b	8	16	119
@@ -210,7 +210,7 @@ GROUP  BY t2a,
           t2i
 HAVING t2b IS NOT NULL
 -- !query 6 schema
-struct<t2a:string,t2b:smallint,count(t2c):bigint,t2d:bigint,t2h:timestamp,t2i:date>
+struct<t2a:string,t2b:smallint,count(t2.t2c):bigint,t2d:bigint,t2h:timestamp,t2i:date>
 -- !query 6 output
 val1b	8	1	119	2015-05-04 01:01:00	2015-05-04
 val1b	8	1	19	2014-07-04 01:01:00	2014-07-04
@@ -266,7 +266,7 @@ WHERE  t2d IN (SELECT min(t1d)
                FROM   t1
                WHERE  t2c = t1c)
 -- !query 7 schema
-struct<t2a:string,t2b:smallint,count(t2c):bigint,t2d:bigint,t2h:timestamp,t2i:date>
+struct<t2a:string,t2b:smallint,count(t2.t2c):bigint,t2d:bigint,t2h:timestamp,t2i:date>
 -- !query 7 output
 val1b	8	1	119	2015-05-04 01:01:00	2015-05-04
 val1b	8	1	19	2014-07-04 01:01:00	2014-07-04
@@ -582,7 +582,7 @@ HAVING   t1b NOT IN
                 FROM   t3)
 ORDER BY t1c DESC NULLS LAST, t1i
 -- !query 15 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint,t1c:int,t1i:date>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint,t1c:int,t1i:date>
 -- !query 15 output
 1	8	16	2014-05-04
 1	8	16	2014-05-05

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-with-cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-with-cte.sql.out
@@ -119,7 +119,7 @@ WHERE  t1b IN
 GROUP BY t1a, t1b, t1c
 HAVING t1c IS NOT NULL
 -- !query 4 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint,t1c:int>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint,t1c:int>
 -- !query 4 output
 1	16	12
 1	6	8
@@ -218,7 +218,7 @@ WHERE    t1b IN
                 FROM   t1)
 GROUP BY t1b
 -- !query 7 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT s.t1a):bigint,t1b:smallint>
 -- !query 7 output
 2	8
 
@@ -267,7 +267,7 @@ FROM   (SELECT cte1.t1a,
                              ON cte1.t1a = cte2.t1a) s
 GROUP  BY s.t1b
 -- !query 9 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<count(DISTINCT s.t1a):bigint,t1b:smallint>
 -- !query 9 output
 2	8
 

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/not-in-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/not-in-group-by.sql.out
@@ -74,7 +74,7 @@ WHERE  t1a NOT IN (SELECT t2a
                    FROM   t2)
 GROUP  BY t1a
 -- !query 3 schema
-struct<t1a:string,avg(t1b):double>
+struct<t1a:string,avg(t1.t1b):double>
 -- !query 3 output
 val1a	11.0
 val1d	10.0
@@ -89,7 +89,7 @@ WHERE  t1d NOT IN (SELECT t2d
                    WHERE  t1h < t2h)
 GROUP  BY t1a
 -- !query 4 schema
-struct<t1a:string,sum(DISTINCT t1b):bigint>
+struct<t1a:string,sum(DISTINCT t1.t1b):bigint>
 -- !query 4 output
 val1a	22
 val1d	10
@@ -123,7 +123,7 @@ WHERE  t1c NOT IN (SELECT Max(t2b)
                    GROUP  BY t2a)
 GROUP BY t1a
 -- !query 6 schema
-struct<t1a:string,max(t1b):smallint>
+struct<t1a:string,max(t1.t1b):smallint>
 -- !query 6 output
 val1a	16
 val1b	8

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/not-in-joins.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/not-in-joins.sql.out
@@ -114,7 +114,7 @@ GROUP BY        t1a, t1b, t1c, t3a, t3b, t3c
 HAVING          count(distinct(t3a)) >= 1
 ORDER BY        t1a, t3b
 -- !query 4 schema
-struct<t1a:string,t1b:smallint,t1c:int,count(DISTINCT t3a):bigint,t3b:smallint,t3c:int>
+struct<t1a:string,t1b:smallint,t1c:int,count(DISTINCT t3.t3a):bigint,t3b:smallint,t3c:int>
 -- !query 4 output
 val1c	8	16	1	6	12
 val1c	8	16	1	10	12
@@ -171,7 +171,7 @@ HAVING t1d NOT IN (SELECT t2d
                    WHERE  t1d = t2d)
 ORDER BY t1b DESC
 -- !query 6 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint,t1c:int,t1d:bigint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint,t1c:int,t1d:bigint>
 -- !query 6 output
 1	16	12	10
 1	16	12	21
@@ -196,7 +196,7 @@ GROUP BY t1b,
          t1d
 HAVING   t1b < sum(t1c)
 -- !query 7 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint,t1c:int,t1d:bigint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint,t1c:int,t1d:bigint>
 -- !query 7 output
 1	6	8	10
 
@@ -224,6 +224,6 @@ GROUP BY t1b,
          t1d
 HAVING   t1b < sum(t1c)
 -- !query 8 schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint,t1c:int,t1d:bigint>
+struct<count(DISTINCT t1.t1a):bigint,t1b:smallint,t1c:int,t1d:bigint>
 -- !query 8 output
 1	6	8	10

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -63,7 +63,7 @@ WHERE  t1a IN (SELECT   min(t2a)
 struct<>
 -- !query 4 output
 org.apache.spark.sql.AnalysisException
-resolved attribute(s) t2b#x missing from min(t2a)#x,t2c#x in operator !Filter t2c#x IN (list#x [t2b#x]);
+resolved attribute(s) t2b#x missing from min(t2.t2a)#x,t2c#x in operator !Filter t2c#x IN (list#x [t2b#x]);
 
 
 -- !query 5

--- a/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
@@ -301,7 +301,7 @@ WHERE  t1a < (SELECT   max(t2a)
               WHERE    t2c = t1c
               GROUP BY t2c)
 -- !query 19 schema
-struct<count(t1a):bigint>
+struct<count(t1.t1a):bigint>
 -- !query 19 output
 7
 

--- a/sql/core/src/test/resources/sql-tests/results/table-aliases.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/table-aliases.sql.out
@@ -30,7 +30,7 @@ struct<col1:int,col2:int>
 -- !query 3
 SELECT col1 AS k, SUM(col2) FROM testData AS t(col1, col2) GROUP BY k
 -- !query 3 schema
-struct<k:int,sum(col2):bigint>
+struct<k:int,sum(t.col2):bigint>
 -- !query 3 output
 1	3
 2	1

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1984,15 +1984,18 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
   test("Auto alias construction of get_json_object") {
     val df = Seq(("1", """{"f1": "value1", "f5": 5.23}""")).toDF("key", "jstring")
-    val expectedMsg = "Cannot create a table having a column whose name contains commas " +
-      "in Hive metastore. Table: `default`.`t`; Column: get_json_object(jstring, $.f1)"
+    def expectedMsg(qualifier: Option[String] = None): String = {
+      val arg0 = s"${qualifier.map(_ + ".").getOrElse("")}jstring"
+      "Cannot create a table having a column whose name contains commas " +
+        s"in Hive metastore. Table: `default`.`t`; Column: get_json_object($arg0, $$.f1)"
+    }
 
     withTable("t") {
       val e = intercept[AnalysisException] {
         df.select($"key", functions.get_json_object($"jstring", "$.f1"))
           .write.format("hive").saveAsTable("t")
       }.getMessage
-      assert(e.contains(expectedMsg))
+      assert(e.contains(expectedMsg()))
     }
 
     withTempView("tempView") {
@@ -2001,7 +2004,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         val e = intercept[AnalysisException] {
           sql("CREATE TABLE t AS SELECT key, get_json_object(jstring, '$.f1') FROM tempView")
         }.getMessage
-        assert(e.contains(expectedMsg))
+        assert(e.contains(expectedMsg(Some("tempview"))))
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added a qualifier for column names in pivot aggregations. #16565 wrongly droped a qualifier for aggregated column names (then, it changed the existing behaviour).
```
// Spark-v2.1
scala> Seq((1, 2)).toDF("id", "v1").createOrReplaceTempView("s")
scala> Seq((1, 2)).toDF("id", "v2").createOrReplaceTempView("t")
scala> val df1 = sql("SELECT * FROM s")
scala> val df2 = sql("SELECT * FROM t")
scala> df1.join(df2, "id" :: Nil).groupBy("id").pivot("id").max("v1", "v2").show
+---+-------------+-------------+                                               
| id|1_max(s.`v1`)|1_max(t.`v2`)|
+---+-------------+-------------+
|  1|            2|            2|
+---+-------------+-------------+

// Master
scala> df1.join(df2, "id" :: Nil).groupBy("id").pivot("id").max("v1", "v2").show
+---+---------+---------+                                                       
| id|1_max(v1)|1_max(v2)|
+---+---------+---------+
|  1|        2|        2|
+---+---------+---------+

// Master with this pr
scala> df1.join(df2, "id" :: Nil).groupBy("id").pivot("id").max("v1", "v2").show
+---+-----------+-----------+                                                       
| id|1_max(s.v1)|1_max(t.v2)|
+---+-----------+-----------+
|  1|          2|          2|
+---+-----------+-----------+
```

## How was this patch tested?
Added tests in `DataFramePivotSuite`.