### PR TITLE
[WIP][SPARK-21536][R] Remove the workaroud to allow dots in field names in R's createDataFame

### DIFF
--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -262,16 +262,6 @@ createDataFrame.default <- function(data, schema = NULL, samplingRatio = 1.0,
       })
     }
 
-    # SPAKR-SQL does not support '.' in column name, so replace it with '_'
-    # TODO(davies): remove this once SPARK-2775 is fixed
-    names <- lapply(names, function(n) {
-      nn <- gsub("[.]", "_", n)
-      if (nn != n) {
-        warning(paste("Use", nn, "instead of", n, " as column name"))
-      }
-      nn
-    })
-
     types <- lapply(row, infer_type)
     fields <- lapply(1:length(row), function(i) {
       structField(names[[i]], types[[i]], TRUE)

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -462,9 +462,15 @@ test_that("create DataFrame from list or data.frame", {
   df <- createDataFrame(l, c("a", "b"))
   expect_equal(columns(df), c("a", "b"))
 
+  df <- createDataFrame(list(list(1, 2)), list("..a", "..."))
+  expect_equal(columns(df), c("..a", "..."))
+
   l <- list(list(a = 1, b = 2), list(a = 3, b = 4))
   df <- createDataFrame(l)
   expect_equal(columns(df), c("a", "b"))
+
+  df <- createDataFrame(list(list(a.a = 1, a.. = 2)))
+  expect_equal(columns(df), c("a.a", "a.."))
 
   a <- 1:3
   b <- c("a", "b", "c")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR removes the workaround for dots in column names in SparkR's `createDataFrame`.

**Before:**

```r
> createDataFrame(list(list(1)), "a.a")
SparkDataFrame[a_a:double]
...
In FUN(X[[i]], ...) : Use a_a instead of a.a  as column name
```

```r
> createDataFrame(list(list(a.a = 1)))
SparkDataFrame[a_a:double]
...
In FUN(X[[i]], ...) : Use a_a instead of a.a  as column name
```

**After:**

```r
> createDataFrame(list(list(1)), "a.a")
SparkDataFrame[a.a:double]
```

```r
> createDataFrame(list(list(a.a = 1)))
SparkDataFrame[a.a:double]
```

This looks introduced in the first place due to SPARK-2775 but now it is fixed in SPARK-6898.

## How was this patch tested?

Unit tests in `test_sparkSQL.R`.
