### PR TITLE
[SPARK-21248][SS]The clean up codes in StreamExecution should not be interrupted

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UninterruptibleThreadSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UninterruptibleThreadSuite.scala
@@ -59,31 +59,6 @@ class UninterruptibleThreadSuite extends SparkFunSuite {
     assert(interruptStatusBeforeExit === true)
   }
 
-  test("interrupt before runUninterruptibly runs") {
-    val interruptLatch = new CountDownLatch(1)
-    @volatile var hasInterruptedException = false
-    @volatile var interruptStatusBeforeExit = false
-    val t = new UninterruptibleThread("test") {
-      override def run(): Unit = {
-        Uninterruptibles.awaitUninterruptibly(interruptLatch, 10, TimeUnit.SECONDS)
-        try {
-          runUninterruptibly {
-            assert(false, "Should not reach here")
-          }
-        } catch {
-          case _: InterruptedException => hasInterruptedException = true
-        }
-        interruptStatusBeforeExit = Thread.interrupted()
-      }
-    }
-    t.start()
-    t.interrupt()
-    interruptLatch.countDown()
-    t.join()
-    assert(hasInterruptedException === true)
-    assert(interruptStatusBeforeExit === false)
-  }
-
   test("nested runUninterruptibly") {
     val enterRunUninterruptibly = new CountDownLatch(1)
     val interruptLatch = new CountDownLatch(1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -358,6 +358,10 @@ class StreamExecution(
           throw e
         }
     } finally microBatchThread.runUninterruptibly {
+      // The whole `finally` block must run inside `runUninterruptibly` to avoid being interrupted
+      // when a query is stopped by the user. We need to make sure the following codes finish
+      // otherwise it may throw `InterruptedException` to `UncaughtExceptionHandler` (SPARK-21248).
+
       // Release latches to unblock the user codes since exception can happen in any place and we
       // may not get a chance to release them
       startLatch.countDown()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -357,7 +357,7 @@ class StreamExecution(
         if (!NonFatal(e)) {
           throw e
         }
-    } finally {
+    } finally microBatchThread.runUninterruptibly {
       // Release latches to unblock the user codes since exception can happen in any place and we
       // may not get a chance to release them
       startLatch.countDown()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR uses `runUninterruptibly` to avoid that the clean up codes in StreamExecution is interrupted. It also removes an optimization in `runUninterruptibly` to make sure this method never throw `InterruptedException`.

## How was this patch tested?

Jenkins