### PR TITLE
[SPARK-21235][TESTS] UTest should clear temp results when run case 

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -663,6 +663,9 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     assert(store.getSingleAndReleaseLock("a2").isDefined, "a2 was in store")
     assert(store.getSingleAndReleaseLock("a3").isDefined, "a3 was in store")
     assert(store.getSingleAndReleaseLock("a1").isDefined, "a1 was in store")
+    store.removeBlock("a1")
+    store.removeBlock("a2")
+    store.removeBlock("a3")
   }
 
   encryptionTest("disk and memory storage") { _conf =>


### PR DESCRIPTION
Signed-off-by: 10087686 <wang.jiaochun@zte.com.cn>

## What changes were proposed in this pull request?
when run this case encryptionTest("on-disk storage")  end, it has temp result not clear
Users\...\AppData\Local\Temp\blockmgr-865114ea-8e5c-4b20-9a25-1224cfe5545b\01\test_a3
Users\...\AppData\Local\Temp\blockmgr-865114ea-8e5c-4b20-9a25-1224cfe5545b\01\test_a2
Users\...\AppData\Local\Temp\blockmgr-865114ea-8e5c-4b20-9a25-1224cfe5545b\01\test_a1

so，I think it's best to clear result file;
(Please fill in changes proposed in this fix)
    store.removeBlock("a1")
    store.removeBlock("a2")
    store.removeBlock("a3")
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
Run encryptionTest("on-disk storage") 
Please review http://spark.apache.org/contributing.html before opening a pull request.
