### PR TITLE
[SPARK-21660][YARN][Shuffle] Yarn ShuffleService failed to start when the chosen dir…

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -341,6 +341,11 @@ public class YarnShuffleService extends AuxiliaryService {
    * @return True if process has read, write and execute access on the path, or false.
    */
   protected Boolean checkFileAccess(File file) {
+    if (!file.exists()) {
+      logger.warn("File is not existed: " + file.toString());
+      return false;
+    }
+
     if (!FileUtil.canRead(file)) {
       logger.warn("File is not readable: " + file.toString());
       return false;
@@ -348,6 +353,11 @@ public class YarnShuffleService extends AuxiliaryService {
 
     if (!FileUtil.canWrite(file)) {
       logger.warn("File is not writable: " + file.toString());
+      return false;
+    }
+
+    if (!FileUtil.canExecute(file)) {
+      logger.warn("File is not executable: " + file.toString());
       return false;
     }
 
@@ -365,8 +375,9 @@ public class YarnShuffleService extends AuxiliaryService {
     if (_recoveryPath != null) {
         File recoveryFile = new File(_recoveryPath.toUri().getPath(), dbName);
 
-        bolRecoveryPathAvailable = checkFileAccess(recoveryFile);
+        bolRecoveryPathAvailable = checkFileAccess(new File(_recoveryPath.toUri().getPath()));
         logger.info("Recovery path {} ldb available: {}.", _recoveryPath, bolRecoveryPathAvailable);
+
         if (recoveryFile.exists() && bolRecoveryPathAvailable) {
           return recoveryFile;
         }

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -334,7 +334,7 @@ public class YarnShuffleService extends AuxiliaryService {
   }
 
   /**
-   * Checks that the current running process can read, write and execute the given file
+   * Checks that the current running process can read, write the given file
    * by using methods of the File objects.
    *
    * @param file File to check
@@ -348,11 +348,6 @@ public class YarnShuffleService extends AuxiliaryService {
 
     if (!FileUtil.canWrite(file)) {
       logger.warn("File is not writable: " + file.toString());
-      return false;
-    }
-
-    if (!FileUtil.canExecute(file)) {
-      logger.warn("File is not executable: " + file.toString());
       return false;
     }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

See [SPARK-21660](https://issues.apache.org/jira/browse/SPARK-21660), this PR add one simple strategy to validate the chosen disk writable to avoid choosing a read-only disk.

## How was this patch tested?

#### How to mock disk corrupted?
> change the recovery path read-only mode: 
> sudo chmod -R 400 /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle

Before this pr, when we start the nodemanager, exception below:

> 2017-08-10 16:30:08,112 INFO  yarn.YarnShuffleService (YarnShuffleService.java:<init>(136)) - Initializing YARN shuffle service for Spark
2017-08-10 16:30:08,112 INFO  containermanager.AuxServices (AuxServices.java:addService(72)) - Adding auxiliary service spark_shuffle, "spark_shuffle"
2017-08-10 16:30:08,218 ERROR util.LevelDBProvider (LevelDBProvider.java:initLevelDB(61)) - error opening leveldb file /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle/registeredExecutors.ldb.  Creating new file, will not be able to recover state for existing applications
org.fusesource.leveldbjni.internal.NativeDB$DBException: IO error: /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle/registeredExecutors.ldb/LOCK: Permission denied
        at org.fusesource.leveldbjni.internal.NativeDB.checkStatus(NativeDB.java:200)
        at org.fusesource.leveldbjni.internal.NativeDB.open(NativeDB.java:218)
        at org.fusesource.leveldbjni.JniDBFactory.open(JniDBFactory.java:168)
        at org.apache.spark.network.util.LevelDBProvider.initLevelDB(LevelDBProvider.java:48)
        at org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.<init>(ExternalShuffleBlockResolver.java:116)
        at org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.<init>(ExternalShuffleBlockResolver.java:94)
        at org.apache.spark.network.shuffle.ExternalShuffleBlockHandler.<init>(ExternalShuffleBlockHandler.java:66)
        at org.apache.spark.network.yarn.YarnShuffleService.serviceInit(YarnShuffleService.java:167)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.yarn.server.nodemanager.containermanager.AuxServices.serviceInit(AuxServices.java:143)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.service.CompositeService.serviceInit(CompositeService.java:107)
        at org.apache.hadoop.yarn.server.nodemanager.containermanager.ContainerManagerImpl.serviceInit(ContainerManagerImpl.java:245)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.service.CompositeService.serviceInit(CompositeService.java:107)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.serviceInit(NodeManager.java:261)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.initAndStartNodeManager(NodeManager.java:495)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.main(NodeManager.java:543)
2017-08-10 16:30:08,220 WARN  util.LevelDBProvider (LevelDBProvider.java:initLevelDB(71)) - error deleting /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle/registeredExecutors.ldb
2017-08-10 16:30:08,220 INFO  service.AbstractService (AbstractService.java:noteFailure(272)) - Service spark_shuffle failed in state INITED; cause: java.io.IOException: Unable to create state store
java.io.IOException: Unable to create state store
        at org.apache.spark.network.util.LevelDBProvider.initLevelDB(LevelDBProvider.java:77)
        at org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.<init>(ExternalShuffleBlockResolver.java:116)
        at org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.<init>(ExternalShuffleBlockResolver.java:94)
        at org.apache.spark.network.shuffle.ExternalShuffleBlockHandler.<init>(ExternalShuffleBlockHandler.java:66)
        at org.apache.spark.network.yarn.YarnShuffleService.serviceInit(YarnShuffleService.java:167)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.yarn.server.nodemanager.containermanager.AuxServices.serviceInit(AuxServices.java:143)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.service.CompositeService.serviceInit(CompositeService.java:107)
        at org.apache.hadoop.yarn.server.nodemanager.containermanager.ContainerManagerImpl.serviceInit(ContainerManagerImpl.java:245)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.service.CompositeService.serviceInit(CompositeService.java:107)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.serviceInit(NodeManager.java:261)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.initAndStartNodeManager(NodeManager.java:495)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.main(NodeManager.java:543)
Caused by: org.fusesource.leveldbjni.internal.NativeDB$DBException: IO error: /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle/registeredExecutors.ldb/LOCK: Permission denied
        at org.fusesource.leveldbjni.internal.NativeDB.checkStatus(NativeDB.java:200)
        at org.fusesource.leveldbjni.internal.NativeDB.open(NativeDB.java:218)
        at org.fusesource.leveldbjni.JniDBFactory.open(JniDBFactory.java:168)
        at org.apache.spark.network.util.LevelDBProvider.initLevelDB(LevelDBProvider.java:75)
        ... 15 more


After this pr:

    

> 2017-08-10 16:36:49,101 INFO  yarn.YarnShuffleService (YarnShuffleService.java:<init>(136)) - Initializing YARN shuffle service for Spark
2017-08-10 16:36:49,101 INFO  containermanager.AuxServices (AuxServices.java:addService(72)) - Adding auxiliary service spark_shuffle, "spark_shuffle"
2017-08-10 16:36:49,102 INFO  yarn.YarnShuffleService (YarnShuffleService.java:initRecoveryDb(359)) - Recovery path /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle ldb available: false.
2017-08-10 16:36:49,102 WARN  yarn.YarnShuffleService (YarnShuffleService.java:initRecoveryDb(367)) - Recovery path /var/log/hadoop-yarn/nodemanager/recovery-state/nm-aux-services/spark_shuffle unavailable: set it to null
2017-08-10 16:36:49,180 INFO  util.LevelDBProvider (LevelDBProvider.java:initLevelDB(51)) - Creating state database at /mnt/dfs/0/hadoop/yarn/local/registeredExecutors.ldb
2017-08-10 16:36:49,317 INFO  util.LevelDBProvider$LevelDBLogger (LevelDBProvider.java:log(93)) - Delete type=3 #1
2017-08-10 16:36:49,548 INFO  yarn.YarnShuffleService (YarnShuffleService.java:serviceInit(186)) - Started YARN shuffle service for Spark on port 7337. Authentication is not enabled.  Registered executor file is /mnt/dfs/0/hadoop/yarn/local/registeredExecutors.ld
b