### PR TITLE
[SPARK-21245][ML] Resolve code duplication for classification/regression summarizers

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -34,10 +34,9 @@ import org.apache.spark.ml.optim.aggregator.LogisticAggregator
 import org.apache.spark.ml.optim.loss.{L2Regularization, RDDLossFunction}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
+import org.apache.spark.ml.stat.Summarizers
 import org.apache.spark.ml.util._
 import org.apache.spark.mllib.evaluation.BinaryClassificationMetrics
-import org.apache.spark.mllib.linalg.VectorImplicits._
-import org.apache.spark.mllib.stat.MultivariateOnlineSummarizer
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
@@ -504,19 +503,8 @@ class LogisticRegression @Since("1.2.0") (
     instr.logParams(regParam, elasticNetParam, standardization, threshold,
       maxIter, tol, fitIntercept)
 
-    val (summarizer, labelSummarizer) = {
-      val seqOp = (c: (MultivariateOnlineSummarizer, MultiClassSummarizer),
-        instance: Instance) =>
-          (c._1.add(instance.features, instance.weight), c._2.add(instance.label, instance.weight))
-
-      val combOp = (c1: (MultivariateOnlineSummarizer, MultiClassSummarizer),
-        c2: (MultivariateOnlineSummarizer, MultiClassSummarizer)) =>
-          (c1._1.merge(c2._1), c1._2.merge(c2._2))
-
-      instances.treeAggregate(
-        new MultivariateOnlineSummarizer, new MultiClassSummarizer
-      )(seqOp, combOp, $(aggregationDepth))
-    }
+    val (summarizer, labelSummarizer) =
+      Summarizers.getClassificationSummarizers(instances, $(aggregationDepth))
 
     val histogram = labelSummarizer.histogram
     val numInvalid = labelSummarizer.countInvalid
@@ -1240,86 +1228,6 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
       DefaultParamsReader.getAndSetParams(model, metadata)
       model
     }
