### PR TITLE
[SPARK-21219][Core] Task retry occurs on same executor due to race condition with blacklisting

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1177,8 +1177,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // retrying the task otherwise there's a race condition where run on
     // the same executor that it was intended to be black listed from.
     val conf = new SparkConf().
-      set(config.BLACKLIST_ENABLED, true).
-      set(config.MAX_TASK_ATTEMPTS_PER_EXECUTOR, 1)
+      set(config.BLACKLIST_ENABLED, true)
 
     // Create a task with two executors.
     sc = new SparkContext("local", "test", conf)
@@ -1208,10 +1207,9 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       }
     )
 
-    // Simulate an out of memory error
-    val e = new OutOfMemoryError
-    taskSetManagerSpy.handleFailedTask(
-      taskDesc.get.taskId, TaskState.FAILED, new ExceptionFailure(e, Seq()))
+    // Simulate a fake exception
+    val e = new ExceptionFailure("a", "b", Array(), "c", None)
+    taskSetManagerSpy.handleFailedTask(taskDesc.get.taskId, TaskState.FAILED, e)
 
     verify(taskSetManagerSpy, times(1)).addPendingTask(anyInt())
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import org.mockito.Matchers.{any, anyInt, anyString}
-import org.mockito.Mockito.{mock, never, spy, verify, when, times}
+import org.mockito.Mockito.{mock, never, spy, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
@@ -1204,7 +1204,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
           val task = invocationOnMock.getArgumentAt(0, classOf[Int])
           assert(taskSetManager.taskSetBlacklistHelperOpt.get.
             isExecutorBlacklistedForTask(exec, task))
-          null
         }
       }
     )


### PR DESCRIPTION

## What changes were proposed in this pull request?

There's a race condition in the current TaskSetManager where a failed task is added for retry (addPendingTask), and can asynchronously be assigned to an executor *prior* to the blacklist state (updateBlacklistForFailedTask), the result is the task might re-execute on the same executor.  This is particularly problematic if the executor is shutting down since the retry task immediately becomes a lost task (ExecutorLostFailure).  Another side effect is that the actual failure reason gets obscured by the retry task which never actually executed.  There are sample logs showing the issue in the https://issues.apache.org/jira/browse/SPARK-21219 

The fix is to change the ordering of the addPendingTask and updatingBlackListForFailedTask calls in TaskSetManager.handleFailedTask

## How was this patch tested?

Implemented a unit test that verifies the task is black listed before it is added to the pending task.  Ran the unit test without the fix and it fails.  Ran the unit test with the fix and it passes.

Please review http://spark.apache.org/contributing.html before opening a pull request.
