### PR TITLE
Remove dropping bus logic.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -171,6 +171,11 @@ package object config {
       .checkValue(_ > 0, "The capacity of listener bus event queue must not be negative")
       .createWithDefault(10000)
 
+  private[spark] val LISTENER_BUS_EVENT_QUEUE_SLOW_THRESHOLD_MS =
+    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.slowThresholdMs")
+      .intConf
+      .createWithDefault(10)
+
   private[spark] val LISTENER_BUS_METRICS_MAX_LISTENER_CLASSES_TIMED =
     ConfigBuilder("spark.scheduler.listenerbus.metrics.maxListenerClassesTimed")
       .internal()


### PR DESCRIPTION
Log warning when event uptake takes too long, but block anyways. Since dropping events is no longer possible, removed that code.

I am somewhat looking for advice on why this is a bad idea, due to my relatively limited experience with spark. Or what else it needs to become a good idea.

## What changes were proposed in this pull request?

LiveListenerBus events are now never dropped. I believe that critical components communicate through this bus. I will also add the argument that a buggy spark UI (because of dropped events) is just as useless, and so I am unaware of any kind of event which can be lossy.

## How was this patch tested?

Basically we ran it in our production environment. Our past couple spark runs now reliably complete with this change since crucial events never get dropped, but it is unclear how much lag this change might be contributing to the overall run time.

We have partition counts in the thousands and executors in the hundreds.

----

Perhaps the events can be tagged as critical (`queue.put`) or not (`queue.offer`), but this small change is meant to get spark stable again. We have turned up the eventqueue size to 1,000,000 (and fiddled with all available settings), but it still isn't enough. With some probability, enough crucial events are dropped and leaves the spark job hung indefinitely unable to recover (sometimes it does). The large eventqueue also maxed out our driver process with 64GB of memory, so that's pretty much untenable. 

With this change and over tens (hundreds?) of millions of events flowing through this bus, only 1100 triggered the slow warning, usually around 20ms with a max of 100ms. The current working hypothesis is that the events tend to arrive in bursts and so quickly overwhelm the queue and then quickly empty out.

Related to https://issues.apache.org/jira/browse/SPARK-18838
