### PR TITLE
fix issue with spark-submit with java

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -361,7 +361,7 @@ $ mvn package
 
 # Use spark-submit to run your application
 $ YOUR_SPARK_HOME/bin/spark-submit \
-  --class "SimpleApp" \
+  --class SimpleApp \
   --master local[4] \
   target/simple-project-1.0.jar
 ...


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove quote when specifying class using spark-submit in command line.
Specifying java class with quote does not work. Suggest to remove it.

## How was this patch tested?

Built and the code for this application, ran jekyll locally per docs/README.md.
