### PR TITLE
[SPARK-21655][YARN] Support Kill CLI for Yarn mode

### DIFF
--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -61,6 +61,15 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-yarn-common</artifactId>
+    </dependency>
+
     <!-- Provided dependencies -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -75,6 +75,7 @@ public class TransportClient implements Closeable {
   private final Channel channel;
   private final TransportResponseHandler handler;
   @Nullable private String clientId;
+  @Nullable private String clientUser;
   private volatile boolean timedOut;
 
   public TransportClient(Channel channel, TransportResponseHandler handler) {
@@ -112,6 +113,25 @@ public class TransportClient implements Closeable {
   public void setClientId(String id) {
     Preconditions.checkState(clientId == null, "Client ID has already been set.");
     this.clientId = id;
+  }
+
+  /**
+   * Returns the user name used by the client to authenticate itself when authentication is enabled.
+   *
+   * @return The client User Name, or null if authentication is disabled.
+   */
+  public String getClientUser() {
+    return clientUser;
+  }
+
+  /**
+   * Sets the authenticated client's user name. This is meant to be used by the authentication layer.
+   *
+   * Trying to set a different client User Name after it's been set will result in an exception.
+   */
+  public void setClientUser(String user) {
+    Preconditions.checkState(clientUser == null, "Client User Name has already been set.");
+    this.clientUser = user;
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslClientBootstrap.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslClientBootstrap.java
@@ -57,7 +57,7 @@ public class SaslClientBootstrap implements TransportClientBootstrap {
    */
   @Override
   public void doBootstrap(TransportClient client, Channel channel) {
-    SparkSaslClient saslClient = new SparkSaslClient(appId, secretKeyHolder, conf.saslEncryption());
+    SparkSaslClient saslClient = new SparkSaslClient(appId, secretKeyHolder, conf.saslEncryption(), conf);
     try {
       byte[] payload = saslClient.firstToken();
 

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
@@ -95,7 +95,7 @@ public class SaslRpcHandler extends RpcHandler {
         // First message in the handshake, setup the necessary state.
         client.setClientId(saslMessage.appId);
         saslServer = new SparkSaslServer(saslMessage.appId, secretKeyHolder,
-          conf.saslServerAlwaysEncrypt());
+          conf.saslServerAlwaysEncrypt(), conf);
       }
 
       byte[] response;
@@ -114,6 +114,7 @@ public class SaslRpcHandler extends RpcHandler {
     // method returns. This assumes that the code ensures, through other means, that no outbound
     // messages are being written to the channel while negotiation is still going on.
     if (saslServer.isComplete()) {
+      cient.setClientUser(saslServer.getUserName());
       if (!SparkSaslServer.QOP_AUTH_CONF.equals(saslServer.getNegotiatedProperty(Sasl.QOP))) {
         logger.debug("SASL authentication successful for channel {}", client);
         complete(true);

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
@@ -114,7 +114,7 @@ public class SaslRpcHandler extends RpcHandler {
     // method returns. This assumes that the code ensures, through other means, that no outbound
     // messages are being written to the channel while negotiation is still going on.
     if (saslServer.isComplete()) {
-      cient.setClientUser(saslServer.getUserName());
+      client.setClientUser(saslServer.getUserName());
       if (!SparkSaslServer.QOP_AUTH_CONF.equals(saslServer.getNegotiatedProperty(Sasl.QOP))) {
         logger.debug("SASL authentication successful for channel {}", client);
         complete(true);

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslClient.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.spark.network.sasl.SparkSaslServer.*;
 
+import org.apache.spark.network.util.TransportConf;
+
 /**
  * A SASL Client for Spark which simply keeps track of the state of a single SASL session, from the
  * initial state to the "authenticated" state. This client initializes the protocol via a
@@ -48,12 +50,25 @@ public class SparkSaslClient implements SaslEncryptionBackend {
   private final String secretKeyId;
   private final SecretKeyHolder secretKeyHolder;
   private final String expectedQop;
+  private TransportConf conf;
   private SaslClient saslClient;
 
-  public SparkSaslClient(String secretKeyId, SecretKeyHolder secretKeyHolder, boolean encrypt) {
+  public SparkSaslClient(
+      String secretKeyId,
+      SecretKeyHolder secretKeyHolder,
+      boolean alwaysEncrypt) {
+    this(secretKeyId,secretKeyHolder,alwaysEncrypt, null);
+  }
+
+  public SparkSaslClient(
+      String secretKeyId,
+      SecretKeyHolder secretKeyHolder,
+      boolean encrypt,
+      TransportConf conf) {
     this.secretKeyId = secretKeyId;
     this.secretKeyHolder = secretKeyHolder;
     this.expectedQop = encrypt ? QOP_AUTH_CONF : QOP_AUTH;
+    this.conf = conf;
 
     Map<String, String> saslProps = ImmutableMap.<String, String>builder()
       .put(Sasl.QOP, expectedQop)
@@ -131,11 +146,23 @@ public class SparkSaslClient implements SaslEncryptionBackend {
         if (callback instanceof NameCallback) {
           logger.trace("SASL client callback: setting username");
           NameCallback nc = (NameCallback) callback;
-          nc.setName(encodeIdentifier(secretKeyHolder.getSaslUser(secretKeyId)));
+          if (conf != null && conf.isConnectionUsingTokens()) {
+            // Token Identifier is already encoded
+            nc.setName(secretKeyHolder.getSaslUser(secretKeyId));
+          } else {
+            nc.setName(encodeIdentifier(secretKeyHolder.getSaslUser(secretKeyId)));
+          }
+
         } else if (callback instanceof PasswordCallback) {
           logger.trace("SASL client callback: setting password");
           PasswordCallback pc = (PasswordCallback) callback;
-          pc.setPassword(encodePassword(secretKeyHolder.getSecretKey(secretKeyId)));
+          if (conf != null && conf.isConnectionUsingTokens()) {
+            // Token Identifier is already encoded
+            pc.setPassword(secretKeyHolder.getSecretKey(secretKeyId).toCharArray());
+          } else {
+            pc.setPassword(encodePassword(secretKeyHolder.getSecretKey(secretKeyId)));
+
+          }
         } else if (callback instanceof RealmCallback) {
           logger.trace("SASL client callback: setting realm");
           RealmCallback rc = (RealmCallback) callback;

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java
@@ -27,6 +27,8 @@ import javax.security.sasl.RealmCallback;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -39,6 +41,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.base64.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.security.token.SecretManager.InvalidToken;
+import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
+import org.apache.hadoop.yarn.security.client.ClientToAMTokenIdentifier;
+
+import org.apache.spark.network.util.TransportConf;
 
 /**
  * A SASL Server for Spark which simply keeps track of the state of a single SASL session, from the
@@ -73,14 +81,25 @@ public class SparkSaslServer implements SaslEncryptionBackend {
   /** Identifier for a certain secret key within the secretKeyHolder. */
   private final String secretKeyId;
   private final SecretKeyHolder secretKeyHolder;
+  private TransportConf conf;
+  private String clientUser;
   private SaslServer saslServer;
 
   public SparkSaslServer(
       String secretKeyId,
       SecretKeyHolder secretKeyHolder,
       boolean alwaysEncrypt) {
+    this(secretKeyId, secretKeyHolder, alwaysEncrypt, null);
+  }
+
+  public SparkSaslServer(
+      String secretKeyId,
+      SecretKeyHolder secretKeyHolder,
+      boolean alwaysEncrypt,
+      TransportConf conf) {
     this.secretKeyId = secretKeyId;
     this.secretKeyHolder = secretKeyHolder;
+    this.conf = conf;
 
     // Sasl.QOP is a comma-separated list of supported values. The value that allows encryption
     // is listed first since it's preferred over the non-encrypted one (if the client also
@@ -96,6 +115,13 @@ public class SparkSaslServer implements SaslEncryptionBackend {
     } catch (SaslException e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  /**
+   * Returns the user name of the client.
+   */
+  public String getUserName() {
+    return clientUser;
   }
 
   /**
@@ -156,15 +182,16 @@ public class SparkSaslServer implements SaslEncryptionBackend {
   private class DigestCallbackHandler implements CallbackHandler {
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+      NameCallback nc = null;
+      PasswordCallback pc = null;
       for (Callback callback : callbacks) {
         if (callback instanceof NameCallback) {
           logger.trace("SASL server callback: setting username");
-          NameCallback nc = (NameCallback) callback;
+          nc = (NameCallback) callback;
           nc.setName(encodeIdentifier(secretKeyHolder.getSaslUser(secretKeyId)));
         } else if (callback instanceof PasswordCallback) {
           logger.trace("SASL server callback: setting password");
-          PasswordCallback pc = (PasswordCallback) callback;
-          pc.setPassword(encodePassword(secretKeyHolder.getSecretKey(secretKeyId)));
+          pc = (PasswordCallback) callback;
         } else if (callback instanceof RealmCallback) {
           logger.trace("SASL server callback: setting realm");
           RealmCallback rc = (RealmCallback) callback;
@@ -182,10 +209,45 @@ public class SparkSaslServer implements SaslEncryptionBackend {
           throw new UnsupportedCallbackException(callback, "Unrecognized SASL DIGEST-MD5 Callback");
         }
       }
+      if (pc != null) {
+        if (conf != null && conf.isConnectionUsingTokens()) {
+          ClientToAMTokenSecretManager secretManager = new ClientToAMTokenSecretManager(null,
+            decodeMasterKey(secretKeyHolder.getSecretKey(secretKeyId)));
+          ClientToAMTokenIdentifier identifier = getIdentifier(nc.getDefaultName());
+          clientUser = identifier.getUser().getShortUserName();
+          pc.setPassword(getClientToAMSecretKey(identifier, secretManager));
+        } else {
+          clientUser = nc.getDefaultName();
+          pc.setPassword(encodePassword(secretKeyHolder.getSecretKey(secretKeyId)));
+        }
+      }
     }
   }
 
-  /* Encode a byte[] identifier as a Base64-encoded string. */
+  /** Creates an ClientToAMTokenIdentifier from the encoded Base-64 String */
+  private static ClientToAMTokenIdentifier getIdentifier(String id) throws InvalidToken {
+    byte[] tokenId = byteBufToByte(Base64.decode(
+      Unpooled.wrappedBuffer(id.getBytes(StandardCharsets.UTF_8))));
+
+    ClientToAMTokenIdentifier tokenIdentifier = new ClientToAMTokenIdentifier();
+    try {
+      tokenIdentifier.readFields(new DataInputStream(new ByteArrayInputStream(tokenId)));
+    } catch (IOException e) {
+      throw (InvalidToken) new InvalidToken(
+              "Can't de-serialize tokenIdentifier").initCause(e);
+    }
+    return tokenIdentifier;
+  }
+
+  /** Returns an Base64-encoded secretKey created from the Identifier and the secretmanager */
+  private char[] getClientToAMSecretKey(ClientToAMTokenIdentifier tokenid,
+                                        ClientToAMTokenSecretManager secretManager) throws InvalidToken {
+    byte[] password =  secretManager.retrievePassword(tokenid);
+    return Base64.encode(Unpooled.wrappedBuffer(password)).toString(StandardCharsets.UTF_8)
+            .toCharArray();
+  }
+
+  /** Encode a String identifier as a Base64-encoded string. */
   public static String encodeIdentifier(String identifier) {
     Preconditions.checkNotNull(identifier, "User cannot be null if SASL is enabled");
     return getBase64EncodedString(identifier);
@@ -197,6 +259,25 @@ public class SparkSaslServer implements SaslEncryptionBackend {
     return getBase64EncodedString(password).toCharArray();
   }
 
+  /** Decode a base64-encoded indentifier as a String. */
+  public static String decodeIdentifier(String identifier) {
+    Preconditions.checkNotNull(identifier, "User cannot be null if SASL is enabled");
+    return Base64.decode(Unpooled.wrappedBuffer(identifier.getBytes(StandardCharsets.UTF_8)))
+            .toString(StandardCharsets.UTF_8);
+  }
+
+  /** Decode a base64-encoded MasterKey as a byte[] array. */
+  public static byte[] decodeMasterKey(String masterKey) {
+    ByteBuf masterKeyByteBuf = Base64.decode(Unpooled.wrappedBuffer(masterKey.getBytes(StandardCharsets.UTF_8)));
+    return byteBufToByte(masterKeyByteBuf);
+  }
+
+  /** Convert an ByteBuf to a byte[] array. */
+  private static byte[] byteBufToByte(ByteBuf byteBuf) {
+    byte[] byteArray = new byte[byteBuf.readableBytes()];
+    byteBuf.readBytes(byteArray);
+    return byteArray;
+  }
   /** Return a Base64-encoded string. */
   private static String getBase64EncodedString(String str) {
     ByteBuf byteBuf = null;

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -108,6 +108,9 @@ public class TransportConf {
   /** Number of threads used in the client thread pool. Default to 0, which is 2x#cores. */
   public int clientThreads() { return conf.getInt(SPARK_NETWORK_IO_CLIENTTHREADS_KEY, 0); }
 
+  /** If true, the current RPC connection is a Client to AM connection */
+  public boolean isConnectionUsingTokens() { return conf.getBoolean("spark.rpc.connectionUsingTokens", false); }
+
   /**
    * Receive buffer size (SO_RCVBUF).
    * Note: the optimal size for receive buffer and send buffer should be

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -222,10 +222,11 @@ private[spark] class SecurityManager(
   setViewAcls(defaultAclUsers, sparkConf.get("spark.ui.view.acls", ""))
   setModifyAcls(defaultAclUsers, sparkConf.get("spark.modify.acls", ""))
 
-  setViewAclsGroups(sparkConf.get("spark.ui.view.acls.groups", ""));
-  setModifyAclsGroups(sparkConf.get("spark.modify.acls.groups", ""));
+  setViewAclsGroups(sparkConf.get("spark.ui.view.acls.groups", ""))
+  setModifyAclsGroups(sparkConf.get("spark.modify.acls.groups", ""))
 
-  private val secretKey = generateSecretKey()
+  private var identifier = "sparkSaslUser"
+  private var secretKey = generateSecretKey()
   logInfo("SecurityManager: authentication " + (if (authOn) "enabled" else "disabled") +
     "; ui acls " + (if (aclsOn) "enabled" else "disabled") +
     "; users  with view permissions: " + viewAcls.toString() +
@@ -533,11 +534,23 @@ private[spark] class SecurityManager(
 
   /**
    * Gets the user used for authenticating SASL connections.
-   * For now use a single hardcoded user.
    * @return the SASL user as a String
    */
-  def getSaslUser(): String = "sparkSaslUser"
+  def getSaslUser(): String = identifier
 
+  /**
+   * This can be a user name or unique identifier
+   */
+  def setSaslUser(ident: String) {
+    identifier = ident
+  }
+
+  /**
+   * set the secret key
+   */
+  def setSecretKey(secret: String) {
+    secretKey = secret
+  }
   /**
    * Gets the secret key.
    * @return the secret key as a String if authentication is enabled, otherwise returns null

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -127,11 +127,46 @@ object SparkSubmit extends CommandLineUtils {
   }
 
   /**
-   * Kill an existing submission using the REST protocol. Standalone and Mesos cluster mode only.
+   * Kill an existing submission
    */
   private def kill(args: SparkSubmitArguments): Unit = {
-    new RestSubmissionClient(args.master)
-      .killSubmission(args.submissionToKill)
+    if (args.master.startsWith("yarn")) {
+      // Use RPC protocol. YARN mode only.
+      val (_, _, sysProps, _) = prepareSubmitEnvironment(args)
+      val applicationID = Seq("--arg", args.submissionToKill)
+      if (args.proxyUser != null) {
+        val proxyUser = UserGroupInformation.createProxyUser(args.proxyUser,
+          UserGroupInformation.getCurrentUser())
+        try {
+          proxyUser.doAs(new PrivilegedExceptionAction[Unit]() {
+            override def run(): Unit = {
+              runMethod(applicationID, ArrayBuffer(), sysProps,
+                "org.apache.spark.deploy.yarn.Client", "yarnKillSubmission", args.verbose)
+            }
+          })
+        } catch {
+          case e: Exception =>
+            // Hadoop's AuthorizationException suppresses the exception's stack trace, which
+            // makes the message printed to the output by the JVM not very helpful. Instead,
+            // detect exceptions with empty stack traces here, and treat them differently.
+            if (e.getStackTrace().length == 0) {
+              // scalastyle:off println
+              printStream.println(s"ERROR: ${e.getClass().getName()}: ${e.getMessage()}")
+              // scalastyle:on println
+              exitFn(1)
+            } else {
+              throw e
+            }
+        }
+      } else {
+        runMethod(applicationID, ArrayBuffer(), sysProps, "org.apache.spark.deploy.yarn.Client",
+          "yarnKillSubmission", args.verbose)
+      }
+    } else {
+      // Use Rest protocol. Standalone and Mesos cluster mode only..
+      new RestSubmissionClient(args.master)
+        .killSubmission(args.submissionToKill)
+    }
   }
 
   /**
@@ -163,7 +198,7 @@ object SparkSubmit extends CommandLineUtils {
         try {
           proxyUser.doAs(new PrivilegedExceptionAction[Unit]() {
             override def run(): Unit = {
-              runMain(childArgs, childClasspath, sysProps, childMainClass, args.verbose)
+              runMethod(childArgs, childClasspath, sysProps, childMainClass, "main", args.verbose)
             }
           })
         } catch {
@@ -181,7 +216,7 @@ object SparkSubmit extends CommandLineUtils {
             }
         }
       } else {
-        runMain(childArgs, childClasspath, sysProps, childMainClass, args.verbose)
+        runMethod(childArgs, childClasspath, sysProps, childMainClass, "main", args.verbose)
       }
     }
 
@@ -681,20 +716,22 @@ object SparkSubmit extends CommandLineUtils {
   }
 
   /**
-   * Run the main method of the child class using the provided launch environment.
+   * Run a method of the child class using the provided launch environment.
    *
    * Note that this main class will not be the one provided by the user if we're
    * running cluster deploy mode or python applications.
    */
-  private def runMain(
+  private def runMethod(
       childArgs: Seq[String],
       childClasspath: Seq[String],
       sysProps: Map[String, String],
       childMainClass: String,
+      childMainMethod: String,
       verbose: Boolean): Unit = {
     // scalastyle:off println
     if (verbose) {
       printStream.println(s"Main class:\n$childMainClass")
+      printStream.println(s"Main method:\n$childMainMethod")
       printStream.println(s"Arguments:\n${childArgs.mkString("\n")}")
       // sysProps may contain sensitive information, so redact before printing
       printStream.println(s"System properties:\n${Utils.redact(sysProps).mkString("\n")}")
@@ -751,7 +788,7 @@ object SparkSubmit extends CommandLineUtils {
       printWarning("Subclasses of scala.App may not work correctly. Use a main() method instead.")
     }
 
-    val mainMethod = mainClass.getMethod("main", new Array[String](0).getClass)
+    val mainMethod = mainClass.getMethod(childMainMethod, new Array[String](0).getClass)
     if (!Modifier.isStatic(mainMethod.getModifiers)) {
       throw new IllegalStateException("The main method in the given main class must be static")
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -294,9 +294,10 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   }
 
   private def validateKillArguments(): Unit = {
-    if (!master.startsWith("spark://") && !master.startsWith("mesos://")) {
+    if (!master.startsWith("spark://") && !master.startsWith("mesos://")
+      && !master.startsWith("yarn")) {
       SparkSubmit.printErrorAndExit(
-        "Killing submissions is only supported in standalone or Mesos mode!")
+        "Killing submissions is only supported in YARN, standalone or Mesos mode!")
     }
     if (submissionToKill == null) {
       SparkSubmit.printErrorAndExit("Please specify a submission to kill.")
@@ -564,9 +565,11 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --driver-cores NUM          Number of cores used by the driver, only in cluster mode
         |                              (Default: 1).
         |
+        | All Spark cluster deploy mode or Yarn client mode only:
+        |  --kill SUBMISSION_ID        If given, kills the driver specified.
+        |
         | Spark standalone or Mesos with cluster deploy mode only:
         |  --supervise                 If given, restarts the driver on failure.
-        |  --kill SUBMISSION_ID        If given, kills the driver specified.
         |  --status SUBMISSION_ID      If given, requests the status of the driver specified.
         |
         | Spark standalone and Mesos only:

--- a/core/src/main/scala/org/apache/spark/rpc/RpcCallContext.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcCallContext.scala
@@ -35,7 +35,12 @@ private[spark] trait RpcCallContext {
   def sendFailure(e: Throwable): Unit
 
   /**
-   * The sender of this message.
+   * The sender's address of this message.
    */
   def senderAddress: RpcAddress
+
+  /**
+   * The sender's User Name of this message.
+   */
+  def senderUserName: String
 }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/Dispatcher.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/Dispatcher.scala
@@ -121,8 +121,8 @@ private[netty] class Dispatcher(nettyEnv: NettyRpcEnv, numUsableCores: Int) exte
 
   /** Posts a message sent by a remote endpoint. */
   def postRemoteMessage(message: RequestMessage, callback: RpcResponseCallback): Unit = {
-    val rpcCallContext =
-      new RemoteNettyRpcCallContext(nettyEnv, callback, message.senderAddress)
+    val rpcCallContext = new RemoteNettyRpcCallContext(nettyEnv, callback,
+      message.senderAddress, message.senderUserName)
     val rpcMessage = RpcMessage(message.senderAddress, message.content, rpcCallContext)
     postMessage(message.receiver.name, rpcMessage, (e) => callback.onFailure(e))
   }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcCallContext.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcCallContext.scala
@@ -23,7 +23,9 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.network.client.RpcResponseCallback
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext}
 
-private[netty] abstract class NettyRpcCallContext(override val senderAddress: RpcAddress)
+private[netty] abstract class NettyRpcCallContext(
+    override val senderAddress: RpcAddress,
+    override val senderUserName: String = null)
   extends RpcCallContext with Logging {
 
   protected def send(message: Any): Unit
@@ -57,8 +59,9 @@ private[netty] class LocalNettyRpcCallContext(
 private[netty] class RemoteNettyRpcCallContext(
     nettyEnv: NettyRpcEnv,
     callback: RpcResponseCallback,
-    senderAddress: RpcAddress)
-  extends NettyRpcCallContext(senderAddress) {
+    senderAddress: RpcAddress,
+    senderUserName: String)
+  extends NettyRpcCallContext(senderAddress, senderUserName) {
 
   override protected def send(message: Any): Unit = {
     val reply = nettyEnv.serialize(message)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -53,6 +53,8 @@ private[spark] object CoarseGrainedClusterMessages {
   case class RegisterExecutorFailed(message: String) extends CoarseGrainedClusterMessage
     with RegisterExecutorResponse
 
+  case class StopSparkContext() extends CoarseGrainedClusterMessage
+
   // Executors to driver
   case class RegisterExecutor(
       executorId: String,

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -453,6 +453,23 @@ To use a custom metrics.properties for the application master and executors, upd
   name matches both the include and the exclude pattern, this file will be excluded eventually.
   </td>
 </tr>
+<tr>
+  <td><code>spark.yarn.clientToAM.port</code></td>
+  <td>0</td>
+  <td>
+  Port the application master listens on for connections from the client.
+  This port is specified when registering the AM with YARN so that client can later know which
+  port to connect to from the application Report.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.yarn.hardKillTimeout</code></td>
+  <td>60s</td>
+  <td>
+  Number of milliseconds to wait before the job client kills the application.
+  After the wait, client will attempt to terminate the YARN application.
+  </td>
+</tr>
 </table>
 
 # Important notes

--- a/out
+++ b/out
@@ -1,0 +1,882 @@
+WARNING: '--force' is deprecated and ignored.
+exec: curl --progress-bar -L https://downloads.typesafe.com/zinc/0.3.15/zinc-0.3.15.tgz
+                                                                           0.1%#                                                                          2.2%#####                                                                      7.6%#############                                                             18.2%#####################                                                     29.3%############################                                              40.2%#####################################                                     51.8%#############################################                             63.2%###################################################                       71.0%#########################################################                 79.5%##############################################################            87.5%###################################################################       93.5%######################################################################## 100.0%
+exec: curl --progress-bar -L https://downloads.typesafe.com/scala/2.11.8/scala-2.11.8.tgz
+                                                                           0.3%#                                                                          2.5%#####                                                                      8.3%########                                                                  11.7%#############                                                             19.0%##################                                                        25.1%#######################                                                   32.0%###########################                                               38.8%################################                                          45.5%#####################################                                     52.7%###########################################                               60.1%################################################                          67.3%#####################################################                     74.3%##########################################################                81.9%################################################################          89.1%#####################################################################     96.6%######################################################################## 100.0%
+Using `mvn` from path: /Users/jlee2/apache-maven-3.5.0/bin/mvn
+[INFO] Scanning for projects...
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Build Order:
+[INFO] 
+[INFO] Spark Project Parent POM
+[INFO] Spark Project Tags
+[INFO] Spark Project Sketch
+[INFO] Spark Project Local DB
+[INFO] Spark Project Networking
+[INFO] Spark Project Shuffle Streaming Service
+[INFO] Spark Project Unsafe
+[INFO] Spark Project Launcher
+[INFO] Spark Project Core
+[INFO] Spark Project ML Local Library
+[INFO] Spark Project GraphX
+[INFO] Spark Project Streaming
+[INFO] Spark Project Catalyst
+[INFO] Spark Project SQL
+[INFO] Spark Project ML Library
+[INFO] Spark Project Tools
+[INFO] Spark Project Hive
+[INFO] Spark Project REPL
+[INFO] Spark Project YARN Shuffle Service
+[INFO] Spark Project YARN
+[INFO] Spark Project Hive Thrift Server
+[INFO] Spark Project Assembly
+[INFO] Spark Project External Flume Sink
+[INFO] Spark Project External Flume
+[INFO] Spark Project External Flume Assembly
+[INFO] Spark Integration for Kafka 0.8
+[INFO] Kafka 0.10 Source for Structured Streaming
+[INFO] Spark Project Examples
+[INFO] Spark Project External Kafka Assembly
+[INFO] Spark Integration for Kafka 0.10
+[INFO] Spark Integration for Kafka 0.10 Assembly
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Parent POM 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-parent_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-parent_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-parent_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-parent_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-parent_2.11 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-parent_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-parent_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-parent_2.11 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-parent_2.11 ---
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-parent_2.11 ---
+Discovery starting.
+Discovery completed in 49 milliseconds.
+Run starting. Expected test count is: 0
+DiscoverySuite:
+Run completed in 153 milliseconds.
+Total number of tests run: 0
+Suites: completed 1, aborted 0
+Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
+No tests were executed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Tags 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-tags_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-tags_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/tags/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/tags/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-tags_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-tags_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-tags_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/tags/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-tags_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-tags_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[info] 'compiler-interface' not yet compiled for Scala 2.11.8. Compiling...
+[info]   Compilation completed in 12.451 s
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 2 Scala sources and 6 Java sources to /Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes...
+[info] Compile success at Aug 10, 2017 11:09:42 AM [16.051s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-tags_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/tags/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-tags_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/tags/src/test/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-tags_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-tags_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-tags_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 3 Java sources to /Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/test-classes...
+[info] Compile success at Aug 10, 2017 11:09:44 AM [1.675s]
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-tags_2.11 ---
+Downloading: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.pom
+Progress (1): 2.8/3.3 kBProgress (1): 3.3 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.pom (3.3 kB at 11 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-providers/2.19.1/surefire-providers-2.19.1.pom
+Progress (1): 2.1/2.6 kBProgress (1): 2.6 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-providers/2.19.1/surefire-providers-2.19.1.pom (2.6 kB at 88 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.jar
+Progress (1): 2.1/75 kBProgress (1): 4.9/75 kBProgress (1): 7.7/75 kBProgress (1): 10/75 kB Progress (1): 13/75 kBProgress (1): 16/75 kBProgress (1): 19/75 kBProgress (1): 21/75 kBProgress (1): 24/75 kBProgress (1): 27/75 kBProgress (1): 30/75 kBProgress (1): 32/75 kBProgress (1): 36/75 kBProgress (1): 40/75 kBProgress (1): 44/75 kBProgress (1): 49/75 kBProgress (1): 53/75 kBProgress (1): 57/75 kBProgress (1): 61/75 kBProgress (1): 65/75 kBProgress (1): 69/75 kBProgress (1): 73/75 kBProgress (1): 75 kB                      Downloaded: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.jar (75 kB at 1.2 MB/s)
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+
+Results :
+
+Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-tags_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-tags_2.11 ---
+Discovery starting.
+Discovery completed in 70 milliseconds.
+Run starting. Expected test count is: 0
+DiscoverySuite:
+Run completed in 145 milliseconds.
+Total number of tests run: 0
+Suites: completed 1, aborted 0
+Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
+No tests were executed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Sketch 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-sketch_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-sketch_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/sketch/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/sketch/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-sketch_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-sketch_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-sketch_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/sketch/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-sketch_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-sketch_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 9 Java sources to /Users/jlee2/Yahoo/yspark_2/common/sketch/target/scala-2.11/classes...
+[info] Compile success at Aug 10, 2017 11:09:49 AM [1.326s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-sketch_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/sketch/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-sketch_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/sketch/src/test/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-sketch_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-sketch_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-sketch_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 3 Scala sources to /Users/jlee2/Yahoo/yspark_2/common/sketch/target/scala-2.11/test-classes...
+[info] Compile success at Aug 10, 2017 11:09:52 AM [3.115s]
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-sketch_2.11 ---
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+
+Results :
+
+Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-sketch_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-sketch_2.11 ---
+Discovery starting.
+Discovery completed in 180 milliseconds.
+Run starting. Expected test count is: 29
+BloomFilterSuite:
+- accuracy - Byte
+- mergeInPlace - Byte
+- accuracy - Short
+- mergeInPlace - Short
+- accuracy - Int
+- mergeInPlace - Int
+- accuracy - Long
+- mergeInPlace - Long
+- accuracy - String
+- mergeInPlace - String
+- incompatible merge
+BitArraySuite:
+- error case when create BitArray
+- bitSize
+- set
+- normal operation
+- merge
+CountMinSketchSuite:
+- accuracy - Byte
+- mergeInPlace - Byte
+- accuracy - Short
+- mergeInPlace - Short
+- accuracy - Int
+- mergeInPlace - Int
+- accuracy - Long
+- mergeInPlace - Long
+- accuracy - String
+- mergeInPlace - String
+- accuracy - Byte array
+- mergeInPlace - Byte array
+- incompatible merge
+Run completed in 14 seconds, 530 milliseconds.
+Total number of tests run: 29
+Suites: completed 4, aborted 0
+Tests: succeeded 29, failed 0, canceled 0, ignored 0, pending 0
+All tests passed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Local DB 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-kvstore_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-kvstore_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-kvstore_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-kvstore_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-kvstore_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-kvstore_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-kvstore_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 12 Java sources to /Users/jlee2/Yahoo/yspark_2/common/kvstore/target/scala-2.11/classes...
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java:174: warning: [rawtypes] found raw type: InMemoryView
+[warn]       return new InMemoryView(type, all, ti);
+[warn]                  ^
+[warn]   missing type arguments for generic class InMemoryView<T>
+[warn]   where T is a type-variable:
+[warn]     T extends Object declared in class InMemoryView
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreIterator.java:34: warning: [try] auto-closeable resource KVStoreIterator<T> has a member method close() that could throw InterruptedException
+[warn] public interface KVStoreIterator<T> extends Iterator<T>, AutoCloseable {
+[warn]        ^
+[warn]   where T is a type-variable:
+[warn]     T extends Object declared in interface KVStoreIterator
+[warn] 2 warnings
+[info] Compile success at Aug 10, 2017 11:10:10 AM [1.727s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-kvstore_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/kvstore/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-kvstore_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 1 resource
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-kvstore_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-kvstore_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-kvstore_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 10 Java sources to /Users/jlee2/Yahoo/yspark_2/common/kvstore/target/scala-2.11/test-classes...
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/DBIteratorSuite.java:387: warning: [try] auto-closeable resource KVStoreIterator<?> has a member method close() that could throw InterruptedException
+[warn]     try(KVStoreIterator<?> it = db.view(i.getClass()).closeableIterator()) {
+[warn]                            ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:67: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]     try(Timer.Context ctx = dbCreation.time()) {
+[warn]                       ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:75: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]       try(Timer.Context ctx = dbClose.time()) {
+[warn]                         ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:194: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]         try(Timer.Context ctx = create.time()) {
+[warn]                           ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:201: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]       try(Timer.Context ctx = iter.time()) {
+[warn]                         ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:210: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]       try(Timer.Context ctx = timer.time()) {
+[warn]                         ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:219: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]       try(Timer.Context ctx = delete.time()) {
+[warn]                         ^
+[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:228: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
+[warn]       try(Timer.Context ctx = delete.time()) {
+[warn]                         ^
+[warn] 8 warnings
+[info] Compile success at Aug 10, 2017 11:10:12 AM [2.305s]
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-kvstore_2.11 ---
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.apache.spark.util.kvstore.ArrayWrappersSuite
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.126 sec - in org.apache.spark.util.kvstore.ArrayWrappersSuite
+Running org.apache.spark.util.kvstore.InMemoryIteratorSuite
+Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.498 sec - in org.apache.spark.util.kvstore.InMemoryIteratorSuite
+Running org.apache.spark.util.kvstore.InMemoryStoreSuite
+Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.apache.spark.util.kvstore.InMemoryStoreSuite
+Running org.apache.spark.util.kvstore.LevelDBIteratorSuite
+Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.982 sec - in org.apache.spark.util.kvstore.LevelDBIteratorSuite
+Running org.apache.spark.util.kvstore.LevelDBSuite
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.156 sec - in org.apache.spark.util.kvstore.LevelDBSuite
+Running org.apache.spark.util.kvstore.LevelDBTypeInfoSuite
+Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec - in org.apache.spark.util.kvstore.LevelDBTypeInfoSuite
+
+Results :
+
+Tests run: 100, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-kvstore_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-kvstore_2.11 ---
+Discovery starting.
+Discovery completed in 225 milliseconds.
+Run starting. Expected test count is: 0
+DiscoverySuite:
+Run completed in 346 milliseconds.
+Total number of tests run: 0
+Suites: completed 1, aborted 0
+Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
+No tests were executed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Networking 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.pom
+Progress (1): 2.1/2.2 kBProgress (1): 2.2 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.pom (2.2 kB at 83 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/apache-curator/2.7.1/apache-curator-2.7.1.pom
+Progress (1): 2.2/32 kBProgress (1): 4.9/32 kBProgress (1): 7.7/32 kBProgress (1): 10/32 kB Progress (1): 13/32 kBProgress (1): 16/32 kBProgress (1): 19/32 kBProgress (1): 21/32 kBProgress (1): 24/32 kBProgress (1): 27/32 kBProgress (1): 30/32 kBProgress (1): 32 kB                      Downloaded: https://repo1.maven.org/maven2/org/apache/curator/apache-curator/2.7.1/apache-curator-2.7.1.pom (32 kB at 884 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.pom
+Progress (1): 2.1/2.3 kBProgress (1): 2.3 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.pom (2.3 kB at 84 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.pom
+Progress (1): 2.1/2.4 kBProgress (1): 2.4 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.pom (2.4 kB at 99 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar
+Progress (1): 2.1/186 kBProgress (1): 4.9/186 kBProgress (1): 7.7/186 kBProgress (1): 10/186 kB Progress (1): 13/186 kBProgress (1): 16/186 kBProgress (1): 19/186 kBProgress (1): 21/186 kBProgress (1): 24/186 kBProgress (1): 27/186 kBProgress (1): 30/186 kBProgress (1): 32/186 kBProgress (1): 36/186 kBProgress (1): 40/186 kBProgress (1): 44/186 kBProgress (1): 49/186 kBProgress (1): 53/186 kBProgress (1): 57/186 kBProgress (1): 61/186 kBProgress (1): 65/186 kBProgress (1): 69/186 kBProgress (1): 73/186 kBProgress (1): 77/186 kBProgress (1): 81/186 kBProgress (1): 85/186 kBProgress (1): 89/186 kBProgress (1): 94/186 kBProgress (1): 98/186 kBProgress (1): 102/186 kBProgress (1): 106/186 kBProgress (1): 110/186 kBProgress (1): 114/186 kBProgress (1): 118/186 kBProgress (1): 122/186 kBProgress (1): 126/186 kBProgress (1): 130/186 kBProgress (1): 135/186 kBProgress (1): 139/186 kBProgress (1): 143/186 kBProgress (1): 147/186 kBProgress (1): 151/186 kBProgress (1): 155/186 kBProgress (1): 159/186 kBProgress (1): 163/186 kBProgress (1): 167/186 kBProgress (1): 171/186 kBProgress (1): 176/186 kBProgress (1): 180/186 kBProgress (1): 184/186 kBProgress (1): 186 kB    Progress (2): 186 kB | 2.1/70 kBProgress (3): 186 kB | 2.1/70 kB | 2.1/270 kBProgress (3): 186 kB | 4.9/70 kB | 2.1/270 kBProgress (3): 186 kB | 7.7/70 kB | 2.1/270 kBProgress (3): 186 kB | 7.7/70 kB | 4.9/270 kBProgress (3): 186 kB | 10/70 kB | 4.9/270 kB Progress (3): 186 kB | 10/70 kB | 7.7/270 kBProgress (3): 186 kB | 10/70 kB | 10/270 kB Progress (3): 186 kB | 13/70 kB | 10/270 kBProgress (3): 186 kB | 16/70 kB | 10/270 kBProgress (3): 186 kB | 16/70 kB | 13/270 kB                                           Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar (186 kB at 3.4 MB/s)
+Progress (2): 19/70 kB | 13/270 kBProgress (2): 19/70 kB | 16/270 kBProgress (2): 21/70 kB | 16/270 kBProgress (2): 21/70 kB | 19/270 kBProgress (2): 24/70 kB | 19/270 kBProgress (2): 24/70 kB | 21/270 kBProgress (2): 27/70 kB | 21/270 kBProgress (2): 27/70 kB | 24/270 kBProgress (2): 30/70 kB | 24/270 kBProgress (2): 30/70 kB | 27/270 kBProgress (2): 32/70 kB | 27/270 kBProgress (2): 32/70 kB | 30/270 kBProgress (2): 32/70 kB | 32/270 kBProgress (2): 36/70 kB | 32/270 kBProgress (2): 40/70 kB | 32/270 kBProgress (2): 44/70 kB | 32/270 kBProgress (2): 49/70 kB | 32/270 kBProgress (2): 49/70 kB | 36/270 kBProgress (2): 49/70 kB | 40/270 kBProgress (2): 49/70 kB | 44/270 kBProgress (2): 53/70 kB | 44/270 kBProgress (2): 53/70 kB | 49/270 kBProgress (2): 57/70 kB | 49/270 kBProgress (2): 61/70 kB | 49/270 kBProgress (2): 65/70 kB | 49/270 kBProgress (2): 69/70 kB | 49/270 kBProgress (2): 69/70 kB | 53/270 kBProgress (2): 70 kB | 53/270 kB   Progress (2): 70 kB | 57/270 kBProgress (2): 70 kB | 61/270 kBProgress (2): 70 kB | 65/270 kBProgress (2): 70 kB | 69/270 kBProgress (2): 70 kB | 73/270 kBProgress (2): 70 kB | 77/270 kBProgress (2): 70 kB | 81/270 kBProgress (2): 70 kB | 85/270 kBProgress (2): 70 kB | 89/270 kBProgress (2): 70 kB | 94/270 kBProgress (2): 70 kB | 98/270 kBProgress (2): 70 kB | 102/270 kBProgress (2): 70 kB | 106/270 kBProgress (2): 70 kB | 110/270 kBProgress (2): 70 kB | 114/270 kBProgress (2): 70 kB | 118/270 kBProgress (2): 70 kB | 122/270 kBProgress (2): 70 kB | 126/270 kBProgress (2): 70 kB | 130/270 kBProgress (2): 70 kB | 135/270 kB                                Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar (70 kB at 891 kB/s)
+Progress (1): 139/270 kBProgress (1): 143/270 kBProgress (1): 147/270 kBProgress (1): 151/270 kBProgress (1): 155/270 kBProgress (1): 159/270 kBProgress (1): 163/270 kBProgress (1): 167/270 kBProgress (1): 171/270 kBProgress (1): 176/270 kBProgress (1): 180/270 kBProgress (1): 184/270 kBProgress (1): 188/270 kBProgress (1): 192/270 kBProgress (1): 196/270 kBProgress (1): 200/270 kBProgress (1): 204/270 kBProgress (1): 208/270 kBProgress (1): 212/270 kBProgress (1): 216/270 kBProgress (1): 221/270 kBProgress (1): 225/270 kBProgress (1): 229/270 kBProgress (1): 233/270 kBProgress (1): 237/270 kBProgress (1): 241/270 kBProgress (1): 245/270 kBProgress (1): 249/270 kBProgress (1): 253/270 kBProgress (1): 257/270 kBProgress (1): 262/270 kBProgress (1): 266/270 kBProgress (1): 270/270 kBProgress (1): 270 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar (270 kB at 2.4 MB/s)
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-network-common_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-network-common_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-common/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-common/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-network-common_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-server-common/2.7.3/hadoop-yarn-server-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-crypto/1.0.0/commons-crypto-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/inject/guice/3.0/guice-3.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/jlee2/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.3/hadoop-auth-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-client/2.7.3/hadoop-client-2.7.3.jar:/Users/jlee2/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.3/hadoop-hdfs-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-shuffle/2.7.3/hadoop-mapreduce-client-shuffle-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/jlee2/.m2/repository/commons-net/commons-net/2.2/commons-net-2.2.jar:/Users/jlee2/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.3/hadoop-mapreduce-client-core-2.7.3.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-common/2.7.3/hadoop-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/jlee2/.m2/repository/com/google/guava/guava/14.0.1/guava-14.0.1.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.3/hadoop-annotations-2.7.3.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/Users/jlee2/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-common/2.7.3/hadoop-mapreduce-client-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-jobclient/2.7.3/hadoop-mapreduce-client-jobclient-2.7.3.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-app/2.7.3/hadoop-mapreduce-client-app-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/.m2/repository/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar:/Users/jlee2/.m2/repository/io/netty/netty-all/4.0.43.Final/netty-all-4.0.43.Final.jar:/Users/jlee2/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-network-common_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-network-common_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/network-common/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-network-common_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-network-common_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 73 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/classes...
+[warn] /Users/jlee2/Yahoo/yspark_2/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java:112: warning: [deprecation] PooledByteBufAllocator(boolean,int,int,int,int,int,int,int) in PooledByteBufAllocator has been deprecated
+[warn]     return new PooledByteBufAllocator(
+[warn]            ^
+[warn] 1 warning
+[info] Compile success at Aug 10, 2017 11:10:24 AM [3.557s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-network-common_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/network-common/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-network-common_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 1 resource
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-network-common_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-network-common_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-network-common_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 18 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/test-classes...
+[warn] /Users/jlee2/Yahoo/yspark_2/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java:105: warning: [rawtypes] found raw type: GenericFutureListener
+[warn]     private List<GenericFutureListener> listeners = new ArrayList<>();
+[warn]                  ^
+[warn]   missing type arguments for generic class GenericFutureListener<F>
+[warn]   where F is a type-variable:
+[warn]     F extends Future<?> declared in interface GenericFutureListener
+[warn] /Users/jlee2/Yahoo/yspark_2/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java:129: warning: [unchecked] unchecked call to operationComplete(F) as a member of the raw type GenericFutureListener
+[warn]           listener.operationComplete(this);
+[warn]                                     ^
+[warn]   where F is a type-variable:
+[warn]     F extends Future<?> declared in interface GenericFutureListener
+[warn] 2 warnings
+[info] Compile success at Aug 10, 2017 11:10:29 AM [3.338s]
+[INFO] 
+[INFO] --- maven-jar-plugin:3.0.2:test-jar (prepare-test-jar) @ spark-network-common_2.11 ---
+[INFO] Building jar: /Users/jlee2/Yahoo/yspark_2/common/network-common/target/spark-network-common_2.11-2.3.0-SNAPSHOT-tests.jar
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-network-common_2.11 ---
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.apache.spark.network.ChunkFetchIntegrationSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.623 sec - in org.apache.spark.network.ChunkFetchIntegrationSuite
+Running org.apache.spark.network.crypto.AuthEngineSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.376 sec - in org.apache.spark.network.crypto.AuthEngineSuite
+Running org.apache.spark.network.crypto.AuthIntegrationSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.665 sec - in org.apache.spark.network.crypto.AuthIntegrationSuite
+Running org.apache.spark.network.crypto.AuthMessagesSuite
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.apache.spark.network.crypto.AuthMessagesSuite
+Running org.apache.spark.network.protocol.MessageWithHeaderSuite
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 sec - in org.apache.spark.network.protocol.MessageWithHeaderSuite
+Running org.apache.spark.network.ProtocolSuite
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in org.apache.spark.network.ProtocolSuite
+Running org.apache.spark.network.RequestTimeoutIntegrationSuite
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.308 sec - in org.apache.spark.network.RequestTimeoutIntegrationSuite
+Running org.apache.spark.network.RpcIntegrationSuite
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.246 sec - in org.apache.spark.network.RpcIntegrationSuite
+Running org.apache.spark.network.sasl.SparkSaslSuite
+Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.322 sec - in org.apache.spark.network.sasl.SparkSaslSuite
+Running org.apache.spark.network.server.OneForOneStreamManagerSuite
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.apache.spark.network.server.OneForOneStreamManagerSuite
+Running org.apache.spark.network.StreamSuite
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 sec - in org.apache.spark.network.StreamSuite
+Running org.apache.spark.network.TransportClientFactorySuite
+Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.123 sec - in org.apache.spark.network.TransportClientFactorySuite
+Running org.apache.spark.network.TransportRequestHandlerSuite
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 sec - in org.apache.spark.network.TransportRequestHandlerSuite
+Running org.apache.spark.network.TransportResponseHandlerSuite
+Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 sec - in org.apache.spark.network.TransportResponseHandlerSuite
+Running org.apache.spark.network.util.CryptoUtilsSuite
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.apache.spark.network.util.CryptoUtilsSuite
+Running org.apache.spark.network.util.TransportFrameDecoderSuite
+Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 sec - in org.apache.spark.network.util.TransportFrameDecoderSuite
+
+Results :
+
+Tests run: 71, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-network-common_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-network-common_2.11 ---
+Discovery starting.
+Discovery completed in 148 milliseconds.
+Run starting. Expected test count is: 0
+DiscoverySuite:
+Run completed in 242 milliseconds.
+Total number of tests run: 0
+Suites: completed 1, aborted 0
+Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
+No tests were executed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Shuffle Streaming Service 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-network-shuffle_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-network-shuffle_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-network-shuffle_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-core/3.1.2/metrics-core-3.1.2.jar:/Users/jlee2/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-server-common/2.7.3/hadoop-yarn-server-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-crypto/1.0.0/commons-crypto-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/inject/guice/3.0/guice-3.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/jlee2/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.3/hadoop-auth-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-client/2.7.3/hadoop-client-2.7.3.jar:/Users/jlee2/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.3/hadoop-hdfs-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-shuffle/2.7.3/hadoop-mapreduce-client-shuffle-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/jlee2/.m2/repository/commons-net/commons-net/2.2/commons-net-2.2.jar:/Users/jlee2/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.3/hadoop-mapreduce-client-core-2.7.3.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-common/2.7.3/hadoop-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/jlee2/.m2/repository/org/slf4j/slf4j-log4j12/1.7.16/slf4j-log4j12-1.7.16.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.3/hadoop-annotations-2.7.3.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/Users/jlee2/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-common/2.7.3/hadoop-mapreduce-client-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-jobclient/2.7.3/hadoop-mapreduce-client-jobclient-2.7.3.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-app/2.7.3/hadoop-mapreduce-client-app-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/.m2/repository/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar:/Users/jlee2/.m2/repository/io/netty/netty-all/4.0.43.Final/netty-all-4.0.43.Final.jar:/Users/jlee2/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-network-shuffle_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-network-shuffle_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-network-shuffle_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-network-shuffle_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 20 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/scala-2.11/classes...
+[info] Compile success at Aug 10, 2017 11:11:15 AM [2.389s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-network-shuffle_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-network-shuffle_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 1 resource
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-network-shuffle_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-network-shuffle_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-network-shuffle_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 10 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/scala-2.11/test-classes...
+[info] Compile success at Aug 10, 2017 11:11:17 AM [2.136s]
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-network-shuffle_2.11 ---
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.apache.spark.network.sasl.SaslIntegrationSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.082 sec - in org.apache.spark.network.sasl.SaslIntegrationSuite
+Running org.apache.spark.network.shuffle.BlockTransferMessagesSuite
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.apache.spark.network.shuffle.BlockTransferMessagesSuite
+Running org.apache.spark.network.shuffle.ExternalShuffleBlockHandlerSuite
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 sec - in org.apache.spark.network.shuffle.ExternalShuffleBlockHandlerSuite
+Running org.apache.spark.network.shuffle.ExternalShuffleBlockResolverSuite
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.295 sec - in org.apache.spark.network.shuffle.ExternalShuffleBlockResolverSuite
+Running org.apache.spark.network.shuffle.ExternalShuffleCleanupSuite
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.792 sec - in org.apache.spark.network.shuffle.ExternalShuffleCleanupSuite
+Running org.apache.spark.network.shuffle.ExternalShuffleIntegrationSuite
+Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.509 sec - in org.apache.spark.network.shuffle.ExternalShuffleIntegrationSuite
+Running org.apache.spark.network.shuffle.ExternalShuffleSecuritySuite
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.078 sec - in org.apache.spark.network.shuffle.ExternalShuffleSecuritySuite
+Running org.apache.spark.network.shuffle.OneForOneBlockFetcherSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in org.apache.spark.network.shuffle.OneForOneBlockFetcherSuite
+Running org.apache.spark.network.shuffle.RetryingBlockFetcherSuite
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 sec - in org.apache.spark.network.shuffle.RetryingBlockFetcherSuite
+
+Results :
+
+Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-network-shuffle_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-network-shuffle_2.11 ---
+Discovery starting.
+Discovery completed in 109 milliseconds.
+Run starting. Expected test count is: 0
+DiscoverySuite:
+Run completed in 177 milliseconds.
+Total number of tests run: 0
+Suites: completed 1, aborted 0
+Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
+No tests were executed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Unsafe 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-unsafe_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-unsafe_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-unsafe_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/com/twitter/chill-java/0.8.0/chill-java-0.8.0.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/minlog/1.3.0/minlog-1.3.0.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/kryo-shaded/3.0.3/kryo-shaded-3.0.3.jar:/Users/jlee2/.m2/repository/com/twitter/chill_2.11/0.8.0/chill_2.11-0.8.0.jar:/Users/jlee2/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-unsafe_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-unsafe_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-unsafe_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-unsafe_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 16 Java sources to /Users/jlee2/Yahoo/yspark_2/common/unsafe/target/scala-2.11/classes...
+[info] Compile success at Aug 10, 2017 11:11:26 AM [4.162s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-unsafe_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/unsafe/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-unsafe_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/test/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-unsafe_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-unsafe_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-unsafe_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 1 Scala source and 5 Java sources to /Users/jlee2/Yahoo/yspark_2/common/unsafe/target/scala-2.11/test-classes...
+[info] Compile success at Aug 10, 2017 11:11:33 AM [7.243s]
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-unsafe_2.11 ---
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.apache.spark.unsafe.array.LongArraySuite
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 sec - in org.apache.spark.unsafe.array.LongArraySuite
+Running org.apache.spark.unsafe.hash.Murmur3_x86_32Suite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.361 sec - in org.apache.spark.unsafe.hash.Murmur3_x86_32Suite
+Running org.apache.spark.unsafe.PlatformUtilSuite
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 sec - in org.apache.spark.unsafe.PlatformUtilSuite
+Running org.apache.spark.unsafe.types.CalendarIntervalSuite
+Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.apache.spark.unsafe.types.CalendarIntervalSuite
+Running org.apache.spark.unsafe.types.UTF8StringSuite
+Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.067 sec - in org.apache.spark.unsafe.types.UTF8StringSuite
+
+Results :
+
+Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-unsafe_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-unsafe_2.11 ---
+Discovery starting.
+Discovery completed in 279 milliseconds.
+Run starting. Expected test count is: 19
+UTF8StringPropertyCheckSuite:
+- toString
+- numChars
+- startsWith
+- endsWith
+- toUpperCase
+- toLowerCase
+- compare
+- substring
+- contains
+- trim, trimLeft, trimRight
+- reverse
+- indexOf
+- repeat
+- lpad, rpad
+- concat
+- concatWs
+- split !!! IGNORED !!!
+- levenshteinDistance
+- hashCode
+- equals
+Run completed in 1 second, 622 milliseconds.
+Total number of tests run: 19
+Suites: completed 2, aborted 0
+Tests: succeeded 19, failed 0, canceled 0, ignored 1, pending 0
+All tests passed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Launcher 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-launcher_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-launcher_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/launcher/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/launcher/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-launcher_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-launcher_2.11 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-launcher_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/launcher/src/main/resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-launcher_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-launcher_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 16 Java sources to /Users/jlee2/Yahoo/yspark_2/launcher/target/scala-2.11/classes...
+[info] Compile success at Aug 10, 2017 11:11:41 AM [2.441s]
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-launcher_2.11 ---
+[INFO] Executing tasks
+
+main:
+    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/launcher/target/tmp
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-launcher_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 2 resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-launcher_2.11 ---
+[INFO] Not compiling test sources
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-launcher_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-launcher_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 6 Java sources to /Users/jlee2/Yahoo/yspark_2/launcher/target/scala-2.11/test-classes...
+[info] Compile success at Aug 10, 2017 11:11:44 AM [1.897s]
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-launcher_2.11 ---
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.apache.spark.launcher.CommandBuilderUtilsSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.076 sec - in org.apache.spark.launcher.CommandBuilderUtilsSuite
+Running org.apache.spark.launcher.LauncherServerSuite
+Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.338 sec - in org.apache.spark.launcher.LauncherServerSuite
+Running org.apache.spark.launcher.OutputRedirectionSuite
+Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.112 sec - in org.apache.spark.launcher.OutputRedirectionSuite
+Running org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
+Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 sec - in org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
+Running org.apache.spark.launcher.SparkSubmitOptionParserSuite
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.155 sec - in org.apache.spark.launcher.SparkSubmitOptionParserSuite
+
+Results :
+
+Tests run: 34, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-launcher_2.11 ---
+[INFO] Skipping execution of surefire because it has already been run for this configuration
+[INFO] 
+[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-launcher_2.11 ---
+Discovery starting.
+Discovery completed in 115 milliseconds.
+Run starting. Expected test count is: 0
+DiscoverySuite:
+Run completed in 220 milliseconds.
+Total number of tests run: 0
+Suites: completed 1, aborted 0
+Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
+No tests were executed.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spark Project Core 2.3.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.pom
+Progress (1): 2.0 kB                    Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.pom (2.0 kB at 70 kB/s)
+Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.jar
+Progress (1): 2.1/39 kBProgress (1): 4.9/39 kBProgress (1): 7.7/39 kBProgress (1): 10/39 kB Progress (1): 13/39 kBProgress (1): 16/39 kBProgress (1): 19/39 kBProgress (1): 21/39 kBProgress (1): 24/39 kBProgress (1): 27/39 kBProgress (1): 30/39 kBProgress (1): 32/39 kBProgress (1): 35/39 kBProgress (1): 38/39 kBProgress (1): 39 kB                      Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.jar (39 kB at 1.2 MB/s)
+[INFO] 
+[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-core_2.11 ---
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-core_2.11 ---
+[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/core/src/main/scala
+[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/core/src/test/scala
+[INFO] 
+[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-core_2.11 ---
+[INFO] Dependencies classpath:
+/Users/jlee2/.m2/repository/mx4j/mx4j/3.0.2/mx4j-3.0.2.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-core/3.1.2/metrics-core-3.1.2.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/module/jackson-module-scala_2.11/2.6.7.1/jackson-module-scala_2.11-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/net/java/dev/jets3t/jets3t/0.9.3/jets3t-0.9.3.jar:/Users/jlee2/.m2/repository/org/lz4/lz4-java/1.4.0/lz4-java-1.4.0.jar:/Users/jlee2/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-continuation/9.3.20.v20170531/jetty-continuation-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-jvm/3.1.2/metrics-jvm-3.1.2.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-servlets/9.3.20.v20170531/jetty-servlets-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/bundles/repackaged/jersey-guava/2.22.2/jersey-guava-2.22.2.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-json/3.1.2/metrics-json-3.1.2.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-crypto/1.0.0/commons-crypto-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/inject/guice/3.0/guice-3.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar:/Users/jlee2/.m2/repository/org/json4s/json4s-jackson_2.11/3.2.11/json4s-jackson_2.11-3.2.11.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.3/hadoop-auth-2.7.3.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/minlog/1.3.0/minlog-1.3.0.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-client/2.7.3/hadoop-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-shuffle/2.7.3/hadoop-mapreduce-client-shuffle-2.7.3.jar:/Users/jlee2/.m2/repository/javax/mail/mail/1.4.7/mail-1.4.7.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-xml/9.3.20.v20170531/jetty-xml-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar:/Users/jlee2/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.51/bcprov-jdk15on-1.51.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/core/jersey-common/2.22.2/jersey-common-2.22.2.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.3/hadoop-mapreduce-client-core-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/hk2-api/2.4.0-b34/hk2-api-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/core/jersey-server/2.22.2/jersey-server-2.22.2.jar:/Users/jlee2/.m2/repository/com/twitter/chill-java/0.8.0/chill-java-0.8.0.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-server/9.3.20.v20170531/jetty-server-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1.1/activation-1.1.1.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/org/javassist/javassist/3.18.1-GA/javassist-3.18.1-GA.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-client/9.3.20.v20170531/jetty-client-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar:/Users/jlee2/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-util/9.3.20.v20170531/jetty-util-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/osgi-resource-locator/1.0.1/osgi-resource-locator-1.0.1.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-common/2.7.3/hadoop-mapreduce-client-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-jobclient/2.7.3/hadoop-mapreduce-client-jobclient-2.7.3.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/hk2-utils/2.4.0-b34/hk2-utils-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/external/aopalliance-repackaged/2.4.0-b34/aopalliance-repackaged-2.4.0-b34.jar:/Users/jlee2/.m2/repository/io/netty/netty-all/4.0.43.Final/netty-all-4.0.43.Final.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/external/javax.inject/2.4.0-b34/javax.inject-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet-core/2.22.2/jersey-container-servlet-core-2.22.2.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/module/jackson-module-paranamer/2.6.7/jackson-module-paranamer-2.6.7.jar:/Users/jlee2/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-compiler/2.11.8/scala-compiler-2.11.8.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/org/roaringbitmap/RoaringBitmap/0.5.11/RoaringBitmap-0.5.11.jar:/Users/jlee2/.m2/repository/log4j/log4j/1.2.17/log4j-1.2.17.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-server-common/2.7.3/hadoop-yarn-server-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/twitter/parquet-hadoop-bundle/1.6.0/parquet-hadoop-bundle-1.6.0.jar:/Users/jlee2/Yahoo/yspark_2/launcher/target/scala-2.11/classes:/Users/jlee2/Yahoo/yspark_2/common/unsafe/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-proxy/9.3.20.v20170531/jetty-proxy-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/jlee2/.m2/repository/com/jamesmurty/utils/java-xmlbuilder/1.0/java-xmlbuilder-1.0.jar:/Users/jlee2/.m2/repository/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar:/Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/apache/xbean/xbean-asm5-shaded/4.4/xbean-asm5-shaded-4.4.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar:/Users/jlee2/.m2/repository/org/json4s/json4s-core_2.11/3.2.11/json4s-core_2.11-3.2.11.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/scala-2.11/classes:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/jlee2/.m2/repository/net/sf/py4j/py4j/0.10.6/py4j-0.10.6.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/kryo-shaded/3.0.3/kryo-shaded-3.0.3.jar:/Users/jlee2/.m2/repository/javax/ws/rs/javax.ws.rs-api/2.0.1/javax.ws.rs-api-2.0.1.jar:/Users/jlee2/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/core/jersey-client/2.22.2/jersey-client-2.22.2.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro-mapred/1.7.7/avro-mapred-1.7.7-hadoop2.jar:/Users/jlee2/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/jlee2/.m2/repository/com/ning/compress-lzf/1.0.3/compress-lzf-1.0.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.3/hadoop-hdfs-2.7.3.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-webapp/9.3.20.v20170531/jetty-webapp-9.3.20.v20170531.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/jlee2/.m2/repository/commons-net/commons-net/2.2/commons-net-2.2.jar:/Users/jlee2/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/jlee2/.m2/repository/org/json4s/json4s-ast_2.11/3.2.11/json4s-ast_2.11-3.2.11.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/jlee2/.m2/repository/org/scala-lang/scalap/2.11.8/scalap-2.11.8.jar:/Users/jlee2/.m2/repository/com/clearspring/analytics/stream/2.7.0/stream-2.7.0.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-http/9.3.20.v20170531/jetty-http-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-security/9.3.20.v20170531/jetty-security-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-common/2.7.3/hadoop-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet/2.22.2/jersey-container-servlet-2.22.2.jar:/Users/jlee2/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar:/Users/jlee2/.m2/repository/org/slf4j/jul-to-slf4j/1.7.16/jul-to-slf4j-1.7.16.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-io/9.3.20.v20170531/jetty-io-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/modules/scala-xml_2.11/1.0.2/scala-xml_2.11-1.0.2.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-plus/9.3.20.v20170531/jetty-plus-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-graphite/3.1.2/metrics-graphite-3.1.2.jar:/Users/jlee2/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/jlee2/.m2/repository/net/iharder/base64/2.3.8/base64-2.3.8.jar:/Users/jlee2/.m2/repository/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar:/Users/jlee2/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar:/Users/jlee2/.m2/repository/org/slf4j/slf4j-log4j12/1.7.16/slf4j-log4j12-1.7.16.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/media/jersey-media-jaxb/2.22.2/jersey-media-jaxb-2.22.2.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro-ipc/1.7.7/avro-ipc-1.7.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.3/hadoop-annotations-2.7.3.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-jndi/9.3.20.v20170531/jetty-jndi-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/jlee2/.m2/repository/com/twitter/chill_2.11/0.8.0/chill_2.11-0.8.0.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/hk2-locator/2.4.0-b34/hk2-locator-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-app/2.7.3/hadoop-mapreduce-client-app-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar:/Users/jlee2/.m2/repository/net/razorvine/pyrolite/4.13/pyrolite-4.13.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-servlet/9.3.20.v20170531/jetty-servlet-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.16/jcl-over-slf4j-1.7.16.jar:/Users/jlee2/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-core_2.11 ---
+[INFO] 
+[INFO] --- maven-antrun-plugin:1.8:run (default) @ spark-core_2.11 ---
+[INFO] Executing tasks
+
+main:
+[INFO] Executed tasks
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-core_2.11 ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 37 resources
+[INFO] Copying 1 resource
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-core_2.11 ---
+[INFO] Not compiling main sources
+[INFO] 
+[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-core_2.11 ---
+[INFO] Using zinc server for incremental compilation
+[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
+[info] Compiling 487 Scala sources and 74 Java sources to /Users/jlee2/Yahoo/yspark_2/core/target/scala-2.11/classes...

--- a/out
+++ b/out
@@ -1,882 +1,0 @@
-WARNING: '--force' is deprecated and ignored.
-exec: curl --progress-bar -L https://downloads.typesafe.com/zinc/0.3.15/zinc-0.3.15.tgz
-                                                                           0.1%#                                                                          2.2%#####                                                                      7.6%#############                                                             18.2%#####################                                                     29.3%############################                                              40.2%#####################################                                     51.8%#############################################                             63.2%###################################################                       71.0%#########################################################                 79.5%##############################################################            87.5%###################################################################       93.5%######################################################################## 100.0%
-exec: curl --progress-bar -L https://downloads.typesafe.com/scala/2.11.8/scala-2.11.8.tgz
-                                                                           0.3%#                                                                          2.5%#####                                                                      8.3%########                                                                  11.7%#############                                                             19.0%##################                                                        25.1%#######################                                                   32.0%###########################                                               38.8%################################                                          45.5%#####################################                                     52.7%###########################################                               60.1%################################################                          67.3%#####################################################                     74.3%##########################################################                81.9%################################################################          89.1%#####################################################################     96.6%######################################################################## 100.0%
-Using `mvn` from path: /Users/jlee2/apache-maven-3.5.0/bin/mvn
-[INFO] Scanning for projects...
-[INFO] ------------------------------------------------------------------------
-[INFO] Reactor Build Order:
-[INFO] 
-[INFO] Spark Project Parent POM
-[INFO] Spark Project Tags
-[INFO] Spark Project Sketch
-[INFO] Spark Project Local DB
-[INFO] Spark Project Networking
-[INFO] Spark Project Shuffle Streaming Service
-[INFO] Spark Project Unsafe
-[INFO] Spark Project Launcher
-[INFO] Spark Project Core
-[INFO] Spark Project ML Local Library
-[INFO] Spark Project GraphX
-[INFO] Spark Project Streaming
-[INFO] Spark Project Catalyst
-[INFO] Spark Project SQL
-[INFO] Spark Project ML Library
-[INFO] Spark Project Tools
-[INFO] Spark Project Hive
-[INFO] Spark Project REPL
-[INFO] Spark Project YARN Shuffle Service
-[INFO] Spark Project YARN
-[INFO] Spark Project Hive Thrift Server
-[INFO] Spark Project Assembly
-[INFO] Spark Project External Flume Sink
-[INFO] Spark Project External Flume
-[INFO] Spark Project External Flume Assembly
-[INFO] Spark Integration for Kafka 0.8
-[INFO] Kafka 0.10 Source for Structured Streaming
-[INFO] Spark Project Examples
-[INFO] Spark Project External Kafka Assembly
-[INFO] Spark Integration for Kafka 0.10
-[INFO] Spark Integration for Kafka 0.10 Assembly
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Parent POM 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-parent_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-parent_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-parent_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-parent_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-parent_2.11 ---
-[INFO] No sources to compile
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-parent_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-parent_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-parent_2.11 ---
-[INFO] No sources to compile
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-parent_2.11 ---
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-parent_2.11 ---
-Discovery starting.
-Discovery completed in 49 milliseconds.
-Run starting. Expected test count is: 0
-DiscoverySuite:
-Run completed in 153 milliseconds.
-Total number of tests run: 0
-Suites: completed 1, aborted 0
-Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
-No tests were executed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Tags 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-tags_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-tags_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/tags/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/tags/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-tags_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-tags_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-tags_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/tags/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-tags_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-tags_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[info] 'compiler-interface' not yet compiled for Scala 2.11.8. Compiling...
-[info]   Compilation completed in 12.451 s
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 2 Scala sources and 6 Java sources to /Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes...
-[info] Compile success at Aug 10, 2017 11:09:42 AM [16.051s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-tags_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/tags/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-tags_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/tags/src/test/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-tags_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-tags_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-tags_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 3 Java sources to /Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/test-classes...
-[info] Compile success at Aug 10, 2017 11:09:44 AM [1.675s]
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-tags_2.11 ---
-Downloading: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.pom
-Progress (1): 2.8/3.3 kBProgress (1): 3.3 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.pom (3.3 kB at 11 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-providers/2.19.1/surefire-providers-2.19.1.pom
-Progress (1): 2.1/2.6 kBProgress (1): 2.6 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-providers/2.19.1/surefire-providers-2.19.1.pom (2.6 kB at 88 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.jar
-Progress (1): 2.1/75 kBProgress (1): 4.9/75 kBProgress (1): 7.7/75 kBProgress (1): 10/75 kB Progress (1): 13/75 kBProgress (1): 16/75 kBProgress (1): 19/75 kBProgress (1): 21/75 kBProgress (1): 24/75 kBProgress (1): 27/75 kBProgress (1): 30/75 kBProgress (1): 32/75 kBProgress (1): 36/75 kBProgress (1): 40/75 kBProgress (1): 44/75 kBProgress (1): 49/75 kBProgress (1): 53/75 kBProgress (1): 57/75 kBProgress (1): 61/75 kBProgress (1): 65/75 kBProgress (1): 69/75 kBProgress (1): 73/75 kBProgress (1): 75 kB                      Downloaded: https://repo1.maven.org/maven2/org/apache/maven/surefire/surefire-junit4/2.19.1/surefire-junit4-2.19.1.jar (75 kB at 1.2 MB/s)
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-
-Results :
-
-Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-tags_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-tags_2.11 ---
-Discovery starting.
-Discovery completed in 70 milliseconds.
-Run starting. Expected test count is: 0
-DiscoverySuite:
-Run completed in 145 milliseconds.
-Total number of tests run: 0
-Suites: completed 1, aborted 0
-Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
-No tests were executed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Sketch 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-sketch_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-sketch_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/sketch/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/sketch/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-sketch_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-sketch_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-sketch_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/sketch/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-sketch_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-sketch_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 9 Java sources to /Users/jlee2/Yahoo/yspark_2/common/sketch/target/scala-2.11/classes...
-[info] Compile success at Aug 10, 2017 11:09:49 AM [1.326s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-sketch_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/sketch/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-sketch_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/sketch/src/test/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-sketch_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-sketch_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-sketch_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 3 Scala sources to /Users/jlee2/Yahoo/yspark_2/common/sketch/target/scala-2.11/test-classes...
-[info] Compile success at Aug 10, 2017 11:09:52 AM [3.115s]
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-sketch_2.11 ---
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-
-Results :
-
-Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-sketch_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-sketch_2.11 ---
-Discovery starting.
-Discovery completed in 180 milliseconds.
-Run starting. Expected test count is: 29
-BloomFilterSuite:
-- accuracy - Byte
-- mergeInPlace - Byte
-- accuracy - Short
-- mergeInPlace - Short
-- accuracy - Int
-- mergeInPlace - Int
-- accuracy - Long
-- mergeInPlace - Long
-- accuracy - String
-- mergeInPlace - String
-- incompatible merge
-BitArraySuite:
-- error case when create BitArray
-- bitSize
-- set
-- normal operation
-- merge
-CountMinSketchSuite:
-- accuracy - Byte
-- mergeInPlace - Byte
-- accuracy - Short
-- mergeInPlace - Short
-- accuracy - Int
-- mergeInPlace - Int
-- accuracy - Long
-- mergeInPlace - Long
-- accuracy - String
-- mergeInPlace - String
-- accuracy - Byte array
-- mergeInPlace - Byte array
-- incompatible merge
-Run completed in 14 seconds, 530 milliseconds.
-Total number of tests run: 29
-Suites: completed 4, aborted 0
-Tests: succeeded 29, failed 0, canceled 0, ignored 0, pending 0
-All tests passed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Local DB 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-kvstore_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-kvstore_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-kvstore_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-kvstore_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-kvstore_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-kvstore_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-kvstore_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 12 Java sources to /Users/jlee2/Yahoo/yspark_2/common/kvstore/target/scala-2.11/classes...
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java:174: warning: [rawtypes] found raw type: InMemoryView
-[warn]       return new InMemoryView(type, all, ti);
-[warn]                  ^
-[warn]   missing type arguments for generic class InMemoryView<T>
-[warn]   where T is a type-variable:
-[warn]     T extends Object declared in class InMemoryView
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreIterator.java:34: warning: [try] auto-closeable resource KVStoreIterator<T> has a member method close() that could throw InterruptedException
-[warn] public interface KVStoreIterator<T> extends Iterator<T>, AutoCloseable {
-[warn]        ^
-[warn]   where T is a type-variable:
-[warn]     T extends Object declared in interface KVStoreIterator
-[warn] 2 warnings
-[info] Compile success at Aug 10, 2017 11:10:10 AM [1.727s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-kvstore_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/kvstore/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-kvstore_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 1 resource
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-kvstore_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-kvstore_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-kvstore_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 10 Java sources to /Users/jlee2/Yahoo/yspark_2/common/kvstore/target/scala-2.11/test-classes...
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/DBIteratorSuite.java:387: warning: [try] auto-closeable resource KVStoreIterator<?> has a member method close() that could throw InterruptedException
-[warn]     try(KVStoreIterator<?> it = db.view(i.getClass()).closeableIterator()) {
-[warn]                            ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:67: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]     try(Timer.Context ctx = dbCreation.time()) {
-[warn]                       ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:75: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]       try(Timer.Context ctx = dbClose.time()) {
-[warn]                         ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:194: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]         try(Timer.Context ctx = create.time()) {
-[warn]                           ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:201: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]       try(Timer.Context ctx = iter.time()) {
-[warn]                         ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:210: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]       try(Timer.Context ctx = timer.time()) {
-[warn]                         ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:219: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]       try(Timer.Context ctx = delete.time()) {
-[warn]                         ^
-[warn] /Users/jlee2/Yahoo/yspark_2/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java:228: warning: [try] auto-closeable resource ctx is never referenced in body of corresponding try statement
-[warn]       try(Timer.Context ctx = delete.time()) {
-[warn]                         ^
-[warn] 8 warnings
-[info] Compile success at Aug 10, 2017 11:10:12 AM [2.305s]
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-kvstore_2.11 ---
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-Running org.apache.spark.util.kvstore.ArrayWrappersSuite
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.126 sec - in org.apache.spark.util.kvstore.ArrayWrappersSuite
-Running org.apache.spark.util.kvstore.InMemoryIteratorSuite
-Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.498 sec - in org.apache.spark.util.kvstore.InMemoryIteratorSuite
-Running org.apache.spark.util.kvstore.InMemoryStoreSuite
-Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.apache.spark.util.kvstore.InMemoryStoreSuite
-Running org.apache.spark.util.kvstore.LevelDBIteratorSuite
-Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.982 sec - in org.apache.spark.util.kvstore.LevelDBIteratorSuite
-Running org.apache.spark.util.kvstore.LevelDBSuite
-Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.156 sec - in org.apache.spark.util.kvstore.LevelDBSuite
-Running org.apache.spark.util.kvstore.LevelDBTypeInfoSuite
-Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec - in org.apache.spark.util.kvstore.LevelDBTypeInfoSuite
-
-Results :
-
-Tests run: 100, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-kvstore_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-kvstore_2.11 ---
-Discovery starting.
-Discovery completed in 225 milliseconds.
-Run starting. Expected test count is: 0
-DiscoverySuite:
-Run completed in 346 milliseconds.
-Total number of tests run: 0
-Suites: completed 1, aborted 0
-Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
-No tests were executed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Networking 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.pom
-Progress (1): 2.1/2.2 kBProgress (1): 2.2 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.pom (2.2 kB at 83 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/apache-curator/2.7.1/apache-curator-2.7.1.pom
-Progress (1): 2.2/32 kBProgress (1): 4.9/32 kBProgress (1): 7.7/32 kBProgress (1): 10/32 kB Progress (1): 13/32 kBProgress (1): 16/32 kBProgress (1): 19/32 kBProgress (1): 21/32 kBProgress (1): 24/32 kBProgress (1): 27/32 kBProgress (1): 30/32 kBProgress (1): 32 kB                      Downloaded: https://repo1.maven.org/maven2/org/apache/curator/apache-curator/2.7.1/apache-curator-2.7.1.pom (32 kB at 884 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.pom
-Progress (1): 2.1/2.3 kBProgress (1): 2.3 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.pom (2.3 kB at 84 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.pom
-Progress (1): 2.1/2.4 kBProgress (1): 2.4 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.pom (2.4 kB at 99 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar
-Progress (1): 2.1/186 kBProgress (1): 4.9/186 kBProgress (1): 7.7/186 kBProgress (1): 10/186 kB Progress (1): 13/186 kBProgress (1): 16/186 kBProgress (1): 19/186 kBProgress (1): 21/186 kBProgress (1): 24/186 kBProgress (1): 27/186 kBProgress (1): 30/186 kBProgress (1): 32/186 kBProgress (1): 36/186 kBProgress (1): 40/186 kBProgress (1): 44/186 kBProgress (1): 49/186 kBProgress (1): 53/186 kBProgress (1): 57/186 kBProgress (1): 61/186 kBProgress (1): 65/186 kBProgress (1): 69/186 kBProgress (1): 73/186 kBProgress (1): 77/186 kBProgress (1): 81/186 kBProgress (1): 85/186 kBProgress (1): 89/186 kBProgress (1): 94/186 kBProgress (1): 98/186 kBProgress (1): 102/186 kBProgress (1): 106/186 kBProgress (1): 110/186 kBProgress (1): 114/186 kBProgress (1): 118/186 kBProgress (1): 122/186 kBProgress (1): 126/186 kBProgress (1): 130/186 kBProgress (1): 135/186 kBProgress (1): 139/186 kBProgress (1): 143/186 kBProgress (1): 147/186 kBProgress (1): 151/186 kBProgress (1): 155/186 kBProgress (1): 159/186 kBProgress (1): 163/186 kBProgress (1): 167/186 kBProgress (1): 171/186 kBProgress (1): 176/186 kBProgress (1): 180/186 kBProgress (1): 184/186 kBProgress (1): 186 kB    Progress (2): 186 kB | 2.1/70 kBProgress (3): 186 kB | 2.1/70 kB | 2.1/270 kBProgress (3): 186 kB | 4.9/70 kB | 2.1/270 kBProgress (3): 186 kB | 7.7/70 kB | 2.1/270 kBProgress (3): 186 kB | 7.7/70 kB | 4.9/270 kBProgress (3): 186 kB | 10/70 kB | 4.9/270 kB Progress (3): 186 kB | 10/70 kB | 7.7/270 kBProgress (3): 186 kB | 10/70 kB | 10/270 kB Progress (3): 186 kB | 13/70 kB | 10/270 kBProgress (3): 186 kB | 16/70 kB | 10/270 kBProgress (3): 186 kB | 16/70 kB | 13/270 kB                                           Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar (186 kB at 3.4 MB/s)
-Progress (2): 19/70 kB | 13/270 kBProgress (2): 19/70 kB | 16/270 kBProgress (2): 21/70 kB | 16/270 kBProgress (2): 21/70 kB | 19/270 kBProgress (2): 24/70 kB | 19/270 kBProgress (2): 24/70 kB | 21/270 kBProgress (2): 27/70 kB | 21/270 kBProgress (2): 27/70 kB | 24/270 kBProgress (2): 30/70 kB | 24/270 kBProgress (2): 30/70 kB | 27/270 kBProgress (2): 32/70 kB | 27/270 kBProgress (2): 32/70 kB | 30/270 kBProgress (2): 32/70 kB | 32/270 kBProgress (2): 36/70 kB | 32/270 kBProgress (2): 40/70 kB | 32/270 kBProgress (2): 44/70 kB | 32/270 kBProgress (2): 49/70 kB | 32/270 kBProgress (2): 49/70 kB | 36/270 kBProgress (2): 49/70 kB | 40/270 kBProgress (2): 49/70 kB | 44/270 kBProgress (2): 53/70 kB | 44/270 kBProgress (2): 53/70 kB | 49/270 kBProgress (2): 57/70 kB | 49/270 kBProgress (2): 61/70 kB | 49/270 kBProgress (2): 65/70 kB | 49/270 kBProgress (2): 69/70 kB | 49/270 kBProgress (2): 69/70 kB | 53/270 kBProgress (2): 70 kB | 53/270 kB   Progress (2): 70 kB | 57/270 kBProgress (2): 70 kB | 61/270 kBProgress (2): 70 kB | 65/270 kBProgress (2): 70 kB | 69/270 kBProgress (2): 70 kB | 73/270 kBProgress (2): 70 kB | 77/270 kBProgress (2): 70 kB | 81/270 kBProgress (2): 70 kB | 85/270 kBProgress (2): 70 kB | 89/270 kBProgress (2): 70 kB | 94/270 kBProgress (2): 70 kB | 98/270 kBProgress (2): 70 kB | 102/270 kBProgress (2): 70 kB | 106/270 kBProgress (2): 70 kB | 110/270 kBProgress (2): 70 kB | 114/270 kBProgress (2): 70 kB | 118/270 kBProgress (2): 70 kB | 122/270 kBProgress (2): 70 kB | 126/270 kBProgress (2): 70 kB | 130/270 kBProgress (2): 70 kB | 135/270 kB                                Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar (70 kB at 891 kB/s)
-Progress (1): 139/270 kBProgress (1): 143/270 kBProgress (1): 147/270 kBProgress (1): 151/270 kBProgress (1): 155/270 kBProgress (1): 159/270 kBProgress (1): 163/270 kBProgress (1): 167/270 kBProgress (1): 171/270 kBProgress (1): 176/270 kBProgress (1): 180/270 kBProgress (1): 184/270 kBProgress (1): 188/270 kBProgress (1): 192/270 kBProgress (1): 196/270 kBProgress (1): 200/270 kBProgress (1): 204/270 kBProgress (1): 208/270 kBProgress (1): 212/270 kBProgress (1): 216/270 kBProgress (1): 221/270 kBProgress (1): 225/270 kBProgress (1): 229/270 kBProgress (1): 233/270 kBProgress (1): 237/270 kBProgress (1): 241/270 kBProgress (1): 245/270 kBProgress (1): 249/270 kBProgress (1): 253/270 kBProgress (1): 257/270 kBProgress (1): 262/270 kBProgress (1): 266/270 kBProgress (1): 270/270 kBProgress (1): 270 kB                        Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar (270 kB at 2.4 MB/s)
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-network-common_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-network-common_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-common/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-common/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-network-common_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-server-common/2.7.3/hadoop-yarn-server-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-crypto/1.0.0/commons-crypto-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/inject/guice/3.0/guice-3.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/jlee2/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.3/hadoop-auth-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-client/2.7.3/hadoop-client-2.7.3.jar:/Users/jlee2/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.3/hadoop-hdfs-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-shuffle/2.7.3/hadoop-mapreduce-client-shuffle-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/jlee2/.m2/repository/commons-net/commons-net/2.2/commons-net-2.2.jar:/Users/jlee2/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.3/hadoop-mapreduce-client-core-2.7.3.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-common/2.7.3/hadoop-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/jlee2/.m2/repository/com/google/guava/guava/14.0.1/guava-14.0.1.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.3/hadoop-annotations-2.7.3.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/Users/jlee2/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-common/2.7.3/hadoop-mapreduce-client-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-jobclient/2.7.3/hadoop-mapreduce-client-jobclient-2.7.3.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-app/2.7.3/hadoop-mapreduce-client-app-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/.m2/repository/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar:/Users/jlee2/.m2/repository/io/netty/netty-all/4.0.43.Final/netty-all-4.0.43.Final.jar:/Users/jlee2/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-network-common_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-network-common_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/network-common/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-network-common_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-network-common_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 73 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/classes...
-[warn] /Users/jlee2/Yahoo/yspark_2/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java:112: warning: [deprecation] PooledByteBufAllocator(boolean,int,int,int,int,int,int,int) in PooledByteBufAllocator has been deprecated
-[warn]     return new PooledByteBufAllocator(
-[warn]            ^
-[warn] 1 warning
-[info] Compile success at Aug 10, 2017 11:10:24 AM [3.557s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-network-common_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/network-common/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-network-common_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 1 resource
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-network-common_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-network-common_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-network-common_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 18 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/test-classes...
-[warn] /Users/jlee2/Yahoo/yspark_2/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java:105: warning: [rawtypes] found raw type: GenericFutureListener
-[warn]     private List<GenericFutureListener> listeners = new ArrayList<>();
-[warn]                  ^
-[warn]   missing type arguments for generic class GenericFutureListener<F>
-[warn]   where F is a type-variable:
-[warn]     F extends Future<?> declared in interface GenericFutureListener
-[warn] /Users/jlee2/Yahoo/yspark_2/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java:129: warning: [unchecked] unchecked call to operationComplete(F) as a member of the raw type GenericFutureListener
-[warn]           listener.operationComplete(this);
-[warn]                                     ^
-[warn]   where F is a type-variable:
-[warn]     F extends Future<?> declared in interface GenericFutureListener
-[warn] 2 warnings
-[info] Compile success at Aug 10, 2017 11:10:29 AM [3.338s]
-[INFO] 
-[INFO] --- maven-jar-plugin:3.0.2:test-jar (prepare-test-jar) @ spark-network-common_2.11 ---
-[INFO] Building jar: /Users/jlee2/Yahoo/yspark_2/common/network-common/target/spark-network-common_2.11-2.3.0-SNAPSHOT-tests.jar
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-network-common_2.11 ---
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-Running org.apache.spark.network.ChunkFetchIntegrationSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.623 sec - in org.apache.spark.network.ChunkFetchIntegrationSuite
-Running org.apache.spark.network.crypto.AuthEngineSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.376 sec - in org.apache.spark.network.crypto.AuthEngineSuite
-Running org.apache.spark.network.crypto.AuthIntegrationSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.665 sec - in org.apache.spark.network.crypto.AuthIntegrationSuite
-Running org.apache.spark.network.crypto.AuthMessagesSuite
-Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.apache.spark.network.crypto.AuthMessagesSuite
-Running org.apache.spark.network.protocol.MessageWithHeaderSuite
-Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 sec - in org.apache.spark.network.protocol.MessageWithHeaderSuite
-Running org.apache.spark.network.ProtocolSuite
-Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in org.apache.spark.network.ProtocolSuite
-Running org.apache.spark.network.RequestTimeoutIntegrationSuite
-Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.308 sec - in org.apache.spark.network.RequestTimeoutIntegrationSuite
-Running org.apache.spark.network.RpcIntegrationSuite
-Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.246 sec - in org.apache.spark.network.RpcIntegrationSuite
-Running org.apache.spark.network.sasl.SparkSaslSuite
-Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.322 sec - in org.apache.spark.network.sasl.SparkSaslSuite
-Running org.apache.spark.network.server.OneForOneStreamManagerSuite
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.apache.spark.network.server.OneForOneStreamManagerSuite
-Running org.apache.spark.network.StreamSuite
-Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 sec - in org.apache.spark.network.StreamSuite
-Running org.apache.spark.network.TransportClientFactorySuite
-Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.123 sec - in org.apache.spark.network.TransportClientFactorySuite
-Running org.apache.spark.network.TransportRequestHandlerSuite
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 sec - in org.apache.spark.network.TransportRequestHandlerSuite
-Running org.apache.spark.network.TransportResponseHandlerSuite
-Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 sec - in org.apache.spark.network.TransportResponseHandlerSuite
-Running org.apache.spark.network.util.CryptoUtilsSuite
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.apache.spark.network.util.CryptoUtilsSuite
-Running org.apache.spark.network.util.TransportFrameDecoderSuite
-Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 sec - in org.apache.spark.network.util.TransportFrameDecoderSuite
-
-Results :
-
-Tests run: 71, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-network-common_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-network-common_2.11 ---
-Discovery starting.
-Discovery completed in 148 milliseconds.
-Run starting. Expected test count is: 0
-DiscoverySuite:
-Run completed in 242 milliseconds.
-Total number of tests run: 0
-Suites: completed 1, aborted 0
-Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
-No tests were executed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Shuffle Streaming Service 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-network-shuffle_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-network-shuffle_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-network-shuffle_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-core/3.1.2/metrics-core-3.1.2.jar:/Users/jlee2/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-server-common/2.7.3/hadoop-yarn-server-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-crypto/1.0.0/commons-crypto-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/inject/guice/3.0/guice-3.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/jlee2/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.3/hadoop-auth-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-client/2.7.3/hadoop-client-2.7.3.jar:/Users/jlee2/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.3/hadoop-hdfs-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-shuffle/2.7.3/hadoop-mapreduce-client-shuffle-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/jlee2/.m2/repository/commons-net/commons-net/2.2/commons-net-2.2.jar:/Users/jlee2/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.3/hadoop-mapreduce-client-core-2.7.3.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-common/2.7.3/hadoop-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/jlee2/.m2/repository/org/slf4j/slf4j-log4j12/1.7.16/slf4j-log4j12-1.7.16.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.3/hadoop-annotations-2.7.3.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/Users/jlee2/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-common/2.7.3/hadoop-mapreduce-client-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-jobclient/2.7.3/hadoop-mapreduce-client-jobclient-2.7.3.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-app/2.7.3/hadoop-mapreduce-client-app-2.7.3.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/.m2/repository/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar:/Users/jlee2/.m2/repository/io/netty/netty-all/4.0.43.Final/netty-all-4.0.43.Final.jar:/Users/jlee2/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-network-shuffle_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-network-shuffle_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-network-shuffle_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-network-shuffle_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 20 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/scala-2.11/classes...
-[info] Compile success at Aug 10, 2017 11:11:15 AM [2.389s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-network-shuffle_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-network-shuffle_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 1 resource
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-network-shuffle_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-network-shuffle_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-network-shuffle_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 10 Java sources to /Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/scala-2.11/test-classes...
-[info] Compile success at Aug 10, 2017 11:11:17 AM [2.136s]
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-network-shuffle_2.11 ---
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-Running org.apache.spark.network.sasl.SaslIntegrationSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.082 sec - in org.apache.spark.network.sasl.SaslIntegrationSuite
-Running org.apache.spark.network.shuffle.BlockTransferMessagesSuite
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.apache.spark.network.shuffle.BlockTransferMessagesSuite
-Running org.apache.spark.network.shuffle.ExternalShuffleBlockHandlerSuite
-Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 sec - in org.apache.spark.network.shuffle.ExternalShuffleBlockHandlerSuite
-Running org.apache.spark.network.shuffle.ExternalShuffleBlockResolverSuite
-Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.295 sec - in org.apache.spark.network.shuffle.ExternalShuffleBlockResolverSuite
-Running org.apache.spark.network.shuffle.ExternalShuffleCleanupSuite
-Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.792 sec - in org.apache.spark.network.shuffle.ExternalShuffleCleanupSuite
-Running org.apache.spark.network.shuffle.ExternalShuffleIntegrationSuite
-Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.509 sec - in org.apache.spark.network.shuffle.ExternalShuffleIntegrationSuite
-Running org.apache.spark.network.shuffle.ExternalShuffleSecuritySuite
-Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.078 sec - in org.apache.spark.network.shuffle.ExternalShuffleSecuritySuite
-Running org.apache.spark.network.shuffle.OneForOneBlockFetcherSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in org.apache.spark.network.shuffle.OneForOneBlockFetcherSuite
-Running org.apache.spark.network.shuffle.RetryingBlockFetcherSuite
-Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 sec - in org.apache.spark.network.shuffle.RetryingBlockFetcherSuite
-
-Results :
-
-Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-network-shuffle_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-network-shuffle_2.11 ---
-Discovery starting.
-Discovery completed in 109 milliseconds.
-Run starting. Expected test count is: 0
-DiscoverySuite:
-Run completed in 177 milliseconds.
-Total number of tests run: 0
-Suites: completed 1, aborted 0
-Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
-No tests were executed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Unsafe 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-unsafe_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-unsafe_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-unsafe_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/com/twitter/chill-java/0.8.0/chill-java-0.8.0.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/minlog/1.3.0/minlog-1.3.0.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/kryo-shaded/3.0.3/kryo-shaded-3.0.3.jar:/Users/jlee2/.m2/repository/com/twitter/chill_2.11/0.8.0/chill_2.11-0.8.0.jar:/Users/jlee2/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-unsafe_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-unsafe_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-unsafe_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-unsafe_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 16 Java sources to /Users/jlee2/Yahoo/yspark_2/common/unsafe/target/scala-2.11/classes...
-[info] Compile success at Aug 10, 2017 11:11:26 AM [4.162s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-unsafe_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/common/unsafe/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-unsafe_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/common/unsafe/src/test/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-unsafe_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-unsafe_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-unsafe_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 1 Scala source and 5 Java sources to /Users/jlee2/Yahoo/yspark_2/common/unsafe/target/scala-2.11/test-classes...
-[info] Compile success at Aug 10, 2017 11:11:33 AM [7.243s]
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-unsafe_2.11 ---
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-Running org.apache.spark.unsafe.array.LongArraySuite
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 sec - in org.apache.spark.unsafe.array.LongArraySuite
-Running org.apache.spark.unsafe.hash.Murmur3_x86_32Suite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.361 sec - in org.apache.spark.unsafe.hash.Murmur3_x86_32Suite
-Running org.apache.spark.unsafe.PlatformUtilSuite
-Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 sec - in org.apache.spark.unsafe.PlatformUtilSuite
-Running org.apache.spark.unsafe.types.CalendarIntervalSuite
-Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.apache.spark.unsafe.types.CalendarIntervalSuite
-Running org.apache.spark.unsafe.types.UTF8StringSuite
-Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.067 sec - in org.apache.spark.unsafe.types.UTF8StringSuite
-
-Results :
-
-Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-unsafe_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-unsafe_2.11 ---
-Discovery starting.
-Discovery completed in 279 milliseconds.
-Run starting. Expected test count is: 19
-UTF8StringPropertyCheckSuite:
-- toString
-- numChars
-- startsWith
-- endsWith
-- toUpperCase
-- toLowerCase
-- compare
-- substring
-- contains
-- trim, trimLeft, trimRight
-- reverse
-- indexOf
-- repeat
-- lpad, rpad
-- concat
-- concatWs
-- split !!! IGNORED !!!
-- levenshteinDistance
-- hashCode
-- equals
-Run completed in 1 second, 622 milliseconds.
-Total number of tests run: 19
-Suites: completed 2, aborted 0
-Tests: succeeded 19, failed 0, canceled 0, ignored 1, pending 0
-All tests passed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Launcher 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-launcher_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-launcher_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/launcher/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/launcher/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-launcher_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-launcher_2.11 ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-launcher_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory /Users/jlee2/Yahoo/yspark_2/launcher/src/main/resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-launcher_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-launcher_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 16 Java sources to /Users/jlee2/Yahoo/yspark_2/launcher/target/scala-2.11/classes...
-[info] Compile success at Aug 10, 2017 11:11:41 AM [2.441s]
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (create-tmp-dir) @ spark-launcher_2.11 ---
-[INFO] Executing tasks
-
-main:
-    [mkdir] Created dir: /Users/jlee2/Yahoo/yspark_2/launcher/target/tmp
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ spark-launcher_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 2 resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ spark-launcher_2.11 ---
-[INFO] Not compiling test sources
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (generate-test-classpath) @ spark-launcher_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ spark-launcher_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 6 Java sources to /Users/jlee2/Yahoo/yspark_2/launcher/target/scala-2.11/test-classes...
-[info] Compile success at Aug 10, 2017 11:11:44 AM [1.897s]
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ spark-launcher_2.11 ---
-
--------------------------------------------------------
- T E S T S
--------------------------------------------------------
-Running org.apache.spark.launcher.CommandBuilderUtilsSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.076 sec - in org.apache.spark.launcher.CommandBuilderUtilsSuite
-Running org.apache.spark.launcher.LauncherServerSuite
-Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.338 sec - in org.apache.spark.launcher.LauncherServerSuite
-Running org.apache.spark.launcher.OutputRedirectionSuite
-Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.112 sec - in org.apache.spark.launcher.OutputRedirectionSuite
-Running org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
-Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 sec - in org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
-Running org.apache.spark.launcher.SparkSubmitOptionParserSuite
-Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.155 sec - in org.apache.spark.launcher.SparkSubmitOptionParserSuite
-
-Results :
-
-Tests run: 34, Failures: 0, Errors: 0, Skipped: 0
-
-[INFO] 
-[INFO] --- maven-surefire-plugin:2.19.1:test (test) @ spark-launcher_2.11 ---
-[INFO] Skipping execution of surefire because it has already been run for this configuration
-[INFO] 
-[INFO] --- scalatest-maven-plugin:1.0:test (test) @ spark-launcher_2.11 ---
-Discovery starting.
-Discovery completed in 115 milliseconds.
-Run starting. Expected test count is: 0
-DiscoverySuite:
-Run completed in 220 milliseconds.
-Total number of tests run: 0
-Suites: completed 1, aborted 0
-Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
-No tests were executed.
-[INFO] 
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Spark Project Core 2.3.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.pom
-Progress (1): 2.0 kB                    Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.pom (2.0 kB at 70 kB/s)
-Downloading: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.jar
-Progress (1): 2.1/39 kBProgress (1): 4.9/39 kBProgress (1): 7.7/39 kBProgress (1): 10/39 kB Progress (1): 13/39 kBProgress (1): 16/39 kBProgress (1): 19/39 kBProgress (1): 21/39 kBProgress (1): 24/39 kBProgress (1): 27/39 kBProgress (1): 30/39 kBProgress (1): 32/39 kBProgress (1): 35/39 kBProgress (1): 38/39 kBProgress (1): 39 kB                      Downloaded: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.7.1/curator-test-2.7.1.jar (39 kB at 1.2 MB/s)
-[INFO] 
-[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-versions) @ spark-core_2.11 ---
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:add-source (eclipse-add-source) @ spark-core_2.11 ---
-[INFO] Add Source directory: /Users/jlee2/Yahoo/yspark_2/core/src/main/scala
-[INFO] Add Test Source directory: /Users/jlee2/Yahoo/yspark_2/core/src/test/scala
-[INFO] 
-[INFO] --- maven-dependency-plugin:3.0.0:build-classpath (default-cli) @ spark-core_2.11 ---
-[INFO] Dependencies classpath:
-/Users/jlee2/.m2/repository/mx4j/mx4j/3.0.2/mx4j-3.0.2.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-core/3.1.2/metrics-core-3.1.2.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/module/jackson-module-scala_2.11/2.6.7.1/jackson-module-scala_2.11-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/jlee2/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/Users/jlee2/.m2/repository/net/java/dev/jets3t/jets3t/0.9.3/jets3t-0.9.3.jar:/Users/jlee2/.m2/repository/org/lz4/lz4-java/1.4.0/lz4-java-1.4.0.jar:/Users/jlee2/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-continuation/9.3.20.v20170531/jetty-continuation-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-jvm/3.1.2/metrics-jvm-3.1.2.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-servlets/9.3.20.v20170531/jetty-servlets-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/bundles/repackaged/jersey-guava/2.22.2/jersey-guava-2.22.2.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-json/3.1.2/metrics-json-3.1.2.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-crypto/1.0.0/commons-crypto-1.0.0.jar:/Users/jlee2/.m2/repository/com/google/inject/guice/3.0/guice-3.0.jar:/Users/jlee2/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar:/Users/jlee2/.m2/repository/org/json4s/json4s-jackson_2.11/3.2.11/json4s-jackson_2.11-3.2.11.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.3/hadoop-auth-2.7.3.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/minlog/1.3.0/minlog-1.3.0.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-client/2.7.3/hadoop-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-shuffle/2.7.3/hadoop-mapreduce-client-shuffle-2.7.3.jar:/Users/jlee2/.m2/repository/javax/mail/mail/1.4.7/mail-1.4.7.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-xml/9.3.20.v20170531/jetty-xml-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar:/Users/jlee2/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.51/bcprov-jdk15on-1.51.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/core/jersey-common/2.22.2/jersey-common-2.22.2.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.3/hadoop-mapreduce-client-core-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/jlee2/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/hk2-api/2.4.0-b34/hk2-api-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/core/jersey-server/2.22.2/jersey-server-2.22.2.jar:/Users/jlee2/.m2/repository/com/twitter/chill-java/0.8.0/chill-java-0.8.0.jar:/Users/jlee2/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-server/9.3.20.v20170531/jetty-server-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-client/2.7.3/hadoop-yarn-client-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar:/Users/jlee2/.m2/repository/org/tukaani/xz/1.0/xz-1.0.jar:/Users/jlee2/.m2/repository/javax/activation/activation/1.1.1/activation-1.1.1.jar:/Users/jlee2/.m2/repository/commons-codec/commons-codec/1.10/commons-codec-1.10.jar:/Users/jlee2/.m2/repository/org/javassist/javassist/3.18.1-GA/javassist-3.18.1-GA.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-client/9.3.20.v20170531/jetty-client-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar:/Users/jlee2/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-util/9.3.20.v20170531/jetty-util-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/osgi-resource-locator/1.0.1/osgi-resource-locator-1.0.1.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.7/jackson-core-2.6.7.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-common/2.7.3/hadoop-mapreduce-client-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-jobclient/2.7.3/hadoop-mapreduce-client-jobclient-2.7.3.jar:/Users/jlee2/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro/1.7.7/avro-1.7.7.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/hk2-utils/2.4.0-b34/hk2-utils-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/external/aopalliance-repackaged/2.4.0-b34/aopalliance-repackaged-2.4.0-b34.jar:/Users/jlee2/.m2/repository/io/netty/netty-all/4.0.43.Final/netty-all-4.0.43.Final.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/external/javax.inject/2.4.0-b34/javax.inject-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet-core/2.22.2/jersey-container-servlet-core-2.22.2.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/module/jackson-module-paranamer/2.6.7/jackson-module-paranamer-2.6.7.jar:/Users/jlee2/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-compiler/2.11.8/scala-compiler-2.11.8.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-common/2.7.3/hadoop-yarn-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-api/2.7.3/hadoop-yarn-api-2.7.3.jar:/Users/jlee2/.m2/repository/org/roaringbitmap/RoaringBitmap/0.5.11/RoaringBitmap-0.5.11.jar:/Users/jlee2/.m2/repository/log4j/log4j/1.2.17/log4j-1.2.17.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-yarn-server-common/2.7.3/hadoop-yarn-server-common-2.7.3.jar:/Users/jlee2/.m2/repository/org/scala-lang/scala-library/2.11.8/scala-library-2.11.8.jar:/Users/jlee2/.m2/repository/com/twitter/parquet-hadoop-bundle/1.6.0/parquet-hadoop-bundle-1.6.0.jar:/Users/jlee2/Yahoo/yspark_2/launcher/target/scala-2.11/classes:/Users/jlee2/Yahoo/yspark_2/common/unsafe/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-proxy/9.3.20.v20170531/jetty-proxy-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/jlee2/.m2/repository/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/jlee2/.m2/repository/com/jamesmurty/utils/java-xmlbuilder/1.0/java-xmlbuilder-1.0.jar:/Users/jlee2/.m2/repository/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar:/Users/jlee2/Yahoo/yspark_2/common/network-common/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/apache/xbean/xbean-asm5-shaded/4.4/xbean-asm5-shaded-4.4.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar:/Users/jlee2/.m2/repository/org/json4s/json4s-core_2.11/3.2.11/json4s-core_2.11-3.2.11.jar:/Users/jlee2/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/jlee2/Yahoo/yspark_2/common/network-shuffle/target/scala-2.11/classes:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar:/Users/jlee2/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/jlee2/.m2/repository/net/sf/py4j/py4j/0.10.6/py4j-0.10.6.jar:/Users/jlee2/.m2/repository/com/esotericsoftware/kryo-shaded/3.0.3/kryo-shaded-3.0.3.jar:/Users/jlee2/.m2/repository/javax/ws/rs/javax.ws.rs-api/2.0.1/javax.ws.rs-api-2.0.1.jar:/Users/jlee2/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/core/jersey-client/2.22.2/jersey-client-2.22.2.jar:/Users/jlee2/.m2/repository/io/netty/netty/3.9.9.Final/netty-3.9.9.Final.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro-mapred/1.7.7/avro-mapred-1.7.7-hadoop2.jar:/Users/jlee2/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/jlee2/.m2/repository/com/ning/compress-lzf/1.0.3/compress-lzf-1.0.3.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.3/hadoop-hdfs-2.7.3.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-webapp/9.3.20.v20170531/jetty-webapp-9.3.20.v20170531.jar:/Users/jlee2/Yahoo/yspark_2/common/tags/target/scala-2.11/classes:/Users/jlee2/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/jlee2/.m2/repository/commons-net/commons-net/2.2/commons-net-2.2.jar:/Users/jlee2/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/jlee2/.m2/repository/org/json4s/json4s-ast_2.11/3.2.11/json4s-ast_2.11-3.2.11.jar:/Users/jlee2/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/jlee2/.m2/repository/org/scala-lang/scalap/2.11.8/scalap-2.11.8.jar:/Users/jlee2/.m2/repository/com/clearspring/analytics/stream/2.7.0/stream-2.7.0.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-http/9.3.20.v20170531/jetty-http-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-security/9.3.20.v20170531/jetty-security-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-common/2.7.3/hadoop-common-2.7.3.jar:/Users/jlee2/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.7/jackson-annotations-2.6.7.jar:/Users/jlee2/.m2/repository/com/thoughtworks/paranamer/paranamer/2.6/paranamer-2.6.jar:/Users/jlee2/.m2/repository/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet/2.22.2/jersey-container-servlet-2.22.2.jar:/Users/jlee2/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar:/Users/jlee2/.m2/repository/org/slf4j/jul-to-slf4j/1.7.16/jul-to-slf4j-1.7.16.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-io/9.3.20.v20170531/jetty-io-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/jlee2/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar:/Users/jlee2/.m2/repository/org/scala-lang/modules/scala-xml_2.11/1.0.2/scala-xml_2.11-1.0.2.jar:/Users/jlee2/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-plus/9.3.20.v20170531/jetty-plus-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar:/Users/jlee2/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/jlee2/.m2/repository/io/dropwizard/metrics/metrics-graphite/3.1.2/metrics-graphite-3.1.2.jar:/Users/jlee2/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/jlee2/.m2/repository/net/iharder/base64/2.3.8/base64-2.3.8.jar:/Users/jlee2/.m2/repository/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar:/Users/jlee2/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar:/Users/jlee2/.m2/repository/org/slf4j/slf4j-log4j12/1.7.16/slf4j-log4j12-1.7.16.jar:/Users/jlee2/.m2/repository/org/xerial/snappy/snappy-java/1.1.2.6/snappy-java-1.1.2.6.jar:/Users/jlee2/.m2/repository/org/glassfish/jersey/media/jersey-media-jaxb/2.22.2/jersey-media-jaxb-2.22.2.jar:/Users/jlee2/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/Users/jlee2/.m2/repository/org/apache/avro/avro-ipc/1.7.7/avro-ipc-1.7.7.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.3/hadoop-annotations-2.7.3.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-jndi/9.3.20.v20170531/jetty-jndi-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/jlee2/.m2/repository/com/twitter/chill_2.11/0.8.0/chill_2.11-0.8.0.jar:/Users/jlee2/.m2/repository/org/glassfish/hk2/hk2-locator/2.4.0-b34/hk2-locator-2.4.0-b34.jar:/Users/jlee2/.m2/repository/org/apache/hadoop/hadoop-mapreduce-client-app/2.7.3/hadoop-mapreduce-client-app-2.7.3.jar:/Users/jlee2/.m2/repository/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar:/Users/jlee2/.m2/repository/net/razorvine/pyrolite/4.13/pyrolite-4.13.jar:/Users/jlee2/.m2/repository/org/eclipse/jetty/jetty-servlet/9.3.20.v20170531/jetty-servlet-9.3.20.v20170531.jar:/Users/jlee2/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.16/jcl-over-slf4j-1.7.16.jar:/Users/jlee2/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/jlee2/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.5:process (default) @ spark-core_2.11 ---
-[INFO] 
-[INFO] --- maven-antrun-plugin:1.8:run (default) @ spark-core_2.11 ---
-[INFO] Executing tasks
-
-main:
-[INFO] Executed tasks
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ spark-core_2.11 ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 37 resources
-[INFO] Copying 1 resource
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ spark-core_2.11 ---
-[INFO] Not compiling main sources
-[INFO] 
-[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ spark-core_2.11 ---
-[INFO] Using zinc server for incremental compilation
-[warn] Pruning sources from previous analysis, due to incompatible CompileSetup.
-[info] Compiling 487 Scala sources and 74 Java sources to /Users/jlee2/Yahoo/yspark_2/core/target/scala-2.11/classes...

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -17,23 +17,22 @@
 
 package org.apache.spark.deploy.yarn
 
-import javax.crypto.SecretKey
-import javax.crypto.spec.SecretKeySpec;
 import java.io.{File, IOException}
 import java.lang.reflect.InvocationTargetException
 import java.net.{Socket, URI, URL}
 import java.util.concurrent.{TimeoutException, TimeUnit}
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
 
 import scala.collection.mutable.HashMap
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.base64.Base64;
-import com.google.common.base.Charsets;
-
+import com.google.common.base.Charsets
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+import io.netty.handler.codec.base64.Base64
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.yarn.api._
 import org.apache.hadoop.yarn.api.records._
@@ -48,17 +47,17 @@ import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.deploy.yarn.security.{AMCredentialRenewer, YARNHadoopDelegationTokenManager}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
-import org.apache.spark.rpc._
-import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, YarnSchedulerBackend}
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
-import org.apache.spark.util._
-import org.apache.spark.network.{TransportContext, BlockDataManager}
+import org.apache.spark.network.{BlockDataManager, TransportContext}
 import org.apache.spark.network.client.TransportClientBootstrap
-import org.apache.spark.network.netty.{SparkTransportConf, NettyBlockRpcServer}
+import org.apache.spark.network.netty.{NettyBlockRpcServer, SparkTransportConf}
 import org.apache.spark.network.sasl.{SaslClientBootstrap, SaslServerBootstrap}
 import org.apache.spark.network.server.{TransportServer, TransportServerBootstrap}
-import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.rpc._
 import org.apache.spark.rpc.netty.NettyRpcCallContext
+import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, YarnSchedulerBackend}
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.util._
 
 /**
  * Common application master functionality for Spark on Yarn.
@@ -451,7 +450,7 @@ private[spark] class ApplicationMaster(
        driverRef: RpcEndpointRef,
        securityManager: SecurityManager): RpcEndpointRef = {
     val serversparkConf = new SparkConf()
-    serversparkConf.set("spark.rpc.connectionUsingTokens","true")
+    serversparkConf.set("spark.rpc.connectionUsingTokens", "true")
 
     val amRpcEnv =
       RpcEnv.create(ApplicationMaster.SYSTEM_NAME, Utils.localHostName(), port, serversparkConf,
@@ -459,8 +458,8 @@ private[spark] class ApplicationMaster(
     clientToAMPort = amRpcEnv.address.port
 
     val clientAMEndpoint =
-      amRpcEnv.setupEndpoint(ApplicationMaster.ENDPOINT_NAME, new ClientToAMEndpoint(amRpcEnv, driverRef,
-        securityManager))
+      amRpcEnv.setupEndpoint(ApplicationMaster.ENDPOINT_NAME,
+        new ClientToAMEndpoint(amRpcEnv, driverRef, securityManager))
     clientAMEndpoint
   }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.deploy.yarn
 
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec;
 import java.io.{File, IOException}
 import java.lang.reflect.InvocationTargetException
 import java.net.{Socket, URI, URL}
@@ -26,6 +28,11 @@ import scala.collection.mutable.HashMap
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.base64.Base64;
+import com.google.common.base.Charsets;
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.yarn.api._
@@ -45,6 +52,13 @@ import org.apache.spark.rpc._
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, YarnSchedulerBackend}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.util._
+import org.apache.spark.network.{TransportContext, BlockDataManager}
+import org.apache.spark.network.client.TransportClientBootstrap
+import org.apache.spark.network.netty.{SparkTransportConf, NettyBlockRpcServer}
+import org.apache.spark.network.sasl.{SaslClientBootstrap, SaslServerBootstrap}
+import org.apache.spark.network.server.{TransportServer, TransportServerBootstrap}
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.rpc.netty.NettyRpcCallContext
 
 /**
  * Common application master functionality for Spark on Yarn.
@@ -89,6 +103,7 @@ private[spark] class ApplicationMaster(
 
   @volatile private var reporterThread: Thread = _
   @volatile private var allocator: YarnAllocator = _
+  @volatile private var clientToAMPort: Int = _
 
   // A flag to check whether user has initialized spark context
   @volatile private var registered = false
@@ -247,7 +262,9 @@ private[spark] class ApplicationMaster(
 
         if (!unregistered) {
           // we only want to unregister if we don't want the RM to retry
-          if (finalStatus == FinalApplicationStatus.SUCCEEDED || isLastAttempt) {
+          if (finalStatus == FinalApplicationStatus.SUCCEEDED ||
+            finalStatus == FinalApplicationStatus.KILLED ||
+            isLastAttempt) {
             unregister(finalStatus, finalMsg)
             cleanupStagingDir()
           }
@@ -283,6 +300,7 @@ private[spark] class ApplicationMaster(
         credentialRenewerThread.start()
         credentialRenewerThread.join()
       }
+      clientToAMPort = sparkConf.getInt("spark.yarn.clientToAM.port", 0)
 
       if (isClusterMode) {
         runDriver(securityMgr)
@@ -402,7 +420,8 @@ private[spark] class ApplicationMaster(
       uiAddress,
       historyAddress,
       securityMgr,
-      localResources)
+      localResources,
+      clientToAMPort)
 
     // Initialize the AM endpoint *after* the allocator has been initialized. This ensures
     // that when the driver sends an initial executor request (e.g. after an AM restart),
@@ -422,6 +441,46 @@ private[spark] class ApplicationMaster(
       YarnSchedulerBackend.ENDPOINT_NAME)
   }
 
+  /**
+   * Create an [[RpcEndpoint]] that communicates with the client.
+   *
+   * @return A reference to the application master's RPC endpoint.
+   */
+  private def runClientAMEndpoint(
+       port: Int,
+       driverRef: RpcEndpointRef,
+       securityManager: SecurityManager): RpcEndpointRef = {
+    val serversparkConf = new SparkConf()
+    serversparkConf.set("spark.rpc.connectionUsingTokens","true")
+
+    val amRpcEnv =
+      RpcEnv.create(ApplicationMaster.SYSTEM_NAME, Utils.localHostName(), port, serversparkConf,
+        securityManager)
+    clientToAMPort = amRpcEnv.address.port
+
+    val clientAMEndpoint =
+      amRpcEnv.setupEndpoint(ApplicationMaster.ENDPOINT_NAME, new ClientToAMEndpoint(amRpcEnv, driverRef,
+        securityManager))
+    clientAMEndpoint
+  }
+
+  /** RpcEndpoint class for ClientToAM */
+  private[spark] class ClientToAMEndpoint(
+      override val rpcEnv: RpcEnv, driverRef: RpcEndpointRef, securityManager: SecurityManager)
+    extends RpcEndpoint with Logging {
+
+    override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+      case ApplicationMasterMessages.KillApplication =>
+        if (securityManager.checkModifyPermissions(context.senderUserName)) {
+          driverRef.send(StopSparkContext)
+          finish(FinalApplicationStatus.KILLED, ApplicationMaster.EXIT_KILLED)
+          context.reply(true)
+        } else {
+          context.reply(false)
+        }
+    }
+  }
+
   private def runDriver(securityMgr: SecurityManager): Unit = {
     addAmIpFilter(None)
     userClassThread = startUserApplication()
@@ -438,8 +497,12 @@ private[spark] class ApplicationMaster(
         val driverRef = createSchedulerRef(
           sc.getConf.get("spark.driver.host"),
           sc.getConf.get("spark.driver.port"))
+        val clientToAMSecurityManager = new SecurityManager(sparkConf)
+        runClientAMEndpoint(clientToAMPort, driverRef, clientToAMSecurityManager)
         registerAM(sc.getConf, rpcEnv, driverRef, sc.ui.map(_.webUrl), securityMgr)
         registered = true
+        clientToAMSecurityManager.setSecretKey(Base64.encode(
+          Unpooled.wrappedBuffer(client.getMasterKey)).toString(Charsets.UTF_8));
       } else {
         // Sanity check; should never happen in normal operation, since sc should only be null
         // if the user app did not create a SparkContext.
@@ -464,10 +527,13 @@ private[spark] class ApplicationMaster(
       amCores, true)
     val driverRef = waitForSparkDriver()
     addAmIpFilter(Some(driverRef))
+    val clientToAMSecurityManager = new SecurityManager(sparkConf)
+    runClientAMEndpoint(clientToAMPort, driverRef, clientToAMSecurityManager)
     registerAM(sparkConf, rpcEnv, driverRef, sparkConf.getOption("spark.driver.appUIAddress"),
       securityMgr)
     registered = true
-
+    clientToAMSecurityManager.setSecretKey(Base64.encode(
+      Unpooled.wrappedBuffer(client.getMasterKey)).toString(Charsets.UTF_8));
     // In client mode the actor will stop the reporter thread.
     reporterThread.join()
   }
@@ -749,7 +815,17 @@ private[spark] class ApplicationMaster(
 
 }
 
+sealed trait ApplicationMasterMessage extends Serializable
+
+private [spark] object ApplicationMasterMessages {
+
+  case class KillApplication() extends ApplicationMasterMessage
+}
+
 object ApplicationMaster extends Logging {
+
+  val SYSTEM_NAME = "sparkYarnAM"
+  val ENDPOINT_NAME = "clientToAM"
 
   // exit codes for different causes, no reason behind the values
   private val EXIT_SUCCESS = 0
@@ -760,6 +836,7 @@ object ApplicationMaster extends Logging {
   private val EXIT_SECURITY = 14
   private val EXIT_EXCEPTION_USER_CLASS = 15
   private val EXIT_EARLY = 16
+  private val EXIT_KILLED = 17
 
   private var master: ApplicationMaster = _
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -22,8 +22,8 @@ import java.net.{InetAddress, InetSocketAddress, UnknownHostException, URI}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.security.PrivilegedExceptionAction
-import java.util.concurrent.TimeoutException
 import java.util.{Locale, Properties, UUID}
+import java.util.concurrent.TimeoutException
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.JavaConverters._
@@ -31,13 +31,12 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, ListBuffer, Map}
 import scala.concurrent.ExecutionContext
 import scala.util.control.Breaks._
 import scala.util.control.NonFatal
-import scala.collection.JavaConversions._
 
-import io.netty.handler.codec.base64.Base64;
-import io.netty.buffer.Unpooled;
 import com.google.common.base.Charsets.UTF_8
 import com.google.common.base.Objects
 import com.google.common.io.Files
+import io.netty.buffer.Unpooled
+import io.netty.handler.codec.base64.Base64
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
@@ -62,8 +61,8 @@ import org.apache.spark.deploy.yarn.security.YARNHadoopDelegationTokenManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle, YarnCommandBuilderUtils}
+import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.util.{CallerContext, RpcUtils, SparkExitCode, ThreadUtils, Utils}
-import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef,RpcEnv, ThreadSafeRpcEndpoint}
 
 private[spark] class Client(
     val args: ClientArguments,
@@ -1179,7 +1178,7 @@ private[spark] class Client(
     var currentTime = System.currentTimeMillis
     val timeKillIssued = currentTime
 
-    val killTimeOut  =sparkConf.get(CLIENT_TO_AM_HARD_KILL_TIMEOUT)
+    val killTimeOut = sparkConf.get(CLIENT_TO_AM_HARD_KILL_TIMEOUT)
     while ((currentTime< timeKillIssued + killTimeOut)
         && !isAppInTerminalState(appId)) {
       try
@@ -1194,7 +1193,9 @@ private[spark] class Client(
     }
   }
 
-  private def setupAMConnection(appId: ApplicationId, securityManager: SecurityManager): RpcEndpointRef = {
+  private def setupAMConnection(
+      appId: ApplicationId,
+      securityManager: SecurityManager): RpcEndpointRef = {
     logInfo(s"APP ID $appId")
     val report = getApplicationReport(appId)
     val state = report.getYarnApplicationState
@@ -1220,7 +1221,7 @@ private[spark] class Client(
       securityManager.setSecretKey(secretkeystring)
     }
 
-    sparkConf.set("spark.rpc.connectionUsingTokens","true")
+    sparkConf.set("spark.rpc.connectionUsingTokens", "true")
     val rpcEnv =
       RpcEnv.create("yarnDriverClient", Utils.localHostName(), 0, sparkConf, securityManager)
     val AMHostPort = RpcAddress(report.getHost, report.getRpcPort)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -75,7 +75,7 @@ private[spark] class YarnRMClient extends Logging {
 
     logInfo("Registering the ApplicationMaster")
     synchronized {
-      var response = amClient.registerApplicationMaster(Utils.localHostName(), port, uiAddress)
+      var response = amClient.registerApplicationMaster(Utils.localHostName(), port, trackingUrl)
       registered = true
       masterkey = response.getClientToAMTokenMasterKey()
     }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.deploy.yarn
 
+import java.nio.ByteBuffer
+
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.yarn.api.records._
@@ -39,6 +41,7 @@ private[spark] class YarnRMClient extends Logging {
   private var amClient: AMRMClient[ContainerRequest] = _
   private var uiHistoryAddress: String = _
   private var registered: Boolean = false
+  private var masterkey: ByteBuffer = _
 
   /**
    * Registers the application master with the RM.
@@ -58,7 +61,8 @@ private[spark] class YarnRMClient extends Logging {
       uiAddress: Option[String],
       uiHistoryAddress: String,
       securityMgr: SecurityManager,
-      localResources: Map[String, LocalResource]
+      localResources: Map[String, LocalResource],
+      port: Int = 0
     ): YarnAllocator = {
     amClient = AMRMClient.createAMRMClient()
     amClient.init(conf)
@@ -71,8 +75,9 @@ private[spark] class YarnRMClient extends Logging {
 
     logInfo("Registering the ApplicationMaster")
     synchronized {
-      amClient.registerApplicationMaster(Utils.localHostName(), 0, trackingUrl)
+      var response = amClient.registerApplicationMaster(Utils.localHostName(), port, uiAddress)
       registered = true
+      masterkey = response.getClientToAMTokenMasterKey()
     }
     new YarnAllocator(driverUrl, driverRef, conf, sparkConf, amClient, getAttemptId(), securityMgr,
       localResources, new SparkRackResolver())
@@ -89,6 +94,9 @@ private[spark] class YarnRMClient extends Logging {
       amClient.unregisterApplicationMaster(status, diagnostics, uiHistoryAddress)
     }
   }
+  /** Obtain the MasterKey reported back from YARN when Registering AM*/
+  def getMasterKey(): ByteBuffer = masterkey
+
 
   /** Returns the attempt ID. */
   def getAttemptId(): ApplicationAttemptId = {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -94,7 +94,7 @@ private[spark] class YarnRMClient extends Logging {
       amClient.unregisterApplicationMaster(status, diagnostics, uiHistoryAddress)
     }
   }
-  /** Obtain the MasterKey reported back from YARN when Registering AM*/
+  /** Obtain the MasterKey reported back from YARN when Registering AM. */
   def getMasterKey(): ByteBuffer = masterkey
 
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -187,6 +187,11 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
+  private[spark] val CLIENT_TO_AM_HARD_KILL_TIMEOUT = ConfigBuilder("spark.yarn.hardKillTimeout")
+    .internal()
+    .timeConf(TimeUnit.MILLISECONDS)
+    .createWithDefaultString("60s")
+
   /* Client-mode AM configuration. */
 
   private[spark] val AM_CORES = ConfigBuilder("spark.yarn.am.cores")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -23,9 +23,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
-import org.apache.hadoop.yarn.api.records.{ApplicationAttemptId, ApplicationId}
 import org.apache.hadoop.io.DataOutputBuffer
 import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hadoop.yarn.api.records.{ApplicationAttemptId, ApplicationId}
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -24,6 +24,8 @@ import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.yarn.api.records.{ApplicationAttemptId, ApplicationId}
+import org.apache.hadoop.io.DataOutputBuffer
+import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
@@ -271,6 +273,8 @@ private[spark] abstract class YarnSchedulerBackend(
             logError("Error requesting driver to remove executor" +
               s" $executorId for reason $reason", e)
         }(ThreadUtils.sameThread)
+      case StopSparkContext =>
+        sc.stop
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Similar to how standalone and Mesos have the capability to safely shut down the spark application, there should be a way to safely shut down spark on Yarn mode. This will ensure a clean shutdown and unregistration from yarn.

This PR adds YARN support for `--kill SUBMISSION_ID` CLI

## How was this patch tested?

Tested by running a word count job and killing it via the kill CLI.

- Test condition
    - Application running on Client mode, cluster mode
    - different ACL condition for the client that is submitting the kill CLI
           - no view, modify ACL
           - only view ACL
           - only modify ACL
           - both view, modify ACL
    - spark.authentication true/false
    - using keytab