### PR TITLE
[SPARK-21173] There are several configuration about SSL displayed in  configuration.md but never be used.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1874,20 +1874,6 @@ Apart from these, the following properties are also available, and may be useful
         </td>
     </tr>
     <tr>
-        <td><code>spark.ssl.[namespace].port</code></td>
-        <td>None</td>
-        <td>
-            The port where the SSL service will listen on.
-
-            <br />The port must be defined within a namespace configuration; see
-            <a href="security.html#ssl-configuration">SSL Configuration</a> for the available
-            namespaces.
-
-            <br />When not set, the SSL port will be derived from the non-SSL port for the
-            same service. A value of "0" will make the service bind to an ephemeral port.
-        </td>
-    </tr>
-    <tr>
         <td><code>spark.ssl.enabledAlgorithms</code></td>
         <td>Empty</td>
         <td>
@@ -1921,26 +1907,12 @@ Apart from these, the following properties are also available, and may be useful
         </td>
     </tr>
     <tr>
-        <td><code>spark.ssl.keyStoreType</code></td>
-        <td>JKS</td>
-        <td>
-            The type of the key-store.
-        </td>
-    </tr>
-    <tr>
         <td><code>spark.ssl.protocol</code></td>
         <td>None</td>
         <td>
             A protocol name. The protocol must be supported by JVM. The reference list of protocols
             one can find on <a href="https://blogs.oracle.com/java-platform-group/entry/diagnosing_tls_ssl_and_https">this</a>
             page.
-        </td>
-    </tr>
-    <tr>
-        <td><code>spark.ssl.needClientAuth</code></td>
-        <td>false</td>
-        <td>
-            Set true if SSL needs client authentication.
         </td>
     </tr>
     <tr>
@@ -1956,13 +1928,6 @@ Apart from these, the following properties are also available, and may be useful
         <td>None</td>
         <td>
             A password to the trust-store.
-        </td>
-    </tr>
-    <tr>
-        <td><code>spark.ssl.trustStoreType</code></td>
-        <td>JKS</td>
-        <td>
-            The type of the trust-store.
         </td>
     </tr>
 </table>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21173](https://issues.apache.org/jira/browse/SPARK-21173)
There are several configuration about SSL displayed in configuration.md but never be used and appear at spark's code.So I think it should be removed from configuration.md.