### PR TITLE
[TEST] Load test table based on case sensitivity

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hive.test
 
 import java.io.File
-import java.util.{Locale, Set => JavaSet}
+import java.util.{Set => JavaSet}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -555,10 +555,10 @@ private[hive] class TestHiveQueryExecution(
     val referencedTables =
       describedTables ++
         logical.collect { case UnresolvedRelation(tableIdent, _) => tableIdent.table }
-    val formattedRefTables = referencedTables.map { t =>
-      if (sparkSession.sessionState.conf.caseSensitiveAnalysis) t else t.toLowerCase(Locale.ROOT)
+    val resolver = sparkSession.sessionState.conf.resolver
+    val referencedTestTables = sparkSession.testTables.keys.filter { testTable =>
+      referencedTables.exists(resolver(_, testTable))
     }
-    val referencedTestTables = formattedRefTables.filter(sparkSession.testTables.contains)
     logDebug(s"Query references test tables: ${referencedTestTables.mkString(", ")}")
     referencedTestTables.foreach(sparkSession.loadTestTable)
     // Proceed with analysis.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
@@ -25,12 +25,14 @@ import org.apache.spark.sql.test.SQLTestUtils
 
 class TestHiveSuite extends TestHiveSingleton with SQLTestUtils {
   test("load test table based on case sensitivity") {
+    val testHiveSparkSession = spark.asInstanceOf[TestHiveSparkSession]
 
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       sql("SELECT * FROM SRC").queryExecution.analyzed
-      assert(spark.asInstanceOf[TestHiveSparkSession].getLoadedTables.contains("src"))
+      assert(testHiveSparkSession.getLoadedTables.contains("src"))
+      assert(testHiveSparkSession.getLoadedTables.size == 1)
     }
-    spark.asInstanceOf[TestHiveSparkSession].reset()
+    testHiveSparkSession.reset()
 
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
       val err = intercept[AnalysisException] {
@@ -38,6 +40,6 @@ class TestHiveSuite extends TestHiveSingleton with SQLTestUtils {
       }
       assert(err.message.contains("Table or view not found"))
     }
-    spark.asInstanceOf[TestHiveSparkSession].reset()
+    testHiveSparkSession.reset()
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestHiveSparkSession}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+
+class TestHiveSuite extends TestHiveSingleton with SQLTestUtils {
+  test("load test table based on case sensitivity") {
+
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+      sql("SELECT * FROM SRC").queryExecution.analyzed
+      assert(spark.asInstanceOf[TestHiveSparkSession].getLoadedTables.contains("src"))
+    }
+    spark.asInstanceOf[TestHiveSparkSession].reset()
+
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val err = intercept[AnalysisException] {
+        sql("SELECT * FROM SRC").queryExecution.analyzed
+      }
+      assert(err.message.contains("Table or view not found"))
+    }
+    spark.asInstanceOf[TestHiveSparkSession].reset()
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is strange that we will get "table not found" error if **the first sql** uses upper case table names, when developers write tests with `TestHiveSingleton`, **although case insensitivity**. This is because in `TestHiveQueryExecution`, test tables are loaded based on exact matching instead of case sensitivity.

## How was this patch tested?

Added a new test case.