### PR TITLE
[SPARK-21593][DOC] Fix broken <code> tag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1081,7 +1081,7 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.storage.replication.proactive<code></td>
+  <td><code>spark.storage.replication.proactive</code></td>
   <td>false</td>
   <td>
     Enables proactive block replication for RDD blocks. Cached RDD block replicas lost due to


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix configuration page [https://spark.apache.org/docs/latest/configuration.html](url)
`<code>` tag wasn't closed which caused anchors after "Memory Management" not to render

## How was this patch tested?
Built docs and opened `127.0.0.1:4000/configuration.html` in Chrome
`SKIP_API=1 jekyll serve --watch`
![afterfix](https://user-images.githubusercontent.com/15244468/28834415-d5604f62-76ea-11e7-8cf7-22479f7399c0.png)


