### PR TITLE
Spark SQL merge small files to big files Update InsertIntoHiveTable.scala

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -419,7 +419,7 @@ case class InsertIntoHiveTable(
     } else if (outputClass.getName.equalsIgnoreCase("org.apache.parquet.hadoop.ParquetOutputCommitter")){
       source = "parquet"
     }
-    //wuzl add merger files
+    //add merger files
     if (source.equals("orc") || source.equals("text")){
       if (partition.nonEmpty && partitionColumnNames.length >= 3){}
       else {
@@ -468,7 +468,7 @@ case class InsertIntoHiveTable(
         }
       }
     }
-    //wuzl end 
+    // end 
     // Invalidate the cache.
     sqlContext.sharedState.cacheManager.invalidateCache(table)
     sqlContext.sessionState.catalog.refreshTable(table.catalogTable.identifier)


### PR DESCRIPTION
Merge hive small files into large files, support  orc and text data table storage format

## What changes were proposed in this pull request?
we have more spark SQL partitions tables ,table partition have more small files。Causing the cluster hdfs a lot of pressure, we use this feature to merge small files, to the cluster down to 1/10 hdfs pressure
##test this function
you can use SQL: INSERT INTO TABLE AS SELECT XXXX

