### PR TITLE
[SPARK-21516][SQL][Test] Overriding afterEach() in DatasetCacheSuite must call super.afterEach()

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -25,15 +25,6 @@ import org.apache.spark.storage.StorageLevel
 class DatasetCacheSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
 
-  // Clear all persistent datasets after each test
-  override def afterEach(): Unit = {
-    try {
-      spark.sharedState.cacheManager.clearCache()
-    } finally {
-      super.afterEach()
-    }
-  }
-
   test("get storage level") {
     val ds1 = Seq("1", "2").toDS().as("a")
     val ds2 = Seq(2, 3).toDS().as("b")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -27,7 +27,11 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
 
   // Clear all persistent datasets after each test
   override def afterEach(): Unit = {
-    spark.sharedState.cacheManager.clearCache()
+    try {
+      spark.sharedState.cacheManager.clearCache()
+    } finally {
+      super.afterEach()
+    }
   }
 
   test("get storage level") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -86,7 +86,12 @@ trait SharedSQLContext extends SQLTestUtils with BeforeAndAfterEach with Eventua
   }
 
   protected override def afterEach(): Unit = {
-    super.afterEach()
+    try {
+      // Clear all persistent datasets after each test
+      spark.sharedState.cacheManager.clearCache()
+    } finally {
+      super.afterEach()
+    }
     // files can be closed from other threads, so wait a bit
     // normally this doesn't take more than 1s
     eventually(timeout(10.seconds)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -86,12 +86,9 @@ trait SharedSQLContext extends SQLTestUtils with BeforeAndAfterEach with Eventua
   }
 
   protected override def afterEach(): Unit = {
-    try {
-      // Clear all persistent datasets after each test
-      spark.sharedState.cacheManager.clearCache()
-    } finally {
-      super.afterEach()
-    }
+    super.afterEach()
+    // Clear all persistent datasets after each test
+    spark.sharedState.cacheManager.clearCache()
     // files can be closed from other threads, so wait a bit
     // normally this doesn't take more than 1s
     eventually(timeout(10.seconds)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR ensures to call `super.afterEach()` in overriding `afterEach()` method in `DatasetCacheSuite`. When we override `afterEach()` method in Testsuite, we have to call `super.afterEach()`.

This is a follow-up of #18719 and SPARK-21512.

## How was this patch tested?

Used the existing test suite