### PR TITLE
[SPARK-21345][SQL][TEST][test-maven] SparkSessionBuilderSuite should clean up stopped sessions.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -80,7 +80,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     defaultSession.stop()
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != defaultSession)
-    newSession.stop()
   }
 
   test("create a new session if the active thread session has been stopped") {
@@ -89,7 +88,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     activeSession.stop()
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != activeSession)
-    newSession.stop()
   }
 
   test("create SparkContext first then SparkSession") {
@@ -102,7 +100,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     // We won't update conf for existing `SparkContext`
     assert(!sparkContext2.conf.contains("key2"))
     assert(sparkContext2.conf.get("key1") == "value1")
-    session.stop()
   }
 
   test("create SparkContext first then pass context to SparkSession") {
@@ -117,14 +114,12 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     // the conf of this sparkContext will not contain the conf set through the API config.
     assert(!session.sparkContext.conf.contains("key2"))
     assert(session.sparkContext.conf.get("spark.app.name") == "test")
-    session.stop()
   }
 
   test("SPARK-15887: hive-site.xml should be loaded") {
     val session = SparkSession.builder().master("local").getOrCreate()
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
     assert(session.sparkContext.hadoopConfiguration.get("hive.in.test") == "true")
-    session.stop()
   }
 
   test("SPARK-15991: Set global Hadoop conf") {
@@ -136,7 +131,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       assert(session.sessionState.newHadoopConf().get(mySpecialKey) == mySpecialValue)
     } finally {
       session.sparkContext.hadoopConfiguration.unset(mySpecialKey)
-      session.stop()
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -56,6 +56,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     val session2 = SparkSession.builder().config("spark-config1", "b").getOrCreate()
     assert(session1 == session2)
     assert(session1.conf.get("spark-config1") == "b")
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
   }
 
@@ -73,6 +74,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     SparkSession.clearActiveSession()
 
     assert(SparkSession.builder().getOrCreate() == defaultSession)
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
   }
 
@@ -83,6 +85,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != defaultSession)
     newSession.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   test("create a new session if the active thread session has been stopped") {
@@ -92,6 +96,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != activeSession)
     newSession.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   test("create SparkContext first then SparkSession") {
@@ -106,6 +112,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(!sparkContext2.conf.contains("key2"))
     assert(sparkContext2.conf.get("key1") == "value1")
     session.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   test("create SparkContext first then pass context to SparkSession") {
@@ -122,6 +130,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(!session.sparkContext.conf.contains("key2"))
     assert(session.sparkContext.conf.get("spark.app.name") == "test")
     session.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   test("SPARK-15887: hive-site.xml should be loaded") {
@@ -129,6 +139,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
     assert(session.sparkContext.hadoopConfiguration.get("hive.in.test") == "true")
     session.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   test("SPARK-15991: Set global Hadoop conf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -42,12 +42,18 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(initialSession.sparkContext.conf.get("some-config") == "v2")
     assert(initialSession.conf.get("some-config") == "v2")
     SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("use global default session") {
     val session = SparkSession.builder().getOrCreate()
     assert(SparkSession.builder().getOrCreate() == session)
     SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("config options are propagated to existing SparkSession") {
@@ -56,8 +62,10 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     val session2 = SparkSession.builder().config("spark-config1", "b").getOrCreate()
     assert(session1 == session2)
     assert(session1.conf.get("spark-config1") == "b")
-    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("use session from active thread session and propagate config options") {
@@ -74,8 +82,10 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     SparkSession.clearActiveSession()
 
     assert(SparkSession.builder().getOrCreate() == defaultSession)
-    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("create a new session if the default session has been stopped") {
@@ -85,8 +95,9 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != defaultSession)
     newSession.stop()
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("create a new session if the active thread session has been stopped") {
@@ -97,7 +108,9 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(newSession != activeSession)
     newSession.stop()
     SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("create SparkContext first then SparkSession") {
@@ -112,8 +125,9 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(!sparkContext2.conf.contains("key2"))
     assert(sparkContext2.conf.get("key1") == "value1")
     session.stop()
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("create SparkContext first then pass context to SparkSession") {
@@ -130,8 +144,9 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(!session.sparkContext.conf.contains("key2"))
     assert(session.sparkContext.conf.get("spark.app.name") == "test")
     session.stop()
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("SPARK-15887: hive-site.xml should be loaded") {
@@ -139,8 +154,9 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
     assert(session.sparkContext.hadoopConfiguration.get("hive.in.test") == "true")
     session.stop()
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("SPARK-15991: Set global Hadoop conf") {
@@ -154,5 +170,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite {
       session.sparkContext.hadoopConfiguration.unset(mySpecialKey)
       session.stop()
     }
+
+    assert(SparkSession.getDefaultSession === None)
+    assert(SparkSession.getActiveSession === None)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -40,8 +40,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   override def afterEach(): Unit = {
     // This suite should not interfere with the other test suites.
-    assert(SparkSession.getDefaultSession === None)
-    assert(SparkSession.getActiveSession === None)
+    SparkSession.clearDefaultSession()
+    SparkSession.clearActiveSession()
   }
 
   test("create with config options and propagate them to SparkContext and SparkSession") {
@@ -49,13 +49,11 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     sparkContext
     assert(initialSession.sparkContext.conf.get("some-config") == "v2")
     assert(initialSession.conf.get("some-config") == "v2")
-    SparkSession.clearDefaultSession()
   }
 
   test("use global default session") {
     val session = SparkSession.builder().getOrCreate()
     assert(SparkSession.builder().getOrCreate() == session)
-    SparkSession.clearDefaultSession()
   }
 
   test("config options are propagated to existing SparkSession") {
@@ -64,7 +62,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     val session2 = SparkSession.builder().config("spark-config1", "b").getOrCreate()
     assert(session1 == session2)
     assert(session1.conf.get("spark-config1") == "b")
-    SparkSession.clearDefaultSession()
   }
 
   test("use session from active thread session and propagate config options") {
@@ -81,7 +78,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     SparkSession.clearActiveSession()
 
     assert(SparkSession.builder().getOrCreate() == defaultSession)
-    SparkSession.clearDefaultSession()
   }
 
   test("create a new session if the default session has been stopped") {
@@ -100,7 +96,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != activeSession)
     newSession.stop()
-    SparkSession.clearActiveSession()
   }
 
   test("create SparkContext first then SparkSession") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SparkSessionBuilderSuite` should clean up stopped sessions. Otherwise, it leaves behind some stopped `SparkContext`s interfereing with other test suites using `ShardSQLContext`.

Recently, master branch fails consequtively.
- https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/

## How was this patch tested?

Pass the Jenkins with a updated suite.