### PR TITLE
[SPARK-21397][BUILD]Maven shade plugin adding dependency-reduced-pom.xml to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2345,6 +2345,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <shadedArtifactAttached>false</shadedArtifactAttached>
+          <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
           <artifactSet>
             <includes>
               <include>org.spark-project.spark:unused</include>


### PR DESCRIPTION
…base directory

## What changes were proposed in this pull request?

1. run `./build/mvn -DskipTests clean package` and we get many files 'dependency-reduced-pom.xml'
under the source directory

2. run `./build/mvn clean`, the files `dependency-reduced-pom.xml` can not be cleaned.

As a trivial Improvement, i suggest to specify dependencyReducedPomLocation to 'target/' to store these files.

## How was this patch tested?

manual tests
