### PR TITLE
[Spark-21542][ML][Python]Python persistence helper functions

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -471,3 +471,26 @@ private[ml] object MetaAlgorithmReadWrite {
     List((instance.uid, instance)) ++ subStageMaps
   }
 }
+
+class FileSystemOverwrite extends BaseReadWrite with Logging {
+
+  // def this() = this(Identifiable.randomUID("logreg"))
+
+  def handleOverwrite(path: String, shouldOverwrite: Boolean): Unit = {
+    val hadoopConf = sc.hadoopConfiguration
+    val outputPath = new Path(path)
+    val fs = outputPath.getFileSystem(hadoopConf)
+    val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
+    if (fs.exists(qualifiedOutputPath)) {
+      if (shouldOverwrite) {
+        logInfo(s"Path $path already exists. It will be overwritten.")
+        // TODO: Revert back to the original content if save is not successful.
+        fs.delete(qualifiedOutputPath, true)
+      } else {
+        throw new IOException(s"Path $path already exists. To overwrite it, " +
+          s"please use write.overwrite().save(path) for Scala and use " +
+          s"write().overwrite().save(path) for Java and Python.")
+      }
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -471,3 +471,26 @@ private[ml] object MetaAlgorithmReadWrite {
     List((instance.uid, instance)) ++ subStageMaps
   }
 }
+
+class FileSystemOverwrite(val uid: String) extends BaseReadWrite with Logging {
+
+  def this() = this(Identifiable.randomUID("logreg"))
+
+  def handleOverwrite(path: String, shouldOverwrite: Boolean): Unit = {
+    val hadoopConf = sc.hadoopConfiguration
+    val outputPath = new Path(path)
+    val fs = outputPath.getFileSystem(hadoopConf)
+    val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
+    if (fs.exists(qualifiedOutputPath)) {
+      if (shouldOverwrite) {
+        logInfo(s"Path $path already exists. It will be overwritten.")
+        // TODO: Revert back to the original content if save is not successful.
+        fs.delete(qualifiedOutputPath, true)
+      } else {
+        throw new IOException(s"Path $path already exists. To overwrite it, " +
+          s"please use write.overwrite().save(path) for Scala and use " +
+          s"write().overwrite().save(path) for Java and Python.")
+      }
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -471,26 +471,3 @@ private[ml] object MetaAlgorithmReadWrite {
     List((instance.uid, instance)) ++ subStageMaps
   }
 }
-
-class FileSystemOverwrite extends BaseReadWrite with Logging {
-
-  // def this() = this(Identifiable.randomUID("logreg"))
-
-  def handleOverwrite(path: String, shouldOverwrite: Boolean): Unit = {
-    val hadoopConf = sc.hadoopConfiguration
-    val outputPath = new Path(path)
-    val fs = outputPath.getFileSystem(hadoopConf)
-    val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-    if (fs.exists(qualifiedOutputPath)) {
-      if (shouldOverwrite) {
-        logInfo(s"Path $path already exists. It will be overwritten.")
-        // TODO: Revert back to the original content if save is not successful.
-        fs.delete(qualifiedOutputPath, true)
-      } else {
-        throw new IOException(s"Path $path already exists. To overwrite it, " +
-          s"please use write.overwrite().save(path) for Scala and use " +
-          s"write().overwrite().save(path) for Java and Python.")
-      }
-    }
-  }
-}

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -472,11 +472,9 @@ private[ml] object MetaAlgorithmReadWrite {
   }
 }
 
-class FileSystemOverwrite extends BaseReadWrite with Logging {
+private[ml] class FileSystemOverwrite extends Logging {
 
-  // def this() = this(Identifiable.randomUID("logreg"))
-
-  def handleOverwrite(path: String, shouldOverwrite: Boolean): Unit = {
+  def handleOverwrite(path: String, shouldOverwrite: Boolean, sc: SparkContext): Unit = {
     val hadoopConf = sc.hadoopConfiguration
     val outputPath = new Path(path)
     val fs = outputPath.getFileSystem(hadoopConf)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -472,9 +472,9 @@ private[ml] object MetaAlgorithmReadWrite {
   }
 }
 
-class FileSystemOverwrite(val uid: String) extends BaseReadWrite with Logging {
+class FileSystemOverwrite extends BaseReadWrite with Logging {
 
-  def this() = this(Identifiable.randomUID("logreg"))
+  // def this() = this(Identifiable.randomUID("logreg"))
 
   def handleOverwrite(path: String, shouldOverwrite: Boolean): Unit = {
     val hadoopConf = sc.hadoopConfiguration

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -96,21 +96,7 @@ abstract class MLWriter extends BaseReadWrite with Logging {
   @Since("1.6.0")
   @throws[IOException]("If the input path already exists but overwrite is not enabled.")
   def save(path: String): Unit = {
-    val hadoopConf = sc.hadoopConfiguration
-    val outputPath = new Path(path)
-    val fs = outputPath.getFileSystem(hadoopConf)
-    val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-    if (fs.exists(qualifiedOutputPath)) {
-      if (shouldOverwrite) {
-        logInfo(s"Path $path already exists. It will be overwritten.")
-        // TODO: Revert back to the original content if save is not successful.
-        fs.delete(qualifiedOutputPath, true)
-      } else {
-        throw new IOException(s"Path $path already exists. To overwrite it, " +
-          s"please use write.overwrite().save(path) for Scala and use " +
-          s"write().overwrite().save(path) for Java and Python.")
-      }
-    }
+    new FileSystemOverwrite().handleOverwrite(path, shouldOverwrite, sc)
     saveImpl(path)
   }
 

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -377,14 +377,13 @@ class Params(Identifiable):
 
     def set(self, param, value):
         """
-            Sets the value for a parameter in the parameter map.
+        Sets a parameter in the embedded param map.
         """
-        if not self.hasParam(param.name):
-            raise TypeError('Invalid param %s given for instance %r. %s' % (p.name, self, e))
+        self._shouldOwn(param)
         try:
             value = param.typeConverter(value)
-        except TypeError as e:
-            raise TypeError('Invalid param value given for param "%s". %s' % (p.name, e))
+        except ValueError as e:
+            raise ValueError('Invalid param value given for param "%s". %s' % (param.name, e))
         self._paramMap[param] = value
 
     def _shouldOwn(self, param):

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -375,6 +375,18 @@ class Params(Identifiable):
         that._defaultParamMap = {}
         return self._copyValues(that, extra)
 
+    def set(self, param, value):
+        """
+            Sets the value for a parameter in the parameter map.
+        """
+        if not self.hasParam(param.name):
+            raise TypeError('Invalid param %s given for instance %r. %s' % (p.name, self, e))
+        try:
+            value = param.typeConverter(value)
+        except TypeError as e:
+            raise TypeError('Invalid param value given for param "%s". %s' % (p.name, e))
+        self._paramMap[param] = value
+
     def _shouldOwn(self, param):
         """
         Validates that the input param belongs to this Params instance.

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -132,11 +132,6 @@ class Pipeline(Estimator, MLReadable, MLWritable):
         """Returns an MLWriter instance for this ML instance."""
         return JavaMLWriter(self)
 
-    @since("2.0.0")
-    def save(self, path):
-        """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
-        self.write().save(path)
-
     @classmethod
     @since("2.0.0")
     def read(cls):
@@ -210,11 +205,6 @@ class PipelineModel(Model, MLReadable, MLWritable):
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
         return JavaMLWriter(self)
-
-    @since("2.0.0")
-    def save(self, path):
-        """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
-        self.write().save(path)
 
     @classmethod
     @since("2.0.0")

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -62,6 +62,7 @@ from pyspark.ml.regression import DecisionTreeRegressor, GeneralizedLinearRegres
     LinearRegression
 from pyspark.ml.stat import ChiSquareTest
 from pyspark.ml.tuning import *
+from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaParams, JavaWrapper
 from pyspark.serializers import PickleSerializer
 from pyspark.sql import DataFrame, Row, SparkSession
@@ -1955,6 +1956,27 @@ class ChiSquareTestTests(SparkSessionTestCase):
         fieldNames = set(field.name for field in res.schema.fields)
         expectedFields = ["pValues", "degreesOfFreedom", "statistics"]
         self.assertTrue(all(field in fieldNames for field in expectedFields))
+
+class DefaultReadWriteTests(SparkSessionTestCase):
+
+    def test_default_read_write(self):
+        lr = LogisticRegression()
+        lr.setMaxIter(50)
+        lr.setThreshold(.75)
+        writer = DefaultParamsWriter(lr)
+        
+        tempFile = tempfile.NamedTemporaryFile(delete=True)
+        tempFile.close()
+
+        writer.save(tempFile.name)
+
+        reader = DefaultParamsReader()
+        lr2 = reader.load(tempFile.name)
+
+        self.assertEqual(lr.uid, lr2.uid)
+        self.assertEqual(lr.extractParamMap(), lr2.extractParamMap())
+
+
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1969,7 +1969,7 @@ class DefaultReadWriteTests(SparkSessionTestCase):
         tempFile = tempfile.NamedTemporaryFile(delete=True)
         tempFile.close()
 
-        writer._save(tempFile.name)
+        writer.saveImpl(tempFile.name)
 
         reader = DefaultParamsReadable.read()
         lr2 = reader.load(tempFile.name)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1971,7 +1971,7 @@ class DefaultReadWriteTests(SparkSessionTestCase):
 
         writer.save(tempFile.name)
 
-        reader = DefaultParamsReader()
+        reader = DefaultParamsReadable.read()
         lr2 = reader.load(tempFile.name)
 
         self.assertEqual(lr.uid, lr2.uid)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1957,6 +1957,7 @@ class ChiSquareTestTests(SparkSessionTestCase):
         expectedFields = ["pValues", "degreesOfFreedom", "statistics"]
         self.assertTrue(all(field in fieldNames for field in expectedFields))
 
+
 class DefaultReadWriteTests(SparkSessionTestCase):
 
     def test_default_read_write(self):
@@ -1964,7 +1965,7 @@ class DefaultReadWriteTests(SparkSessionTestCase):
         lr.setMaxIter(50)
         lr.setThreshold(.75)
         writer = DefaultParamsWriter(lr)
-        
+
         tempFile = tempfile.NamedTemporaryFile(delete=True)
         tempFile.close()
 
@@ -1975,8 +1976,6 @@ class DefaultReadWriteTests(SparkSessionTestCase):
 
         self.assertEqual(lr.uid, lr2.uid)
         self.assertEqual(lr.extractParamMap(), lr2.extractParamMap())
-
-
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1174,7 +1174,7 @@ class PersistenceTest(SparkSessionTestCase):
         writer = DefaultParamsWriter(lr)
 
         savePath = temp_path + "/lr"
-        writer.saveImpl(savePath)
+        writer.save(savePath)
 
         reader = DefaultParamsReadable.read()
         lr2 = reader.load(savePath)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1969,7 +1969,7 @@ class DefaultReadWriteTests(SparkSessionTestCase):
         tempFile = tempfile.NamedTemporaryFile(delete=True)
         tempFile.close()
 
-        writer.save(tempFile.name)
+        writer._save(tempFile.name)
 
         reader = DefaultParamsReadable.read()
         lr2 = reader.load(tempFile.name)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1165,6 +1165,33 @@ class PersistenceTest(SparkSessionTestCase):
         except OSError:
             pass
 
+    def test_default_read_write(self):
+        temp_path = tempfile.mkdtemp()
+
+        lr = LogisticRegression()
+        lr.setMaxIter(50)
+        lr.setThreshold(.75)
+        writer = DefaultParamsWriter(lr)
+
+        savePath = temp_path + "/lr"
+        writer.saveImpl(savePath)
+
+        reader = DefaultParamsReadable.read()
+        lr2 = reader.load(savePath)
+
+        self.assertEqual(lr.uid, lr2.uid)
+        self.assertEqual(lr.extractParamMap(), lr2.extractParamMap())
+
+        # test overwrite
+        lr.setThreshold(.8)
+        writer.overwrite().save(savePath)
+
+        reader = DefaultParamsReadable.read()
+        lr3 = reader.load(savePath)
+
+        self.assertEqual(lr.uid, lr3.uid)
+        self.assertEqual(lr.extractParamMap(), lr3.extractParamMap())
+
 
 class LDATest(SparkSessionTestCase):
 
@@ -1962,46 +1989,6 @@ class ChiSquareTestTests(SparkSessionTestCase):
         fieldNames = set(field.name for field in res.schema.fields)
         expectedFields = ["pValues", "degreesOfFreedom", "statistics"]
         self.assertTrue(all(field in fieldNames for field in expectedFields))
-
-
-class DefaultReadWriteTests(SparkSessionTestCase):
-
-    def test_default_read_write(self):
-        temp_path = tempfile.mkdtemp()
-
-        lr = LogisticRegression()
-        lr.setMaxIter(50)
-        lr.setThreshold(.75)
-        writer = DefaultParamsWriter(lr)
-
-        savePath = temp_path + "/lr"
-        writer.saveImpl(savePath)
-
-        reader = DefaultParamsReadable.read()
-        lr2 = reader.load(savePath)
-
-        self.assertEqual(lr.uid, lr2.uid)
-        self.assertEqual(lr.extractParamMap(), lr2.extractParamMap())
-
-    def test_default_read_write_with_overwrite(self):
-        temp_path = tempfile.mkdtemp()
-
-        lr = LogisticRegression()
-        lr.setMaxIter(50)
-        lr.setThreshold(.75)
-        writer = DefaultParamsWriter(lr)
-
-        savePath = temp_path + "/lr"
-        writer.saveImpl(savePath)
-
-        lr.setThreshold(.8)
-        writer.overwrite().save(savePath)
-
-        reader = DefaultParamsReadable.read()
-        lr2 = reader.load(savePath)
-
-        self.assertEqual(lr.uid, lr2.uid)
-        self.assertEqual(lr.extractParamMap(), lr2.extractParamMap())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -353,6 +353,8 @@ class DefaultParamsWritable(MLWritable):
 
     def write(self):
         """Returns a DefaultParamsWriter instance for this class."""
+        from pyspark.ml.param import Params
+
         if isinstance(self, Params):
             return DefaultParamsWriter(self)
         else:

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -150,7 +150,7 @@ class MLWriter(BaseReadWrite):
 @inherit_doc
 class JavaMLWriter(MLWriter):
     """
-    (Private) Specialization of :py:class:'MLWriter' for :py:class:'JavaParams' types
+    (Private) Specialization of :py:class:`MLWriter` for :py:class:`JavaParams` types
     """
 
     def __init__(self, instance):
@@ -188,7 +188,7 @@ class JavaMLWriter(MLWriter):
 @inherit_doc
 class MLWritable(object):
     """
-    Mixin for ML instances that provide :py:class:'MLWriter'.
+    Mixin for ML instances that provide :py:class:`MLWriter`.
 
     .. versionadded:: 2.0.0
     """
@@ -205,7 +205,7 @@ class MLWritable(object):
 @inherit_doc
 class JavaMLWritable(MLWritable):
     """
-    (Private) Mixin for ML instances that provide :py:class:'JavaMLWriter'.
+    (Private) Mixin for ML instances that provide :py:class:`JavaMLWriter`.
     """
 
     def write(self):
@@ -232,7 +232,7 @@ class MLReader(BaseReadWrite):
 @inherit_doc
 class JavaMLReader(MLReader):
     """
-    (Private) Specialization of :py:class:'MLReader' for :py:class:'JavaParams' types
+    (Private) Specialization of :py:class:`MLReader` for :py:class:`JavaParams` types
     """
 
     def __init__(self, clazz):
@@ -291,7 +291,7 @@ class JavaMLReader(MLReader):
 @inherit_doc
 class MLReadable(object):
     """
-    Mixin for instances that provide :py:class:'MLReader'.
+    Mixin for instances that provide :py:class:`MLReader`.
 
     .. versionadded:: 2.0.0
     """
@@ -340,11 +340,11 @@ class DefaultParamsWritable(MLWritable):
     """
     .. note:: DeveloperApi
 
-    Helper trait for making simple :py:class:'Params' types writable.  If a :py:class:'Params'
-    class stores all data as :py:class:'Param' values, then extending this trait will provide
+    Helper trait for making simple :py:class:`Params` types writable.  If a :py:class:`Params`
+    class stores all data as :py:class:`Param` values, then extending this trait will provide
     a default implementation of writing saved instances of the class.
-    This only handles simple :py:class:'Param' types; e.g., it will not handle
-    :py:class:'Dataset'. See :py:class:'DefaultParamsReadable', the counterpart to this trait.
+    This only handles simple :py:class:`Param` types; e.g., it will not handle
+    :py:class:`Dataset`. See :py:class:`DefaultParamsReadable`, the counterpart to this trait.
 
     .. versionadded:: 2.3.0
     """
@@ -365,7 +365,7 @@ class DefaultParamsWriter(MLWriter):
     """
     .. note:: DeveloperApi
 
-    Specialization of :py:class:`MLWriter` for :py:class:'Params' types
+    Specialization of :py:class:`MLWriter` for :py:class:`Params` types
 
     Class for writing Estimators and Transformers whose parameters are JSON-serializable.
 
@@ -402,10 +402,10 @@ class DefaultParamsWriter(MLWriter):
     @staticmethod
     def _get_metadata_to_save(instance, sc, extraMetadata=None, paramMap=None):
         """
-        Helper for :py:meth:'DefaultParamsWriter.saveMetadata' which extracts the JSON to save.
+        Helper for :py:meth:`DefaultParamsWriter.saveMetadata` which extracts the JSON to save.
         This is useful for ensemble models which need to save metadata for many sub-models.
 
-        .. note:: :py:meth:'DefaultParamsWriter.saveMetadata' for details on what this includes.
+        .. note:: :py:meth:`DefaultParamsWriter.saveMetadata` for details on what this includes.
         """
         uid = instance.uid
         cls = instance.__module__ + '.' + instance.__class__.__name__
@@ -428,11 +428,11 @@ class DefaultParamsReadable(MLReadable):
     """
     .. note:: DeveloperApi
 
-    Helper trait for making simple :py:class:'Params' types readable.
-    If a :py:class:'Params' class stores all data as :py:class:'Param' values,
+    Helper trait for making simple :py:class:`Params` types readable.
+    If a :py:class:`Params` class stores all data as :py:class:`Param` values,
     then extending this trait will provide a default implementation of reading saved
-    instances of the class. This only handles simple :py:class:'Param' types;
-    e.g., it will not handle :py:class:'Dataset'. See :py:class:'DefaultParamsWritable',
+    instances of the class. This only handles simple :py:class:`Param` types;
+    e.g., it will not handle :py:class:`Dataset`. See :py:class:`DefaultParamsWritable`,
     the counterpart to this trait.
 
     .. versionadded:: 2.3.0
@@ -449,9 +449,9 @@ class DefaultParamsReader(MLReader):
     """
     .. note:: DeveloperApi
 
-    Specialization of :py:class:'MLReader' for :py:class:'Params' types
+    Specialization of :py:class:`MLReader` for :py:class:`Params` types
 
-    Default 'MLReader' implementation for transformers and estimators that
+    Default :py:class:`MLReader` implementation for transformers and estimators that
     contain basic (json-serializable) params and no data. This will not handle
     more complex params or types with data (e.g., models with coefficients).
 
@@ -485,7 +485,7 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def loadMetadata(path, sc, expectedClassName=""):
         """
-        Load metadata saved using :py:meth:'DefaultParamsWriter.saveMetadata'
+        Load metadata saved using :py:meth:`DefaultParamsWriter.saveMetadata`
 
         :param expectedClassName:  If non empty, this is checked against the loaded metadata.
         """
@@ -497,8 +497,8 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def _parseMetaData(metadataStr, expectedClassName=""):
         """
-        Parse metadata JSON string produced by :py:meth:'DefaultParamsWriter._get_metadata_to_save'.
-        This is a helper function for :py:meth:'DefaultParamsReader.loadMetadata'.
+        Parse metadata JSON string produced by :py:meth`DefaultParamsWriter._get_metadata_to_save`.
+        This is a helper function for :py:meth:`DefaultParamsReader.loadMetadata`.
 
         :param metadataStr:  JSON string of metadata
         :param expectedClassName:  If non empty, this is checked against the loaded metadata.
@@ -523,8 +523,8 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def loadParamsInstance(path, sc):
         """
-        Load a :py:class:'Params' instance from the given path, and return it.
-        This assumes the instance inherits from :py:class:'MLReadable'.
+        Load a :py:class:`Params` instance from the given path, and return it.
+        This assumes the instance inherits from :py:class:`MLReadable`.
         """
         metadata = DefaultParamsReader.loadMetadata(path, sc)
         pythonClassName = metadata['class'].replace("org.apache.spark", "pyspark")

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -146,10 +146,6 @@ class MLWriter(BaseReadWrite):
         self.shouldOverwrite = True
         return self
 
-    def session(self, sparkSession):
-        """Sets the Spark Session to use for saving."""
-        super(MLWriter, self).session(sparkSession)
-
 
 @inherit_doc
 class JavaMLWriter(MLWriter):
@@ -231,10 +227,6 @@ class MLReader(BaseReadWrite):
     def load(self, path):
         """Load the ML instance from the input path."""
         raise NotImplementedError("MLReader is not yet implemented for type: %s" % type(self))
-
-    def session(self, sparkSession):
-        """Sets the Spark Session to use for loading."""
-        super(MLReader, self).session(sparkSession)
 
 
 @inherit_doc
@@ -373,6 +365,8 @@ class DefaultParamsWriter(MLWriter):
     """
     .. note:: DeveloperApi
 
+    Specialization of :py:class:`MLWriter` for :py:class:`Params` types
+
     Class for writing Estimators and Transformers whose parameters are JSON-serializable.
 
     .. versionadded:: 2.3.0
@@ -383,10 +377,10 @@ class DefaultParamsWriter(MLWriter):
         self.instance = instance
 
     def saveImpl(self, path):
-        DefaultParamsWriter.save_metadata(self.instance, path, self.sc)
+        DefaultParamsWriter.saveMetadata(self.instance, path, self.sc)
 
     @staticmethod
-    def save_metadata(instance, path, sc, extraMetadata=None, paramMap=None):
+    def saveMetadata(instance, path, sc, extraMetadata=None, paramMap=None):
         """
         Saves metadata + Params to: path + "/metadata"
         - class
@@ -408,10 +402,10 @@ class DefaultParamsWriter(MLWriter):
     @staticmethod
     def _get_metadata_to_save(instance, sc, extraMetadata=None, paramMap=None):
         """
-        Helper for [[save_metadata()]] which extracts the JSON to save.
+        Helper for [[saveMetadata()]] which extracts the JSON to save.
         This is useful for ensemble models which need to save metadata for many sub-models.
 
-        @see [[save_metadata()]] for details on what this includes.
+        @see [[saveMetadata()]] for details on what this includes.
         """
         uid = instance.uid
         cls = instance.__module__ + '.' + instance.__class__.__name__
@@ -455,6 +449,8 @@ class DefaultParamsReadable(MLReadable):
 class DefaultParamsReader(MLReader):
     """
     .. note:: DeveloperApi
+
+    Specialization of :py:class:`MLReader` for :py:class:`Params` types
 
     Default `MLReader` implementation for transformers and estimators that
     contain basic (json-serializable) params and no data. This will not handle

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -532,6 +532,7 @@ class DefaultParamsReader(MLReader):
         This assumes the instance inherits from [[MLReadable]].
         """
         metadata = DefaultParamsReader.loadMetadata(path, sc)
-        py_type = DefaultParamsReader.__get_class(metadata['class'])
-        instance = py_type()
+        pythonClassName = metadata['class'].replace("org.apache.spark", "pyspark")
+        py_type = DefaultParamsReader.__get_class(pythonClassName)
+        instance = py_type.load(path)
         return instance

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -25,6 +25,7 @@ import warnings
 if sys.version > '3':
     basestring = str
     unicode = str
+    long = int
 
 from pyspark import SparkContext, since
 from pyspark.ml.common import inherit_doc

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -75,32 +75,34 @@ class BaseReadWrite(object):
     """
 
     def __init__(self):
-        self.sparkSession = None
+        self._sparkSession = None
 
     def context(self, sqlContext):
         """
-        Sets the SQL context to use for saving.
+        Sets the Spark SQLContext to use for saving/loading.
 
         .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
         """
-        # raise NotImplementedError("MLWriter is not yet implemented for type: %s" % type(self))
-        self.sparkSession = sqlContext.sparkSession
-        return self
+        raise NotImplementedError("MLWriter is not yet implemented for type: %s" % type(self))
+        # self._sparkSession = sqlContext.sparkSession
+        # return self
 
     def session(self, sparkSession):
-        """Sets the Spark Session to use for saving."""
+        """
+        Sets the Spark Session to use for saving/loading.
+        """
         # raise NotImplementedError("MLWriter is not yet implemented for type: %s" % type(self))
-        self.sparkSession = sparkSession
+        self._sparkSession = sparkSession
         return self
 
-    def getOrCreateSparkSession(self):
-        if self.sparkSession is None:
-            self.sparkSession = SparkSession.builder.getOrCreate()
-        return self.sparkSession
+    def sparkSession(self):
+        if self._sparkSession is None:
+            self._sparkSession = SparkSession.builder.getOrCreate()
+        return self._sparkSession
 
     @property
     def sc(self):
-        return self.getOrCreateSparkSession().sparkContext
+        return self.sparkSession().sparkContext
 
 
 @inherit_doc
@@ -115,7 +117,7 @@ class MLWriter(BaseReadWrite):
         super(MLWriter, self).__init__()
         self.shouldOverwrite = False
 
-    def save(self, path):
+    def _save(self, path):
         """Save the ML instance to the input path."""
         if isinstance(self, JavaMLWriter):
             self.saveImpl(path)
@@ -130,6 +132,7 @@ class MLWriter(BaseReadWrite):
     def overwrite(self):
         """Overwrites if the output path already exists."""
         self.shouldOverwrite = True
+        return self
 
     def context(self, sqlContext):
         """
@@ -137,7 +140,7 @@ class MLWriter(BaseReadWrite):
 
         .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
         """
-        super(MLWriter, self).context(sqlContext)
+        raise NotImplementedError("MLWriter is not yet implemented for type: %s" % type(self))
 
     def session(self, sparkSession):
         """Sets the Spark Session to use for saving."""
@@ -196,7 +199,7 @@ class MLWritable(object):
 
     def save(self, path):
         """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
-        self.write().save(path)
+        self.write()._save(path)
 
 
 @inherit_doc

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
+import json
 import sys
+import os
+import time
 import uuid
 import warnings
 
@@ -67,6 +70,9 @@ class MLWriter(object):
 
     .. versionadded:: 2.0.0
     """
+
+    def __init__(self):
+        self.shouldOverwrite = False
 
     def save(self, path):
         """Save the ML instance to the input path."""
@@ -288,32 +294,76 @@ class JavaPredictionModel():
 @inherit_doc
 class DefaultParamsWritable(MLWritable):
 
+    # overrides the write() function in MLWriteable
+    # users call .save() in MLWriteable which calls this write() function and then calls the .save() in DefaultParamsWriter
+    # this can be overridden to return a different Writer (ex. OneVsRestWriter as seen in Scala)
     def write(self):
-        return DefaultParamsWriter()
+        # instance of check for params?
+        return DefaultParamsWriter(self)
 
 
 @inherit_doc
 class DefaultParamsWriter(MLWriter):
 
     def __init__(self, instance):
+        super(DefaultParamsWriter, self).__init__()
         self.instance = instance
+        self.sc = SparkContext._active_spark_context
 
-    def saveImpl(self, path):
-        # need spark context as well?
-        DefaultParamsWriter.save_metadata(instance, path)
+    # if a model extends DefaultParamsWriteable this save() function is called
+    def save(self, path):
+        if self.shouldOverwrite:
+            # This command removes a file. Is this enough?
+            os.remove(path)
+        DefaultParamsWriter.save_metadata(self.instance, path, self.sc)
+
+
+    def overwrite(self):
+        self.shouldOverwrite = True
+        return self
+
+    # # used to mimic the structure in Scala
+    # # can be overridden by other writers (ex. OneVsRestWriter as seen in Scala)
+    # def saveImpl(self, path):
+    #     # need spark context as well?
+    #     DefaultParamsWriter.save_metadata(instance, path, self.sc)
 
     @staticmethod
-    def save_metadata(path):
-        pass
+    def save_metadata(instance, path, sc, extraMetadata=None, paramMap=None):
+        #print "sc in save_metadata:",sc
+        metadataPath = os.path.join(path, "metadata")
+        metadataJson = DefaultParamsWriter.get_metadata_to_save(instance, metadataPath, sc, extraMetadata, paramMap)
+        sc.parallelize([metadataJson], 1).saveAsTextFile(metadataPath)
 
     @staticmethod
-    def get_metatdata_to_save():
-        pass
+    def get_metadata_to_save(instance, path, sc, extraMetadata=None, paramMap=None):
+        uid = instance.uid
+        cls = instance.__module__ + '.' + instance.__class__.__name__ # should be the name of the class of instance
+        # params = list(instance.extractParamMap())
+        params = instance.extractParamMap()
+        #print "sc in function:",sc
+        jsonParams = {}
+        if paramMap is not None:
+            for p in paramMap:
+                jsonParams[p.name] = paramMap[p]
+        else:
+            for p in params:
+                jsonParams[p.name] = params[p]
+        basicMetadata = {"class": cls, "timestamp": int(round(time.time() * 1000)), \
+                         "sparkVersion": sc.version, "uid": uid, "paramMap": jsonParams}
+        if extraMetadata is not None:
+            basicMetadata.update(extraMetadata)
+        return json.dumps(basicMetadata)
+
+
+        
 
 
 @inherit_doc
 class DefaultParamsReadable(MLReadable):
 
+    # overrides the read() functino in MLReadable
+    # users call .load() in MLReadable which calls this read() function and reads using the DefaultParamsReader load() function
     def read(self):
         return DefaultParamsReader()
 
@@ -322,24 +372,63 @@ class DefaultParamsReadable(MLReadable):
 class DefaultParamsReader(MLReader):
 
     def __init__(self):
-        pass
+        #print "spark context pre init",sc
+        super(DefaultParamsReader, self).__init__()
+        self.sc = SparkContext._active_spark_context
+        print "spark context post init",self.sc
 
-    def load(self):
-        pass
+    # made this a static method just for testing purposes (normally it takes self and does not take a spark context)
+    def load(self, path):
+
+        def __get_class(clazz):
+            """
+            Loads Python class from its name.
+            """
+            parts = clazz.split('.')
+            module = ".".join(parts[:-1])
+            m = __import__(module)
+            for comp in parts[1:]:
+                m = getattr(m, comp)
+            return m
+
+        metadata = DefaultParamsReader.loadMetadata(path, self.sc)
+        print "metadata:",metadata
+        py_type = __get_class(metadata['class'])
+        print "py_type:",py_type
+        instance = py_type()
+        print "instance:",instance
+        instance._resetUid(metadata['uid'])
+        DefaultParamsReader.getAndSetParams(instance, metadata)
+        print "instance param map:",instance.extractParamMap()
+        return instance
 
     # TODO: missing getParamName from case class Metadata in Scala - Check what to do with this
 
     @staticmethod
-    def loadMetadata():
-        pass
+    def loadMetadata(path, sc, expectedClassName=""):
+        metadataPath = os.path.join(path, "metadata")
+        metadataStr = sc.textFile(metadataPath, 1).first()
+        # print "metadata str:",metadataStr
+        loadedVals = DefaultParamsReader.parseMetaData(metadataStr, expectedClassName)
+        # print "Loaded vals:",loadedVals
+        return loadedVals
 
     @staticmethod
-    def parseMetaData():
-        pass
+    def parseMetaData(metadataStr, expectedClassName=""):
+        metadata = json.loads(metadataStr)
+        className = metadata['class']
+        if len(expectedClassName) > 0:
+            assert className == expectedClassName, "Error loading metadata: Expected class name {} " + \
+                "but found class name {}".format(expectedClassName, className)
+        return metadata
 
     @staticmethod
-    def getAndSetParams():
-        pass
+    def getAndSetParams(instance, metadata):
+        for paramName in metadata['paramMap']:
+            param = instance.getParam(paramName)
+            paramValue = metadata['paramMap'][paramName]
+            instance.set(param, paramValue)
+        
 
     @staticmethod
     def loadParamsInstance():

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -150,7 +150,7 @@ class MLWriter(BaseReadWrite):
 @inherit_doc
 class JavaMLWriter(MLWriter):
     """
-    (Private) Specialization of :py:class:`MLWriter` for :py:class:`JavaParams` types
+    (Private) Specialization of :py:class:'MLWriter' for :py:class:'JavaParams' types
     """
 
     def __init__(self, instance):
@@ -188,7 +188,7 @@ class JavaMLWriter(MLWriter):
 @inherit_doc
 class MLWritable(object):
     """
-    Mixin for ML instances that provide :py:class:`MLWriter`.
+    Mixin for ML instances that provide :py:class:'MLWriter'.
 
     .. versionadded:: 2.0.0
     """
@@ -198,14 +198,14 @@ class MLWritable(object):
         raise NotImplementedError("MLWritable is not yet implemented for type: %r" % type(self))
 
     def save(self, path):
-        """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
+        """Save this ML instance to the given path, a shortcut of 'write().save(path)'."""
         self.write().save(path)
 
 
 @inherit_doc
 class JavaMLWritable(MLWritable):
     """
-    (Private) Mixin for ML instances that provide :py:class:`JavaMLWriter`.
+    (Private) Mixin for ML instances that provide :py:class:'JavaMLWriter'.
     """
 
     def write(self):
@@ -232,7 +232,7 @@ class MLReader(BaseReadWrite):
 @inherit_doc
 class JavaMLReader(MLReader):
     """
-    (Private) Specialization of :py:class:`MLReader` for :py:class:`JavaParams` types
+    (Private) Specialization of :py:class:'MLReader' for :py:class:'JavaParams' types
     """
 
     def __init__(self, clazz):
@@ -291,7 +291,7 @@ class JavaMLReader(MLReader):
 @inherit_doc
 class MLReadable(object):
     """
-    Mixin for instances that provide :py:class:`MLReader`.
+    Mixin for instances that provide :py:class:'MLReader'.
 
     .. versionadded:: 2.0.0
     """
@@ -340,11 +340,11 @@ class DefaultParamsWritable(MLWritable):
     """
     .. note:: DeveloperApi
 
-    Helper trait for making simple :py:class`Params` types writable.  If a :py:class`Params`
+    Helper trait for making simple :py:class:'Params' types writable.  If a :py:class:'Params'
     class stores all data as :py:class:'Param' values, then extending this trait will provide
     a default implementation of writing saved instances of the class.
     This only handles simple :py:class:'Param' types; e.g., it will not handle
-    :py:class:'Dataset'. See :py:class:`DefaultParamsReadable`, the counterpart to this trait.
+    :py:class:'Dataset'. See :py:class:'DefaultParamsReadable', the counterpart to this trait.
 
     .. versionadded:: 2.3.0
     """
@@ -365,7 +365,7 @@ class DefaultParamsWriter(MLWriter):
     """
     .. note:: DeveloperApi
 
-    Specialization of :py:class:`MLWriter` for :py:class:`Params` types
+    Specialization of :py:class:`MLWriter` for :py:class:'Params' types
 
     Class for writing Estimators and Transformers whose parameters are JSON-serializable.
 
@@ -428,11 +428,11 @@ class DefaultParamsReadable(MLReadable):
     """
     .. note:: DeveloperApi
 
-    Helper trait for making simple :py:class:`Params` types readable.
-    If a :py:class:`Params` class stores all data as :py:class:'Param' values,
+    Helper trait for making simple :py:class:'Params' types readable.
+    If a :py:class:'Params' class stores all data as :py:class:'Param' values,
     then extending this trait will provide a default implementation of reading saved
     instances of the class. This only handles simple :py:class:'Param' types;
-    e.g., it will not handle :py:class:'Dataset'. See :py:class:`DefaultParamsWritable`,
+    e.g., it will not handle :py:class:'Dataset'. See :py:class:'DefaultParamsWritable',
     the counterpart to this trait.
 
     .. versionadded:: 2.3.0
@@ -449,9 +449,9 @@ class DefaultParamsReader(MLReader):
     """
     .. note:: DeveloperApi
 
-    Specialization of :py:class:`MLReader` for :py:class:`Params` types
+    Specialization of :py:class:'MLReader' for :py:class:'Params' types
 
-    Default `MLReader` implementation for transformers and estimators that
+    Default 'MLReader' implementation for transformers and estimators that
     contain basic (json-serializable) params and no data. This will not handle
     more complex params or types with data (e.g., models with coefficients).
 
@@ -523,7 +523,7 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def loadParamsInstance(path, sc):
         """
-        Load a :py:class:`Params` instance from the given path, and return it.
+        Load a :py:class:'Params' instance from the given path, and return it.
         This assumes the instance inherits from :py:class:'MLReadable'.
         """
         metadata = DefaultParamsReader.loadMetadata(path, sc)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -418,8 +418,7 @@ class DefaultParamsWriter(MLWriter):
         params = instance.extractParamMap()
         jsonParams = {}
         if paramMap is not None:
-            for p in paramMap:
-                jsonParams[p.name] = paramMap[p]
+            jsonParams = paramMap
         else:
             for p in params:
                 jsonParams[p.name] = params[p]

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -283,3 +283,65 @@ class JavaPredictionModel():
         Returns the number of features the model was trained on. If unknown, returns -1
         """
         return self._call_java("numFeatures")
+
+
+@inherit_doc
+class DefaultParamsWritable(MLWritable):
+
+    def write(self):
+        return DefaultParamsWriter()
+
+
+@inherit_doc
+class DefaultParamsWriter(MLWriter):
+
+    def __init__(self, instance):
+        self.instance = instance
+
+    def saveImpl(self, path):
+        # need spark context as well?
+        DefaultParamsWriter.save_metadata(instance, path)
+
+    @staticmethod
+    def save_metadata(path):
+        pass
+
+    @staticmethod
+    def get_metatdata_to_save():
+        pass
+
+
+@inherit_doc
+class DefaultParamsReadable(MLReadable):
+
+    def read(self):
+        return DefaultParamsReader()
+
+
+@inherit_doc
+class DefaultParamsReader(MLReader):
+
+    def __init__(self):
+        pass
+
+    def load(self):
+        pass
+
+    # TODO: missing getParamName from case class Metadata in Scala - Check what to do with this
+
+    @staticmethod
+    def loadMetadata():
+        pass
+
+    @staticmethod
+    def parseMetaData():
+        pass
+
+    @staticmethod
+    def getAndSetParams():
+        pass
+
+    @staticmethod
+    def loadParamsInstance():
+        pass
+

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -340,13 +340,11 @@ class DefaultParamsWritable(MLWritable):
     """
     .. note:: DeveloperApi
 
-    Helper trait for making simple `Params` types writable.  If a `Params` class stores
-    all data as [[pyspark.ml.param.Param]] values, then extending this trait will provide
+    Helper trait for making simple :py:class`Params` types writable.  If a :py:class`Params`
+    class stores all data as :py:class:'Param' values, then extending this trait will provide
     a default implementation of writing saved instances of the class.
-    This only handles simple [[pyspark.ml.param.Param]] types; e.g., it will not handle
-    [[pyspark.sql.Dataset]].
-
-    @see `DefaultParamsReadable`, the counterpart to this trait
+    This only handles simple :py:class:'Param' types; e.g., it will not handle
+    :py:class:'Dataset'. See :py:class:`DefaultParamsReadable`, the counterpart to this trait.
 
     .. versionadded:: 2.3.0
     """
@@ -391,8 +389,8 @@ class DefaultParamsWriter(MLWriter):
         - uid
         - paramMap
         - (optionally, extra metadata)
-        @param extraMetadata  Extra metadata to be saved at same level as uid, paramMap, etc.
-        @param paramMap  If given, this is saved in the "paramMap" field.
+        :param extraMetadata:  Extra metadata to be saved at same level as uid, paramMap, etc.
+        :param paramMap:  If given, this is saved in the "paramMap" field.
         """
         metadataPath = os.path.join(path, "metadata")
         metadataJson = DefaultParamsWriter._get_metadata_to_save(instance,
@@ -404,10 +402,10 @@ class DefaultParamsWriter(MLWriter):
     @staticmethod
     def _get_metadata_to_save(instance, sc, extraMetadata=None, paramMap=None):
         """
-        Helper for [[saveMetadata()]] which extracts the JSON to save.
+        Helper for :py:meth:'DefaultParamsWriter.saveMetadata' which extracts the JSON to save.
         This is useful for ensemble models which need to save metadata for many sub-models.
 
-        @see [[saveMetadata()]] for details on what this includes.
+        .. note:: :py:meth:'DefaultParamsWriter.saveMetadata' for details on what this includes.
         """
         uid = instance.uid
         cls = instance.__module__ + '.' + instance.__class__.__name__
@@ -430,13 +428,12 @@ class DefaultParamsReadable(MLReadable):
     """
     .. note:: DeveloperApi
 
-    Helper trait for making simple `Params` types readable.  If a `Params` class stores
-    all data as [[pyspark.ml.param.Param]] values, then extending this trait will provide
-    a default implementation of reading saved instances of the class.
-    This only handles simple [[pyspark.ml.param.Param]] types; e.g., it will not handle
-    [[pyspark.sql.Dataset]].
-
-    @see `DefaultParamsWritable`, the counterpart to this trait
+    Helper trait for making simple :py:class:`Params` types readable.
+    If a :py:class:`Params` class stores all data as :py:class:'Param' values,
+    then extending this trait will provide a default implementation of reading saved
+    instances of the class. This only handles simple :py:class:'Param' types;
+    e.g., it will not handle :py:class:'Dataset'. See :py:class:`DefaultParamsWritable`,
+    the counterpart to this trait.
 
     .. versionadded:: 2.3.0
     """
@@ -488,9 +485,9 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def loadMetadata(path, sc, expectedClassName=""):
         """
-        Load metadata saved using [[DefaultParamsWriter.saveMetadata()]]
+        Load metadata saved using :py:meth:'DefaultParamsWriter.saveMetadata'
 
-        @param expectedClassName  If non empty, this is checked against the loaded metadata.
+        :param expectedClassName:  If non empty, this is checked against the loaded metadata.
         """
         metadataPath = os.path.join(path, "metadata")
         metadataStr = sc.textFile(metadataPath, 1).first()
@@ -500,11 +497,11 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def _parseMetaData(metadataStr, expectedClassName=""):
         """
-        Parse metadata JSON string produced by [[DefaultParamsWriter._get_metadata_to_save()]].
-        This is a helper function for [[loadMetadata()]].
+        Parse metadata JSON string produced by :py:meth:'DefaultParamsWriter._get_metadata_to_save'.
+        This is a helper function for :py:meth:'DefaultParamsReader.loadMetadata'.
 
-        @param metadataStr  JSON string of metadata
-        @param expectedClassName  If non empty, this is checked against the loaded metadata.
+        :param metadataStr:  JSON string of metadata
+        :param expectedClassName:  If non empty, this is checked against the loaded metadata.
         """
         metadata = json.loads(metadataStr)
         className = metadata['class']
@@ -526,8 +523,8 @@ class DefaultParamsReader(MLReader):
     @staticmethod
     def loadParamsInstance(path, sc):
         """
-        Load a `Params` instance from the given path, and return it.
-        This assumes the instance inherits from [[MLReadable]].
+        Load a :py:class:`Params` instance from the given path, and return it.
+        This assumes the instance inherits from :py:class:'MLReadable'.
         """
         metadata = DefaultParamsReader.loadMetadata(path, sc)
         pythonClassName = metadata['class'].replace("org.apache.spark", "pyspark")

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -111,8 +111,8 @@ class MLWriter(BaseReadWrite):
     def _handleOverwrite(path):
         from pyspark.ml.wrapper import JavaWrapper
 
-        # _java_obj = JavaWrapper._new_java_obj("org.apache.ml.ReadWrite.FileSystemOverwrite")
-        _java_obj = JavaWrapper._new_java_obj("org.apache.ml.classification.LogisticRegression", "2")
+        _java_obj = JavaWrapper._new_java_obj("org.apache.spark.ml.ReadWrite.FileSystemOverwrite")
+        # _java_obj = JavaWrapper._new_java_obj("org.apache.spark.ml.classification.LogisticRegression")
         wrapper = JavaWrapper(_java_obj)
         wrapper._call_java("handleOverwrite", path, True)
 

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -58,10 +58,8 @@ class JavaWrapper(object):
         sc = SparkContext._active_spark_context
         java_obj = _jvm()
         for name in java_class.split("."):
-            print "name used:",name
             java_obj = getattr(java_obj, name)
         java_args = [_py2java(sc, arg) for arg in args]
-        print "java obj:",java_obj
         return java_obj(*java_args)
 
     @staticmethod

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -58,8 +58,10 @@ class JavaWrapper(object):
         sc = SparkContext._active_spark_context
         java_obj = _jvm()
         for name in java_class.split("."):
+            print "name used:",name
             java_obj = getattr(java_obj, name)
         java_args = [_py2java(sc, arg) for arg in args]
+        print "java obj:",java_obj
         return java_obj(*java_args)
 
     @staticmethod


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added DefaultParamsWriteable, DefaultParamsReadable, DefaultParamsWriter, and DefaultParamsReader to Python to support Python-only persistence of Json-serializable parameters. 

## How was this patch tested?

Instantiated an estimator with Json-serializable parameters (ex. LogisticRegression), saved it using the added helper functions, and loaded it back, and compared it to the original instance to make sure it is the same. This test was both done in the Python REPL and implemented in the unit tests.

Note to reviewers: there are a few excess comments that I left in the code for clarity but will remove before the code is merged to master.
