### PR TITLE
[SPARK-21520][SQL]Improvement a special case for non-deterministic projects in optimizer

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
@@ -119,4 +119,28 @@ class CollapseProjectSuite extends PlanTest {
 
     comparePlans(optimized, correctAnswer)
   }
+
+  test("SPARK-21520 collapse project contains nondeterministic, dependent into one deterministic") {
+    val query = testRelation
+      .select(('a).as('a_plus))
+      .select(Rand(10).as('rand), 'a_plus)
+
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = query.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-21520 collapse project into one nondeterministic, dependent into two deterministic") {
+    val query = testRelation
+      .select(('a ).as('a_plus), ('b).as('b_plus))
+      .select(Rand(10).as('rand))
+
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = query.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -360,5 +360,47 @@ class ColumnPruningSuite extends PlanTest {
     comparePlans(optimized2, expected2.analyze)
   }
 
+  test("SPARK-21520 the fields of project only is nondeterministic") {
+    val testRelation = LocalRelation('key.int, 'value.string)
+
+    // The fields of project only is non-deterministic.
+    val originalQuery =
+    testRelation
+      .select(Rand(10).as("rand"))
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    // correctAnswer:
+    // Project [rand(10) AS rand#5]
+    // +- LocalRelation <empty>, [key#0, value#1]
+    val correctAnswer = originalQuery.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-21520 the fields of project contains nondeterministic") {
+    val testRelation = LocalRelation('key.int, 'value.string)
+
+    // The fields of project contains non-deterministic.
+    // e.g Rand function. project will be split to two project.
+    val originalQuery =
+    testRelation
+      .select($"key".as("key_a"), Rand(10).as("rand"))
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    // correctAnswer:
+    // Project [key#0 AS key_a#4, rand(10) AS rand#5]
+    // +- Project [key#0]
+    //    +- LocalRelation <empty>, [key#0, value#1]
+    val correctAnswer =
+    testRelation
+      .select($"key")
+      .select($"key".as("key_a"), Rand(10).as("rand"))
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
   // todo: add more tests for column pruning
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Did a lot of special handling for non-deterministic projects and filters in optimizer. but not good enough. this patch add a new special case for non-deterministic projects. Deal with that we only need to read user needs fields for non-deterministic projects in optimizer.
For example, the fields of project contains nondeterministic function(rand function), after a executedPlan optimizer generated:
```
*HashAggregate(keys=[k#403L], functions=[partial_sum(cast(id#402 as bigint))], output=[k#403L, sum#800L])
+- Project [d004#607 AS id#402, FLOOR((rand(8828525941469309371) * 10000.0)) AS k#403L]
   +- HiveTableScan [c030#606L, d004#607, d005#608, d025#609, c002#610, d023#611, d024#612, c005#613L, c008#614, c009#615, c010#616, d021#617, d022#618, c017#619, c018#620, c019#621, c020#622, c021#623, c022#624, c023#625, c024#626, c025#627, c026#628, c027#629, ... 169 more fields], MetastoreRelation XXX_database, XXX_table
```
HiveTableScan will read all the fields from table. but we only need to ‘d004’ . it will affect the performance of task.

## How was this patch tested?

Should be covered existing test cases and add test cases.
