### PR TITLE
[SPARK-21689][YARN] Download user jar from remote in case of getting hadoop token …

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -342,8 +342,8 @@ object SparkSubmit extends CommandLineUtils {
       }.orNull
     }
 
-    // In yarn-cluster mode, download remote '--jars' and
-    // primaryResource in order to get correct hadoop token.
+    // In yarn cluster mode, download remote jars and primary resource to local,
+    // these jars will be added to classpath of YARN client to get tokens.
     if (isYarnCluster) {
       args.primaryResource = Option(args.primaryResource).map {
         downloadFile(_, targetDir, args.sparkProperties, hadoopConf)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -218,9 +218,9 @@ object SparkSubmit extends CommandLineUtils {
    * Exposed for testing.
    */
   private[deploy] def prepareSubmitEnvironment(
-       args: SparkSubmitArguments,
-       hadoopConf: HadoopConfiguration = new HadoopConfiguration())
-      : (Seq[String], Seq[String], Map[String, String], String) = {
+    args: SparkSubmitArguments,
+    hadoopConf: HadoopConfiguration = new HadoopConfiguration())
+  : (Seq[String], Seq[String], Map[String, String], String) = {
     // Return values
     val childArgs = new ArrayBuffer[String]()
     val childClasspath = new ArrayBuffer[String]()

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -218,8 +218,8 @@ object SparkSubmit extends CommandLineUtils {
    * Exposed for testing.
    */
   private[deploy] def prepareSubmitEnvironment(
-    args: SparkSubmitArguments,
-    hadoopConf: HadoopConfiguration = new HadoopConfiguration())
+      args: SparkSubmitArguments,
+      hadoopConf: HadoopConfiguration = new HadoopConfiguration())
   : (Seq[String], Seq[String], Map[String, String], String) = {
     // Return values
     val childArgs = new ArrayBuffer[String]()

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -217,7 +217,9 @@ object SparkSubmit extends CommandLineUtils {
    *   (4) the main class for the child
    * Exposed for testing.
    */
-  private[deploy] def prepareSubmitEnvironment(args: SparkSubmitArguments)
+  private[deploy] def prepareSubmitEnvironment(
+       args: SparkSubmitArguments,
+       hadoopConf: HadoopConfiguration = new HadoopConfiguration())
       : (Seq[String], Seq[String], Map[String, String], String) = {
     // Return values
     val childArgs = new ArrayBuffer[String]()
@@ -319,8 +321,7 @@ object SparkSubmit extends CommandLineUtils {
         RPackageUtils.checkAndBuildRPackage(args.jars, printStream, args.verbose)
       }
     }
-
-    val hadoopConf = new HadoopConfiguration()
+    
     val targetDir = DependencyUtils.createTempDir()
 
     // Resolve glob path for different resources.

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -346,9 +346,11 @@ object SparkSubmit extends CommandLineUtils {
     // In yarn cluster mode, download remote jars and primary resource to local,
     // these jars will be added to classpath of YARN client to get tokens.
     if (isYarnCluster) {
-      args.primaryResource = Option(args.primaryResource).map {
-        downloadFile(_, targetDir, args.sparkProperties, hadoopConf)
-      }.orNull
+      if (isUserJar(args.primaryResource)) {
+        args.primaryResource = Option(args.primaryResource).map {
+          downloadFile(_, targetDir, args.sparkProperties, hadoopConf)
+        }.orNull
+      }
       args.jars = Option(args.jars).map {
         downloadFileList(_, targetDir, args.sparkProperties, hadoopConf)
       }.orNull

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -494,6 +494,10 @@ object SparkSubmit extends CommandLineUtils {
     if (deployMode == CLIENT || isYarnCluster) {
       childMainClass = args.mainClass
       if (isUserJar(args.primaryResource)) {
+        val hadoopConf = new HadoopConfiguration()
+        args.primaryResource =
+          Option(args.primaryResource).map(
+            downloadFile(_, targetDir, args.sparkProperties, hadoopConf)).orNull
         childClasspath += args.primaryResource
       }
       if (args.jars != null) { childClasspath ++= args.jars.split(",") }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -250,14 +250,14 @@ class SparkSubmitSuite
     sysProps("SPARK_SUBMIT") should be ("true")
   }
 
-  test("handles YARN cluster mode with remote user jar") {
+  test("handles YARN cluster mode with remote jars") {
     val hadoopConf = new Configuration()
     // Set hdfs implementation to local file system for testing.
     hadoopConf.set("fs.hdfs.impl", "org.apache.spark.deploy.TestFileSystem")
     // Disable file system impl cache to make sure the test file system is picked up.
     hadoopConf.set("fs.hdfs.impl.disable.cache", "true")
-    val jarFile = File.createTempFile("thejar", ".jar")
-    jarFile.deleteOnExit()
+    val theJarFile = File.createTempFile("thejar", ".jar")
+    theJarFile.deleteOnExit()
     val clArgs = Seq(
       "--deploy-mode", "cluster",
       "--master", "yarn",
@@ -265,13 +265,9 @@ class SparkSubmitSuite
       "--class", "org.SomeClass",
       "--jars", "one.jar,two.jar,three.jar",
       "--driver-memory", "4g",
-      s"hdfs://${jarFile.getAbsolutePath}")
+      s"hdfs://${theJarFile.getAbsolutePath}")
     val appArgs = new SparkSubmitArguments(clArgs)
-    val (childArgs, classpath, sysProps, mainClass) = prepareSubmitEnvironment(appArgs, hadoopConf)
-    val childArgsStr = childArgs.mkString(" ")
-    childArgsStr should include ("--class org.SomeClass")
-    childArgsStr should include regex ("--jar .*thejar.*.jar")
-    mainClass should be ("org.apache.spark.deploy.yarn.Client")
+    val (_, classpath, _, _) = prepareSubmitEnvironment(appArgs, hadoopConf)
 
     // In yarn cluster mode, also adding remote jars to classpath
     classpath(0) should endWith regex ("thejar.*.jar")
@@ -279,41 +275,24 @@ class SparkSubmitSuite
     classpath(2) should endWith ("two.jar")
     classpath(3) should endWith ("three.jar")
 
-    sysProps("spark.executor.memory") should be ("5g")
-    sysProps("spark.driver.memory") should be ("4g")
-  }
-
-  test("handles YARN cluster mode with remote --jars") {
-    val hadoopConf = new Configuration()
-    // Set hdfs implementation to local file system for testing.
-    hadoopConf.set("fs.hdfs.impl", "org.apache.spark.deploy.TestFileSystem")
-    // Disable file system impl cache to make sure the test file system is picked up.
-    hadoopConf.set("fs.hdfs.impl.disable.cache", "true")
-    val jarFile = File.createTempFile("onejar", ".jar")
-    jarFile.deleteOnExit()
+    val oneJarFile = File.createTempFile("onejar", ".jar")
+    oneJarFile.deleteOnExit()
     val clArgs = Seq(
       "--deploy-mode", "cluster",
       "--master", "yarn",
       "--executor-memory", "5g",
       "--class", "org.SomeClass",
-      "--jars", s"hdfs://${jarFile.getAbsolutePath}" + ",two.jar,three.jar",
+      "--jars", s"hdfs://${oneJarFile.getAbsolutePath}" + ",two.jar,three.jar",
       "--driver-memory", "4g",
       "thejar.jar")
     val appArgs = new SparkSubmitArguments(clArgs)
-    val (childArgs, classpath, sysProps, mainClass) = prepareSubmitEnvironment(appArgs, hadoopConf)
-    val childArgsStr = childArgs.mkString(" ")
-    childArgsStr should include ("--class org.SomeClass")
-    childArgsStr should include regex ("--jar .*thejar.jar")
-    mainClass should be ("org.apache.spark.deploy.yarn.Client")
+    val (_, classpath, _, _) = prepareSubmitEnvironment(appArgs, hadoopConf)
 
     // In yarn cluster mode, also adding remote jars to classpath
     classpath(0) should endWith ("thejar.jar")
     classpath(1) should endWith regex ("one.*.jar")
     classpath(2) should endWith ("two.jar")
     classpath(3) should endWith ("three.jar")
-
-    sysProps("spark.executor.memory") should be ("5g")
-    sysProps("spark.driver.memory") should be ("4g")
   }
 
   test("handles YARN client mode") {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -258,7 +258,7 @@ class SparkSubmitSuite
     hadoopConf.set("fs.hdfs.impl.disable.cache", "true")
     val theJarFile = File.createTempFile("thejar", ".jar")
     theJarFile.deleteOnExit()
-    val clArgs = Seq(
+    var clArgs = Seq(
       "--deploy-mode", "cluster",
       "--master", "yarn",
       "--executor-memory", "5g",
@@ -266,7 +266,7 @@ class SparkSubmitSuite
       "--jars", "one.jar,two.jar,three.jar",
       "--driver-memory", "4g",
       s"hdfs://${theJarFile.getAbsolutePath}")
-    val appArgs = new SparkSubmitArguments(clArgs)
+    var appArgs = new SparkSubmitArguments(clArgs)
     val (_, classpath, _, _) = prepareSubmitEnvironment(appArgs, hadoopConf)
 
     // In yarn cluster mode, also adding remote jars to classpath
@@ -277,7 +277,7 @@ class SparkSubmitSuite
 
     val oneJarFile = File.createTempFile("onejar", ".jar")
     oneJarFile.deleteOnExit()
-    val clArgs = Seq(
+    clArgs = Seq(
       "--deploy-mode", "cluster",
       "--master", "yarn",
       "--executor-memory", "5g",
@@ -285,14 +285,14 @@ class SparkSubmitSuite
       "--jars", s"hdfs://${oneJarFile.getAbsolutePath}" + ",two.jar,three.jar",
       "--driver-memory", "4g",
       "thejar.jar")
-    val appArgs = new SparkSubmitArguments(clArgs)
-    val (_, classpath, _, _) = prepareSubmitEnvironment(appArgs, hadoopConf)
+    appArgs = new SparkSubmitArguments(clArgs)
+    val (_, classpath1, _, _) = prepareSubmitEnvironment(appArgs, hadoopConf)
 
     // In yarn cluster mode, also adding remote jars to classpath
-    classpath(0) should endWith ("thejar.jar")
-    classpath(1) should endWith regex ("one.*.jar")
-    classpath(2) should endWith ("two.jar")
-    classpath(3) should endWith ("three.jar")
+    classpath1(0) should endWith ("thejar.jar")
+    classpath1(1) should endWith regex ("one.*.jar")
+    classpath1(2) should endWith ("two.jar")
+    classpath1(3) should endWith ("three.jar")
   }
 
   test("handles YARN client mode") {


### PR DESCRIPTION
…failed

## What changes were proposed in this pull request?

When use yarn cluster mode,and we need scan hbase,there will be a case which can not work:
If we put user jar on hdfs,when local classpath will has no hbase,which will let get hbase token failed.Then later when job submitted to yarn, it will failed since has no token to access hbase table.I mock three cases:
1：user jar is on classpath, and has hbase
`17/08/10 13:48:03 INFO security.HadoopFSDelegationTokenProvider: Renewal interval is 86400050 for token HDFS_DELEGATION_TOKEN
17/08/10 13:48:03 INFO security.HadoopDelegationTokenManager: Service hive
17/08/10 13:48:03 INFO security.HadoopDelegationTokenManager: Service hbase
17/08/10 13:48:05 INFO security.HBaseDelegationTokenProvider: Attempting to fetch HBase security token.`

Logs showing we can get token normally.


2：user jar on hdfs
`17/08/10 13:43:58 WARN security.HBaseDelegationTokenProvider: Class org.apache.hadoop.hbase.HBaseConfiguration not found.
17/08/10 13:43:58 INFO security.HBaseDelegationTokenProvider: Failed to get token from service hbase
java.lang.ClassNotFoundException: org.apache.hadoop.hbase.security.token.TokenUtil
	at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.apache.spark.deploy.security.HBaseDelegationTokenProvider.obtainDelegationTokens(HBaseDelegationTokenProvider.scala:41)
	at org.apache.spark.deploy.security.HadoopDelegationTokenManager$$anonfun$obtainDelegationTokens$2.apply(HadoopDelegationTokenManager.scala:112)
	at org.apache.spark.deploy.security.HadoopDelegationTokenManager$$anonfun$obtainDelegationTokens$2.apply(HadoopDelegationTokenManager.scala:109)
	at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:241)
	at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:241)`


Logs showing we can get token failed with ClassNotFoundException.

If we download user jar from remote first,then things will work correctly.So this patch will download user jar from remote when in yarn cluster mode.Below is the log when download from remote first.

`17/08/10 13:46:33 WARN shortcircuit.DomainSocketFactory: The short-circuit local reads feature cannot be used because libhadoop cannot be loaded.
Downloading hdfs://xxx//spark/spark-examples-hadoop.jar to /tmp/tmp2982380061657838182/spark-examples-hadoop.jar.
...
17/08/10 13:46:36 INFO security.HadoopDelegationTokenManager: Service hbase
17/08/10 13:46:38 INFO security.HBaseDelegationTokenProvider: Attempting to fetch HBase security token.`


## How was this patch tested?

Manually tested by execute spark-submit scripts with different user jars.
