### PR TITLE
[SPARK-21305][ML][MLLIB]Add options to disable multi-threading of native BLAS

### DIFF
--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -62,6 +62,6 @@
 # - SPARK_NICENESS      The scheduling priority for daemons. (Default: 0)
 # - SPARK_NO_DAEMONIZE  Run the proposed command in the foreground. It will not output a PID file.
 # Options for native BLAS, like Intel MKL, OpenBLAS, and so on.
-# You shoud enable these options if use native BLAS (SPARK-21305).
+# You shoud enable these options if using native BLAS (see SPARK-21305).
 # - MKL_NUM_THREADS=1        Disable multi-threading of Intel MKL
 # - OPENBLAS_NUM_THREADS=1   Disable multi-threading of OpenBLAS

--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -62,6 +62,6 @@
 # - SPARK_NICENESS      The scheduling priority for daemons. (Default: 0)
 # - SPARK_NO_DAEMONIZE  Run the proposed command in the foreground. It will not output a PID file.
 # Options for native BLAS, like Intel MKL, OpenBLAS, and so on.
-# You shoud enable these options if using native BLAS (see SPARK-21305).
+# You might get better performance to enable these options if using native BLAS (see SPARK-21305).
 # - MKL_NUM_THREADS=1        Disable multi-threading of Intel MKL
 # - OPENBLAS_NUM_THREADS=1   Disable multi-threading of OpenBLAS

--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -61,3 +61,7 @@
 # - SPARK_IDENT_STRING  A string representing this instance of spark. (Default: $USER)
 # - SPARK_NICENESS      The scheduling priority for daemons. (Default: 0)
 # - SPARK_NO_DAEMONIZE  Run the proposed command in the foreground. It will not output a PID file.
+# Options for native BLAS, like Intel MKL, OpenBLAS, and so on.
+# You shoud enable these options if use native BLAS (SPARK-21305).
+# - MKL_NUM_THREADS=1        Disable multi-threading of Intel MKL
+# - OPENBLAS_NUM_THREADS=1   Disable multi-threading of OpenBLAS

