### PR TITLE
[SPARK-21538][SQL] Fix attribute resolution inconsistency in Dataset API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1107,7 +1107,7 @@ class Dataset[T] private[sql](
    */
   @scala.annotation.varargs
   def sort(sortCol: String, sortCols: String*): Dataset[T] = {
-    sort((sortCol +: sortCols).map(apply) : _*)
+    sort((sortCol +: sortCols).map(Column(_)) : _*)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1304,6 +1304,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       assert(rlike3.count() == 0)
     }
   }
+
+  test("SPARK-21538: Attribute resolution inconsistency in Dataset API") {
+    val df = spark.range(1).withColumnRenamed("id", "x")
+    checkAnswer(df.sort(col("id")), df.sort("id"))
+    checkAnswer(df.sort($"id"), df.sort("id"))
+    checkAnswer(df.sort('id), df.sort("id"))
+  }
 }
 
 case class WithImmutableMap(id: String, map_test: scala.collection.immutable.Map[Long, String])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Given a string column name, the following operation fails with an `AnalysisException`:

    spark.range(1).withColumnRenamed("id", "x").sort("id")

However, the other APIs work:

    spark.range(1).withColumnRenamed("id", "x").sort(col("id"))
    spark.range(1).withColumnRenamed("id", "x").sort($"id")
    spark.range(1).withColumnRenamed("id", "x").sort('id)

This `sort` API should defer attribute resolution to analysis.

## How was this patch tested?

Added unit test.
