### PR TITLE
[SPARK-21455][CORE]RpcFailure should be call on RpcResponseCallback.onFailure

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcCallContext.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcCallContext.scala
@@ -49,6 +49,10 @@ private[netty] class LocalNettyRpcCallContext(
   override protected def send(message: Any): Unit = {
     p.success(message)
   }
+
+  override def sendFailure(e: Throwable): Unit = {
+    p.failure(e)
+  }
 }
 
 /**
@@ -63,5 +67,9 @@ private[netty] class RemoteNettyRpcCallContext(
   override protected def send(message: Any): Unit = {
     val reply = nettyEnv.serialize(message)
     callback.onSuccess(reply)
+  }
+
+  override def sendFailure(e: Throwable): Unit = {
+    callback.onFailure(e)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, when there is a `RpcFailure` need be sent back to client, we call `RpcCallContext.sendFailure`, then it will call `NettyRpcCallContext.send`. However, we can see the follow code snippets in the implementation class.

```scala
private[netty] class RemoteNettyRpcCallContext(
    nettyEnv: NettyRpcEnv,
    callback: RpcResponseCallback,
    senderAddress: RpcAddress)
  extends NettyRpcCallContext(senderAddress) {

  override protected def send(message: Any): Unit = {
    val reply = nettyEnv.serialize(message)
    callback.onSuccess(reply)
  }
}
```
This is unreasonable, there are two reasons:

1. Send back failure message by `RpcResponseCallback.onSuccess`, we can't get the details exception messages(such as `StackTrace`) in currently implements.

2. `RpcResponseCallback.onSuccess` and `RpcResponseCallback.onFailure` could have different behavior. Such as:
NettyBlockTransferService#uploadBlock

```scala
new RpcResponseCallback {
        override def onSuccess(response: ByteBuffer): Unit = {
          logTrace(s"Successfully uploaded block $blockId")
          result.success((): Unit)
        }
        override def onFailure(e: Throwable): Unit = {
          logError(s"Error while uploading block $blockId", e)
          result.failure(e)
        }
}
```


## How was this patch tested?

Existing tests, and modified tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
