### PR TITLE
[SPARK-21435][SQL] Empty files should be skipped while write to file

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -237,6 +237,7 @@ object FileFormatWriter extends Logging {
 
     val writeTask =
       if (sparkPartitionId != 0 && !iterator.hasNext) {
+        // In case of empty job, leave first partition to save meta for file format like parquet.
         new EmptyDirectoryWriteTask
       } else if (description.partitionColumns.isEmpty && description.bucketIdExpression.isEmpty) {
         new SingleDirectoryWriteTask(description, taskAttemptContext, committer)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -236,7 +236,7 @@ object FileFormatWriter extends Logging {
     committer.setupTask(taskAttemptContext)
 
     val writeTask =
-      if (!iterator.hasNext) {
+      if (sparkPartitionId != 0 && !iterator.hasNext) {
         new EmptyDirectoryWriteTask
       } else if (description.partitionColumns.isEmpty && description.bucketIdExpression.isEmpty) {
         new SingleDirectoryWriteTask(description, taskAttemptContext, committer)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -236,7 +236,9 @@ object FileFormatWriter extends Logging {
     committer.setupTask(taskAttemptContext)
 
     val writeTask =
-      if (description.partitionColumns.isEmpty && description.bucketIdExpression.isEmpty) {
+      if (!iterator.hasNext) {
+        new EmptyDirectoryWriteTask
+      } else if (description.partitionColumns.isEmpty && description.bucketIdExpression.isEmpty) {
         new SingleDirectoryWriteTask(description, taskAttemptContext, committer)
       } else {
         new DynamicPartitionWriteTask(description, taskAttemptContext, committer)
@@ -299,6 +301,20 @@ object FileFormatWriter extends Logging {
         0L
       }
     }
+  }
+
+  /** ExecuteWriteTask for empty partitions */
+  private class EmptyDirectoryWriteTask extends ExecuteWriteTask {
+
+    override def execute(iter: Iterator[InternalRow]): ExecutedWriteSummary = {
+      ExecutedWriteSummary(
+        updatedPartitions = Set.empty,
+        numOutputFile = 0,
+        numOutputBytes = 0,
+        numOutputRows = 0)
+    }
+
+    override def releaseResources(): Unit = {}
   }
 
   /** Writes data to a single directory (used for non-dynamic-partition writes). */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
@@ -23,21 +23,11 @@ import org.apache.spark.sql.test.SharedSQLContext
 class FileFormatWriterSuite extends QueryTest with SharedSQLContext {
 
   test("empty file should be skipped while write to file") {
-    withTempPath { dir =>
-      dir.delete()
-      // make sure the input dir has 10 files
-      spark.range(10000).repartition(10).write.parquet(dir.toString)
-      val df = spark.read.parquet(dir.toString)
-
-      withTempPath { dst_dir =>
-        dst_dir.delete()
-        df.where("id = 50").write.parquet(dst_dir.toString)
-        val allFiles = dst_dir.listFiles().filter { f =>
-          f.isFile && !f.getName.startsWith(".") && !f.getName.startsWith("_")
-        }
-        // First partition file and the data file
-        assert(allFiles.length == 2)
-      }
+    withTempPath { path =>
+      spark.range(100).repartition(10).where("id = 50").write.parquet(path.toString)
+      val partFiles = path.listFiles()
+        .filter(f => f.isFile && !f.getName.startsWith(".") && !f.getName.startsWith("_"))
+      assert(partFiles.length === 2)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.{File, FilenameFilter}
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSQLContext
+
+class FileFormatWriterSuite extends QueryTest with SharedSQLContext {
+
+  test("empty file should be skipped while write to file") {
+    withTempDir { dir =>
+      dir.delete()
+      spark.range(1000).repartition(2).write.parquet(dir.toString)
+      val df = spark.read.parquet(dir.toString)
+
+      withTempDir { dst_dir =>
+        dst_dir.delete()
+        df.where("id = 50").write.parquet(dst_dir.toString)
+        val allFiles = dst_dir.listFiles(new FilenameFilter {
+          override def accept(dir: File, name: String): Boolean = {
+            !name.startsWith(".") && !name.startsWith("_")
+          }
+        })
+        assert(allFiles.length == 1)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
@@ -27,8 +27,14 @@ class FileFormatWriterSuite extends QueryTest with SharedSQLContext {
   test("empty file should be skipped while write to file") {
     withTempDir { dir =>
       dir.delete()
-      spark.range(1000).repartition(2).write.parquet(dir.toString)
+      spark.range(10000).repartition(10).write.parquet(dir.toString)
       val df = spark.read.parquet(dir.toString)
+      val allFiles = dir.listFiles(new FilenameFilter {
+        override def accept(dir: File, name: String): Boolean = {
+          !name.startsWith(".") && !name.startsWith("_")
+        }
+      })
+      assert(allFiles.length == 10)
 
       withTempDir { dst_dir =>
         dst_dir.delete()
@@ -38,7 +44,8 @@ class FileFormatWriterSuite extends QueryTest with SharedSQLContext {
             !name.startsWith(".") && !name.startsWith("_")
           }
         })
-        assert(allFiles.length == 1)
+        // First partition file and the data file
+        assert(allFiles.length == 2)
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add EmptyDirectoryWriteTask for empty task while writing files. Fix the empty result for parquet format by leaving the first partition for meta writing.

## How was this patch tested?

Add new test in `FileFormatWriterSuite `