### PR TITLE
[SPARK-19507][SPARK-21296][PYTHON] Avoid per-record type dispatch in schema verification and improve exception message

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -627,7 +627,6 @@ class RDD(object):
     def sortByKey(self, ascending=True, numPartitions=None, keyfunc=lambda x: x):
         """
         Sorts this RDD, which is assumed to consist of (key, value) pairs.
-        # noqa
 
         >>> tmp = [('a', 1), ('b', 2), ('1', 3), ('d', 4), ('2', 5)]
         >>> sc.parallelize(tmp).sortByKey().first()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -33,7 +33,7 @@ from pyspark.sql.conf import RuntimeConfig
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader
 from pyspark.sql.streaming import DataStreamReader
-from pyspark.sql.types import Row, DataType, StringType, StructType, _verify_type, \
+from pyspark.sql.types import Row, DataType, StringType, StructType, _make_type_verifier, \
     _infer_schema, _has_nulltype, _merge_type, _create_converter, _parse_datatype_string
 from pyspark.sql.utils import install_exception_handler
 
@@ -514,17 +514,21 @@ class SparkSession(object):
                 schema = [str(x) for x in data.columns]
             data = [r.tolist() for r in data.to_records(index=False)]
 
-        verify_func = _verify_type if verifySchema else lambda _, t: True
         if isinstance(schema, StructType):
+            verify_func = _make_type_verifier(schema) if verifySchema else lambda _: True
+
             def prepare(obj):
-                verify_func(obj, schema)
+                verify_func(obj)
                 return obj
         elif isinstance(schema, DataType):
             dataType = schema
             schema = StructType().add("value", schema)
 
+            verify_func = _make_type_verifier(
+                dataType, name="field value") if verifySchema else lambda _: True
+
             def prepare(obj):
-                verify_func(obj, dataType, name='value')
+                verify_func(obj)
                 return obj,
         else:
             if isinstance(schema, list):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -524,7 +524,7 @@ class SparkSession(object):
             schema = StructType().add("value", schema)
 
             def prepare(obj):
-                verify_func(obj, dataType)
+                verify_func(obj, dataType, name='value')
                 return obj,
         else:
             if isinstance(schema, list):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2639,15 +2639,16 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
 class DataTypeVerificationTests(unittest.TestCase):
 
     def test_verify_type_exception_msg(self):
-        msg = "Expected verify_type() to throw so test can check exception message."
-        with self.assertRaises(Exception, msg=msg) as cm:
-            _make_type_verifier(StringType(), nullable=False, name="test_name")(None)
-        self.assertTrue(str(cm.exception).startswith("test_name"))
+        self.assertRaisesRegexp(
+            ValueError,
+            "test_name",
+            lambda: _make_type_verifier(StringType(), nullable=False, name="test_name")(None))
 
         schema = StructType([StructField('a', StructType([StructField('b', IntegerType())]))])
-        with self.assertRaises(Exception, msg=msg) as cm:
-            _make_type_verifier(schema)([["data"]])
-        self.assertTrue(str(cm.exception).startswith("field b in field a"))
+        self.assertRaisesRegexp(
+            TypeError,
+            "field b in field a",
+            lambda: _make_type_verifier(schema)([["data"]]))
 
     def test_verify_type_ok_nullable(self):
         obj = None

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -30,16 +30,6 @@ import pickle
 import functools
 import time
 import datetime
-import traceback
-
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 import py4j
 try:

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2644,6 +2644,13 @@ class TypesTest(unittest.TestCase):
         except Exception as e:
             self.assertTrue(str(e).startswith(name))
 
+        schema = StructType([StructField('a', StructType([StructField('b', IntegerType())]))])
+        try:
+            _verify_type([["data"]], schema)
+            self.fail('Expected _verify_type() to throw so test can check exception message')
+        except Exception as e:
+            self.assertTrue(str(e).startswith("a.b:"))
+
     def test_verify_type_ok_nullable(self):
         obj = None
         for data_type in [IntegerType(), FloatType(), StringType(), StructType([])]:
@@ -2659,7 +2666,7 @@ class TypesTest(unittest.TestCase):
         import datetime
         import decimal
 
-        MyStructType = StructType([
+        schema = StructType([
             StructField('s', StringType(), nullable=False),
             StructField('i', IntegerType(), nullable=True)])
 
@@ -2754,26 +2761,26 @@ class TypesTest(unittest.TestCase):
              ValueError),
 
             # Struct
-            ({"s": "a", "i": 1}, MyStructType, None),
-            ({"s": "a", "i": None}, MyStructType, None),
-            ({"s": "a"}, MyStructType, None),
-            ({"s": "a", "f": 1.0}, MyStructType, None),     # Extra fields OK
-            ({"s": "a", "i": "1"}, MyStructType, TypeError),
-            (Row(s="a", i=1), MyStructType, None),
-            (Row(s="a", i=None), MyStructType, None),
-            (Row(s="a", i=1, f=1.0), MyStructType, None),   # Extra fields OK
-            (Row(s="a"), MyStructType, ValueError),     # Row can't have missing field
-            (Row(s="a", i="1"), MyStructType, TypeError),
-            (["a", 1], MyStructType, None),
-            (["a", None], MyStructType, None),
-            (["a"], MyStructType, ValueError),
-            (["a", "1"], MyStructType, TypeError),
-            (("a", 1), MyStructType, None),
-            (MyObj(s="a", i=1), MyStructType, None),
-            (MyObj(s="a", i=None), MyStructType, None),
-            (MyObj(s="a"), MyStructType, None),
-            (MyObj(s="a", i="1"), MyStructType, TypeError),
-            (MyObj(s=None, i="1"), MyStructType, ValueError),
+            ({"s": "a", "i": 1}, schema, None),
+            ({"s": "a", "i": None}, schema, None),
+            ({"s": "a"}, schema, None),
+            ({"s": "a", "f": 1.0}, schema, None),     # Extra fields OK
+            ({"s": "a", "i": "1"}, schema, TypeError),
+            (Row(s="a", i=1), schema, None),
+            (Row(s="a", i=None), schema, None),
+            (Row(s="a", i=1, f=1.0), schema, None),   # Extra fields OK
+            (Row(s="a"), schema, ValueError),     # Row can't have missing field
+            (Row(s="a", i="1"), schema, TypeError),
+            (["a", 1], schema, None),
+            (["a", None], schema, None),
+            (["a"], schema, ValueError),
+            (["a", "1"], schema, TypeError),
+            (("a", 1), schema, None),
+            (MyObj(s="a", i=1), schema, None),
+            (MyObj(s="a", i=None), schema, None),
+            (MyObj(s="a"), schema, None),
+            (MyObj(s="a", i="1"), schema, TypeError),
+            (MyObj(s=None, i="1"), schema, ValueError),
         ]
 
         for obj, data_type, exp in spec:

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2642,12 +2642,12 @@ class DataTypeVerificationTests(unittest.TestCase):
         msg = "Expected verify_type() to throw so test can check exception message."
         with self.assertRaises(Exception, msg=msg) as cm:
             _make_type_verifier(StringType(), nullable=False, name="test_name")(None)
-            self.assertTrue(str(cm.exception).startswith("test_name"))
+        self.assertTrue(str(cm.exception).startswith("test_name"))
 
         schema = StructType([StructField('a', StructType([StructField('b', IntegerType())]))])
         with self.assertRaises(Exception, msg=msg) as cm:
             _make_type_verifier(schema)([["data"]])
-            self.assertTrue(str(cm.exception).startswith("field b in field a"))
+        self.assertTrue(str(cm.exception).startswith("field b in field a"))
 
     def test_verify_type_ok_nullable(self):
         obj = None

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2636,7 +2636,7 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
         importlib.reload(window)
 
 
-class TypesTest(unittest.TestCase):
+class DataTypeVerificationTests(unittest.TestCase):
 
     def test_verify_type_exception_msg(self):
         msg = "Expected verify_type() to throw so test can check exception message."

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -40,9 +40,6 @@ if sys.version_info[:2] <= (2, 6):
         sys.exit(1)
 else:
     import unittest
-    if sys.version_info[0] >= 3:
-        xrange = range
-        basestring = str
 
 import py4j
 try:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1249,7 +1249,7 @@ _acceptable_types = {
 }
 
 
-def _verify_type(obj, dataType, nullable=True, name=None):
+def _make_type_verifier(dataType, nullable=True, name=None):
     """
     Verify the type of obj against dataType, raise a TypeError if they do not match.
 
