### PR TITLE
[SPARK-21481][ML] Add indexOf method for ml.feature.HashingTF

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -40,8 +40,6 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
 class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   extends Transformer with HasInputCol with HasOutputCol with DefaultParamsWritable {
 
-  private[this] var hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
-
   @Since("1.2.0")
   def this() = this(Identifiable.randomUID("hashingTF"))
 
@@ -76,6 +74,8 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
   setDefault(numFeatures -> (1 << 18), binary -> false)
 
+  private[this] var hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
+
   /** @group getParam */
   @Since("1.2.0")
   def getNumFeatures: Int = $(numFeatures)
@@ -83,8 +83,9 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   /** @group setParam */
   @Since("1.2.0")
   def setNumFeatures(value: Int): this.type = {
+    val t = set(numFeatures, value)
     hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
-    set(numFeatures, value)
+    t
   }
 
   /** @group getParam */
@@ -94,8 +95,9 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   /** @group setParam */
   @Since("2.0.0")
   def setBinary(value: Boolean): this.type = {
-    hashingTF.setBinary(value)
-    set(binary, value)
+    val t = set(binary, value)
+    hashingTF.setBinary($(binary))
+    t
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
@@ -76,11 +76,11 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
       .setInputCol("words")
       .setOutputCol("features")
       .setNumFeatures(n)
-    hashingTF.transform(df)
-    assert(hashingTF.indexOf("a") === 70)
-    assert(hashingTF.indexOf("b") === 61)
-    assert(hashingTF.indexOf("c") === 22)
-    assert(hashingTF.indexOf("d") === 94)
+    val mLlibHashingTF = new MLlibHashingTF(n)
+    assert(hashingTF.indexOf("a") === mLlibHashingTF.indexOf("a"))
+    assert(hashingTF.indexOf("b") === mLlibHashingTF.indexOf("b"))
+    assert(hashingTF.indexOf("c") === mLlibHashingTF.indexOf("c"))
+    assert(hashingTF.indexOf("d") === mLlibHashingTF.indexOf("d"))
   }
 
   test("read/write") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
@@ -69,6 +69,20 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     assert(features ~== expected absTol 1e-14)
   }
 
+  test("indexOf method") {
+    val df = Seq((0, "a a b b c d".split(" ").toSeq)).toDF("id", "words")
+    val n = 100
+    val hashingTF = new HashingTF()
+      .setInputCol("words")
+      .setOutputCol("features")
+      .setNumFeatures(n)
+    hashingTF.transform(df)
+    assert(hashingTF.indexOf("a") === 70)
+    assert(hashingTF.indexOf("b") === 61)
+    assert(hashingTF.indexOf("c") === 22)
+    assert(hashingTF.indexOf("d") === 94)
+  }
+
   test("read/write") {
     val t = new HashingTF()
       .setInputCol("myInputCol")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add indexOf method for ml.feature.HashingTF.

The PR is a hotfix by storing hashingTF of mllib.
I believe it is better to migrate native implement from mllib to ml. I can work on it, but perhaps it's better to tackle in two steps: at first add API (this JIRA), and then migrate code (next JIRA).

## How was this patch tested?

+ [x] add a test case.
