### PR TITLE
[SPARK-21093][R] Terminate R's worker processes in the parent of R's daemon to prevent a leak

### DIFF
--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -75,7 +75,7 @@ while (TRUE) {
       }
     })
   } else if (is.null(children)) {
-    # If it is NULL, there are no such children. Waits indefinitely for a socket connecion.
+    # If it is NULL, there are no children. Waits indefinitely for a socket connecion.
     selectTimeout <- NULL
   }
 

--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -95,7 +95,7 @@ while (TRUE) {
       Sys.setenv(SPARKR_WORKER_PORT = port)
       try(source(script))
       # Note that this mcexit does not fully terminate this child. So, this writes back
-      # a custom data, -1, so that the parent can read and terminate this child.
+      # a custom exit code so that the parent can read and terminate this child.
       parallel:::mcexit(0L, send = exitCode)
     } else {
       # Forking succeeded and we need to check if they finished their jobs every second.

--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -75,7 +75,7 @@ while (TRUE) {
       }
     })
   } else if (is.null(children)) {
-    # If it is NULL, there are no such workers. Waits indefinitely for a socket connecion.
+    # If it is NULL, there are no such children. Waits indefinitely for a socket connecion.
     selectTimeout <- NULL
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`mcfork` in R looks opening a pipe ahead but the existing logic does not properly close it when it is executed hot. This leads to the failure of more forking due to the limit for number of files open.

This hot execution looks particularly for `gapply`/`gapplyCollect`. For unknown reason, this happens more easily in CentOS and could be reproduced in Mac too.

All the details are described in https://issues.apache.org/jira/browse/SPARK-21093

This PR proposes simply to terminate R's worker processes in the parent of R's daemon to prevent a leak.

## How was this patch tested?

I ran the codes below on both CentOS and Mac with that configuration disabled/enabled.

```r
df <- createDataFrame(list(list(1L, 1, "1", 0.1)), c("a", "b", "c", "d"))
collect(gapply(df, "a", function(key, x) { x }, schema(df)))
collect(gapply(df, "a", function(key, x) { x }, schema(df)))
...  # 30 times
```

Also, now it passes R tests on CentOS as below:

```
SparkSQL functions: Spark package found in SPARK_HOME: .../spark
..............................................................................................................................................................
..............................................................................................................................................................
..............................................................................................................................................................
..............................................................................................................................................................
..............................................................................................................................................................
....................................................................................................................................
```
