### PR TITLE
[SPARK-8288][SQL] ScalaReflection can use companion object constructor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -864,7 +864,11 @@ trait ScalaReflection {
   }
 
   protected def constructParams(tpe: Type): Seq[Symbol] = {
-    val constructorSymbol = tpe.member(termNames.CONSTRUCTOR)
+    val constructorSymbol = tpe.member(termNames.CONSTRUCTOR) match {
+      case NoSymbol =>
+        tpe.typeSymbol.asClass.companion.asTerm.typeSignature.member(universe.TermName("apply"))
+      case sym => sym
+    }
     val params = if (constructorSymbol.isMethod) {
       constructorSymbol.asMethod.paramLists
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -105,6 +105,21 @@ object TestingUDT {
   }
 }
 
+trait ScroogeLikeExample extends Product1[Int] with java.io.Serializable {
+  import ScroogeLikeExample._
+
+  def _1: Int
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[ScroogeLikeExample]
+}
+
+object ScroogeLikeExample {
+  def apply(x: Int): ScroogeLikeExample = new Immutable(x)
+
+  class Immutable(x: Int) extends ScroogeLikeExample {
+    def _1: Int = x
+  }
+}
 
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
@@ -335,4 +350,10 @@ class ScalaReflectionSuite extends SparkFunSuite {
     assert(linkedHashMapDeserializer.dataType == ObjectType(classOf[LHMap[_, _]]))
   }
 
+  test("SPARK-8288") {
+    val schema = schemaFor[ScroogeLikeExample]
+    assert(schema === Schema(
+      StructType(Seq(
+        StructField("x", IntegerType, nullable = false))), nullable = true))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change fixes a particular scenario where default spark SQL can't encode (thrift) types that are generated by twitter scrooge. In particular, these types have the pattern of being a trait with a constructor defined only in a companion object, rather than a case class. The situation is described in the original issue in more detail. In this case, the type has no corresponding constructor symbol and causes an exception. This change catches the case where the type has no constructor and looks for an `apply` method on the type's companion object. There might be situations in which this approach would also fail in a new way, but it does work for the specific scrooge example.

Note: this fix does not enable using scrooge thrift enums, additional work for this is necessary.

## How was this patch tested?

I've added a single new test that failed prior to my fix. The failure is shown below. The test includes an example type that resembles what scrooge generates. For an full scrooge example, see https://gist.github.com/anonymous/ba13d4b612396ca72725eaa989900314

```
[info] - SPARK-8288 *** FAILED *** (7 milliseconds)
[info]   scala.ScalaReflectionException: <none> is not a term
[info]   at scala.reflect.api.Symbols$SymbolApi$class.asTerm(Symbols.scala:199)
[info]   at scala.reflect.internal.Symbols$SymbolContextApiImpl.asTerm(Symbols.scala:84)
[info]   at org.apache.spark.sql.catalyst.ScalaReflection$class.constructParams(ScalaReflection.scala:872)
```
