### PR TITLE
[SPARK-21269][Core][WIP] Fix FetchFailedException when enable maxReqSizeShuffleToMem and KryoSerializer

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -22,6 +22,8 @@ import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import com.esotericsoftware.kryo.io.{Input, Output}
 import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.SparkEnv
@@ -142,7 +144,7 @@ private[spark] class HighlyCompressedMapStatus private (
     private[this] var emptyBlocks: RoaringBitmap,
     private[this] var avgSize: Long,
     private var hugeBlockSizes: Map[Int, Byte])
-  extends MapStatus with Externalizable {
+  extends MapStatus with Externalizable with KryoSerializable {
 
   // loc could be null when the default constructor is called during deserialization
   require(loc == null || avgSize > 0 || hugeBlockSizes.size > 0 || numNonEmptyBlocks == 0,
@@ -189,6 +191,15 @@ private[spark] class HighlyCompressedMapStatus private (
     }
     hugeBlockSizes = hugeBlockSizesArray.toMap
   }
+
+  override def write(kryo: Kryo, output: Output): Unit = {
+    kryo.writeClassAndObject(output, hugeBlockSizes)
+  }
+
+  override def read(kryo: Kryo, input: Input): Unit = {
+    hugeBlockSizes = kryo.readClassAndObject(input).asInstanceOf[Map[Int, Byte]]
+  }
+
 }
 
 private[spark] object HighlyCompressedMapStatus {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 Spark **cluster** can reproduce, **local** can't:

1. Start a spark context with `spark.reducer.maxReqSizeShuffleToMem=1K` and `spark.serializer=org.apache.spark.serializer.KryoSerializer`:
```
$ spark-shell --conf spark.reducer.maxReqSizeShuffleToMem=1K --conf spark.serializer=org.apache.spark.serializer.KryoSerializer
```

2.  A shuffle:
```
scala> sc.parallelize(0 until 3000000, 10).repartition(2001).count()
```

The error messages:

```
org.apache.spark.shuffle.MetadataFetchFailedException: Missing an output location for shuffle 0
        at org.apache.spark.MapOutputTracker$$anonfun$convertMapStatuses$2.apply(MapOutputTracker.scala:808)
        at org.apache.spark.MapOutputTracker$$anonfun$convertMapStatuses$2.apply(MapOutputTracker.scala:804)
        at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
        at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
        at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
        at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
        at org.apache.spark.MapOutputTracker$.convertMapStatuses(MapOutputTracker.scala:804)
        at org.apache.spark.MapOutputTrackerWorker.getMapSizesByExecutorId(MapOutputTracker.scala:618)
        at org.apache.spark.shuffle.BlockStoreShuffleReader.read(BlockStoreShuffleReader.scala:49)
        at org.apache.spark.rdd.ShuffledRDD.compute(ShuffledRDD.scala:105)
        at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
        at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
        at org.apache.spark.rdd.CoalescedRDD$$anonfun$compute$1.apply(CoalescedRDD.scala:100)
        at org.apache.spark.rdd.CoalescedRDD$$anonfun$compute$1.apply(CoalescedRDD.scala:99)
        at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
        at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
        at org.apache.spark.util.Utils$.getIteratorSize(Utils.scala:1802)
        at org.apache.spark.rdd.RDD$$anonfun$count$1.apply(RDD.scala:1159)
        at org.apache.spark.rdd.RDD$$anonfun$count$1.apply(RDD.scala:1159)
        at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2065)
        at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2065)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
        at org.apache.spark.scheduler.Task.run(Task.scala:108)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:341)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

)
...
```
This PR fix this issue.

## How was this patch tested?
Add later
