### PR TITLE
[SPARK-21178][ML] Add support for label specific metrics in MulticlassCla…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluator.scala
@@ -110,7 +110,7 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
         case "tpr" => metrics.truePositiveRate(getLabelValue)
         case "fpr" => metrics.falsePositiveRate(getLabelValue)
         case weightedMetric
-          if(MulticlassClassificationEvaluator.weightedOptions.contains(weightedMetric)) =>
+          if (MulticlassClassificationEvaluator.weightedOptions.contains(weightedMetric)) =>
           throw new IllegalArgumentException(
             s"metricName $weightedMetric cannot be specified when label value is set.")
         case _ => throw new IllegalArgumentException(
@@ -132,9 +132,11 @@ class MulticlassClassificationEvaluator @Since("1.5.0") (@Since("1.5.0") overrid
   @Since("1.5.0")
   override def isLargerBetter: Boolean = {
     // Lower False Positive Rate is better for evaluation
-    if(isSet(labelValue) && getMetricName.equals("fpr"))
+    if (isSet(labelValue) && getMetricName.equals("fpr")) {
       false
-    else true
+    } else {
+      true
+    }
   }
 
   @Since("1.5.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluatorSuite.scala
@@ -37,6 +37,15 @@ class MulticlassClassificationEvaluatorSuite
     testDefaultReadWrite(evaluator)
   }
 
+  test("read/write with label Value") {
+    val evaluator = new MulticlassClassificationEvaluator()
+        .setPredictionCol("myPrediction")
+        .setLabelCol("myLabel")
+        .setLabelValue(1)
+        .setMetricName("tpr")
+    testDefaultReadWrite(evaluator)
+  }
+
   test("should support all NumericType labels and not support other types") {
     MLTestingUtils.checkNumericTypes(new MulticlassClassificationEvaluator, spark)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/MulticlassClassificationEvaluatorSuite.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.ml.evaluation
 
+import scala.util.Try
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
-import scala.util.Try
 
 class MulticlassClassificationEvaluatorSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {


### PR DESCRIPTION
…ssificationEvaluator

## What changes were proposed in this pull request?

Added support for providing a label value (optional) in MulticlassClassificationEvaluator 
Added support for following metrics, when a label value is provided - 
f1, precision, recall, true positive rate, false positive rate.
This allows for optimizing on a label specific metric when learning a model.

## How was this patch tested?

Added unit-tests in accordance with the existing tests on MulticlassClassificationEvaluator
Done manual testing to verify it's working correctly.

Please review http://spark.apache.org/contributing.html before opening a pull request.
