### PR TITLE
[SPARK-21533][SQL] Print warning messages when override function `configure` found in Hive UDFs

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
+import org.apache.spark.sql.hive.HiveShim._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DecimalType, DoubleType}
 import org.apache.spark.util.Utils
@@ -66,6 +66,8 @@ private[sql] class HiveSessionCatalog(
    * Construct a [[FunctionBuilder]] based on the provided class that represents a function.
    */
   private def makeFunctionBuilder(name: String, clazz: Class[_]): FunctionBuilder = {
+    validateHiveUserDefinedFunction(clazz)
+
     // When we instantiate hive UDF wrapper class, we may throw exception if the input
     // expressions don't satisfy the hive UDF, such as type mismatch, input number
     // mismatch, etc. Here we catch the exception and throw AnalysisException instead.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -18,19 +18,20 @@
 package org.apache.spark.sql.hive
 
 import java.io.{InputStream, OutputStream}
+import java.lang.reflect.Type
 import java.rmi.server.UID
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
+import scala.reflect.{classTag, ClassTag}
 
 import com.google.common.base.Objects
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.hive.ql.exec.{UDF, Utilities}
+import org.apache.hadoop.hive.ql.exec.{MapredContext, UDF, Utilities}
 import org.apache.hadoop.hive.ql.plan.{FileSinkDesc, TableDesc}
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMacro
+import org.apache.hadoop.hive.ql.udf.generic.{GenericUDF, GenericUDFMacro, GenericUDTF}
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils
 import org.apache.hadoop.hive.serde2.avro.{AvroGenericRecordWritable, AvroSerdeUtils}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector
@@ -42,7 +43,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.types.Decimal
 import org.apache.spark.util.Utils
 
-private[hive] object HiveShim {
+private[hive] object HiveShim extends Logging {
   // Precision and scale to pass for unlimited decimals; these are the same as the precision and
   // scale Hive 0.13 infers for BigDecimals from sources that don't specify them (e.g. UDFs)
   val UNLIMITED_DECIMAL_PRECISION = 38
@@ -108,6 +109,31 @@ private[hive] object HiveShim {
         hdoi.precision(), hdoi.scale())
     } else {
       Decimal(hdoi.getPrimitiveJavaObject(data).bigDecimalValue(), hdoi.precision(), hdoi.scale())
+    }
+  }
+
+  private def isSubClassOf(t: Type, parent: Class[_]): Boolean = t match {
+    case cls: Class[_] => parent.isAssignableFrom(cls)
+    case _ => false
+  }
+
+  private def hasInheritanceOf[UDFType: ClassTag](funcName: String, clazz: Class[_]): Boolean = {
+    val clsTag = classTag[UDFType].runtimeClass
+    if (isSubClassOf(clazz, clsTag)) {
+      val funcClass = clazz.getMethod(funcName, classOf[MapredContext])
+      funcClass.getDeclaringClass != clsTag
+    } else {
+      false
+    }
+  }
+
+  def validateHiveUserDefinedFunction(udfClass: Class[_]): Unit = {
+    if (hasInheritanceOf[GenericUDF]("configure", udfClass) ||
+        hasInheritanceOf[GenericUDTF]("configure", udfClass)) {
+      logWarning(s"Found an overridden method `configure` in ${udfClass.getSimpleName}, but " +
+        "Spark does not call the method during initialization because Spark does not use " +
+        "MapredContext inside (See SPARK-21533). So, you might reconsider the implementation of " +
+        s"${udfClass.getSimpleName}.")
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -24,6 +24,7 @@ import java.rmi.server.UID
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 import scala.reflect.{classTag, ClassTag}
+import scala.util.control.NonFatal
 
 import com.google.common.base.Objects
 import org.apache.avro.Schema
@@ -120,8 +121,12 @@ private[hive] object HiveShim extends Logging {
   private def hasInheritanceOf[UDFType: ClassTag](funcName: String, clazz: Class[_]): Boolean = {
     val clsTag = classTag[UDFType].runtimeClass
     if (isSubClassOf(clazz, clsTag)) {
-      val funcClass = clazz.getMethod(funcName, classOf[MapredContext])
-      funcClass.getDeclaringClass != clsTag
+      try {
+        val funcClass = clazz.getMethod(funcName, classOf[MapredContext])
+        funcClass.getDeclaringClass != clsTag
+      } catch {
+        case NonFatal(_) => false
+      }
     } else {
       false
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added code to print warning messages when an unsupported function `public void configure(MapredContext mapredContext)` used in `GenericUDF` and `GenericUDF`. This is because Spark does not call `configure` internally and this is error-prone.

## How was this patch tested?
Manually checked. If this pr applied, you hit a warning message below;
```
scala> sql("CREATE TEMPORARY FUNCTION test AS 'test.TestUDTF'")
17/07/29 11:57:08 WARN HiveShim: Found an overridden method `configure` in TestUDTF, but Spark does not call the method during initialization because Spark does not use MapredContext inside (See SPARK-21533). So, you might reconsider the implementation of TestUDTF.
```