### PR TITLE
[SPARK-21610][SQL] Corrupt records are not handled properly when creating a dataframe from a file

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1544,7 +1544,7 @@ options.
 
 ## Upgrading From Spark SQL 2.2 to 2.3
 
-  - The queries which select only `spark.sql.columnNameOfCorruptRecord` column are disallowed now. Notice that the queries which have only the column after column pruning (e.g. filtering on the column followed by a counting operation) are also disallowed. If you want to select only the corrupt records, you should cache or save the Dataset and DataFrame before running such queries.
+  - The queries which select only `spark.sql.columnNameOfCorruptRecord` column are disallowed now. Notice that the queries which have only the column after column pruning (e.g. filtering on the column followed by a counting operation) are also disallowed. If you want to select only the corrupt records, you should cache or save the underlying Dataset and DataFrame before running such queries.
 
 ## Upgrading From Spark SQL 2.1 to 2.2
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1544,7 +1544,7 @@ options.
 
 ## Upgrading From Spark SQL 2.2 to 2.3
 
-  - The queries which select only `spark.sql.columnNameOfCorruptRecord` column are disallowed now. Notice that the queries which have only the column after column pruning (e.g. filtering on the column followed by a counting operation) are also disallowed. If you want to select only the corrupt records, you should cache or save the underlying Dataset and DataFrame before running such queries.
+  - Since Spark 2.3, the queries from raw JSON/CSV files are disallowed when the referenced columns only include the internal corrupt record column (named `_corrupt_record` by default). For example, `spark.read.schema(schema).json(file).filter($"_corrupt_record".isNotNull).count()` and `spark.read.schema(schema).json(file).select("_corrupt_record").show()`. Instead, you can cache or save the parsed results and then send the same query. For example, `val df = spark.read.schema(schema).json(file).cache()` and then `df.filter($"_corrupt_record".isNotNull).count()`.
 
 ## Upgrading From Spark SQL 2.1 to 2.2
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1542,6 +1542,10 @@ options.
 
 # Migration Guide
 
+## Upgrading From Spark SQL 2.2 to 2.3
+
+  - The queries which select only `spark.sql.columnNameOfCorruptRecord` column are disallowed now. Notice that the queries which have only the column after column pruning (e.g. filtering on the column followed by a counting operation) are also disallowed. If you want to select only the corrupt records, you should cache or save the Dataset and DataFrame before running such queries.
+
 ## Upgrading From Spark SQL 2.1 to 2.2
 
   - Spark 2.1.1 introduced a new configuration key: `spark.sql.hive.caseSensitiveInferenceMode`. It had a default setting of `NEVER_INFER`, which kept behavior identical to 2.1.0. However, Spark 2.2.0 changes this setting's default value to `INFER_AND_SAVE` to restore compatibility with reading Hive metastore tables whose underlying file schema have mixed-case column names. With the `INFER_AND_SAVE` configuration value, on first access Spark will perform schema inference on any Hive metastore table for which it has not already saved an inferred schema. Note that schema inference can be a very time consuming operation for tables with thousands of partitions. If compatibility with mixed-case column names is not a concern, you can safely set `spark.sql.hive.caseSensitiveInferenceMode` to `NEVER_INFER` to avoid the initial overhead of schema inference. Note that with the new default `INFER_AND_SAVE` setting, the results of the schema inference are saved as a metastore key for future use. Therefore, the initial schema inference occurs only at a table's first access.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -118,7 +118,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // the derived `actualSchema` is empty and the `_corrupt_record` are all null for all rows.
       // When users requires only `_corrupt_record`, we assume that the corrupt records are required
       // for all json fields, i.g., all items in dataSchema.
