### PR TITLE
[SPARK-21253][CORE] Disable use DownloadCallback fetch big blocks

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -119,12 +119,7 @@ public class OneForOneBlockFetcher {
           // Immediately request all chunks -- we expect that the total size of the request is
           // reasonable due to higher level chunking in [[ShuffleBlockFetcherIterator]].
           for (int i = 0; i < streamHandle.numChunks; i++) {
-            if (shuffleFiles != null) {
-              client.stream(OneForOneStreamManager.genStreamChunkId(streamHandle.streamId, i),
-                new DownloadCallback(shuffleFiles[i], i));
-            } else {
-              client.fetchChunk(streamHandle.streamId, i, chunkCallback);
-            }
+            client.fetchChunk(streamHandle.streamId, i, chunkCallback);
           }
         } catch (Exception e) {
           logger.error("Failed while starting block fetches after success", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

[DownloadCallback](https://github.com/apache/spark/blob/v2.2.0-rc5/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java#L154) has some issues cause `FetchFailedException`.


 Spark **cluster** can reproduce, **local** can't:

1. Start a spark context with `spark.reducer.maxReqSizeShuffleToMem=1K`:
```
$ spark-shell --conf spark.reducer.maxReqSizeShuffleToMem=1K
```

2.  A shuffle:
```
scala> sc.parallelize(0 until 3000000, 10).repartition(2001).count()
```

The error messages:

```
org.apache.spark.shuffle.FetchFailedException: Failed to send request for 1649611690367_2 to yhd-jqhadoop166.int.yihaodian.com/10.17.28.166:7337: java.io.IOException: Connection reset by peer
        at org.apache.spark.storage.ShuffleBlockFetcherIterator.throwFetchFailedException(ShuffleBlockFetcherIterator.scala:442)
        at org.apache.spark.storage.ShuffleBlockFetcherIterator.next(ShuffleBlockFetcherIterator.scala:418)
        at org.apache.spark.storage.ShuffleBlockFetcherIterator.next(ShuffleBlockFetcherIterator.scala:59)
        at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
        at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
...
```

Immediately to release 2.2,  how about disable `DownloadCallback` to fetch big blocks?

## How was this patch tested?

manual tests because need a spark cluster

