### PR TITLE
[SPARK-12717][PYTHON] Adding thread-safe broadcast pickle registry

### DIFF
--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -139,6 +139,29 @@ class Broadcast(object):
         return _from_id, (self._jbroadcast.id(),)
 
 
+class BroadcastPickleRegistry(object):
+    """ Thread-safe registry for broadcast variables that have been pickled
+    """
+
+    def __init__(self, lock):
+        self._registry = set()
+        self._lock = lock
+
+    @property
+    def lock(self):
+        return self._lock
+
+    def add(self, bcast):
+        with self._lock:
+            self._registry.add(bcast)
+
+    def get_and_clear(self):
+        with self._lock:
+            registry_copy = self._registry.copy()
+            self._registry.clear()
+        return registry_copy
+
+
 if __name__ == "__main__":
     import doctest
     (failure_count, test_count) = doctest.testmod()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -30,7 +30,7 @@ from py4j.protocol import Py4JError
 
 from pyspark import accumulators
 from pyspark.accumulators import Accumulator
-from pyspark.broadcast import Broadcast
+from pyspark.broadcast import Broadcast, BroadcastPickleRegistry
 from pyspark.conf import SparkConf
 from pyspark.files import SparkFiles
 from pyspark.java_gateway import launch_gateway
@@ -195,7 +195,7 @@ class SparkContext(object):
         # This allows other code to determine which Broadcast instances have
         # been pickled, so it can determine which Java broadcast objects to
         # send.
-        self._pickled_broadcast_vars = set()
+        self._pickled_broadcast_registry = BroadcastPickleRegistry(self._lock)
 
         SparkFiles._sc = self
         root_dir = SparkFiles.getRootDirectory()
@@ -793,7 +793,7 @@ class SparkContext(object):
         object for reading it in distributed functions. The variable will
         be sent to each cluster only once.
         """
-        return Broadcast(self, value, self._pickled_broadcast_vars)
+        return Broadcast(self, value, self._pickled_broadcast_registry)
 
     def accumulator(self, value, accum_param=None):
         """

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -195,7 +195,7 @@ class SparkContext(object):
         # This allows other code to determine which Broadcast instances have
         # been pickled, so it can determine which Java broadcast objects to
         # send.
-        self._pickled_broadcast_registry = BroadcastPickleRegistry(self._lock)
+        self._pickled_broadcast_registry = BroadcastPickleRegistry()
 
         SparkFiles._sc = self
         root_dir = SparkFiles.getRootDirectory()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -195,7 +195,7 @@ class SparkContext(object):
         # This allows other code to determine which Broadcast instances have
         # been pickled, so it can determine which Java broadcast objects to
         # send.
-        self._pickled_broadcast_registry = BroadcastPickleRegistry()
+        self._pickled_broadcast_vars = BroadcastPickleRegistry()
 
         SparkFiles._sc = self
         root_dir = SparkFiles.getRootDirectory()
@@ -793,7 +793,7 @@ class SparkContext(object):
         object for reading it in distributed functions. The variable will
         be sent to each cluster only once.
         """
-        return Broadcast(self, value, self._pickled_broadcast_registry)
+        return Broadcast(self, value, self._pickled_broadcast_vars)
 
     def accumulator(self, value, accum_param=None):
         """

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2375,8 +2375,8 @@ def _prepare_for_python_RDD(sc, command):
         # The broadcast will have same life cycle as created PythonRDD
         broadcast = sc.broadcast(pickled_command)
         pickled_command = ser.dumps(broadcast)
-    broadcast_vars = [x._jbroadcast for x in sc._pickled_broadcast_registry]
-    sc._pickled_broadcast_registry.clear()
+    broadcast_vars = [x._jbroadcast for x in sc._pickled_broadcast_vars]
+    sc._pickled_broadcast_vars.clear()
     return pickled_command, broadcast_vars, sc.environment, sc._python_includes
 
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2370,14 +2370,13 @@ class RDD(object):
 def _prepare_for_python_RDD(sc, command):
     # the serialized command will be compressed by broadcast
     ser = CloudPickleSerializer()
-    with sc._pickled_broadcast_registry.lock:
-        pickled_command = ser.dumps(command)
-        if len(pickled_command) > (1 << 20):  # 1M
-            # The broadcast will have same life cycle as created PythonRDD
-            broadcast = sc.broadcast(pickled_command)
-            pickled_command = ser.dumps(broadcast)
-        pickled_broadcast_vars = sc._pickled_broadcast_registry.get_and_clear()
-    broadcast_vars = [x._jbroadcast for x in pickled_broadcast_vars]
+    pickled_command = ser.dumps(command)
+    if len(pickled_command) > (1 << 20):  # 1M
+        # The broadcast will have same life cycle as created PythonRDD
+        broadcast = sc.broadcast(pickled_command)
+        pickled_command = ser.dumps(broadcast)
+    broadcast_vars = [x._jbroadcast for x in sc._pickled_broadcast_registry]
+    sc._pickled_broadcast_registry.clear()
     return pickled_command, broadcast_vars, sc.environment, sc._python_includes
 
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2370,13 +2370,14 @@ class RDD(object):
 def _prepare_for_python_RDD(sc, command):
     # the serialized command will be compressed by broadcast
     ser = CloudPickleSerializer()
