### PR TITLE
[SPARK-21587][SS] Added pushdown through watermarks.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -344,9 +344,6 @@ object LimitPushDown extends Rule[LogicalPlan] {
         case _ => join
       }
       LocalLimit(exp, newJoin)
-
-    case LocalLimit(exp, watermark: EventTimeWatermark) =>
-      LocalLimit(exp, watermark.copy(child = LocalLimit(exp, watermark.child)))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -144,13 +144,5 @@ class LimitPushdownSuite extends PlanTest {
     val correctAnswer = Limit(1, Limit(2, x).join(Limit(2, y), FullOuter)).analyze
     comparePlans(optimized, correctAnswer)
   }
-
-  test("watermark") {
-    val interval = new CalendarInterval(2, 2000L)
-    val originalQuery = EventTimeWatermark('a, interval, testRelation).limit(2)
-    val correctAnswer = Limit(2, EventTimeWatermark(
-      'a, interval, LocalLimit(2, testRelation))).analyze
-    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer, checkAnalysis = false)
-  }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.Add
 import org.apache.spark.sql.catalyst.plans.{FullOuter, LeftOuter, PlanTest, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
-import org.apache.spark.unsafe.types.CalendarInterval
 
 class LimitPushdownSuite extends PlanTest {
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
@@ -31,7 +31,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
     val batches = Batch(
       "RemoveAliasOnlyProject",
       FixedPoint(50),
-      PushProjectionThroughUnion,
+      PushProjection,
       RemoveRedundantAliases,
       RemoveRedundantProject) :: Nil
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.unsafe.types.CalendarInterval
 
 class SetOperationSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
@@ -32,7 +33,7 @@ class SetOperationSuite extends PlanTest {
         EliminateSubqueryAliases) ::
       Batch("Union Pushdown", Once,
         CombineUnions,
-        PushProjectionThroughUnion,
+        PushProjection,
         PushDownPredicate,
         PruneFilters) :: Nil
   }
@@ -143,5 +144,18 @@ class SetOperationSuite extends PlanTest {
       Union(Distinct(Union(query1 :: query2 :: Nil)),
             Distinct(Union(query3 :: query4 :: Nil))).analyze
     comparePlans(distinctUnionCorrectAnswer2, optimized2)
+  }
+
+  test("Push project through watermark when it contains the watermarked attribute") {
+    val interval = new CalendarInterval(2, 2000L)
+    val query = EventTimeWatermark('c, interval, testRelation).select('a, 'c)
+    val correctAnswer = EventTimeWatermark('c, interval, testRelation.select('a, 'c)).analyze
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze, checkAnalysis = false)
+  }
+
+  test("Don't push project through watermark when it doesn't contain the attribute") {
+    val interval = new CalendarInterval(2, 2000L)
+    val query = EventTimeWatermark('c, interval, testRelation).select('a, 'b')
+    comparePlans(Optimize.execute(query.analyze), query.analyze, checkAnalysis = false)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Filter predicates can be pushed through EventTimeWatermark if they're deterministic and do not reference the watermarked attribute.
Projects can be pushed through EventTimeWatermark if they include the watermarked attribute.

This is a copy of PR 18790, which I had to make so I could build the right commit history.

## How was this patch tested?

new unit tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
