### PR TITLE
[SPARK-21509][SQL] Add a config to enable adaptive query execution only for the last que…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -204,6 +204,11 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val ADAPTIVE_ONLY_FOR_LAST_SHUFFLE = buildConf("spark.sql.adaptiveOnlyForLastShuffle")
+    .doc("When true, adaptive query execution is enabled only for the last shuffle.")
+    .booleanConf
+    .createWithDefault(false)
+
   val SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS =
     buildConf("spark.sql.adaptive.minNumPostShufflePartitions")
       .internal()
@@ -969,6 +974,8 @@ class SQLConf extends Serializable with Logging {
     getConf(SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE)
 
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
+
+  def adaptiveOnlyForLastShuffle: Boolean = getConf(ADAPTIVE_ONLY_FOR_LAST_SHUFFLE)
 
   def minNumPostShufflePartitions: Int =
     getConf(SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -100,6 +100,9 @@ class ExchangeCoordinator(
   // synchronized.
   @volatile private[this] var estimated: Boolean = false
 
+  // A boolean that indicates if this coordinator is active for adaptive query execution.
+  @volatile private[this] var active: Boolean = true
+
   /**
    * Registers a [[ShuffleExchange]] operator to this coordinator. This method is only allowed to
    * be called in the `doPrepare` method of a [[ShuffleExchange]] operator.
@@ -110,6 +113,12 @@ class ExchangeCoordinator(
   }
 
   def isEstimated: Boolean = estimated
+
+  def deactivate: Unit = {
+    active = false
+  }
+
+  def isActive: Boolean = active
 
   /**
    * Estimates partition start indices for post-shuffle partitions based on

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
@@ -116,7 +116,7 @@ case class ShuffleExchange(
     // Returns the same ShuffleRowRDD if this plan is used by multiple plans.
     if (cachedShuffleRDD == null) {
       cachedShuffleRDD = coordinator match {
-        case Some(exchangeCoordinator) =>
+        case Some(exchangeCoordinator) if exchangeCoordinator.isActive =>
           val shuffleRDD = exchangeCoordinator.postShuffleRDD(this)
           assert(shuffleRDD.partitions.length == newPartitioning.numPartitions)
           shuffleRDD


### PR DESCRIPTION
## What changes were proposed in this pull request?
Feature of adaptive query execution is a good way to avoid generating too many small files on HDFS, like mentioned in SPARK-16188.
When feature of adaptive query execution is enabled, all shuffles will be coordinated. The drawbacks:
1. It's hard to balance the num of reducers(this decides the processing speed) and file size on HDFS;
2. It generates some more shuffles(https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala#L101);
3. It generates lots of jobs, which have extra cost for scheduling.

We can add a config and enable adaptive query execution only for the last shuffle.

## How was this patch tested?

Unit test.