### PR TITLE
[SPARK-21306][ML] OneVsRest should support setWeightCol

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -320,7 +320,7 @@ final class OneVsRest @Since("1.4.0") (
 
     val multiclassLabeled = getClassifier match {
       // SPARK-21306: cache weightCol if necessary
-      case c: HasWeightCol if c.isDefined(c.weightCol) && !c.getWeightCol.isEmpty =>
+      case c: HasWeightCol if c.isDefined(c.weightCol) && c.getWeightCol.nonEmpty =>
         dataset.select($(labelCol), $(featuresCol), c.getWeightCol)
       case _ => dataset.select($(labelCol), $(featuresCol))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -296,7 +296,15 @@ final class OneVsRest @Since("1.4.0") (
   @Since("1.5.0")
   def setPredictionCol(value: String): this.type = set(predictionCol, value)
 
-  /** @group setParam */
+  /**
+   * Sets the value of param [[weightCol]].
+   *
+   * This is ignored if weight is not supported by [[classifier]].
+   * If this is not set or empty, we treat all instance weights as 1.0.
+   * Default is not set, so all instances have weight one.
+   *
+   * @group setParam
+   */
   @Since("2.3.0")
   def setWeightCol(value: String): this.type = set(weightCol, value)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -323,7 +323,6 @@ final class OneVsRest @Since("1.4.0") (
     val numClasses = MetadataUtils.getNumClasses(labelSchema).fold(computeNumClasses())(identity)
     instr.logNumClasses(numClasses)
 
-    // SPARK-21306: cache weightCol if necessary
     val weightColIsUsed = isDefined(weightCol) && $(weightCol).nonEmpty && {
       getClassifier match {
         case _: HasWeightCol => true

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -159,7 +159,7 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
   test("SPARK-21306: OneVsRest should cache weightCol if necessary") {
     val dataset2 = dataset.withColumn("weight", lit(1))
     val ova = new OneVsRest().setClassifier(new LogisticRegression().setWeightCol("weight"))
-    // run without any exception.
+    // failed if weightCol is not cached.
     val ovaModel = ova.fit(dataset2)
     assert(ovaModel !== null)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -156,6 +156,14 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     assert(output.schema.fieldNames.toSet === Set("label", "features", "prediction"))
   }
 
+  test("SPARK-21306: OneVsRest should cache weightCol if necessary") {
+    val dataset2 = dataset.withColumn("weight", lit(1))
+    val ova = new OneVsRest().setClassifier(new LogisticRegression().setWeightCol("weight"))
+    // run without any exception.
+    val ovaModel = ova.fit(dataset2)
+    assert(ovaModel !== null)
+  }
+
   test("OneVsRest.copy and OneVsRestModel.copy") {
     val lr = new LogisticRegression()
       .setMaxIter(1)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -158,7 +158,7 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
 
   test("SPARK-21306: OneVsRest should cache weightCol if necessary") {
     val dataset2 = dataset.withColumn("weight", lit(1))
-    val ova = new OneVsRest().setClassifier(new LogisticRegression().setWeightCol("weight"))
+    val ova = new OneVsRest().setWeightCol("weight").setClassifier(new LogisticRegression())
     // failed if weightCol is not cached.
     val ovaModel = ova.fit(dataset2)
     assert(ovaModel !== null)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -158,9 +158,12 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
 
   test("SPARK-21306: OneVsRest should support setWeightCol") {
     val dataset2 = dataset.withColumn("weight", lit(1))
+    // classifier inherits hasWeightCol
     val ova = new OneVsRest().setWeightCol("weight").setClassifier(new LogisticRegression())
-    val ovaModel = ova.fit(dataset2)
-    assert(ovaModel !== null)
+    assert(ova.fit(dataset2) !== null)
+    // classifier doesn't inherit hasWeightCol
+    val ova2 = new OneVsRest().setWeightCol("weight").setClassifier(new DecisionTreeClassifier())
+    assert(ova2.fit(dataset2) !== null)
   }
 
   test("OneVsRest.copy and OneVsRestModel.copy") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -156,10 +156,9 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     assert(output.schema.fieldNames.toSet === Set("label", "features", "prediction"))
   }
 
-  test("SPARK-21306: OneVsRest should cache weightCol if necessary") {
+  test("SPARK-21306: OneVsRest should support setWeightCol") {
     val dataset2 = dataset.withColumn("weight", lit(1))
     val ova = new OneVsRest().setWeightCol("weight").setClassifier(new LogisticRegression())
-    // failed if weightCol is not cached.
     val ovaModel = ova.fit(dataset2)
     assert(ovaModel !== null)
   }

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1546,7 +1546,9 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
         numClasses = int(dataset.agg({labelCol: "max"}).head()["max("+labelCol+")"]) + 1
 
-        if isinstance(classifier, HasWeightCol) and classifier.getWeightCol():
+        if (isinstance(classifier, HasWeightCol) and
+            classifier.isDefined(classifier.weightCol) and
+            classifier.getWeightCol()):
             multiclassLabeled = dataset.select(labelCol, featuresCol, classifier.getWeightCol())
         else:
             multiclassLabeled = dataset.select(labelCol, featuresCol)

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1546,7 +1546,10 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
         numClasses = int(dataset.agg({labelCol: "max"}).head()["max("+labelCol+")"]) + 1
 
-        multiclassLabeled = dataset.select(labelCol, featuresCol)
+        if isinstance(classifier, HasWeightCol) and classifier.getWeightCol():
+            multiclassLabeled = dataset.select(labelCol, featuresCol, classifier.getWeightCol())
+        else:
+            multiclassLabeled = dataset.select(labelCol, featuresCol)
 
         # persist if underlying dataset is not persistent.
         handlePersistence = \

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1546,9 +1546,9 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
         numClasses = int(dataset.agg({labelCol: "max"}).head()["max("+labelCol+")"]) + 1
 
-        if (isinstance(classifier, HasWeightCol) and
-            classifier.isDefined(classifier.weightCol) and
-            classifier.getWeightCol()):
+        if (isinstance(classifier, HasWeightCol)
+                and classifier.isDefined(classifier.weightCol)
+                and classifier.getWeightCol()):
             multiclassLabeled = dataset.select(labelCol, featuresCol, classifier.getWeightCol())
         else:
             multiclassLabeled = dataset.select(labelCol, featuresCol)

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1548,7 +1548,6 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
         numClasses = int(dataset.agg({labelCol: "max"}).head()["max("+labelCol+")"]) + 1
 
-        # SPARK - 21306: cache weightCol if necessary
         weightCol = None
         if (self.isDefined(self.weightCol) and self.getWeightCol()):
             if isinstance(classifier, HasWeightCol):

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1447,7 +1447,7 @@ class MultilayerPerceptronClassificationModel(JavaModel, JavaPredictionModel, Ja
         return self._call_java("weights")
 
 
-class OneVsRestParams(HasFeaturesCol, HasLabelCol, HasPredictionCol):
+class OneVsRestParams(HasFeaturesCol, HasLabelCol, HasWeightCol, HasPredictionCol):
     """
     Parameters for OneVsRest and OneVsRestModel.
     """
@@ -1517,10 +1517,10 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
     @keyword_only
     def __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction",
-                 classifier=None):
+                 weightCol=None, classifier=None):
         """
         __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
-                 classifier=None)
+                 weightCol=None, classifier=None)
         """
         super(OneVsRest, self).__init__()
         kwargs = self._input_kwargs
@@ -1528,9 +1528,11 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
     @keyword_only
     @since("2.0.0")
-    def setParams(self, featuresCol=None, labelCol=None, predictionCol=None, classifier=None):
+    def setParams(self, featuresCol=None, labelCol=None, predictionCol=None,
+                  weightCol=None, classifier=None):
         """
-        setParams(self, featuresCol=None, labelCol=None, predictionCol=None, classifier=None):
+        setParams(self, featuresCol=None, labelCol=None, predictionCol=None, \
+                  weightCol=None, classifier=None):
         Sets params for OneVsRest.
         """
         kwargs = self._input_kwargs
@@ -1546,10 +1548,17 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
         numClasses = int(dataset.agg({labelCol: "max"}).head()["max("+labelCol+")"]) + 1
 
-        if (isinstance(classifier, HasWeightCol)
-                and classifier.isDefined(classifier.weightCol)
-                and classifier.getWeightCol()):
-            multiclassLabeled = dataset.select(labelCol, featuresCol, classifier.getWeightCol())
+        # SPARK - 21306: cache weightCol if necessary
+        weightCol = None
+        if (self.isDefined(self.weightCol) and self.getWeightCol()):
+            if isinstance(classifier, HasWeightCol):
+                weightCol = self.getWeightCol()
+            else:
+                warnings.warn("weightCol is ignored, "
+                              "as it is not supported by {} now.".format(classifier))
+
+        if weightCol:
+            multiclassLabeled = dataset.select(labelCol, featuresCol, weightCol)
         else:
             multiclassLabeled = dataset.select(labelCol, featuresCol)
 
@@ -1567,6 +1576,8 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
             paramMap = dict([(classifier.labelCol, binaryLabelCol),
                             (classifier.featuresCol, featuresCol),
                             (classifier.predictionCol, predictionCol)])
+            if weightCol:
+                paramMap[classifier.weightCol] = weightCol
             return classifier.fit(trainingDataset, paramMap)
 
         # TODO: Parallel training for all classes.

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1517,10 +1517,10 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
 
     @keyword_only
     def __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction",
-                 weightCol=None, classifier=None):
+                 classifier=None, weightCol=None):
         """
         __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
-                 weightCol=None, classifier=None)
+                 classifier=None, weightCol=None)
         """
         super(OneVsRest, self).__init__()
         kwargs = self._input_kwargs
@@ -1529,10 +1529,10 @@ class OneVsRest(Estimator, OneVsRestParams, MLReadable, MLWritable):
     @keyword_only
     @since("2.0.0")
     def setParams(self, featuresCol=None, labelCol=None, predictionCol=None,
-                  weightCol=None, classifier=None):
+                  classifier=None, weightCol=None):
         """
         setParams(self, featuresCol=None, labelCol=None, predictionCol=None, \
-                  weightCol=None, classifier=None):
+                  classifier=None, weightCol=None):
         Sets params for OneVsRest.
         """
         kwargs = self._input_kwargs

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1255,6 +1255,16 @@ class OneVsRestTests(SparkSessionTestCase):
         output = model.transform(df)
         self.assertEqual(output.columns, ["label", "features", "prediction"])
 
+    def test_cache_weightCol_if_necessary(self):
+        df = self.spark.createDataFrame([(0.0, Vectors.dense(1.0, 0.8), 1.0),
+                                         (1.0, Vectors.sparse(2, [], []), 1.0),
+                                         (2.0, Vectors.dense(0.5, 0.5), 1.0)],
+                                        ["label", "features", "weight"])
+        lr = LogisticRegression(maxIter=5, regParam=0.01, weightCol="weight")
+        ovr = OneVsRest(classifier=lr)
+        model = ovr.fit(df)
+        self.assertIsNone(model)
+
 
 class HashingTFTest(SparkSessionTestCase):
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1263,7 +1263,7 @@ class OneVsRestTests(SparkSessionTestCase):
         lr = LogisticRegression(maxIter=5, regParam=0.01, weightCol="weight")
         ovr = OneVsRest(classifier=lr)
         model = ovr.fit(df)
-        self.assertIsNone(model)
+        self.assertIsNotNone(model)
 
 
 class HashingTFTest(SparkSessionTestCase):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1260,11 +1260,18 @@ class OneVsRestTests(SparkSessionTestCase):
                                          (1.0, Vectors.sparse(2, [], []), 1.0),
                                          (2.0, Vectors.dense(0.5, 0.5), 1.0)],
                                         ["label", "features", "weight"])
+        # classifier inherits hasWeightCol
         lr = LogisticRegression(maxIter=5, regParam=0.01)
         ovr = OneVsRest(classifier=lr, weightCol="weight")
         self.assertIsNotNone(ovr.fit(df))
         ovr2 = OneVsRest(classifier=lr).setWeightCol("weight")
         self.assertIsNotNone(ovr2.fit(df))
+        # classifier doesn't inherit hasWeightCol
+        dt = DecisionTreeClassifier()
+        ovr3 = OneVsRest(classifier=dt, weightCol="weight")
+        self.assertIsNotNone(ovr3.fit(df))
+        ovr4 = OneVsRest(classifier=dt).setWeightCol("weight")
+        self.assertIsNotNone(ovr4.fit(df))
 
 
 class HashingTFTest(SparkSessionTestCase):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1260,8 +1260,8 @@ class OneVsRestTests(SparkSessionTestCase):
                                          (1.0, Vectors.sparse(2, [], []), 1.0),
                                          (2.0, Vectors.dense(0.5, 0.5), 1.0)],
                                         ["label", "features", "weight"])