-    pickled_command = ser.dumps(command)
-    if len(pickled_command) > (1 << 20):  # 1M
-        # The broadcast will have same life cycle as created PythonRDD
-        broadcast = sc.broadcast(pickled_command)
-        pickled_command = ser.dumps(broadcast)
-    broadcast_vars = [x._jbroadcast for x in sc._pickled_broadcast_vars]
-    sc._pickled_broadcast_vars.clear()
+    with sc._pickled_broadcast_registry.lock:
+        pickled_command = ser.dumps(command)
+        if len(pickled_command) > (1 << 20):  # 1M
+            # The broadcast will have same life cycle as created PythonRDD
+            broadcast = sc.broadcast(pickled_command)
+            pickled_command = ser.dumps(broadcast)
+        pickled_broadcast_vars = sc._pickled_broadcast_registry.get_and_clear()
+    broadcast_vars = [x._jbroadcast for x in pickled_broadcast_vars]
     return pickled_command, broadcast_vars, sc.environment, sc._python_includes
 
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -864,9 +864,11 @@ class RDDTests(ReusedPySparkTestCase):
         b1 = self.sc.broadcast(list(range(3)))
         b2 = self.sc.broadcast(list(range(3)))
 
-        def f1(): return b1.value
+        def f1():
+            return b1.value
 
-        def f2(): return b2.value
+        def f2():
+            return b2.value
 
         funcs_num_pickled = {f1: None, f2: None}
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -858,6 +858,47 @@ class RDDTests(ReusedPySparkTestCase):
         self.assertEqual(N, size)
         self.assertEqual(checksum, csum)
 
+    def test_multithread_broadcast_pickle(self):
+        import threading
+
+        b1 = self.sc.broadcast(list(range(3)))
+        b2 = self.sc.broadcast(list(range(3)))
+
+        def f1(): return b1.value
+
+        def f2(): return b2.value
+
+        funcs_num_pickled = {f1: None, f2: None}
+
+        def do_pickle(f, sc):
+            command = (f, None, sc.serializer, sc.serializer)
+            ser = CloudPickleSerializer()
+            ser.dumps(command)
+
+        def process_vars(sc):
+            broadcast_vars = [x for x in sc._pickled_broadcast_vars]
+            num_pickled = len(broadcast_vars)
+            sc._pickled_broadcast_vars.clear()
+            return num_pickled
+
+        def run(f, sc):
+            do_pickle(f, sc)
+            funcs_num_pickled[f] = process_vars(sc)
+
+        # pickle f1, adds b1 to sc._pickled_broadcast_vars in main thread local storage
+        do_pickle(f1, self.sc)
+
+        # run all for f2, should only add/count/clear b2 from worker thread local storage
+        t = threading.Thread(target=run, args=(f2, self.sc))
+        t.start()
+        t.join()
+
+        # count number of vars pickled in main thread, only b1 should be counted and cleared
+        funcs_num_pickled[f1] = process_vars(self.sc)
+
+        self.assertEqual(funcs_num_pickled[f1], 1)
+        self.assertEqual(funcs_num_pickled[f2], 1)
+
     def test_large_closure(self):
         N = 200000
         data = [float(i) for i in xrange(N)]

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -878,7 +878,7 @@ class RDDTests(ReusedPySparkTestCase):
             ser.dumps(command)
 
         def process_vars(sc):
-            broadcast_vars = [x for x in sc._pickled_broadcast_vars]
+            broadcast_vars = list(sc._pickled_broadcast_vars)
             num_pickled = len(broadcast_vars)
             sc._pickled_broadcast_vars.clear()
             return num_pickled
@@ -900,6 +900,7 @@ class RDDTests(ReusedPySparkTestCase):
 
         self.assertEqual(funcs_num_pickled[f1], 1)
         self.assertEqual(funcs_num_pickled[f2], 1)
+        self.assertEqual(len(list(self.sc._pickled_broadcast_vars)), 0)
 
     def test_large_closure(self):
         N = 200000


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using PySpark broadcast variables in a multi-threaded environment,  `SparkContext._pickled_broadcast_vars` becomes a shared resource.  A race condition can occur when broadcast variables that are pickled from one thread get added to the shared ` _pickled_broadcast_vars` and become part of the python command from another thread.  This PR introduces a thread-safe pickled registry using thread local storage so that when python command is pickled (causing the broadcast variable to be pickled and added to the registry) each thread will have their own view of the pickle registry to retrieve and clear the broadcast variables used.

## How was this patch tested?

Added a unit test that causes this race condition using another thread.
