### PR TITLE
[SPARK-21298][spark core]Don't need to modified name when it's added the same ids

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
@@ -60,7 +60,7 @@ class StorageListener(storageStatusListener: StorageStatusListener) extends Bloc
 
   override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = synchronized {
     val rddInfos = stageSubmitted.stageInfo.rddInfos
-    rddInfos.foreach { info => _rddInfoMap.getOrElseUpdate(info.id, info).name = info.name }
+    rddInfos.foreach { info => _rddInfoMap.getOrElseUpdate(info.id, info)}
   }
 
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = synchronized {


### PR DESCRIPTION
## What changes were proposed in this pull request?
It's not need to replace name when the key has exsited.
I have a stage,named freedom and id is 0,  then adding a stage that named nofreedom and id is 0. In this case, i think it's not need to modified the stage name. returns existing values only. 


## How was this patch tested?
Unit test
