### PR TITLE
[SPARK-21520][SQL]Hivetable scan for all the columns the SQL statement contains the 'rand'

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
@@ -119,4 +119,29 @@ class CollapseProjectSuite extends PlanTest {
 
     comparePlans(optimized, correctAnswer)
   }
+
+  test("collapse one nondeterministic, one deterministic, dependent projects into one") {
+    val query = testRelation
+      .select(('a).as('a_plus))
+      .select(Rand(10).as('rand), 'a_plus)
+
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = query.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("collapse one nondeterministic, independent projects into two") {
+    val query = testRelation
+      .select(('a ).as('a_plus), ('b).as('b_plus))
+      .select(Rand(10).as('rand))
+
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = query.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -143,8 +143,8 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery)
 
     val correctAnswer = testRelation
-      .where(Rand(10) > 5 || 'a > 5)
       .select('a)
+      .where(Rand(10) > 5 || 'a > 5)
       .analyze
 
     comparePlans(optimized, correctAnswer)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, if expressions is not deterministic(contains the 'rand') for a project. we might be able to read some unnecessary columns from the database.  e.g:
```
*HashAggregate(keys=[k#403L], functions=[partial_sum(cast(id#402 as bigint))], output=[k#403L, sum#800L])
+- Project [d004#607 AS id#402, FLOOR((rand(8828525941469309371) * 10000.0)) AS k#403L]
   +- HiveTableScan [c030#606L, d004#607, d005#608, d025#609, c002#610, d023#611, d024#612, c005#613L, c008#614, c009#615, c010#616, d021#617, d022#618, c017#619, c018#620, c019#621, c020#622, c021#623, c022#624, c023#625, c024#626, c025#627, c026#628, c027#629, ... 169 more fields], MetastoreRelation XXX_database, XXX_table
```
HiveTableScan read all the columns from XXX_table. but we only need to ‘d004’ . 
this PR describe we only need to read user needs fields for expressions is not deterministic.

## How was this patch tested?

The new unit test.
