### PR TITLE
[SPARK-21134][SQL] Don't collapse codegen-only expressions with upper CodegenFallback expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -631,3 +631,11 @@ abstract class TernaryExpression extends Expression {
     }
   }
 }
+
+/**
+ * A expression extending this trait can only be evaluated under codegen.
+ */
+trait CodegenOnlyExpression extends Expression {
+  final override def eval(input: InternalRow): Any =
+    throw new UnsupportedOperationException("Only code-generated evaluation is supported.")
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch is going to prevent codegen-only expressions from collapsing into upper `CodegenFallback` expression and cause an exception in runtime.

The rule `CollapseProject` in optimizer collapses lower and upper expressions if they have common expressions.

We have seen a use case that `MapObjects` is used to do some operations on array elements. A custom `CodegenFallback` expression is then used to process those results.

`MapObjects` is a codegen-only expression and it is collapsed with upper `CodegenFallback` expression.

Because all children expressions under `CodegenFallback` will be evaluated with non-codegen path `eval`, it causes an exception in runtime.

## How was this patch tested?

Added test case.
