### PR TITLE
added support word2vec training with additional data

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -39,11 +39,11 @@ private[feature] trait Word2VecBase extends Params
   with HasInputCol with HasOutputCol with HasMaxIter with HasStepSize with HasSeed {
 
   /**
-    * The dimension of the code that you want to transform from words.
-    * Default: 100
-    *
-    * @group param
-    */
+   * The dimension of the code that you want to transform from words.
+   * Default: 100
+   *
+   * @group param
+   */
   final val vectorSize = new IntParam(
     this, "vectorSize", "the dimension of codes after transforming from words (> 0)",
     ParamValidators.gt(0))
@@ -53,11 +53,11 @@ private[feature] trait Word2VecBase extends Params
   def getVectorSize: Int = $(vectorSize)
 
   /**
-    * The window size (context words from [-window, window]).
-    * Default: 5
-    *
-    * @group expertParam
-    */
+   * The window size (context words from [-window, window]).
+   * Default: 5
+   *
+   * @group expertParam
+   */
   final val windowSize = new IntParam(
     this, "windowSize", "the window size (context words from [-window, window]) (> 0)",
     ParamValidators.gt(0))
@@ -67,11 +67,11 @@ private[feature] trait Word2VecBase extends Params
   def getWindowSize: Int = $(windowSize)
 
   /**
-    * Number of partitions for sentences of words.
-    * Default: 1
-    *
-    * @group param
-    */
+   * Number of partitions for sentences of words.
+   * Default: 1
+   *
+   * @group param
+   */
   final val numPartitions = new IntParam(
     this, "numPartitions", "number of partitions for sentences of words (> 0)",
     ParamValidators.gt(0))
@@ -89,12 +89,12 @@ private[feature] trait Word2VecBase extends Params
   def getSupplementaryWords: Array[String] = $(supplementaryWords)
 
   /**
-    * The minimum number of times a token must appear to be included in the word2vec model's
-    * vocabulary.
-    * Default: 5
-    *
-    * @group param
-    */
+   * The minimum number of times a token must appear to be included in the word2vec model's
+   * vocabulary.
+   * Default: 5
+   *
+   * @group param
+   */
   final val minCount = new IntParam(this, "minCount", "the minimum number of times a token must " +
     "appear to be included in the word2vec model's vocabulary (>= 0)", ParamValidators.gtEq(0))
   setDefault(minCount -> 5)
@@ -103,13 +103,13 @@ private[feature] trait Word2VecBase extends Params
   def getMinCount: Int = $(minCount)
 
   /**
-    * Sets the maximum length (in words) of each sentence in the input data.
-    * Any sentence longer than this threshold will be divided into chunks of
-    * up to `maxSentenceLength` size.
-    * Default: 1000
-    *
-    * @group param
-    */
+   * Sets the maximum length (in words) of each sentence in the input data.
+   * Any sentence longer than this threshold will be divided into chunks of
+   * up to `maxSentenceLength` size.
+   * Default: 1000
+   *
+   * @group param
+   */
   final val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Maximum length " +
     "(in words) of each sentence in the input data. Any sentence longer than this threshold will " +
     "be divided into chunks up to the size (> 0)", ParamValidators.gt(0))