-        lr = LogisticRegression(maxIter=5, regParam=0.01, weightCol="weight")
-        ovr = OneVsRest(classifier=lr)
+        lr = LogisticRegression(maxIter=5, regParam=0.01)
+        ovr = OneVsRest(classifier=lr, weightCol="weight")
         model = ovr.fit(df)
         self.assertIsNotNone(model)
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1264,14 +1264,10 @@ class OneVsRestTests(SparkSessionTestCase):
         lr = LogisticRegression(maxIter=5, regParam=0.01)
         ovr = OneVsRest(classifier=lr, weightCol="weight")
         self.assertIsNotNone(ovr.fit(df))
-        ovr2 = OneVsRest(classifier=lr).setWeightCol("weight")
-        self.assertIsNotNone(ovr2.fit(df))
         # classifier doesn't inherit hasWeightCol
         dt = DecisionTreeClassifier()
-        ovr3 = OneVsRest(classifier=dt, weightCol="weight")
-        self.assertIsNotNone(ovr3.fit(df))
-        ovr4 = OneVsRest(classifier=dt).setWeightCol("weight")
-        self.assertIsNotNone(ovr4.fit(df))
+        ovr2 = OneVsRest(classifier=dt, weightCol="weight")
+        self.assertIsNotNone(ovr2.fit(df))
 
 
 class HashingTFTest(SparkSessionTestCase):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1255,15 +1255,16 @@ class OneVsRestTests(SparkSessionTestCase):
         output = model.transform(df)
         self.assertEqual(output.columns, ["label", "features", "prediction"])
 
-    def test_cache_weightCol_if_necessary(self):
+    def test_support_for_weightCol(self):
         df = self.spark.createDataFrame([(0.0, Vectors.dense(1.0, 0.8), 1.0),
                                          (1.0, Vectors.sparse(2, [], []), 1.0),
                                          (2.0, Vectors.dense(0.5, 0.5), 1.0)],
                                         ["label", "features", "weight"])
         lr = LogisticRegression(maxIter=5, regParam=0.01)
         ovr = OneVsRest(classifier=lr, weightCol="weight")
-        model = ovr.fit(df)
-        self.assertIsNotNone(model)
+        self.assertIsNotNone(ovr.fit(df))
+        ovr2 = OneVsRest(classifier=lr).setWeightCol("weight")
+        self.assertIsNotNone(ovr2.fit(df))
 
 
 class HashingTFTest(SparkSessionTestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

add `setWeightCol` method for OneVsRest.

`weightCol` is ignored if classifier doesn't inherit HasWeightCol trait.

## How was this patch tested?

+ [x] add an unit test.
