### PR TITLE
[SPARK-20713][Spark Core] Convert CommitDenied to TaskKilled.

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CommitDeniedException.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CommitDeniedException.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.executor
 
-import org.apache.spark.{TaskCommitDenied, TaskFailedReason}
+import org.apache.spark.TaskCommitDenied
 
 /**
  * Exception thrown when a task attempts to commit output to HDFS but is denied by the driver.
@@ -29,5 +29,5 @@ private[spark] class CommitDeniedException(
     attemptNumber: Int)
   extends Exception(msg) {
 
-  def toTaskFailedReason: TaskFailedReason = TaskCommitDenied(jobID, splitID, attemptNumber)
+  def toTaskCommitDeniedReason: TaskCommitDenied = TaskCommitDenied(jobID, splitID, attemptNumber)
 }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -463,9 +463,9 @@ private[spark] class Executor(
             taskId, TaskState.KILLED, ser.serialize(TaskKilled(killReason)))
 
         case CausedBy(cDE: CommitDeniedException) =>
-          val reason = cDE.toTaskFailedReason
+          val reason = cDE.toTaskCommitDeniedReason
           setTaskFinishedAndClearInterruptStatus()
-          execBackend.statusUpdate(taskId, TaskState.FAILED, ser.serialize(reason))
+          execBackend.statusUpdate(taskId, TaskState.KILLED, ser.serialize(reason))
 
         case t: Throwable =>
           // Attempt to exit cleanly by informing the driver of our failure.

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -375,7 +375,9 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
           execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
             kill.reason, execSummary.reasonToNumKilled.getOrElse(kill.reason, 0) + 1)
         case TaskCommitDenied(jobID, partitionID, attemptNumber) =>
-          execSummary.killedTasks += 1
+          val error_msg = TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString
+          execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
+            error_msg, execSummary.reasonToNumKilled.getOrElse(error_msg, 0) + 1)
         case _ =>
           execSummary.failedTasks += 1
       }
@@ -393,8 +395,10 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
               kill.reason, stageData.reasonToNumKilled.getOrElse(kill.reason, 0) + 1)
             Some(kill.toErrorString)
           case TaskCommitDenied(jobID, partitionID, attemptNumber) =>
-            stageData.numKilledTasks += 1 // In speculation, TaskCommitDenied is marked as killed
-            Some(TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString)
+            val error_msg = TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString
+            execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
+              error_msg, execSummary.reasonToNumKilled.getOrElse(error_msg, 0) + 1)
+            Some(error_msg)
           case e: ExceptionFailure => // Handle ExceptionFailure because we might have accumUpdates
             stageData.numFailedTasks += 1
             Some(e.toErrorString)
@@ -434,7 +438,9 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
             jobData.reasonToNumKilled = jobData.reasonToNumKilled.updated(
               kill.reason, jobData.reasonToNumKilled.getOrElse(kill.reason, 0) + 1)
           case TaskCommitDenied(jobID, partitionID, attemptNumber) =>
-            jobData.numKilledTasks += 1
+            val error_msg = TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString
+            execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
+              error_msg, execSummary.reasonToNumKilled.getOrElse(error_msg, 0) + 1)
           case _ =>
             jobData.numFailedTasks += 1
         }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -374,10 +374,10 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
         case kill: TaskKilled =>
           execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
             kill.reason, execSummary.reasonToNumKilled.getOrElse(kill.reason, 0) + 1)
-        case TaskCommitDenied(jobID, partitionID, attemptNumber) =>
-          val error_msg = TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString
+        case commitDenied: TaskCommitDenied =>
           execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
-            error_msg, execSummary.reasonToNumKilled.getOrElse(error_msg, 0) + 1)
+            commitDenied.toErrorString, execSummary.reasonToNumKilled.getOrElse(
+              commitDenied.toErrorString, 0) + 1)
         case _ =>
           execSummary.failedTasks += 1
       }
@@ -394,11 +394,11 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
             stageData.reasonToNumKilled = stageData.reasonToNumKilled.updated(
               kill.reason, stageData.reasonToNumKilled.getOrElse(kill.reason, 0) + 1)
             Some(kill.toErrorString)
-          case TaskCommitDenied(jobID, partitionID, attemptNumber) =>
-            val error_msg = TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString
-            execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
-              error_msg, execSummary.reasonToNumKilled.getOrElse(error_msg, 0) + 1)
-            Some(error_msg)
+          case commitDenied: TaskCommitDenied =>
+            stageData.reasonToNumKilled = stageData.reasonToNumKilled.updated(
+              commitDenied.toErrorString, stageData.reasonToNumKilled.getOrElse(
+                commitDenied.toErrorString, 0) + 1)
+            Some(commitDenied.toErrorString)
           case e: ExceptionFailure => // Handle ExceptionFailure because we might have accumUpdates
             stageData.numFailedTasks += 1
             Some(e.toErrorString)
@@ -437,10 +437,10 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
           case kill: TaskKilled =>
             jobData.reasonToNumKilled = jobData.reasonToNumKilled.updated(
               kill.reason, jobData.reasonToNumKilled.getOrElse(kill.reason, 0) + 1)
-          case TaskCommitDenied(jobID, partitionID, attemptNumber) =>
-            val error_msg = TaskCommitDenied(jobID, partitionID, attemptNumber).toErrorString
-            execSummary.reasonToNumKilled = execSummary.reasonToNumKilled.updated(
-              error_msg, execSummary.reasonToNumKilled.getOrElse(error_msg, 0) + 1)
+          case commitDenied: TaskCommitDenied =>
+            jobData.reasonToNumKilled = jobData.reasonToNumKilled.updated(
+              commitDenied.toErrorString, jobData.reasonToNumKilled.getOrElse(
+                commitDenied.toErrorString, 0) + 1)
           case _ =>
             jobData.numFailedTasks += 1
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In executor, toTaskFailedReason is converted to toTaskCommitDeniedReason to avoid the inconsistency of taskState. In JobProgressListener, add case TaskCommitDenied so that now the stage killed number is been incremented other than failed number.
This pull request is picked up from: https://github.com/apache/spark/pull/18070 using commit: ff93ade0248baf3793ab55659042f9d7b8efbdef
The case match for TaskCommitDenied is added incrementing the correct num of killed after pull/18070.

## How was this patch tested?

Run a normal speculative job and check the Stage UI page, should have no failed displayed.
