### PR TITLE
[SPARK-21615][ML][MLlib][DOCS] Fix broken redirect in collaborative filtering docs to databricks training repo

### DIFF
--- a/docs/mllib-collaborative-filtering.md
+++ b/docs/mllib-collaborative-filtering.md
@@ -119,5 +119,5 @@ a dependency.
 
 ## Tutorial
 
-The [training exercises](https://databricks-training.s3.amazonaws.com/index.html) from the Spark Summit 2014 include a hands-on tutorial for
-[personalized movie recommendation with `spark.mllib`](https://databricks-training.s3.amazonaws.com/movie-recommendation-with-mllib.html).
+The [training exercises](https://github.com/databricks/spark-training) from the Spark Summit 2014 include a hands-on tutorial for
+[personalized movie recommendation with `spark.mllib`](https://github.com/databricks/spark-training/blob/master/website/movie-recommendation-with-mllib.md).


### PR DESCRIPTION
## What changes were proposed in this pull request?
* Current [MLlib Collaborative Filtering tutorial](https://spark.apache.org/docs/latest/mllib-collaborative-filtering.html) points to broken links to old databricks website.
* Databricks moved all their content to [git repo](https://github.com/databricks/spark-training)
* Two links needs to be fixed,
  * [training exercises](https://databricks-training.s3.amazonaws.com/index.html)
  * [personalized movie recommendation with spark.mllib](https://databricks-training.s3.amazonaws.com/movie-recommendation-with-mllib.html)

## How was this patch tested?
Generated docs locally