@@ -1257,41 +1257,42 @@ def _verify_type(obj, dataType, nullable=True, name=None):
     range, e.g. using 128 as ByteType will overflow. Note that, Python float is not checked, so it
     will become infinity when cast to Java float if it overflows.
 
-    >>> _verify_type(None, StructType([]))
-    >>> _verify_type("", StringType())
-    >>> _verify_type(0, LongType())
-    >>> _verify_type(list(range(3)), ArrayType(ShortType()))
-    >>> _verify_type(set(), ArrayType(StringType())) # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> _make_type_verifier(StructType([]))(None)
+    >>> _make_type_verifier(StringType())("")
+    >>> _make_type_verifier(LongType())(0)
+    >>> _make_type_verifier(ArrayType(ShortType()))(list(range(3)))
+    >>> _make_type_verifier(ArrayType(StringType()))(set()) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     TypeError:...
-    >>> _verify_type({}, MapType(StringType(), IntegerType()))
-    >>> _verify_type((), StructType([]))
-    >>> _verify_type([], StructType([]))
-    >>> _verify_type([1], StructType([])) # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> _make_type_verifier(MapType(StringType(), IntegerType()))({})
+    >>> _make_type_verifier(StructType([]))(())
+    >>> _make_type_verifier(StructType([]))([])
+    >>> _make_type_verifier(StructType([]))([1]) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     ValueError:...
     >>> # Check if numeric values are within the allowed range.
