### PR TITLE
[SPARK-21601][BUILD] Modify the pom.xml file, increase the maven compiler jdk attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,12 @@
     <spark.test.home>${session.executionRootDirectory}</spark.test.home>
 
     <CodeCacheSize>512m</CodeCacheSize>
+    <!--
+       Modify the JDK version of the Maven compilation
+      -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
   </properties>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
+
   </properties>
   <repositories>
     <repository>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using maven to compile spark, I want to add a modified jdk property. This is user-friendly.

## How was this patch tested?

mvn test