-  }
-}
-
-
-/**
- * MultiClassSummarizer computes the number of distinct labels and corresponding counts,
- * and validates the data to see if the labels used for k class multi-label classification
- * are in the range of {0, 1, ..., k - 1} in an online fashion.
- *
- * Two MultilabelSummarizer can be merged together to have a statistical summary of the
- * corresponding joint dataset.
- */
-private[ml] class MultiClassSummarizer extends Serializable {
-  // The first element of value in distinctMap is the actually number of instances,
-  // and the second element of value is sum of the weights.
-  private val distinctMap = new mutable.HashMap[Int, (Long, Double)]
-  private var totalInvalidCnt: Long = 0L
-
-  /**
-   * Add a new label into this MultilabelSummarizer, and update the distinct map.
-   *
-   * @param label The label for this data point.
-   * @param weight The weight of this instances.
-   * @return This MultilabelSummarizer
-   */
-  def add(label: Double, weight: Double = 1.0): this.type = {
-    require(weight >= 0.0, s"instance weight, $weight has to be >= 0.0")
-
-    if (weight == 0.0) return this
-
-    if (label - label.toInt != 0.0 || label < 0) {
-      totalInvalidCnt += 1
-      this
-    }
-    else {
-      val (counts: Long, weightSum: Double) = distinctMap.getOrElse(label.toInt, (0L, 0.0))
-      distinctMap.put(label.toInt, (counts + 1L, weightSum + weight))
-      this
-    }
-  }
-
-  /**
-   * Merge another MultilabelSummarizer, and update the distinct map.
-   * (Note that it will merge the smaller distinct map into the larger one using in-place
-   * merging, so either `this` or `other` object will be modified and returned.)
-   *
-   * @param other The other MultilabelSummarizer to be merged.
-   * @return Merged MultilabelSummarizer object.
-   */
-  def merge(other: MultiClassSummarizer): MultiClassSummarizer = {
-    val (largeMap, smallMap) = if (this.distinctMap.size > other.distinctMap.size) {
-      (this, other)
-    } else {
-      (other, this)
-    }
-    smallMap.distinctMap.foreach {
-      case (key, value) =>
-        val (counts: Long, weightSum: Double) = largeMap.distinctMap.getOrElse(key, (0L, 0.0))
-        largeMap.distinctMap.put(key, (counts + value._1, weightSum + value._2))
-    }
-    largeMap.totalInvalidCnt += smallMap.totalInvalidCnt
-    largeMap
-  }
-
-  /** @return The total invalid input counts. */
-  def countInvalid: Long = totalInvalidCnt
-
-  /** @return The number of distinct labels in the input dataset. */
-  def numClasses: Int = if (distinctMap.isEmpty) 0 else distinctMap.keySet.max + 1
-
-  /** @return The weightSum of each label in the input dataset. */
-  def histogram: Array[Double] = {
-    val result = Array.ofDim[Double](numClasses)
-    var i = 0
-    val len = result.length
-    while (i < len) {
-      result(i) = distinctMap.getOrElse(i, (0L, 0.0))._2
-      i += 1
-    }
-    result
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/MultiClassSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/MultiClassSummarizer.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import scala.collection.mutable
+
+/**
+ * MultiClassSummarizer computes the number of distinct labels and corresponding counts,
+ * and validates the data to see if the labels used for k class multi-label classification
+ * are in the range of {0, 1, ..., k - 1} in an online fashion.
+ *
+ * Two MultilabelSummarizer can be merged together to have a statistical summary of the
+ * corresponding joint dataset.
+ */
+private[ml] class MultiClassSummarizer extends Serializable {
+  // The first element of value in distinctMap is the actually number of instances,
+  // and the second element of value is sum of the weights.
+  private val distinctMap = new mutable.HashMap[Int, (Long, Double)]
+  private var totalInvalidCnt: Long = 0L
+
+  /**
+   * Add a new label into this MultilabelSummarizer, and update the distinct map.
+   *
+   * @param label The label for this data point.
+   * @param weight The weight of this instances.
+   * @return This MultilabelSummarizer
+   */
+  def add(label: Double, weight: Double = 1.0): this.type = {
+    require(weight >= 0.0, s"instance weight, $weight has to be >= 0.0")
+
+    if (weight == 0.0) return this
+
+    if (label - label.toInt != 0.0 || label < 0) {
+      totalInvalidCnt += 1
+      this
+    }
+    else {
+      val (counts: Long, weightSum: Double) = distinctMap.getOrElse(label.toInt, (0L, 0.0))
+      distinctMap.put(label.toInt, (counts + 1L, weightSum + weight))
+      this
+    }
+  }
+
+  /**
+   * Merge another MultilabelSummarizer, and update the distinct map.
+   * (Note that it will merge the smaller distinct map into the larger one using in-place
+   * merging, so either `this` or `other` object will be modified and returned.)
+   *
+   * @param other The other MultilabelSummarizer to be merged.
+   * @return Merged MultilabelSummarizer object.
+   */
+  def merge(other: MultiClassSummarizer): MultiClassSummarizer = {
+    val (largeMap, smallMap) = if (this.distinctMap.size > other.distinctMap.size) {
+      (this, other)
+    } else {
+      (other, this)
+    }
+    smallMap.distinctMap.foreach {
+      case (key, value) =>
+        val (counts: Long, weightSum: Double) = largeMap.distinctMap.getOrElse(key, (0L, 0.0))
+        largeMap.distinctMap.put(key, (counts + value._1, weightSum + value._2))
+    }
+    largeMap.totalInvalidCnt += smallMap.totalInvalidCnt
+    largeMap
+  }
+
+  /** @return The total invalid input counts. */
+  def countInvalid: Long = totalInvalidCnt
+
+  /** @return The number of distinct labels in the input dataset. */
+  def numClasses: Int = if (distinctMap.isEmpty) 0 else distinctMap.keySet.max + 1
+
+  /** @return The weightSum of each label in the input dataset. */
+  def histogram: Array[Double] = {
+    val result = Array.ofDim[Double](numClasses)
+    var i = 0
+    val len = result.length
+    while (i < len) {
+      result(i) = distinctMap.getOrElse(i, (0L, 0.0))._2
+      i += 1
+    }
+    result
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizers.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import org.apache.spark.ml.feature.Instance
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.mllib.linalg.VectorImplicits._
+import org.apache.spark.mllib.stat.MultivariateOnlineSummarizer
+import org.apache.spark.rdd.RDD
+
+/**
+ * Summarizers provides helper functions to get feature and label summarizers from provided data.
+ */
+private[ml] object Summarizers extends Serializable {
+
+  /** Get regression feature and label summarizers for provided data. */
+  def getRegressionSummarizers(
+      instances: RDD[Instance],
+      aggregationDepth: Int = 2): (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer) = {
+    val seqOp = (c: (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer),
+                 instance: Instance) =>
+      (c._1.add(instance.features, instance.weight),
+        c._2.add(Vectors.dense(instance.label), instance.weight))
+
+    val combOp = (c1: (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer),
+                  c2: (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer)) =>
+      (c1._1.merge(c2._1), c1._2.merge(c2._2))
+
+    instances.treeAggregate(
+      new MultivariateOnlineSummarizer, new MultivariateOnlineSummarizer
+    )(seqOp, combOp, aggregationDepth)
+  }
+
+  /** Get classification feature and label summarizers for provided data. */
+  def getClassificationSummarizers(
+      instances: RDD[Instance],
+      aggregationDepth: Int = 2): (MultivariateOnlineSummarizer, MultiClassSummarizer) = {
+    val seqOp = (c: (MultivariateOnlineSummarizer, MultiClassSummarizer),
+                 instance: Instance) =>
+      (c._1.add(instance.features, instance.weight),
+        c._2.add(instance.label, instance.weight))
+
+    val combOp = (c1: (MultivariateOnlineSummarizer, MultiClassSummarizer),
+                  c2: (MultivariateOnlineSummarizer, MultiClassSummarizer)) =>
+      (c1._1.merge(c2._1), c1._2.merge(c2._2))
+
+    instances.treeAggregate(
+      new MultivariateOnlineSummarizer, new MultiClassSummarizer
+    )(seqOp, combOp, aggregationDepth)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{DenseMatrix, Matrices, Matrix, SparseMatrix, Vector, Vectors}
 import org.apache.spark.ml.optim.aggregator.LogisticAggregator
 import org.apache.spark.ml.param.{ParamMap, ParamsSuite}
+import org.apache.spark.ml.stat.MultiClassSummarizer
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
@@ -551,72 +552,6 @@ class LogisticRegressionSuite
     val prob2 = results(1).getAs[Vector](1)
     assert(raw2 === Vectors.dense(-1.0, -2.0, -3.0))
     assert(prob2 ~== Vectors.dense(0.66524096, 0.24472847, 0.09003057) relTol eps)
-  }
-
-  test("MultiClassSummarizer") {
-    val summarizer1 = (new MultiClassSummarizer)
-      .add(0.0).add(3.0).add(4.0).add(3.0).add(6.0)
-    assert(summarizer1.histogram === Array[Double](1, 0, 0, 2, 1, 0, 1))
-    assert(summarizer1.countInvalid === 0)
-    assert(summarizer1.numClasses === 7)
-
-    val summarizer2 = (new MultiClassSummarizer)
-      .add(1.0).add(5.0).add(3.0).add(0.0).add(4.0).add(1.0)
-    assert(summarizer2.histogram === Array[Double](1, 2, 0, 1, 1, 1))
-    assert(summarizer2.countInvalid === 0)
-    assert(summarizer2.numClasses === 6)
-
-    val summarizer3 = (new MultiClassSummarizer)
-      .add(0.0).add(1.3).add(5.2).add(2.5).add(2.0).add(4.0).add(4.0).add(4.0).add(1.0)
-    assert(summarizer3.histogram === Array[Double](1, 1, 1, 0, 3))
-    assert(summarizer3.countInvalid === 3)
-    assert(summarizer3.numClasses === 5)
-
-    val summarizer4 = (new MultiClassSummarizer)
-      .add(3.1).add(4.3).add(2.0).add(1.0).add(3.0)
-    assert(summarizer4.histogram === Array[Double](0, 1, 1, 1))
-    assert(summarizer4.countInvalid === 2)
-    assert(summarizer4.numClasses === 4)
-
-    val summarizer5 = new MultiClassSummarizer
-    assert(summarizer5.histogram.isEmpty)
-    assert(summarizer5.numClasses === 0)
-
-    // small map merges large one
-    val summarizerA = summarizer1.merge(summarizer2)
-    assert(summarizerA.hashCode() === summarizer2.hashCode())
-    assert(summarizerA.histogram === Array[Double](2, 2, 0, 3, 2, 1, 1))
-    assert(summarizerA.countInvalid === 0)
-    assert(summarizerA.numClasses === 7)
-
-    // large map merges small one
-    val summarizerB = summarizer3.merge(summarizer4)
-    assert(summarizerB.hashCode() === summarizer3.hashCode())
-    assert(summarizerB.histogram === Array[Double](1, 2, 2, 1, 3))
-    assert(summarizerB.countInvalid === 5)
-    assert(summarizerB.numClasses === 5)
-  }
-
-  test("MultiClassSummarizer with weighted samples") {
-    val summarizer1 = (new MultiClassSummarizer)
-      .add(label = 0.0, weight = 0.2).add(3.0, 0.8).add(4.0, 3.2).add(3.0, 1.3).add(6.0, 3.1)
-    assert(Vectors.dense(summarizer1.histogram) ~==
-      Vectors.dense(Array(0.2, 0, 0, 2.1, 3.2, 0, 3.1)) absTol 1E-10)
-    assert(summarizer1.countInvalid === 0)
-    assert(summarizer1.numClasses === 7)
-
-    val summarizer2 = (new MultiClassSummarizer)
-      .add(1.0, 1.1).add(5.0, 2.3).add(3.0).add(0.0).add(4.0).add(1.0).add(2, 0.0)
-    assert(Vectors.dense(summarizer2.histogram) ~==
-      Vectors.dense(Array[Double](1.0, 2.1, 0.0, 1, 1, 2.3)) absTol 1E-10)
-    assert(summarizer2.countInvalid === 0)
-    assert(summarizer2.numClasses === 6)
-
-    val summarizer = summarizer1.merge(summarizer2)
-    assert(Vectors.dense(summarizer.histogram) ~==
-      Vectors.dense(Array(1.2, 2.1, 0.0, 3.1, 4.2, 2.3, 3.1)) absTol 1E-10)
-    assert(summarizer.countInvalid === 0)
-    assert(summarizer.numClasses === 7)
   }
 
   test("binary logistic regression with intercept without regularization") {

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/DifferentiableLossAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/DifferentiableLossAggregatorSuite.scala
@@ -17,12 +17,9 @@
 package org.apache.spark.ml.optim.aggregator
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.classification.MultiClassSummarizer
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors}
 import org.apache.spark.ml.util.TestingUtils._
-import org.apache.spark.mllib.linalg.VectorImplicits._
-import org.apache.spark.mllib.stat.MultivariateOnlineSummarizer
 
 class DifferentiableLossAggregatorSuite extends SparkFunSuite {
 
@@ -159,39 +156,5 @@ object DifferentiableLossAggregatorSuite {
       }
       this
     }
-  }
-
-  /** Get feature and label summarizers for provided data. */
-  private[ml] def getRegressionSummarizers(
-      instances: Array[Instance]): (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer) = {
-    val seqOp = (c: (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer),
-                 instance: Instance) =>
-      (c._1.add(instance.features, instance.weight),
-        c._2.add(Vectors.dense(instance.label), instance.weight))
-
-    val combOp = (c1: (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer),
-                  c2: (MultivariateOnlineSummarizer, MultivariateOnlineSummarizer)) =>
-      (c1._1.merge(c2._1), c1._2.merge(c2._2))
-
-    instances.aggregate(
-      new MultivariateOnlineSummarizer, new MultivariateOnlineSummarizer
-    )(seqOp, combOp)
-  }
-
-  /** Get feature and label summarizers for provided data. */
-  private[ml] def getClassificationSummarizers(
-      instances: Array[Instance]): (MultivariateOnlineSummarizer, MultiClassSummarizer) = {
-    val seqOp = (c: (MultivariateOnlineSummarizer, MultiClassSummarizer),
-                 instance: Instance) =>
-      (c._1.add(instance.features, instance.weight),
-        c._2.add(instance.label, instance.weight))
-
-    val combOp = (c1: (MultivariateOnlineSummarizer, MultiClassSummarizer),
-                  c2: (MultivariateOnlineSummarizer, MultiClassSummarizer)) =>
-      (c1._1.merge(c2._1), c1._2.merge(c2._2))
-
-    instances.aggregate(
-      new MultivariateOnlineSummarizer, new MultiClassSummarizer
-    )(seqOp, combOp)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/LeastSquaresAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/LeastSquaresAggregatorSuite.scala
@@ -19,12 +19,11 @@ package org.apache.spark.ml.optim.aggregator
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors}
+import org.apache.spark.ml.stat.Summarizers
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 class LeastSquaresAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
-
-  import DifferentiableLossAggregatorSuite.getRegressionSummarizers
 
   @transient var instances: Array[Instance] = _
   @transient var instancesConstantFeature: Array[Instance] = _
@@ -54,7 +53,8 @@ class LeastSquaresAggregatorSuite extends SparkFunSuite with MLlibTestSparkConte
       instances: Array[Instance],
       coefficients: Vector,
       fitIntercept: Boolean): LeastSquaresAggregator = {
-    val (featuresSummarizer, ySummarizer) = getRegressionSummarizers(instances)
+    val (featuresSummarizer, ySummarizer) =
+      Summarizers.getRegressionSummarizers(sc.parallelize(instances))
     val yStd = math.sqrt(ySummarizer.variance(0))
     val yMean = ySummarizer.mean(0)
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
@@ -105,7 +105,8 @@ class LeastSquaresAggregatorSuite extends SparkFunSuite with MLlibTestSparkConte
      */
     val coefficients = Vectors.dense(1.0, 2.0)
     val numFeatures = coefficients.size
-    val (featuresSummarizer, ySummarizer) = getRegressionSummarizers(instances)
+    val (featuresSummarizer, ySummarizer) =
+      Summarizers.getRegressionSummarizers(sc.parallelize(instances))
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
     val featuresMean = featuresSummarizer.mean.toArray
     val yStd = math.sqrt(ySummarizer.variance(0))

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/LogisticAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/LogisticAggregatorSuite.scala
@@ -19,12 +19,11 @@ package org.apache.spark.ml.optim.aggregator
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{BLAS, Matrices, Vector, Vectors}
+import org.apache.spark.ml.stat.Summarizers
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 class LogisticAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
-
-  import DifferentiableLossAggregatorSuite.getClassificationSummarizers
 
   @transient var instances: Array[Instance] = _
   @transient var instancesConstantFeature: Array[Instance] = _
@@ -50,7 +49,7 @@ class LogisticAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
       fitIntercept: Boolean,
       isMultinomial: Boolean): LogisticAggregator = {
     val (featuresSummarizer, ySummarizer) =
-      DifferentiableLossAggregatorSuite.getClassificationSummarizers(instances)
+      Summarizers.getClassificationSummarizers(sc.parallelize(instances))
     val numClasses = ySummarizer.histogram.length
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
     val bcFeaturesStd = spark.sparkContext.broadcast(featuresStd)
@@ -128,7 +127,8 @@ class LogisticAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
     val numFeatures = instances.head.features.size
     val numClasses = instances.map(_.label).toSet.size
     val intercepts = Vectors.dense(interceptArray)
-    val (featuresSummarizer, ySummarizer) = getClassificationSummarizers(instances)
+    val (featuresSummarizer, ySummarizer) =
+      Summarizers.getClassificationSummarizers(sc.parallelize(instances))
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
     val weightSum = instances.map(_.weight).sum
 
@@ -194,7 +194,8 @@ class LogisticAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
     val coefArray = Array(1.0, 2.0)
     val intercept = 1.0
     val numFeatures = binaryInstances.head.features.size
-    val (featuresSummarizer, _) = getClassificationSummarizers(binaryInstances)
+    val (featuresSummarizer, _) =
+      Summarizers.getClassificationSummarizers(sc.parallelize(binaryInstances))
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
     val weightSum = binaryInstances.map(_.weight).sum
 

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/MultiClassSummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/MultiClassSummarizerSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.util.TestingUtils._
+
+class MultiClassSummarizerSuite extends SparkFunSuite {
+
+  test("MultiClassSummarizer") {
+    val summarizer1 = (new MultiClassSummarizer)
+      .add(0.0).add(3.0).add(4.0).add(3.0).add(6.0)
+    assert(summarizer1.histogram === Array[Double](1, 0, 0, 2, 1, 0, 1))
+    assert(summarizer1.countInvalid === 0)
+    assert(summarizer1.numClasses === 7)
+
+    val summarizer2 = (new MultiClassSummarizer)
+      .add(1.0).add(5.0).add(3.0).add(0.0).add(4.0).add(1.0)
+    assert(summarizer2.histogram === Array[Double](1, 2, 0, 1, 1, 1))
+    assert(summarizer2.countInvalid === 0)
+    assert(summarizer2.numClasses === 6)
+
+    val summarizer3 = (new MultiClassSummarizer)
+      .add(0.0).add(1.3).add(5.2).add(2.5).add(2.0).add(4.0).add(4.0).add(4.0).add(1.0)
+    assert(summarizer3.histogram === Array[Double](1, 1, 1, 0, 3))
+    assert(summarizer3.countInvalid === 3)
+    assert(summarizer3.numClasses === 5)
+
+    val summarizer4 = (new MultiClassSummarizer)
+      .add(3.1).add(4.3).add(2.0).add(1.0).add(3.0)
+    assert(summarizer4.histogram === Array[Double](0, 1, 1, 1))
+    assert(summarizer4.countInvalid === 2)
+    assert(summarizer4.numClasses === 4)
+
+    val summarizer5 = new MultiClassSummarizer
+    assert(summarizer5.histogram.isEmpty)
+    assert(summarizer5.numClasses === 0)
+
+    // small map merges large one
+    val summarizerA = summarizer1.merge(summarizer2)
+    assert(summarizerA.hashCode() === summarizer2.hashCode())
+    assert(summarizerA.histogram === Array[Double](2, 2, 0, 3, 2, 1, 1))
+    assert(summarizerA.countInvalid === 0)
+    assert(summarizerA.numClasses === 7)
+
+    // large map merges small one
+    val summarizerB = summarizer3.merge(summarizer4)
+    assert(summarizerB.hashCode() === summarizer3.hashCode())
+    assert(summarizerB.histogram === Array[Double](1, 2, 2, 1, 3))
+    assert(summarizerB.countInvalid === 5)
+    assert(summarizerB.numClasses === 5)
+  }
+
+  test("MultiClassSummarizer with weighted samples") {
+    val summarizer1 = (new MultiClassSummarizer)
+      .add(label = 0.0, weight = 0.2).add(3.0, 0.8).add(4.0, 3.2).add(3.0, 1.3).add(6.0, 3.1)
+    assert(Vectors.dense(summarizer1.histogram) ~==
+      Vectors.dense(Array(0.2, 0, 0, 2.1, 3.2, 0, 3.1)) absTol 1E-10)
+    assert(summarizer1.countInvalid === 0)
+    assert(summarizer1.numClasses === 7)
+
+    val summarizer2 = (new MultiClassSummarizer)
+      .add(1.0, 1.1).add(5.0, 2.3).add(3.0).add(0.0).add(4.0).add(1.0).add(2, 0.0)
+    assert(Vectors.dense(summarizer2.histogram) ~==
+      Vectors.dense(Array[Double](1.0, 2.1, 0.0, 1, 1, 2.3)) absTol 1E-10)
+    assert(summarizer2.countInvalid === 0)
+    assert(summarizer2.numClasses === 6)
+
+    val summarizer = summarizer1.merge(summarizer2)
+    assert(Vectors.dense(summarizer.histogram) ~==
+      Vectors.dense(Array(1.2, 2.1, 0.0, 3.1, 4.2, 2.3, 3.1)) absTol 1E-10)
+    assert(summarizer.countInvalid === 0)
+    assert(summarizer.numClasses === 7)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizersSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizersSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.feature.Instance
+import org.apache.spark.mllib.linalg.VectorImplicits._
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
+
+class SummarizersSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  test("getRegressionSummarizers") {
+    val instances = sc.parallelize(Seq(
+      Instance(1.0, 1.0, Vectors.dense(-2.0, 0.0).toSparse),
+      Instance(3.0, 1.0, Vectors.dense(0.0, 4.0))))
+    val (featureSummarizer, labelSummarizer) =
+      Summarizers.getRegressionSummarizers(instances)
+
+    // verify feature summarizer
+    assert(featureSummarizer.mean ~== Vectors.dense(-1.0, 2.0) absTol 1E-5)
+    assert(featureSummarizer.min ~== Vectors.dense(-2.0, 0.0) absTol 1E-5)
+    assert(featureSummarizer.max ~== Vectors.dense(0.0, 4.0) absTol 1E-5)
+    assert(featureSummarizer.numNonzeros ~== Vectors.dense(1, 1) absTol 1E-5)
+    assert(featureSummarizer.variance ~== Vectors.dense(2.0, 8.0) absTol 1E-5)
+    assert(featureSummarizer.count === 2)
+
+    // verify regression label summarizer
+    assert(labelSummarizer.mean ~== Vectors.dense(2.0) absTol 1E-5)
+    assert(labelSummarizer.min ~== Vectors.dense(1.0) absTol 1E-5)
+    assert(labelSummarizer.max ~== Vectors.dense(3.0) absTol 1E-5)
+    assert(labelSummarizer.numNonzeros ~== Vectors.dense(2.0) absTol 1E-5)
+    assert(labelSummarizer.variance ~== Vectors.dense(2.0) absTol 1E-5)
+    assert(labelSummarizer.count === 2)
+  }
+
+  test("getClassificationSummarizers") {
+    val instances = sc.parallelize(Seq(
+      Instance(0.0, 1.0, Vectors.dense(-2.0, 0.0).toSparse),
+      Instance(1.0, 9.0, Vectors.dense(0.0, 4.0))))
+    val (featureSummarizer, labelSummarizer) =
+      Summarizers.getClassificationSummarizers(instances)
+
+    // verify feature summarizer
+    assert(featureSummarizer.mean ~== Vectors.dense(-0.2, 3.6) absTol 1E-5)
+    assert(featureSummarizer.min ~== Vectors.dense(-2.0, 0.0) absTol 1E-5)
+    assert(featureSummarizer.max ~== Vectors.dense(0.0, 4.0) absTol 1E-5)
+    assert(featureSummarizer.numNonzeros ~== Vectors.dense(1, 1) absTol 1E-5)
+    assert(featureSummarizer.count === 2)
+
+    // verify classification label summarizer
+    assert(labelSummarizer.histogram === Array[Double](1, 9))
+    assert(labelSummarizer.countInvalid === 0)
+    assert(labelSummarizer.numClasses === 2)
+  }
+}


### PR DESCRIPTION
## Why the change?

In several places (LogReg, LinReg, SVC) in Spark ML, we collect summary information about training data using `MultivariateOnlineSummarizer` and `MulticlassSummarizer`. We have the same code appearing in several places (including test suites). We can eliminate this by creating a common implementation.

## What changes were proposed in this pull request?

1. A new class `ml.stat.Summarizers.scala` with `def getRegressionSummarizers` and `def getClassificationSummarizers` that provides a pair of feature and label summarizers.
This centralizes the duplicated code in: `LinearRegression`, `LinearSVC`, `LogisticRegression` and `DifferentiableLossAggregatorSuite`.
2. Moves `MultiClassSummarizer.scala`(and testSuite) out of `LogisticRegression.scala` to new file `ml.stat.MultiClassSummarizer.scala`, because it is also used by `LinearSVC` and can be generalized.

## How was this patch tested?

`ml.stat.SummarizersSuite.scala`