### PR TITLE
[SPARK-21125][PYTHON] Extend setJobDescription to PySpark and JavaSpark APIs

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -757,6 +757,12 @@ class JavaSparkContext(val sc: SparkContext)
    */
   def getLocalProperty(key: String): String = sc.getLocalProperty(key)
 
+  /**
+   *  Set a human readable description of the current job.
+   *  @since 2.3.0
+   */
+  def setJobDescription(value: String): Unit = sc.setJobDescription(value)
+
   /** Control our logLevel. This overrides any user-defined log settings.
    * @param logLevel The desired log level as a string.
    * Valid log levels include: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -942,6 +942,12 @@ class SparkContext(object):
         """
         return self._jsc.getLocalProperty(key)
 
+    def setJobDescription(self, value):
+        """
+        Set a human readable description of the current job.
+        """
+        self._jsc.setJobDescription(value)
+
     def sparkUser(self):
         """
         Get SPARK_USER for user who is running SparkContext.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extend setJobDescription to PySpark and JavaSpark APIs

SPARK-21125

## How was this patch tested?

Testing was done by running a local Spark shell on the built UI. I originally had added a unit test but the PySpark context cannot easily access the Scala Spark Context's private variable with the Job Description key so I omitted the test, due to the simplicity of this addition.

Also ran the existing tests.

# Misc

This contribution is my original work and that I license the work to the project under the project's open source license.