### PR TITLE
[SPARK-21426] [2.0] [SQL] [TEST] Fix test failure due to missing literal representation 

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/comparator.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/comparator.sql
@@ -1,3 +1,3 @@
 -- binary type
-select x'00' < x'0f';
-select x'00' < x'ff';
+select hex('00') < hex('0f');
+select hex('00') < hex('ff');

--- a/sql/core/src/test/resources/sql-tests/results/comparator.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/comparator.sql.out
@@ -5,14 +5,26 @@
 -- !query 0
 select x'00' < x'0f'
 -- !query 0 schema
-struct<(X'00' < X'0F'):boolean>
+struct<>
 -- !query 0 output
-true
+org.apache.spark.sql.catalyst.parser.ParseException
+
+Literals of type 'X' are currently not supported.(line 1, pos 7)
+
+== SQL ==
+select x'00' < x'0f'
+-------^^^
 
 
 -- !query 1
 select x'00' < x'ff'
 -- !query 1 schema
-struct<(X'00' < X'FF'):boolean>
+struct<>
 -- !query 1 output
-true
+org.apache.spark.sql.catalyst.parser.ParseException
+
+Literals of type 'X' are currently not supported.(line 1, pos 7)
+
+== SQL ==
+select x'00' < x'ff'
+-------^^^

--- a/sql/core/src/test/resources/sql-tests/results/comparator.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/comparator.sql.out
@@ -3,28 +3,16 @@
 
 
 -- !query 0
-select x'00' < x'0f'
+select hex('00') < hex('0f')
 -- !query 0 schema
-struct<>
+struct<(hex(00) < hex(0f)):boolean>
 -- !query 0 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-Literals of type 'X' are currently not supported.(line 1, pos 7)
-
-== SQL ==
-select x'00' < x'0f'
--------^^^
+true
 
 
 -- !query 1
-select x'00' < x'ff'
+select hex('00') < hex('ff')
 -- !query 1 schema
-struct<>
+struct<(hex(00) < hex(ff)):boolean>
 -- !query 1 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-Literals of type 'X' are currently not supported.(line 1, pos 7)
-
-== SQL ==
-select x'00' < x'ff'
--------^^^
+true


### PR DESCRIPTION
## What changes were proposed in this pull request?
SPARK 2.0 does not support hex literal. Thus, the test case failed after backporting https://github.com/apache/spark/pull/18571

## How was this patch tested?
N/A