### PR TITLE
[SPARK-21113][CORE] Read ahead input stream to amortize disk IO cost …

### DIFF
--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -14,6 +14,7 @@
 package org.apache.spark.io;
 
 import com.google.common.base.Preconditions;
+import org.apache.spark.storage.StorageUtils;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
@@ -267,5 +268,12 @@ public class ReadAheadInputStream extends InputStream {
     readAheadBuffer.flip();
     long skippedFromInputStream = underlyingInputStream.skip(toSkip);
     return skippedBytes + skippedFromInputStream;
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    executorService.shutdown();
+    StorageUtils.dispose(activeBuffer);
+    StorageUtils.dispose(readAheadBuffer);
   }
 }

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -1,0 +1,258 @@
+package org.apache.spark.io;
+
+import com.google.common.base.Preconditions;
+
+import javax.annotation.concurrent.GuardedBy;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * {@link InputStream} implementation which asynchronously reads ahead from the underlying input
+ * stream when specified amount of data has been read from the current buffer. It does it by maintaining
+ * two buffer - active buffer and read ahead buffer. Active buffer contains data which should be returned
+ * when a read() call is issued. The read ahead buffer is used to asynchronously read from the underlying
+ * input stream and once the current active buffer is exhausted, we flip the two buffers so that we can
+ * start reading from the read ahead buffer without being blocked in disk I/O.
+ */
+public class ReadAheadInputStream extends InputStream {
+
+  private Lock stateChangeLock = new ReentrantLock();
+
+  @GuardedBy("stateChangeLock")
+  private ByteBuffer activeBuffer;
+
+  @GuardedBy("stateChangeLock")
+  private ByteBuffer readAheadBuffer;
+
+  @GuardedBy("stateChangeLock")
+  private boolean endOfStream;
+
+  @GuardedBy("stateChangeLock")
+  // true if async read is in progress
+  private boolean isReadInProgress;
+
+  @GuardedBy("stateChangeLock")
+  // true if read is aborted due to an exception in reading from underlying input stream.
+  private boolean isReadAborted;
+
+  @GuardedBy("stateChangeLock")
+  private Exception readException;
+
+  // If the remaining data size in the current buffer is below this threshold,
+  // we issue an async read from the underlying input stream.
+  private final int readAheadThresholdInBytes;
+
+  private final InputStream underlyingInputStream;
+
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  private final Condition asyncReadComplete = stateChangeLock.newCondition();
+
+  private final byte[] oneByte = new byte[1];
+
+  public ReadAheadInputStream(InputStream inputStream, int bufferSizeInBytes, int readAheadThresholdInBytes) {
+    Preconditions.checkArgument(bufferSizeInBytes > 0, "bufferSizeInBytes should be greater than 0");
+    Preconditions.checkArgument(readAheadThresholdInBytes > 0 && readAheadThresholdInBytes < bufferSizeInBytes,
+                                "readAheadThresholdInBytes should be greater than 0 and less than bufferSizeInBytes" );
+    activeBuffer = ByteBuffer.allocate(bufferSizeInBytes);
+    readAheadBuffer = ByteBuffer.allocate(bufferSizeInBytes);
+    this.readAheadThresholdInBytes = readAheadThresholdInBytes;
+    this.underlyingInputStream = inputStream;
+    activeBuffer.flip();
+    readAheadBuffer.flip();
+  }
+
+  private boolean isEndOfStream() {
+    if(activeBuffer.remaining() == 0 && readAheadBuffer.remaining() == 0 && endOfStream) {
+      return true;
+    }
+    return  false;
+  }
+
+
+  private void readAsync(final ByteBuffer byteBuffer) throws IOException {
+    stateChangeLock.lock();
+    if (endOfStream || isReadInProgress) {
+      stateChangeLock.unlock();
+      return;
+    }
+    byteBuffer.position(0);
+    byteBuffer.flip();
+    isReadInProgress = true;
+    stateChangeLock.unlock();
+    executorService.execute(() -> {
+      byte[] arr;
+      stateChangeLock.lock();
+      arr = byteBuffer.array();
+      stateChangeLock.unlock();
+      // Please note that it is safe to release the lock and read into the read ahead buffer
+      // because either of following two conditions will hold - 1. The active buffer has
+      // data available to read so the reader will not read from the read ahead buffer.
+      // 2. The active buffer is exhausted, in that case the reader waits for this async
+      // read to complete. So there is no race condition in both the situations.
+      int nRead = 0;
+      while (nRead == 0) {
+        try {
+          nRead = underlyingInputStream.read(arr);
+          if (nRead < 0) {
+            // We hit end of the underlying input stream
+            break;
+          }
+        } catch (Exception e) {
+          stateChangeLock.lock();
+          // We hit a read exception, which should be propagated to the reader
+          // in the next read() call.
+          isReadAborted = true;
+          readException = e;
+          stateChangeLock.unlock();
+        }
+      }
+      stateChangeLock.lock();
+      if (nRead < 0) {
+        endOfStream = true;
+      }
+      else {
+        // fill the byte buffer
+        byteBuffer.limit(nRead);
+      }
+      isReadInProgress = false;
+      signalAsyncReadComplete();
+      stateChangeLock.unlock();
+    });
+  }
+
+  private void signalAsyncReadComplete() {
+    stateChangeLock.lock();
+    try {
+      asyncReadComplete.signalAll();
+    } finally {
+      stateChangeLock.unlock();
+    }
+  }
+
+  private void waitForAsyncReadComplete() {
+    stateChangeLock.lock();
+    try {
+      asyncReadComplete.await();
+    } catch (InterruptedException e) {
+    } finally {
+      stateChangeLock.unlock();
+    }
+  }
+
+  @Override
+  public synchronized int read() throws IOException {
+    int val = read(oneByte, 0, 1);
+    if (val == -1) {
+      return -1;
+    }
+    return oneByte[0] & 0xFF;
+  }
+
+  @Override
+  public synchronized int read(byte[] b, int offset, int len) throws IOException {
+    stateChangeLock.lock();
+    try {
+      len = readInternal(b, offset, len);
+    }
+    finally {
+      stateChangeLock.unlock();
+    }
+    return len;
+  }
+
+  /**
+   * Internal read function which should be called only from read() api. The assumption is that
+   * the stateChangeLock is already acquired in the caller before calling this function.
+   */
+  private int readInternal(byte[] b, int offset, int len) throws IOException {
+
+    if (offset < 0 || len < 0 || offset + len < 0 || offset + len > b.length) {
+      throw new IndexOutOfBoundsException();
+    }
+    if (!activeBuffer.hasRemaining() && !isReadInProgress) {
+      // This condition will only be triggered for the first time read is called.
+      readAsync(activeBuffer);
+      waitForAsyncReadComplete();
+    }
+    if (!activeBuffer.hasRemaining() && isReadInProgress) {
+      waitForAsyncReadComplete();
+    }
+
+    if (isReadAborted) {
+      throw new IOException(readException);
+    }
+    if (isEndOfStream()) {
+      return -1;
+    }
+    len = Math.min(len, activeBuffer.remaining());
+    activeBuffer.get(b, offset, len);
+
+    if (activeBuffer.remaining() <= readAheadThresholdInBytes && !readAheadBuffer.hasRemaining()) {
+      readAsync(readAheadBuffer);
+    }
+    if (!activeBuffer.hasRemaining()) {
+      ByteBuffer temp = activeBuffer;
+      activeBuffer = readAheadBuffer;
+      readAheadBuffer = temp;
+    }
+    return len;
+  }
+
+  @Override
+  public synchronized int available() throws IOException {
+    stateChangeLock.lock();
+    int val = activeBuffer.remaining() + readAheadBuffer.remaining();
+    stateChangeLock.unlock();
+    return val;
+  }
+
+  @Override
+  public synchronized long skip(long n) throws IOException {
+    stateChangeLock.lock();
+    long skipped;
+    try {
+      skipped = skipInternal(n);
+    } finally {
+      stateChangeLock.unlock();
+    }
+    return skipped;
+  }
+
+  /**
+   * Internal skip function which should be called only from skip() api. The assumption is that
+   * the stateChangeLock is already acquired in the caller before calling this function.
+   */
+  private long skipInternal(long n) throws IOException {
+    if (n <= 0L) {
+      return 0L;
+    }
+    if (isReadInProgress) {
+      waitForAsyncReadComplete();
+    }
+    if (available() >= n) {
+      // we can skip from the internal buffers
+      int toSkip = (int)n;
+      byte[] temp = new byte[toSkip];
+      while (toSkip > 0) {
+        int skippedBytes = read(temp, 0, toSkip);
+        toSkip -= skippedBytes;
+      }
+      return n;
+    }
+    int skippedBytes = available();
+    long toSkip = n - skippedBytes;
+    activeBuffer.position(0);
+    activeBuffer.flip();
+    readAheadBuffer.position(0);
+    readAheadBuffer.flip();
+    long skippedFromInputStream = underlyingInputStream.skip(toSkip);
+    return skippedBytes + skippedFromInputStream;
+  }
+}

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.io;
 
 import com.google.common.base.Preconditions;

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -14,7 +14,6 @@
 package org.apache.spark.io;
 
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import org.apache.spark.storage.StorageUtils;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -262,7 +261,7 @@ public class ReadAheadInputStream extends InputStream {
     }
     if (available() >= n) {
       // we can skip from the internal buffers
-      int toSkip = Ints.checkedCast(n);
+      int toSkip = (int)n;
       byte[] temp = new byte[toSkip];
       while (toSkip > 0) {
         int skippedBytes = read(temp, 0, toSkip);

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -79,9 +79,11 @@ public class ReadAheadInputStream extends InputStream {
    *                                      threshold, an async read is triggered.
    */
   public ReadAheadInputStream(InputStream inputStream, int bufferSizeInBytes, int readAheadThresholdInBytes) {
-    Preconditions.checkArgument(bufferSizeInBytes > 0, "bufferSizeInBytes should be greater than 0");
-    Preconditions.checkArgument(readAheadThresholdInBytes > 0 && readAheadThresholdInBytes < bufferSizeInBytes,
-                                "readAheadThresholdInBytes should be greater than 0 and less than bufferSizeInBytes" );
+    Preconditions.checkArgument(bufferSizeInBytes > 0,
+            "bufferSizeInBytes should be greater than 0");
+    Preconditions.checkArgument(readAheadThresholdInBytes > 0 &&
+                    readAheadThresholdInBytes < bufferSizeInBytes,
+            "readAheadThresholdInBytes should be greater than 0 and less than bufferSizeInBytes" );
     activeBuffer = ByteBuffer.allocate(bufferSizeInBytes);
     readAheadBuffer = ByteBuffer.allocate(bufferSizeInBytes);
     this.readAheadThresholdInBytes = readAheadThresholdInBytes;
@@ -231,6 +233,8 @@ public class ReadAheadInputStream extends InputStream {
   public synchronized int available() throws IOException {
     stateChangeLock.lock();
     int val = activeBuffer.remaining() + readAheadBuffer.remaining();
+    // Make sure we have no integer overflow.
+    assert (val > 0);
     stateChangeLock.unlock();
     return val;
   }

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -232,9 +232,9 @@ public class ReadAheadInputStream extends InputStream {
   @Override
   public synchronized int available() throws IOException {
     stateChangeLock.lock();
-    int val = activeBuffer.remaining() + readAheadBuffer.remaining();
     // Make sure we have no integer overflow.
-    assert (val > 0);
+    int val = (int) Math.min((long) Integer.MAX_VALUE,
+            (long) activeBuffer.remaining() + readAheadBuffer.remaining());
     stateChangeLock.unlock();
     return val;
   }

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -37,7 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class ReadAheadInputStream extends InputStream {
 
-  private Lock stateChangeLock = new ReentrantLock();
+  private ReentrantLock stateChangeLock = new ReentrantLock();
 
   @GuardedBy("stateChangeLock")
   private ByteBuffer activeBuffer;
@@ -197,6 +196,7 @@ public class ReadAheadInputStream extends InputStream {
    * the stateChangeLock is already acquired in the caller before calling this function.
    */
   private int readInternal(byte[] b, int offset, int len) throws IOException {
+    assert (stateChangeLock.isLocked());
     if (offset < 0 || len < 0 || offset + len < 0 || offset + len > b.length) {
       throw new IndexOutOfBoundsException();
     }
@@ -253,6 +253,7 @@ public class ReadAheadInputStream extends InputStream {
    * the stateChangeLock is already acquired in the caller before calling this function.
    */
   private long skipInternal(long n) throws IOException {
+    assert (stateChangeLock.isLocked());
     if (n <= 0L) {
       return 0L;
     }

--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -14,7 +14,10 @@
 package org.apache.spark.io;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import org.apache.spark.util.ThreadUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.EOFException;
@@ -37,6 +40,8 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class ReadAheadInputStream extends InputStream {
 
+  private static final Logger logger = LoggerFactory.getLogger(ReadAheadInputStream.class);
+
   private ReentrantLock stateChangeLock = new ReentrantLock();
 
   @GuardedBy("stateChangeLock")
@@ -57,7 +62,20 @@ public class ReadAheadInputStream extends InputStream {
   private boolean readAborted;
 
   @GuardedBy("stateChangeLock")
-  private Exception readException;
+  private Throwable readException;
+
+  @GuardedBy("stateChangeLock")
+  // whether the close method is called.
+  private boolean isClosed;
+
+  @GuardedBy("stateChangeLock")
+  // true when the close method will close the underlying input stream. This is valid only if
+  // `isClosed` is true.
+  private boolean isUnderlyingInputStreamBeingClosed;
+
+  @GuardedBy("stateChangeLock")
+  // whether there is a read ahead task running,
+  private boolean isReading;
 
   // If the remaining data size in the current buffer is below this threshold,
   // we issue an async read from the underlying input stream.
@@ -75,18 +93,18 @@ public class ReadAheadInputStream extends InputStream {
    * Creates a <code>ReadAheadInputStream</code> with the specified buffer size and read-ahead
    * threshold
    *
-   * @param   inputStream                 The underlying input stream.
-   * @param   bufferSizeInBytes           The buffer size.
-   * @param   readAheadThresholdInBytes   If the active buffer has less data than the read-ahead
-   *                                      threshold, an async read is triggered.
+   * @param inputStream The underlying input stream.
+   * @param bufferSizeInBytes The buffer size.
+   * @param readAheadThresholdInBytes If the active buffer has less data than the read-ahead
+   *                                  threshold, an async read is triggered.
    */
   public ReadAheadInputStream(InputStream inputStream, int bufferSizeInBytes, int readAheadThresholdInBytes) {
     Preconditions.checkArgument(bufferSizeInBytes > 0,
-            "bufferSizeInBytes should be greater than 0, but the value is " + bufferSizeInBytes);
+        "bufferSizeInBytes should be greater than 0, but the value is " + bufferSizeInBytes);
     Preconditions.checkArgument(readAheadThresholdInBytes > 0 &&
-                    readAheadThresholdInBytes < bufferSizeInBytes,
-            "readAheadThresholdInBytes should be greater than 0 and less than bufferSizeInBytes, but the" +
-                    "value is " + readAheadThresholdInBytes );
+            readAheadThresholdInBytes < bufferSizeInBytes,
+        "readAheadThresholdInBytes should be greater than 0 and less than bufferSizeInBytes, but the" +
+            "value is " + readAheadThresholdInBytes);
     activeBuffer = ByteBuffer.allocate(bufferSizeInBytes);
     readAheadBuffer = ByteBuffer.allocate(bufferSizeInBytes);
     this.readAheadThresholdInBytes = readAheadThresholdInBytes;
@@ -99,57 +117,104 @@ public class ReadAheadInputStream extends InputStream {
     return (!activeBuffer.hasRemaining() && !readAheadBuffer.hasRemaining() && endOfStream);
   }
 
-  private void readAsync(final ByteBuffer byteBuffer) throws IOException {
+  private void checkReadException() throws IOException {
+    if (readAborted) {
+      Throwables.propagateIfPossible(readException, IOException.class);
+      throw new IOException(readException);
+    }
+  }
+
+  /** Read data from underlyingInputStream to readAheadBuffer asynchronously. */
+  private void readAsync() throws IOException {
     stateChangeLock.lock();
-    final byte[] arr = byteBuffer.array();
+    final byte[] arr = readAheadBuffer.array();
     try {
       if (endOfStream || readInProgress) {
         return;
       }
-      byteBuffer.position(0);
-      byteBuffer.flip();
+      checkReadException();
+      readAheadBuffer.position(0);
+      readAheadBuffer.flip();
       readInProgress = true;
     } finally {
       stateChangeLock.unlock();
     }
     executorService.execute(new Runnable() {
+
       @Override
       public void run() {
+        stateChangeLock.lock();
+        try {
+          if (isClosed) {
+            readInProgress = false;
+            return;
+          }
+          // Flip this so that the close method will not close the underlying input stream when we
+          // are reading.
+          isReading = true;
+        } finally {
+          stateChangeLock.unlock();
+        }
+
         // Please note that it is safe to release the lock and read into the read ahead buffer
         // because either of following two conditions will hold - 1. The active buffer has
         // data available to read so the reader will not read from the read ahead buffer.
         // 2. This is the first time read is called or the active buffer is exhausted,
         // in that case the reader waits for this async read to complete.
         // So there is no race condition in both the situations.
-        boolean handled = false;
         int read = 0;
-        Exception exception = null;
+        Throwable exception = null;
         try {
           while (true) {
             read = underlyingInputStream.read(arr);
             if (0 != read) break;
           }
-          handled = true;
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
           exception = ex;
+          if (ex instanceof Error) {
+            // `readException` may not be reported to the user. Rethrow Error to make sure at least
+            // The user can see Error in UncaughtExceptionHandler.
+            throw (Error) ex;
+          }
         } finally {
           stateChangeLock.lock();
-          if (read < 0 || (exception instanceof EOFException) ) {
+          if (read < 0 || (exception instanceof EOFException)) {
             endOfStream = true;
-          } else if (!handled) {
+          } else if (exception != null) {
             readAborted = true;
-            readException = exception != null ? exception: new Exception("Unknown exception in ReadAheadInputStream");
+            readException = exception;
           } else {
-            byteBuffer.limit(read);
+            readAheadBuffer.limit(read);
           }
           readInProgress = false;
           signalAsyncReadComplete();
           stateChangeLock.unlock();
+          closeUnderlyingInputStreamIfNecessary();
         }
       }
     });
   }
 
+  private void closeUnderlyingInputStreamIfNecessary() {
+    boolean needToCloseUnderlyingInputStream = false;
+    stateChangeLock.lock();
+    try {
+      isReading = false;
+      if (isClosed && !isUnderlyingInputStreamBeingClosed) {
+        // close method cannot close underlyingInputStream because we were reading.
+        needToCloseUnderlyingInputStream = true;
+      }
+    } finally {
+      stateChangeLock.unlock();
+    }
+    if (needToCloseUnderlyingInputStream) {
+      try {
+        underlyingInputStream.close();
+      } catch (IOException e) {
+        logger.warn(e.getMessage(), e);
+      }
+    }
+  }
 
   private void signalAsyncReadComplete() {
     stateChangeLock.lock();
@@ -163,27 +228,28 @@ public class ReadAheadInputStream extends InputStream {
   private void waitForAsyncReadComplete() throws IOException {
     stateChangeLock.lock();
     try {
-      while (readInProgress)
-      asyncReadComplete.await();
+      while (readInProgress) {
+        asyncReadComplete.await();
+      }
     } catch (InterruptedException e) {
-      throw  new InterruptedIOException(e.getMessage());
+      InterruptedIOException iio = new InterruptedIOException(e.getMessage());
+      iio.initCause(e);
+      throw iio;
     } finally {
       stateChangeLock.unlock();
     }
+    checkReadException();
   }
 
   @Override
   public int read() throws IOException {
-    int val = read(oneByte.get(), 0, 1);
-    if (val == -1) {
-      return -1;
-    }
-    return oneByte.get()[0] & 0xFF;
+    byte[] oneByteArray = oneByte.get();
+    return read(oneByteArray, 0, 1) == -1 ? -1 : oneByteArray[0] & 0xFF;
   }
 
   @Override
   public int read(byte[] b, int offset, int len) throws IOException {
-    if (offset < 0 || len < 0 || offset + len < 0 || offset + len > b.length) {
+    if (offset < 0 || len < 0 || len > b.length - offset) {
       throw new IndexOutOfBoundsException();
     }
     if (len == 0) {
@@ -198,34 +264,41 @@ public class ReadAheadInputStream extends InputStream {
   }
 
   /**
+   * flip the active and read ahead buffer
+   */
+  private void swapBuffers() {
+    ByteBuffer temp = activeBuffer;
+    activeBuffer = readAheadBuffer;
+    readAheadBuffer = temp;
+  }
+
+  /**
    * Internal read function which should be called only from read() api. The assumption is that
    * the stateChangeLock is already acquired in the caller before calling this function.
    */
   private int readInternal(byte[] b, int offset, int len) throws IOException {
     assert (stateChangeLock.isLocked());
     if (!activeBuffer.hasRemaining()) {
-      if (!readInProgress) {
-        // This condition will only be triggered for the first time read is called.
-        readAsync(activeBuffer);
-      }
       waitForAsyncReadComplete();
-    }
-    if (readAborted) {
-      throw new IOException(readException);
-    }
-    if (isEndOfStream()) {
-      return -1;
+      if (readAheadBuffer.hasRemaining()) {
+        swapBuffers();
+      } else {
+        // The first read or activeBuffer is skipped.
+        readAsync();
+        waitForAsyncReadComplete();
+        if (isEndOfStream()) {
+          return -1;
+        }
+        swapBuffers();
+      }
+    } else {
+      checkReadException();
     }
     len = Math.min(len, activeBuffer.remaining());
     activeBuffer.get(b, offset, len);
 
     if (activeBuffer.remaining() <= readAheadThresholdInBytes && !readAheadBuffer.hasRemaining()) {
-      readAsync(readAheadBuffer);
-    }
-    if (!activeBuffer.hasRemaining()) {
-      ByteBuffer temp = activeBuffer;
-      activeBuffer = readAheadBuffer;
-      readAheadBuffer = temp;
+      readAsync();
     }
     return len;
   }
@@ -236,7 +309,7 @@ public class ReadAheadInputStream extends InputStream {
     // Make sure we have no integer overflow.
     try {
       return (int) Math.min((long) Integer.MAX_VALUE,
-              (long) activeBuffer.remaining() + readAheadBuffer.remaining());
+          (long) activeBuffer.remaining() + readAheadBuffer.remaining());
     } finally {
       stateChangeLock.unlock();
     }
@@ -263,15 +336,20 @@ public class ReadAheadInputStream extends InputStream {
    */
   private long skipInternal(long n) throws IOException {
     assert (stateChangeLock.isLocked());
-    if (readInProgress) {
-      waitForAsyncReadComplete();
+    waitForAsyncReadComplete();
+    if (isEndOfStream()) {
+      return 0;
     }
     if (available() >= n) {
       // we can skip from the internal buffers
-      int toSkip = (int)n;
+      int toSkip = (int) n;
       if (toSkip <= activeBuffer.remaining()) {
         // Only skipping from active buffer is sufficient
         activeBuffer.position(toSkip + activeBuffer.position());
+        if (activeBuffer.remaining() <= readAheadThresholdInBytes
+            && !readAheadBuffer.hasRemaining()) {
+          readAsync();
+        }
         return n;
       }
       // We need to skip from both active buffer and read ahead buffer
@@ -279,35 +357,52 @@ public class ReadAheadInputStream extends InputStream {
       activeBuffer.position(0);
       activeBuffer.flip();
       readAheadBuffer.position(toSkip + readAheadBuffer.position());
-      // flip the active and read ahead buffer
-      ByteBuffer temp = activeBuffer;
-      activeBuffer = readAheadBuffer;
-      readAheadBuffer = temp;
-      readAsync(readAheadBuffer);
+      swapBuffers();
+      readAsync();
       return n;
+    } else {
+      int skippedBytes = available();
+      long toSkip = n - skippedBytes;
+      activeBuffer.position(0);
+      activeBuffer.flip();
+      readAheadBuffer.position(0);
+      readAheadBuffer.flip();
+      long skippedFromInputStream = underlyingInputStream.skip(toSkip);
+      readAsync();
+      return skippedBytes + skippedFromInputStream;
     }
-    int skippedBytes = available();
-    long toSkip = n - skippedBytes;
-    activeBuffer.position(0);
-    activeBuffer.flip();
-    readAheadBuffer.position(0);
-    readAheadBuffer.flip();
-    long skippedFromInputStream = underlyingInputStream.skip(toSkip);
-    readAsync(activeBuffer);
-    return skippedBytes + skippedFromInputStream;
   }
 
   @Override
   public void close() throws IOException {
-    executorService.shutdown();
+    boolean isSafeToCloseUnderlyingInputStream = false;
+    stateChangeLock.lock();
     try {
-      executorService.awaitTermination(10, TimeUnit.SECONDS);
-      stateChangeLock.lock();
-      underlyingInputStream.close();
-    } catch (InterruptedException e) {
-      throw new InterruptedIOException(e.getMessage());
+      if (isClosed) {
+        return;
+      }
+      isClosed = true;
+      if (!isReading) {
+        // Nobody is reading, so we can close the underlying input stream in this method.
+        isSafeToCloseUnderlyingInputStream = true;
+        // Flip this to make sure the read ahead task will not close the underlying input stream.
+        isUnderlyingInputStreamBeingClosed = true;
+      }
     } finally {
       stateChangeLock.unlock();
+    }
+
+    try {
+      executorService.shutdownNow();
+      executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      InterruptedIOException iio = new InterruptedIOException(e.getMessage());
+      iio.initCause(e);
+      throw iio;
+    } finally {
+      if (isSafeToCloseUnderlyingInputStream) {
+        underlyingInputStream.close();
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util.collection.unsafe.sort;
 
+import java.io.*;
+
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import org.apache.spark.SparkEnv;
@@ -28,12 +30,6 @@ import org.apache.spark.storage.BlockId;
 import org.apache.spark.unsafe.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Closeable;
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Reads spill files written by {@link UnsafeSorterSpillWriter} (see that class for a description

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -73,7 +73,8 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
     }
 
     final Double readAheadFraction =
-      SparkEnv.get().conf().getDouble("spark.unsafe.sorter.spill.read.ahead.fraction", 0.5);
+        SparkEnv.get() == null ? 0.5 :
+             SparkEnv.get().conf().getDouble("spark.unsafe.sorter.spill.read.ahead.fraction", 0.5);
 
     final InputStream bs =
         new ReadAheadInputStream(

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -72,10 +72,13 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
       bufferSizeBytes = DEFAULT_BUFFER_SIZE_BYTES;
     }
 
+    final Double readAheadFraction =
+      SparkEnv.get().conf().getDouble("spark.unsafe.sorter.spill.read.ahead.fraction", 0.5);
+
     final InputStream bs =
         new ReadAheadInputStream(
             new NioBufferedFileInputStream(file, (int) bufferSizeBytes),
-            (int)bufferSizeBytes, (int)bufferSizeBytes / 2);
+            (int)bufferSizeBytes, (int)(bufferSizeBytes * readAheadFraction));
     try {
       this.in = serializerManager.wrapStream(blockId, bs);
       this.din = new DataInputStream(this.in);

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -77,7 +77,7 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
              SparkEnv.get().conf().getDouble("spark.unsafe.sorter.spill.read.ahead.fraction", 0.5);
 
     final InputStream bs =
-            new NioBufferedFileInputStream(file, (int) bufferSizeBytes);
+        new NioBufferedFileInputStream(file, (int) bufferSizeBytes);
     try {
       this.in = new ReadAheadInputStream(serializerManager.wrapStream(blockId, bs),
               (int)bufferSizeBytes, (int)(bufferSizeBytes * readAheadFraction));

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -77,11 +77,10 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
              SparkEnv.get().conf().getDouble("spark.unsafe.sorter.spill.read.ahead.fraction", 0.5);
 
     final InputStream bs =
-        new ReadAheadInputStream(
-            new NioBufferedFileInputStream(file, (int) bufferSizeBytes),
-            (int)bufferSizeBytes, (int)(bufferSizeBytes * readAheadFraction));
+            new NioBufferedFileInputStream(file, (int) bufferSizeBytes);
     try {
-      this.in = serializerManager.wrapStream(blockId, bs);
+      this.in = new ReadAheadInputStream(serializerManager.wrapStream(blockId, bs),
+              (int)bufferSizeBytes, (int)(bufferSizeBytes * readAheadFraction));
       this.din = new DataInputStream(this.in);
       numRecords = numRecordsRemaining = din.readInt();
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -17,8 +17,6 @@
 
 package org.apache.spark.util.collection.unsafe.sort;
 
-import java.io.*;
-
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import org.apache.spark.SparkEnv;
@@ -30,6 +28,8 @@ import org.apache.spark.storage.BlockId;
 import org.apache.spark.unsafe.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
 
 /**
  * Reads spill files written by {@link UnsafeSorterSpillWriter} (see that class for a description
@@ -72,15 +72,23 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
       bufferSizeBytes = DEFAULT_BUFFER_SIZE_BYTES;
     }
 
-    final Double readAheadFraction =
+    final double readAheadFraction =
         SparkEnv.get() == null ? 0.5 :
              SparkEnv.get().conf().getDouble("spark.unsafe.sorter.spill.read.ahead.fraction", 0.5);
+
+    final boolean readAheadEnabled =
+            SparkEnv.get() == null ? false :
+                    SparkEnv.get().conf().getBoolean("spark.unsafe.sorter.spill.read.ahead.enabled", true);
 
     final InputStream bs =
         new NioBufferedFileInputStream(file, (int) bufferSizeBytes);
     try {
-      this.in = new ReadAheadInputStream(serializerManager.wrapStream(blockId, bs),
-              (int)bufferSizeBytes, (int)(bufferSizeBytes * readAheadFraction));
+      if (readAheadEnabled) {
+        this.in = new ReadAheadInputStream(serializerManager.wrapStream(blockId, bs),
+                (int) bufferSizeBytes, (int) (bufferSizeBytes * readAheadFraction));
+      } else {
+        this.in = serializerManager.wrapStream(blockId, bs);
+      }
       this.din = new DataInputStream(this.in);
       numRecords = numRecordsRemaining = din.readInt();
     } catch (IOException e) {

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests functionality of {@link NioBufferedFileInputStream}
  */
-public class GenericFileInputStreamSuite {
+public abstract class GenericFileInputStreamSuite {
 
   private byte[] randomBytes;
 

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -31,11 +31,13 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests functionality of {@link NioBufferedFileInputStream}
  */
-public class NioBufferedFileInputStreamSuite {
+public class GenericFileInputStreamSuite {
 
   private byte[] randomBytes;
 
-  private File inputFile;
+  protected File inputFile;
+
+  protected InputStream inputStream;
 
   @Before
   public void setUp() throws IOException {
@@ -52,7 +54,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testReadOneByte() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile);
     for (int i = 0; i < randomBytes.length; i++) {
       assertEquals(randomBytes[i], (byte) inputStream.read());
     }
@@ -60,7 +61,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testReadMultipleBytes() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile);
     byte[] readBytes = new byte[8 * 1024];
     int i = 0;
     while (i < randomBytes.length) {
@@ -74,7 +74,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testBytesSkipped() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile);
     assertEquals(1024, inputStream.skip(1024));
     for (int i = 1024; i < randomBytes.length; i++) {
       assertEquals(randomBytes[i], (byte) inputStream.read());
@@ -83,7 +82,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testBytesSkippedAfterRead() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile);
     for (int i = 0; i < 1024; i++) {
       assertEquals(randomBytes[i], (byte) inputStream.read());
     }
@@ -95,7 +93,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testNegativeBytesSkippedAfterRead() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile);
     for (int i = 0; i < 1024; i++) {
       assertEquals(randomBytes[i], (byte) inputStream.read());
     }
@@ -111,7 +108,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testSkipFromFileChannel() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile, 10);
     // Since the buffer is smaller than the skipped bytes, this will guarantee
     // we skip from underlying file channel.
     assertEquals(1024, inputStream.skip(1024));
@@ -128,7 +124,6 @@ public class NioBufferedFileInputStreamSuite {
 
   @Test
   public void testBytesSkippedAfterEOF() throws IOException {
-    InputStream inputStream = new NioBufferedFileInputStream(inputFile);
     assertEquals(randomBytes.length, inputStream.skip(randomBytes.length + 1));
     assertEquals(-1, inputStream.read());
   }

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -52,7 +52,6 @@ public abstract class GenericFileInputStreamSuite {
     inputFile.delete();
   }
 
-
   @Test
   public void testReadOneByte() throws IOException {
     for (int i = 0; i < randomBytes.length; i++) {

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -52,6 +52,8 @@ public abstract class GenericFileInputStreamSuite {
     inputFile.delete();
   }
 
+
+
   @Test
   public void testReadOneByte() throws IOException {
     for (int i = 0; i < randomBytes.length; i++) {

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -53,7 +53,6 @@ public abstract class GenericFileInputStreamSuite {
   }
 
 
-
   @Test
   public void testReadOneByte() throws IOException {
     for (int i = 0; i < randomBytes.length; i++) {

--- a/core/src/test/java/org/apache/spark/io/NioBufferedInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/NioBufferedInputStreamSuite.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.io;
+
+import org.junit.Before;
+
+import java.io.IOException;
+
+/**
+ * Tests functionality of {@link NioBufferedFileInputStream}
+ */
+public class NioBufferedInputStreamSuite extends GenericFileInputStreamSuite {
+
+  @Before
+  public void setUp() throws IOException {
+    super.setUp();
+    inputStream = new NioBufferedFileInputStream(inputFile);
+  }
+}

--- a/core/src/test/java/org/apache/spark/io/ReadAheadInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/ReadAheadInputStreamSuite.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.io;
+
+import org.junit.Before;
+
+import java.io.IOException;
+
+/**
+ * Tests functionality of {@link NioBufferedFileInputStream}
+ */
+public class ReadAheadInputStreamSuite extends GenericFileInputStreamSuite {
+
+  @Before
+  public void setUp() throws IOException {
+    super.setUp();
+    inputStream = new ReadAheadInputStream(new NioBufferedFileInputStream(inputFile), 8 * 1024, 4 * 1024);
+  }
+}


### PR DESCRIPTION
Profiling some of our big jobs, we see that around 30% of the time is being spent in reading the spill files from disk. In order to amortize the disk IO cost, the idea is to implement a read ahead input stream which asynchronously reads ahead from the underlying input stream when specified amount of data has been read from the current buffer. It does it by maintaining two buffer - active buffer and read ahead buffer. The active buffer contains data which should be returned when a read() call is issued. The read-ahead buffer is used to asynchronously read from the underlying input stream and once the active buffer is exhausted, we flip the two buffers so that we can start reading from the read ahead buffer without being blocked in disk I/O.

## How was this patch tested?

Tested by running a job on the cluster and could see up to 8% CPU improvement. 
