### PR TITLE
[SPARK-21478][SQL]  Avoid unpersisting related Datasets

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -114,18 +114,15 @@ class CacheManager extends Logging {
   }
 
   /**
-   * Un-cache all the cache entries that refer to the given plan.
+   * Un-cache the cache entry that refers to the given plan.
    */
   def uncacheQuery(spark: SparkSession, plan: LogicalPlan, blocking: Boolean): Unit = writeLock {
     val it = cachedData.iterator()
-    val cachedList = cachedData.asScala
     while (it.hasNext) {
       val cd = it.next()
-      cachedList.find(cData => plan.sameResult(cData.plan)) match {
-        case Some(_) =>
-          cd.cachedRepresentation.cachedColumnBuffers.unpersist(blocking)
-          it.remove()
-        case _ =>
+      if (plan.sameResult(cd.plan)) {
+        cd.cachedRepresentation.cachedColumnBuffers.unpersist(blocking)
+        it.remove()
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -118,11 +118,14 @@ class CacheManager extends Logging {
    */
   def uncacheQuery(spark: SparkSession, plan: LogicalPlan, blocking: Boolean): Unit = writeLock {
     val it = cachedData.iterator()
+    val cachedList = cachedData.asScala
     while (it.hasNext) {
       val cd = it.next()
-      if (cd.plan.find(_.sameResult(plan)).isDefined) {
-        cd.cachedRepresentation.cachedColumnBuffers.unpersist(blocking)
-        it.remove()
+      cachedList.find(cData => plan.sameResult(cData.plan)) match {
+        case Some(_) =>
+          cd.cachedRepresentation.cachedColumnBuffers.unpersist(blocking)
+          it.remove()
+        case _ =>
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -43,6 +43,10 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     // joined Dataset should not be persisted
     val joined = ds1.joinWith(ds2, $"a.value" === $"b.value")
     assert(joined.storageLevel == StorageLevel.NONE)
+    // cleanup
+    ds1.unpersist()
+    assert(ds1.storageLevel == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
+
   }
 
   test("persist and unpersist") {
@@ -58,7 +62,7 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
       2, 3, 4)
     // Drop the cache.
     cached.unpersist()
-    assert(cached.storageLevel == StorageLevel.NONE, "The Dataset should not be cached.")
+    assert(cached.storageLevel == StorageLevel.NONE, "The Dataset cached should not be cached.")
   }
 
   test("persist and then rebind right encoder when join 2 datasets") {
@@ -94,6 +98,8 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext {
     ds1.unpersist()
     assert(ds1.storageLevel == StorageLevel.NONE, "The Dataset ds1 should not be cached.")
     assert(ds2.storageLevel.useMemory, "The Dataset ds2 should be cached.")
+    ds2.unpersist()
+    assert(ds2.storageLevel == StorageLevel.NONE, "The Dataset ds2 should not be cached.")
   }
 
   test("persist and then groupBy columns asKey, map") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
While unpersisting a dataset, only unpersist and remove that datasets's plan from Cachemanager's cachedData.
## How was this patch tested?
 Added unit tests


