### PR TITLE
[SPARK-21247][SQL] Type comparison should respect case-sensitive SQL conf

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -181,6 +181,17 @@ object TypeCoercion {
         case (ArrayType(et1, containsNull1), ArrayType(et2, containsNull2)) =>
           findWiderTypeWithoutStringPromotionForTwo(et1, et2)
             .map(ArrayType(_, containsNull1 || containsNull2))
+        case (st1 @ StructType(fields1), st2 @ StructType(fields2)) if st1.sameType(st2) =>
+          Some(StructType(fields1.zip(fields2).map { case (sf1, sf2) =>
+            // Since `st1.sameType(st2)` is true, two StructTypes have the same DataType
+            // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
+            // - Different names: use a lower case name because
+            //                    findWiderTypeWithoutStringPromotionForTwo is commutative.
+            // - Different nullabilities: `nullable` is true iff one of them is nullable.
+            val name = if (sf1.name == sf2.name) sf1.name else sf1.name.toLowerCase(Locale.ROOT)
+            val dataType = findWiderTypeWithoutStringPromotionForTwo(sf1.dataType, sf2.dataType).get
+            StructField(name, dataType, nullable = sf1.nullable || sf2.nullable)
+          }))
         case _ => None
       })
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -148,6 +148,10 @@ object TypeCoercion {
           findWiderTypeForTwo(et1, et2).map(ArrayType(_, containsNull1 || containsNull2))
         case (st1 @ StructType(fields1), st2 @ StructType(fields2)) if st1.sameType(st2) =>
           Some(StructType(fields1.zip(fields2).map { case (sf1, sf2) =>
+            // Since `st1.sameType(st2)` is true, two StructTypes have the same DataType
+            // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
+            // - Different names: use a lower case name because findWiderTypeForTwo is commutative.
+            // - Different nullabilities: `nullable` is true iff one of them is nullable.
             val name = if (sf1.name == sf2.name) sf1.name else sf1.name.toLowerCase(Locale.ROOT)
             val dataType = findWiderTypeForTwo(sf1.dataType, sf2.dataType).get
             StructField(name, dataType, nullable = sf1.nullable || sf2.nullable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -101,6 +101,17 @@ object TypeCoercion {
     case (_: TimestampType, _: DateType) | (_: DateType, _: TimestampType) =>
       Some(TimestampType)
 
+    case (t1 @ StructType(fields1), t2 @ StructType(fields2)) if t1.sameType(t2) =>
+      Some(StructType(fields1.zip(fields2).map { case (f1, f2) =>
+        // Since `t1.sameType(t2)` is true, two StructTypes have the same DataType
+        // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
+        // - Different names: use a lower case name because findTightestCommonType is commutative.
+        // - Different nullabilities: `nullable` is true iff one of them is nullable.
+        val name = if (f1.name == f2.name) f1.name else f1.name.toLowerCase(Locale.ROOT)
+        val dataType = findTightestCommonType(f1.dataType, f2.dataType).get
+        StructField(name, dataType, nullable = f1.nullable || f2.nullable)
+      }))
+
     case _ => None
   }
 
@@ -146,16 +157,6 @@ object TypeCoercion {
       .orElse((t1, t2) match {
         case (ArrayType(et1, containsNull1), ArrayType(et2, containsNull2)) =>
           findWiderTypeForTwo(et1, et2).map(ArrayType(_, containsNull1 || containsNull2))
-        case (st1 @ StructType(fields1), st2 @ StructType(fields2)) if st1.sameType(st2) =>
-          Some(StructType(fields1.zip(fields2).map { case (sf1, sf2) =>
-            // Since `st1.sameType(st2)` is true, two StructTypes have the same DataType
-            // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
-            // - Different names: use a lower case name because findWiderTypeForTwo is commutative.
-            // - Different nullabilities: `nullable` is true iff one of them is nullable.
-            val name = if (sf1.name == sf2.name) sf1.name else sf1.name.toLowerCase(Locale.ROOT)
-            val dataType = findWiderTypeForTwo(sf1.dataType, sf2.dataType).get
-            StructField(name, dataType, nullable = sf1.nullable || sf2.nullable)
-          }))
         case _ => None
       })
   }
@@ -181,17 +182,6 @@ object TypeCoercion {
         case (ArrayType(et1, containsNull1), ArrayType(et2, containsNull2)) =>
           findWiderTypeWithoutStringPromotionForTwo(et1, et2)
             .map(ArrayType(_, containsNull1 || containsNull2))
-        case (st1 @ StructType(fields1), st2 @ StructType(fields2)) if st1.sameType(st2) =>
-          Some(StructType(fields1.zip(fields2).map { case (sf1, sf2) =>
-            // Since `st1.sameType(st2)` is true, two StructTypes have the same DataType
-            // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
-            // - Different names: use a lower case name because
-            //                    findWiderTypeWithoutStringPromotionForTwo is commutative.
-            // - Different nullabilities: `nullable` is true iff one of them is nullable.
-            val name = if (sf1.name == sf2.name) sf1.name else sf1.name.toLowerCase(Locale.ROOT)
-            val dataType = findWiderTypeWithoutStringPromotionForTwo(sf1.dataType, sf2.dataType).get
-            StructField(name, dataType, nullable = sf1.nullable || sf2.nullable)
-          }))
         case _ => None
       })
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import java.util.Locale
 import javax.annotation.Nullable
 
 import scala.annotation.tailrec
@@ -105,11 +104,10 @@ object TypeCoercion {
       Some(StructType(fields1.zip(fields2).map { case (f1, f2) =>
         // Since `t1.sameType(t2)` is true, two StructTypes have the same DataType
         // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
-        // - Different names: use a lower case name because findTightestCommonType is commutative.
+        // - Different names: use f1.name
         // - Different nullabilities: `nullable` is true iff one of them is nullable.
-        val name = if (f1.name == f2.name) f1.name else f1.name.toLowerCase(Locale.ROOT)
         val dataType = findTightestCommonType(f1.dataType, f2.dataType).get
-        StructField(name, dataType, nullable = f1.nullable || f2.nullable)
+        StructField(f1.name, dataType, nullable = f1.nullable || f2.nullable)
       }))
 
     case _ => None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -26,6 +26,7 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
 /**
@@ -80,7 +81,11 @@ abstract class DataType extends AbstractDataType {
    * (`StructField.nullable`, `ArrayType.containsNull`, and `MapType.valueContainsNull`).
    */
   private[spark] def sameType(other: DataType): Boolean =
-    DataType.equalsIgnoreNullability(this, other)
+    if (SQLConf.get.caseSensitiveAnalysis) {
+      DataType.equalsIgnoreNullability(this, other)
+    } else {
+      DataType.equalsIgnoreCaseAndNullability(this, other)
+    }
 
   /**
    * Returns the same data type but set all nullability fields are true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -447,6 +447,15 @@ class TypeCoercionSuite extends AnalysisTest {
       None)
     widenTestWithStringPromotion(
       StructType(Seq(StructField("a", IntegerType, nullable = false))),
+      StructType(Seq(StructField("a", DoubleType, nullable = false))),
+      None)
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", IntegerType, nullable = false))),
+      StructType(Seq(StructField("a", DoubleType, nullable = false))),
+      None)
+
+    widenTestWithStringPromotion(
+      StructType(Seq(StructField("a", IntegerType, nullable = false))),
       StructType(Seq(StructField("a", IntegerType, nullable = false))),
       Some(StructType(Seq(StructField("a", IntegerType, nullable = false)))))
     widenTestWithStringPromotion(
@@ -461,14 +470,40 @@ class TypeCoercionSuite extends AnalysisTest {
       StructType(Seq(StructField("a", IntegerType, nullable = true))),
       StructType(Seq(StructField("a", IntegerType, nullable = true))),
       Some(StructType(Seq(StructField("a", IntegerType, nullable = true)))))
+
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", IntegerType, nullable = false))),
+      StructType(Seq(StructField("a", IntegerType, nullable = false))),
+      Some(StructType(Seq(StructField("a", IntegerType, nullable = false)))))
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", IntegerType, nullable = false))),
+      StructType(Seq(StructField("a", IntegerType, nullable = true))),
+      Some(StructType(Seq(StructField("a", IntegerType, nullable = true)))))
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", IntegerType, nullable = true))),
+      StructType(Seq(StructField("a", IntegerType, nullable = false))),
+      Some(StructType(Seq(StructField("a", IntegerType, nullable = true)))))
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", IntegerType, nullable = true))),
+      StructType(Seq(StructField("a", IntegerType, nullable = true))),
+      Some(StructType(Seq(StructField("a", IntegerType, nullable = true)))))
+
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
       widenTestWithStringPromotion(
+        StructType(Seq(StructField("a", IntegerType))),
+        StructType(Seq(StructField("A", IntegerType))),
+        None)
+      widenTestWithoutStringPromotion(
         StructType(Seq(StructField("a", IntegerType))),
         StructType(Seq(StructField("A", IntegerType))),
         None)
     }
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       widenTestWithStringPromotion(
+        StructType(Seq(StructField("a", IntegerType), StructField("B", IntegerType))),
+        StructType(Seq(StructField("A", IntegerType), StructField("b", IntegerType))),
+        Some(StructType(Seq(StructField("a", IntegerType), StructField("b", IntegerType)))))
+      widenTestWithoutStringPromotion(
         StructType(Seq(StructField("a", IntegerType), StructField("B", IntegerType))),
         StructType(Seq(StructField("A", IntegerType), StructField("b", IntegerType))),
         Some(StructType(Seq(StructField("a", IntegerType), StructField("b", IntegerType)))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -131,14 +131,17 @@ class TypeCoercionSuite extends AnalysisTest {
       widenFunc: (DataType, DataType) => Option[DataType],
       t1: DataType,
       t2: DataType,
-      expected: Option[DataType]): Unit = {
+      expected: Option[DataType],
+      isSymmetric: Boolean = true): Unit = {
     var found = widenFunc(t1, t2)
     assert(found == expected,
       s"Expected $expected as wider common type for $t1 and $t2, found $found")
     // Test both directions to make sure the widening is symmetric.
-    found = widenFunc(t2, t1)
-    assert(found == expected,
-      s"Expected $expected as wider common type for $t2 and $t1, found $found")
+    if (isSymmetric) {
+      found = widenFunc(t2, t1)
+      assert(found == expected,
+        s"Expected $expected as wider common type for $t2 and $t1, found $found")
+    }
   }
 
   test("implicit type cast - ByteType") {
@@ -419,10 +422,12 @@ class TypeCoercionSuite extends AnalysisTest {
         None)
     }
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-      widenTest(
+      checkWidenType(
+        TypeCoercion.findTightestCommonType,
         StructType(Seq(StructField("a", IntegerType), StructField("B", IntegerType))),
         StructType(Seq(StructField("A", IntegerType), StructField("b", IntegerType))),
-        Some(StructType(Seq(StructField("a", IntegerType), StructField("b", IntegerType)))))
+        Some(StructType(Seq(StructField("a", IntegerType), StructField("B", IntegerType)))),
+        isSymmetric = false)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is an effort to reduce the difference between Hive and Spark. Spark supports case-sensitivity in columns. Especially, for Struct types, with `spark.sql.caseSensitive=true`, the following is supported.

```scala
scala> sql("select named_struct('a', 1, 'A', 2).a").show
+--------------------------+
|named_struct(a, 1, A, 2).a|
+--------------------------+
|                         1|
+--------------------------+

scala> sql("select named_struct('a', 1, 'A', 2).A").show
+--------------------------+
|named_struct(a, 1, A, 2).A|
+--------------------------+
|                         2|
+--------------------------+
```

And vice versa, with `spark.sql.caseSensitive=false`, the following is supported.
```scala
scala> sql("select named_struct('a', 1).A, named_struct('A', 1).a").show
+--------------------+--------------------+
|named_struct(a, 1).A|named_struct(A, 1).a|
+--------------------+--------------------+
|                   1|                   1|
+--------------------+--------------------+
```

However, types are considered different. For example, SET operations fail.
```scala
scala> sql("SELECT named_struct('a',1) union all (select named_struct('A',2))").show
org.apache.spark.sql.AnalysisException: Union can only be performed on tables with the compatible column types. struct<A:int> <> struct<a:int> at the first column of the second table;;
'Union
:- Project [named_struct(a, 1) AS named_struct(a, 1)#57]
:  +- OneRowRelation$
+- Project [named_struct(A, 2) AS named_struct(A, 2)#58]
   +- OneRowRelation$
```

This PR aims to support case-insensitive type equality. For example, in Set operation, the above operation succeed when `spark.sql.caseSensitive=false`. 

```scala
scala> sql("SELECT named_struct('a',1) union all (select named_struct('A',2))").show
+------------------+
|named_struct(a, 1)|
+------------------+
|               [1]|
|               [2]|
+------------------+
```

## How was this patch tested?

Pass the Jenkins with a newly add test case.