### PR TITLE
[SPARK-21636] Several configurations which only are used in unit tests should be removed

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
@@ -60,7 +60,7 @@ public class RequestTimeoutIntegrationSuite {
   @Before
   public void setUp() throws Exception {
     Map<String, String> configMap = new HashMap<>();
-    configMap.put("spark.shuffle.io.connectionTimeout", "10s");
+    configMap.put("spark.network.timeout", "10s");
     conf = new TransportConf("shuffle", new MapConfigProvider(configMap));
 
     defaultManager = new StreamManager() {

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportClientFactorySuite.java
@@ -188,7 +188,7 @@ public class TransportClientFactorySuite {
 
       @Override
       public String get(String name) {
-        if ("spark.shuffle.io.connectionTimeout".equals(name)) {
+        if ("spark.network.timeout".equals(name)) {
           // We should make sure there is enough time for us to observe the channel is active
           return "1s";
         }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
@@ -93,7 +93,7 @@ trait BlockManagerReplicationBehavior extends SparkFunSuite
     conf.set("spark.storage.unrollMemoryThreshold", "512")
 
     // to make a replication attempt to inactive store fail fast
-    conf.set("spark.core.connection.ack.wait.timeout", "1s")
+    conf.set("spark.network.timeout", "1s")
     // to make cached peers refresh frequently
     conf.set("spark.storage.cachedPeersTtl", "10")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1292,9 +1292,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>120s</td>
   <td>
     Default timeout for all network interactions. This config will be used in place of
-    <code>spark.core.connection.ack.wait.timeout</code>,
     <code>spark.storage.blockManagerSlaveTimeoutMs</code>,
-    <code>spark.shuffle.io.connectionTimeout</code>, <code>spark.rpc.askTimeout</code> or
+    <code>spark.rpc.askTimeout</code> or
     <code>spark.rpc.lookupTimeout</code> if they are not configured.
   </td>
 </tr>
@@ -1828,15 +1827,6 @@ Apart from these, the following properties are also available, and may be useful
   <td>false</td>
   <td>
     Disable unencrypted connections for services that support SASL authentication.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.core.connection.ack.wait.timeout</code></td>
-  <td><code>spark.network.timeout</code></td>
-  <td>
-    How long for the connection to wait for ack to occur before timing
-    out and giving up. To avoid unwilling timeout caused by long pause like GC,
-    you can set larger value.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21636](https://issues.apache.org/jira/browse/SPARK-21636)

spark.core.connection.ack.wait.timeout and spark.shuffle.io.connectionTimeout only are used in unit tests.So I think they should be removed and we can replace them with spark.network.timeout 
in those unit tests.