### PR TITLE
[SPARK-9825][yarn] Do not overwrite final Hadoop config entries.

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -721,6 +721,12 @@ private[spark] class Client(
         }
       }
 
+      // Save the YARN configuration into a separate file that will be overlayed on top of the
+      // cluster's Hadoop conf.
+      confStream.putNextEntry(new ZipEntry(SPARK_HADOOP_CONF_FILE))
+      yarnConf.writeXml(confStream)
+      confStream.closeEntry()
+
       // Save Spark configuration to a file in the archive.
       val props = new Properties()
       sparkConf.getAll.foreach { case (k, v) => props.setProperty(k, v) }
@@ -1193,6 +1199,10 @@ private object Client extends Logging {
 
   // Name of the file in the conf archive containing Spark configuration.
   val SPARK_CONF_FILE = "__spark_conf__.properties"
+
+  // Name of the file containing the gateway's Hadoop configuration, to be overlayed on top of the
+  // cluster's Hadoop config.
+  val SPARK_HADOOP_CONF_FILE = "__spark_conf__.xml"
 
   // Subdirectory where the user's python files (not archives) will be placed.
   val LOCALIZED_PYTHON_DIR = "__pyfiles__"

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1202,7 +1202,7 @@ private object Client extends Logging {
 
   // Name of the file containing the gateway's Hadoop configuration, to be overlayed on top of the
   // cluster's Hadoop config.
-  val SPARK_HADOOP_CONF_FILE = "__spark_conf__.xml"
+  val SPARK_HADOOP_CONF_FILE = "__spark_hadoop_conf__.xml"
 
   // Subdirectory where the user's python files (not archives) will be placed.
   val LOCALIZED_PYTHON_DIR = "__pyfiles__"

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -63,18 +63,7 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   // subsystems. Always create a new config, don't reuse yarnConf.
   override def newConfiguration(conf: SparkConf): Configuration = {
     val hadoopConf = new YarnConfiguration(super.newConfiguration(conf))
-
-    // These resources may be distributed by Client.scala when starting the YARN application, and
-    // include any config customizations done at the gateway; overlay them on top of the cluster's
-    // config, so that final entries are not overwritten.
-    //
-    // The list of files used by YarnConfiguration doesn't seem to be available through any API,
-    // but these are the listed files when you dump a fresh YarnConfiguration into XML.
-    val resourceDir = Client.LOCALIZED_HADOOP_CONF_DIR
-    Array("core-site.xml", "hdfs-site.xml", "yarn-site.xml", "mapred-site.xml").foreach { res =>
-      hadoopConf.addResource(s"$resourceDir/$res")
-    }
-
+    hadoopConf.addResource(Client.SPARK_HADOOP_CONF_FILE)
     hadoopConf
   }
 


### PR DESCRIPTION
When localizing the gateway config files in a YARN application, avoid
overwriting final configs by distributing the gateway files to a separate
directory, and explicitly loading them into the Hadoop config, instead
of placing those files before the cluster's files in the classpath.

This is done by saving the gateway's config to a separate XML file
distributed with the rest of the Spark app's config, and loading that
file when creating a new config through `YarnSparkHadoopUtil`.

Tested with existing unit tests, and by verifying the behavior in a YARN
cluster (final values are not overridden, non-final values are).