### PR TITLE
[SPARK-21374][CORE] Fix reading globbed paths from S3 into DF with disabled FS cache

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -226,14 +226,22 @@ class SparkHadoopUtil extends Logging {
   }
 
   def globPath(pattern: Path): Seq[Path] = {
-    val fs = pattern.getFileSystem(conf)
+    globPath(pattern, conf)
+  }
+
+  def globPath(pattern: Path, hadoopConf: Configuration): Seq[Path] = {
+    val fs = pattern.getFileSystem(hadoopConf)
     Option(fs.globStatus(pattern)).map { statuses =>
       statuses.map(_.getPath.makeQualified(fs.getUri, fs.getWorkingDirectory)).toSeq
     }.getOrElse(Seq.empty[Path])
   }
 
   def globPathIfNecessary(pattern: Path): Seq[Path] = {
-    if (isGlobPath(pattern)) globPath(pattern) else Seq(pattern)
+    globPathIfNecessary(pattern, conf)
+  }
+
+  def globPathIfNecessary(pattern: Path, hadoopConf: Configuration): Seq[Path] = {
+    if (isGlobPath(pattern)) globPath(pattern, hadoopConf) else Seq(pattern)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -132,7 +132,7 @@ case class DataSource(
         val hdfsPath = new Path(path)
         val fs = hdfsPath.getFileSystem(hadoopConf)
         val qualified = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-        SparkHadoopUtil.get.globPathIfNecessary(qualified)
+        SparkHadoopUtil.get.globPathIfNecessary(qualified, hadoopConf)
       }.toArray
       new InMemoryFileIndex(sparkSession, globbedPaths, options, None, fileStatusCache)
     }
@@ -364,7 +364,7 @@ case class DataSource(
           val hdfsPath = new Path(path)
           val fs = hdfsPath.getFileSystem(hadoopConf)
           val qualified = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-          val globPath = SparkHadoopUtil.get.globPathIfNecessary(qualified)
+          val globPath = SparkHadoopUtil.get.globPathIfNecessary(qualified, hadoopConf)
 
           if (globPath.isEmpty) {
             throw new AnalysisException(s"Path does not exist: $qualified")


### PR DESCRIPTION
## What changes were proposed in this pull request?

SparkHadoopUtil.globPath method uses incorrect configuration to retrieve instance of org.apache.hadoop.fs.FileSystem.
 
Accidentally, this can work correctly for two reasons:
 -  Filesystem cache is enabled by default for all filesystems which are derived from org.apache.hadoop.fs.FileSystem
 -  Configuration is not considered when instance of FileSystem is retrieved from the cache - it is not used to identify cache's key.  

Therefore, incorrect configuration is omitted in SparkHadoopUtil.globPath and previously initialized instance of FileSystem is returned with correct configuration. 

However, if filesystem caching is disabled (non-default behavior) incorrect configuration in SparkHadoopUtils.globPath is passed to org.apache.hadoop.fs.FileSystem.get() method what creates new instance of FileSystem with this incorrect configuration. 

In this change two overloaded methods (globPath and globPathIfNecessary) are added to SparkHadoopUtil class which can receive up to date configuration from caller method. These two methods are used in DataSource class to read into DataFrame from globbed path. 

## How was this patch tested?
./dev/run-tests passed + example from SPARK-21374 was tested with patched jars.

@zsxwing @liancheng 