### PR TITLE
[SPARK-21599][SQL] Collecting column statistics for datasource tables may fail with java.util.NoSuchElementException

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -643,11 +643,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         statsProperties += STATISTICS_NUM_ROWS -> stats.get.rowCount.get.toString()
       }
 
-      // For datasource tables the data schema is stored in the table properties.
-      val schema = rawTable.properties.get(DATASOURCE_PROVIDER) match {
-        case Some(provider) => getSchemaFromTableProperties(rawTable)
-        case _ => rawTable.schema
-      }
+      // For datasource tables and hive serde tables created by spark 2.1 or higher,
+      // the data schema is stored in the table properties.
+      val schema = restoreTableMetadata(rawTable).schema
 
       val colNameTypeMap: Map[String, DataType] =
         schema.fields.map(f => (f.name, f.dataType)).toMap

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -39,6 +39,12 @@ import org.apache.spark.sql.types._
 
 
 class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleton {
+  private def dropMetadata(schema: StructType): StructType = {
+    val newFields = schema.fields.map { f =>
+      StructField(f.name, f.dataType, f.nullable, Metadata.empty)
+    }
+    StructType(newFields)
+  }
 
   test("Hive serde tables should fallback to HDFS for size estimation") {
     withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true") {
@@ -128,6 +134,20 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
           |USING parquet
           |OPTIONS (skipHiveMetadata true)
         """.stripMargin)
+
+      // Verify that the schema stored in catalog is a dummy one used for
+      // data source tables. The actual schema is stored in table properties.
+      val rawSchema = dropMetadata(hiveClient.getTable("default", table).schema)
+      val expectedRawSchema = new StructType()
+        .add("col", "array<string>")
+      assert(rawSchema == expectedRawSchema)
+
+      val actualSchema = spark.sharedState.externalCatalog.getTable("default", table).schema
+      val expectedActualSchema = new StructType()
+        .add("a", "int")
+        .add("b", "int")
+      assert(actualSchema == expectedActualSchema)
+
       sql(s"INSERT INTO $table VALUES (1, 1)")
       sql(s"INSERT INTO $table VALUES (2, 1)")
       sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS a, b")
@@ -140,17 +160,12 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
   }
 
   test("Analyze hive serde tables when schema is not same as schema in table properties") {
-    def dropMetadata(schema: StructType): StructType = {
-      val newFields = schema.fields.map { f =>
-        StructField(f.name, f.dataType, f.nullable, Metadata.empty)
-      }
-      StructType(newFields)
-    }
+
     val table = "hive_serde"
     withTable(table) {
       sql(s"CREATE TABLE $table (C1 INT, C2 STRING, C3 DOUBLE)")
 
-      // First verify that the table schema stored in hive catalog is
+      // Verify that the table schema stored in hive catalog is
       // different than the schema stored in table properties.
       val rawSchema = dropMetadata(hiveClient.getTable("default", table).schema)
       val expectedRawSchema = new StructType()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -149,18 +149,23 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     val table = "hive_serde"
     withTable(table) {
       sql(s"CREATE TABLE $table (C1 INT, C2 STRING, C3 DOUBLE)")
+
+      // First verify that the table schema stored in hive catalog is
+      // different than the schema stored in table properties.
       val rawSchema = dropMetadata(hiveClient.getTable("default", table).schema)
       val expectedRawSchema = new StructType()
         .add("c1", "int")
         .add("c2", "string")
         .add("c3", "double")
       assert(rawSchema == expectedRawSchema)
+
       val actualSchema = spark.sharedState.externalCatalog.getTable("default", table).schema
       val expectedActualSchema = new StructType()
         .add("C1", "int")
         .add("C2", "string")
         .add("C3", "double")
       assert(actualSchema == expectedActualSchema)
+      
       sql(s"INSERT INTO TABLE $table SELECT 1, 'a', 10.0")
       sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS C1")
       val fetchedStats1 =

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -165,7 +165,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
         .add("C2", "string")
         .add("C3", "double")
       assert(actualSchema == expectedActualSchema)
-      
+
       sql(s"INSERT INTO TABLE $table SELECT 1, 'a', 10.0")
       sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS C1")
       val fetchedStats1 =

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -126,8 +126,8 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
           |USING parquet
           |OPTIONS (skipHiveMetadata true)
         """.stripMargin)
-      sql(s"insert into $table values (1, 1)")
-      sql(s"insert into $table values (2, 1)")
+      sql(s"INSERT INTO $table VALUES (1, 1)")
+      sql(s"INSERT INTO $table VALUES (2, 1)")
       sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS a, b")
       val fetchedStats0 =
         checkTableStats(table, hasSizeInBytes = true, expectedRowCounts = Some(2))


### PR DESCRIPTION
## What changes were proposed in this pull request?
In case of datasource tables (when they are stored in non-hive compatible way) , the schema information is recorded as table properties in hive meta-store. The alterTableStats method needs to get the schema information from table properties for data source tables before recording the column level statistics. Currently, we don't get the correct schema information and fail with java.util.NoSuchElement exception.

## How was this patch tested?
A new test case is added in StatisticsSuite.

