### PR TITLE
[SPARK-21492][SQL] Memory leak in SortMergeJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -969,7 +969,7 @@ private class SortMergeFullOuterJoinScanner(
 
   def destruct(): Unit = {
     while (leftIter.advanceNext()) {}
-    while(rightIter.advanceNext()) {}
+    while (rightIter.advanceNext()) {}
   }
   // --- Private methods --------------------------------------------------------------------------
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -179,6 +179,7 @@ case class SortMergeJoinExec(
                     currentRightMatches = null
                     currentLeftRow = null
                     rightMatchesIterator = null
+                    smjScanner.destruct()
                     return false
                   }
                 }
@@ -188,6 +189,7 @@ case class SortMergeJoinExec(
                   return true
                 }
               }
+              smjScanner.destruct()
               false
             }
 
@@ -266,6 +268,7 @@ case class SortMergeJoinExec(
                   }
                 }
               }
+              smjScanner.destruct()
               false
             }
 
@@ -306,6 +309,7 @@ case class SortMergeJoinExec(
                   return true
                 }
               }
+              smjScanner.destruct()
               false
             }
 
@@ -344,6 +348,7 @@ case class SortMergeJoinExec(
                 numOutputRows += 1
                 return true
               }
+              smjScanner.destruct()
               false
             }
 
@@ -604,6 +609,12 @@ case class SortMergeJoinExec(
        |  }
        |  if (shouldStop()) return;
        |}
+       |while ($leftInput.hasNext()) {
+       |  $leftInput.next();
+       |}
+       while ($rightInput.hasNext()) {
+       |  $rightInput.next();
+       |}
      """.stripMargin
   }
 }
@@ -648,6 +659,11 @@ private[joins] class SortMergeJoinScanner(
 
   // Initialization (note: do _not_ want to advance streamed here).
   advancedBufferedToRowWithNullFreeJoinKey()
+
+  def destruct(): Unit = {
+     while (streamedIter.advanceNext()) {}
+     while (bufferedIter.advanceNext()) {}
+  }
 
   // --- Public methods ---------------------------------------------------------------------------
 
@@ -915,7 +931,11 @@ private abstract class OneSideOuterIterator(
 
   override def advanceNext(): Boolean = {
     val r = advanceBufferUntilBoundConditionSatisfied() || advanceStream()
-    if (r) numOutputRows += 1
+    if (r) {
+      numOutputRows += 1
+    } else {
+      smjScanner.destruct()
+    }
     r
   }
 
@@ -947,6 +967,10 @@ private class SortMergeFullOuterJoinScanner(
   advancedLeft()
   advancedRight()
 
+  def destruct(): Unit = {
+    while (leftIter.advanceNext()) {}
+    while(rightIter.advanceNext()) {}
+  }
   // --- Private methods --------------------------------------------------------------------------
 
   /**
@@ -1103,7 +1127,11 @@ private class FullOuterIterator(
 
   override def advanceNext(): Boolean = {
     val r = smjScanner.advanceNext()
-    if (r) numRows += 1
+    if (r) {
+      numRows += 1
+    } else {
+      smjScanner.destruct();
+    }
     r
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the memory leak error message is degraded to warning. But it does happens and impact perf of running jobs. This diff fix the memory leak caused in SortMergeJoin.

The diff is trying to exhaust the iterator, even it is not required, in order to make sure the iterator is destructed.

## How was this patch tested?
Relies on existing unit test. Test in production job, and the memory leak is fixed by the diff.
