### PR TITLE
[SPARK-21372] spark writes one log file even I set the number of spark_rotate_log to 0

### DIFF
--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -78,6 +78,12 @@ spark_rotate_log ()
     if [ -n "$2" ]; then
 	num=$2
     fi
+
+    expr $num + 0 &>/dev/null
+    if [ $? -ne 0 ] || [ $num -eq 0 ]; then
+        num=5
+    fi
+
     if [ -f "$log" ]; then # rotate logs
 	while [ $num -gt 1 ]; do
 	    prev=`expr $num - 1`


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21372](https://issues.apache.org/jira/browse/SPARK-21372)
Spark writes one log file even I set the number of spark_rotate_log to 0.Meanwhile,the number of spark_rotate_log also can set to a string type and other type.So I think we should make some changes.
