### PR TITLE
[SPARK-19909][SS] Disabling the usage of a temporary directory for the checkpoint location if the temporary directory is on a filesystem different from the default one.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.streaming
 
-import java.net.URI
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -30,7 +29,7 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.streaming.{ForeachSink, MemoryPlan, MemorySink}
-
+import org.apache.spark.util.Utils
 
 /**
  * Interface used to write a streaming `Dataset` to external storage systems (e.g. file systems,
@@ -241,7 +240,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
 
     val hadoopConf = df.sparkSession.sessionState.newHadoopConf()
     val defaultFS = FileSystem.getDefaultUri(hadoopConf).getScheme
-    val tmpFS = new URI(System.getProperty("java.io.tmpdir")).getScheme
+    val tmpFS = Utils.resolveURI(System.getProperty("java.io.tmpdir")).getScheme
 
     val isTempCheckpointLocationAvailable = tmpFS match {
       case null | "file" =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql.streaming
 import java.net.URI
 import java.util.Locale
 
-import org.apache.hadoop.fs.FileSystem
 import scala.collection.JavaConverters._
+
+import org.apache.hadoop.fs.FileSystem
 
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.sql.{AnalysisException, Dataset, ForeachWriter}
@@ -29,6 +30,7 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.streaming.{ForeachSink, MemoryPlan, MemorySink}
+
 
 /**
  * Interface used to write a streaming `Dataset` to external storage systems (e.g. file systems,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -568,7 +568,7 @@ class StreamSuite extends StreamTest {
         streamingQuery = input.toDF().writeStream.format("console").start()
       )
     } finally {
-      if (streamingQuery ne null) {
+      if (streamingQuery != null) {
         streamingQuery.stop()
       }
       // Restore previous state


### PR DESCRIPTION
## What changes were proposed in this pull request?

As stated in [SPARK-19909](https://issues.apache.org/jira/browse/SPARK-19909), if the `checkpointLocation` is not set, for some formats Spark falls back using a directory in the `java.io.tmp` dir to store the metadata. This fails with a weird exception (permission denied) if the default filesystem is different from the temp one. This is the case if the default filesystem is HDFS, for instance, and the temp directory is written on the local filesystem. 

The change proposed in this PR disables the usage of the temp directory in this case. Thus, a meaningful `AnalysisException` is thrown, suggesting the proper fix to the user, i.e. to set a value for `checkpointLocation`, instead of a `PermissionDenied` exception which is hard to understand and fix.

This behavior is consistent with what happens in all the cases in which the `checkpointLocation` needs to be set.

## How was this patch tested?

A unit test was added to check the patch and all the unit tests have been run.
