### PR TITLE
Update SortMergeJoinExec.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -82,7 +82,7 @@ case class SortMergeJoinExec(
 
   override def outputOrdering: Seq[SortOrder] = joinType match {
     // For inner join, orders of both sides keys should be kept.
-    case Inner =>
+    case _: InnerLike =>
       val leftKeyOrdering = getKeyOrdering(leftKeys, left.outputOrdering)
       val rightKeyOrdering = getKeyOrdering(rightKeys, right.outputOrdering)
       leftKeyOrdering.zip(rightKeyOrdering).map { case (lKey, rKey) =>


### PR DESCRIPTION
fix a bug in outputOrdering

## What changes were proposed in this pull request?

Change `case Inner` to `case _: InnerLike` so that Cross will be handled properly.

## How was this patch tested?

No unit tests are needed.

Please review http://spark.apache.org/contributing.html before opening a pull request.
