### PR TITLE
[SPARK-21417][SQL] Infer join conditions using propagated constraints

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressionMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressionMap.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.EquivalentExpressionMap.SemanticallyEqualExpr
+
+/**
+ * ﻿A class that allows you to map an expression into a set of equivalent expressions. The keys are
+ * handled based on their semantic meaning and ignoring cosmetic differences. The values are
+ * represented as [[ExpressionSet]]s.
+ *
+ * The underlying representation of keys depends on the [[Expression.semanticHash]] and
+ * [[Expression.semanticEquals]] methods.
+ *
+ * {{{
+ *   val map = new EquivalentExpressionMap()
+ *
+ *   map.put(1 + 2, a)
+ *   map.put(rand(), b)
+ *
+ *   map.get(2 + 1) => Set(a) // 1 + 2 and 2 + 1 are semantically equivalent
+ *   map.get(1 + 2) => Set(a) // 1 + 2 and 2 + 1 are semantically equivalent
+ *   map.get(rand()) => Set() // non-deterministic expressions are not equivalent
+ * }}}
+ */
+class EquivalentExpressionMap {
+
+  private val equivalenceMap = mutable.HashMap.empty[SemanticallyEqualExpr, ExpressionSet]
+
+  def put(expression: Expression, equivalentExpression: Expression): Unit = {
+    val equivalentExpressions = equivalenceMap.getOrElseUpdate(expression, ExpressionSet.empty)
+    equivalenceMap(expression) = equivalentExpressions + equivalentExpression
+  }
+
+  def get(expression: Expression): Set[Expression] =
+    equivalenceMap.getOrElse(expression, ExpressionSet.empty)
+}
+
+object EquivalentExpressionMap {
+
+  private implicit class SemanticallyEqualExpr(val expr: Expression) {
+    override def equals(obj: Any): Boolean = obj match {
+      case other: SemanticallyEqualExpr => expr.semanticEquals(other.expr)
+      case _ => false
+    }
+
+    override def hashCode: Int = expr.semanticHash()
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressionMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressionMap.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.catalyst.expressions.EquivalentExpressionMap.SemanticallyEqualExpr
 
 /**
- * ﻿A class that allows you to map an expression into a set of equivalent expressions. The keys are
+ * A class that allows you to map an expression into a set of equivalent expressions. The keys are
  * handled based on their semantic meaning and ignoring cosmetic differences. The values are
  * represented as [[ExpressionSet]]s.
  *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
@@ -27,6 +27,8 @@ object ExpressionSet {
     expressions.foreach(set.add)
     set
   }
+
+  val empty: ExpressionSet = ExpressionSet(Nil)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -86,7 +86,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PushProjectionThroughUnion,
       ReorderJoin,
       EliminateOuterJoin,
-      InferJoinConditionsFromConstraints,
+      EliminateCrossJoin,
       InferFiltersFromConstraints,
       BooleanSimplification,
       PushPredicateThroughJoin,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -86,6 +86,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PushProjectionThroughUnion,
       ReorderJoin,
       EliminateOuterJoin,
+      InferJoinConditionsFromConstraints,
       InferFiltersFromConstraints,
       BooleanSimplification,
       PushPredicateThroughJoin,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -155,7 +155,9 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
 
 /**
  * A rule that uses propagated constraints to infer join conditions. The optimization is applicable
- * only to CROSS joins.
+ * only to CROSS joins. For other join types, adding inferred join conditions would potentially
+ * shuffle children as child node's partitioning won't satisfy the JOIN node's requirements
+ * which otherwise could have.
  *
  * For instance, if there is a CROSS join, where the left relation has 'a = 1' and the right
  * relation has 'b = 1', then the rule infers 'a = b' as a join predicate.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressionMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressionMapSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.dsl.expressions._
+
+class EquivalentExpressionMapSuite extends SparkFunSuite {
+
+  private val onePlusTwo = Literal(1) + Literal(2)
+  private val twoPlusOne = Literal(2) + Literal(1)
+  private val rand = Rand(10)
+
+  test("behaviour of the equivalent expression map") {
+    val equivalentExpressionMap = new EquivalentExpressionMap()
+    equivalentExpressionMap.put(onePlusTwo, 'a)
+    equivalentExpressionMap.put(Literal(1) + Literal(3), 'b)
+    equivalentExpressionMap.put(rand, 'c)
+
+    // 1 + 2 should be equivalent to 2 + 1
+    assertResult(ExpressionSet(Seq('a)))(equivalentExpressionMap.get(twoPlusOne))
+    // non-deterministic expressions should not be equivalent
+    assertResult(ExpressionSet.empty)(equivalentExpressionMap.get(rand))
+
+    // if the same (key, value) is added several times, the map still returns only one entry
+    equivalentExpressionMap.put(onePlusTwo, 'a)
+    equivalentExpressionMap.put(twoPlusOne, 'a)
+    assertResult(ExpressionSet(Seq('a)))(equivalentExpressionMap.get(twoPlusOne))
+
+    // get several equivalent attributes
+    equivalentExpressionMap.put(onePlusTwo, 'e)
+    assertResult(ExpressionSet(Seq('a, 'e)))(equivalentExpressionMap.get(onePlusTwo))
+    assertResult(2)(equivalentExpressionMap.get(onePlusTwo).size)
+
+    // several non-deterministic expressions should not be equivalent
+    equivalentExpressionMap.put(rand, 'd)
+    assertResult(ExpressionSet.empty)(equivalentExpressionMap.get(rand))
+    assertResult(0)(equivalentExpressionMap.get(rand).size)
+  }
+
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferJoinConditionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferJoinConditionsSuite.scala
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.{Cross, Inner, JoinType, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf.CONSTRAINT_PROPAGATION_ENABLED
+import org.apache.spark.sql.types.IntegerType
+
+class InferJoinConditionsSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Infer Join Conditions", FixedPoint(10),
+        InferJoinConditionsFromConstraints,
+        PushPredicateThroughJoin) :: Nil
+  }
+
+  val testRelation1 = LocalRelation('a.int, 'b.int)
+  val testRelation2 = LocalRelation('c.int, 'd.int)
+
+  test("successful detection of join conditions (1)") {
+    checkJoinOptimization(
+      originalFilter = 'a === 1 && 'c === 1 && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === 1,
+      expectedRightRelationFilter = 'c === 1 && 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'c && 'a === 'd))
+  }
+
+  test("successful detection of join conditions (2)") {
+    checkJoinOptimization(
+      originalFilter = 'a === 1 && 'b === 2 && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === 1 && 'b === 2,
+      expectedRightRelationFilter = 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'd))
+  }
+
+  test("successful detection of join conditions (3)") {
+    checkJoinOptimization(
+      originalFilter = 'a === 1 && Literal(1) === 'c && 'd === 'a,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === 1,
+      expectedRightRelationFilter = Literal(1) === 'c,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'c && 'd === 'a))
+  }
+
+  test("successful detection of join conditions (4)") {
+    // PushPredicateThroughJoin will push down 'd === 'a as a join condition
+    // InferJoinConditionsFromConstraints will NOT infer any semantically new predicates,
+    // so the join type will stay the same (i.e., CROSS)
+    checkJoinOptimization(
+      originalFilter = 'a === 1 && Literal(1) === 'd && 'd === 'a,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === 1,
+      expectedRightRelationFilter = Literal(1) === 'd,
+      expectedJoinType = Cross,
+      expectedJoinCondition = Some('a === 'd))
+  }
+
+  test("successful detection of join conditions (5)") {
+    // Literal(1) * Literal(2) and Literal(2) * Literal(1) are semantically equal
+    checkJoinOptimization(
+      originalFilter = 'a === Literal(1) * Literal(2) && Literal(2) * Literal(1) === 'c,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === Literal(1) * Literal(2),
+      expectedRightRelationFilter = Literal(2) * Literal(1) === 'c,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'c))
+  }
+
+  test("successful detection of join conditions (6)") {
+    checkJoinOptimization(
+      originalFilter = 'a === 1 && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = Some('a === 'c),
+      expectedLeftRelationFilter = 'a === 1,
+      expectedRightRelationFilter = 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'c && 'a === 'd))
+  }
+
+  test("successful detection of join conditions (7)") {
+    checkJoinOptimization(
+      originalFilter = 'b === 1 && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = Some('a > 'c),
+      expectedLeftRelationFilter = 'b === 1,
+      expectedRightRelationFilter = 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a > 'c && 'b === 'd))
+  }
+
+  test("successful detection of join conditions (8)") {
+    checkJoinOptimization(
+      originalFilter = 'a === 'b + 'd && 'a === 1 && 'c === 'b + 'd && 'd === 4,
+      originalJoinType = Cross,
+      originalJoinCondition = Some('a >= 'c),
+      expectedLeftRelationFilter = 'a === 1,
+      expectedRightRelationFilter = 'd === 4,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'c && 'a >= 'c && 'a === 'b + 'd && 'c === 'b + 'd))
+  }
+
+  test("successful detection of complex join conditions via InferJoinConditionsFromConstraints") {
+    checkJoinOptimization(
+      originalFilter = 'a === Cast("1", IntegerType) && 'c === Cast("1", IntegerType) && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === Cast("1", IntegerType),
+      expectedRightRelationFilter = 'c === Cast("1", IntegerType) && 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'c))
+  }
+
+  test("successful detection of complex join conditions via PushPredicateThroughJoin") {
+    checkJoinOptimization(
+      originalFilter = 'a === ('b % 2) && 'c === ('b % 2) && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === ('b % 2),
+      expectedRightRelationFilter = 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('c === ('b % 2) && 'a === 'c))
+  }
+
+  test("successful detection of complex join conditions") {
+    // InferJoinConditionsFromConstraints will infer 'a === d'
+    // PushPredicateThroughJoin will add 'a === (c % 2)' to the join condition
+    checkJoinOptimization(
+      originalFilter = 'a === 1 && 'a === ('c % 2) && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a === 1,
+      expectedRightRelationFilter = 'd === 1,
+      expectedJoinType = Inner,
+      expectedJoinCondition = Some('a === 'd && 'a === ('c % 2)))
+  }
+
+  test("inability to detect join conditions when constant propagation is disabled") {
+    withSQLConf(CONSTRAINT_PROPAGATION_ENABLED.key -> "false") {
+      checkJoinOptimization(
+        originalFilter = 'a === 1 && 'c === 1 && 'd === 1,
+        originalJoinType = Cross,
+        originalJoinCondition = None,
+        expectedLeftRelationFilter = 'a === 1,
+        expectedRightRelationFilter = 'c === 1 && 'd === 1,
+        expectedJoinType = Cross,
+        expectedJoinCondition = None)
+    }
+  }
+
+  test("inability to detect join conditions (1)") {
+    checkJoinOptimization(
+      originalFilter = 'a >= 1 && 'c === 1 && 'd >= 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'a >= 1,
+      expectedRightRelationFilter = 'c === 1 && 'd >= 1,
+      expectedJoinType = Cross,
+      expectedJoinCondition = None)
+  }
+
+
+  test("inability to detect join conditions (2)") {
+    // The join condition appears due to PushPredicateThroughJoin
+    checkJoinOptimization(
+      originalFilter = (('a >= 1 && 'c === 1) || 'd === 10) && 'b === 10 && 'c === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = 'b === 10,
+      expectedRightRelationFilter = 'c === 1,
+      expectedJoinType = Cross,
+      expectedJoinCondition = Some(('a >= 1 && 'c === 1) || 'd === 10))
+  }
+
+  test("inability to detect join conditions (3)") {
+    checkJoinOptimization(
+      originalFilter = Literal(1) === 'b && ('c === 1 || 'd === 1),
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = Literal(1) === 'b,
+      expectedRightRelationFilter = 'c === 1 || 'd === 1,
+      expectedJoinType = Cross,
+      expectedJoinCondition = None)
+  }
+
+  test("inability to detect join conditions (4)") {
+    checkJoinOptimization(
+      originalFilter = Literal(1) === 'b && 'c === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = Some('c === 'b),
+      expectedLeftRelationFilter = Literal(1) === 'b,
+      expectedRightRelationFilter = 'c === 1,
+      expectedJoinType = Cross,
+      expectedJoinCondition = Some('c === 'b))
+  }
+
+  test("inability to detect join conditions (5)") {
+    checkJoinOptimization(
+      originalFilter = Not('a === 1) && 'd === 1,
+      originalJoinType = Cross,
+      originalJoinCondition = None,
+      expectedLeftRelationFilter = Not('a === 1),
+      expectedRightRelationFilter = 'd === 1,
+      expectedJoinType = Cross,
+      expectedJoinCondition = None)
+  }
+
+  private def checkJoinOptimization(
+      originalFilter: Expression,
+      originalJoinType: JoinType,
+      originalJoinCondition: Option[Expression],
+      expectedLeftRelationFilter: Expression,
+      expectedRightRelationFilter: Expression,
+      expectedJoinType: JoinType,
+      expectedJoinCondition: Option[Expression]): Unit = {
+
+    val originalQuery = testRelation1
+      .join(testRelation2, originalJoinType, originalJoinCondition)
+      .where(originalFilter)
+    val optimizedQuery = Optimize.execute(originalQuery.analyze)
+
+    val left = testRelation1.where(expectedLeftRelationFilter)
+    val right = testRelation2.where(expectedRightRelationFilter)
+    val expectedQuery = left.join(right, expectedJoinType, expectedJoinCondition).analyze
+    comparePlans(optimizedQuery, expectedQuery)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds an optimization rule that infers join conditions using propagated constraints.

For instance, if there is a join, where the left relation has 'a = 1' and the right relation has 'b = 1', then the rule infers 'a = b' as a join predicate. Only semantically new predicates are appended to the existing join condition.

Refer to the corresponding ticket and tests for more details.

## How was this patch tested?

This patch comes with a new test suite to cover the implemented logic.
