### PR TITLE
[MINOR][DOC] Version related doc fix in functions.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2118,7 +2118,7 @@ object functions {
    * Calculates the hash code of given columns, and returns the result as an int column.
    *
    * @group misc_funcs
-   * @since 2.0
+   * @since 2.0.0
    */
   @scala.annotation.varargs
   def hash(cols: Column*): Column = withExpr {
@@ -3078,9 +3078,8 @@ object functions {
    * string.
    *
    * @param e a string column containing JSON data.
-   * @param schema the schema to use when parsing the json string as a json string. In Spark 2.1,
-   *               the user-provided schema has to be in JSON format. Since Spark 2.2, the DDL
-   *               format is also supported for the schema.
+   * @param schema the schema to use when parsing the json string as a json string
+   *               or a DDL-formatted string.
    *
    * @group collection_funcs
    * @since 2.3.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to 

- remove description about behaviour change information about 2.1.0 and 2.2.0 in `from_json` added in 2.3.0.

- fix `@since 2.0` to `@since 2.0.0` for consistency in `hash`.

## How was this patch tested?

N/A