### PR TITLE
[SPARK-21690][ML] one-pass imputer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
@@ -134,6 +134,8 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
     transformSchema(dataset.schema, logging = true)
     val spark = dataset.sparkSession
 
+    val casted = dataset.select($(inputCols).map(col(_).cast("double")): _*)
+
     val cols = $(inputCols).map { inputCol =>
       when(col(inputCol).equalTo($(missingValue)), null)
         .when(col(inputCol).isNaN, null)
@@ -143,7 +145,7 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
 
     val results = $(strategy) match {
       case Imputer.mean =>
-        val row = dataset.select(cols.map(avg): _*).head()
+        val row = casted.select(cols.map(avg): _*).head()
         Array.range(0, $(inputCols).length).map { i =>
           if (row.isNullAt(i)) {
             Double.NaN
@@ -153,7 +155,7 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
         }
 
       case Imputer.median =>
-        dataset.select(cols: _*).stat.approxQuantile($(inputCols), Array(0.5), 0.001)
+        casted.select(cols: _*).stat.approxQuantile($(inputCols), Array(0.5), 0.001)
           .map { array =>
             if (array.isEmpty) {
               Double.NaN

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
@@ -149,8 +149,8 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
       combOp = { case (sum1, sum2) => sum1.merge(sum2) }
     )
 
-    val emptyCols = ($(inputCols) zip summary.counts).filter(_._2 == 0).map(_._1)
-    if(emptyCols.nonEmpty) {
+    val emptyCols = $(inputCols).zip(summary.counts).filter(_._2 == 0).map(_._1)
+    if (emptyCols.nonEmpty) {
       throw new SparkException(s"surrogate cannot be computed. " +
         s"All the values in ${emptyCols.mkString(",")} are Null, Nan or " +
         s"missingValue(${$(missingValue)})")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
@@ -137,13 +137,14 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
     val surrogates = $(strategy) match {
       case Imputer.mean =>
         val numInputCols = $(inputCols).length
+        val missing = $(missingValue)
         val (_, avgs) = dataset.select($(inputCols).map(col(_).cast("double")): _*).rdd
           .treeAggregate((Array.ofDim[Long](numInputCols), Array.ofDim[Double](numInputCols)))(
             seqOp = { case ((counts, avgs), row) =>
               counts.indices.foreach { i =>
                 if (!row.isNullAt(i)) {
                   val v = row.getDouble(i)
-                  if (!v.isNaN) {
+                  if (v != missing && !v.isNaN) {
                     val diff = v - avgs(i)
                     counts(i) += 1
                     avgs(i) += diff / counts(i)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
@@ -144,6 +144,8 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
 
     val results = $(strategy) match {
       case Imputer.mean =>
+        // Function avg will ignore null automatically.
+        // For a column only containing null, avg will return null.
         val row = dataset.select(cols.map(avg): _*).head()
         Array.range(0, $(inputCols).length).map { i =>
           if (row.isNullAt(i)) {
@@ -154,6 +156,8 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
         }
 
       case Imputer.median =>
+        // Function approxQuantile will ignore null automatically.
+        // For a column only containing null, approxQuantile will return an empty array.
         dataset.select(cols: _*).stat.approxQuantile($(inputCols), Array(0.5), 0.001)
           .map { array =>
             if (array.isEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala
@@ -137,7 +137,8 @@ class Imputer @Since("2.2.0") (@Since("2.2.0") override val uid: String)
     val cols = $(inputCols).map { inputCol =>
       when(col(inputCol).equalTo($(missingValue)), null)
         .when(col(inputCol).isNaN, null)
-        .otherwise(col(inputCol).cast("double"))
+        .otherwise(col(inputCol))
+        .cast("double")
         .as(inputCol)
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
parallelize the computation of all columns

performance tests:

|numColums| Mean(Old) | Median(Old) | Mean(RDD) | Median(RDD) | Mean(DF) | Median(DF) |
|------|----------|------------|----------|------------|----------|------------|
|1|0.0771394713|0.0658712813|0.080779802|0.048165981499999996|0.10525509870000001|0.0499620203|
|10|0.7234340630999999|0.5954440414|0.0867935197|0.13263428659999998|0.09255724889999999|0.1573943635|
|100|7.3756451568|6.2196631259|0.1911931552|0.8625376817000001|0.5557462431|1.7216837982000002|

## How was this patch tested?
existing tests
