### PR TITLE
[SPARK-21094][PYTHON] Add popen_kwargs to launch_gateway

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -42,7 +42,7 @@ def launch_gateway(conf=None, popen_kwargs=None):
     launch jvm gateway
     :param conf: spark configuration passed to spark-submit
     :param popen_kwargs: Dictionary of kwargs to pass to Popen when spawning
-        the py4j JVM. This is a developer feature intended for useful in
+        the py4j JVM. This is a developer feature intended for use in
         customizing how pyspark interacts with the py4j JVM (e.g., capturing
         stdout/stderr).
     :return:

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -42,7 +42,9 @@ def launch_gateway(conf=None, popen_kwargs=None):
     launch jvm gateway
     :param conf: spark configuration passed to spark-submit
     :param popen_kwargs: Dictionary of kwargs to pass to Popen when spawning
-        the py4j JVM.
+        the py4j JVM. This is a developer feature intended for useful in
+        customizing how pyspark interacts with the py4j JVM (e.g., capturing
+        stdout/stderr).
     :return:
     """
     if "PYSPARK_GATEWAY_PORT" in os.environ:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow the caller to customize the py4j JVM subprocess pipes and buffers for programmatic capturing of its output.

https://issues.apache.org/jira/browse/SPARK-21094 has more detail about the use case.

## How was this patch tested?

Tested by running the pyspark unit tests locally.