### PR TITLE
[SPARK-21649][SQL] Support writing data into hive bucket table.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -202,14 +202,14 @@ object CatalogUtils {
       tableCols: Seq[String],
       bucketSpec: BucketSpec,
       resolver: Resolver): BucketSpec = {
-    val BucketSpec(numBuckets, bucketColumnNames, sortColumnNames, _) = bucketSpec
+    val BucketSpec(numBuckets, bucketColumnNames, sortColumnNames, isHiveBucket) = bucketSpec
     val normalizedBucketCols = bucketColumnNames.map { colName =>
       normalizeColumnName(tableName, tableCols, colName, "bucket", resolver)
     }
     val normalizedSortCols = sortColumnNames.map { colName =>
       normalizeColumnName(tableName, tableCols, colName, "sort", resolver)
     }
-    BucketSpec(numBuckets, normalizedBucketCols, normalizedSortCols, bucketSpec.isHiveBucket)
+    BucketSpec(numBuckets, normalizedBucketCols, normalizedSortCols, isHiveBucket)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -202,14 +202,14 @@ object CatalogUtils {
       tableCols: Seq[String],
       bucketSpec: BucketSpec,
       resolver: Resolver): BucketSpec = {
-    val BucketSpec(numBuckets, bucketColumnNames, sortColumnNames) = bucketSpec
+    val BucketSpec(numBuckets, bucketColumnNames, sortColumnNames, _) = bucketSpec
     val normalizedBucketCols = bucketColumnNames.map { colName =>
       normalizeColumnName(tableName, tableCols, colName, "bucket", resolver)
     }
     val normalizedSortCols = sortColumnNames.map { colName =>
       normalizeColumnName(tableName, tableCols, colName, "sort", resolver)
     }
-    BucketSpec(numBuckets, normalizedBucketCols, normalizedSortCols)
+    BucketSpec(numBuckets, normalizedBucketCols, normalizedSortCols, bucketSpec.isHiveBucket)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -155,11 +155,13 @@ case class CatalogTablePartition(
  * @param numBuckets number of buckets.
  * @param bucketColumnNames the names of the columns that used to generate the bucket id.
  * @param sortColumnNames the names of the columns that used to sort data in each bucket.
+ * @param isHiveBucket if the spec is for Hive bucket table.
  */
 case class BucketSpec(
     numBuckets: Int,
     bucketColumnNames: Seq[String],
-    sortColumnNames: Seq[String]) {
+    sortColumnNames: Seq[String],
+    isHiveBucket: Boolean = false) {
   if (numBuckets <= 0 || numBuckets >= 100000) {
     throw new AnalysisException(
       s"Number of buckets should be greater than 0 but less than 100000. Got `$numBuckets`")
@@ -172,7 +174,12 @@ case class BucketSpec(
     } else {
       ""
     }
-    s"$numBuckets buckets, $bucketString$sortString"
+    val isHiveBucketString = if (isHiveBucket) {
+      ", it is hive bucket."
+    } else {
+      ", it is not hive bucket."
+    }
+    s"$numBuckets buckets, $bucketString$sortString$isHiveBucketString"
   }
 
   def toLinkedHashMap: mutable.LinkedHashMap[String, String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -47,7 +47,8 @@ case object AllTuples extends Distribution
  * Represents data where tuples that share the same values for the `clustering`
  * [[Expression Expressions]] will be co-located. Based on the context, this
  * can mean such tuples are either co-located in the same partition or they will be contiguous
- * within a single partition.
+ * within a single partition. `clusterOpt` indicates the numbers of partitions. `useHiveHash`
+ * tells if Hive hash should be used when do partitioning.
  */
 case class ClusteredDistribution(clustering: Seq[Expression], clustersOpt: Option[Int] = None,
                                  useHiveHash: Boolean = false) extends Distribution {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -80,6 +80,31 @@ class DistributionSuite extends SparkFunSuite {
       false)
 
     checkSatisfied(
+      HashPartitioning(Seq('a, 'b), 10),
+      ClusteredDistribution(Seq('a, 'b), Some(10)),
+      true)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b), 10),
+      ClusteredDistribution(Seq('a, 'b), Some(5)),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b), 10, useHiveHash = true),
+      ClusteredDistribution(Seq('a, 'b), Some(10), useHiveHash = true),
+      true)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b), 10, useHiveHash = false),
+      ClusteredDistribution(Seq('a, 'b), Some(10), useHiveHash = true),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b), 10, useHiveHash = true),
+      ClusteredDistribution(Seq('a, 'b), Some(10), useHiveHash = false),
+      false)
+
+    checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
       AllTuples,
       false)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/PartitioningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/PartitioningSuite.scala