-      val querySchema = if (actualSchema.isEmpty) {
+      val querySchema = if (actualSchema.isEmpty && requiredSchema.nonEmpty) {
         StructType(dataSchema.filterNot(_.name == parsedOptions.columnNameOfCorruptRecord))
       } else {
         actualSchema

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -120,7 +120,9 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // for all json fields, i.g., all items in dataSchema.
       val querySchema = if (actualSchema.isEmpty) {
         StructType(dataSchema.filterNot(_.name == parsedOptions.columnNameOfCorruptRecord))
-      } else { actualSchema }
+      } else {
+        actualSchema
+      }
       val parser = new JacksonParser(querySchema, parsedOptions)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -118,7 +118,10 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // the derived `actualSchema` is empty and the `_corrupt_record` are all null for all rows.
       // When users requires only `_corrupt_record`, we assume that the corrupt records are required
       // for all json fields, i.g., all items in dataSchema.
-      val querySchema = if (actualSchema.isEmpty) dataSchema else actualSchema
+      val querySchema =
+      if (actualSchema.isEmpty) {
+        StructType(dataSchema.filterNot(_.name == parsedOptions.columnNameOfCorruptRecord))
+      } else actualSchema
       val parser = new JacksonParser(querySchema, parsedOptions)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -118,10 +118,9 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // the derived `actualSchema` is empty and the `_corrupt_record` are all null for all rows.
       // When users requires only `_corrupt_record`, we assume that the corrupt records are required
       // for all json fields, i.g., all items in dataSchema.
-      val querySchema =
-      if (actualSchema.isEmpty) {
+      val querySchema = if (actualSchema.isEmpty) {
         StructType(dataSchema.filterNot(_.name == parsedOptions.columnNameOfCorruptRecord))
-      } else actualSchema
+      } else { actualSchema }
       val parser = new JacksonParser(querySchema, parsedOptions)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -114,7 +114,8 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     }
 
     (file: PartitionedFile) => {
-      val parser = new JacksonParser(actualSchema, parsedOptions)
+      val parser = new JacksonParser(
+        if (actualSchema.isEmpty) dataSchema else actualSchema, parsedOptions)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,
         file,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -116,13 +116,13 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     if (requiredSchema.length == 1 &&
       requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
       throw new AnalysisException(
-        s"""
-           |'${parsedOptions.columnNameOfCorruptRecord}' cannot be selected alone without other
-           |data columns. If you want to select corrupt records only, cache or save the Dataset
-           |before executing queries. For example:
-           |df.cache() then
-           |df.select("${parsedOptions.columnNameOfCorruptRecord}")
-         """.stripMargin.replaceAll(System.lineSeparator(), " "))
+        s"'${parsedOptions.columnNameOfCorruptRecord}' cannot be selected alone without other " +
+        "data columns, because its content is completely derived from the data columns parsed.\n" +
+        "If you want to select corrupt records only, cache or save the Dataset " +
+        "before executing queries, as this parses all fields under the hood. For example: \n" +
+        "df.cache()\n" +
+        s"""df.select("${parsedOptions.columnNameOfCorruptRecord}")"""
+      )
     }
 
     (file: PartitionedFile) => {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -119,7 +119,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
         throw new AnalysisException(
           s"""
              |'${parsedOptions.columnNameOfCorruptRecord}' must be selected along with input schema.
-             |If you want to select corrupt records only, cache DataFrame before executing queries.
+             |If you want to select corrupt records only, cache or save the Dataset before executing queries.
              |For example:
              |df.cache()
              |df.select("${parsedOptions.columnNameOfCorruptRecord}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -116,9 +116,12 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     if (requiredSchema.length == 1 &&
       requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
       throw new AnalysisException(
-        s"'${parsedOptions.columnNameOfCorruptRecord}' cannot be selected alone without other " +
+        s"'${parsedOptions.columnNameOfCorruptRecord}' cannot be selected alone without other\n" +
         "data columns, because its content is completely derived from the data columns parsed.\n" +
-        "If you want to select corrupt records only, cache or save the Dataset " +
+        "Even your queries looks not only select this column, if after column pruning it isn't\n" +
+        "involving paring any data fields, e.g., filtering on the column followed by a \n" +
+        "counting, it can produce incorrect results and so disallowed.\n" +
+        "If you want to select corrupt records only, cache or save the Dataset\n" +
         "before executing queries, as this parses all fields under the hood. For example: \n" +
         "df.cache()\n" +
         s"""df.select("${parsedOptions.columnNameOfCorruptRecord}")"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -118,12 +118,18 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // the derived `actualSchema` is empty and the `_corrupt_record` are all null for all rows.
       // When users requires only `_corrupt_record`, we assume that the corrupt records are required
       // for all json fields, i.g., all items in dataSchema.
-      val querySchema = if (actualSchema.isEmpty && requiredSchema.nonEmpty) {
-        StructType(dataSchema.filterNot(_.name == parsedOptions.columnNameOfCorruptRecord))
-      } else {
-        actualSchema
+      if (actualSchema.isEmpty && requiredSchema.length == 1 &&
+        requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
+        throw new AnalysisException(
+          s"""
+             |'${parsedOptions.columnNameOfCorruptRecord}' must be selected along with input schema.
+             |If you want to select corrupt records only, cache DataFrame before executing queries.
+             |For example:
+             |df.cache()
+             |df.select("${parsedOptions.columnNameOfCorruptRecord}")
+         """.stripMargin)
       }
-      val parser = new JacksonParser(querySchema, parsedOptions)
+      val parser = new JacksonParser(actualSchema, parsedOptions)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,
         file,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -116,15 +116,14 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     if (requiredSchema.length == 1 &&
       requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
       throw new AnalysisException(
-        s"'${parsedOptions.columnNameOfCorruptRecord}' cannot be selected alone without other\n" +
-        "data columns, because its content is completely derived from the data columns parsed.\n" +
-        "Even your queries looks not only select this column, if after column pruning it isn't\n" +
-        "involving paring any data fields, e.g., filtering on the column followed by a \n" +
-        "counting, it can produce incorrect results and so disallowed.\n" +
-        "If you want to select corrupt records only, cache or save the Dataset\n" +
-        "before executing queries, as this parses all fields under the hood. For example: \n" +
-        "df.cache()\n" +
-        s"""df.select("${parsedOptions.columnNameOfCorruptRecord}")"""
+        "Since Spark 2.3, the queries from raw JSON/CSV files are disallowed when the\n" +
+        "referenced columns only include the internal corrupt record column\n" +
+        s"(named ${parsedOptions.columnNameOfCorruptRecord} by default). For example:\n" +
+        "spark.read.schema(schema).json(file).filter($\"_corrupt_record\".isNotNull).count()\n" +
+        "and spark.read.schema(schema).json(file).select(\"_corrupt_record\").show().\n" +
+        "Instead, you can cache or save the parsed results and then send the same query.\n" +
+        "For example, val df = spark.read.schema(schema).json(file).cache() and then\n" +
+        "df.filter($\"_corrupt_record\".isNotNull).count()."
       )
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -113,18 +113,19 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       }
     }
 
+    if (requiredSchema.length == 1 &&
+      requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
+      throw new AnalysisException(
+        s"""
+           |'${parsedOptions.columnNameOfCorruptRecord}' cannot be selected alone without other
+           |data columns. If you want to select corrupt records only, cache or save the Dataset
+           |before executing queries. For example:
+           |df.cache() then
+           |df.select("${parsedOptions.columnNameOfCorruptRecord}")
+         """.stripMargin.replaceAll(System.lineSeparator(), " "))
+    }
+
     (file: PartitionedFile) => {
-      if (actualSchema.isEmpty && requiredSchema.length == 1 &&
-        requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
-        throw new AnalysisException(
-          s"""
-             |'${parsedOptions.columnNameOfCorruptRecord}' must be selected along with input schema.
-             |If you want to select corrupt records only, cache or save the Dataset before executing queries.
-             |For example:
-             |df.cache()
-             |df.select("${parsedOptions.columnNameOfCorruptRecord}")
-         """.stripMargin)
-      }
       val parser = new JacksonParser(actualSchema, parsedOptions)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -114,10 +114,6 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     }
 
     (file: PartitionedFile) => {
-      // SPARK-21610: when the `requiredSchema` only contains `_corrupt_record`,
-      // the derived `actualSchema` is empty and the `_corrupt_record` are all null for all rows.
-      // When users requires only `_corrupt_record`, we assume that the corrupt records are required
-      // for all json fields, i.g., all items in dataSchema.
       if (actualSchema.isEmpty && requiredSchema.length == 1 &&
         requiredSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
         throw new AnalysisException(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2051,9 +2051,14 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
       .add("field", ByteType)
       .add("_corrupt_record", StringType)
 
-    val dfFromFile = spark.read.schema(schema).json(file.getAbsolutePath)
-    assert(dfFromFile.filter($"_corrupt_record".isNotNull).count() == 1)
-    assert(dfFromFile.filter($"_corrupt_record".isNull).count() == 2)
+    val errMsg = intercept[SparkException] {
+      spark.read
+        .schema(schema)
+        .json(file.getAbsolutePath)
+        .select("_corrupt_record")
+        .show()
+    }.getMessage
+    assert(errMsg.contains("'_corrupt_record' must be selected along with input schema."))
 
     Utils.deleteRecursively(tempDir)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2043,7 +2043,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         """{"field": 1}
           |{"field": 2}
           |{"field": "3"}""".stripMargin
-      sparkContext.parallelize(Seq(data), 1).saveAsTextFile(path)
+      Seq(data).toDF().repartition(1).write.text(path)
 
       val schema = new StructType()
         .add("field", ByteType)
@@ -2053,7 +2053,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         spark.read.schema(schema).json(path).select("_corrupt_record").collect()
       }.getMessage
       assert(errMsg.contains(
-        "'_corrupt_record' cannot be selected alone without other data columns."))
+        "'_corrupt_record' cannot be selected alone without other data columns"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2052,8 +2052,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
       val errMsg = intercept[AnalysisException] {
         spark.read.schema(schema).json(path).select("_corrupt_record").collect()
       }.getMessage
-      assert(errMsg.contains(
-        "'_corrupt_record' cannot be selected alone without other data columns"))
+      assert(errMsg.contains("'_corrupt_record' cannot be selected alone"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -782,7 +782,11 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
     val tempDir = Utils.createTempDir()
     val file = new File(tempDir, "sample.json")
     val writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)
-    writer.write(Seq("{\"field\": 1}", "{\"field\": 2}", "{\"field\": \"3\"}").mkString("\n"))
+    val data =
+      """{"field": 1}
+        |{"field": 2}
+        |{"field": "3"}""".stripMargin
+    writer.write(data)
     writer.close()
 
     val schema = new StructType()
@@ -792,5 +796,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
     val dfFromFile = spark.read.schema(schema).json(file.getAbsolutePath)
     assert(dfFromFile.filter($"_corrupt_record".isNotNull).count() == 1)
     assert(dfFromFile.filter($"_corrupt_record".isNull).count() == 2)
+
+    Utils.deleteRecursively(tempDir)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.test
 
-import java.io.{File, FileOutputStream, OutputStreamWriter}
-import java.nio.charset.StandardCharsets
+import java.io.File
 import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -775,28 +774,5 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
         }
       }
     }
-  }
-
-  test("SPARK-21610: Corrupt records are not handled properly when creating a dataframe " +
-    "from a file") {
-    val tempDir = Utils.createTempDir()
-    val file = new File(tempDir, "sample.json")
-    val writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)
-    val data =
-      """{"field": 1}
-        |{"field": 2}
-        |{"field": "3"}""".stripMargin
-    writer.write(data)
-    writer.close()
-
-    val schema = new StructType()
-      .add("field", ByteType)
-      .add("_corrupt_record", StringType)
-
-    val dfFromFile = spark.read.schema(schema).json(file.getAbsolutePath)
-    assert(dfFromFile.filter($"_corrupt_record".isNotNull).count() == 1)
-    assert(dfFromFile.filter($"_corrupt_record".isNull).count() == 2)
-
-    Utils.deleteRecursively(tempDir)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.test
 
-import java.io.File
+import java.io.{File, FileOutputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
 import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -774,5 +775,22 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
         }
       }
     }
