### PR TITLE
[SPARK-21120][CORE] Increasing the master's metric is conducive to the spark cluster management system monitoring.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -74,7 +74,7 @@ private[deploy] class Master(
   private val completedApps = new ArrayBuffer[ApplicationInfo]
   private var nextAppNumber = 0
 
-  private val drivers = new HashSet[DriverInfo]
+  val drivers = new HashSet[DriverInfo]
   private val completedDrivers = new ArrayBuffer[DriverInfo]
   // Drivers currently spooled for scheduling
   private val waitingDrivers = new ArrayBuffer[DriverInfo]

--- a/core/src/main/scala/org/apache/spark/deploy/master/MasterSource.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/MasterSource.scala
@@ -35,6 +35,21 @@ private[spark] class MasterSource(val master: Master) extends Source {
     override def getValue: Int = master.workers.count(_.state == WorkerState.ALIVE)
   })
 
+  // Gauge for dead worker numbers in cluster
+  metricRegistry.register(MetricRegistry.name("deadWorkers"), new Gauge[Int]{
+    override def getValue: Int = master.workers.count(_.state == WorkerState.DEAD)
+  })
+
+  // Gauge for decommissioned worker numbers in cluster
+  metricRegistry.register(MetricRegistry.name("decommissionedWorkers"), new Gauge[Int]{
+    override def getValue: Int = master.workers.count(_.state == WorkerState.DECOMMISSIONED)
+  })
+
+  // Gauge for unknown worker numbers in cluster
+  metricRegistry.register(MetricRegistry.name("unknownWorkers"), new Gauge[Int]{
+    override def getValue: Int = master.workers.count(_.state == WorkerState.UNKNOWN)
+  })
+
   // Gauge for application numbers in cluster
   metricRegistry.register(MetricRegistry.name("apps"), new Gauge[Int] {
     override def getValue: Int = master.apps.size
@@ -43,5 +58,70 @@ private[spark] class MasterSource(val master: Master) extends Source {
   // Gauge for waiting application numbers in cluster
   metricRegistry.register(MetricRegistry.name("waitingApps"), new Gauge[Int] {
     override def getValue: Int = master.apps.count(_.state == ApplicationState.WAITING)
+  })
+
+  // Gauge for running application numbers in cluster
+  metricRegistry.register(MetricRegistry.name("runningApps"), new Gauge[Int] {
+    override def getValue: Int = master.apps.count(_.state == ApplicationState.RUNNING)
+  })
+
+  // Gauge for finished application numbers in cluster
+  metricRegistry.register(MetricRegistry.name("finishedApps"), new Gauge[Int] {
+    override def getValue: Int = master.apps.count(_.state == ApplicationState.FINISHED)
+  })
+
+  // Gauge for failed application numbers in cluster
+  metricRegistry.register(MetricRegistry.name("failedApps"), new Gauge[Int] {
+    override def getValue: Int = master.apps.count(_.state == ApplicationState.FAILED)
+  })
+
+  // Gauge for killed application numbers in cluster
+  metricRegistry.register(MetricRegistry.name("killedApps"), new Gauge[Int] {
+    override def getValue: Int = master.apps.count(_.state == ApplicationState.KILLED)
+  })
+
+  // Gauge for unknown application numbers in cluster
+  metricRegistry.register(MetricRegistry.name("unknownApps"), new Gauge[Int] {
+    override def getValue: Int = master.apps.count(_.state == ApplicationState.UNKNOWN)
+  })
+
+  // Gauge for submitted driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("submittedDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.SUBMITTED)
+  })
+
+  // Gauge for running driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("runningDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.RUNNING)
+  })
+
+  // Gauge for finished driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("finishedDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.FINISHED)
+  })
+
+  // Gauge for relaunching driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("relaunchingDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.RELAUNCHING)
+  })
+
+  // Gauge for unknown driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("unknownDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.UNKNOWN)
+  })
+
+  // Gauge for killed driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("killedDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.KILLED)
+  })
+
+  // Gauge for failed driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("failedDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.FAILED)
+  })
+
+  // Gauge for error driver numbers in cluster
+  metricRegistry.register(MetricRegistry.name("errorDrivers"), new Gauge[Int] {
+    override def getValue: Int = master.drivers.count(_.state == DriverState.ERROR)
   })
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

The current number of master metric is very small, unable to meet the needs of spark large-scale cluster management system. So I am as much as possible to complete the relevant metric.

fix after master metrics:
![1](https://user-images.githubusercontent.com/26266482/27267724-20eebb10-54dd-11e7-98bc-a1e73b70b4d1.png)



## How was this patch tested?

 manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