-    >>> _verify_type(12, ByteType())
-    >>> _verify_type(1234, ByteType()) # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> _make_type_verifier(ByteType())(12)
+    >>> _make_type_verifier(ByteType())(1234) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     ValueError:...
-    >>> _verify_type(None, ByteType(), False) # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> _make_type_verifier(ByteType(), False)(None) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     ValueError:...
-    >>> _verify_type([1, None], ArrayType(ShortType(), False)) # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> _make_type_verifier(
+    ...     ArrayType(ShortType(), False))([1, None]) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     ValueError:...
-    >>> _verify_type({None: 1}, MapType(StringType(), IntegerType()))
+    >>> _make_type_verifier(MapType(StringType(), IntegerType()))({None: 1})
     Traceback (most recent call last):
         ...
     ValueError:...
     >>> schema = StructType().add("a", IntegerType()).add("b", StringType(), False)
-    >>> _verify_type((1, None), schema) # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> _make_type_verifier(schema)((1, None)) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     ValueError:...
@@ -1299,91 +1300,150 @@ def _verify_type(obj, dataType, nullable=True, name=None):
 
     if name is None:
         new_msg = lambda msg: msg
-        new_element_name = lambda idx: "[%d]" % idx
-        new_key_name = lambda key: "[%s](key)" % key
-        new_value_name = lambda key: "[%s]" % key
-        new_name = lambda n: n
+        new_name = lambda n: "field %s" % n
     else:
         new_msg = lambda msg: "%s: %s" % (name, msg)
-        new_element_name = lambda idx: "%s[%d]" % (name, idx)
-        new_key_name = lambda key: "%s[%s](key)" % (name, key)
-        new_value_name = lambda key: "%s[%s]" % (name, key)
-        new_name = lambda n: "%s.%s" % (name, n)
+        new_name = lambda n: "field %s in %s" % (n, name)
 
-    if obj is None:
-        if nullable:
-            return
+    def verify_nullability(obj):
+        if obj is None:
+            if nullable:
+                return True
+            else:
+                raise ValueError(new_msg("This field is not nullable, but got None"))
         else:
-            raise ValueError(new_msg("This field is not nullable, but got None"))
+            return False
 
     # StringType can work with any types
     if isinstance(dataType, StringType):
-        return
+        def verify_string(obj):
+            if verify_nullability(obj):
+                return None
+        return verify_string
 
     if isinstance(dataType, UserDefinedType):
-        if not (hasattr(obj, '__UDT__') and obj.__UDT__ == dataType):
-            raise ValueError(new_msg("%r is not an instance of type %r" % (obj, dataType)))
-        _verify_type(dataType.toInternal(obj), dataType.sqlType(), name=name)
-        return
+        verifier = _make_type_verifier(dataType.sqlType(), name=name)
+
+        def verify_udf(obj):
+            if verify_nullability(obj):
+                return None
+            if not (hasattr(obj, '__UDT__') and obj.__UDT__ == dataType):
+                raise ValueError(new_msg("%r is not an instance of type %r" % (obj, dataType)))
+            verifier(dataType.toInternal(obj))
+        return verify_udf
 
     _type = type(dataType)
