### PR TITLE
[SPARK-21484][SQL] Fix inconsistent query plans of Dataset after persist/unpersist

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -159,13 +159,9 @@ private[sql] object Dataset {
 @InterfaceStability.Stable
 class Dataset[T] private[sql](
     @transient val sparkSession: SparkSession,
-    @transient private var _queryExecution: QueryExecution,
+    @DeveloperApi @InterfaceStability.Unstable @transient val queryExecution: QueryExecution,
     encoder: Encoder[T])
   extends Serializable {
-
-  @DeveloperApi
-  @InterfaceStability.Unstable
-  def queryExecution: QueryExecution = _queryExecution
 
   queryExecution.assertAnalyzed()
 
@@ -2705,7 +2701,6 @@ class Dataset[T] private[sql](
    */
   def persist(): this.type = {
     sparkSession.sharedState.cacheManager.cacheQuery(this)
-    this._queryExecution = sparkSession.sessionState.executePlan(logicalPlan)
     this
   }
 
@@ -2753,7 +2748,6 @@ class Dataset[T] private[sql](
    */
   def unpersist(blocking: Boolean): this.type = {
     sparkSession.sharedState.cacheManager.uncacheQuery(this, blocking)
-    this._queryExecution = sparkSession.sessionState.executePlan(logicalPlan)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -69,33 +69,26 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
     sparkSession.sessionState.analyzer.execute(logical)
   }
 
-  lazy val withCachedData: LogicalPlan = {
-    assertAnalyzed()
-    assertSupported()
-    sparkSession.sharedState.cacheManager.useCachedData(analyzed)
-  }
+  val cacheWatcher: CacheWatcher = new CacheWatcher(this)
 
-  lazy val optimizedPlan: LogicalPlan = sparkSession.sessionState.optimizer.execute(withCachedData)
+  def withCachedData: LogicalPlan = cacheWatcher.synchronized { cacheWatcher.withCachedData }
 
-  lazy val sparkPlan: SparkPlan = {
-    SparkSession.setActiveSession(sparkSession)
-    // TODO: We use next(), i.e. take the first plan returned by the planner, here for now,
-    //       but we will implement to choose the best plan.
-    planner.plan(ReturnAnswer(optimizedPlan)).next()
-  }
+  def optimizedPlan: LogicalPlan = cacheWatcher.synchronized { cacheWatcher.optimizedPlan }
+
+  def sparkPlan: SparkPlan = cacheWatcher.synchronized { cacheWatcher.sparkPlan }
 
   // executedPlan should not be used to initialize any SparkPlan. It should be
   // only used for execution.
-  lazy val executedPlan: SparkPlan = prepareForExecution(sparkPlan)
+  def executedPlan: SparkPlan = cacheWatcher.synchronized { cacheWatcher.executedPlan }
 
   /** Internal version of the RDD. Avoids copies and has no schema */
-  lazy val toRdd: RDD[InternalRow] = executedPlan.execute()
+  def toRdd: RDD[InternalRow] = cacheWatcher.synchronized { cacheWatcher.toRdd }
 
   /**
    * Prepares a planned [[SparkPlan]] for execution by inserting shuffle operations and internal
    * row format conversions as needed.
    */
-  protected def prepareForExecution(plan: SparkPlan): SparkPlan = {
+  def prepareForExecution(plan: SparkPlan): SparkPlan = {
     preparations.foldLeft(plan) { case (sp, rule) => rule.apply(sp) }
   }
 
@@ -254,5 +247,107 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
     def codegenToSeq(): Seq[(String, String)] = {
       org.apache.spark.sql.execution.debug.codegenStringSeq(executedPlan)
     }
+  }
+}
+
+/**
+ * Used by `QueryExecution` to prepare various query plans while keeping updated with cache changes.
+ * This keeps the copies of query plans. Once there're cache changes that invalidate the kept query
+ * plans, e.g. a fragement of query plan is cached/uncached, this class resets the copies of query
+ * plans.
+ */
+class CacheWatcher(val queryExecution: QueryExecution) {
+  private var _withCachedData: Option[LogicalPlan] = None
+  private var _optimizedPlan: Option[LogicalPlan] = None
+  private var _sparkPlan: Option[SparkPlan] = None
+  private var _executedPlan: Option[SparkPlan] = None
+  private var _rdd: Option[RDD[InternalRow]] = None
+
+  private def reset(): Unit = {
+    _withCachedData = None
+    _optimizedPlan = None
+    _sparkPlan = None
+    _executedPlan = None
+    _rdd = None
+  }
+
+  // Check if the query plan needs to be changed due to changes in cache status.
+  private def updateWithCachePlans(): Unit = if (_withCachedData.isEmpty) {
+    queryExecution.assertAnalyzed()
+    queryExecution.assertSupported()
+    val cachedPlan =
+      queryExecution.sparkSession.sharedState.cacheManager.useCachedData(queryExecution.analyzed)
+    _withCachedData = Some(cachedPlan)
+  } else {
+    _withCachedData.foreach { cachedPlan =>
+      val newPlan =
+        queryExecution.sparkSession.sharedState.cacheManager.useCachedData(queryExecution.analyzed)
+      if (newPlan.canonicalized != cachedPlan.canonicalized) {
+        // Cache status changed for the query plan.
+        reset()
+        _withCachedData = Some(newPlan)
+      }
+    }
+  }
+
+  def withCachedData: LogicalPlan = {
+    updateWithCachePlans()
+    _withCachedData.get
+  }
+
+  private def updateAndGetOptimizedPlan(): LogicalPlan = {
+    val plan = queryExecution.sparkSession.sessionState.optimizer.execute(withCachedData)
+    _optimizedPlan = Some(plan)
+    plan
+  }
+
+  def optimizedPlan: LogicalPlan = if (_optimizedPlan.isEmpty) {
+    updateAndGetOptimizedPlan()
+  } else {
+    updateWithCachePlans()
+    _optimizedPlan.getOrElse(updateAndGetOptimizedPlan())
+  }
+
+  private def updateAndGetSparkPlan(): SparkPlan = {
+    SparkSession.setActiveSession(queryExecution.sparkSession)
+    // TODO: We use next(), i.e. take the first plan returned by the planner, here for now,
+    //       but we will implement to choose the best plan.
+    val plan =
+      queryExecution.sparkSession.sessionState.planner.plan(ReturnAnswer(optimizedPlan)).next()
+    _sparkPlan = Some(plan)
+    plan
+  }
+
+  def sparkPlan: SparkPlan = if (_sparkPlan.isEmpty) {
+    updateAndGetSparkPlan()
+  } else {
+    updateWithCachePlans()
+    _sparkPlan.getOrElse(updateAndGetSparkPlan())
+  }
+
+  private def updateAndGetExecutedPlan(): SparkPlan = {
+    val plan = queryExecution.prepareForExecution(sparkPlan)
+    _executedPlan = Some(plan)
+    plan
+  }
+
+  def executedPlan: SparkPlan = if (_executedPlan.isEmpty) {
+    updateAndGetExecutedPlan()
+  } else {
+    updateWithCachePlans()
+    _executedPlan.getOrElse(updateAndGetExecutedPlan())
+  }
+
+  private def updateAndGetRDD(): RDD[InternalRow] = {
+    val rdd = executedPlan.execute()
+    _rdd = Some(rdd)
+    rdd
+  }
+
+  def toRdd: RDD[InternalRow] = if (_rdd.isEmpty) {
+    updateAndGetRDD()
+  } else {
+    updateWithCachePlans()
+    _rdd.getOrElse(updateAndGetRDD())
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CacheWatcherSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CacheWatcherSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
+import org.apache.spark.sql.test.SharedSQLContext
+
+class CacheWatcherSuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  private def assertCachedPlan(plan: LogicalPlan, numCachedTables: Int = 1): Unit = {
+    val cachedData = plan.collect {
+      case cached: InMemoryRelation => cached
+    }
+    assert(cachedData.size == numCachedTables)
+  }
+
+  private def assertCachedExecPlan(plan: SparkPlan, numCachedTables: Int = 1): Unit = {
+    val cachedData = plan.collect {
+      case cached: InMemoryTableScanExec => cached
+    }
+    assert(cachedData.size == numCachedTables)
+  }
+
+  test("Query plans with cached/uncached nodes after persist/unpersist") {
+    withTable("t") {
+      Seq("1", "2").toDF().write.saveAsTable("t")
+      val ds1 = spark.table("t")
+      val ds2 = spark.table("t")
+
+      val watcher1 = ds1.queryExecution.cacheWatcher
+      val watcher2 = ds1.queryExecution.cacheWatcher
+
+      assertCachedPlan(watcher1.withCachedData, 0)
+      assertCachedPlan(watcher2.withCachedData, 0)
+      assertCachedExecPlan(watcher1.executedPlan, 0)
+      assertCachedExecPlan(watcher2.executedPlan, 0)
+      assertCached(ds1, 0)
+      assertCached(ds2, 0)
+
+      ds1.persist()
+      assertCachedPlan(watcher1.withCachedData, 1)
+      assertCachedPlan(watcher2.withCachedData, 1)
+      assertCachedExecPlan(watcher1.executedPlan, 1)
+      assertCachedExecPlan(watcher2.executedPlan, 1)
+      assertCached(ds1, 1)
+      assertCached(ds2, 1)
+
+      ds2.unpersist()
+      assertCachedPlan(watcher1.withCachedData, 0)
+      assertCachedPlan(watcher2.withCachedData, 0)
+      assertCachedExecPlan(watcher1.executedPlan, 0)
+      assertCachedExecPlan(watcher2.executedPlan, 0)
+      assertCached(ds1, 0)
+      assertCached(ds2, 0)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
@@ -247,6 +247,7 @@ object SparkPlanTest {
                 sys.error(s"Invalid Test: Cannot resolve $u given input $inputMap"))
           }
       }
+      override lazy val executedPlan: SparkPlan = prepareForExecution(sparkPlan)
     }
     execution.executedPlan.executeCollectPublic().toSeq
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the call of persist/unpersis, the query plans of a `Dataset` should be changed accordingly. But currently the query plans are the same. So you will see the inconsistent query plans like:

    scala> val x1 = Seq(1).toDF()
    x1: org.apache.spark.sql.DataFrame = [value: int]
    scala> println(x1.queryExecution.executedPlan) // query plans are materialized before persist()
    LocalTableScan [value#1]
    scala> x1.persist()
    scala> x1.count()
    scala> println(x1.queryExecution.executedPlan)
    LocalTableScan [value#1]

    scala> val x1 = Seq(1).toDF()
    x1: org.apache.spark.sql.DataFrame = [value: int]
    scala> x1.persist()
    scala> x1.count()
    scala> println(x1.queryExecution.executedPlan) // query plans are materialized after persist()
    InMemoryTableScan [value#24]
       +- InMemoryRelation [value#24], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
             +- LocalTableScan [value#1]
    scala> x1.unpersist()
    scala> println(x1.queryExecution.executedPlan)
    InMemoryTableScan [value#24]
       +- InMemoryRelation [value#24], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
             +- LocalTableScan [value#1]

After this fix:

    scala> val x1 = Seq(1).toDF()
    x1: org.apache.spark.sql.DataFrame = [value: int]
    scala> println(x1.queryExecution.executedPlan)
    LocalTableScan [value#1]
    scala> x1.persist()
    scala> x1.count()
    scala> println(x1.queryExecution.executedPlan)
    InMemoryTableScan [value#1]
       +- InMemoryRelation [value#1], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
             +- LocalTableScan [value#1]
    scala> x1.unpersist()
    scala> println(x1.queryExecution.executedPlan)
    LocalTableScan [value#1]


## How was this patch tested?

Added test case.
