### PR TITLE
[SPARK-21624]optimzie RF communicaiton cost

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
@@ -100,6 +100,10 @@ private[spark] class DTStatsAggregator(
    *                           from [[getFeatureOffset]].
    */
   def getImpurityCalculator(featureOffset: Int, binIndex: Int): ImpurityCalculator = {
+    if (allStats == null) {
+      allStats = compressedAllStats.toArray
+    }
+
     impurityAggregator.getCalculator(allStats, featureOffset + binIndex * statsSize)
   }
 
@@ -156,6 +160,10 @@ private[spark] class DTStatsAggregator(
    * @param otherBinIndex  This bin is not modified.
    */
   def mergeForFeature(featureOffset: Int, binIndex: Int, otherBinIndex: Int): Unit = {
+    if (allStats == null) {
+      allStats = compressedAllStats.toArray
+    }
+
     impurityAggregator.merge(allStats, featureOffset + binIndex * statsSize,
       featureOffset + otherBinIndex * statsSize)
   }
@@ -169,7 +177,7 @@ private[spark] class DTStatsAggregator(
       s"DTStatsAggregator.merge requires that both aggregators have the same length stats vectors."
         + s" This aggregator is of length $allStatsSize, but the other is ${other.allStatsSize}.")
 
-    if(allStats == null) {
+    if (allStats == null) {
       allStats = compressedAllStats.toArray
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DTStatsAggregator.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.ml.tree.impl
 
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.tree.impurity._
 
 
@@ -74,7 +75,15 @@ private[spark] class DTStatsAggregator(
    * Index for start of stats for a (feature, bin) is:
    *   index = featureOffsets(featureIndex) + binIndex * statsSize
    */
-  private val allStats: Array[Double] = new Array[Double](allStatsSize)
+  @transient private var allStats: Array[Double] = new Array[Double](allStatsSize)
+
+  // This is used for reducing shuffle communication cost
+  private var compressedAllStats: Vector = null
+
+  def compressAllStats(): DTStatsAggregator = {
+    compressedAllStats = Vectors.dense(allStats).compressed
+    this
+  }
 
   /**
    * Array of parent node sufficient stats.
@@ -159,12 +168,12 @@ private[spark] class DTStatsAggregator(
     require(allStatsSize == other.allStatsSize,
       s"DTStatsAggregator.merge requires that both aggregators have the same length stats vectors."
         + s" This aggregator is of length $allStatsSize, but the other is ${other.allStatsSize}.")
-    var i = 0
-    // TODO: Test BLAS.axpy
-    while (i < allStatsSize) {
-      allStats(i) += other.allStats(i)
-      i += 1
+
+    if(allStats == null) {
+      allStats = compressedAllStats.toArray
     }
+
+    other.compressedAllStats.foreachActive((i, v) => allStats(i) += v)
 
     require(statsSize == other.statsSize,
       s"DTStatsAggregator.merge requires that both aggregators have the same length parent " +

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -526,9 +526,10 @@ private[spark] object RandomForest extends Logging {
         // iterator all instances in current partition and update aggregate stats
         points.foreach(binSeqOpWithNodeIdCache(nodeStatsAggregators, _))
 
-        // transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
+        // compress allStats of nodeAggregateStats,
+        // and transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
         // which can be combined with other partition using `reduceByKey`
-        nodeStatsAggregators.view.zipWithIndex.map(_.swap).iterator
+        nodeStatsAggregators.view.map(_.compressAllStats()).zipWithIndex.map(_.swap).iterator
       }
     } else {
       input.mapPartitions { points =>
@@ -544,9 +545,10 @@ private[spark] object RandomForest extends Logging {
         // iterator all instances in current partition and update aggregate stats
         points.foreach(binSeqOp(nodeStatsAggregators, _))
 
-        // transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
+        // compress allStats of nodeAggregateStats,
+        // and transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
         // which can be combined with other partition using `reduceByKey`
-        nodeStatsAggregators.view.zipWithIndex.map(_.swap).iterator
+        nodeStatsAggregators.view.map(_.compressAllStats()).zipWithIndex.map(_.swap).iterator
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The implementation of RF is bound by either the cost of statistics computation on workers or by communicating the sufficient statistics.
This PR will focus on optimizing communication cost.
The statistics are stored in allStats:
`  private var allStats: Array[Double] = new Array[Double](allStatsSize)`
In real use case, the size of allStats is very large, and it can be very sparse, especially on the nodes that near the leave of the tree. 
It is better to change allStats from Array to SparseVector before shufffle.
My tests show the communication is down by about **50% to 90%** with this PR. 
Test cases: 
1000 features * 200Bins* 2 label, 
1000 features * 50Bins * 2label
10000 features * 200Bins * 2 label
featureSubsetStrategy: auto, 0.2, 0.1
All test cases with the config: spark.shuffle.compress=true.

## How was this patch tested?
The exist UT

