### PR TITLE
resolve com.esotericsoftware.kryo.KryoException

### DIFF
--- a/external/kinesis-asl/src/main/java/org/apache/spark/examples/streaming/JavaKinesisWordCountASL.java
+++ b/external/kinesis-asl/src/main/java/org/apache/spark/examples/streaming/JavaKinesisWordCountASL.java
@@ -129,7 +129,9 @@ public final class JavaKinesisWordCountASL { // needs to be public for access fr
     String regionName = KinesisExampleUtils.getRegionNameByEndpoint(endpointUrl);
 
     // Setup the Spark config and StreamingContext
-    SparkConf sparkConfig = new SparkConf().setAppName("JavaKinesisWordCountASL");
+    SparkConf sparkConfig = new SparkConf()
+      .setAppName("JavaKinesisWordCountASL")
+      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
     JavaStreamingContext jssc = new JavaStreamingContext(sparkConfig, batchInterval);
 
     // Create the Kinesis DStreams


### PR DESCRIPTION
## What changes were proposed in this pull request?

Explicitly setting "spark.serializer" to "org.apache.spark.serializer.KryoSerializer" could resolve "com.esotericsoftware.kryo.KryoException: Encountered unregistered class ID" for this example code.

## How was this patch tested?

This example code always report "com.esotericsoftware.kryo.KryoException: Encountered unregistered class ID" after launching. With this patch the code could run normally.
