### PR TITLE
case class should be independent

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
@@ -26,10 +26,11 @@ import org.apache.spark.sql.types._
 // $example off:data_types$
 // $example off:programmatic_schema$
 
+case class Person(name: String, age: Long)
+
 object SparkSQLExample {
 
   // $example on:create_ds$
-  case class Person(name: String, age: Long)
   // $example off:create_ds$
 
   def main(args: Array[String]) {


### PR DESCRIPTION
Scala style says case class should be independent not be part of any object . so it could be access outside of that object , without interrupting it .

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
