### PR TITLE
[SPARK-21239][STREAMING] Support WAL recover in windows

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -135,8 +135,11 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
         // FileBasedWriteAheadLog will not create any file or directory at that path. Also,
         // this dummy directory should not already exist otherwise the WAL will try to recover
         // past events from the directory and throw errors.
+        // Specifically, the nonExistentDirectory will contain a colon in windows, this is invalid
+        // for hadoop. Remove the drive letter and colon, e.g. "D:" out of this path by default
         val nonExistentDirectory = new File(
-          System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString).getAbsolutePath
+          System.getProperty("java.io.tmpdir").replaceFirst("[a-zA-Z]:", ""),
+          UUID.randomUUID().toString).getPath
         writeAheadLog = WriteAheadLogUtils.createLogForReceiver(
           SparkEnv.get.conf, nonExistentDirectory, hadoopConf)
         dataRead = writeAheadLog.read(partition.walRecordHandle)

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -138,8 +138,8 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
         // Specifically, the nonExistentDirectory will contain a colon in windows, this is invalid
         // for hadoop. Remove the drive letter and colon, e.g. "D:" out of this path by default
         val nonExistentDirectory = new File(
-          System.getProperty("java.io.tmpdir").replaceFirst("[a-zA-Z]:", ""),
-          UUID.randomUUID().toString).getPath
+          System.getProperty("java.io.tmpdir"), 
+          UUID.randomUUID().toString).getAbsolutePath.replaceFirst("[a-zA-Z]:", "")
         writeAheadLog = WriteAheadLogUtils.createLogForReceiver(
           SparkEnv.get.conf, nonExistentDirectory, hadoopConf)
         dataRead = writeAheadLog.read(partition.walRecordHandle)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When driver failed over, it will read WAL from HDFS by calling WriteAheadLogBackedBlockRDD.getBlockFromWriteAheadLog(), however, it need a dummy local path to satisfy the method parameter requirements, but the path in windows will contain a colon which is not valid for hadoop. I removed the potential driver letter and colon.

I found one email from spark-user ever talked about [this bug](https://www.mail-archive.com/user@spark.apache.org/msg55030.html)

## How was this patch tested?

Without this fix, once driver failed over on YARN, WAL recovery would not take effect. But the WAL recovery mechanism would take effect once patched this fix of this PR on windows YARN cluster.
