### PR TITLE
[SPARK-21161][CORE] Make the parseHostPort method tolerate non digital charactors

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -978,7 +978,7 @@ private[spark] object Utils extends Logging {
       return retval
     }
 
-    val retval = (hostPort.substring(0, indx).trim(), hostPort.substring(indx + 1).trim().toInt)
+    val retval = (hostPort.substring(0, indx).trim(), hostPort.substring(indx + 1).replaceAll("[^0-9]", "").toInt)
     hostPortParseResults.putIfAbsent(hostPort, retval)
     hostPortParseResults.get(hostPort)
   }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -262,6 +262,17 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(Utils.splitCommandString("\"\"") === Seq(""))
   }
 
+  test("parseHostPort") {
+    // No port
+    assert(Utils.parseHostPort("spark.apache.org") === ("spark.apache.org", 0))
+
+    // With port
+    assert(Utils.parseHostPort("spark.apache.org:8080") === ("spark.apache.org", 8080))
+
+    // Port with non digital charactors
+    assert(Utils.parseHostPort("server1:8983_solr") === ("server1", 8983))
+  }
+
   test("string formatting of time durations") {
     val second = 1000
     val minute = second * 60


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following port parse bug when querying Solr data.

```
17/06/21 12:40:53 INFO ContextLauncher: 17/06/21 12:40:53 ERROR scheduler.DAGSchedulerEventProcessLoop: DAGSchedulerEventProcessLoop failed; shutting down SparkContext
17/06/21 12:40:53 INFO ContextLauncher: java.lang.NumberFormatException: For input string: “8983_solr”
17/06/21 12:40:53 INFO ContextLauncher: 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
17/06/21 12:40:53 INFO ContextLauncher: 	at java.lang.Integer.parseInt(Integer.java:580)
17/06/21 12:40:53 INFO ContextLauncher: 	at java.lang.Integer.parseInt(Integer.java:615)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:272)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.StringOps.toInt(StringOps.scala:29)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.util.Utils$.parseHostPort(Utils.scala:959)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.cluster.YarnScheduler.getRackForHost(YarnScheduler.scala:36)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager$$anonfun$org$apache$spark$scheduler$TaskSetManager$$addPendingTask$1.apply(TaskSetManager.scala:200)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager$$anonfun$org$apache$spark$scheduler$TaskSetManager$$addPendingTask$1.apply(TaskSetManager.scala:181)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager.org$apache$spark$scheduler$TaskSetManager$$addPendingTask(TaskSetManager.scala:181)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager$$anonfun$1.apply$mcVI$sp(TaskSetManager.scala:160)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager.<init>(TaskSetManager.scala:159)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSchedulerImpl.createTaskSetManager(TaskSchedulerImpl.scala:212)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSchedulerImpl.submitTasks(TaskSchedulerImpl.scala:176)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.submitMissingTasks(DAGScheduler.scala:1043)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitStage(DAGScheduler.scala:918)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler$$anonfun$org$apache$spark$scheduler$DAGScheduler$$submitStage$4.apply(DAGScheduler.scala:921)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler$$anonfun$org$apache$spark$scheduler$DAGScheduler$$submitStage$4.apply(DAGScheduler.scala:920)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.List.foreach(List.scala:381)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitStage(DAGScheduler.scala:920)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.handleJobSubmitted(DAGScheduler.scala:862)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1613)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1605)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1594)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:48)
```

## How was this patch tested?

Unit tests added. Also did integrated test with Solr.
