### PR TITLE
[SPARK-21573][BUILD] Tests failing with run-tests.py SyntaxError occasionally in Jenkins

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -20,4 +20,8 @@
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
-exec python -u ./dev/run-tests.py "$@"
+PYTHON_EXECUTABLE=python
+if hash python2.7 2>/dev/null; then
+  PYTHON_EXECUTABLE=python2.7
+fi
+exec $PYTHON_EXECUTABLE -u ./dev/run-tests.py "$@"

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -120,8 +120,8 @@ def determine_modules_to_test(changed_modules):
     # If we need to run all of the tests, then we should short-circuit and return 'root'
     if modules.root in modules_to_test:
         return [modules.root]
-    return toposort_flatten(dict(
-        (m, set(m.dependencies).intersection(modules_to_test)) for m in modules_to_test), sort=True)
+    return toposort_flatten(
+        {m: set(m.dependencies).intersection(modules_to_test) for m in modules_to_test}, sort=True)
 
 
 def determine_tags_to_exclude(changed_modules):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -120,8 +120,8 @@ def determine_modules_to_test(changed_modules):
     # If we need to run all of the tests, then we should short-circuit and return 'root'
     if modules.root in modules_to_test:
         return [modules.root]
-    return toposort_flatten(
-        {m: set(m.dependencies).intersection(modules_to_test) for m in modules_to_test}, sort=True)
+    return toposort_flatten(dict(
+        (m, set(m.dependencies).intersection(modules_to_test)) for m in modules_to_test), sort=True)
 
 
 def determine_tags_to_exclude(changed_modules):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Select Python 2.7 explicitly on Jenkins machines

## How was this patch tested?

Existing tests