### PR TITLE
[SPARK-21377][YARN] Make jars specify with --jars/--packages load-able in AM's credential renwer

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -443,11 +443,11 @@ private[spark] class ApplicationMaster(
 
     // If the credentials file config is present, we must periodically renew tokens. So create
     // a new AMDelegationTokenRenewer
-    if (sparkConf.contains(CREDENTIALS_FILE_PATH.key)) {
+    if (sparkConf.contains(CREDENTIALS_FILE_PATH)) {
       // Start a short-lived thread for AMCredentialRenewer, the only purpose is to set the
       // classloader so that main jar and secondary jars could be used by AMCredentialRenewer.
       val credentialRenewerThread = new Thread {
-        setName("AMCredentialRenewerThread")
+        setName("AMCredentialRenewerStarter")
         setContextClassLoader(userClassLoader)
 
         override def run(): Unit = {
@@ -647,7 +647,7 @@ private[spark] class ApplicationMaster(
         try {
           // If the credentials file config is present, we must periodically renew tokens. So create
           // a new AMDelegationTokenRenewer
-          if (sparkConf.contains(CREDENTIALS_FILE_PATH.key)) {
+          if (sparkConf.contains(CREDENTIALS_FILE_PATH)) {
             startAMCredentialRenewer()
           }
           mainMethod.invoke(null, userArgs.toArray)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -701,20 +701,6 @@ private[spark] class ApplicationMaster(
     credentialRenewer.scheduleLoginFromKeytab()
   }
 
-  private def startAMCredentialRenewerThread(): Thread = {
-    val thread = new Thread {
-      override def run(): Unit = {
-        startAMCredentialRenewer()
-      }
-    }
-
-    thread.setDaemon(true)
-    thread.setName("AMCredentialRenewerThread")
-    thread.setContextClassLoader(userClassLoader)
-    thread.start()
-    thread
-  }
-
   /**
    * An [[RpcEndpoint]] that communicates with the driver's scheduler backend.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this issue we have a long running Spark application with secure HBase, which requires `HBaseCredentialProvider` to get tokens periodically, we specify HBase related jars with `--packages`, but these dependencies are not added into AM classpath, so when `HBaseCredentialProvider` tries to initialize HBase connections to get tokens, it will be failed.

Currently because jars specified with `--jars` or `--packages` are not added into AM classpath, the only way to extend AM classpath is to use "spark.driver.extraClassPath" which supposed to be used in yarn cluster mode.

So in this fix, we proposed to use/reuse a classloader for `AMCredentialRenewer` to acquire new tokens.

Also in this patch, we fixed AM cannot get tokens from HDFS issue, it is because FileSystem is gotten before kerberos logged, so using this FS to get tokens will throw exception.

## How was this patch tested?

Manual verification.