### PR TITLE
[SPARK-21189][INFRA] Handle unknown error codes in Jenkins rather then leaving incomplete comment in PRs

### DIFF
--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -137,7 +137,9 @@ def run_tests(tests_timeout):
     if test_result_code == 0:
         test_result_note = ' * This patch passes all tests.'
     else:
-        test_result_note = ' * This patch **fails %s**.' % failure_note_by_errcode[test_result_code]
+        note = failure_note_by_errcode.get(
+            test_result_code, "due to an unknown error code, %s" % test_result_code)
+        test_result_note = ' * This patch **fails %s**.' % note
 
     return [test_result_code, test_result_note]
 

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -114,7 +114,7 @@ def run_tests(tests_timeout):
                                          tests_timeout,
                                          os.path.join(SPARK_HOME, 'dev', 'run-tests')]).wait()
 
-    test_result_code = -9
+    test_result_code = -10
 
     failure_note_by_errcode = {
         1: 'executing the `dev/run-tests` script',  # error to denote run-tests script failures

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -114,8 +114,6 @@ def run_tests(tests_timeout):
                                          tests_timeout,
                                          os.path.join(SPARK_HOME, 'dev', 'run-tests')]).wait()
 
-    test_result_code = -10
-
     failure_note_by_errcode = {
         1: 'executing the `dev/run-tests` script',  # error to denote run-tests script failures
         ERROR_CODES["BLOCK_GENERAL"]: 'some tests',

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -114,6 +114,8 @@ def run_tests(tests_timeout):
                                          tests_timeout,
                                          os.path.join(SPARK_HOME, 'dev', 'run-tests')]).wait()
 
+    test_result_code = -9
+
     failure_note_by_errcode = {
         1: 'executing the `dev/run-tests` script',  # error to denote run-tests script failures
         ERROR_CODES["BLOCK_GENERAL"]: 'some tests',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recently, Jenkins tests were unstable due to unknown reasons as below:

```
 /home/jenkins/workspace/SparkPullRequestBuilder/dev/lint-r ; process was terminated by signal 9
    test_result_code, test_result_note = run_tests(tests_timeout)
  File "./dev/run-tests-jenkins.py", line 140, in run_tests
    test_result_note = ' * This patch **fails %s**.' % failure_note_by_errcode[test_result_code]
KeyError: -9
```

```
Traceback (most recent call last):
  File "./dev/run-tests-jenkins.py", line 226, in <module>
    main()
  File "./dev/run-tests-jenkins.py", line 213, in main
    test_result_code, test_result_note = run_tests(tests_timeout)
  File "./dev/run-tests-jenkins.py", line 140, in run_tests
    test_result_note = ' * This patch **fails %s**.' % failure_note_by_errcode[test_result_code]
KeyError: -10
```

This exception looks causing failing to update the comments in the PR. For example:

![2017-06-23 4 19 41](https://user-images.githubusercontent.com/6477701/27470626-d035ecd8-582f-11e7-883e-0ae6941659b7.png)

![2017-06-23 4 19 50](https://user-images.githubusercontent.com/6477701/27470629-d11ba782-582f-11e7-97e0-64d28cbc19aa.png)

these comment just remain. 

This always requires, for both reviewers and the author, a overhead to click and check the logs, which I believe are not really useful.

This PR proposes to leave the code in the PR comment messages and let update the comments.

## How was this patch tested?

Jenkins tests below, I manually gave the error code to test this.