### PR TITLE
[SPARK-21261][DOCS]SQL Regex document fix

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -268,7 +268,10 @@ case class StringSplit(str: Expression, pattern: Expression)
   usage = "_FUNC_(str, regexp, rep) - Replaces all substrings of `str` that match `regexp` with `rep`.",
   extended = """
     Examples:
-      > SELECT _FUNC_('100-200', '(\d+)', 'num');
+      spark-sql> SELECT _FUNC_('100-200', '(\\d+)', 'num');
+       num-num
+
+      scala> SELECT _FUNC_('100-200', '(\\\\d+)', 'num');
        num-num
   """)
 // scalastyle:on line.size.limit
@@ -375,7 +378,10 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
   usage = "_FUNC_(str, regexp[, idx]) - Extracts a group that matches `regexp`.",
   extended = """
     Examples:
-      > SELECT _FUNC_('100-200', '(\d+)-(\d+)', 1);
+      spark-sql> SELECT _FUNC_('100-200', '(\\d+)-(\\d+)', 1);
+       100
+
+      scala> SELECT _FUNC_('100-200', '(\\\\d+)-(\\\\d+)', 1);
        100
   """)
 case class RegExpExtract(subject: Expression, regexp: Expression, idx: Expression)


### PR DESCRIPTION
SQL regex docs change:
`SELECT _FUNC_('100-200', '(\d+)', 'num') => SELECT _FUNC_('100-200', '(\\d+)', 'num')`