### PR TITLE
[SPARK-21629][SQL][WIP] Fix Or nullability

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -396,6 +396,8 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
 
   override def sqlOperator: String = "OR"
 
+  override def nullable: Boolean = left.nullable && right.nullable
+
   override def eval(input: InternalRow): Any = {
     val input1 = left.eval(input)
     if (input1 == true) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Override `nullable` of `Or` to make sure nullable behavior is correct. 
`Or.eval` will return TRUE when left or right expression is TRUE but the other is maybe null.
Therefore, `Or.nullable` isn't `left.nullable ||  right.nullable`. It's `left.nullable && right.nullable`.

## How was this patch tested?
I'll add test case later

cc @viirya 