### PR TITLE
[SPARK-21713][SC] Replace streaming bit with OutputMode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.TreeNodeRef
 import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
 
 /**
@@ -2311,7 +2312,7 @@ object CleanupAliases extends Rule[LogicalPlan] {
  */
 object EliminateEventTimeWatermark extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case EventTimeWatermark(_, _, child) if !child.isStreaming => child
+    case EventTimeWatermark(_, _, child) if child.outputMode == OutputMode.Complete() => child
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -75,7 +75,7 @@ object UnsupportedOperationChecker {
     // Only allow multiple `FlatMapGroupsWithState(Append)`s in append mode.
     if (flatMapGroupsWithStates.size >= 2 && (
       outputMode != InternalOutputModes.Append ||
-        flatMapGroupsWithStates.exists(_.outputMode != InternalOutputModes.Append)
+        flatMapGroupsWithStates.exists(_.funcOutputMode != InternalOutputModes.Append)
       )) {
       throwError(
         "Multiple flatMapGroupsWithStates are not supported when they are not all in append mode" +
@@ -167,7 +167,7 @@ object UnsupportedOperationChecker {
             if (aggsAfterFlatMapGroups.isEmpty) {
               // flatMapGroupsWithState without aggregation: operation's output mode must
               // match query output mode
-              m.outputMode match {
+              m.funcOutputMode match {
                 case InternalOutputModes.Update if outputMode != InternalOutputModes.Update =>
                   throwError(
                     "flatMapGroupsWithState in update mode is not supported with " +
@@ -183,7 +183,7 @@ object UnsupportedOperationChecker {
             } else {
               // flatMapGroupsWithState with aggregation: update operation mode not allowed, and
               // *groupsWithState after aggregation not allowed
-              if (m.outputMode == InternalOutputModes.Update) {
+              if (m.funcOutputMode == InternalOutputModes.Update) {
                 throwError(
                   "flatMapGroupsWithState in update mode is not supported with " +
                     "aggregation on a streaming DataFrame/Dataset")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -52,7 +52,7 @@ object UnsupportedOperationChecker {
     }
 
     val mapGroupsWithStates = plan.collect {
-      case f: FlatMapGroupsWithState if f.funcOutputMode == OutputMode.Append()
+      case f: FlatMapGroupsWithState if f.outputMode == OutputMode.Append()
         && f.isMapGroupsWithState => f
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
 
 /**
@@ -1185,7 +1186,7 @@ object ReplaceDistinctWithAggregate extends Rule[LogicalPlan] {
  */
 object ReplaceDeduplicateWithAggregate extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case Deduplicate(keys, child, streaming) if !streaming =>
+    case d @ Deduplicate(keys, child, _) if d.originalOutputMode != OutputMode.Append() =>
       val keyExprIds = keys.map(_.exprId)
       val aggCols = child.output.map { attr =>
         if (keyExprIds.contains(attr.exprId)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 
 
@@ -47,8 +48,11 @@ abstract class LogicalPlan
    */
   def analyzed: Boolean = _analyzed
 
-  /** Returns true if this subtree contains any streaming data sources. */
-  def isStreaming: Boolean = children.exists(_.isStreaming == true)
+  /** Returns the output mode of this subtree. */
+  def outputMode: OutputMode = {
+    if (children.exists(_.outputMode == OutputMode.Append())) OutputMode.Append()
+    else OutputMode.Complete()
+  }
 
   /**
    * Returns a copy of this node where `rule` has been recursively applied first to all of its

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation._
+import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 import org.apache.spark.util.random.RandomSampler
@@ -779,10 +780,16 @@ case object OneRowRelation extends LeafNode {
 }
 
 /** A logical plan for `dropDuplicates`. */
+case object Deduplicate {
+  def apply(keys: Seq[Attribute], child: LogicalPlan): Deduplicate = {
+    Deduplicate(keys, child, child.outputMode)
+  }
+}
+
 case class Deduplicate(
     keys: Seq[Attribute],
     child: LogicalPlan,
-    streaming: Boolean) extends UnaryNode {
+    originalOutputMode: OutputMode) extends UnaryNode {
 
   override def output: Seq[Attribute] = child.output
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -402,7 +402,7 @@ object FlatMapGroupsWithState {
  * @param dataAttributes used to read the data
  * @param outputObjAttr used to define the output object
  * @param stateEncoder used to serialize/deserialize state before calling `func`
- * @param outputMode the output mode of `func`
+ * @param funcOutputMode the output mode of `func`
  * @param isMapGroupsWithState whether it is created by the `mapGroupsWithState` method
  * @param timeout used to timeout groups that have not received data in a while
  */
@@ -414,13 +414,13 @@ case class FlatMapGroupsWithState(
     dataAttributes: Seq[Attribute],
     outputObjAttr: Attribute,
     stateEncoder: ExpressionEncoder[Any],
-    outputMode: OutputMode,
+    funcOutputMode: OutputMode,
     isMapGroupsWithState: Boolean = false,
     timeout: GroupStateTimeout,
     child: LogicalPlan) extends UnaryNode with ObjectProducer {
 
   if (isMapGroupsWithState) {
-    assert(outputMode == OutputMode.Update)
+    assert(funcOutputMode == OutputMode.Update)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -368,18 +368,18 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     Aggregate(
       Seq(attributeWithWatermark),
       aggExprs("c"),
-      Deduplicate(Seq(att), streamRelation, streaming = true)),
+      Deduplicate(Seq(att), streamRelation)),
     outputMode = Append)
 
   assertNotSupportedInStreamingPlan(
     "Deduplicate - Deduplicate on streaming relation after aggregation",
-    Deduplicate(Seq(att), Aggregate(Nil, aggExprs("c"), streamRelation), streaming = true),
+    Deduplicate(Seq(att), Aggregate(Nil, aggExprs("c"), streamRelation)),
     outputMode = Complete,
     expectedMsgs = Seq("dropDuplicates"))
 
   assertSupportedInStreamingPlan(
     "Deduplicate - Deduplicate on batch relation inside a streaming query",
-    Deduplicate(Seq(att), batchRelation, streaming = false),
+    Deduplicate(Seq(att), batchRelation),
     outputMode = Append
   )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -711,11 +711,11 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
 
   case class StreamingPlanWrapper(child: LogicalPlan) extends UnaryNode {
     override def output: Seq[Attribute] = child.output
-    override def isStreaming: Boolean = true
+    override def outputMode: OutputMode = OutputMode.Append()
   }
 
   case class TestStreamingRelation(output: Seq[Attribute]) extends LeafNode {
     def this(attribute: Attribute) = this(Seq(attribute))
-    override def isStreaming: Boolean = true
+    override def outputMode: OutputMode = OutputMode.Append()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -53,6 +53,7 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.streaming.DataStreamWriter
+import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SchemaUtils
 import org.apache.spark.storage.StorageLevel
@@ -515,7 +516,7 @@ class Dataset[T] private[sql](
    * @since 2.0.0
    */
   @InterfaceStability.Evolving
-  def isStreaming: Boolean = logicalPlan.isStreaming
+  def isStreaming: Boolean = logicalPlan.outputMode == OutputMode.Append()
 
   /**
    * Eagerly checkpoint a Dataset and return the new Dataset. Checkpointing can be used to truncate

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2202,7 +2202,8 @@ class Dataset[T] private[sql](
       }
       cols
     }
-    Deduplicate(groupCols, logicalPlan, isStreaming)
+
+    Deduplicate(groupCols, logicalPlan)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchange
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.streaming.StreamingQuery
+import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery}
 
 /**
  * Converts a logical plan into zero or more SparkPlans.  This API is exposed for experimenting
@@ -248,7 +248,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
    */
   object StreamingDeduplicationStrategy extends Strategy {
     override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-      case Deduplicate(keys, child, true) =>
+      case d @ Deduplicate(keys, child, _) if d.originalOutputMode == OutputMode.Append() =>
         StreamingDeduplicateExec(keys, planLater(child)) :: Nil
 
       case _ => Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -127,7 +127,7 @@ case class ExplainCommand(
   // Run through the optimizer to generate the physical plan.
   override def run(sparkSession: SparkSession): Seq[Row] = try {
     val queryExecution =
-      if (logicalPlan.isStreaming) {
+      if (logicalPlan.outputMode == OutputMode.Append()) {
         // This is used only by explaining `Dataset/DataFrame` created by `spark.readStream`, so the
         // output mode does not matter since there is no `Sink`.
         new IncrementalExecution(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LeafNode
 import org.apache.spark.sql.execution.LeafExecNode
 import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.streaming.OutputMode
 
 object StreamingRelation {
   def apply(dataSource: DataSource): StreamingRelation = {
@@ -40,7 +41,7 @@ object StreamingRelation {
  */
 case class StreamingRelation(dataSource: DataSource, sourceName: String, output: Seq[Attribute])
   extends LeafNode {
-  override def isStreaming: Boolean = true
+  override def outputMode: OutputMode = OutputMode.Append()
   override def toString: String = sourceName
 }
 
@@ -49,7 +50,7 @@ case class StreamingRelation(dataSource: DataSource, sourceName: String, output:
  * [[org.apache.spark.sql.catalyst.plans.logical.LogicalPlan]].
  */
 case class StreamingExecutionRelation(source: Source, output: Seq[Attribute]) extends LeafNode {
-  override def isStreaming: Boolean = true
+  override def outputMode: OutputMode = OutputMode.Append()
   override def toString: String = source.toString
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Replace LogicalPlan.isStreaming with output mode.
* Replace Deduplicate.streaming with output mode.

Note that this is an implementation-only change, so it deliberately does not change isStreaming in the Dataset API.

## How was this patch tested?

refactoring only - ran existing unit tests
