### PR TITLE
[Spark-17025][ML][Python] Persistence for Pipelines with Python-only Stages

### DIFF
--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 if sys.version > '3':
     basestring = str
@@ -23,7 +24,8 @@ if sys.version > '3':
 from pyspark import since, keyword_only, SparkContext
 from pyspark.ml.base import Estimator, Model, Transformer
 from pyspark.ml.param import Param, Params
-from pyspark.ml.util import JavaMLWriter, JavaMLReader, MLReadable, MLWritable
+from pyspark.ml.util import JavaMLWriter, JavaMLReader, MLReadable, MLWritable, \
+    DefaultParamsWriter, DefaultParamsReader
 from pyspark.ml.wrapper import JavaParams
 from pyspark.ml.common import inherit_doc
 
@@ -130,13 +132,20 @@ class Pipeline(Estimator, MLReadable, MLWritable):
     @since("2.0.0")
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
-        return JavaMLWriter(self)
+        allStagesAreJava = True
+        stages = self.getStages()
+        for stage in stages:
+            if not isinstance(stage, JavaMLWritable):
+                allStagesAreJava = False
+        if allStagesAreJava:
+            return JavaMLWriter(self)
+        return PipelineWriter(self)
 
     @classmethod
     @since("2.0.0")
     def read(cls):
         """Returns an MLReader instance for this class."""
-        return JavaMLReader(cls)
+        return PipelineReader(cls)
 
     @classmethod
     def _from_java(cls, java_stage):
@@ -172,6 +181,76 @@ class Pipeline(Estimator, MLReadable, MLWritable):
 
 
 @inherit_doc
