### PR TITLE
[SPARK-21045][PYSPARK]Fixed executor blocked because traceback.format_exc throw UnicodeDecodeError

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -36,6 +36,9 @@ from pyspark import shuffle
 pickleSer = PickleSerializer()
 utf8_deserializer = UTF8Deserializer()
 
+if sys.version >= '3':
+    unicode = str
+
 
 def report_times(outfile, boot, init, finish):
     write_int(SpecialLengths.TIMING_DATA, outfile)
@@ -177,8 +180,11 @@ def main(infile, outfile):
             process()
     except Exception:
         try:
+            exc_info = traceback.format_exc()
+            if isinstance(exc_info, unicode):
+                exc_info = exc_info.encode('utf-8')
             write_int(SpecialLengths.PYTHON_EXCEPTION_THROWN, outfile)
-            write_with_length(traceback.format_exc().encode("utf-8"), outfile)
+            write_with_length(exc_info, outfile)
         except IOError:
             # JVM close the socket
             pass


### PR DESCRIPTION
## What changes were proposed in this pull request?

check if traceback.format_exc() is unicode then encode utf8.

## How was this patch tested?

We can run in pyspark:
```python
def f():
    raise Exception("中")
spark = SparkSession.builder.master('local').getOrCreate()
spark.sparkContext.parallelize([1]).map(lambda x: f()).count()
```

Before fixed this bug, this program will be blocked.
After fixed this bug, this program will throw exception expected.

And I have added the test to pyspark.tests.