### PR TITLE
[SPARK-21079] [SQL] Calculate total size of a partition table as a sum of individual partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeTableCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeTableCommand.scala
@@ -86,7 +86,7 @@ object AnalyzeTableCommand extends Logging {
     if (catalogTable.partitionColumnNames.isEmpty) {
       calculateLocationSize(sessionState, catalogTable.identifier, catalogTable.storage.locationUri)
     } else {
-      // Calculate table size as a sum of its partitions. See SPARK-21079
+      // Calculate table size as a sum of the visible partitions. See SPARK-21079
       val partitions = sessionState.catalog.listPartitions(catalogTable.identifier)
       partitions.map(p =>
         calculateLocationSize(sessionState, catalogTable.identifier, p.storage.locationUri)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeTableCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeTableCommand.scala
@@ -108,13 +108,13 @@ object AnalyzeTableCommand extends Logging {
     // countFileSize to count the table size.
     val stagingDir = sessionState.conf.getConfString("hive.exec.stagingdir", ".hive-staging")
 
-    def calculateTableSize(fs: FileSystem, path: Path): Long = {
+    def calculateLocationSize(fs: FileSystem, path: Path): Long = {
       val fileStatus = fs.getFileStatus(path)
       val size = if (fileStatus.isDirectory) {
         fs.listStatus(path)
           .map { status =>
             if (!status.getPath.getName.startsWith(stagingDir)) {
-              calculateTableSize(fs, status.getPath)
+              calculateLocationSize(fs, status.getPath)
             } else {
               0L
             }
@@ -130,7 +130,7 @@ object AnalyzeTableCommand extends Logging {
       val path = new Path(p)
       try {
         val fs = path.getFileSystem(sessionState.newHadoopConf())
-        calculateTableSize(fs, path)
+        calculateLocationSize(fs, path)
       } catch {
         case NonFatal(e) =>
           logWarning(

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -130,12 +130,12 @@ private[sql] trait SQLTestUtils
    * Creates the requested number of temporary path (without creating the actual file/directory),
    * which are then passed to f and will be deleted after f returns.
    *
-   * @param num Number of directories to create
+   * @param numPaths Number of paths to create
    * @param f Function to invoke with the created paths
    */
-  protected def withTempPaths(num: Int)(f: List[File] => Unit) {
+  protected def withTempPaths(numPaths: Int)(f: List[File] => Unit) {
     val paths = mutable.ListBuffer[File]()
-    for (i <- 0 until num) {
+    for (i <- 0 until numPaths) {
       val path = Utils.createTempDir().getCanonicalFile
       path.delete()
       paths += path

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -22,7 +22,6 @@ import java.net.URI
 import java.nio.file.Files
 import java.util.{Locale, UUID}
 
-import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.util.control.NonFatal

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -127,27 +127,6 @@ private[sql] trait SQLTestUtils
   }
 
   /**
-   * Creates the requested number of temporary path (without creating the actual file/directory),
-   * which are then passed to f and will be deleted after f returns.
-   *
-   * @param numPaths Number of paths to create
-   * @param f Function to invoke with the created paths
-   */
-  protected def withTempPaths(numPaths: Int)(f: List[File] => Unit) {
-    val paths = mutable.ListBuffer[File]()
-    for (i <- 0 until numPaths) {
-      val path = Utils.createTempDir().getCanonicalFile
-      path.delete()
-      paths += path
-    }
-    try {
-      f(paths.toList)
-    } finally {
-      paths.foreach(Utils.deleteRecursively)
-    }
-  }
-
-  /**
    * Copy file in jar's resource to a temp file, then pass it to `f`.
    * This function is used to make `f` can use the path of temp file(e.g. file:/), instead of
    * path of jar's resource which starts with 'jar:file:/'

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -135,14 +135,14 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
 
     val tableName = "analyzeTable_part"
     withTable(tableName) {
-      withTempPaths(4) {
+      // Create 4 paths: one to use as table location and one for each of the 3 partitions
+      withTempPaths(numPaths = 4) {
         case tablePath :: partitionPaths =>
           sql(
             s"""
                |CREATE TABLE ${tableName} (key STRING, value STRING) PARTITIONED BY (ds STRING)
                |LOCATION '${tablePath}'
-             """.
-              stripMargin).collect()
+             """.stripMargin).collect()
 
           val partitionDates = List("2010-01-01", "2010-01-02", "2010-01-03")
           partitionDates.zip(partitionPaths).foreach {
@@ -151,14 +151,12 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
                 s"""
                    |ALTER TABLE ${tableName} ADD PARTITION (ds='${ds}')
                    |LOCATION '${path.toString}'
-                """.
-                  stripMargin).collect()
+                """.stripMargin).collect()
               sql(
                 s"""
                    |INSERT INTO TABLE ${tableName} PARTITION (ds='${ds}')
                    |SELECT * FROM src
-                """.
-                  stripMargin).collect()
+                """.stripMargin).collect()
           }
 
           sql(s"ANALYZE TABLE ${tableName} COMPUTE STATISTICS noscan")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Storage URI of a partitioned table may or may not point to a directory under which individual partitions are stored. In fact, individual partitions may be located in totally unrelated directories. Before this change, ANALYZE TABLE table COMPUTE STATISTICS command calculated total size of a table by adding up sizes of files found under table's storage URI. This calculation could produce 0 if partitions are stored elsewhere.

This change uses storage URIs of individual partitions to calculate the sizes of all partitions of a table and adds these up to produce the total size of a table.

CC: @wzhfy

## How was this patch tested?

Added unit test.

Ran ANALYZE TABLE xxx COMPUTE STATISTICS on a partitioned Hive table and verified that sizeInBytes is calculated correctly. Before this change, the size would be zero.