### PR TITLE
[SPARK-21609][WEB-UI]In the Master ui add "log directory" display, is conducive to users to quickly find the log directory path.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -122,6 +122,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                 {state.activeDrivers.length} Running,
                 {state.completedDrivers.length} Completed </li>
               <li><strong>Status:</strong> {state.status}</li>
+              <li><strong>Log Directory:</strong> {System.getenv("SPARK_LOG_DIR")}</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the Master ui add "log directory" display, is conducive to users to quickly find the log directory path.

In the spark application development process, we not only view the executor log and driver log, but also to see the master log and worker log, but the current UI will not show the master and worker log path, resulting in the user is not very clear to find the log path. So, I add "log directory" display.
![1](https://user-images.githubusercontent.com/26266482/28864517-60fd4a7a-779f-11e7-896c-195646af01a0.png)

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
