### PR TITLE
[SPARK-21194][SQL] Fail the putNullmethod when containsNull=false.

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -1079,7 +1079,7 @@ public abstract class ColumnVector implements AutoCloseable {
       } else if (type instanceof BinaryType || type instanceof StringType) {
         childType = DataTypes.ByteType;
         childCapacity *= DEFAULT_ARRAY_LENGTH;
-        this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode, false);
+        this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode, containsNull = false);
       } else {
         childType = DataTypes.ByteType;
         childCapacity *= DEFAULT_ARRAY_LENGTH;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -1076,6 +1076,10 @@ public abstract class ColumnVector implements AutoCloseable {
         childType = ((ArrayType)type).elementType();
         this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode,
           ((ArrayType) type).containsNull());
+      } else if (type instanceof BinaryType || type instanceof StringType) {
+        childType = DataTypes.ByteType;
+        childCapacity *= DEFAULT_ARRAY_LENGTH;
+        this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode, false);
       } else {
         childType = DataTypes.ByteType;
         childCapacity *= DEFAULT_ARRAY_LENGTH;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -69,7 +69,7 @@ public abstract class ColumnVector implements AutoCloseable {
       int capacity,
       DataType type,
       MemoryMode mode,
-      Boolean containsNull) {
+      boolean containsNull) {
     if (mode == MemoryMode.OFF_HEAP) {
       return new OffHeapColumnVector(capacity, type, containsNull);
     } else {
@@ -1062,7 +1062,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * Sets up the common state and also handles creating the child columns if this is a nested
    * type.
    */
-  protected ColumnVector(int capacity, DataType type, MemoryMode memMode, Boolean containsNull) {
+  protected ColumnVector(int capacity, DataType type, MemoryMode memMode, boolean containsNull) {
     this.capacity = capacity;
     this.type = type;
     this.containsNull = containsNull;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -62,10 +62,18 @@ public abstract class ColumnVector implements AutoCloseable {
    * in number of elements, not number of bytes.
    */
   public static ColumnVector allocate(int capacity, DataType type, MemoryMode mode) {
+    return allocate(capacity, type, mode, true);
+  }
+
+  public static ColumnVector allocate(
+      int capacity,
+      DataType type,
+      MemoryMode mode,
+      Boolean containsNull) {
     if (mode == MemoryMode.OFF_HEAP) {
-      return new OffHeapColumnVector(capacity, type);
+      return new OffHeapColumnVector(capacity, type, containsNull);
     } else {
-      return new OnHeapColumnVector(capacity, type);
+      return new OnHeapColumnVector(capacity, type, containsNull);
     }
   }
 
@@ -959,6 +967,11 @@ public abstract class ColumnVector implements AutoCloseable {
   protected final DataType type;
 
   /**
+   * Indicates if values can be `null`.
+   */
+  protected boolean containsNull;
+
+  /**
    * Number of nulls in this column. This is an optimization for the reader, to skip NULL checks.
    */
   protected int numNulls;
@@ -1049,22 +1062,25 @@ public abstract class ColumnVector implements AutoCloseable {
    * Sets up the common state and also handles creating the child columns if this is a nested
    * type.
    */
-  protected ColumnVector(int capacity, DataType type, MemoryMode memMode) {
+  protected ColumnVector(int capacity, DataType type, MemoryMode memMode, Boolean containsNull) {
     this.capacity = capacity;
     this.type = type;
+    this.containsNull = containsNull;
 
     if (type instanceof ArrayType || type instanceof BinaryType || type instanceof StringType
         || DecimalType.isByteArrayDecimalType(type)) {
       DataType childType;
       int childCapacity = capacity;
+      this.childColumns = new ColumnVector[1];
       if (type instanceof ArrayType) {
         childType = ((ArrayType)type).elementType();
+        this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode,
+          ((ArrayType) type).containsNull());
       } else {
         childType = DataTypes.ByteType;
         childCapacity *= DEFAULT_ARRAY_LENGTH;
+        this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode);
       }
-      this.childColumns = new ColumnVector[1];
-      this.childColumns[0] = ColumnVector.allocate(childCapacity, childType, memMode);
       this.resultArray = new Array(this.childColumns[0]);
       this.resultStruct = null;
     } else if (type instanceof StructType) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -40,7 +40,7 @@ public final class OffHeapColumnVector extends ColumnVector {
   private long lengthData;
   private long offsetData;
 
-  protected OffHeapColumnVector(int capacity, DataType type, Boolean containsNull) {
+  protected OffHeapColumnVector(int capacity, DataType type, boolean containsNull) {
     super(capacity, type, MemoryMode.OFF_HEAP, containsNull);
 
     nulls = 0;
@@ -85,7 +85,7 @@ public final class OffHeapColumnVector extends ColumnVector {
 
   @Override
   public void putNull(int rowId) {
-    if(!containsNull) {
+    if (!containsNull) {
       throw new RuntimeException("Not allowed to put null in this column.");
     }
     Platform.putByte(null, nulls + rowId, (byte) 1);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -40,8 +40,8 @@ public final class OffHeapColumnVector extends ColumnVector {
   private long lengthData;
   private long offsetData;
 
-  protected OffHeapColumnVector(int capacity, DataType type) {
-    super(capacity, type, MemoryMode.OFF_HEAP);
+  protected OffHeapColumnVector(int capacity, DataType type, Boolean containsNull) {
+    super(capacity, type, MemoryMode.OFF_HEAP, containsNull);
 
     nulls = 0;
     data = 0;
@@ -85,6 +85,9 @@ public final class OffHeapColumnVector extends ColumnVector {
 
   @Override
   public void putNull(int rowId) {
+    if(!containsNull) {
+      throw new RuntimeException("Not allowed to put null in this column.");
+    }
     Platform.putByte(null, nulls + rowId, (byte) 1);
     ++numNulls;
     anyNullsSet = true;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -95,6 +95,9 @@ public final class OffHeapColumnVector extends ColumnVector {
 
   @Override
   public void putNulls(int rowId, int count) {
+    if (!containsNull) {
+      throw new RuntimeException("Not allowed to put nulls in this column.");
+    }
     long offset = nulls + rowId;
     for (int i = 0; i < count; ++i, ++offset) {
       Platform.putByte(null, offset, (byte) 1);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -51,8 +51,8 @@ public final class OnHeapColumnVector extends ColumnVector {
   private int[] arrayLengths;
   private int[] arrayOffsets;
 
-  protected OnHeapColumnVector(int capacity, DataType type) {
-    super(capacity, type, MemoryMode.ON_HEAP);
+  protected OnHeapColumnVector(int capacity, DataType type, Boolean containsNull) {
+    super(capacity, type, MemoryMode.ON_HEAP, containsNull);
     reserveInternal(capacity);
     reset();
   }
@@ -81,6 +81,9 @@ public final class OnHeapColumnVector extends ColumnVector {
 
   @Override
   public void putNull(int rowId) {
+    if(!containsNull) {
+      throw new RuntimeException("Not allowed to put null in this column.");
+    }
     nulls[rowId] = (byte)1;
     ++numNulls;
     anyNullsSet = true;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -91,6 +91,9 @@ public final class OnHeapColumnVector extends ColumnVector {
 
   @Override
   public void putNulls(int rowId, int count) {
+    if (!containsNull) {
+      throw new RuntimeException("Not allowed to put nulls in this column.");
+    }
     for (int i = 0; i < count; ++i) {
       nulls[rowId + i] = (byte)1;
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -51,7 +51,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   private int[] arrayLengths;
   private int[] arrayOffsets;
 
-  protected OnHeapColumnVector(int capacity, DataType type, Boolean containsNull) {
+  protected OnHeapColumnVector(int capacity, DataType type, boolean containsNull) {
     super(capacity, type, MemoryMode.ON_HEAP, containsNull);
     reserveInternal(capacity);
     reset();
@@ -81,7 +81,7 @@ public final class OnHeapColumnVector extends ColumnVector {
 
   @Override
   public void putNull(int rowId) {
-    if(!containsNull) {
+    if (!containsNull) {
       throw new RuntimeException("Not allowed to put null in this column.");
     }
     nulls[rowId] = (byte)1;

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -758,7 +758,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
     }}
   }
 
-  test("Putting null should fail when null is forbidden in array.") {
+  test("Putting null(s) should fail when null is forbidden in array.") {
     (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode =>
       val column = ColumnVector.allocate(10, new ArrayType(IntegerType, false), memMode)
       val data = column.arrayData();
@@ -766,10 +766,14 @@ class ColumnarBatchSuite extends SparkFunSuite {
       data.putInt(1, 1)
       assert(data.getInt(0) === 0)
       assert(data.getInt(1) === 1)
-      val ex = intercept[RuntimeException] {
+      val ex0 = intercept[RuntimeException] {
         data.putNull(2)
       }
-      assert(ex.getMessage.contains("Not allowed to put null in this column."))
+      assert(ex0.getMessage.contains("Not allowed to put null in this column."))
+      val ex1 = intercept[RuntimeException] {
+        data.putNulls(2, 2)
+      }
+      assert(ex1.getMessage.contains("Not allowed to put nulls in this column."))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -758,6 +758,35 @@ class ColumnarBatchSuite extends SparkFunSuite {
     }}
   }
 
+  test("Putting null should fail when null is forbidden in array.") {
+    (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode =>
+      val column = ColumnVector.allocate(10, new ArrayType(IntegerType, false), memMode)
+      val data = column.arrayData();
+      data.putInt(0, 0)
+      data.putInt(1, 1)
+      assert(data.getInt(0) === 0)
+      assert(data.getInt(1) === 1)
+      val ex = intercept[RuntimeException] {
+        data.putNull(2)
+      }
+      assert(ex.getMessage.contains("Not allowed to put null in this column."))
+    }
+  }
+
+  test("Putting null should fail when null is forbidden in column.")  {
+    (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode =>
+      val column = ColumnVector.allocate(10, IntegerType, memMode, false)
+      column.putInt(0, 0)
+      column.putInt(1, 1)
+      assert(column.getInt(0) === 0)
+      assert(column.getInt(1) === 1)
+      val ex = intercept[RuntimeException] {
+        column.putNull(2)
+      }
+      assert(ex.getMessage.contains("Not allowed to put null in this column."))
+    }
+  }
+
   test("Struct Column") {
     (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode => {
       val schema = new StructType().add("int", IntegerType).add("double", DoubleType)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently there's no check for putting null into a `ArrayType(IntegerType, false)` ;
It's better to fail the `putNull` method in `OffHeapColumnVector` and `OnHeapColumnVector` when `containsNull`=false.

## How was this patch tested?
Added unit test.