### PR TITLE
[SPARK-21340] Bring pyspark BinaryClassificationMetrics to parity with the Scala API

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/BinaryClassificationMetricsWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/BinaryClassificationMetricsWrapper.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.mllib.api.python
+
+import org.apache.spark.mllib.evaluation.BinaryClassificationMetrics
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.DataFrame
+
+/**
+ * A Wrapper of BinaryClassificationMetrics to provide helper method for Python
+ */
+private[python] class BinaryClassificationMetricsWrapper(
+    scoreAndLabels: DataFrame
+  ) extends BinaryClassificationMetrics(scoreAndLabels) {
+
+  def wrappedRoc(): RDD[Array[Any]] = {
+    SerDe.fromTuple2RDD(roc().asInstanceOf[RDD[(Any, Any)]])
+  }
+
+  def wrappedPr(): RDD[Array[Any]] = {
+    SerDe.fromTuple2RDD(pr().asInstanceOf[RDD[(Any, Any)]])
+  }
+
+  def wrappedFMeasureByThreshold(beta: Double): RDD[Array[Any]] = {
+    SerDe.fromTuple2RDD(fMeasureByThreshold(beta).asInstanceOf[RDD[(Any, Any)]])
+  }
+
+  def wrappedPrecisionByThreshold(): RDD[Array[Any]] = {
+    SerDe.fromTuple2RDD(precisionByThreshold().asInstanceOf[RDD[(Any, Any)]])
+  }
+
+  def wrappedRecallByThreshold(): RDD[Array[Any]] = {
+    SerDe.fromTuple2RDD(recallByThreshold().asInstanceOf[RDD[(Any, Any)]])
+  }
+
+}

--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -50,7 +50,7 @@ class BinaryClassificationMetrics(JavaModelWrapper):
         df = sql_ctx.createDataFrame(scoreAndLabels, schema=StructType([
             StructField("score", DoubleType(), nullable=False),
             StructField("label", DoubleType(), nullable=False)]))
-        java_class = sc._jvm.org.apache.spark.mllib.evaluation.BinaryClassificationMetrics
+        java_class = sc._jvm.org.apache.spark.mllib.api.python.BinaryClassificationMetricsWrapper
         java_model = java_class(df._jdf)
         super(BinaryClassificationMetrics, self).__init__(java_model)
 
@@ -77,6 +77,50 @@ class BinaryClassificationMetrics(JavaModelWrapper):
         Unpersists intermediate RDDs used in the computation.
         """
         self.call("unpersist")
+
+    @property
+    def thresholds(self):
+        """
+        Returns thresholds in descending order.
+        """
+        return self.call("thresholds")
+
+    @property
+    def roc(self):
+        """
+        Returns the receiver operating characteristic (ROC) curve,
+        which is an RDD of (false positive rate, true positive rate)
+        with (0.0, 0.0) prepended and (1.0, 1.0) appended to it.
+        """
+        return self.call("wrappedRoc")
+
+    @property
+    def pr(self):
+        """
+        Returns the precision-recall curve, which is an RDD of (recall, precision),
+        NOT (precision, recall), with (0.0, 1.0) prepended to it.
+        """
+        return self.call("wrappedPr")
+
+    def fMeasureByThreshold(self, beta=1.0):
+        """
+        Returns the (threshold, F-Measure) curve.
+        """
+        return self.call("wrappedFMeasureByThreshold", beta)
+
+    @property
+    def precisionByThreshold(self):
+        """
+        Returns the (threshold, precision) curve.
+        """
+        return self.call("wrappedPrecisionByThreshold")
+
+    @property
+    def recallByThreshold(self):
+        """
+        Returns the (threshold, recall) curve.
+        """
+        return self.call("wrappedRecallByThreshold")
 
 
 class RegressionMetrics(JavaModelWrapper):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding all the missing methods in the pyspark API for the BinaryClassificationMetrics, ie.:

- thresholds
- roc
- pr
- fMeasureByThreshold
- precisionByThreshold
- recallByThreshold

## How was this patch tested?

Tested manually.
