### PR TITLE
[SPARK-21176] [Web UI] Limit number of selector threads for admin ui proxy servlets to 8

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -213,7 +213,7 @@ private[spark] object JettyUtils extends Logging {
       override def newHttpClient(): HttpClient = {
         // Use the Jetty logic to calculate the number of selector threads (#CPUs/2),
         // but limit it to 8 max.
-        val numSelectors = math.max(1,math.min(8,Runtime.getRuntime().availableProcessors()/2))
+        val numSelectors = math.max(1, math.min(8, Runtime.getRuntime().availableProcessors()/2))
         return new HttpClient(new HttpClientTransportOverHTTP(numSelectors), null)
       }
 

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -213,8 +213,8 @@ private[spark] object JettyUtils extends Logging {
       override def newHttpClient(): HttpClient = {
         // Use the Jetty logic to calculate the number of selector threads (#CPUs/2),
         // but limit it to 8 max.
-        val numSelectors = math.max(1, math.min(8, Runtime.getRuntime().availableProcessors()/2))
-        return new HttpClient(new HttpClientTransportOverHTTP(numSelectors), null)
+        val numSelectors = math.max(1, math.min(8, Runtime.getRuntime().availableProcessors() / 2))
+        new HttpClient(new HttpClientTransportOverHTTP(numSelectors), null)
       }
 
       override def filterServerResponseHeader(

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -26,6 +26,8 @@ import scala.language.implicitConversions
 import scala.xml.Node
 
 import org.eclipse.jetty.client.api.Response
+import org.eclipse.jetty.client.HttpClient
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP
 import org.eclipse.jetty.proxy.ProxyServlet
 import org.eclipse.jetty.server._
 import org.eclipse.jetty.server.handler._
@@ -206,6 +208,13 @@ private[spark] object JettyUtils extends Logging {
           return null
         }
         rewrittenURI.toString()
+      }
+
+      override def newHttpClient(): HttpClient = {
+        // Use the Jetty logic to calculate the number of selector threads (#CPUs/2),
+        // but limit it to 8 max.
+        val numSelectors = math.max(1,math.min(8,Runtime.getRuntime().availableProcessors()/2))
+        return new HttpClient(new HttpClientTransportOverHTTP(numSelectors), null)
       }
 
       override def filterServerResponseHeader(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Please see also https://issues.apache.org/jira/browse/SPARK-21176

This change limits the number of selector threads that jetty creates to maximum 8 per proxy servlet (Jetty default is number of processors / 2).
The newHttpClient for Jettys ProxyServlet class is overwritten to avoid the Jetty defaults (which are designed for high-performance http servers).
Once https://github.com/eclipse/jetty.project/issues/1643 is available, the code could be cleaned up to avoid the method override.

I really need this on v2.1.1 - what is the best way for a backport automatic merge works fine)? Shall I create another PR?

## How was this patch tested?
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
The patch was tested manually on a Spark cluster with a head node that has 88 processors using JMX to verify that the number of selector threads is now limited to 8 per proxy.

@gurvindersingh @zsxwing can you please review the change?