### PR TITLE
[SPARK-21281][SQL] Use string types by default if array and map have no argument

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -526,18 +526,15 @@ case class Least(children: Seq[Expression]) extends Expression {
   private lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    TypeUtils.checkTypeInputDimension(
-        children.map(_.dataType), s"function $prettyName", requiredMinDimension = 2) match {
-      case TypeCheckResult.TypeCheckSuccess =>
-        if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
-          TypeCheckResult.TypeCheckFailure(
-            s"The expressions should all have the same type," +
-              s" got LEAST(${children.map(_.dataType.simpleString).mkString(", ")}).")
-        } else {
-          TypeUtils.checkForOrderingExpr(dataType, s"function $prettyName")
-        }
-      case typeCheckFailure =>
-        typeCheckFailure
+    if (children.length <= 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"input to function $prettyName requires at least two arguments")
+    } else if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"The expressions should all have the same type," +
+          s" got LEAST(${children.map(_.dataType.simpleString).mkString(", ")}).")
+    } else {
+      TypeUtils.checkForOrderingExpr(dataType, s"function $prettyName")
     }
   }
 
@@ -595,18 +592,15 @@ case class Greatest(children: Seq[Expression]) extends Expression {
   private lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    TypeUtils.checkTypeInputDimension(
-        children.map(_.dataType), s"function $prettyName", requiredMinDimension = 2) match {
-      case TypeCheckResult.TypeCheckSuccess =>
-        if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
-          TypeCheckResult.TypeCheckFailure(
-            s"The expressions should all have the same type," +
-              s" got GREATEST(${children.map(_.dataType.simpleString).mkString(", ")}).")
-        } else {
-          TypeUtils.checkForOrderingExpr(dataType, s"function $prettyName")
-        }
-      case typeCheckFailure =>
-        typeCheckFailure
+    if (children.length <= 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"input to function $prettyName requires at least two arguments")
+    } else if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"The expressions should all have the same type," +
+          s" got GREATEST(${children.map(_.dataType.simpleString).mkString(", ")}).")
+    } else {
+      TypeUtils.checkForOrderingExpr(dataType, s"function $prettyName")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -526,14 +526,18 @@ case class Least(children: Seq[Expression]) extends Expression {
   private lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (children.length <= 1) {
-      TypeCheckResult.TypeCheckFailure(s"LEAST requires at least 2 arguments")
-    } else if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
-      TypeCheckResult.TypeCheckFailure(
-        s"The expressions should all have the same type," +
-          s" got LEAST(${children.map(_.dataType.simpleString).mkString(", ")}).")
-    } else {
-      TypeUtils.checkForOrderingExpr(dataType, "function " + prettyName)
+    TypeUtils.checkTypeInputDimension(
+        children.map(_.dataType), s"function $prettyName", requiredMinDimension = 2) match {
+      case TypeCheckResult.TypeCheckSuccess =>
+        if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
+          TypeCheckResult.TypeCheckFailure(
+            s"The expressions should all have the same type," +
+              s" got LEAST(${children.map(_.dataType.simpleString).mkString(", ")}).")
+        } else {
+          TypeUtils.checkForOrderingExpr(dataType, s"function $prettyName")
+        }
+      case typeCheckFailure =>
+        typeCheckFailure
     }
   }
 
