### PR TITLE
[SPARK-21263][SQL] Do not allow partially parsing double and floats via NumberFormat in CSV

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
@@ -111,9 +111,7 @@ class UnivocityParser(
         case options.nanValue => Float.NaN
         case options.negativeInf => Float.NegativeInfinity
         case options.positiveInf => Float.PositiveInfinity
-        case datum =>
-          Try(datum.toFloat)
-            .getOrElse(NumberFormat.getInstance(Locale.US).parse(datum).floatValue())
+        case datum => datum.toFloat
       }
 
     case _: DoubleType => (d: String) =>
@@ -121,9 +119,7 @@ class UnivocityParser(
         case options.nanValue => Double.NaN
         case options.negativeInf => Double.NegativeInfinity
         case options.positiveInf => Double.PositiveInfinity
-        case datum =>
-          Try(datum.toDouble)
-            .getOrElse(NumberFormat.getInstance(Locale.US).parse(datum).doubleValue())
+        case datum => datum.toDouble
       }
 
     case _: BooleanType => (d: String) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1182,7 +1182,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
         .csv(Seq("10u12").toDS())
         .collect()
     }
-    assert(exception.getMessage.contains("10u12"))
+    assert(exception.getMessage.contains("""input string: "10u12""""))
 
     val count = spark.read.schema("a FLOAT")
       .option("mode", "DROPMALFORMED")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1175,7 +1175,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       }
   }
 
-  test("Do not partially lose data when parsing float and double") {
+  test("SPARK-21263: Invalid float and double are handled correctly in different modes") {
     val exception = intercept[SparkException] {
       spark.read.schema("a DOUBLE")
         .option("mode", "FAILFAST")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParserSuite.scala
@@ -130,7 +130,7 @@ class UnivocityParserSuite extends SparkFunSuite {
       DateTimeUtils.millisToDays(DateTimeUtils.stringToTime("2015-01-01").getTime))
   }
 
-  test("Float and Double Types do not allow partial results") {
+  test("Throws exception for casting an invalid string to Float and Double Types") {
     val options = new CSVOptions(Map.empty[String, String], "GMT")
     var message = intercept[NumberFormatException] {
       parser.makeConverter("_1", FloatType, options = options).apply("10u000")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParserSuite.scala
@@ -130,17 +130,17 @@ class UnivocityParserSuite extends SparkFunSuite {
       DateTimeUtils.millisToDays(DateTimeUtils.stringToTime("2015-01-01").getTime))
   }
 
-  test("Float and Double Types are cast without respect to platform default Locale") {
-    val originalLocale = Locale.getDefault
-    try {
-      Locale.setDefault(new Locale("fr", "FR"))
-      // Would parse as 1.0 in fr-FR
-      val options = new CSVOptions(Map.empty[String, String], "GMT")
-      assert(parser.makeConverter("_1", FloatType, options = options).apply("1,00") == 100.0)
-      assert(parser.makeConverter("_1", DoubleType, options = options).apply("1,00") == 100.0)
-    } finally {
-      Locale.setDefault(originalLocale)
-    }
+  test("Float and Double Types do not allow partial results") {
+    val options = new CSVOptions(Map.empty[String, String], "GMT")
+    var message = intercept[NumberFormatException] {
+      parser.makeConverter("_1", FloatType, options = options).apply("10u000")
+    }.getMessage
+    assert(message.contains("10u000"))
+
+    message = intercept[NumberFormatException] {
+      parser.makeConverter("_1", DoubleType, options = options).apply("10u000")
+    }.getMessage
+    assert(message.contains("10u000"))
   }
 
   test("Float NaN values are parsed correctly") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParserSuite.scala
@@ -132,15 +132,16 @@ class UnivocityParserSuite extends SparkFunSuite {
 
   test("Throws exception for casting an invalid string to Float and Double Types") {
     val options = new CSVOptions(Map.empty[String, String], "GMT")
-    var message = intercept[NumberFormatException] {
-      parser.makeConverter("_1", FloatType, options = options).apply("10u000")
-    }.getMessage
-    assert(message.contains("10u000"))
-
-    message = intercept[NumberFormatException] {
-      parser.makeConverter("_1", DoubleType, options = options).apply("10u000")
-    }.getMessage
-    assert(message.contains("10u000"))
+    val types = Seq(DoubleType, FloatType)
+    val input = Seq("10u000", "abc", "1 2/3")
+    types.foreach { dt =>
+      input.foreach { v =>
+        val message = intercept[NumberFormatException] {
+          parser.makeConverter("_1", dt, options = options).apply(v)
+        }.getMessage
+        assert(message.contains(v))
+      }
+    }
   }
 
   test("Float NaN values are parsed correctly") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to remove `NumberFormat.parse` use to disallow a case of partially parsed data. For example,

```
scala> spark.read.schema("a DOUBLE").option("mode", "FAILFAST").csv(Seq("10u12").toDS).show()
+----+
|   a|
+----+
|10.0|
+----+
```

## How was this patch tested?

Unit tests added in `UnivocityParserSuite` and `CSVSuite`.
