### PR TITLE
[SPARK-21353][CORE]add checkValue in spark.internal.config about how to correctly set configurations

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -40,6 +40,7 @@ package object config {
   private[spark] val DRIVER_MEMORY = ConfigBuilder("spark.driver.memory")
     .doc("Amount of memory to use for the driver process, in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
+    .checkValue(_ > 0, "The driver memory must be greater than 0 MiB.")
     .createWithDefaultString("1g")
 
   private[spark] val DRIVER_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.memoryOverhead")
@@ -87,6 +88,7 @@ package object config {
   private[spark] val EXECUTOR_MEMORY = ConfigBuilder("spark.executor.memory")
     .doc("Amount of memory to use per executor process, in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
+    .checkValue(_ > 0, "The executor memory must be greater than 0 MiB.")
     .createWithDefaultString("1g")
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD = ConfigBuilder("spark.executor.memoryOverhead")
@@ -114,17 +116,29 @@ package object config {
   private[spark] val IS_PYTHON_APP = ConfigBuilder("spark.yarn.isPython").internal()
     .booleanConf.createWithDefault(false)
 
-  private[spark] val CPUS_PER_TASK = ConfigBuilder("spark.task.cpus").intConf.createWithDefault(1)
+  private[spark] val CPUS_PER_TASK = ConfigBuilder("spark.task.cpus")
+    .intConf
+    .checkValue(_ > 0,
+      "Number of cores to allocate for task event queue must be positive.")
+    .createWithDefault(1)
 
   private[spark] val DYN_ALLOCATION_MIN_EXECUTORS =
-    ConfigBuilder("spark.dynamicAllocation.minExecutors").intConf.createWithDefault(0)
+    ConfigBuilder("spark.dynamicAllocation.minExecutors")
+      .intConf
+      .checkValue(v => v >= 0,
+        "Lower bound for the number of executors should be greater than or equal to 0.")
+      .createWithDefault(0)
 
   private[spark] val DYN_ALLOCATION_INITIAL_EXECUTORS =
     ConfigBuilder("spark.dynamicAllocation.initialExecutors")
       .fallbackConf(DYN_ALLOCATION_MIN_EXECUTORS)
 
   private[spark] val DYN_ALLOCATION_MAX_EXECUTORS =
-    ConfigBuilder("spark.dynamicAllocation.maxExecutors").intConf.createWithDefault(Int.MaxValue)
+    ConfigBuilder("spark.dynamicAllocation.maxExecutors")
+      .intConf
+      .checkValue(v => v >= 0,
+        "Upper bound for the number of executors should be greater than or equal to 0.")
+      .createWithDefault(Int.MaxValue)
 
   private[spark] val LOCALITY_WAIT = ConfigBuilder("spark.locality.wait")
     .timeConf(TimeUnit.MILLISECONDS)
@@ -165,31 +179,43 @@ package object config {
   private[spark] val MAX_TASK_ATTEMPTS_PER_EXECUTOR =
     ConfigBuilder("spark.blacklist.task.maxTaskAttemptsPerExecutor")
       .intConf
+      .checkValue(_ > 0,
+        "spark.blacklist.task.maxTaskAttemptsPerExecutor should be greater than 0.")
       .createWithDefault(1)
 
   private[spark] val MAX_TASK_ATTEMPTS_PER_NODE =
     ConfigBuilder("spark.blacklist.task.maxTaskAttemptsPerNode")
       .intConf
+      .checkValue(_ > 0,
+        "spark.blacklist.task.maxTaskAttemptsPerNode should be greater than 0.")
       .createWithDefault(2)
 
   private[spark] val MAX_FAILURES_PER_EXEC =
     ConfigBuilder("spark.blacklist.application.maxFailedTasksPerExecutor")
       .intConf
+      .checkValue(_ > 0,
+        "spark.blacklist.application.maxFailedTasksPerExecutor should be greater than 0.")
       .createWithDefault(2)
 
   private[spark] val MAX_FAILURES_PER_EXEC_STAGE =
     ConfigBuilder("spark.blacklist.stage.maxFailedTasksPerExecutor")
       .intConf
+      .checkValue(_ > 0,
+        "spark.blacklist.stage.maxFailedTasksPerExecutor should be greater than 0.")
       .createWithDefault(2)
 
   private[spark] val MAX_FAILED_EXEC_PER_NODE =
     ConfigBuilder("spark.blacklist.application.maxFailedExecutorsPerNode")
       .intConf
+      .checkValue(_ > 0,
+        "spark.blacklist.application.maxFailedExecutorsPerNode should be greater than 0.")
       .createWithDefault(2)
 
   private[spark] val MAX_FAILED_EXEC_PER_NODE_STAGE =
     ConfigBuilder("spark.blacklist.stage.maxFailedExecutorsPerNode")
       .intConf
+      .checkValue(_ > 0,
+        "spark.blacklist.stage.maxFailedExecutorsPerNode should be greater than 0.")
       .createWithDefault(2)
 
   private[spark] val BLACKLIST_TIMEOUT_CONF =
@@ -288,6 +314,9 @@ package object config {
   private[spark] val BLOCK_MANAGER_PORT = ConfigBuilder("spark.blockManager.port")
     .doc("Port to use for the block manager when a more specific setting is not provided.")
     .intConf
+    .checkValue(v => v == 0 || (1024 <= v && v < 65536),
+      "blockManager port should be between 1024 and 65535 (inclusive), " +
+      "or 0 for a random free port.")
     .createWithDefault(0)
 
   private[spark] val DRIVER_BLOCK_MANAGER_PORT = ConfigBuilder("spark.driver.blockManager.port")
@@ -385,6 +414,8 @@ package object config {
     ConfigBuilder("spark.shuffle.registration.timeout")
       .doc("Timeout in milliseconds for registration to the external shuffle service.")
       .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(_ > 0,
+        "Timeout in milliseconds for registration event queue must be positive.")
       .createWithDefault(5000)
 
   private[spark] val SHUFFLE_REGISTRATION_MAX_ATTEMPTS =
@@ -414,6 +445,8 @@ package object config {
         "external shuffle service, this feature can only be worked when external shuffle" +
         "service is newer than Spark 2.2.")
       .bytesConf(ByteUnit.BYTE)
+      .checkValue(_ > 0,
+        "Size of the request is above this threshold event queue must be positive.")
       .createWithDefault(Long.MaxValue)
 
   private[spark] val TASK_METRICS_TRACK_UPDATED_BLOCK_STATUSES =

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -421,7 +421,7 @@ private[scheduler] object BlacklistTracker extends Logging {
   def validateBlacklistConfs(conf: SparkConf): Unit = {
 
     def mustBePos(k: String, v: String): Unit = {
-      throw new IllegalArgumentException(s"$k was $v, but must be > 0.")
+      throw new IllegalArgumentException(s"$k should be greater than 0.")
     }
 
     Seq(

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -83,7 +83,7 @@ private[spark] class TaskSchedulerImpl(
   val STARVATION_TIMEOUT_MS = conf.getTimeAsMs("spark.starvation.timeout", "15s")
 
   // CPUs to request per task
-  val CPUS_PER_TASK = conf.getInt("spark.task.cpus", 1)
+  val CPUS_PER_TASK = conf.get(config.CPUS_PER_TASK)
 
   // TaskSetManagers are not thread safe, so any access to one should be synchronized
   // on this class.

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -67,11 +67,11 @@ class ExecutorAllocationManagerSuite
 
     // Min < 0
     val conf1 = conf.clone().set("spark.dynamicAllocation.minExecutors", "-1")
-    intercept[SparkException] { contexts += new SparkContext(conf1) }
+    intercept[IllegalArgumentException] { contexts += new SparkContext(conf1) }
 
     // Max < 0
     val conf2 = conf.clone().set("spark.dynamicAllocation.maxExecutors", "-1")
-    intercept[SparkException] { contexts += new SparkContext(conf2) }
+    intercept[IllegalArgumentException] { contexts += new SparkContext(conf2) }
 
     // Both min and max, but min > max
     intercept[SparkException] { createSparkContext(2, 1) }

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -472,7 +472,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
       val excMsg = intercept[IllegalArgumentException] {
         BlacklistTracker.validateBlacklistConfs(conf)
       }.getMessage()
-      assert(excMsg.contains(s"${config.key} was 0, but must be > 0."))
+      assert(excMsg.contains(s"${config.key} should be greater than 0."))
       conf.remove(config)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, some of the configuration parameters of spark.internal.config without adding checkValue function, which is incorrect, this PR will be add checkValue for the configuration parameters. 

## How was this patch tested?
existing test and add a new test case.
