### PR TITLE
[SPARK-21635][SQL] ACOS(2) and ASIN(2) should be null

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -190,7 +190,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("asin") {
     testUnary(Asin, math.asin, (-10 to 10).map(_ * 0.1))
-    testUnary(Asin, math.asin, (11 to 20).map(_ * 0.1), expectNaN = true)
+    testUnary(Asin, math.asin, (11 to 20).map(_ * 0.1), expectNull = true)
     checkConsistencyBetweenInterpretedAndCodegen(Asin, DoubleType)
   }
 
@@ -206,7 +206,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("acos") {
     testUnary(Acos, math.acos, (-10 to 10).map(_ * 0.1))
-    testUnary(Acos, math.acos, (11 to 20).map(_ * 0.1), expectNaN = true)
+    testUnary(Acos, math.acos, (11 to 20).map(_ * 0.1), expectNull = true)
     checkConsistencyBetweenInterpretedAndCodegen(Acos, DoubleType)
   }
 

--- a/sql/hive/src/test/resources/golden/udf_acos-6-4d2bd33cee047e9a8bb740760c7cc3b4
+++ b/sql/hive/src/test/resources/golden/udf_acos-6-4d2bd33cee047e9a8bb740760c7cc3b4
@@ -1,1 +1,1 @@
-NaN
+NULL

--- a/sql/hive/src/test/resources/golden/udf_asin-6-114c8141f1e831c70d70c570f0ae778f
+++ b/sql/hive/src/test/resources/golden/udf_asin-6-114c8141f1e831c70d70c570f0ae778f
@@ -1,1 +1,1 @@
-NaN
+NULL


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes ACOS(2) and ASIN(2) to null, same as MySQL.

```
mysql> select ACOS(2), ASIN(2);
+---------+---------+
| ACOS(2) | ASIN(2) |
+---------+---------+
|    NULL |    NULL |
+---------+---------+
1 row in set (0.01 sec)

mysql> 
```

I have submit a [patch](https://issues.apache.org/jira/browse/HIVE-17240) for Hive.

## How was this patch tested?

unit tests