### PR TITLE
delete the superfluous ‘ symbol in rdd-programming-guide.md

### DIFF
--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -1136,7 +1136,7 @@ ordered data following shuffle then it's possible to use:
 * `sortBy` to make a globally ordered RDD
 
 Operations which can cause a shuffle include **repartition** operations like
-[`repartition`](#RepartitionLink) and [`coalesce`](#CoalesceLink), **'ByKey** operations
+[`repartition`](#RepartitionLink) and [`coalesce`](#CoalesceLink), **ByKey** operations
 (except for counting) like [`groupByKey`](#GroupByLink) and [`reduceByKey`](#ReduceByLink), and
 **join** operations like [`cogroup`](#CogroupLink) and [`join`](#JoinLink).
 
@@ -1152,7 +1152,7 @@ read the relevant sorted blocks.
 
 Certain shuffle operations can consume significant amounts of heap memory since they employ
 in-memory data structures to organize records before or after transferring them. Specifically,
-`reduceByKey` and `aggregateByKey` create these structures on the map side, and `'ByKey` operations
+`reduceByKey` and `aggregateByKey` create these structures on the map side, and `ByKey` operations
 generate these on the reduce side. When data does not fit in memory Spark will spill these tables
 to disk, incurring the additional overhead of disk I/O and increased garbage collection.
 


### PR DESCRIPTION
**'ByKey** --> **ByKey**
and `'ByKey` operations  --> and `ByKey` operations

## How was this patch tested?
before -->
![5x9 z l kssfjjb0a072 h](https://user-images.githubusercontent.com/26565020/28410296-ccc50d04-6d6f-11e7-8999-6ae8057de3aa.png)

delete the superfluous ‘ symbol