### PR TITLE
[SPARK-21168][DStreams] Set kafka clientId while fetch messages

### DIFF
--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -187,7 +187,7 @@ class KafkaRDD[
     }
 
     private def fetchBatch: Iterator[MessageAndOffset] = {
-      val req = new FetchRequestBuilder()
+      val req = new FetchRequestBuilder().clientId(kc.config.clientId)
         .addFetch(part.topic, part.partition, requestOffset, kc.config.fetchMessageMaxBytes)
         .build()
       val resp = consumer.fetch(req)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change KafkaRDD to set kafka clientId while fetch messages, as in our case ,we use clientId at kafka server side.

## How was this patch tested?

All tests still passed.
