### PR TITLE
[SPARK-21389][ML][MLLIB] Optimize ALS recommendForAll by gemm

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/BoundedPriorityQueue.scala
+++ b/core/src/main/scala/org/apache/spark/util/BoundedPriorityQueue.scala
@@ -51,6 +51,10 @@ private[spark] class BoundedPriorityQueue[A](maxSize: Int)(implicit ord: Orderin
     this
   }
 
+  def poll(): A = {
+    underlying.poll()
+  }
+
   override def +=(elem1: A, elem2: A, elems: A*): this.type = {
     this += elem1 += elem2 ++= elems
   }

--- a/core/src/main/scala/org/apache/spark/util/BoundedPriorityQueue.scala
+++ b/core/src/main/scala/org/apache/spark/util/BoundedPriorityQueue.scala
@@ -51,10 +51,6 @@ private[spark] class BoundedPriorityQueue[A](maxSize: Int)(implicit ord: Orderin
     this
   }
 
-  def poll(): A = {
-    underlying.poll()
-  }
-
   override def +=(elem1: A, elem2: A, elems: A*): this.type = {
     this += elem1 += elem2 ++= elems
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -359,7 +359,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
       val row = rateSum._3.numRows
       var i = 0
       val tempIdMatrix = new Array[Int](row * num)
-      val tempScoreMatrix = new Array[Double](row * num)
+      val tempScoreMatrix = Array.fill[Double](row * num)(Double.MinValue)
       while (i < row) {
         var j = 0
         var sum_index = 0

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -319,7 +319,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
           j += num
           pq.clear()
         }
-        index -> (srcIds, dstIdMatrix, new DenseMatrix(m, num, scoreMatrix))
+        (index, (srcIds, dstIdMatrix, new DenseMatrix(m, num, scoreMatrix)))
     }
     ratings.aggregateByKey(null: Array[Int], null: Array[Int], null: DenseMatrix)(
       (rateSum, rate) => mergeFunc(rateSum, rate, num),

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -347,7 +347,8 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
         output(i) = (value._2._1(i), factors)
         i += 1
       }
-      output.toSeq})
+      output.toSeq
+    })
   }
 
   private def mergeFunc(rateSum: (Array[Int], Array[Int], DenseMatrix),

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -307,16 +307,15 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
             pq += dstIds(k) -> ratings(i, k)
             k += 1
           }
-          var size = pq.size
-          while (size > 0) {
-            size -= 1
-            val factor = pq.poll()
-            dstIdMatrix(j + size) = factor._1
-            scoreMatrix(j + size) = factor._2
+          k = 0
+          pq.toArray.sortBy(-_._2).foreach { case (id, score) =>
+            dstIdMatrix(j + k) = id
+            scoreMatrix(j + k) = score
+            k += 1
           }
-          i += 1
           // pq.size maybe less than num, corner case
           j += num
+          i += 1
           pq.clear()
         }
         (index, (srcIds, dstIdMatrix, new DenseMatrix(m, num, scoreMatrix, true)))

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -319,7 +319,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
           j += num
           pq.clear()
         }
-        (index, (srcIds, dstIdMatrix, new DenseMatrix(m, num, scoreMatrix)))
+        (index, (srcIds, dstIdMatrix, new DenseMatrix(m, num, scoreMatrix, true)))
     }
     ratings.aggregateByKey(null: Array[Int], null: Array[Int], null: DenseMatrix)(
       (rateSum, rate) => mergeFunc(rateSum, rate, num),
@@ -366,7 +366,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
             tempIdMatrix(matrixIndex + j) = rate._2(matrixIndex + rate_index)
             tempScoreMatrix(matrixIndex + j) = rate._3(i, rate_index)
             rate_index += 1
-          } else if (rate._3(i, rate_index) < rateSum._3(i, sum_index)) {
+          } else {
             tempIdMatrix(matrixIndex + j) = rateSum._2(matrixIndex + sum_index)
             tempScoreMatrix(matrixIndex + j) = rateSum._3(i, sum_index)
             sum_index += 1
@@ -375,7 +375,7 @@ object MatrixFactorizationModel extends Loader[MatrixFactorizationModel] {
         }
         i += 1
       }
-      (rateSum._1, tempIdMatrix, new DenseMatrix(row, num, tempScoreMatrix))
+      (rateSum._1, tempIdMatrix, new DenseMatrix(row, num, tempScoreMatrix, true))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Spark 2.2, we have optimized ALS recommendForAll, which uses a handwriting matrix multiplication, and get the topK items for each matrix. The method effectively reduce the GC problem. However, Native BLAS GEMM, like Intel MKL, and OpenBLAS, the performance of matrix multiplication is about 10X comparing with handwriting method.

I have rewritten the code of recommendForAll with GEMM, and got about 50% improvement comparing with the master recommendForAll method.

The key point of this optimization:
1), use GEMM to replace hand-written matrix multiplication. 
2), Use matrix to keep temp result, largely reduce GC and computing time.  The master method create many small objects, which causes using GEMM directly cannot get good performance.
3), Use sort and merge to get the topK items, which don't need to call priority queue two times.

Test Result:
479818 users, 13727 products, rank = 10, topK = 20.
3 workers, each with 35 cores. Native BLAS is Intel MKL.
Block Size:       1000===2000===4000===8000 
Master Method:40s-----39.4s-----39.5s----39.1s
This Method     26.5s---25.9s----26s-----27.1s

Performance Improvement: (OldTime - NewTime)/NewTime = about 50%
    
 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
