### PR TITLE
[SPARK-21612] Allow unicode strings in __getitem__ of StructType

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -536,7 +536,7 @@ class StructType(DataType):
 
     def __getitem__(self, key):
         """Access fields by name or slice."""
-        if isinstance(key, str):
+        if isinstance(key, basestring):
             for field in self:
                 if field.name == key:
                     return field


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check against `basestring` instead of `str`.