### PR TITLE
[SPARK-21377][YARN] Add a new configuration to extend AM classpath in yarn client mode

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -300,6 +300,15 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
 </tr>
 <tr>
+  <td><code>spark.yarn.am.extraClassPath</code></td>
+  <td>(none)</td>
+  <td>
+  Extra classpath entries to prepend to the classpath of the YARN Application Master in client mode. 
+  A string of extra JVM options to pass to the YARN Application Master in client mode.
+  In cluster mode, use <code>spark.driver.extraClassPath</code> instead.
+  </td>
+</tr>
+<tr>
   <td><code>spark.yarn.am.extraJavaOptions</code></td>
   <td>(none)</td>
   <td>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -733,12 +733,17 @@ private[spark] class Client(
   /**
    * Set up the environment for launching our ApplicationMaster container.
    */
-  private def setupLaunchEnv(
+  private[yarn] def setupLaunchEnv(
       stagingDirPath: Path,
       pySparkArchives: Seq[String]): HashMap[String, String] = {
     logInfo("Setting up the launch environment for our AM container")
     val env = new HashMap[String, String]()
-    populateClasspath(args, yarnConf, sparkConf, env, sparkConf.get(DRIVER_CLASS_PATH))
+    val extraClassPath = if (isClusterMode) {
+      sparkConf.get(DRIVER_CLASS_PATH)
+    } else {
+      sparkConf.get(AM_EXTRA_CLASSPATH)
+    }
+    populateClasspath(args, yarnConf, sparkConf, env, extraClassPath)
     env("SPARK_YARN_MODE") = "true"
     env("SPARK_YARN_STAGING_DIR") = stagingDirPath.toString
     env("SPARK_USER") = UserGroupInformation.getCurrentUser().getShortUserName()

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -197,6 +197,11 @@ package object config {
     .stringConf
     .createOptional
 
+  private[spark] val AM_EXTRA_CLASSPATH = ConfigBuilder("spark.yarn.am.extraClassPath")
+    .doc("Extra classpath for client-mode AM.")
+    .stringConf
+    .createOptional
+
   private[spark] val AM_MEMORY_OVERHEAD = ConfigBuilder("spark.yarn.am.memoryOverhead")
     .bytesConf(ByteUnit.MiB)
     .createOptional

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -375,6 +375,22 @@ class ClientSuite extends SparkFunSuite with Matchers with BeforeAndAfterAll
     sparkConf.get(SECONDARY_JARS) should be (Some(Seq(new File(jar2.toURI).getName)))
   }
 
+  test("add extra classpath to AM in client mode") {
+    val temp = Utils.createTempDir()
+    val jarsDir = new File(temp, "jars")
+    assert(jarsDir.mkdir())
+    val jar = TestUtils.createJarWithFiles(Map(), jarsDir)
+    new FileOutputStream(new File(temp, "RELEASE")).close()
+
+    val sparkConf = new SparkConf()
+      .set(AM_EXTRA_CLASSPATH, jar.toString)
+      .set("spark.submit.deployMode", "client")
+    val client = createClient(sparkConf)
+    val env = client.setupLaunchEnv(new Path(temp.getAbsolutePath), Nil)
+    val cp = classpath(env)
+    cp should contain (jar.getPath)
+  }
+
   object Fixtures {
 
     val knownDefYarnAppCP: Seq[String] =


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR propose a new configuration "spark.yarn.am.extraClassPath" to extend AM classpath in yarn client mode. The specific scenario is that we have custom `ServiceCredentialProvider` which will be loaded in AM, and this provider requires its additional dependencies to be added in AM classpath. 

Using "spark.driver.extraClassPath" (the current code) is not so proper in yarn client mode and if dependency paths are different for driver and AM node, then it is impossible to use this configuration. So instead we add a new configuration to extend AM classpath in yarn client mode.

## How was this patch tested?

UT added and manual verification on local cluster.
