### PR TITLE
[SPARK-21163][SQL] DataFrame.toPandas should respect the data type

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1731,7 +1731,7 @@ class DataFrame(object):
         pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
 
         for f, t in dtype.items():
-            pdf[f] = pdf[f].astype(t)
+            pdf[f] = pdf[f].astype(t, copy=False)
         return pdf
 
     ##########################################################################################

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1728,7 +1728,8 @@ class DataFrame(object):
             if (pandas_type):
                 dtype[field.name] = pandas_type
 
-        return pd.DataFrame.from_records(self.collect(), columns=self.columns).astype(dtype)
+        df = pd.DataFrame.from_records(self.collect(), columns=self.columns)
+        return df.astype(dtype, copy=False)
 
     ##########################################################################################
     # Pandas compatibility

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1725,11 +1725,14 @@ class DataFrame(object):
         dtype = {}
         for field in self.schema:
             pandas_type = _to_corrected_pandas_type(field.dataType)
-            if (pandas_type):
+            if pandas_type is not None:
                 dtype[field.name] = pandas_type
 
-        df = pd.DataFrame.from_records(self.collect(), columns=self.columns)
-        return df.astype(dtype, copy=False)
+        pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
+
+        for f, t in dtype.items():
+            pdf[f] = pdf[f].astype(t)
+        return pdf
 
     ##########################################################################################
     # Pandas compatibility

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1721,7 +1721,14 @@ class DataFrame(object):
         1    5    Bob
         """
         import pandas as pd
-        return pd.DataFrame.from_records(self.collect(), columns=self.columns)
+
+        dtype = {}
+        for field in self.schema:
+            pandas_type = _to_corrected_pandas_type(field.dataType)
+            if (pandas_type):
+                dtype[field.name] = pandas_type
+
+        return pd.DataFrame.from_records(self.collect(), columns=self.columns).astype(dtype)
 
     ##########################################################################################
     # Pandas compatibility
@@ -1748,6 +1755,24 @@ def _to_scala_map(sc, jm):
     Convert a dict into a JVM Map.
     """
     return sc._jvm.PythonUtils.toScalaMap(jm)
+
+
+def _to_corrected_pandas_type(dt):
+    """
+    When converting Spark SQL records to Pandas DataFrame, the inferred data type may be wrong.
+    This method gets the correted data type for Pandas if that type may be inferred uncorrectly.
+    """
+    import numpy as np
+    if type(dt) == ByteType:
+        return np.int8
+    elif type(dt) == ShortType:
+        return np.int16
+    elif type(dt) == IntegerType:
+        return np.int32
+    elif type(dt) == FloatType:
+        return np.float32
+    else:
+        return None
 
 
 class DataFrameNaFunctions(object):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1764,7 +1764,7 @@ def _to_scala_map(sc, jm):
 def _to_corrected_pandas_type(dt):
     """
     When converting Spark SQL records to Pandas DataFrame, the inferred data type may be wrong.
-    This method gets the correted data type for Pandas if that type may be inferred uncorrectly.
+    This method gets the corrected data type for Pandas if that type may be inferred uncorrectly.
     """
     import numpy as np
     if type(dt) == ByteType:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we convert a spark DataFrame to Pandas Dataframe by `pd.DataFrame.from_records`. It infers the data type from the data and doesn't respect the spark DataFrame Schema. This PR fixes it.

## How was this patch tested?

a new regression test