+class PipelineWriter(MLWriter):
+    """
+    (Private) Specialization of :py:class:`MLWriter` for :py:class:`Pipeline` types
+    """
+
+    def __init__(self, instance):
+        super(PipelineWriter, self).__init__()
+        self.instance = instance
+
+    def saveImpl(self, path):
+        stages = self.instance.getStages()
+        SharedReadWrite.validateStages(stages)
+        SharedReadWrite.saveImpl(self.instance, stages, self.sc, path)
+
+
+@inherit_doc
+class PipelineReader(MLReader):
+    """
+    (Private) Specialization of :py:class:`MLReader` for :py:class:`Pipeline` types
+    """
+
+    def __init__(self, cls):
+        super(PipelineReader, self).__init__()
+        self.cls = cls
+
+    def load(self, path):
+        metadata = DefaultParamsReader.loadMetadata(path, self.sc)
+        if 'savedAsPython' not in metadata['paramMap']:
+            return JavaMLReader(self.cls).load(path)
+        else:
+            uid, stages = SharedReadWrite.load(metadata, self.sc, path)
+            return Pipeline(stages=stages)._resetUid(uid)
+
+
+@inherit_doc
+class PipelineModelWriter(MLWriter):
+    """
+    (Private) Specialization of :py:class:`MLWriter` for :py:class:`PipelineModel` types
+    """
+
+    def __init__(self, instance):
+        super(PipelineModelWriter, self).__init__()
+        self.instance = instance
+
+    def saveImpl(self, path):
+        stages = self.instance.stages
+        SharedReadWrite.validateStages(stages)
+        SharedReadWrite.saveImpl(self.instance, stages, self.sc, path)
+
+
+@inherit_doc
+class PipelineModelReader(MLReader):
+    """
+    (Private) Specialization of :py:class:`MLReader` for :py:class:`PipelineModel` types
+    """
+
+    def __init__(self, cls):
+        super(PipelineModelReader, self).__init__()
+        self.cls = cls
+
+    def load(self, path):
+        metadata = DefaultParamsReader.loadMetadata(path, self.sc)
+        if 'savedAsPython' not in metadata['paramMap']:
+            return JavaMLReader(self.cls).load(path)
+        else:
+            uid, stages = SharedReadWrite.load(metadata, self.sc, path)
+            return PipelineModel(stages=stages)._resetUid(uid)
+
+
+@inherit_doc
 class PipelineModel(Model, MLReadable, MLWritable):
     """
     Represents a compiled pipeline with transformers and fitted models.
@@ -204,13 +283,20 @@ class PipelineModel(Model, MLReadable, MLWritable):
     @since("2.0.0")
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
-        return JavaMLWriter(self)
+        allStagesAreJava = True
+        stages = self.stages
+        for stage in stages:
+            if not isinstance(stage, JavaMLWritable):
+                allStagesAreJava = False
+        if allStagesAreJava:
+            return JavaMLWriter(self)
+        return PipelineModelWriter(self)
 
     @classmethod
     @since("2.0.0")
     def read(cls):
         """Returns an MLReader instance for this class."""
-        return JavaMLReader(cls)
+        return PipelineModelReader(cls)
 
     @classmethod
     def _from_java(cls, java_stage):
@@ -242,3 +328,65 @@ class PipelineModel(Model, MLReadable, MLWritable):
             JavaParams._new_java_obj("org.apache.spark.ml.PipelineModel", self.uid, java_stages)
 
         return _java_obj
+
+
+@inherit_doc
+class SharedReadWrite():
+    """
+    Functions for :py:class:`MLReader` and :py:class:`MLWriter` shared between
+    :py:class:'Pipeline' and :py:class'PipelineModel'
+
+    .. versionadded:: 2.3.0
+    """
+
+    @staticmethod
+    def validateStages(stages):
+        """
+        Check that all stages are Writable
+        """
+        for stage in stages:
+            if not isinstance(stage, MLWritable):
+                raise ValueError("Pipeline write will fail on this pipline " +
+                                 "because stage %s of type %s is not MLWritable",
+                                 stage.uid, type(stage))
+
+    @staticmethod
+    def saveImpl(instance, stages, sc, path):
+        """
+        Save metadata and stages for a :py:class:`Pipeline` or :py:class:`PipelineModel`
+        - save metadata to path/metadata
+        - save stages to stages/IDX_UID
+        """
+        stageUids = map(lambda x: x.uid, stages)
+        jsonParams = {'stageUids': stageUids, 'savedAsPython': True}
+        DefaultParamsWriter.saveMetadata(instance, path, sc, paramMap=jsonParams)
+        stagesDir = os.path.join(path, "stages")
+        for index, stage in enumerate(stages):
+            stage.write().save(SharedReadWrite
+                               .getStagePath(stage.uid, index, len(stages), stagesDir))
+
+    @staticmethod
+    def load(metadata, sc, path):
+        """
+        Load metadata and stages for a :py:class:`Pipeline` or :py:class:`PipelineModel`
+
+        :return:  (UID, list of stages)
+        """
+        stagesDir = os.path.join(path, "stages")
+        stageUids = metadata['paramMap']['stageUids']
+        stages = []
+        for index, stageUid in enumerate(stageUids):
+            stagePath = SharedReadWrite.getStagePath(stageUid, index, len(stageUids), stagesDir)
+            stage = DefaultParamsReader.loadParamsInstance(stagePath, sc)
+            stages.append(stage)
+        return (metadata['uid'], stages)
+
+    @staticmethod
+    def getStagePath(stageUid, stageIdx, numStages, stagesDir):
+        """
+        Get path for saving the given stage.
+        """
+        stageIdxDigits = len(str(numStages))
+        stageDir = str(stageIdxDigits) + "_" + stageUid
+        stagePath = os.path.join(stagesDir, stageDir)
+        return stagePath

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -24,8 +24,7 @@ if sys.version > '3':
 from pyspark import since, keyword_only, SparkContext
 from pyspark.ml.base import Estimator, Model, Transformer
 from pyspark.ml.param import Param, Params
-from pyspark.ml.util import JavaMLWriter, JavaMLReader, MLReadable, MLWritable, \
-    DefaultParamsWriter, DefaultParamsReader
+from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaParams
 from pyspark.ml.common import inherit_doc
 

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -131,11 +131,7 @@ class Pipeline(Estimator, MLReadable, MLWritable):
     @since("2.0.0")
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
-        allStagesAreJava = True
-        stages = self.getStages()
-        for stage in stages:
-            if not isinstance(stage, JavaMLWritable):
-                allStagesAreJava = False
+        allStagesAreJava = SharedReadWrite.checkStagesForJava(self.getStages())
         if allStagesAreJava:
             return JavaMLWriter(self)
         return PipelineWriter(self)
@@ -282,11 +278,7 @@ class PipelineModel(Model, MLReadable, MLWritable):
     @since("2.0.0")
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
-        allStagesAreJava = True
-        stages = self.stages
-        for stage in stages:
-            if not isinstance(stage, JavaMLWritable):
-                allStagesAreJava = False
+        allStagesAreJava = SharedReadWrite.checkStagesForJava(self.stages)
         if allStagesAreJava:
             return JavaMLWriter(self)
         return PipelineModelWriter(self)
@@ -337,6 +329,16 @@ class SharedReadWrite():
 
     .. versionadded:: 2.3.0
     """
