### PR TITLE
[SPARK-21241][MLlib]- Add setIntercept to StreamingLinearRegressionWi…

### DIFF
--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -199,6 +199,10 @@ class LinearRegressionModel(LinearRegressionModelBase):
         model = LinearRegressionModel(weights, intercept)
         return model
 
+    @since("2.3.0")
+    def setIntercept(self, intercept):
+        self._intercept = intercept
+
 
 # train_func should take two parameters, namely data and initial_weights, and
 # return the result of a call to the appropriate JVM stub.
@@ -794,6 +798,11 @@ class StreamingLinearRegressionWithSGD(StreamingLinearAlgorithm):
         self._model = None
         super(StreamingLinearRegressionWithSGD, self).__init__(
             model=self._model)
+
+    @since("2.3.0")
+    def setIntercept(self, intercept):
+        """Set if the algorithm should add an intercept"""
+        self._model.setIntercept(intercept)
 
     @since("1.5.0")
     def setInitialWeights(self, initialWeights):

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -203,7 +203,6 @@ class LinearRegressionModel(LinearRegressionModelBase):
     def setIntercept(self, intercept):
         self._intercept = intercept
 
-
 # train_func should take two parameters, namely data and initial_weights, and
 # return the result of a call to the appropriate JVM stub.
 # _regression_train_wrapper is responsible for setup and error checking.


### PR DESCRIPTION
…thSGD in Pyspark.
## What changes were proposed in this pull request?
StreamingLinearRegressionWithSGD class in PySpark is missing the setIntercept Method which offers the possibility to turn on/off the intercept value. API parity is not respected between Python and Scala. We added the setIntercept Method to StreamingLinearRegressionWithSGD class which calls setIntercept Method in LinearRegressionModel class in order to turn on/off the intercept. A big thanks to Matthieu CANEILL for his precious help in solving this issue.

## How was this patch tested?
This patch was tested by running all tests with ./dev/run-tests.

