### PR TITLE
[SPARK-21652][SQL] Filter out meaningless constraints inferred in inferAdditionalConstraints

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/OptimizerUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/OptimizerUtils.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.sql.catalyst.expressions._
+
+
+/**
+ * Common utility methods used by Optimizer stuffs.
+ */
+object OptimizerUtils {
+
+  private def containsNonConjunctionPredicates(expression: Expression): Boolean = expression.find {
+    case _: Not | _: Or => true
+    case _ => false
+  }.isDefined
+
+  def getLiteralEqualityPredicates(conjunctivePredicates: Seq[Expression])
+    : Seq[((AttributeReference, Literal), BinaryComparison)] = {
+    val conjunctiveEqualPredicates =
+      conjunctivePredicates
+        .filter(expr => expr.isInstanceOf[EqualTo] || expr.isInstanceOf[EqualNullSafe])
+        .filterNot(expr => containsNonConjunctionPredicates(expr))
+    conjunctiveEqualPredicates.collect {
+      case e @ EqualTo(left: AttributeReference, right: Literal) => ((left, right), e)
+      case e @ EqualTo(left: Literal, right: AttributeReference) => ((right, left), e)
+      case e @ EqualNullSafe(left: AttributeReference, right: Literal) => ((left, right), e)
+      case e @ EqualNullSafe(left: Literal, right: AttributeReference) => ((right, left), e)
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added code to filter out meaningless constraints inferred in `inferAdditionalConstraints` (e.g., given constraint `a = 1`, `b = 1`, `a = c`, and  `b = c`, we inferred `a = b` and this predicate was trivially true). These constraints possibly cause some `Optimizer` overhead and, for example;
```
scala> Seq((1, 2)).toDF("col1", "col2").write.saveAsTable("t1")
scala> Seq(1, 2).toDF("col").write.saveAsTable("t2")
scala> spark.sql("SELECT * FROM t1, t2 WHERE t1.col1 = 1 AND 1 = t1.col2 AND t1.col1 = t2.col AND t1.col2 = t2.col").explain(true)
```

In this query, `InferFiltersFromConstraints` infers a new constraint '(col2#33 = col1#32)' that is appended to the join condition, then `PushPredicateThroughJoin` pushes it down, `ConstantPropagation` replaces '(col2#33 = col1#32)' with '1 = 1' based on other propagated constraints, `ConstantFolding` replaces '1 = 1' with 'true and `BooleanSimplification` finally removes this predicate. However, `InferFiltersFromConstraints` will again infer '(col2#33 = col1#32)' on the next iteration and the process will continue until the limit of iterations is reached.
See below for more details

```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints ===
!Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))                                       Join Inner, ((col2#33 = col1#32) && ((col1#32 = col#34) && (col2#33 = col#34)))
 :- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))   :- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))
 :  +- Relation[col1#32,col2#33] parquet                                                      :  +- Relation[col1#32,col2#33] parquet
 +- Filter ((1 = col#34) && isnotnull(col#34))                                                +- Filter ((1 = col#34) && isnotnull(col#34))
    +- Relation[col#34] parquet                                                                  +- Relation[col#34] parquet
                

=== Applying Rule org.apache.spark.sql.catalyst.optimizer.PushPredicateThroughJoin ===
!Join Inner, ((col2#33 = col1#32) && ((col1#32 = col#34) && (col2#33 = col#34)))              Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))
!:- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))   :- Filter (col2#33 = col1#32)
!:  +- Relation[col1#32,col2#33] parquet                                                      :  +- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))
!+- Filter ((1 = col#34) && isnotnull(col#34))                                                :     +- Relation[col1#32,col2#33] parquet
!   +- Relation[col#34] parquet                                                               +- Filter ((1 = col#34) && isnotnull(col#34))
!                                                                                                +- Relation[col#34] parquet
                

=== Applying Rule org.apache.spark.sql.catalyst.optimizer.CombineFilters ===
 Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))                                          Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))
!:- Filter (col2#33 = col1#32)                                                                   :- Filter (((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33))) && (col2#33 = col1#32))
!:  +- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))   :  +- Relation[col1#32,col2#33] parquet
!:     +- Relation[col1#32,col2#33] parquet                                                      +- Filter ((1 = col#34) && isnotnull(col#34))
!+- Filter ((1 = col#34) && isnotnull(col#34))                                                      +- Relation[col#34] parquet
!   +- Relation[col#34] parquet                                                                  
                

=== Applying Rule org.apache.spark.sql.catalyst.optimizer.ConstantPropagation ===
 Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))                                                                Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))
!:- Filter (((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33))) && (col2#33 = col1#32))   :- Filter (((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33))) && (1 = 1))
 :  +- Relation[col1#32,col2#33] parquet                                                                               :  +- Relation[col1#32,col2#33] parquet
 +- Filter ((1 = col#34) && isnotnull(col#34))                                                                         +- Filter ((1 = col#34) && isnotnull(col#34))
    +- Relation[col#34] parquet                                                                                           +- Relation[col#34] parquet
                

=== Applying Rule org.apache.spark.sql.catalyst.optimizer.ConstantFolding ===
 Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))                                                    Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))
!:- Filter (((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33))) && (1 = 1))   :- Filter (((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33))) && true)
 :  +- Relation[col1#32,col2#33] parquet                                                                   :  +- Relation[col1#32,col2#33] parquet
 +- Filter ((1 = col#34) && isnotnull(col#34))                                                             +- Filter ((1 = col#34) && isnotnull(col#34))
    +- Relation[col#34] parquet                                                                               +- Relation[col#34] parquet
                

=== Applying Rule org.apache.spark.sql.catalyst.optimizer.BooleanSimplification ===
 Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))                                                 Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))
!:- Filter (((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33))) && true)   :- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))
 :  +- Relation[col1#32,col2#33] parquet                                                                :  +- Relation[col1#32,col2#33] parquet
 +- Filter ((1 = col#34) && isnotnull(col#34))                                                          +- Filter ((1 = col#34) && isnotnull(col#34))
    +- Relation[col#34] parquet                                                                            +- Relation[col#34] parquet
                

=== Applying Rule org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints ===
!Join Inner, ((col1#32 = col#34) && (col2#33 = col#34))                                       Join Inner, ((col2#33 = col1#32) && ((col1#32 = col#34) && (col2#33 = col#34)))
 :- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))   :- Filter ((isnotnull(col1#32) && isnotnull(col2#33)) && ((col1#32 = 1) && (1 = col2#33)))
 :  +- Relation[col1#32,col2#33] parquet                                                      :  +- Relation[col1#32,col2#33] parquet
 +- Filter ((1 = col#34) && isnotnull(col#34))                                                +- Filter ((1 = col#34) && isnotnull(col#34))
    +- Relation[col#34] parquet  
```

## How was this patch tested?
Added tests in `InferFiltersFromConstraintsSuite`.