@@ -52,4 +52,12 @@ class PartitioningSuite extends SparkFunSuite {
     assert(partitioningA.guarantees(partitioningA))
     assert(partitioningA.compatibleWith(partitioningA))
   }
+
+  test("HashPartitioning compatibility should be sensitive to whether Hive hash is used.") {
+    val expressions = Seq(Literal(2), Literal(3))
+    val partitioningA = HashPartitioning(expressions, 100, useHiveHash = false)
+    val partitioningB = HashPartitioning(expressions, 100, useHiveHash = true)
+    assert(!partitioningA.compatibleWith(partitioningB))
+    assert(!partitioningA.guarantees(partitioningB))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -427,12 +427,13 @@ class TreeNodeSuite extends SparkFunSuite {
 
     // Converts BucketSpec to JSON
     assertJSON(
-      BucketSpec(1, Seq("bucket"), Seq("sort")),
+      BucketSpec(1, Seq("bucket"), Seq("sort"), true),
       JObject(
         "product-class" -> classOf[BucketSpec].getName,
         "numBuckets" -> 1,
         "bucketColumnNames" -> "[bucket]",
-        "sortColumnNames" -> "[sort]"))
+        "sortColumnNames" -> "[sort]",
+        "isHiveBucket" -> true))
 
     // Converts WindowFrame to JSON
     assertJSON(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1093,7 +1093,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
     val partitionCols = Option(ctx.partitionColumns).map(visitColTypeList).getOrElse(Nil)
     val properties = Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty)
     val selectQuery = Option(ctx.query).map(plan)
