### PR TITLE
[SPARK-21560][Core] Add hold mode for the LiveListenerBus

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -177,6 +177,16 @@ package object config {
       .intConf
       .createWithDefault(128)
 
+  private[spark] val LISTENER_BUS_EVENT_QUEUE_OPEN_HOLD =
+    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.openHold")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val LISTENER_BUS_EVENT_QUEUE_IDLE_CAPACITY =
+    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.idleCapacity")
+      .doubleConf
+      .createWithDefault(0.6)
+
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
     .stringConf


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Add config for hold strategy and the idle capacity.
2. Hold the post method while event queue is full.
3. Notify all holding thread while event queue empty rate lager than the configuration.

## How was this patch tested?

Add a new test in SparkListenerSuite