### PR TITLE
[SPARK-21098] Set lineseparator csv multiline and csv write to \n

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -90,6 +90,7 @@ class CSVOptions(
   val quote = getChar("quote", '\"')
   val escape = getChar("escape", '\\')
   val comment = getChar("comment", '\u0000')
+  val lineSeparator = "\n"
 
   val headerFlag = getBool("header")
   val inferSchemaFlag = getBool("inferSchema")
@@ -149,6 +150,7 @@ class CSVOptions(
     format.setQuote(quote)
     format.setQuoteEscape(escape)
     format.setComment(comment)
+    format.setLineSeparator(lineSeparator)
     writerSettings.setIgnoreLeadingWhitespaces(ignoreLeadingWhiteSpaceFlagInWrite)
     writerSettings.setIgnoreTrailingWhitespaces(ignoreTrailingWhiteSpaceFlagInWrite)
     writerSettings.setNullValue(nullValue)
@@ -166,6 +168,7 @@ class CSVOptions(
     format.setQuote(quote)
     format.setQuoteEscape(escape)
     format.setComment(comment)
+    format.setLineSeparator(lineSeparator)
     settings.setIgnoreLeadingWhitespaces(ignoreLeadingWhiteSpaceInRead)
     settings.setIgnoreTrailingWhitespaces(ignoreTrailingWhiteSpaceInRead)
     settings.setReadInputOnSeparateThread(false)


### PR DESCRIPTION
This commit sets the lineseparator for reading a multiline csv file
or writing a csv file. We cannot make this configurable for reading
as it depends on LineReader from Hadoop, which has a hardcoded
\n as line ending.

## What changes were proposed in this pull request?

The Univocity-parser library uses the system line ending character as the default line ending character. Rather than remain dependent on the setting in this lib, we could set the default to \n. We cannot make this configurable for reading as it depends on LineReader from Hadoop, which has a hardcoded \n as line ending.

## How was this patch tested?

Existing tests all pass.