### PR TITLE
[MINOR][CORE][TEST]Repeat stop SparkContext in ExecutorAllocationManagerSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -39,16 +39,6 @@ class ExecutorAllocationManagerSuite
   import ExecutorAllocationManager._
   import ExecutorAllocationManagerSuite._
 
-  private val contexts = new mutable.ListBuffer[SparkContext]()
-
-  before {
-    contexts.clear()
-  }
-
-  after {
-    contexts.foreach(_.stop())
-  }
-
   test("verify min/max executors") {
     val conf = new SparkConf()
       .setMaster("myDummyLocalExternalClusterManager")
@@ -56,17 +46,16 @@ class ExecutorAllocationManagerSuite
       .set("spark.dynamicAllocation.enabled", "true")
       .set("spark.dynamicAllocation.testing", "true")
     val sc0 = new SparkContext(conf)
-    contexts += sc0
     assert(sc0.executorAllocationManager.isDefined)
     sc0.stop()
 
     // Min < 0
     val conf1 = conf.clone().set("spark.dynamicAllocation.minExecutors", "-1")
-    intercept[SparkException] { contexts += new SparkContext(conf1) }
+    intercept[SparkException] { new SparkContext(conf1) }
 
     // Max < 0
     val conf2 = conf.clone().set("spark.dynamicAllocation.maxExecutors", "-1")
-    intercept[SparkException] { contexts += new SparkContext(conf2) }
+    intercept[SparkException] { new SparkContext(conf2) }
 
     // Both min and max, but min > max
     intercept[SparkException] { createSparkContext(2, 1) }
@@ -956,7 +945,6 @@ class ExecutorAllocationManagerSuite
       .set("spark.dynamicAllocation.executorIdleTimeout", s"${executorIdleTimeout.toString}s")
       .set("spark.dynamicAllocation.testing", "true")
     val sc = new SparkContext(conf)
-    contexts += sc
     sc
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

this PR is Remove the variable conexts that repeat stop sparkconext.
Stop Sparkconext already in LocalSparkContext override def afterEach() 
So probably use contexts stop Sparkconext again makes duplication.

## How was this patch tested?

Used the existing test suite
