### PR TITLE
[SPARK-21216][SS] Hive strategies missed in Structured Streaming IncrementalExecution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -48,7 +48,6 @@ class IncrementalExecution(
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
     override def strategies: Seq[Strategy] =
-      sparkSession.sessionState.experimentalMethods.extraStrategies ++
       extraPlanningStrategies ++
       sparkSession.sessionState.planner.strategies
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -51,11 +51,11 @@ class IncrementalExecution(
       sparkSession.sessionState.planner.strategies
 
     override def extraPlanningStrategies: Seq[Strategy] = {
-      sparkSession.sessionState.planner.extraPlanningStrategies ++
-        (StatefulAggregationStrategy ::
-          FlatMapGroupsWithStateStrategy ::
-          StreamingRelationStrategy ::
-          StreamingDeduplicationStrategy :: Nil)
+      (StatefulAggregationStrategy ::
+        FlatMapGroupsWithStateStrategy ::
+        StreamingRelationStrategy ::
+        StreamingDeduplicationStrategy :: Nil) ++
+      sparkSession.sessionState.planner.extraPlanningStrategies
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -48,7 +48,7 @@ class IncrementalExecution(
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
     override def extraPlanningStrategies: Seq[Strategy] = {
-      //  We shouldn't miss the
+      //  We shouldn't miss the parent's strategies
       val parentPlanner = sparkSession.sessionState.planner
 
       parentPlanner.extraPlanningStrategies ++ parentPlanner.strategies ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -51,7 +51,7 @@ class IncrementalExecution(
       //  We shouldn't miss the parent's strategies
       val parentPlanner = sparkSession.sessionState.planner
 
-      parentPlanner.extraPlanningStrategies ++ parentPlanner.strategies ++
+      parentPlanner.strategies ++ parentPlanner.extraPlanningStrategies ++
         (StatefulAggregationStrategy ::
           FlatMapGroupsWithStateStrategy ::
           StreamingRelationStrategy ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -48,13 +48,11 @@ class IncrementalExecution(
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
 
-    //  We shouldn't miss the parent's strategies
-    val parentPlanner = sparkSession.sessionState.planner
-
-    override def strategies: Seq[Strategy] = parentPlanner.strategies
+    override def strategies: Seq[Strategy] =
+      sparkSession.sessionState.planner.strategies
 
     override def extraPlanningStrategies: Seq[Strategy] = {
-      parentPlanner.extraPlanningStrategies ++
+      sparkSession.sessionState.planner.extraPlanningStrategies ++
         (StatefulAggregationStrategy ::
           FlatMapGroupsWithStateStrategy ::
           StreamingRelationStrategy ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -48,15 +48,15 @@ class IncrementalExecution(
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
     override def strategies: Seq[Strategy] =
+      sparkSession.sessionState.experimentalMethods.extraStrategies ++
+      extraPlanningStrategies ++
       sparkSession.sessionState.planner.strategies
 
-    override def extraPlanningStrategies: Seq[Strategy] = {
-      (StatefulAggregationStrategy ::
+    override def extraPlanningStrategies: Seq[Strategy] =
+      StatefulAggregationStrategy ::
         FlatMapGroupsWithStateStrategy ::
         StreamingRelationStrategy ::
-        StreamingDeduplicationStrategy :: Nil) ++
-      sparkSession.sessionState.planner.extraPlanningStrategies
-    }
+        StreamingDeduplicationStrategy :: Nil
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -47,7 +47,6 @@ class IncrementalExecution(
       sparkSession.sparkContext,
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
-
     override def strategies: Seq[Strategy] =
       sparkSession.sessionState.planner.strategies
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -47,11 +47,16 @@ class IncrementalExecution(
       sparkSession.sparkContext,
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
-    override def extraPlanningStrategies: Seq[Strategy] =
-      StatefulAggregationStrategy ::
-      FlatMapGroupsWithStateStrategy ::
-      StreamingRelationStrategy ::
-      StreamingDeduplicationStrategy :: Nil
+    override def extraPlanningStrategies: Seq[Strategy] = {
+      //  We shouldn't miss the
+      val parentPlanner = sparkSession.sessionState.planner
+
+      parentPlanner.extraPlanningStrategies ++ parentPlanner.strategies ++
+        (StatefulAggregationStrategy ::
+          FlatMapGroupsWithStateStrategy ::
+          StreamingRelationStrategy ::
+          StreamingDeduplicationStrategy :: Nil)
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -47,11 +47,14 @@ class IncrementalExecution(
       sparkSession.sparkContext,
       sparkSession.sessionState.conf,
       sparkSession.sessionState.experimentalMethods) {
-    override def extraPlanningStrategies: Seq[Strategy] = {
-      //  We shouldn't miss the parent's strategies
-      val parentPlanner = sparkSession.sessionState.planner
 
-      parentPlanner.strategies ++ parentPlanner.extraPlanningStrategies ++
+    //  We shouldn't miss the parent's strategies
+    val parentPlanner = sparkSession.sessionState.planner
+
+    override def strategies: Seq[Strategy] = parentPlanner.strategies
+
+    override def extraPlanningStrategies: Seq[Strategy] = {
+      parentPlanner.extraPlanningStrategies ++
         (StatefulAggregationStrategy ::
           FlatMapGroupsWithStateStrategy ::
           StreamingRelationStrategy ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -53,9 +53,9 @@ class IncrementalExecution(
 
     override def extraPlanningStrategies: Seq[Strategy] =
       StatefulAggregationStrategy ::
-        FlatMapGroupsWithStateStrategy ::
-        StreamingRelationStrategy ::
-        StreamingDeduplicationStrategy :: Nil
+      FlatMapGroupsWithStateStrategy ::
+      StreamingRelationStrategy ::
+      StreamingDeduplicationStrategy :: Nil
   }
 
   /**

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1989,7 +1989,7 @@ class HiveDDLSuite
 
       checkAnswer(
         spark.table("t2"),
-        Seq(Row(1, "one"), Row(2, "two"))
+        Seq(Row(1, "one", 1), Row(2, "two", 2))
       )
     } finally {
       sq.stop()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -160,7 +160,6 @@ class HiveCatalogedDDLSuite extends DDLSuite with TestHiveSingleton with BeforeA
   test("drop table") {
     testDropTable(isDatasourceTable = false)
   }
-
 }
 
 class HiveDDLSuite
@@ -1954,6 +1953,46 @@ class HiveDDLSuite
           }
         }
       }
+    }
+  }
+
+  test("SPARK-21216: join with a streaming DataFrame") {
+    import org.apache.spark.sql.execution.streaming.MemoryStream
+    import testImplicits._
+
+    implicit val _sqlContext = spark.sqlContext
+
+    Seq((1, "one"), (2, "two"), (4, "four")).toDF("number", "word").createOrReplaceTempView("t1")
+    // Make a table and ensure it will be broadcast.
+    sql("""CREATE TABLE smallTable(word string, number int)
+          |ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+          |STORED AS TEXTFILE
+        """.stripMargin)
+
+    sql(
+      """INSERT INTO smallTable
+        |SELECT word, number from t1
+      """.stripMargin)
+
+    val inputData = MemoryStream[Int]
+    val joined = inputData.toDS().toDF()
+      .join(spark.table("smallTable"), $"value" === $"number")
+
+    val sq = joined.writeStream
+      .format("memory")
+      .queryName("t2")
+      .start()
+    try {
+      inputData.addData(1, 2)
+
+      sq.processAllAvailable()
+
+      checkAnswer(
+        spark.table("t2"),
+        Seq(Row(1, "one"), Row(2, "two"))
+      )
+    } finally {
+      sq.stop()
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If someone creates a HiveSession, the planner in `IncrementalExecution` doesn't take into account the Hive scan strategies. This causes joins of Streaming DataFrame's with Hive tables to fail.

## How was this patch tested?

Regression test
