### PR TITLE
[SPARK-21126] The configuration which named "spark.core.connection.auth.wait.timeout" hasn't been used in spark

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1775,14 +1775,6 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.core.connection.auth.wait.timeout</code></td>
-  <td>30s</td>
-  <td>
-    How long for the connection to wait for authentication to occur before timing
-    out and giving up.
-  </td>
-</tr>
-<tr>
   <td><code>spark.modify.acls</code></td>
   <td>Empty</td>
   <td>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21126](https://issues.apache.org/jira/browse/SPARK-21126)
The configuration which named "spark.core.connection.auth.wait.timeout" hasn't been used in spark,so I think it should be removed from configuration.md.