### PR TITLE
[SPARK-21386] ML LinearRegression supports warm start from user provided initial model.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedGeneralTypeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedGeneralTypeParams.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.param.shared
+
+import org.apache.spark.ml.Model
+import org.apache.spark.ml.param._
+
+private[ml] trait HasInitialModel[T <: Model[T]] extends Params {
+
+  def initialModel: Param[T]
+
+  /** @group getParam */
+  final def getInitialModel: T = $(initialModel)
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -51,9 +51,9 @@ import org.apache.spark.storage.StorageLevel
  * Params for linear regression model.
  */
 private[regression] trait LinearRegressionModelParams extends PredictorParams
-  with HasRegParam with HasElasticNetParam with HasMaxIter with HasTol
-  with HasFitIntercept with HasStandardization with HasWeightCol with HasSolver
-  with HasAggregationDepth {
+    with HasRegParam with HasElasticNetParam with HasMaxIter with HasTol
+    with HasFitIntercept with HasStandardization with HasWeightCol with HasSolver
+    with HasAggregationDepth {
 
   import LinearRegression._
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -1012,6 +1012,13 @@ object MimaExcludes {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.ml.classification.RandomForestClassificationModel.setFeatureSubsetStrategy"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.ml.regression.RandomForestRegressionModel.numTrees"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.ml.regression.RandomForestRegressionModel.setFeatureSubsetStrategy")
+    ) ++ Seq(
+      // [SPARK-21386] ML LinearRegression supports warm start from user provided initial model.
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.regression.LinearRegressionModelParams.org$apache$spark$ml$regression$LinearRegressionModelParams$_setter_$solver_="),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.param.shared.HasInitialModel.initialModel"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.param.shared.HasInitialModel.getInitialModel"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.regression.LinearRegression$"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.regression.LinearRegressionModel")
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Allow users to set initial model when running ```LinearRegression```. This is the first step to make ML supports warm-start, we can distribute tasks for other algorithms after this get merged.

Note: The design behind this PR follows discussions at #11119 and #17117 . With regards to those PRs, ```KMeans``` involves lots of issues which is not related to initial model itself. I'd like to proceed this work from ```LinearRegression``` which is more independent and clean.

## How was this patch tested?
Added unit test.
