### PR TITLE
[SPARK-21710][StSt] Fix OOM on ConsoleSink with large inputs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
@@ -49,7 +49,7 @@ class ConsoleSink(options: Map[String, String]) extends Sink with Logging {
     println("-------------------------------------------")
     // scalastyle:off println
     data.sparkSession.createDataFrame(
-      data.sparkSession.sparkContext.parallelize(data.collect()), data.schema)
+      data.sparkSession.sparkContext.parallelize(data.take(numRowsToShow)), data.schema)
       .show(numRowsToShow, isTruncated)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace a full `collect` with a `take` using the expected number of elements as output, which is readily available at this point in order to limit the amount of data that is brought to the driver and hence, prevent the OOM from happening.

## How was this patch tested?

existing tests