### PR TITLE
[SPARK-21535][ML]Reduce memory requirement for CrossValidator and TrainValidationSplit

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -108,16 +108,16 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
 
     // multi-model training
     logDebug(s"Train split with multiple sets of parameters.")
-    val models = est.fit(trainingDataset, epm).asInstanceOf[Seq[Model[_]]]
-    trainingDataset.unpersist()
     var i = 0
     while (i < numModels) {
+      val model = est.fit(trainingDataset, epm(i)).asInstanceOf[Model[_]]
       // TODO: duplicate evaluator to take extra params from input
-      val metric = eval.evaluate(models(i).transform(validationDataset, epm(i)))
+      val metric = eval.evaluate(model.transform(validationDataset, epm(i)))
       logDebug(s"Got metric $metric for model trained with ${epm(i)}.")
       metrics(i) += metric
       i += 1
     }
+    trainingDataset.unpersist()
     validationDataset.unpersist()
 
     logInfo(s"Train validation split metrics: ${metrics.toSeq}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

CrossValidator and TrainValidationSplit both use
`models = est.fit(trainingDataset, epm) `
to fit the models, where epm is `Array[ParamMap]`.
Even though the training process is sequential, current implementation consumes extra driver memory for holding the trained models, which is not necessary and often leads to memory exception for both CrossValidator and TrainValidationSplit. My proposal is to optimize the training implementation, thus that used model can be collected by GC, to avoid the unnecessary OOM exceptions.

E.g. when grid search space is 12, old implementation needs to hold all 12 trained models in the driver memory at the same time, while the new implementation only needs to hold 1 trained model at a time, and previous model can be cleared by GC.

## How was this patch tested?
Existing unit test since there's no change to logic.

I've manually tested and the new implementation can allow CrossValidator and TrainValidationSplit to train on much larger models with the same max-heap-memory. 

