### PR TITLE
[SPARK-21605][BUILD] Let IntelliJ IDEA correctly detect Language level and Target byte code version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2020,6 +2020,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.1</version>
           <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
             <skipMain>true</skipMain> <!-- skip compile -->
             <skip>true</skip> <!-- skip testCompile -->
           </configuration>


### PR DESCRIPTION
With SPARK-21592, removing source and target properties from maven-compiler-plugin lets IntelliJ IDEA use default Language level and Target byte code version which are 1.4.

This change adds source, target and encoding properties back to fix this issue.  As I test, it doesn't increase compile time.