### PR TITLE
[SPARK-21217][SQL] Support ColumnVector.Array.to<type>Array()

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -80,14 +80,6 @@ public abstract class ColumnVector implements AutoCloseable {
     public int length;
     public int offset;
 
-    // reused buffer to return a primitive array
-    protected byte[] reuseByteArray;
-    protected short[] reuseShortArray;
-    protected int[] reuseIntArray;
-    protected long[] reuseLongArray;
-    protected float[] reuseFloatArray;
-    protected double[] reuseDoubleArray;
-
     // Populate if binary data is required for the Array. This is stored here as an optimization
     // for string data.
     public byte[] byteArray;
@@ -109,58 +101,25 @@ public abstract class ColumnVector implements AutoCloseable {
     }
 
     @Override
-    public byte[] toByteArray() {
-      if (reuseByteArray == null || reuseByteArray.length != length) {
-        reuseByteArray = new byte[length];
-      }
-      data.getBytes(reuseByteArray, offset, length);
-      return reuseByteArray;
-    }
+    public boolean[] toBooleanArray() { return data.getBooleans(offset, length); }
 
     @Override
-    public short[] toShortArray() {
-      if (reuseShortArray == null || reuseShortArray.length != length) {
-        reuseShortArray = new short[length];
-      }
-      data.getShorts(reuseShortArray, offset, length);
-      return reuseShortArray;
-    }
+    public byte[] toByteArray() { return data.getBytes(offset, length); }
 
     @Override
-    public int[] toIntArray() {
-      if (reuseIntArray == null || reuseIntArray.length != length) {
-        reuseIntArray = new int[length];
-      }
-      data.getInts(reuseIntArray, offset, length);
-      return reuseIntArray;
-    }
+    public short[] toShortArray() { return data.getShorts(offset, length); }
 
     @Override
-    public long[] toLongArray() {
-      if (reuseLongArray == null || reuseLongArray.length != length) {
-        reuseLongArray = new long[length];
-      }
-      data.getLongs(reuseLongArray, offset, length);
-      return reuseLongArray;
-    }
+    public int[] toIntArray() { return data.getInts(offset, length); }
 
     @Override
-    public float[] toFloatArray() {
-      if (reuseFloatArray == null || reuseFloatArray.length != length) {
-        reuseFloatArray = new float[length];
-      }
-      data.getFloats(reuseFloatArray, offset, length);
-      return reuseFloatArray;
-    }
+    public long[] toLongArray() { return data.getLongs(offset, length); }
 
     @Override
-    public double[] toDoubleArray() {
-      if (reuseDoubleArray == null || reuseDoubleArray.length != length) {
-        reuseDoubleArray = new double[length];
-      }
-      data.getDoubles(reuseDoubleArray, offset, length);
-      return reuseDoubleArray;
-    }
+    public float[] toFloatArray() { return data.getFloats(offset, length); }
+
+    @Override
+    public double[] toDoubleArray() { return data.getDoubles(offset, length); }
 
     // TODO: this is extremely expensive.
     @Override
@@ -429,6 +388,11 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract boolean getBoolean(int rowId);
 
   /**
+   * Gets values from [rowId, rowId + count)
+   */
+  public abstract boolean[] getBooleans(int rowId, int count);
+
+  /**
    * Sets the value at rowId to `value`.
    */
   public abstract void putByte(int rowId, byte value);
@@ -449,9 +413,9 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract byte getByte(int rowId);
 
   /**
-   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   * Gets values from [rowId, rowId + count)
    */
-  public abstract void getBytes(byte[] dst, int rowId, int count);
+  public abstract byte[] getBytes(int rowId, int count);
 
   /**
    * Sets the value at rowId to `value`.
@@ -474,9 +438,9 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract short getShort(int rowId);
 
   /**
-   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   * Gets values from [rowId, rowId + count)
    */
-  public abstract void getShorts(short[] dst, int rowId, int count);
+  public abstract short[] getShorts(int rowId, int count);
 
   /**
    * Sets the value at rowId to `value`.
@@ -505,9 +469,9 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract int getInt(int rowId);
 
   /**
-   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   * Gets values from [rowId, rowId + count)
    */
-  public abstract void getInts(int[] dst, int rowId, int count);
+  public abstract int[] getInts(int rowId, int count);
 
   /**
    * Returns the dictionary Id for rowId.
@@ -543,9 +507,9 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract long getLong(int rowId);
 
   /**
-   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   * Gets values from [rowId, rowId + count)
    */
-  public abstract void getLongs(long[] dst, int rowId, int count);
+  public abstract long[] getLongs(int rowId, int count);
 
   /**
    * Sets the value at rowId to `value`.
@@ -574,9 +538,9 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract float getFloat(int rowId);
 
   /**
-   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   * Gets values from [rowId, rowId + count)
    */
-  public abstract void getFloats(float[] dst, int rowId, int count);
+  public abstract float[] getFloats(int rowId, int count);
 
   /**
    * Sets the value at rowId to `value`.
@@ -605,9 +569,9 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract double getDouble(int rowId);
 
   /**
-   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   * Gets values from [rowId, rowId + count)
    */
-  public abstract void getDoubles(double[] dst, int rowId, int count);
+  public abstract double[] getDoubles(int rowId, int count);
 
   /**
    * Puts a byte array that already exists in this column.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -100,6 +100,54 @@ public abstract class ColumnVector implements AutoCloseable {
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    public byte[] toByteArray() {
+      int size = length;
+      byte[] values = new byte[size];
+      data.getBytes(values, offset, size);
+      return values;
+    }
+
+    @Override
+    public short[] toShortArray() {
+      int size = length;
+      short[] values = new short[size];
+      data.getShorts(values, offset, size);
+      return values;
+    }
+
+    @Override
+    public int[] toIntArray() {
+      int size = length;
+      int[] values = new int[size];
+      data.getInts(values, offset, size);
+      return values;
+    }
+
+    @Override
+    public long[] toLongArray() {
+      int size = length;
+      long[] values = new long[size];
+      data.getLongs(values, offset, size);
+      return values;
+    }
+
+    @Override
+    public float[] toFloatArray() {
+      int size = length;
+      float[] values = new float[size];
+      data.getFloats(values, offset, size);
+      return values;
+    }
+
+    @Override
+    public double[] toDoubleArray() {
+      int size = length;
+      double[] values = new double[size];
+      data.getDoubles(values, offset, size);
+      return values;
+    }
+
     // TODO: this is extremely expensive.
     @Override
     public Object[] array() {
@@ -387,6 +435,11 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract byte getByte(int rowId);
 
   /**
+   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   */
+  public abstract void getBytes(byte[] dst, int rowId, int count);
+
+  /**
    * Sets the value at rowId to `value`.
    */
   public abstract void putShort(int rowId, short value);
@@ -405,6 +458,11 @@ public abstract class ColumnVector implements AutoCloseable {
    * Returns the value for rowId.
    */
   public abstract short getShort(int rowId);
+
+  /**
+   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   */
+  public abstract void getShorts(short[] dst, int rowId, int count);
 
   /**
    * Sets the value at rowId to `value`.
@@ -431,6 +489,11 @@ public abstract class ColumnVector implements AutoCloseable {
    * Returns the value for rowId.
    */
   public abstract int getInt(int rowId);
+
+  /**
+   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   */
+  public abstract void getInts(int[] dst, int rowId, int count);
 
   /**
    * Returns the dictionary Id for rowId.
@@ -466,6 +529,11 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract long getLong(int rowId);
 
   /**
+   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   */
+  public abstract void getLongs(long[] dst, int rowId, int count);
+
+  /**
    * Sets the value at rowId to `value`.
    */
   public abstract void putFloat(int rowId, float value);
@@ -492,6 +560,11 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract float getFloat(int rowId);
 
   /**
+   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   */
+  public abstract void getFloats(float[] dst, int rowId, int count);
+
+  /**
    * Sets the value at rowId to `value`.
    */
   public abstract void putDouble(int rowId, double value);
@@ -516,6 +589,11 @@ public abstract class ColumnVector implements AutoCloseable {
    * Returns the value for rowId.
    */
   public abstract double getDouble(int rowId);
+
+  /**
+   * Gets values from [rowId, rowId + count) to [dst, dst + count)
+   */
+  public abstract void getDoubles(double[] dst, int rowId, int count);
 
   /**
    * Puts a byte array that already exists in this column.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -80,6 +80,14 @@ public abstract class ColumnVector implements AutoCloseable {
     public int length;
     public int offset;
 
+    // reused buffer to return a primitive array
+    protected byte[] reuseByteArray;
+    protected short[] reuseShortArray;
+    protected int[] reuseIntArray;
+    protected long[] reuseLongArray;
+    protected float[] reuseFloatArray;
+    protected double[] reuseDoubleArray;
+
     // Populate if binary data is required for the Array. This is stored here as an optimization
     // for string data.
     public byte[] byteArray;
@@ -102,50 +110,56 @@ public abstract class ColumnVector implements AutoCloseable {
 
     @Override
     public byte[] toByteArray() {
-      int size = length;
-      byte[] values = new byte[size];
-      data.getBytes(values, offset, size);
-      return values;
+      if (reuseByteArray == null || reuseByteArray.length != length) {
+        reuseByteArray = new byte[length];
+      }
+      data.getBytes(reuseByteArray, offset, length);
+      return reuseByteArray;
     }
 
     @Override
     public short[] toShortArray() {
-      int size = length;
-      short[] values = new short[size];
-      data.getShorts(values, offset, size);
-      return values;
+      if (reuseShortArray == null || reuseShortArray.length != length) {
+        reuseShortArray = new short[length];
+      }
+      data.getShorts(reuseShortArray, offset, length);
+      return reuseShortArray;
     }
 
     @Override
     public int[] toIntArray() {
-      int size = length;
-      int[] values = new int[size];
-      data.getInts(values, offset, size);
-      return values;
+      if (reuseIntArray == null || reuseIntArray.length != length) {
+        reuseIntArray = new int[length];
+      }
+      data.getInts(reuseIntArray, offset, length);
+      return reuseIntArray;
     }
 
     @Override
     public long[] toLongArray() {
-      int size = length;
-      long[] values = new long[size];
-      data.getLongs(values, offset, size);
-      return values;
+      if (reuseLongArray == null || reuseLongArray.length != length) {
+        reuseLongArray = new long[length];
+      }
+      data.getLongs(reuseLongArray, offset, length);
+      return reuseLongArray;
     }
 
     @Override
     public float[] toFloatArray() {
-      int size = length;
-      float[] values = new float[size];
-      data.getFloats(values, offset, size);
-      return values;
+      if (reuseFloatArray == null || reuseFloatArray.length != length) {
+        reuseFloatArray = new float[length];
+      }
+      data.getFloats(reuseFloatArray, offset, length);
+      return reuseFloatArray;
     }
 
     @Override
     public double[] toDoubleArray() {
-      int size = length;
-      double[] values = new double[size];
-      data.getDoubles(values, offset, size);
-      return values;
+      if (reuseDoubleArray == null || reuseDoubleArray.length != length) {
+        reuseDoubleArray = new double[length];
+      }
+      data.getDoubles(reuseDoubleArray, offset, length);
+      return reuseDoubleArray;
     }
 
     // TODO: this is extremely expensive.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -134,6 +134,16 @@ public final class OffHeapColumnVector extends ColumnVector {
   @Override
   public boolean getBoolean(int rowId) { return Platform.getByte(null, data + rowId) == 1; }
 
+  @Override
+  public boolean[] getBooleans(int rowId, int count) {
+    assert(dictionary == null);
+    boolean[] array = new boolean[count];
+    for (int i = 0; i < count; ++i) {
+      array[i] = (Platform.getByte(null, data + rowId + i) == 1);
+    }
+    return array;
+  }
+
   //
   // APIs dealing with Bytes
   //
@@ -166,9 +176,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getBytes(byte[] dst, int rowId, int count) {
+  public byte[] getBytes(int rowId, int count) {
     assert(dictionary == null);
-    Platform.copyMemory(null, data + rowId, dst, Platform.BYTE_ARRAY_OFFSET, count);
+    byte[] array = new byte[count];
+    Platform.copyMemory(null, data + rowId, array, Platform.BYTE_ARRAY_OFFSET, count);
+    return array;
   }
 
   //
@@ -204,9 +216,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getShorts(short[] dst, int rowId, int count) {
+  public short[] getShorts(int rowId, int count) {
     assert(dictionary == null);
-    Platform.copyMemory(null, data + rowId * 2, dst, Platform.SHORT_ARRAY_OFFSET, count * 2);
+    short[] array = new short[count];
+    Platform.copyMemory(null, data + rowId * 2, array, Platform.SHORT_ARRAY_OFFSET, count * 2);
+    return array;
   }
 
   //
@@ -257,9 +271,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getInts(int[] dst, int rowId, int count) {
+  public int[] getInts(int rowId, int count) {
     assert(dictionary == null);
-    Platform.copyMemory(null, data + rowId * 4, dst, Platform.INT_ARRAY_OFFSET, count * 4);
+    int[] array = new int[count];
+    Platform.copyMemory(null, data + rowId * 4, array, Platform.INT_ARRAY_OFFSET, count * 4);
+    return array;
   }
 
   /**
@@ -321,9 +337,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getLongs(long[] dst, int rowId, int count) {
+  public long[] getLongs(int rowId, int count) {
     assert(dictionary == null);
-    Platform.copyMemory(null, data + rowId * 8, dst, Platform.LONG_ARRAY_OFFSET, count * 8);
+    long[] array = new long[count];
+    Platform.copyMemory(null, data + rowId * 8, array, Platform.LONG_ARRAY_OFFSET, count * 8);
+    return array;
   }
 
   //
@@ -373,8 +391,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getFloats(float[] dst, int rowId, int count) {
-    Platform.copyMemory(null, data + rowId * 4, dst, Platform.FLOAT_ARRAY_OFFSET, count * 4);
+  public float[] getFloats(int rowId, int count) {
+    assert(dictionary == null);
+    float[] array = new float[count];
+    Platform.copyMemory(null, data + rowId * 4, array, Platform.FLOAT_ARRAY_OFFSET, count * 4);
+    return array;
   }
 
 
@@ -425,8 +446,11 @@ public final class OffHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getDoubles(double[] dst, int rowId, int count) {
-    Platform.copyMemory(null, data + rowId * 8, dst, Platform.DOUBLE_ARRAY_OFFSET, count * 8);
+  public double[] getDoubles(int rowId, int count) {
+    assert(dictionary == null);
+    double[] array = new double[count];
+    Platform.copyMemory(null, data + rowId * 8, array, Platform.DOUBLE_ARRAY_OFFSET, count * 8);
+    return array;
   }
 
   //

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -165,6 +165,12 @@ public final class OffHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getBytes(byte[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    Platform.copyMemory(null, data + rowId, dst, Platform.BYTE_ARRAY_OFFSET, count);
+  }
+
   //
   // APIs dealing with shorts
   //
@@ -195,6 +201,12 @@ public final class OffHeapColumnVector extends ColumnVector {
     } else {
       return (short) dictionary.decodeToInt(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getShorts(short[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    Platform.copyMemory(null, data + rowId * 2, dst, Platform.SHORT_ARRAY_OFFSET, count * 2);
   }
 
   //
@@ -242,6 +254,12 @@ public final class OffHeapColumnVector extends ColumnVector {
     } else {
       return dictionary.decodeToInt(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getInts(int[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    Platform.copyMemory(null, data + rowId * 4, dst, Platform.INT_ARRAY_OFFSET, count * 4);
   }
 
   /**
@@ -302,6 +320,12 @@ public final class OffHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getLongs(long[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    Platform.copyMemory(null, data + rowId * 8, dst, Platform.LONG_ARRAY_OFFSET, count * 8);
+  }
+
   //
   // APIs dealing with floats
   //
@@ -346,6 +370,11 @@ public final class OffHeapColumnVector extends ColumnVector {
     } else {
       return dictionary.decodeToFloat(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getFloats(float[] dst, int rowId, int count) {
+    Platform.copyMemory(null, data + rowId * 4, dst, Platform.FLOAT_ARRAY_OFFSET, count * 4);
   }
 
 
@@ -393,6 +422,11 @@ public final class OffHeapColumnVector extends ColumnVector {
     } else {
       return dictionary.decodeToDouble(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getDoubles(double[] dst, int rowId, int count) {
+    Platform.copyMemory(null, data + rowId * 8, dst, Platform.DOUBLE_ARRAY_OFFSET, count * 8);
   }
 
   //

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -201,7 +201,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   @Override
   public void getShorts(short[] dst, int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(byteData, rowId, dst, 0, count);
+    System.arraycopy(shortData, rowId, dst, 0, count);
   }
 
 
@@ -307,7 +307,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   @Override
   public void getLongs(long[] dst, int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(byteData, rowId, dst, 0, count);
+    System.arraycopy(longData, rowId, dst, 0, count);
   }
 
   //
@@ -352,7 +352,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   @Override
   public void getFloats(float[] dst, int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(byteData, rowId, dst, 0, count);
+    System.arraycopy(floatData, rowId, dst, 0, count);
   }
 
   //
@@ -399,7 +399,7 @@ public final class OnHeapColumnVector extends ColumnVector {
   @Override
   public void getDoubles(double[] dst, int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(byteData, rowId, dst, 0, count);
+    System.arraycopy(doubleData, rowId, dst, 0, count);
   }
 
   //

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -162,6 +162,12 @@ public final class OnHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getBytes(byte[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    System.arraycopy(byteData, rowId, dst, 0, count);
+  }
+
   //
   // APIs dealing with Shorts
   //
@@ -190,6 +196,12 @@ public final class OnHeapColumnVector extends ColumnVector {
     } else {
       return (short) dictionary.decodeToInt(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getShorts(short[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    System.arraycopy(byteData, rowId, dst, 0, count);
   }
 
 
@@ -232,6 +244,12 @@ public final class OnHeapColumnVector extends ColumnVector {
     } else {
       return dictionary.decodeToInt(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getInts(int[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    System.arraycopy(intData, rowId, dst, 0, count);
   }
 
   /**
@@ -286,6 +304,12 @@ public final class OnHeapColumnVector extends ColumnVector {
     }
   }
 
+  @Override
+  public void getLongs(long[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    System.arraycopy(byteData, rowId, dst, 0, count);
+  }
+
   //
   // APIs dealing with floats
   //
@@ -323,6 +347,12 @@ public final class OnHeapColumnVector extends ColumnVector {
     } else {
       return dictionary.decodeToFloat(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getFloats(float[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    System.arraycopy(byteData, rowId, dst, 0, count);
   }
 
   //
@@ -364,6 +394,12 @@ public final class OnHeapColumnVector extends ColumnVector {
     } else {
       return dictionary.decodeToDouble(dictionaryIds.getDictId(rowId));
     }
+  }
+
+  @Override
+  public void getDoubles(double[] dst, int rowId, int count) {
+    assert(dictionary == null);
+    System.arraycopy(byteData, rowId, dst, 0, count);
   }
 
   //

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -130,6 +130,16 @@ public final class OnHeapColumnVector extends ColumnVector {
     return byteData[rowId] == 1;
   }
 
+  @Override
+  public boolean[] getBooleans(int rowId, int count) {
+    assert(dictionary == null);
+    boolean[] array = new boolean[count];
+    for (int i = 0; i < count; ++i) {
+      array[i] = (byteData[rowId + i] == 1);
+    }
+   return array;
+  }
+
   //
 
   //
@@ -163,9 +173,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getBytes(byte[] dst, int rowId, int count) {
+  public byte[] getBytes(int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(byteData, rowId, dst, 0, count);
+    byte[] array = new byte[count];
+    System.arraycopy(byteData, rowId, array, 0, count);
+    return array;
   }
 
   //
@@ -199,9 +211,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getShorts(short[] dst, int rowId, int count) {
+  public short[] getShorts(int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(shortData, rowId, dst, 0, count);
+    short[] array = new short[count];
+    System.arraycopy(shortData, rowId, array, 0, count);
+    return array;
   }
 
 
@@ -247,9 +261,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getInts(int[] dst, int rowId, int count) {
+  public int[] getInts(int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(intData, rowId, dst, 0, count);
+    int[] array = new int[count];
+    System.arraycopy(intData, rowId, array, 0, count);
+    return array;
   }
 
   /**
@@ -305,9 +321,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getLongs(long[] dst, int rowId, int count) {
+  public long[] getLongs(int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(longData, rowId, dst, 0, count);
+    long[] array = new long[count];
+    System.arraycopy(longData, rowId, array, 0, count);
+    return array;
   }
 
   //
@@ -350,9 +368,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getFloats(float[] dst, int rowId, int count) {
+  public float[] getFloats(int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(floatData, rowId, dst, 0, count);
+    float[] array = new float[count];
+    System.arraycopy(floatData, rowId, array, 0, count);
+    return array;
   }
 
   //
@@ -397,9 +417,11 @@ public final class OnHeapColumnVector extends ColumnVector {
   }
 
   @Override
-  public void getDoubles(double[] dst, int rowId, int count) {
+  public double[] getDoubles(int rowId, int count) {
     assert(dictionary == null);
-    System.arraycopy(doubleData, rowId, dst, 0, count);
+    double[] array = new double[count];
+    System.arraycopy(doubleData, rowId, array, 0, count);
+    return array;
   }
 
   //

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -709,6 +709,55 @@ class ColumnarBatchSuite extends SparkFunSuite {
     }}
   }
 
+  test("toArray for primitive types") {
+    // (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode => {
+    (MemoryMode.ON_HEAP :: Nil).foreach { memMode => {
+      val len = 4
+
+      val columnBool = ColumnVector.allocate(len, new ArrayType(BooleanType, false), memMode)
+      val boolArray = Array(false, true, false, true)
+      boolArray.zipWithIndex.map { case (v, i) => columnBool.arrayData.putBoolean(i, v) }
+      columnBool.putArray(0, 0, len)
+      assert(columnBool.getArray(0).toBooleanArray === boolArray)
+
+      val columnByte = ColumnVector.allocate(len, new ArrayType(ByteType, false), memMode)
+      val byteArray = Array[Byte](0, 1, 2, 3)
+      byteArray.zipWithIndex.map { case (v, i) => columnByte.arrayData.putByte(i, v) }
+      columnByte.putArray(0, 0, len)
+      assert(columnByte.getArray(0).toByteArray === byteArray)
+
+      val columnShort = ColumnVector.allocate(len, new ArrayType(ShortType, false), memMode)
+      val shortArray = Array[Short](0, 1, 2, 3)
+      shortArray.zipWithIndex.map { case (v, i) => columnShort.arrayData.putShort(i, v) }
+      columnShort.putArray(0, 0, len)
+      assert(columnShort.getArray(0).toShortArray === shortArray)
+
+      val columnInt = ColumnVector.allocate(len, new ArrayType(IntegerType, false), memMode)
+      val intArray = Array(0, 1, 2, 3)
+      intArray.zipWithIndex.map { case (v, i) => columnInt.arrayData.putInt(i, v) }
+      columnInt.putArray(0, 0, len)
+      assert(columnInt.getArray(0).toIntArray === intArray)
+
+      val columnLong = ColumnVector.allocate(len, new ArrayType(LongType, false), memMode)
+      val longArray = Array[Long](0, 1, 2, 3)
+      longArray.zipWithIndex.map { case (v, i) => columnLong.arrayData.putLong(i, v) }
+      columnLong.putArray(0, 0, len)
+      assert(columnLong.getArray(0).toLongArray === longArray)
+
+      val columnFloat = ColumnVector.allocate(len, new ArrayType(FloatType, false), memMode)
+      val floatArray = Array(0.0F, 1.1F, 2.2F, 3.3F)
+      floatArray.zipWithIndex.map { case (v, i) => columnFloat.arrayData.putFloat(i, v) }
+      columnFloat.putArray(0, 0, len)
+      assert(columnFloat.getArray(0).toFloatArray === floatArray)
+
+      val columnDouble = ColumnVector.allocate(len, new ArrayType(DoubleType, false), memMode)
+      val doubleArray = Array(0.0, 1.1, 2.2, 3.3)
+      doubleArray.zipWithIndex.map { case (v, i) => columnDouble.arrayData.putDouble(i, v) }
+      columnDouble.putArray(0, 0, len)
+      assert(columnDouble.getArray(0).toDoubleArray === doubleArray)
+    }}
+  }
+
   test("Struct Column") {
     (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode => {
       val schema = new StructType().add("int", IntegerType).add("double", DoubleType)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR implements bulk-copy for `ColumnVector.Array.to<type>Array()` methods (e.g. `toIntArray()`) in `ColumnVector.Array` by using `System.arrayCopy()` or `Platform.copyMemory()`.

Before this PR, when one of these method is called, the generic method in `ArrayData` is called. It is not fast since element-wise copy is performed.

This PR can improve performance of a benchmark program by 1.9x and 3.2x.

Without this PR
```
OpenJDK 64-Bit Server VM 1.8.0_131-8u131-b11-0ubuntu1.16.04.2-b11 on Linux 4.4.0-66-generic
Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz

Int Array                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)
------------------------------------------------------------------------------------------------
ON_HEAP                                        586 /  628         14.3          69.9
OFF_HEAP                                       893 /  902          9.4         106.5
```


With this PR
```
OpenJDK 64-Bit Server VM 1.8.0_131-8u131-b11-0ubuntu1.16.04.2-b11 on Linux 4.4.0-66-generic
Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz

Int Array                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)
------------------------------------------------------------------------------------------------
ON_HEAP                                        306 /  331         27.4          36.4
OFF_HEAP                                       282 /  287         29.8          33.6
```

Source program
```
    (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode => {
      val len = 8 * 1024 * 1024
      val column = ColumnVector.allocate(len * 2, new ArrayType(IntegerType, false), memMode)

      val data = column.arrayData
      var i = 0
      while (i < len) {
        data.putInt(i, i)
        i += 1
      }
      column.putArray(0, 0, len)

      val benchmark = new Benchmark("Int Array", len, minNumIters = 20)
      benchmark.addCase(s"$memMode") { iter =>
        var i = 0
        while (i < 50) {
          column.getArray(0).toIntArray
          i += 1
        }
      }
      benchmark.run
    }}
```

## How was this patch tested?

Added test suite