@@ -122,8 +122,8 @@ private[feature] trait Word2VecBase extends Params
   setDefault(maxIter -> 1)
 
   /**
-    * Validate and transform the input schema.
-    */
+   * Validate and transform the input schema.
+   */
   protected def validateAndTransformSchema(schema: StructType): StructType = {
     val typeCandidates = List(new ArrayType(StringType, true), new ArrayType(StringType, false))
     SchemaUtils.checkColumnTypes(schema, $(inputCol), typeCandidates)
@@ -222,8 +222,8 @@ object Word2Vec extends DefaultParamsReadable[Word2Vec] {
 }
 
 /**
-  * Model fitted by [[Word2Vec]].
-  */
+ * Model fitted by [[Word2Vec]].
+ */
 @Since("1.4.0")
 class Word2VecModel private[ml](
                                  @Since("1.4.0") override val uid: String,
@@ -233,9 +233,9 @@ class Word2VecModel private[ml](
   import Word2VecModel._
 
   /**
-    * Returns a dataframe with two fields, "word" and "vector", with "word" being a String and
-    * and the vector the DenseVector that it is mapped to.
-    */
+   * Returns a dataframe with two fields, "word" and "vector", with "word" being a String and
+   * and the vector the DenseVector that it is mapped to.
+   */
   @Since("1.5.0")
   @transient lazy val getVectors: DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
@@ -244,12 +244,12 @@ class Word2VecModel private[ml](
   }
 
   /**
-    * Find "num" number of words closest in similarity to the given word, not
-    * including the word itself.
-    *
-    * @return a dataframe with columns "word" and "similarity" of the word and the cosine
-    *         similarities between the synonyms and the given word vector.
-    */
+   * Find "num" number of words closest in similarity to the given word, not
+   * including the word itself.
+   *
+   * @return a dataframe with columns "word" and "similarity" of the word and the cosine
+   *         similarities between the synonyms and the given word vector.
+   */
   @Since("1.5.0")
   def findSynonyms(word: String, num: Int): DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
@@ -257,13 +257,13 @@ class Word2VecModel private[ml](
   }
 
   /**
-    * Find "num" number of words whose vector representation is most similar to the supplied vector.
-    * If the supplied vector is the vector representation of a word in the model's vocabulary,
-    * that word will be in the results.
-    *
-    * @return a dataframe with columns "word" and "similarity" of the word and the cosine
-    *         similarities between the synonyms and the given word vector.
-    */
+   * Find "num" number of words whose vector representation is most similar to the supplied vector.
+   * If the supplied vector is the vector representation of a word in the model's vocabulary,
+   * that word will be in the results.
+   *
+   * @return a dataframe with columns "word" and "similarity" of the word and the cosine
+   *         similarities between the synonyms and the given word vector.
+   */
   @Since("2.0.0")
   def findSynonyms(vec: Vector, num: Int): DataFrame = {
     val spark = SparkSession.builder().getOrCreate()
@@ -271,25 +271,25 @@ class Word2VecModel private[ml](
   }
 
   /**
-    * Find "num" number of words whose vector representation is most similar to the supplied vector.
-    * If the supplied vector is the vector representation of a word in the model's vocabulary,
-    * that word will be in the results.
-    *
-    * @return an array of the words and the cosine similarities between the synonyms given
-    *         word vector.
-    */
+   * Find "num" number of words whose vector representation is most similar to the supplied vector.
+   * If the supplied vector is the vector representation of a word in the model's vocabulary,
+   * that word will be in the results.
+   *
+   * @return an array of the words and the cosine similarities between the synonyms given
+   *         word vector.
+   */
   @Since("2.2.0")
   def findSynonymsArray(vec: Vector, num: Int): Array[(String, Double)] = {
     wordVectors.findSynonyms(vec, num)
   }
 
   /**
-    * Find "num" number of words closest in similarity to the given word, not
-    * including the word itself.
-    *
-    * @return an array of the words and the cosine similarities between the synonyms given
-    *         word vector.
-    */
+   * Find "num" number of words closest in similarity to the given word, not
+   * including the word itself.
+   *
+   * @return an array of the words and the cosine similarities between the synonyms given
+   *         word vector.
+   */
   @Since("2.2.0")
   def findSynonymsArray(word: String, num: Int): Array[(String, Double)] = {
     wordVectors.findSynonyms(word, num)
@@ -304,9 +304,9 @@ class Word2VecModel private[ml](
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
   /**
-    * Transform a sentence column to a vector column to represent the whole sentence. The transform
-    * is performed by averaging all word vectors it contains.
-    */
+   * Transform a sentence column to a vector column to represent the whole sentence. The transform
+   * is performed by averaging all word vectors it contains.
+   */
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
@@ -375,14 +375,14 @@ object Word2VecModel extends MLReadable[Word2VecModel] {
   private[feature]
   object Word2VecModelWriter {
     /**
-      * Calculate the number of partitions to use in saving the model.
-      * [SPARK-11994] - We want to partition the model in partitions smaller than
-      * spark.kryoserializer.buffer.max
-      *
-      * @param bufferSizeInBytes Set to spark.kryoserializer.buffer.max
-      * @param numWords          Vocab size
-      * @param vectorSize        Vector length for each word
-      */
+     * Calculate the number of partitions to use in saving the model.
+     * [SPARK-11994] - We want to partition the model in partitions smaller than
+     * spark.kryoserializer.buffer.max
+     *
+     * @param bufferSizeInBytes Set to spark.kryoserializer.buffer.max
+     * @param numWords          Vocab size
+     * @param vectorSize        Vector length for each word
+     */
     def calculateNumberOfPartitions(
                                      bufferSizeInBytes: Long,
                                      numWords: Int,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Word2Vec is trained unsupervised. The more data it is trained on, the more "accurate" are the word vectors. Hence, Word2Vec should support to be fit on additional data. 

## How was this patch tested?

Additional unit test.

Please review http://spark.apache.org/contributing.html before opening a pull request.
