### PR TITLE
[SPARK-21362][SQL][Adding Apache Drill JDBC Dialect]

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/ApacheDrillDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/ApacheDrillDialect.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Types
-
-import org.apache.spark.sql.types.{BooleanType, DataType, LongType, MetadataBuilder}
 
 private case object ApacheDrillDialect extends JdbcDialect {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/ApacheDrillDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/ApacheDrillDialect.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.sql.Types
+
+import org.apache.spark.sql.types.{BooleanType, DataType, LongType, MetadataBuilder}
+
+private case object ApacheDrillDialect extends JdbcDialect {
+
+  override def canHandle(url : String): Boolean = url.startsWith("jdbc:drill")
+
+  override def quoteIdentifier(colName: String): String = {
+    s"`$colName`"
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -200,6 +200,7 @@ object JdbcDialects {
   registerDialect(DerbyDialect)
   registerDialect(OracleDialect)
   registerDialect(TeradataDialect)
+  registerDialect(ApacheDrillDialect)
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding Apache Drill to the JDBC Dialect

## How was this patch tested?
I tested this manually by building and using RStudio to connect to the spark server and running a query against an apache drill cluster

the contribution is my original work and that I license the work to the project under the project’s open source license
Please review http://spark.apache.org/contributing.html before opening a pull request.
