### PR TITLE
[SPARK-21169] [core] Make sure to update application status to RUNNING if executors are accepted and RUNNING after recovery

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -566,10 +566,15 @@ private[deploy] class Master(
     // Update application state if executors are accepted and RUNNING
     apps.foreach(appInfo => {
       val app = idToApp(appInfo.id)
-      if(app.executors.filter(_._2.state != ExecutorState.RUNNING).isEmpty) {
-        app.state = ApplicationState.RUNNING
-        logInfo(s"Application :: ${app.id} status updated to RUNNING state")
-      }})
+      apps.foreach(f = appInfo => {
+        val app = idToApp(appInfo.id)
+        if (app.executors.size > 0 &&
+          app.executors.filter(_._2.state != ExecutorState.RUNNING).isEmpty) {
+          app.state = ApplicationState.RUNNING
+          logInfo(s"Application :: ${app.id} status updated to RUNNING state")
+        }
+      })
+    })
 
     state = RecoveryState.ALIVE
     schedule()

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -563,6 +563,14 @@ private[deploy] class Master(
       }
     }
 
+    // Update application state if executors are accepted and RUNNING
+    apps.foreach(appInfo => {
+      val app = idToApp(appInfo.id)
+      if(app.executors.filter(_._2.state != ExecutorState.RUNNING).isEmpty) {
+        app.state = ApplicationState.RUNNING
+        logInfo(s"Application :: ${app.id} status updated to RUNNING state")
+      }})
+
     state = RecoveryState.ALIVE
     schedule()
     logInfo("Recovery complete - resuming operations!")

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -565,16 +565,12 @@ private[deploy] class Master(
 
     // Update application state if executors are accepted and RUNNING
     apps.foreach(appInfo => {
-      val app = idToApp(appInfo.id)
-      apps.foreach(f = appInfo => {
         val app = idToApp(appInfo.id)
-        if (app.executors.size > 0 &&
-          app.executors.filter(_._2.state != ExecutorState.RUNNING).isEmpty) {
+        if (app.executors.nonEmpty && app.executors.forall(_._2.state == ExecutorState.RUNNING)) {
           app.state = ApplicationState.RUNNING
           logInfo(s"Application :: ${app.id} status updated to RUNNING state")
         }
       })
-    })
 
     state = RecoveryState.ALIVE
     schedule()


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Spark-HA, after active master failure, stand-by mater is choosen and workers,applications will be re-registered with new master.
However, application state is not moving from WAITING state to RUNNING state.

This code change checks applications after recovery and if all executors are RUNNING

(Please fill in changes proposed in this fix)

In the method completeRecovery in org.apache.spark.deploy.master.Master class, where cleanup of the workers and applictions is being done,
i have added code change to move the application to RUNNING state, if application has more than 1 executors and all of them are in RUNNING status.

In some cases, executors will be in LOADING status, but we cannot consider those to change application state to RUNNING, as executors in LOADING status might also happen due to resource unavailability.

## How was this patch tested?

To check existing bug.
	1) Created a zookeeper cluster
	2) I have configured spark with recovery mode zookeeper and updated spark-env.sh with recovery mode settings.
	3) Updated spark-defaults in both worker and master with both the masters. spark://<host1>:7077,<host2>:7077 
	4) Started spark master1 and spark master 2 and and workers in the order.
	5) master1 is ACTIVE and master2 showed as STANDBY.
	6) Started a sample streaming application.
	7) Killed the spark-master1, and waited for the workers and applications to appear in master2. They appeared and job showed up in WAITING state.


To check implemented fix:
	1) I have built spark-core  
	2) removed spark-core jar in SPARK_HOME/jars folder and replaced with the newly built one.
	3) Performed the same steps as above, and checked job status
	4) checked spark-master logs to ensure the log message got printed and

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Master 1 UI Before Fix
![master1_ui_before_fix](https://user-images.githubusercontent.com/5573733/27513139-faef55a0-5928-11e7-9ee3-2aa601fe5dc3.png)
Master 2 UI Before Fix
![master2_ui_before_fix](https://user-images.githubusercontent.com/5573733/27513138-faef56ae-5928-11e7-947c-57f5593f7564.png)

Master 2 UI (before fix), which became active after Master is killed. 
(Application can be seen with WAITING status)

![master2_ui_after_master1_is_killed_before_fix](https://user-images.githubusercontent.com/5573733/27513206-2fcb5f2e-592b-11e7-9b63-07cb1141a20e.png)


-------------------

Master 1 UI after fix

![master1_ui_with_fix](https://user-images.githubusercontent.com/5573733/27513136-fae0c9d6-5928-11e7-9a49-553a35014ad8.png)

Mater 2 UI (after fix), after master is killed and Master became active.
(Application can be see with RUNNING state)
![master2_ui_after_recovery_with_fix](https://user-images.githubusercontent.com/5573733/27513135-facff9f8-5928-11e7-9042-03d42b1e9728.png)


he.org/contributing.html before opening a pull request.