--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -61,8 +61,10 @@ To configure `netlib-java` / Breeze to use system optimised binaries, include
 project and read the [netlib-java](https://github.com/fommil/netlib-java) documentation for your
 platform's additional installation instructions.
 
-The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), OpenBLAS, are based on multi-threading, which will conflict with Spark.
-To use multi-threading based native BLAS, you must set it to use single thread first (SPARK-21305).
+The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), [OpenBLAS](http://www.openblas.net), are based on multi-threading. 
+For example, when OpenBLAS is loaded, it will create a thread pool with `MAX_CPU_NUMBER` threads, and the threads are using spinlock by default, which will conflict with Spark.
+
+If using a native BLAS based on multi-threading, for the best performance you must set it to use single thread first ([SPARK-21305](https://issues.apache.org/jira/browse/SPARK-21305)).
 
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
 

--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -62,7 +62,7 @@ project and read the [netlib-java](https://github.com/fommil/netlib-java) docume
 platform's additional installation instructions.
 
 Some popular native BLAS (e.g. Intel MKL, OpenBLAS) are based on multi-threading, which will conflict with Spark.
-To use multi-threading based native BLAS, you must set it to use single thread first.
+To use multi-threading based native BLAS, you must set it to use single thread first (SPARK-21305).
 
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
 

--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -61,11 +61,11 @@ To configure `netlib-java` / Breeze to use system optimised binaries, include
 project and read the [netlib-java](https://github.com/fommil/netlib-java) documentation for your
 platform's additional installation instructions.
 
-The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), [OpenBLAS](http://www.openblas.net), are based on multi-threading, which will conflict with Spark.
+The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), [OpenBLAS](http://www.openblas.net), can use multiple threads in a single operation, which can conflict with Spark's execution model.
 
-If using a native BLAS based on multi-threading, you might get better performance to set it to use single thread first ([SPARK-21305](https://issues.apache.org/jira/browse/SPARK-21305)). 
+Configuring these BLAS implementations to use a single thread for operations may actually improve performance (see [SPARK-21305](https://issues.apache.org/jira/browse/SPARK-21305)). It is usually optimal to match this to the number of cores each Spark task is configured to use, which is 1 by default and typically left at 1.
 
-Please reference the recommended settings for [Intel MKL](https://software.intel.com/en-us/articles/recommended-settings-for-calling-intel-mkl-routines-from-multi-threaded-applications) and [OpenBLAS](https://github.com/xianyi/OpenBLAS/wiki/faq#multi-threaded).
+Please refer to resources like the following to understand how to configure the number of threads these BLAS implementations use: [Intel MKL](https://software.intel.com/en-us/articles/recommended-settings-for-calling-intel-mkl-routines-from-multi-threaded-applications) and [OpenBLAS](https://github.com/xianyi/OpenBLAS/wiki/faq#multi-threaded).
 
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
 

--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -61,6 +61,9 @@ To configure `netlib-java` / Breeze to use system optimised binaries, include
 project and read the [netlib-java](https://github.com/fommil/netlib-java) documentation for your
 platform's additional installation instructions.
 
+Some popular native BLAS (e.g. Intel MKL, OpenBLAS) are based on multi-threading, which will conflict with Spark.
+To use multi-threading based native BLAS, you must set it to use single thread first.
+
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
 
 [^1]: To learn more about the benefits and background of system optimised natives, you may wish to

--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -61,10 +61,11 @@ To configure `netlib-java` / Breeze to use system optimised binaries, include
 project and read the [netlib-java](https://github.com/fommil/netlib-java) documentation for your
 platform's additional installation instructions.
 
-The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), [OpenBLAS](http://www.openblas.net), are based on multi-threading. 
-For example, when OpenBLAS is loaded, it will create a thread pool with `MAX_CPU_NUMBER` threads, and the threads are using spinlock by default, which will conflict with Spark.
+The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), [OpenBLAS](http://www.openblas.net), are based on multi-threading, which will conflict with Spark.
 
-If using a native BLAS based on multi-threading, for the best performance you must set it to use single thread first ([SPARK-21305](https://issues.apache.org/jira/browse/SPARK-21305)).
+If using a native BLAS based on multi-threading, you might get better performance to set it to use single thread first ([SPARK-21305](https://issues.apache.org/jira/browse/SPARK-21305)). 
+
+Please reference the recommended settings for [Intel MKL](https://software.intel.com/en-us/articles/recommended-settings-for-calling-intel-mkl-routines-from-multi-threaded-applications) and [OpenBLAS](https://github.com/xianyi/OpenBLAS/wiki/faq#multi-threaded).
 
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
 

--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -61,7 +61,7 @@ To configure `netlib-java` / Breeze to use system optimised binaries, include
 project and read the [netlib-java](https://github.com/fommil/netlib-java) documentation for your
 platform's additional installation instructions.
 
-Some popular native BLAS (e.g. Intel MKL, OpenBLAS) are based on multi-threading, which will conflict with Spark.
+The most popular native BLAS such as [Intel MKL](https://software.intel.com/en-us/mkl), OpenBLAS, are based on multi-threading, which will conflict with Spark.
 To use multi-threading based native BLAS, you must set it to use single thread first (SPARK-21305).
 
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Many ML/MLLIB algorithms use native BLAS (like Intel MKL, ATLAS, OpenBLAS) to improvement the performance. 
Many popular Native BLAS, like Intel MKL, OpenBLAS, use multi-threading technology, which will conflict with Spark.  Spark should provide options to disable multi-threading of Native BLAS.

https://github.com/xianyi/OpenBLAS/wiki/faq#multi-threaded
https://software.intel.com/en-us/articles/recommended-settings-for-calling-intel-mkl-routines-from-multi-threaded-applications

## How was this patch tested?
The existing UT.

