### PR TITLE
[HOTFIX] Disable SSL verification to install pyarrow with conda

### DIFF
--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -83,6 +83,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     if [ -n "$USE_CONDA" ]; then
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
       source activate "$VIRTUALENV_PATH"
+      conda config --set ssl_verify false
       conda install -y -c conda-forge pyarrow=0.4.0
       TEST_PYARROW=1
     else
@@ -91,7 +92,7 @@ for python in "${PYTHON_EXECS[@]}"; do
       source "$VIRTUALENV_PATH"/bin/activate
     fi
     # Upgrade pip & friends if using virutal env
-    if [ ! -n "USE_CONDA" ]; then
+    if [ ! -n "$USE_CONDA" ]; then
       pip install --upgrade pip pypandoc wheel numpy
     fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I tried to test with lower versions of conda (3.6.0 on Ubuntu 14.04). I could reproduce a _similar_ error with this.

This PR proposes to disable SSL verification with conda to unblock other PRs.

## How was this patch tested?

Manually tested via shell.