-    val bucketSpec = Option(ctx.bucketSpec()).map(visitBucketSpec)
+    val bucketSpec = Option(ctx.bucketSpec()).map(visitBucketSpec).map(_.copy(isHiveBucket = true))
 
     // Note: Hive requires partition columns to be distinct from the schema, so we need
     // to include the partition columns here explicitly

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -50,7 +50,8 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       numPartitions: Int): Partitioning = {
     requiredDistribution match {
       case AllTuples => SinglePartition
-      case ClusteredDistribution(clustering) => HashPartitioning(clustering, numPartitions)
+      case ClusteredDistribution(clustering, clustersOpt, useHiveHash) =>
+        HashPartitioning(clustering, clustersOpt.getOrElse(numPartitions), useHiveHash)
       case OrderedDistribution(ordering) => RangePartitioning(ordering, numPartitions)
       case dist => sys.error(s"Do not know how to satisfy distribution $dist")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
@@ -203,7 +203,7 @@ object ShuffleExchange {
       serializer: Serializer): ShuffleDependency[Int, InternalRow, InternalRow] = {
     val part: Partitioner = newPartitioning match {
       case RoundRobinPartitioning(numPartitions) => new HashPartitioner(numPartitions)
-      case HashPartitioning(_, n) =>
+      case HashPartitioning(_, n, _) =>
         new Partitioner {
           override def numPartitions: Int = n
           // For HashPartitioning, the partitioning key is already a valid partition ID, as we use

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ReorderJoinPredicates.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ReorderJoinPredicates.scala
@@ -54,13 +54,13 @@ class ReorderJoinPredicates extends Rule[SparkPlan] {
 
     if (leftKeys.forall(_.deterministic) && rightKeys.forall(_.deterministic)) {
       leftPartitioning match {
-        case HashPartitioning(leftExpressions, _)
+        case HashPartitioning(leftExpressions, _, _)
           if leftExpressions.length == leftKeys.length &&
             leftKeys.forall(x => leftExpressions.exists(_.semanticEquals(x))) =>
           reorder(leftExpressions, leftKeys)
 
         case _ => rightPartitioning match {
-          case HashPartitioning(rightExpressions, _)
+          case HashPartitioning(rightExpressions, _, _)
             if rightExpressions.length == rightKeys.length &&
               rightKeys.forall(x => rightExpressions.exists(_.semanticEquals(x))) =>
             reorder(rightExpressions, rightKeys)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -92,7 +92,7 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
     withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
       val strategy = DataSourceStrategy(spark.sessionState.conf)
       val bucketedDataFrame = spark.table("bucketed_table").select("i", "j", "k")
-      val BucketSpec(numBuckets, bucketColumnNames, _) = bucketSpec
+      val BucketSpec(numBuckets, bucketColumnNames, _, _) = bucketSpec
       // Limit: bucket pruning only works when the bucket column has one and only one column
       assert(bucketColumnNames.length == 1)
       val bucketColumnIndex = bucketedDataFrame.schema.fieldIndex(bucketColumnNames.head)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -413,8 +413,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
 
     if (bucketSpec.isDefined) {
-      val BucketSpec(numBuckets, bucketColumnNames, sortColumnNames) = bucketSpec.get
+      val BucketSpec(numBuckets, bucketColumnNames, sortColumnNames, isHiveBucket) = bucketSpec.get
 
+      properties.put(DATASOURCE_SCHEMA_ISHIVEBUCKET, isHiveBucket.toString)
       properties.put(DATASOURCE_SCHEMA_NUMBUCKETS, numBuckets.toString)
       properties.put(DATASOURCE_SCHEMA_NUMBUCKETCOLS, bucketColumnNames.length.toString)
       bucketColumnNames.zipWithIndex.foreach { case (bucketCol, index) =>
@@ -737,9 +738,10 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
 
     // Get the original table properties as defined by the user.
-    table.copy(
+    val ret = table.copy(
       createVersion = version,
       properties = table.properties.filterNot { case (key, _) => key.startsWith(SPARK_SQL_PREFIX) })
+    ret
   }
 
   // Reorder table schema to put partition columns at the end. Before Spark 2.2, the partition
@@ -757,9 +759,17 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   private def restoreHiveSerdeTable(table: CatalogTable): CatalogTable = {
-    val hiveTable = table.copy(
-      provider = Some(DDLUtils.HIVE_PROVIDER),
-      tracksPartitionsInCatalog = true)
+    val hiveTable = table.bucketSpec match {
+      case Some(spec) =>
+        table.copy(
+          provider = Some(DDLUtils.HIVE_PROVIDER),
+          tracksPartitionsInCatalog = true,
+          bucketSpec = Some(spec.copy(isHiveBucket = true)))
+      case None =>
+        table.copy(
+          provider = Some(DDLUtils.HIVE_PROVIDER),
+          tracksPartitionsInCatalog = true)
+    }
 
     // If this is a Hive serde table created by Spark 2.1 or higher versions, we should restore its
     // schema from table properties.
@@ -1196,6 +1206,7 @@ object HiveExternalCatalog {
   val DATASOURCE_SCHEMA_NUMPARTS = DATASOURCE_SCHEMA_PREFIX + "numParts"
   val DATASOURCE_SCHEMA_NUMPARTCOLS = DATASOURCE_SCHEMA_PREFIX + "numPartCols"
   val DATASOURCE_SCHEMA_NUMSORTCOLS = DATASOURCE_SCHEMA_PREFIX + "numSortCols"
+  val DATASOURCE_SCHEMA_ISHIVEBUCKET = DATASOURCE_SCHEMA_PREFIX + "isHiveBucket"
   val DATASOURCE_SCHEMA_NUMBUCKETS = DATASOURCE_SCHEMA_PREFIX + "numBuckets"
   val DATASOURCE_SCHEMA_NUMBUCKETCOLS = DATASOURCE_SCHEMA_PREFIX + "numBucketCols"
   val DATASOURCE_SCHEMA_PART_PREFIX = DATASOURCE_SCHEMA_PREFIX + "part."
@@ -1281,7 +1292,8 @@ object HiveExternalCatalog {
       BucketSpec(
         numBuckets.toInt,
         getColumnNamesByType(metadata.properties, "bucket", "bucketing columns"),
-        getColumnNamesByType(metadata.properties, "sort", "sorting columns"))
+        getColumnNamesByType(metadata.properties, "sort", "sorting columns"),
+        metadata.properties.get(DATASOURCE_SCHEMA_ISHIVEBUCKET).getOrElse("false") == "true")
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -738,10 +738,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
 
     // Get the original table properties as defined by the user.
-    val ret = table.copy(
+    table.copy(
       createVersion = version,
       properties = table.properties.filterNot { case (key, _) => key.startsWith(SPARK_SQL_PREFIX) })
-    ret
   }
 
   // Reorder table schema to put partition columns at the end. Before Spark 2.2, the partition


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support writing hive bucket table. Spark internally uses Murmur3Hash for partitioning. We can use hive hash for compatibility when write to bucket table.

## How was this patch tested?

Unit test.