### PR TITLE
[SPARK-19426][SQL] Custom coalescer for Dataset

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -1158,8 +1158,17 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
  * Took this class out of the test suite to prevent "Task not serializable" exceptions.
  */
 class SizeBasedCoalescer(val maxSize: Int) extends PartitionCoalescer with Serializable {
+
+  def getPartitions(parent: RDD[_]): Array[Partition] = {
+    parent.asInstanceOf[HadoopRDD[Any, Any]].getPartitions
+  }
+
+  def getPartitionSize(partition: Partition): Long = {
+    partition.asInstanceOf[HadoopPartition].inputSplit.value.getLength
+  }
+
   override def coalesce(maxPartitions: Int, parent: RDD[_]): Array[PartitionGroup] = {
-    val partitions: Array[Partition] = parent.asInstanceOf[HadoopRDD[Any, Any]].getPartitions
+    val partitions = getPartitions(parent)
     val groups = ArrayBuffer[PartitionGroup]()
     var currentGroup = new PartitionGroup()
     var currentSum = 0L
@@ -1168,8 +1177,8 @@ class SizeBasedCoalescer(val maxSize: Int) extends PartitionCoalescer with Seria
 
     // sort partitions based on the size of the corresponding input splits
     partitions.sortWith((partition1, partition2) => {
-      val partition1Size = partition1.asInstanceOf[HadoopPartition].inputSplit.value.getLength
-      val partition2Size = partition2.asInstanceOf[HadoopPartition].inputSplit.value.getLength
+      val partition1Size = getPartitionSize(partition1)
+      val partition2Size = getPartitionSize(partition2)
       partition1Size < partition2Size
     })
 
@@ -1185,23 +1194,21 @@ class SizeBasedCoalescer(val maxSize: Int) extends PartitionCoalescer with Seria
       totalSum += splitSize
     }
 
-    while (index < partitions.size) {
+    while (index < partitions.length) {
       val partition = partitions(index)
-      val fileSplit =
-        partition.asInstanceOf[HadoopPartition].inputSplit.value.asInstanceOf[FileSplit]
-      val splitSize = fileSplit.getLength
+      val splitSize = getPartitionSize(partition)
       if (currentSum + splitSize < maxSize) {
         addPartition(partition, splitSize)
         index += 1
-        if (index == partitions.size) {
-          updateGroups
+        if (index == partitions.length) {
+          updateGroups()
         }
       } else {
-        if (currentGroup.partitions.size == 0) {
+        if (currentGroup.partitions.isEmpty) {
           addPartition(partition, splitSize)
           index += 1
         } else {
-          updateGroups
+          updateGroups()
         }
       }
     }

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -1194,21 +1194,21 @@ class SizeBasedCoalescer(val maxSize: Int) extends PartitionCoalescer with Seria
       totalSum += splitSize
     }
 
-    while (index < partitions.length) {
+    while (index < partitions.size) {
       val partition = partitions(index)
       val splitSize = getPartitionSize(partition)
       if (currentSum + splitSize < maxSize) {
         addPartition(partition, splitSize)
         index += 1
-        if (index == partitions.length) {
-          updateGroups()
+        if (index == partitions.size) {
+          updateGroups
         }
       } else {
-        if (currentGroup.partitions.isEmpty) {
+        if (currentGroup.partitions.size == 0) {
           addPartition(partition, splitSize)
           index += 1
         } else {
-          updateGroups()
+          updateGroups
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -600,10 +600,12 @@ object CollapseRepartition extends Rule[LogicalPlan] {
     //   strategy), but the child enables the shuffle. Returns the child node if the last
     //   numPartitions is bigger; otherwise, keep unchanged.
     // 2) In the other cases, returns the top node with the child's child
-    case r @ Repartition(_, _, child: RepartitionOperation, None) =>
+    case r @ Repartition(_, _, child: RepartitionOperation, coalescer) =>
       (r.shuffle, child.shuffle) match {
-        case (false, true) => if (r.numPartitions >= child.numPartitions) child else r
-        case _ => r.copy(child = child.child)
+        case (false, true) =>
+          if (coalescer.isEmpty && r.numPartitions >= child.numPartitions) child else r
+        case _ =>
+          r.copy(child = child.child)
       }
     // Case 2: When a RepartitionByExpression has a child of Repartition or RepartitionByExpression
     // we can remove the child.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
+import org.apache.spark.rdd.PartitionCoalescer
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
@@ -751,6 +752,19 @@ case class Repartition(numPartitions: Int, shuffle: Boolean, child: LogicalPlan)
   extends RepartitionOperation {
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
 }
+
+/**
+ * Returns a new RDD that has at most `numPartitions` partitions. This behavior can be modified by
+ * supplying a [[PartitionCoalescer]] to control the behavior of the partitioning.
+ */
+case class PartitionCoalesce(
+    numPartitions: Int,
+    partitionCoalescer: Option[PartitionCoalescer],
+    child: LogicalPlan) extends UnaryNode {
+  require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
+  override def output: Seq[Attribute] = child.output
+}
+
 
 /**
  * This method repartitions data using [[Expression]]s into `numPartitions`, and receives

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.statsEstimation._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 import org.apache.spark.util.random.RandomSampler
@@ -755,16 +754,13 @@ case class Repartition(numPartitions: Int, shuffle: Boolean, child: LogicalPlan)
 
 /**
  * Returns a new RDD that has at most `numPartitions` partitions. This behavior can be modified by
- * supplying a [[PartitionCoalescer]] to control the behavior of the partitioning.
+ * supplying a `PartitionCoalescer` to control the behavior of the partitioning.
  */
-case class PartitionCoalesce(
-    numPartitions: Int,
-    partitionCoalescer: Option[PartitionCoalescer],
-    child: LogicalPlan) extends UnaryNode {
+case class PartitionCoalesce(numPartitions: Int, coalescer: PartitionCoalescer, child: LogicalPlan)
+  extends UnaryNode {
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
   override def output: Seq[Attribute] = child.output
 }
-
 
 /**
  * This method repartitions data using [[Expression]]s into `numPartitions`, and receives

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -762,6 +762,8 @@ case class Repartition(
     coalescer: Option[PartitionCoalescer] = None)
   extends RepartitionOperation {
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
+  require(!shuffle || coalescer.isEmpty,
+    "Custom coalescer is not allowed for repartition(shuffle=true)")
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -746,20 +746,22 @@ abstract class RepartitionOperation extends UnaryNode {
  * [[RepartitionByExpression]] as this method is called directly by DataFrame's, because the user
  * asked for `coalesce` or `repartition`. [[RepartitionByExpression]] is used when the consumer
  * of the output requires some specific ordering or distribution of the data.
+ *
+ * If `shuffle` = false (`coalesce` cases), this logical plan can have an user-specified strategy
+ * to coalesce input partitions.
+ *
+ * @param numPartitions How many partitions to use in the output RDD
+ * @param shuffle Whether to shuffle when repartitioning
+ * @param child the LogicalPlan
+ * @param coalescer Optional coalescer that an user specifies
  */
-case class Repartition(numPartitions: Int, shuffle: Boolean, child: LogicalPlan)
+case class Repartition(
+    numPartitions: Int,
+    shuffle: Boolean,
+    child: LogicalPlan,
+    coalescer: Option[PartitionCoalescer] = None)
   extends RepartitionOperation {
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
-}
-
-/**
- * Returns a new RDD that has at most `numPartitions` partitions. This behavior can be modified by
- * supplying a `PartitionCoalescer` to control the behavior of the partitioning.
- */
-case class PartitionCoalesce(numPartitions: Int, coalescer: PartitionCoalescer, child: LogicalPlan)
-  extends UnaryNode {
-  require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
-  override def output: Seq[Attribute] = child.output
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2680,8 +2680,9 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 2.3.0
    */
-  def coalesce(numPartitions: Int, userDefinedCoalescer: Option[PartitionCoalescer])
-    : Dataset[T] = withTypedPlan {
+  def coalesce(
+      numPartitions: Int,
+      userDefinedCoalescer: Option[PartitionCoalescer]): Dataset[T] = withTypedPlan {
     Repartition(numPartitions, shuffle = false, logicalPlan, userDefinedCoalescer)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2680,14 +2680,9 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 2.3.0
    */
-  def coalesce(numPartitions: Int, userDefinedCoalescer: Option[PartitionCoalescer]): Dataset[T] = {
-    userDefinedCoalescer.map { coalescer =>
-      withTypedPlan {
-        PartitionCoalesce(numPartitions, coalescer, logicalPlan)
-      }
-    }.getOrElse {
-      coalesce(numPartitions)
-    }
+  def coalesce(numPartitions: Int, userDefinedCoalescer: Option[PartitionCoalescer])
+    : Dataset[T] = withTypedPlan {
+    Repartition(numPartitions, shuffle = false, logicalPlan, userDefinedCoalescer)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -33,7 +33,7 @@ import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.java.function._
 import org.apache.spark.api.python.{PythonRDD, SerDeUtil}
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.{PartitionCoalescer, RDD}
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.CatalogRelation
@@ -2662,7 +2662,7 @@ class Dataset[T] private[sql](
   }
 
   /**
-   * Returns a new Dataset that has exactly `numPartitions` partitions, when the fewer partitions
+   * Returns a new Dataset that has at most `numPartitions` partitions.
    * are requested. If a larger number of partitions is requested, it will stay at the current
    * number of partitions. Similar to coalesce defined on an `RDD`, this operation results in
    * a narrow dependency, e.g. if you go from 1000 partitions to 100 partitions, there will not
@@ -2675,12 +2675,27 @@ class Dataset[T] private[sql](
    * current upstream partitions will be executed in parallel (per whatever
    * the current partitioning is).
    *
+   * A [[PartitionCoalescer]] can also be supplied allowing the behavior of the partitioning to be
+   * customized similar to [[RDD.coalesce]].
+   *
+   * @group typedrel
+   * @since 2.2.0
+   */
+  def coalesce(numPartitions: Int, partitionCoalescer: Option[PartitionCoalescer]): Dataset[T] =
+    withTypedPlan {
+      PartitionCoalesce(numPartitions, partitionCoalescer, logicalPlan)
+    }
+
+  /**
+   * Returns a new Dataset that has exactly `numPartitions` partitions.
+   * Similar to coalesce defined on an `RDD`, this operation results in a narrow dependency, e.g.
+   * if you go from 1000 partitions to 100 partitions, there will not be a shuffle, instead each of
+   * the 100 new partitions will claim 10 of the current partitions.
+   *
    * @group typedrel
    * @since 1.6.0
    */
-  def coalesce(numPartitions: Int): Dataset[T] = withTypedPlan {
-    Repartition(numPartitions, shuffle = false, logicalPlan)
-  }
+  def coalesce(numPartitions: Int): Dataset[T] = coalesce(numPartitions, None)
 
   /**
    * Returns a new Dataset that contains only the unique rows from this Dataset.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -394,8 +394,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         if (shuffle) {
           ShuffleExchange(RoundRobinPartitioning(numPartitions), planLater(child)) :: Nil
         } else {
-          execution.CoalesceExec(numPartitions, planLater(child)) :: Nil
+          execution.CoalesceExec(numPartitions, planLater(child), None) :: Nil
         }
+      case logical.PartitionCoalesce(numPartitions, partitionCoalescer, child) =>
+        execution.CoalesceExec(numPartitions, planLater(child), partitionCoalescer) :: Nil
       case logical.Sort(sortExprs, global, child) =>
         execution.SortExec(sortExprs, global, planLater(child)) :: Nil
       case logical.Project(projectList, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -390,14 +390,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           f, key, lObj, rObj, lGroup, rGroup, lAttr, rAttr, oAttr,
           planLater(left), planLater(right)) :: Nil
 
-      case logical.Repartition(numPartitions, shuffle, child) =>
+      case logical.Repartition(numPartitions, shuffle, child, coalescer) =>
         if (shuffle) {
           ShuffleExchange(RoundRobinPartitioning(numPartitions), planLater(child)) :: Nil
         } else {
-          execution.CoalesceExec(numPartitions, planLater(child), None) :: Nil
+          execution.CoalesceExec(numPartitions, planLater(child), coalescer) :: Nil
         }
-      case logical.PartitionCoalesce(numPartitions, coalescer, child) =>
-        execution.CoalesceExec(numPartitions, planLater(child), Some(coalescer)) :: Nil
       case logical.Sort(sortExprs, global, child) =>
         execution.SortExec(sortExprs, global, planLater(child)) :: Nil
       case logical.Project(projectList, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -396,8 +396,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         } else {
           execution.CoalesceExec(numPartitions, planLater(child), None) :: Nil
         }
-      case logical.PartitionCoalesce(numPartitions, partitionCoalescer, child) =>
-        execution.CoalesceExec(numPartitions, planLater(child), partitionCoalescer) :: Nil
+      case logical.PartitionCoalesce(numPartitions, coalescer, child) =>
+        execution.CoalesceExec(numPartitions, planLater(child), Some(coalescer)) :: Nil
       case logical.Sort(sortExprs, global, child) =>
         execution.SortExec(sortExprs, global, planLater(child)) :: Nil
       case logical.Project(projectList, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -560,7 +560,7 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
  * Physical plan for returning a new RDD that has exactly `numPartitions` partitions.
  * Similar to coalesce defined on an [[RDD]], this operation results in a narrow dependency, e.g.
  * if you go from 1000 partitions to 100 partitions, there will not be a shuffle, instead each of
- * the 100 new partitions will claim 10 of the current partitions.  If a larger number of partitions
+ * the 100 new partitions will claim 10 of the current partitions. If a larger number of partitions
  * is requested, it will stay at the current number of partitions.
  *
  * However, if you're doing a drastic coalesce, e.g. to numPartitions = 1,
@@ -569,6 +569,13 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
  * you see ShuffleExchange. This will add a shuffle step, but means the
  * current upstream partitions will be executed in parallel (per whatever
  * the current partitioning is).
+ *
+ * If you want to define how to coalesce partitions, you can set a custom strategy
+ * to coalesce partitions in `coalescer`.
+ *
+ * @param numPartitions Number of partitions this coalescer tries to reduce partitions into
+ * @param child the SparkPlan
+ * @param coalescer Optional coalescer that an user specifies
  */
 case class CoalesceExec(numPartitions: Int, child: SparkPlan, coalescer: Option[PartitionCoalescer])
   extends UnaryExecNode {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -20,10 +20,13 @@ package org.apache.spark.sql
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import java.sql.{Date, Timestamp}
 
+import org.apache.spark.Partition
+import org.apache.spark.rdd._
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.execution.{LogicalRDD, RDDScanExec}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchange}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
@@ -117,6 +120,46 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDatasetUnorderly(
       ds.coalesce(1),
       data: _*)
+  }
+
+  test("coalesce, custom") {
+
+    val maxSplitSize = 512
+    // Similar to the implementation of `test("custom RDD coalescer")` from [[RDDSuite]] we first
+    // write out to disk, to ensure that our splits are in fact [[FileSplit]] instances.
+    withTempPath { path =>
+      val data = (1 to 1000).map(i => ClassData(i.toString, i))
+      data.toDS().repartition(50).write.format("csv").save(path.toString)
+
+      val schema = StructType(Seq($"a".string, $"b".int))
+
+      withSQLConf(
+        SQLConf.FILES_MAX_PARTITION_BYTES.key -> "200",
+        SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "1") {
+
+        val ds = spark.read.format("csv")
+          .schema(schema)
+          .load(path.toString)
+          .as[ClassData]
+
+        val coalescedDataSet =
+          ds.coalesce(4,
+            partitionCoalescer = Option(new DataSetSizeBasedPartitionCoalescer(maxSplitSize)))
+
+        assert(coalescedDataSet.rdd.partitions.length <= 50)
+
+        var totalPartitionCount = 0L
+        coalescedDataSet.rdd.partitions.foreach(partition => {
+          var splitSizeSum = 0L
+          partition.asInstanceOf[CoalescedRDDPartition].parents.foreach(partition => {
+            splitSizeSum +=
+              partition.asInstanceOf[FilePartition].files.map(_.length).sum
+            totalPartitionCount += 1
+          })
+          assert(splitSizeSum <= maxSplitSize)
+        })
+      }
+    }
   }
 
   test("as tuple") {
@@ -1402,3 +1445,18 @@ case class CircularReferenceClassB(cls: CircularReferenceClassA)
 case class CircularReferenceClassC(ar: Array[CircularReferenceClassC])
 case class CircularReferenceClassD(map: Map[String, CircularReferenceClassE])
 case class CircularReferenceClassE(id: String, list: List[CircularReferenceClassD])
+
+
+class DataSetSizeBasedPartitionCoalescer(maxSize: Int) extends
+  SizeBasedCoalescer(maxSize) {
+
+  override def getPartitions(parent: RDD[_]): Array[Partition] = {
+    parent.firstParent.asInstanceOf[FileScanRDD].partitions
+  }
+
+  override def getPartitionSize(partition: Partition): Long = {
+    val res = partition.asInstanceOf[FilePartition].files.map(
+      x => x.length - x.start).sum
+    res
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -244,7 +244,7 @@ class PlannerSuite extends SharedSQLContext {
     assert(countRepartitions(doubleRepartitioned.queryExecution.logical) === 3)
     assert(countRepartitions(doubleRepartitioned.queryExecution.optimizedPlan) === 2)
     doubleRepartitioned.queryExecution.optimizedPlan match {
-      case Repartition (numPartitions, shuffle, Repartition(_, shuffleChild, _)) =>
+      case Repartition(numPartitions, shuffle, Repartition(_, shuffleChild, _, _), _) =>
         assert(numPartitions === 5)
         assert(shuffle === false)
         assert(shuffleChild === true)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added a new API for `coalesce` in `Dataset`; users can specify the custom coalescer which reduces an input Dataset into fewer partitions. This coalescer implementation is the same with the one in `RDD#coalesce` added in #11865 (SPARK-14042).

This is the rework of #16766.

## How was this patch tested?
Added tests in `DatasetSuite`.