### PR TITLE
[SPARK-21099][Spark Core] INFO Log Message Using Incorrect Executor I…

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -432,8 +432,8 @@ private[spark] class ExecutorAllocationManager(
     if (testing || executorsRemoved.nonEmpty) {
       executorsRemoved.foreach { removedExecutorId =>
         newExecutorTotal -= 1
-        val hasCachedBlocks = SparkEnv.get.blockManager.master.hasCachedBlocks(executorId);
-        val timeout = if (hasCachedBlocks) cachedExecutorIdleTimeoutS else executorIdleTimeoutS;
+        val hasCachedBlocks = SparkEnv.get.blockManager.master.hasCachedBlocks(removedExecutorId)
+        val timeout = if (hasCachedBlocks) cachedExecutorIdleTimeoutS else executorIdleTimeoutS
         logInfo(s"Removing executor $removedExecutorId because it has been idle for " +
           s"$timeout seconds (new desired total will be $newExecutorTotal)")
         executorsPendingToRemove.add(removedExecutorId)

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -432,8 +432,10 @@ private[spark] class ExecutorAllocationManager(
     if (testing || executorsRemoved.nonEmpty) {
       executorsRemoved.foreach { removedExecutorId =>
         newExecutorTotal -= 1
+        val hasCachedBlocks = SparkEnv.get.blockManager.master.hasCachedBlocks(executorId);
+        val timeout = if (hasCachedBlocks) cachedExecutorIdleTimeoutS else executorIdleTimeoutS;
         logInfo(s"Removing executor $removedExecutorId because it has been idle for " +
-          s"$executorIdleTimeoutS seconds (new desired total will be $newExecutorTotal)")
+          s"$timeout seconds (new desired total will be $newExecutorTotal)")
         executorsPendingToRemove.add(removedExecutorId)
       }
       executorsRemoved

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -435,7 +435,7 @@ private[spark] class ExecutorAllocationManager(
         val hasCachedBlocks = SparkEnv.get.blockManager.master.hasCachedBlocks(removedExecutorId)
         val timeout = if (hasCachedBlocks) cachedExecutorIdleTimeoutS else executorIdleTimeoutS
         logInfo(s"Removing executor $removedExecutorId because it has been idle for " +
-          s"$timeout seconds (new desired total will be $newExecutorTotal)")
+          s"${if (SparkEnv.get.blockManager.master.hasCachedBlocks(executorId)) cachedExecutorIdleTimeoutS else executorIdleTimeoutS} seconds (new desired total will be $newExecutorTotal)")
         executorsPendingToRemove.add(removedExecutorId)
       }
       executorsRemoved


### PR DESCRIPTION
…dle Timeout Value

## What changes were proposed in this pull request?

Updated the INFO logging method (logInfo) to use $timeout instead, which uses cachedExecutorIdleTimeoutS if the executor has cached blocks

## How was this patch tested?

Testing was done by doing the following:
1. Update spark-defaults.conf to set the following:
executorIdleTimeout=30
cachedExecutorIdleTimeout=20
2. Update log4j.properties to set the following:
shell.log.level=INFO
3. Run the following in spark-shell:
scala> val textFile = sc.textFile("/user/spark/applicationHistory/app_1234")
scala> textFile.cache().count()
4. After 20 secs I see the timeout message for idle cache, and after 30 secs I see the timeout message for executor (executorIdleTimeoutS).

Please review http://spark.apache.org/contributing.html before opening a pull request.
