### PR TITLE
[SPARK-21628][BUILD] Explicitly specify Java version in maven compiler plugin so IntelliJ imports project correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2022,6 +2022,8 @@
           <configuration>
             <skipMain>true</skipMain> <!-- skip compile -->
             <skip>true</skip> <!-- skip testCompile -->
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Explicitly specify Java version in maven compiler plugin so IntelliJ imports project correctly. See https://stackoverflow.com/questions/27037657/stop-intellij-idea-to-switch-java-language-level-every-time-the-pom-is-reloaded

## How was this patch tested?

Manually tested reload of pom in IntelliJ.
