### PR TITLE
[SPARK-21412][SQL] Reset BufferHolder while initialize an UnsafeRowWriter

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -51,6 +51,7 @@ public class UnsafeRowWriter {
     this.nullBitsSize = UnsafeRow.calculateBitSetWidthInBytes(numFields);
     this.fixedSize = nullBitsSize + 8 * numFields;
     this.startingOffset = holder.cursor;
+    holder.reset();
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

`UnsafeRowWriter`'s construtor should contain `BufferHolder.reset` to make the writer out of the box.

While writing `UnsafeRow` using `UnsafeRowWriter`, developers should manually call `BufferHolder.reset` to make the `BufferHolder`'s `cursor`(which indicates where to write variable length portion) right in order to write variable length fields like UTF8String, byte[], etc.

If a developer doesn't reuse the `BufferHolder` so maybe he never noticed `reset` and the comments in code, the `UnsafeRow` won't be correct if he also writes variable length UTF8String. This API design doesn't make sense. We should reset the `BufferHolder` to make `UnsafeRowWriter` out of the box, but not let user read the code and manually call it.
 
## How was this patch tested?

`makeKeyRow(long k1, String k2)` in `RowBasedKeyValueBatchSuite` already tested it.