### PR TITLE
[SPARK-21620][WEB-UI][CORE]Add metrics url in spark web ui.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -101,6 +101,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
           <div class="span12">
             <ul class="unstyled">
               <li><strong>URL:</strong> {state.uri}</li>
+              <li><strong><a href="/metrics/master/json/">Master Metrics</a></strong></li>
               {
                 state.restUri.map { uri =>
                   <li>
@@ -210,9 +211,14 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
         <a href="#" onclick={confirm} class="kill-link">(kill)</a>
       </form>
     }
+    val appMetrics = if (!app.isFinished) {
+      <a class="kill-link" href={UIUtils.makeHref(parent.master.reverseProxy,
+        app.id, app.desc.appUiUrl) + "/metrics/json/jmx/"}>(App Metrics)</a>
+    }
     <tr>
       <td>
         <a href={"app?appId=" + app.id}>{app.id}</a>
+        {appMetrics}
         {killLink}
       </td>
       <td>

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -66,6 +66,7 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
             <li><strong>
               Master URL:</strong> {workerState.masterUrl}
             </li>
+            <li><strong><a href="/metrics/json/jmx">Master Metrics</a></strong></li>
             <li><strong>Cores:</strong> {workerState.cores} ({workerState.coresUsed} Used)</li>
             <li><strong>Memory:</strong> {Utils.megabytesToString(workerState.memory)}
               ({Utils.megabytesToString(workerState.memoryUsed)} Used)</li>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add metrics url in spark web ui.
Big data system several other components of the ui are related metrics, such as Hadoop, hbase. 
So i think spark ui should increase the relevant metrics.

**Hadoop's metrics**：
![hadoop](https://user-images.githubusercontent.com/26266482/28904370-0fde1522-783d-11e7-8921-57cb62df5104.png)

**hbase's metrics** ：
![hbase](https://user-images.githubusercontent.com/26266482/28904374-18c1ddae-783d-11e7-99c8-292198e0a8f2.png)

**fix after 'master metrics'**:
![1](https://user-images.githubusercontent.com/26266482/28904379-21f2ca78-783d-11e7-9360-e5b36b00cd35.png)

![3](https://user-images.githubusercontent.com/26266482/28905150-dcb1f02e-7841-11e7-92c2-c5e4ad580050.png)



**fix after 'worker metrics'**:
![2](https://user-images.githubusercontent.com/26266482/28905125-bd855b28-7841-11e7-849a-a372bd204ab5.png)

![4](https://user-images.githubusercontent.com/26266482/28905133-c973cb86-7841-11e7-8f32-426550ffee92.png)


**fix after 'app metrics**':
![1](https://user-images.githubusercontent.com/26266482/28904379-21f2ca78-783d-11e7-9360-e5b36b00cd35.png)

![5](https://user-images.githubusercontent.com/26266482/28904418-6186a376-783d-11e7-919e-094bd52efb12.png)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
