### PR TITLE
[SPARK-21662] modify the appname to [SparkSQL::localHostName] instead of [SparkSQL::lP]	

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -940,7 +940,7 @@ private[spark] object Utils extends Logging {
    * Get the local machine's hostname.
    */
   def localHostName(): String = {
-    customHostname.getOrElse(localIpAddress.getHostAddress)
+    customHostname.getOrElse(localIpAddress.getCanonicalHostName)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -940,7 +940,7 @@ private[spark] object Utils extends Logging {
    * Get the local machine's hostname.
    */
   def localHostName(): String = {
-    customHostname.getOrElse(localIpAddress.getCanonicalHostName)
+    customHostname.getOrElse(localIpAddress.getHostAddress)
   }
 
   /**

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -35,7 +35,7 @@ private[hive] object SparkSQLEnv extends Logging {
   def init() {
     if (sqlContext == null) {
       val sparkConf = new SparkConf(loadDefaults = true)
-      // If user doesn't specify the appName, we want to get [SparkSQL::localHostName] instead of
+      // If user doesn't specify the appName, we will get [SparkSQL::IP] instead of
       // the default appName [SparkSQLCLIDriver] in cli or beeline.
       val maybeAppName = sparkConf
         .getOption("spark.app.name")


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-21662](https://issues.apache.org/jira/browse/SPARK-21662)
As it says "If user doesn't specify the appName, we want to get [SparkSQL::localHostName]" in SparkSqlEnv.scala,line 38,appname should be SparkSQL::localHostName,but it is SparkSQL::lP in fact.So I modify the localHostName method to get localhost with getCanonicalHostName method.