+
+    @staticmethod
+    def checkStagesForJava(stages):
+        allStagesAreJava = True
+        stages = self.stages
+        for stage in stages:
+            if not isinstance(stage, JavaMLWritable):
+                allStagesAreJava = False
+                break
+        return allStagesAreJava
 
     @staticmethod
     def validateStages(stages):

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -356,7 +356,7 @@ class SharedReadWrite():
         - save metadata to path/metadata
         - save stages to stages/IDX_UID
         """
-        stageUids = map(lambda x: x.uid, stages)
+        stageUids = [stage.uid for stage in stages]
         jsonParams = {'stageUids': stageUids, 'savedAsPython': True}
         DefaultParamsWriter.saveMetadata(instance, path, sc, paramMap=jsonParams)
         stagesDir = os.path.join(path, "stages")

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -333,7 +333,6 @@ class SharedReadWrite():
     @staticmethod
     def checkStagesForJava(stages):
         allStagesAreJava = True
-        stages = self.stages
         for stage in stages:
             if not isinstance(stage, JavaMLWritable):
                 allStagesAreJava = False

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -325,7 +325,7 @@ class PipelineModel(Model, MLReadable, MLWritable):
 class SharedReadWrite():
     """
     Functions for :py:class:`MLReader` and :py:class:`MLWriter` shared between
-    :py:class:'Pipeline' and :py:class'PipelineModel'
+    :py:class:`Pipeline` and :py:class`PipelineModel`
 
     .. versionadded:: 2.3.0
     """
@@ -387,6 +387,6 @@ class SharedReadWrite():
         Get path for saving the given stage.
         """
         stageIdxDigits = len(str(numStages))
-        stageDir = str(stageIdxDigits) + "_" + stageUid
+        stageDir = str(stageIdx).zfill(stageIdxDigits) + "_" + stageUid
         stagePath = os.path.join(stagesDir, stageDir)
         return stagePath

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -324,6 +324,8 @@ class PipelineModel(Model, MLReadable, MLWritable):
 @inherit_doc
 class PipelineSharedReadWrite():
     """
+    .. note:: DeveloperApi
+
     Functions for :py:class:`MLReader` and :py:class:`MLWriter` shared between
     :py:class:`Pipeline` and :py:class:`PipelineModel`
 

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -369,7 +369,7 @@ class SharedReadWrite():
         """
         Load metadata and stages for a :py:class:`Pipeline` or :py:class:`PipelineModel`
 
-        :return:  (UID, list of stages)
+        :return: (UID, list of stages)
         """
         stagesDir = os.path.join(path, "stages")
         stageUids = metadata['paramMap']['stageUids']

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -419,8 +419,7 @@ class DefaultParamsWriter(MLWriter):
         basicMetadata = {"class": cls, "timestamp": long(round(time.time() * 1000)),
                          "sparkVersion": sc.version, "uid": uid, "paramMap": jsonParams}
         if extraMetadata is not None:
-            for key in extraMetadata:
-                basicMetadata[key] = extraMetadata[key]
+            basicMetadata.update(extraMetadata)
         return json.dumps(basicMetadata, separators=[',',  ':'])
 
 

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -419,7 +419,8 @@ class DefaultParamsWriter(MLWriter):
         basicMetadata = {"class": cls, "timestamp": long(round(time.time() * 1000)),
                          "sparkVersion": sc.version, "uid": uid, "paramMap": jsonParams}
         if extraMetadata is not None:
-            basicMetadata.update(extraMetadata)
+            for key, value in extraMetadata:
+                basicMetadata[key] = value
         return json.dumps(basicMetadata, separators=[',',  ':'])
 
 

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -419,8 +419,8 @@ class DefaultParamsWriter(MLWriter):
         basicMetadata = {"class": cls, "timestamp": long(round(time.time() * 1000)),
                          "sparkVersion": sc.version, "uid": uid, "paramMap": jsonParams}
         if extraMetadata is not None:
-            for key, value in extraMetadata:
-                basicMetadata[key] = value
+            for key in extraMetadata:
+                basicMetadata[key] = extraMetadata[key]
         return json.dumps(basicMetadata, separators=[',',  ':'])
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implemented a Python-only persistence framework for pipelines containing stages that cannot be saved using Java.

## How was this patch tested?

Created a custom Python-only UnaryTransformer, included it in a Pipeline, and saved/loaded the pipeline. The loaded pipeline was compared against the original using _compare_pipelines() in tests.py.