### PR TITLE
[SPARK-21600][docs] The description of "this requires spark.shuffle.service.enabled to be set" for the spark.dynamicAllocation.enabled configuration item is not clear

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1638,7 +1638,7 @@ Apart from these, the following properties are also available, and may be useful
     For more detail, see the description
     <a href="job-scheduling.html#dynamic-resource-allocation">here</a>.
     <br><br>
-    This requires <code>spark.shuffle.service.enabled</code> to be set.
+    This requires <code>spark.shuffle.service.enabled</code> to be set true.
     The following configurations are also relevant:
     <code>spark.dynamicAllocation.minExecutors</code>,
     <code>spark.dynamicAllocation.maxExecutors</code>, and


### PR DESCRIPTION
## What changes were proposed in this pull request?

The description of "this requires spark.shuffle.service.enabled to be set" for the spark.dynamicAllocation.enabled configuration item is not clear. I am not sure how to set spark.shuffle.service.enabled is true or false, so that the user to guess, resulting in doubts. All i have changed here, stressed that must spark.shuffle.service.enabled to be set true.

When I set spark.dynamicAllocation.enabled=true, but set spark.shuffle.service.enabled false, When I submit the spark-submit --master yarn job, the program throws the exception.

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
