### PR TITLE
[SPARK-21543][YARN] Should not count executor initialize failed towards tas…

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -587,6 +587,9 @@ private[yarn] class YarnAllocator(
             // merely to do resource sharing, and tasks that fail due to preempted executors could
             // just as easily finish on any other executor. See SPARK-8167.
             (false, s"Container ${containerId}${onHostStr} was preempted.")
+          // Should not count executor initialize failed towards task failures
+          case INIT_FAILED_EXIT_CODE =>
+            (false, s"Container exit due to executor initialize failed.")
           // Should probably still count memory exceeded exit codes towards task failures
           case VMEM_EXCEEDED_EXIT_CODE =>
             (true, memLimitExceededLogMessage(
@@ -731,6 +734,7 @@ private object YarnAllocator {
     Pattern.compile(s"$MEM_REGEX of $MEM_REGEX virtual memory used")
   val VMEM_EXCEEDED_EXIT_CODE = -103
   val PMEM_EXCEEDED_EXIT_CODE = -104
+  val INIT_FAILED_EXIT_CODE = 1
 
   def memLimitExceededLogMessage(diagnostics: String, pattern: Pattern): String = {
     val matcher = pattern.matcher(diagnostics)


### PR DESCRIPTION
…k failures

## What changes were proposed in this pull request?

Till now, when executor init failed and exit with error code = 1, it will count toward task failures.Which i think should not count executor initialize failed towards task failures.

## How was this patch tested?
In production cluster.

