### PR TITLE
[SPARK-21231] Disable installing pyarrow during run pip tests

### DIFF
--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -83,8 +83,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     if [ -n "$USE_CONDA" ]; then
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
       source activate "$VIRTUALENV_PATH"
-      conda install -y -c conda-forge pyarrow=0.4.0
-      TEST_PYARROW=1
     else
       mkdir -p "$VIRTUALENV_PATH"
       virtualenv --python=$python "$VIRTUALENV_PATH"
@@ -122,10 +120,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     python "$FWDIR"/dev/pip-sanity-check.py
     echo "Run the tests for context.py"
     python "$FWDIR"/python/pyspark/context.py
-    if [ -n "$TEST_PYARROW" ]; then
-      echo "Run tests for pyarrow"
-      SPARK_TESTING=1 "$FWDIR"/bin/pyspark pyspark.sql.tests ArrowTests
-    fi
 
     cd "$FWDIR"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable installing pyarrow during run pip tests, this was causing flakiness due to the conda-forge binstar -> conda migration and our out of date version of conda (which we still have).

## How was this patch tested?

Now that pyarrow is installed in the py3k env we don't need to use the hack for pyarrow testing during the pip tests.

cc @BryanCutler @shaneknapp 