### PR TITLE
[SPARK-21349][CORE] Make TASK_SIZE_TO_WARN_KB configurable by spark.task.size.warnThreshold

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -62,6 +62,12 @@ package object config {
 
   private[spark] val CPUS_PER_TASK = ConfigBuilder("spark.task.cpus").intConf.createWithDefault(1)
 
+  private[spark] val TASK_SIZE_THRESHOLD_TO_WARN = ConfigBuilder("spark.task.size.warnThreshold")
+    .doc("Warning threshold for task size in bytes")
+    .intConf
+    .checkValue(_ > 0, "The warning threshold of task size must be positive")
+    .createWithDefault(100 * 1024)
+
   private[spark] val DYN_ALLOCATION_MIN_EXECUTORS =
     ConfigBuilder("spark.dynamicAllocation.minExecutors").intConf.createWithDefault(0)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Although this is just a warning message, this issue tries to make `TASK_SIZE_TO_WARN_KB` into a normal Spark configuration for advanced users.

**Case 1**
```scala
scala> val data = (1 to (24*365*3)).map(i => (i, s"$i", i % 2 == 0)).toDF("col1", "part1", "part2")
data: org.apache.spark.sql.DataFrame = [col1: int, part1: string ... 1 more field]

scala> data.write.format("parquet").partitionBy("part1", "part2").mode("overwrite").saveAsTable("t")
17/08/29 21:08:04 WARN TaskSetManager: Stage 0 contains a task of very large size (190 KB). The maximum recommended task size is 100 KB.
17/08/29 21:09:34 WARN TaskSetManager: Stage 2 contains a task of very large size (233 KB). The maximum recommended task size is 100 KB.

scala> spark.version
res1: String = 2.3.0-SNAPSHOT
```

According to the [log](https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-sbt-hadoop-2.7/3170/consoleFull
), we have 123 warnings. This is useful, but it would be great if this is configurable.

## How was this patch tested?

Pass the Jenkins with a newly added test case.