### PR TITLE
[SPARK-21632] There is no need to make attempts for createDirectory if the dir had existed

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -294,8 +294,13 @@ private[spark] object Utils extends Logging {
       }
       try {
         dir = new File(root, namePrefix + "-" + UUID.randomUUID.toString)
-        if (dir.exists() || !dir.mkdirs()) {
+        if (!dir.mkdirs()) {
           dir = null
+        }
+        if (dir.exists()) {
+          logInfo(s"$dir exists,can't create a new directory.")
+          dir = null
+          return dir.getCanonicalFile
         }
       } catch { case e: SecurityException => dir = null; }
     }


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21632](https://issues.apache.org/jira/browse/SPARK-21632)

There is no need to make attempts for createDirectory if the dir had existed.So I think we should log it,and Jump out of the loop