-    assert _type in _acceptable_types, \
-        new_msg("unknown datatype: %s for object %r" % (dataType, obj))
 
-    if _type is StructType:
-        # check the type and fields later
-        pass
-    else:
+    def assert_acceptable_types(obj):
+        assert _type in _acceptable_types, \
+            new_msg("unknown datatype: %s for object %r" % (dataType, obj))
+
+    def verify_acceptable_types(obj):
         # subclass of them can not be fromInternal in JVM
         if type(obj) not in _acceptable_types[_type]:
             raise TypeError(new_msg("%s can not accept object %r in type %s"
                                     % (dataType, obj, type(obj))))
 
     if isinstance(dataType, ByteType):
-        if obj < -128 or obj > 127:
-            raise ValueError(new_msg("object of ByteType out of range, got: %s" % obj))
+        def verify_byte(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+            verify_acceptable_types(obj)
+            if obj < -128 or obj > 127:
+                raise ValueError(new_msg("object of ByteType out of range, got: %s" % obj))
+        return verify_byte
 
     elif isinstance(dataType, ShortType):
-        if obj < -32768 or obj > 32767:
-            raise ValueError(new_msg("object of ShortType out of range, got: %s" % obj))
+        def verify_short(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+            verify_acceptable_types(obj)
+            if obj < -32768 or obj > 32767:
+                raise ValueError(new_msg("object of ShortType out of range, got: %s" % obj))
+        return verify_short
 
     elif isinstance(dataType, IntegerType):
-        if obj < -2147483648 or obj > 2147483647:
-            raise ValueError(new_msg("object of IntegerType out of range, got: %s" % obj))
+        def verify_integer(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+            verify_acceptable_types(obj)
+            if obj < -2147483648 or obj > 2147483647:
+                raise ValueError(
+                    new_msg("object of IntegerType out of range, got: %s" % obj))
+        return verify_integer
 
     elif isinstance(dataType, ArrayType):
-        for i, value in enumerate(obj):
-            _verify_type(
-                value, dataType.elementType, dataType.containsNull, name=new_element_name(i))
+        element_verifier = _make_type_verifier(
+            dataType.elementType, dataType.containsNull, name="element in array %s" % name)
+
+        def verify_array(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+            verify_acceptable_types(obj)
+            for i in obj:
+                element_verifier(i)
+        return verify_array
 
     elif isinstance(dataType, MapType):
-        for k, v in obj.items():
-            _verify_type(k, dataType.keyType, False, name=new_key_name(k))
-            _verify_type(
-                v, dataType.valueType, dataType.valueContainsNull, name=new_value_name(k))
+        key_verifier = _make_type_verifier(dataType.keyType, False, name="key of map %s" % name)
+        value_verifier = _make_type_verifier(
+            dataType.valueType, dataType.valueContainsNull, name="value of map %s" % name)
+
+        def verify_map(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+            verify_acceptable_types(obj)
+            for k, v in obj.items():
+                key_verifier(k)
+                value_verifier(v)
+        return verify_map
 
     elif isinstance(dataType, StructType):
-        if isinstance(obj, dict):
-            for f in dataType.fields:
-                _verify_type(obj.get(f.name), f.dataType, f.nullable, name=new_name(f.name))
-        elif isinstance(obj, Row) and getattr(obj, "__from_dict__", False):
-            # the order in obj could be different than dataType.fields
-            for f in dataType.fields:
-                _verify_type(obj[f.name], f.dataType, f.nullable, name=new_name(f.name))
-        elif isinstance(obj, (tuple, list)):
-            if len(obj) != len(dataType.fields):
-                raise ValueError(
-                    new_msg("Length of object (%d) does not match with "
-                            "length of fields (%d)" % (len(obj), len(dataType.fields))))
-            for v, f in zip(obj, dataType.fields):
-                _verify_type(v, f.dataType, f.nullable, name=new_name(f.name))
-        elif hasattr(obj, "__dict__"):
-            d = obj.__dict__
-            for f in dataType.fields:
-                _verify_type(d.get(f.name), f.dataType, f.nullable, name=new_name(f.name))
-        else:
-            raise TypeError(new_msg("StructType can not accept object %r in type %s"
-                                    % (obj, type(obj))))
+        verifiers = []
+        for f in dataType.fields:
+            verifier = _make_type_verifier(f.dataType, f.nullable, name=new_name(f.name))
+            verifiers.append((f.name, verifier))
+
+        def verify_struct(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+
+            if isinstance(obj, dict):
+                for f, verifier in verifiers:
+                    verifier(obj.get(f))
+            elif isinstance(obj, Row) and getattr(obj, "__from_dict__", False):
+                # the order in obj could be different than dataType.fields
+                for f, verifier in verifiers:
+                    verifier(obj[f])
+            elif isinstance(obj, (tuple, list)):
+                if len(obj) != len(verifiers):
+                    raise ValueError(
+                        new_msg("Length of object (%d) does not match with "
+                                "length of fields (%d)" % (len(obj), len(verifiers))))
+                for v, (_, verifier) in zip(obj, verifiers):
+                    verifier(v)
+            elif hasattr(obj, "__dict__"):
+                d = obj.__dict__
+                for f, verifier in verifiers:
+                    verifier(d.get(f))
+            else:
+                raise TypeError(new_msg("StructType can not accept object %r in type %s"
+                                        % (obj, type(obj))))
+        return verify_struct
+
+    else:
+        def verify_default(obj):
+            if verify_nullability(obj):
+                return None
+            assert_acceptable_types(obj)
+            verify_acceptable_types(obj)
+        return verify_default
 
 
 # This is used to unpickle a Row from JVM

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1251,11 +1251,12 @@ _acceptable_types = {
 
 def _make_type_verifier(dataType, nullable=True, name=None):
     """
-    Verify the type of obj against dataType, raise a TypeError if they do not match.
+    Make a verifier that checks the type of obj against dataType and raises a TypeError if they do
+    not match.
 
-    Also verify the value of obj against datatype, raise a ValueError if it's not within the allowed
-    range, e.g. using 128 as ByteType will overflow. Note that, Python float is not checked, so it
-    will become infinity when cast to Java float if it overflows.
+    This verifier also checks the value of obj against datatype and raises a ValueError if it's not
+    within the allowed range, e.g. using 128 as ByteType will overflow. Note that, Python float is
+    not checked, so it will become infinity when cast to Java float if it overflows.
 
     >>> _make_type_verifier(StructType([]))(None)
     >>> _make_type_verifier(StringType())("")


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Context**

While reviewing https://github.com/apache/spark/pull/17227, I realised here we type-dispatch per record. The PR itself is fine in terms of performance as is but this prints a prefix, `"obj"` in exception message as below:

```
from pyspark.sql.types import *
schema = StructType([StructField('s', IntegerType(), nullable=False)])
spark.createDataFrame([["1"]], schema)
...
TypeError: obj.s: IntegerType can not accept object '1' in type <type 'str'>
```

I suggested to get rid of this but during investigating this, I realised my approach might bring a performance regression as it is a hot path.

Only for SPARK-19507 and https://github.com/apache/spark/pull/17227, It needs more changes to cleanly get rid of the prefix and I rather decided to fix both issues together.

**Propersal**

This PR tried to

  - get rid of per-record type dispatch as we do in many code paths in Scala  so that it improves the performance (roughly ~25% improvement) - SPARK-21296

    This was tested with a simple code `spark.createDataFrame(range(1000000), "int")`. However, I am quite sure the actual improvement in practice is larger than this, in particular, when the schema is complicated.

   - improve error message in exception describing field information as prose - SPARK-19507

## How was this patch tested?

Manually tested and unit tests were added in `python/pyspark/sql/tests.py`.

Benchmark - codes: https://gist.github.com/HyukjinKwon/c3397469c56cb26c2d7dd521ed0bc5a3
Error message - codes: https://gist.github.com/HyukjinKwon/b1b2c7f65865444c4a8836435100e398

**Before**

Benchmark:
  - Results: https://gist.github.com/HyukjinKwon/4a291dab45542106301a0c1abcdca924

Error message
  - Results: https://gist.github.com/HyukjinKwon/57b1916395794ce924faa32b14a3fe19
 
**After**

Benchmark  
  - Results: https://gist.github.com/HyukjinKwon/21496feecc4a920e50c4e455f836266e

Error message
  - Results: https://gist.github.com/HyukjinKwon/7a494e4557fe32a652ce1236e504a395

Closes #17227