### PR TITLE
[SPARK-21029][SS] All StreamingQuery should be stopped when the SparkSession is stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
+++ b/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
@@ -165,7 +165,7 @@ private[spark] object ShutdownHookManager extends Logging {
 
 }
 
-private [util] class SparkShutdownHookManager {
+private [spark] class SparkShutdownHookManager {
 
   private val hooks = new PriorityQueue[SparkShutdownHook]()
   @volatile private var shuttingDown = false

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -690,6 +690,7 @@ class SparkSession private(
    * @since 2.0.0
    */
   def stop(): Unit = {
+    streams.stopAllQueries()
     sparkContext.stop()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -690,7 +690,6 @@ class SparkSession private(
    * @since 2.0.0
    */
   def stop(): Unit = {
-    streams.stopAllQueries()
     sparkContext.stop()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -696,6 +696,7 @@ class StreamExecution(
    * batch. This method blocks until the thread stops running.
    */
   override def stop(): Unit = {
+    logInfo(s"Stopping query $prettyIdString")
     // Set the state to TERMINATED so that the batching thread knows that it was interrupted
     // intentionally
     state.set(TERMINATED)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
 
@@ -326,7 +327,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
       try {
         query.stop()
       } catch {
-        case e: Throwable =>
+        case NonFatal(e) =>
           logError(s"Exception while stopping query ${query.id}", e)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorRef
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.{Clock, ShutdownHookManager, SystemClock, Utils}
+import org.apache.spark.util.{Clock, SystemClock, Utils}
 
 /**
  * A class to manage all the [[StreamingQuery]] active in a `SparkSession`.
@@ -52,8 +52,6 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
 
   @GuardedBy("awaitTerminationLock")
   private var lastTerminatedQuery: StreamingQuery = null
-
-  ShutdownHookManager.addShutdownHook(stopAllQueries _)
 
   /**
    * Returns a list of active queries associated with this SQLContext

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -54,6 +54,8 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
   @GuardedBy("awaitTerminationLock")
   private var lastTerminatedQuery: StreamingQuery = null
 
+  sparkSession.sparkContext.addStopHook(stopAllQueries)
+
   /**
    * Returns a list of active queries associated with this SQLContext
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -239,6 +239,15 @@ class StreamingQueryManagerSuite extends StreamTest with BeforeAndAfter {
     }
   }
 
+  test("stopAllQueries") {
+    val datasets = Seq.fill(5)(makeDataset._2)
+    withQueriesOn(datasets: _*) { queries =>
+      assert(queries.forall(_.isActive))
+      spark.sessionState.streamingQueryManager.stopAllQueries()
+      assert(queries.forall(_.isActive == false), "Queries are still running")
+    }
+  }
+
   /** Run a body of code by defining a query on each dataset */
   private def withQueriesOn(datasets: Dataset[_]*)(body: Seq[StreamingQuery] => Unit): Unit = {
     failAfter(streamingTimeout) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -250,21 +250,15 @@ class StreamingQueryManagerSuite extends StreamTest with BeforeAndAfter {
     val inputData = MemoryStream[Int]
     val mapped = inputData.toDS.map(6 / _)
     var query: StreamingQuery = null
-    try {
-      query = mapped.toDF.writeStream
-        .format("memory")
-        .queryName(s"queryInNewSession")
-        .outputMode("append")
-        .start()
-      assert(query.isActive)
-      spark.stop()
-      assert(spark.sparkContext.isStopped)
-      assert(query.isActive == false, "Query is still running")
-    } catch {
-      case NonFatal(e) =>
-        if (query != null) query.stop()
-        throw e
-    }
+    query = mapped.toDF.writeStream
+      .format("memory")
+      .queryName(s"queryInNewSession")
+      .outputMode("append")
+      .start()
+    assert(query.isActive)
+    spark.stop()
+    assert(spark.sparkContext.isStopped)
+    assert(query.isActive == false, "Query is still running")
     // set spark session back up
     super.afterAll()
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -28,11 +28,10 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.SparkException
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.streaming.util.BlockingSource
-import org.apache.spark.sql.test.TestSparkSession
 import org.apache.spark.util.Utils
 
 class StreamingQueryManagerSuite extends StreamTest with BeforeAndAfter {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds method to `StreamingQueryManager` that stops all active queries. Calls this method when `SparkSession.stop` is called.

## How was this patch tested?

Two unit tests.