### PR TITLE
[SPARK-21262] Stop sending 'stream request' when shuffle blocks.

### DIFF
--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -61,6 +61,11 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
     <!-- Provided dependencies -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -28,6 +28,7 @@ import java.nio.channels.FileChannel;
 import com.google.common.base.Objects;
 import com.google.common.io.ByteStreams;
 import io.netty.channel.DefaultFileRegion;
+import org.apache.commons.io.FileUtils;
 
 import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.network.util.LimitedInputStream;
@@ -150,5 +151,13 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
       .add("offset", offset)
       .add("length", length)
       .toString();
+  }
+
+  public static FileSegmentManagedBuffer fromManagedBuffer(
+      ManagedBuffer buffer,
+      TransportConf conf,
+      File file) throws IOException {
+    FileUtils.copyInputStreamToFile(buffer.createInputStream(), file);
+    return new FileSegmentManagedBuffer(conf, file, 0, file.length());
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -18,11 +18,7 @@
 package org.apache.spark.network.shuffle;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
 
 import org.slf4j.Logger;
@@ -32,9 +28,7 @@ import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.ChunkReceivedCallback;
 import org.apache.spark.network.client.RpcResponseCallback;
-import org.apache.spark.network.client.StreamCallback;
 import org.apache.spark.network.client.TransportClient;
-import org.apache.spark.network.server.OneForOneStreamManager;
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 import org.apache.spark.network.shuffle.protocol.OpenBlocks;
 import org.apache.spark.network.shuffle.protocol.StreamHandle;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current code, client will fetch the remote huge blocks to disk. It is implemented by sending 'stream request', which needs server side support(change). Thus it will break old shuffle service.
Instead of fetching the stream to disk, this pr proposes to convert chunk to `FileSegmentManagedBuffer`.