### PR TITLE
[SPARK-21618][DOCS] Note that http(s) not accepted in spark-submit jar uri

### DIFF
--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -182,7 +182,7 @@ Spark uses the following URL scheme to allow different strategies for disseminat
 
 - **file:** - Absolute paths and `file:/` URIs are served by the driver's HTTP file server, and
   every executor pulls the file from the driver HTTP server.
-- **hdfs:**, **http:**, **https:**, **ftp:** - these pull down files and JARs from the URI as expected
+- **hdfs:**, **http:**, **ftp:** - these pull down files and JARs from the URI as expected
 - **local:** - a URI starting with local:/ is expected to exist as a local file on each worker node.  This
   means that no network IO will be incurred, and works well for large files/JARs that are pushed to each worker,
   or shared via NFS, GlusterFS, etc.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove https from list of supported URIs, until it's explicitly supported. This just makes the docs consistent with behavior, doesn't address the issue that HTTPS should ideally work. That is, this doesn't resolve the JIRA.

## How was this patch tested?

Doc build