### PR TITLE
[SPARK-21701][CORE] Enable RPC client to use SO_RCVBUF, SO_SNDBUF and SO_BACKLOG in SparkConf

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -210,6 +210,18 @@ public class TransportClientFactory implements Closeable {
       .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, conf.connectionTimeoutMs())
       .option(ChannelOption.ALLOCATOR, pooledAllocator);
 
+    if (conf.backLog() > 0) {
+      bootstrap.option(ChannelOption.SO_BACKLOG, conf.backLog());
+    }
+
+    if (conf.receiveBuf() > 0) {
+      bootstrap.option(ChannelOption.SO_RCVBUF, conf.receiveBuf());
+    }
+
+    if (conf.sendBuf() > 0) {
+      bootstrap.option(ChannelOption.SO_SNDBUF, conf.sendBuf());
+    }
+
     final AtomicReference<TransportClient> clientRef = new AtomicReference<>();
     final AtomicReference<Channel> channelRef = new AtomicReference<>();
 

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -35,15 +35,6 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar {
     new NettyRpcEnvFactory().create(config)
   }
 
-  test("non-existent endpoint") {
-    val uri = RpcEndpointAddress(env.address, "nonexist-endpoint").toString
-    val e = intercept[SparkException] {
-      env.setupEndpointRef(env.address, "nonexist-endpoint")
-    }
-    assert(e.getCause.isInstanceOf[RpcEndpointNotFoundException])
-    assert(e.getCause.getMessage.contains(uri))
-  }
-
   test("advertise address different from bind address") {
     val sparkConf = new SparkConf()
     val config = RpcEnvConfig(sparkConf, "test", "localhost", "example.com", 0,


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. TCP parameters like SO_RCVBUF, SO_SNDBUF and SO_BACKLOG can be set in `SparkConf`, and `org.apache.spark.network.server.TransportServer` can use those parameters to build server by leveraging netty. But for `TransportClientFactory`, there is no such way to set those parameters from `SparkConf`. This could be inconsistent in server and client side when people set parameters in `SparkConf`. So this PR make RPC client to be enable to use those TCP parameters as well.

2. Add some comments to `MessageDecoder` class to show how wire format looks like for a RPC message and draw a vivid graph to present to detailed wire protocol.

## How was this patch tested?
Existing tests and refine asking non-existent endpoint test case in `RpcEnvSuite`.
