### PR TITLE
[SPARK-21530] Update description of spark.shuffle.maxChunksBeingTransferred.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -259,6 +259,8 @@ public class TransportConf {
 
   /**
    * The max number of chunks allowed to being transferred at the same time on shuffle service.
+   * Note that new coming connections will be closed when the max number is hit. Client should
+   * have retry mechanism, otherwise it will end up with fetch failure.
    */
   public long maxChunksBeingTransferred() {
     return conf.getLong("spark.shuffle.maxChunksBeingTransferred", Long.MAX_VALUE);

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -260,8 +260,9 @@ public class TransportConf {
   /**
    * The max number of chunks allowed to be transferred at the same time on shuffle service.
    * Note that new incoming connections will be closed when the max number is hit. The client will
-   * retry according to the shuffle retry configs (see spark.shuffle.io.maxRetries and
-   * spark.shuffle.io.retryWait), if those limits are reached the task will fail with fetch failure.
+   * retry according to the shuffle retry configs (see `spark.shuffle.io.maxRetries` and
+   * `spark.shuffle.io.retryWait`), if those limits are reached the task will fail with fetch
+   * failure.
    */
   public long maxChunksBeingTransferred() {
     return conf.getLong("spark.shuffle.maxChunksBeingTransferred", Long.MAX_VALUE);

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -258,9 +258,10 @@ public class TransportConf {
   }
 
   /**
-   * The max number of chunks allowed to being transferred at the same time on shuffle service.
-   * Note that new coming connections will be closed when the max number is hit. Client should
-   * have retry mechanism, otherwise it will end up with fetch failure.
+   * The max number of chunks allowed to be transferred at the same time on shuffle service.
+   * Note that new incoming connections will be closed when the max number is hit. The client will
+   * retry according to the shuffle retry configs (see spark.shuffle.io.maxRetries and
+   * spark.shuffle.io.retryWait), if those limits are reached the task will fail with fetch failure.
    */
   public long maxChunksBeingTransferred() {
     return conf.getLong("spark.shuffle.maxChunksBeingTransferred", Long.MAX_VALUE);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -635,9 +635,10 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.shuffle.maxChunksBeingTransferred</code></td>
   <td>Long.MAX_VALUE</td>
   <td>
-    The max number of chunks allowed to being transferred at the same time on shuffle service.
-    Note that new coming connections will be closed when the max number is hit. Client should
-    have retry mechanism, otherwise it will end up with fetch failure.
+    The max number of chunks allowed to be transferred at the same time on shuffle service.
+    Note that new incoming connections will be closed when the max number is hit. The client will
+    retry according to the shuffle retry configs (see spark.shuffle.io.maxRetries and
+    spark.shuffle.io.retryWait), if those limits are reached the task will fail with fetch failure.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -637,8 +637,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The max number of chunks allowed to be transferred at the same time on shuffle service.
     Note that new incoming connections will be closed when the max number is hit. The client will
-    retry according to the shuffle retry configs (see spark.shuffle.io.maxRetries and
-    spark.shuffle.io.retryWait), if those limits are reached the task will fail with fetch failure.
+    retry according to the shuffle retry configs (see <code>spark.shuffle.io.maxRetries</code> and
+    <code>spark.shuffle.io.retryWait</code>), if those limits are reached the task will fail with
+    fetch failure.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -636,6 +636,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>Long.MAX_VALUE</td>
   <td>
     The max number of chunks allowed to being transferred at the same time on shuffle service.
+    Note that new coming connections will be closed when the max number is hit. Client should
+    have retry mechanism, otherwise it will end up with fetch failure.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the description of `spark.shuffle.maxChunksBeingTransferred` to include that the new coming connections will be closed when the max is hit and client should have retry mechanism.