### PR TITLE
[SPARK-21413][SQL] Fix 64KB JVM bytecode limit problem in multiple projections with CASE WHEN

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -302,7 +302,7 @@ case class CaseWhenCodegen(
         val fullFuncName = ctx.addNewFunction(funcName, funcBody)
         isGlobalVariable = true
 
-        generatedCode = s"if ($funcName(${ctx.INPUT_ROW})) {\n// do nothing\n} else {\n"
+        generatedCode = s"if ($fullFuncName(${ctx.INPUT_ROW})) {\n// do nothing\n} else {\n"
         numIfthen = 1
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -264,7 +264,6 @@ case class CaseWhenCodegen(
 
     val isNull = ctx.freshName("caseWhenIsNull")
     val value = ctx.freshName("caseWhenValue")
-    // Split these expressions only if they are created from a row object
 
     val cases = branches.map { case (condExpr, valueExpr) =>
       val (condFunc, condIsNull, condValue) = genCodeForExpression(ctx, condExpr)
@@ -286,7 +285,9 @@ case class CaseWhenCodegen(
       generatedCode += ifthen + "\nelse {\n"
       numIfthen += 1
 
-      if (generatedCode.length > 1024 && (ctx.INPUT_ROW != null && ctx.currentVars == null)) {
+      if (generatedCode.length > 1024 &&
+        // Split these expressions only if they are created from a row object
+        (ctx.INPUT_ROW != null && ctx.currentVars == null)) {
         val flag = "flag"
         generatedCode += s" $flag = false;\n" + "}\n" * numIfthen
         val funcName = ctx.freshName("caseWhenNestedIf")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -281,7 +281,7 @@ case class CaseWhenCodegen(
 
     var isGlobalVariable = false
     val (generatedIfThenElse, numBrankets) = if (cases.map(s => s.length).sum <= 1024) {
-      (cases.mkString("\nelse {\n"), cases.length - 1)
+      (cases.mkString("", "\nelse {\n", "\nelse {\n"), cases.length)
     } else {
       var numIfThen = 0
       var code = ""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -286,7 +286,7 @@ case class CaseWhenCodegen(
       generatedCode += ifthen + "\nelse {\n"
       numIfthen += 1
 
-      if (generatedCode.length > 1024) {
+      if (generatedCode.length > 1024 && (ctx.INPUT_ROW != null && ctx.currentVars == null)) {
         val flag = "flag"
         generatedCode += s" $flag = false;\n" + "}\n" * numIfthen
         val funcName = ctx.freshName("caseWhenNestedIf")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -111,6 +111,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
 
     ev.copy(code = generatedCode)
   }
+
   override def toString: String = s"if ($predicate) $trueValue else $falseValue"
 
   override def sql: String = s"(IF(${predicate.sql}, ${trueValue.sql}, ${falseValue.sql}))"
@@ -341,8 +342,7 @@ case class CaseWhenCodegen(
     val ev = expression.genCode(ctx)
     if (ev.code.length > 1024 && (ctx.INPUT_ROW != null && ctx.currentVars == null)) {
       val (funcName, globalIsNull, globalValue) =
-        CondExpression.createAndAddFunction(ctx, ev, expression.dataType,
-          "caseWhenElseExpr")
+        ctx.createAndAddFunction(ev, expression.dataType, "caseWhenElseExpr")
       (s"$funcName(${ctx.INPUT_ROW});", globalIsNull, globalValue)
     } else {
       (ev.code, ev.isNull, ev.value)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -342,7 +342,6 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     projection(row)
   }
 
-<<<<<<< HEAD
   test("SPARK-21720: split large predications into blocks due to JVM code size limit") {
     val length = 600
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -403,7 +403,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
       fail(s"Incorrect Evaluation: expressions: $expr1, actual: $result1, expected: $expectedInt")
     }
 
-    // Code size of condition or then expression is large
+    // Code size of else expression is large
     var expr2 = exprStr
     for (i <- 1 to 512) {
       expr2 = CaseWhen(Seq((EqualTo(exprStr, Literal(s"def$i")), Literal(s"xyz$i"))), expr2)
@@ -419,7 +419,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
       fail(s"Incorrect Evaluation: expressions: $expr2, actual: $result2, expected: $expectedStr")
     }
 
-    // Code size of total conditional branches is large
+    // total code size of conditional branches is large
     val cases = (1 to 512).map(i => (EqualTo(exprStr, Literal(s"def$i")), Literal(s"xyz$i")))
     val expr3 = CaseWhen(cases, exprStr).toCodegen()
     val plan3 = GenerateMutableProjection.generate(Seq(expr3))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -383,20 +383,53 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-21413: split large case when into blocks due to JVM code size limit") {
-    val expected = 2
-    var expr: Expression = BoundReference(0, IntegerType, true)
-    for (_ <- 1 to 10) {
-      expr = CaseWhen(Seq((EqualTo(expr, Literal(0)), Literal(-1))), expr)
+    val expectedInt = -2
+    var exprInt: Expression = BoundReference(0, IntegerType, true)
+    val expectedStr = UTF8String.fromString("abc")
+    val exprStr: Expression = BoundReference(0, StringType, true)
+
+    // Code size of condition or then expression is large
+    var expr1 = exprInt
+    for (i <- 1 to 10) {
+      expr1 = CaseWhen(Seq((EqualTo(expr1, Literal(i)), Literal(-1))), expr1).toCodegen()
+    }
+    val plan1 = GenerateMutableProjection.generate(Seq(expr1))
+    val row1 = new GenericInternalRow(Array[Any](1))
+    row1.setInt(0, expectedInt)
+    val actual1 = plan1(row1).toSeq(Seq(expr1.dataType))
+    assert(actual1.length == 1)
+    val result1 = actual1(0)
+    if (!checkResult(result1, expectedInt, expr1.dataType)) {
+      fail(s"Incorrect Evaluation: expressions: $expr1, actual: $result1, expected: $expectedInt")
+    }
+
+    // Code size of condition or then expression is large
+    var expr2 = exprStr
+    for (i <- 1 to 512) {
+      expr2 = CaseWhen(Seq((EqualTo(exprStr, Literal(s"def$i")), Literal(s"xyz$i"))), expr2)
         .toCodegen()
     }
-    val plan = GenerateMutableProjection.generate(Seq(expr))
-    val row = new GenericInternalRow(Array[Any](1))
-    row.setInt(0, expected)
-    val actual = plan(row).toSeq(Seq(expr.dataType))
-    assert(actual.length == 1)
+    val plan2 = GenerateMutableProjection.generate(Seq(expr2))
+    val row2 = new GenericInternalRow(Array[Any](1))
+    row2.update(0, expectedStr)
+    val actual2 = plan2(row2).toSeq(Seq(expr2.dataType))
+    assert(actual2.length == 1)
+    val result2 = actual2(0)
+    if (!checkResult(result2, expectedStr, expr2.dataType)) {
+      fail(s"Incorrect Evaluation: expressions: $expr2, actual: $result2, expected: $expectedStr")
+    }
 
-    if (!checkResult(actual(0), expected, expr.dataType)) {
-      fail(s"Incorrect Evaluation: expressions: $expr, actual: ${actual(0)}, expected: $expected")
+    // Code size of total conditional branches is large
+    val cases = (1 to 512).map(i => (EqualTo(exprStr, Literal(s"def$i")), Literal(s"xyz$i")))
+    val expr3 = CaseWhen(cases, exprStr).toCodegen()
+    val plan3 = GenerateMutableProjection.generate(Seq(expr3))
+    val row3 = new GenericInternalRow(Array[Any](1))
+    row3.update(0, expectedStr)
+    val actual3 = plan3(row3).toSeq(Seq(expr3.dataType))
+    assert(actual3.length == 1)
+    val result3 = actual3(0)
+    if (!checkResult(result3, expectedStr, expr3.dataType)) {
+      fail(s"Incorrect Evaluation: expressions: $expr3, actual: $result3, expected: $expectedStr")
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -430,5 +430,18 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     if (!checkResult(result3, expectedStr, expr3.dataType)) {
       fail(s"Incorrect Evaluation: expressions: $expr3, actual: $result3, expected: $expectedStr")
     }
+
+    // total code size is small
+    val cases4 = Seq((EqualTo(exprStr, Literal("def")), Literal("xyz")))
+    val expr4 = CaseWhen(cases4, exprStr).toCodegen()
+    val plan4 = GenerateMutableProjection.generate(Seq(expr4))
+    val row4 = new GenericInternalRow(Array[Any](1))
+    row4.update(0, expectedStr)
+    val actual4 = plan4(row4).toSeq(Seq(expr4.dataType))
+    assert(actual4.length == 1)
+    val result4 = actual4(0)
+    if (!checkResult(result4, expectedStr, expr4.dataType)) {
+      fail(s"Incorrect Evaluation: expressions: $expr4, actual: $result4, expected: $expectedStr")
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2132,6 +2132,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+<<<<<<< HEAD
   test("order-by ordinal.") {
     checkAnswer(
       testData2.select(lit(7), 'a, 'b).orderBy(lit(1), lit(2), lit(3)),
@@ -2157,5 +2158,22 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       .select(col("DecimalCol")).describe()
     val mean = result.select("DecimalCol").where($"summary" === "mean")
     assert(mean.collect().toSet === Set(Row("0.0345678900000000000000000000000000000")))
+  }
+
+  testQuietly("SPARK-21413: Multiple projections with CASE WHEN fails") {
+    val schema = StructType(StructField("a", IntegerType) :: Nil)
+    val df = spark.createDataFrame(sparkContext.parallelize(Seq(Row(1))), schema)
+    val df1 =
+      df.withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
+    checkAnswer(df1, Row(1))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2159,20 +2159,13 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(mean.collect().toSet === Set(Row("0.0345678900000000000000000000000000000")))
   }
 
-  testQuietly("SPARK-21413: Multiple projections with CASE WHEN fails") {
+  // ignore end-to-end test since sbt test does not go to fallback path in whole-stage codegen
+  ignore("SPARK-21413: Multiple projections with CASE WHEN fails") {
     val schema = StructType(StructField("a", IntegerType) :: Nil)
-    val df = spark.createDataFrame(sparkContext.parallelize(Seq(Row(1))), schema)
-    val df1 =
-      df.withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-        .withColumn("a", when($"a" === 0, null).otherwise($"a"))
-    checkAnswer(df1, Row(1))
+    var df = spark.createDataFrame(sparkContext.parallelize(Seq(Row(1))), schema)
+    for (i <- 1 to 10) {
+      df = df.withColumn("a", when($"a" === 0, null).otherwise($"a"))
+    }
+    checkAnswer(df, Row(1))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2132,7 +2132,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-<<<<<<< HEAD
   test("order-by ordinal.") {
     checkAnswer(
       testData2.select(lit(7), 'a, 'b).orderBy(lit(1), lit(2), lit(3)),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes Case When code generation to place condition and then expressions' generated code into separated methods if these size could be large. When the method is newly generated, variables for `isNull` and `value` are declared as an instance variable to pass these values (e.g. `isNull1409` and ` value1409`) to the callers of the generated method.

This PR resolved three cases:

1. large code size of condition or then expression
2. large code size of else expression
3. large code size of total conditional branches


Case 1 before this PR 
```java
/* 005 */ class SpecificMutableProjection extends org.apache.spark.sql.catalyst.expressions.codegen.BaseMutableProjection {
...
/* 034 */   public java.lang.Object apply(java.lang.Object _i) {
/* 035 */     InternalRow i = (InternalRow) _i;
/* 036 */
/* 037 */
/* 038 */
/* 039 */     boolean isNull = true;
/* 040 */     int value = -1;
/* 041 */
/* 042 */
/* 043 */     boolean isNull1 = true;
/* 044 */     boolean value1 = false;
/* 045 */
/* 046 */     boolean isNull2 = true;
/* 047 */     int value2 = -1;
/* 048 */
/* 049 */
/* 050 */     boolean isNull3 = true;
/* 051 */     boolean value3 = false;
/* 052 */
/* 053 */     boolean isNull4 = true;
/* 054 */     int value4 = -1;
/* 055 */
/* 056 */
/* 057 */     boolean isNull5 = true;
/* 058 */     boolean value5 = false;
/* 059 */
/* 060 */     boolean isNull6 = true;
/* 061 */     int value6 = -1;
/* 062 */
/* 063 */
/* 064 */     boolean isNull7 = true;
/* 065 */     boolean value7 = false;
/* 066 */
/* 067 */     boolean isNull8 = true;
/* 068 */     int value8 = -1;
/* 069 */
/* 070 */
/* 071 */     boolean isNull9 = true;
/* 072 */     boolean value9 = false;
/* 073 */
/* 074 */     boolean isNull10 = true;
/* 075 */     int value10 = -1;
/* 076 */
/* 077 */
/* 078 */     boolean isNull11 = true;
/* 079 */     boolean value11 = false;
/* 080 */
/* 081 */     boolean isNull12 = true;
/* 082 */     int value12 = -1;
/* 083 */
/* 084 */
/* 085 */     boolean isNull13 = true;
/* 086 */     boolean value13 = false;
/* 087 */
/* 088 */     boolean isNull14 = true;
/* 089 */     int value14 = -1;
/* 090 */
/* 091 */
/* 092 */     boolean isNull15 = true;
/* 093 */     boolean value15 = false;
/* 094 */
/* 095 */     boolean isNull16 = true;
/* 096 */     int value16 = -1;
/* 097 */
/* 098 */
/* 099 */     boolean isNull17 = true;
/* 100 */     boolean value17 = false;
/* 101 */
/* 102 */     boolean isNull18 = true;
/* 103 */     int value18 = -1;
/* 104 */
/* 105 */
/* 106 */     boolean isNull19 = true;
/* 107 */     boolean value19 = false;
/* 108 */
/* 109 */     boolean isNull20 = i.isNullAt(0);
/* 110 */     int value20 = isNull20 ? -1 : (i.getInt(0));
/* 111 */     if (!isNull20) {
/* 112 */
/* 113 */
/* 114 */       isNull19 = false; // resultCode could change nullability.
/* 115 */       value19 = value20 == 0;
/* 116 */
/* 117 */     }
/* 118 */     if (!isNull19 && value19) {
/* 119 */
/* 120 */       isNull18 = false;
/* 121 */       value18 = -1;
/* 122 */     }
/* 123 */
/* 124 */     else {
/* 125 */
/* 126 */
/* 127 */       boolean isNull23 = i.isNullAt(0);
/* 128 */       int value23 = isNull23 ? -1 : (i.getInt(0));
/* 129 */       isNull18 = isNull23;
/* 130 */       value18 = value23;
/* 131 */     }
...
```

Case 2 after this PR
```java
/* 005 */ class SpecificMutableProjection extends org.apache.spark.sql.catalyst.expressions.codegen.BaseMutableProjection {
...
/* 263 */   private boolean isNull1409;
/* 264 */   private boolean value1409;
...
/* 519 */   private boolean isNull2815;
/* 520 */   private boolean value2815;
...
/* 1073 */   public java.lang.Object apply(java.lang.Object _i) {
/* 1074 */     InternalRow i = (InternalRow) _i;
/* 1075 */
/* 1076 */
/* 1077 */
/* 1078 */     boolean isNull = true;
/* 1079 */     int value = -1;
/* 1080 */
/* 1081 */     caseWhenCondExpr255(i);
/* 1082 */     if (!isNull2815 && value2815) {
/* 1083 */
/* 1084 */       isNull = false;
/* 1085 */       value = -1;
/* 1086 */     }
/* 1087 */
/* 1088 */     else {
/* 1089 */
/* 1090 */
/* 1091 */       boolean isNull2816 = true;
/* 1092 */       int value2816 = -1;
/* 1093 */
/* 1094 */       caseWhenCondExpr383(i);
/* 1095 */       if (!isNull4223 && value4223) {
/* 1096 */
/* 1097 */         isNull2816 = false;
/* 1098 */         value2816 = -1;
/* 1099 */       }
...
/* 30171 */   private void caseWhenCondExpr255(InternalRow i) {
/* 30172 */     boolean isNull1 = true;
/* 30173 */     boolean value1 = false;
/* 30174 */
/* 30175 */     boolean isNull2 = true;
/* 30176 */     int value2 = -1;
/* 30177 */
/* 30178 */     caseWhenCondExpr127(i);
/* 30179 */     if (!isNull1409 && value1409) {
/* 30180 */
/* 30181 */       isNull2 = false;
/* 30182 */       value2 = -1;
/* 30183 */     }
/* 30184 */
/* 30185 */     else {
/* 30186 */
/* 30187 */
/* 30188 */       boolean isNull1410 = true;
/* 30189 */       int value1410 = -1;
/* 30190 */
/* 30191 */       caseWhenCondExpr191(i);
/* 30192 */       if (!isNull2113 && value2113) {
/* 30193 */
/* 30194 */         isNull1410 = false;
/* 30195 */         value1410 = -1;
/* 30196 */       }
...
/* 30342 */     if (!isNull2) {
/* 30343 */
/* 30344 */
/* 30345 */       isNull1 = false; // resultCode could change nullability.
/* 30346 */       value1 = value2 == 0;
/* 30347 */
/* 30348 */     }
/* 30349 */     isNull2815 = isNull1;
/* 30350 */     value2815 = value1;
/* 30351 */   }
...
```

## How was this patch tested?

Added new test suites into `CodeGenerationSuite` and `DataFrameSuite`