+  }
+
+  test("SPARK-21610: Corrupt records are not handled properly when creating a dataframe " +
+    "from a file") {
+    val tempDir = Utils.createTempDir()
+    val file = new File(tempDir, "sample.json")
+    val writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)
+    writer.write(Seq("{\"field\": 1}", "{\"field\": 2}", "{\"field\": \"3\"}").mkString("\n"))
+    writer.close()
+
+    val schema = new StructType()
+      .add("field", ByteType)
+      .add("_corrupt_record", StringType)
+
+    val dfFromFile = spark.read.schema(schema).json(file.getAbsolutePath)
+    assert(dfFromFile.filter($"_corrupt_record".isNotNull).count() == 1)
+    assert(dfFromFile.filter($"_corrupt_record".isNull).count() == 2)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
```
echo '{"field": 1}
{"field": 2}
{"field": "3"}' >/tmp/sample.json
```

```scala
import org.apache.spark.sql.types._

val schema = new StructType()
  .add("field", ByteType)
  .add("_corrupt_record", StringType)

val file = "/tmp/sample.json"

val dfFromFile = spark.read.schema(schema).json(file)

scala> dfFromFile.show(false)
+-----+---------------+
|field|_corrupt_record|
+-----+---------------+
|1    |null           |
|2    |null           |
|null |{"field": "3"} |
+-----+---------------+

scala> dfFromFile.filter($"_corrupt_record".isNotNull).count()
res1: Long = 0

scala> dfFromFile.filter($"_corrupt_record".isNull).count()
res2: Long = 3
```
When the `requiredSchema` only contains `_corrupt_record`, the derived `actualSchema` is empty and the `_corrupt_record` are all null for all rows. This PR captures above situation and raise an exception with a reasonable workaround messag so that users can know what happened and how to fix the query.

## How was this patch tested?

Added test case.