@@ -591,14 +595,18 @@ case class Greatest(children: Seq[Expression]) extends Expression {
   private lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (children.length <= 1) {
-      TypeCheckResult.TypeCheckFailure(s"GREATEST requires at least 2 arguments")
-    } else if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
-      TypeCheckResult.TypeCheckFailure(
-        s"The expressions should all have the same type," +
-          s" got GREATEST(${children.map(_.dataType.simpleString).mkString(", ")}).")
-    } else {
-      TypeUtils.checkForOrderingExpr(dataType, "function " + prettyName)
+    TypeUtils.checkTypeInputDimension(
+        children.map(_.dataType), s"function $prettyName", requiredMinDimension = 2) match {
+      case TypeCheckResult.TypeCheckSuccess =>
+        if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
+          TypeCheckResult.TypeCheckFailure(
+            s"The expressions should all have the same type," +
+              s" got GREATEST(${children.map(_.dataType.simpleString).mkString(", ")}).")
+        } else {
+          TypeUtils.checkForOrderingExpr(dataType, s"function $prettyName")
+        }
+      case typeCheckFailure =>
+        typeCheckFailure
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -299,20 +299,18 @@ trait CreateNamedStructLike extends Expression {
     if (children.length < 1) {
       TypeCheckResult.TypeCheckFailure(
         s"input to function $prettyName requires at least one argument")
+    } else if (children.size % 2 != 0) {
+      TypeCheckResult.TypeCheckFailure(s"$prettyName expects an even number of arguments.")
     } else {
-      if (children.size % 2 != 0) {
-        TypeCheckResult.TypeCheckFailure(s"$prettyName expects an even number of arguments.")
+      val invalidNames = nameExprs.filterNot(e => e.foldable && e.dataType == StringType)
+      if (invalidNames.nonEmpty) {
+        TypeCheckResult.TypeCheckFailure(
+          "Only foldable StringType expressions are allowed to appear at odd position, got:" +
+            s" ${invalidNames.mkString(",")}")
+      } else if (!names.contains(null)) {
+        TypeCheckResult.TypeCheckSuccess
       } else {
-        val invalidNames = nameExprs.filterNot(e => e.foldable && e.dataType == StringType)
-        if (invalidNames.nonEmpty) {
-          TypeCheckResult.TypeCheckFailure(
-            "Only foldable StringType expressions are allowed to appear at odd position, got:" +
-              s" ${invalidNames.mkString(",")}")
-        } else if (!names.contains(null)) {
-          TypeCheckResult.TypeCheckSuccess
-        } else {
-          TypeCheckResult.TypeCheckFailure("Field name should not be null")
-        }
+        TypeCheckResult.TypeCheckFailure("Field name should not be null")
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -41,8 +41,13 @@ case class CreateArray(children: Seq[Expression]) extends Expression {
 
   override def foldable: Boolean = children.forall(_.foldable)
 
-  override def checkInputDataTypes(): TypeCheckResult =
-    TypeUtils.checkForSameTypeInputExpr(children.map(_.dataType), "function array")
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (children == Nil) {
+      TypeCheckResult.TypeCheckFailure("input to function coalesce cannot be empty")
+    } else {
+      TypeUtils.checkForSameTypeInputExpr(children.map(_.dataType), "function array")
+    }
+  }
 
   override def dataType: ArrayType = {
     ArrayType(
@@ -168,7 +173,9 @@ case class CreateMap(children: Seq[Expression]) extends Expression {
   override def foldable: Boolean = children.forall(_.foldable)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (children.size % 2 != 0) {
+    if (children == Nil) {
+      TypeCheckResult.TypeCheckFailure("input to function coalesce cannot be empty")
+    } else if (children.size % 2 != 0) {
       TypeCheckResult.TypeCheckFailure(s"$prettyName expects a positive even number of arguments.")
     } else if (keys.map(_.dataType).distinct.length > 1) {
       TypeCheckResult.TypeCheckFailure("The given keys of function map should all be the same " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -47,7 +47,7 @@ case class CreateArray(children: Seq[Expression]) extends Expression {
 
   override def dataType: ArrayType = {
     ArrayType(
-      children.headOption.map(_.dataType).getOrElse(NullType),
+      children.headOption.map(_.dataType).getOrElse(StringType),
       containsNull = children.exists(_.nullable))
   }
 
@@ -94,7 +94,7 @@ private [sql] object GenArrayData {
     if (!ctx.isPrimitiveType(elementType)) {
       val genericArrayClass = classOf[GenericArrayData].getName
       ctx.addMutableState("Object[]", arrayName,
-        s"$arrayName = new Object[${numElements}];")
+        s"$arrayName = new Object[$numElements];")
 
       val assignments = elementsCode.zipWithIndex.map { case (eval, i) =>
         val isNullAssignment = if (!isMapKey) {
@@ -120,7 +120,7 @@ private [sql] object GenArrayData {
         UnsafeArrayData.calculateHeaderPortionInBytes(numElements) +
         ByteArrayMethods.roundNumberOfBytesToNearestWord(elementType.defaultSize * numElements)
       val baseOffset = Platform.BYTE_ARRAY_OFFSET
-      ctx.addMutableState("UnsafeArrayData", arrayDataName, "");
+      ctx.addMutableState("UnsafeArrayData", arrayDataName, "")
 
       val primitiveValueTypeName = ctx.primitiveTypeName(elementType)
       val assignments = elementsCode.zipWithIndex.map { case (eval, i) =>
@@ -169,32 +169,26 @@ case class CreateMap(children: Seq[Expression]) extends Expression {
   override def foldable: Boolean = children.forall(_.foldable)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    TypeUtils.checkTypeInputDimension(
-        children.map(_.dataType), s"function $prettyName", requiredMinDimension = 1) match {
-      case TypeCheckResult.TypeCheckSuccess =>
-        if (children.size % 2 != 0) {
-          TypeCheckResult.TypeCheckFailure(
-            s"$prettyName expects a positive even number of arguments.")
-        } else if (keys.map(_.dataType).distinct.length > 1) {
-          TypeCheckResult.TypeCheckFailure(
-            "The given keys of function map should all be the same type, but they are " +
-              keys.map(_.dataType.simpleString).mkString("[", ", ", "]"))
-        } else if (values.map(_.dataType).distinct.length > 1) {
-          TypeCheckResult.TypeCheckFailure(
-            "The given values of function map should all be the same type, but they are " +
-              values.map(_.dataType.simpleString).mkString("[", ", ", "]"))
-        } else {
-          TypeCheckResult.TypeCheckSuccess
-        }
-      case typeCheckFailure =>
-        typeCheckFailure
+    if (children.size % 2 != 0) {
+      TypeCheckResult.TypeCheckFailure(
+        s"$prettyName expects a positive even number of arguments.")
+    } else if (keys.map(_.dataType).distinct.length > 1) {
+      TypeCheckResult.TypeCheckFailure(
+        "The given keys of function map should all be the same type, but they are " +
+          keys.map(_.dataType.simpleString).mkString("[", ", ", "]"))
+    } else if (values.map(_.dataType).distinct.length > 1) {
+      TypeCheckResult.TypeCheckFailure(
+        "The given values of function map should all be the same type, but they are " +
+          values.map(_.dataType.simpleString).mkString("[", ", ", "]"))
+    } else {
+      TypeCheckResult.TypeCheckSuccess
     }
   }
 
   override def dataType: DataType = {
     MapType(
-      keyType = keys.headOption.map(_.dataType).getOrElse(NullType),
-      valueType = values.headOption.map(_.dataType).getOrElse(NullType),
+      keyType = keys.headOption.map(_.dataType).getOrElse(StringType),
+      valueType = values.headOption.map(_.dataType).getOrElse(StringType),
       valueContainsNull = values.exists(_.nullable))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -28,7 +28,7 @@ import org.apache.commons.codec.digest.DigestUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen._
-import org.apache.spark.sql.catalyst.util.{ArrayData, MapData, TypeUtils}
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.hash.Murmur3_x86_32
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -247,8 +247,12 @@ abstract class HashExpression[E] extends Expression {
   override def nullable: Boolean = false
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    TypeUtils.checkTypeInputDimension(
-      children.map(_.dataType), s"function $prettyName", requiredMinDimension = 1)
+    if (children.length < 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"input to function $prettyName requires at least one argument")
+    } else {
+      TypeCheckResult.TypeCheckSuccess
+    }
   }
 
   override def eval(input: InternalRow = null): Any = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -28,7 +28,7 @@ import org.apache.commons.codec.digest.DigestUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen._
-import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.hash.Murmur3_x86_32
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -247,11 +247,8 @@ abstract class HashExpression[E] extends Expression {
   override def nullable: Boolean = false
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (children.isEmpty) {
-      TypeCheckResult.TypeCheckFailure("function hash requires at least one argument")
-    } else {
-      TypeCheckResult.TypeCheckSuccess
-    }
+    TypeUtils.checkTypeInputDimension(
+      children.map(_.dataType), s"function $prettyName", requiredMinDimension = 1)
   }
 
   override def eval(input: InternalRow = null): Any = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -52,11 +52,7 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
   override def foldable: Boolean = children.forall(_.foldable)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (children == Nil) {
-      TypeCheckResult.TypeCheckFailure("input to function coalesce cannot be empty")
-    } else {
-      TypeUtils.checkForSameTypeInputExpr(children.map(_.dataType), "function coalesce")
-    }
+    TypeUtils.checkForSameTypeInputExpr(children.map(_.dataType), s"function $prettyName")
   }
 
   override def dataType: DataType = children.head.dataType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -52,13 +52,11 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
   override def foldable: Boolean = children.forall(_.foldable)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    val inputDataTypes = children.map(_.dataType)
-    TypeUtils.checkTypeInputDimension(
-        inputDataTypes, s"function $prettyName", requiredMinDimension = 1) match {
-      case TypeCheckResult.TypeCheckSuccess =>
-        TypeUtils.checkForSameTypeInputExpr(inputDataTypes, s"function $prettyName")
-      case typeCheckFailure =>
-        typeCheckFailure
+    if (children.length < 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"input to function $prettyName requires at least one argument")
+    } else {
+      TypeUtils.checkForSameTypeInputExpr(children.map(_.dataType), s"function $prettyName")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -52,7 +52,14 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
   override def foldable: Boolean = children.forall(_.foldable)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    TypeUtils.checkForSameTypeInputExpr(children.map(_.dataType), s"function $prettyName")
+    val inputDataTypes = children.map(_.dataType)
+    TypeUtils.checkTypeInputDimension(
+        inputDataTypes, s"function $prettyName", requiredMinDimension = 1) match {
+      case TypeCheckResult.TypeCheckSuccess =>
+        TypeUtils.checkForSameTypeInputExpr(inputDataTypes, s"function $prettyName")
+      case typeCheckFailure =>
+        typeCheckFailure
+    }
   }
 
   override def dataType: DataType = children.head.dataType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -57,17 +57,6 @@ object TypeUtils {
     }
   }
 
-  def checkTypeInputDimension(types: Seq[DataType], caller: String, requiredMinDimension: Int)
-    : TypeCheckResult = {
-    if (types.size >= requiredMinDimension) {
-      TypeCheckResult.TypeCheckSuccess
-    } else {
-      TypeCheckResult.TypeCheckFailure(
-        s"input to $caller requires at least $requiredMinDimension " +
-          s"argument${if (requiredMinDimension > 1) "s"}")
-    }
-  }
-
   def getNumeric(t: DataType): Numeric[Any] =
     t.asInstanceOf[NumericType].numeric.asInstanceOf[Numeric[Any]]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -42,23 +42,18 @@ object TypeUtils {
   }
 
   def checkForSameTypeInputExpr(types: Seq[DataType], caller: String): TypeCheckResult = {
-    checkTypeInputDimension(types, caller, requiredMinDimension = 1) match {
-      case TypeCheckResult.TypeCheckSuccess =>
-        if (types.size == 1) {
-          TypeCheckResult.TypeCheckSuccess
-        } else {
-          val firstType = types.head
-          types.foreach { t =>
-            if (!t.sameType(firstType)) {
-              return TypeCheckResult.TypeCheckFailure(
-                s"input to $caller should all be the same type, but it's " +
-                  types.map(_.simpleString).mkString("[", ", ", "]"))
-            }
-          }
-          TypeCheckResult.TypeCheckSuccess
+    if (types.size <= 1) {
+      TypeCheckResult.TypeCheckSuccess
+    } else {
+      val firstType = types.head
+      types.foreach { t =>
+        if (!t.sameType(firstType)) {
+          return TypeCheckResult.TypeCheckFailure(
+            s"input to $caller should all be the same type, but it's " +
+              types.map(_.simpleString).mkString("[", ", ", "]"))
         }
-      case typeCheckFailure =>
-        typeCheckFailure
+      }
+      TypeCheckResult.TypeCheckSuccess
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -155,7 +155,7 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
       "input to function array should all be the same type")
     assertError(Coalesce(Seq('intField, 'booleanField)),
       "input to function coalesce should all be the same type")
-    assertError(Coalesce(Nil), "input to function coalesce cannot be empty")
+    assertError(Coalesce(Nil), "function coalesce requires at least one argument")
     assertError(new Murmur3Hash(Nil), "function hash requires at least one argument")
     assertError(Explode('intField),
       "input to function explode should be array or map type")
@@ -207,7 +207,7 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
 
   test("check types for Greatest/Least") {
     for (operator <- Seq[(Seq[Expression] => Expression)](Greatest, Least)) {
-      assertError(operator(Seq('booleanField)), "requires at least 2 arguments")
+      assertError(operator(Seq('booleanField)), "requires at least two arguments")
       assertError(operator(Seq('intField, 'stringField)), "should all have the same type")
       assertError(operator(Seq('mapField, 'mapField)), "does not support ordering")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1566,10 +1566,7 @@ object functions {
    * @since 1.5.0
    */
   @scala.annotation.varargs
-  def greatest(exprs: Column*): Column = withExpr {
-    require(exprs.length > 1, "greatest requires at least 2 arguments.")
-    Greatest(exprs.map(_.expr))
-  }
+  def greatest(exprs: Column*): Column = withExpr { Greatest(exprs.map(_.expr)) }
 
   /**
    * Returns the greatest value of the list of column names, skipping null values.
@@ -1673,10 +1670,7 @@ object functions {
    * @since 1.5.0
    */
   @scala.annotation.varargs
-  def least(exprs: Column*): Column = withExpr {
-    require(exprs.length > 1, "least requires at least 2 arguments.")
-    Least(exprs.map(_.expr))
-  }
+  def least(exprs: Column*): Column = withExpr { Least(exprs.map(_.expr)) }
 
   /**
    * Returns the least value of the list of column names, skipping null values.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -471,7 +471,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       ("hash", (df: DataFrame) => df.selectExpr("hash()")) :: Nil
     funcsMustHaveAtLeastOneArg.foreach { case (name, func) =>
       val errMsg = intercept[AnalysisException] { func(df) }.getMessage
-      assert(errMsg.contains(s"input to function $name requires at least 1 argument"))
+      assert(errMsg.contains(s"input to function $name requires at least one argument"))
     }
 
     val funcsMustHaveAtLeastTwoArgs =
@@ -481,7 +481,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       ("least", (df: DataFrame) => df.selectExpr("least()")) :: Nil
     funcsMustHaveAtLeastTwoArgs.foreach { case (name, func) =>
       val errMsg = intercept[AnalysisException] { func(df) }.getMessage
-      assert(errMsg.contains(s"input to function $name requires at least 2 arguments"))
+      assert(errMsg.contains(s"input to function $name requires at least two arguments"))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr modified code to use string types by default if `array` and `map` in functions have no argument. This behaviour is the same with Hive one;
```
hive> CREATE TEMPORARY TABLE t1 AS SELECT map();
hive> DESCRIBE t1;
_c0   map<string,string>                          

hive> CREATE TEMPORARY TABLE t2 AS SELECT array();
hive> DESCRIBE t2;
_c0   array<string>
```

## How was this patch tested?
Added tests in `DataFrameFunctionsSuite`.