### PR TITLE
[WIP][SPARK-21722][SQL][PYTHON] Enable timezone-aware timestamp type when creating Pandas DataFrame.

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1760,6 +1760,15 @@ class DataFrame(object):
 
             for f, t in dtype.items():
                 pdf[f] = pdf[f].astype(t, copy=False)
+
+            if self.sql_ctx.getConf("spark.sql.execution.pandas.timeZoneAware", "false").lower() \
+                    == "true":
+                timezone = self.sql_ctx.getConf("spark.sql.session.timeZone")
+                for field in self.schema:
+                    if type(field.dataType) == TimestampType:
+                        pdf[field.name] = pdf[field.name].apply(
+                            lambda ts: ts.tz_localize('tzlocal()').tz_convert(timezone))
+
             return pdf
 
     def _collectAsArrow(self):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1763,11 +1763,13 @@ class DataFrame(object):
 
             if self.sql_ctx.getConf("spark.sql.execution.pandas.timeZoneAware", "false").lower() \
                     == "true":
+                from dateutil import tz
+                tzlocal = tz.tzlocal()
                 timezone = self.sql_ctx.getConf("spark.sql.session.timeZone")
                 for field in self.schema:
                     if type(field.dataType) == TimestampType:
                         pdf[field.name] = pdf[field.name].apply(
-                            lambda ts: ts.tz_localize('tzlocal()').tz_convert(timezone))
+                            lambda ts: ts.tz_localize(tzlocal).tz_convert(timezone))
 
             return pdf
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2510,6 +2510,8 @@ class SQLTests(ReusedPySparkTestCase):
     @unittest.skipIf(not _have_pandas, "Pandas not installed")
     def test_to_pandas_timezone_aware(self):
         import pandas as pd
+        from dateutil import tz
+        tzlocal = tz.tzlocal()
         ts = datetime.datetime(1970, 1, 1)
         pdf = pd.DataFrame.from_records([[ts]], columns=['ts'])
 
@@ -2530,7 +2532,7 @@ class SQLTests(ReusedPySparkTestCase):
 
         pdf_pst_naive = pdf_pst.copy()
         pdf_pst_naive['ts'] = pdf_pst_naive['ts'].apply(
-            lambda ts: ts.tz_convert('tzlocal()').tz_localize(None))
+            lambda ts: ts.tz_convert(tzlocal).tz_localize(None))
         self.assertTrue(pdf_pst_naive.equals(pdf))
 
         self.spark.conf.unset('spark.sql.execution.pandas.timeZoneAware')

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -912,6 +912,14 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val PANDAS_TIMEZONE_AWARE =
+    buildConf("spark.sql.execution.pandas.timeZoneAware")
+      .internal()
+      .doc("When true, make Pandas DataFrame with timezone-aware timestamp type when converting " +
+        "by pyspark.sql.DataFrame.toPandas. The session local timezone is used for the timezone.")
+      .booleanConf
+      .createWithDefault(false)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make Pandas DataFrame with timezone-aware timestamp type when converting `DataFrame` to Pandas DataFrame by `pyspark.sql.DataFrame.toPandas`.
The session local timezone is used for the timezone.

## How was this patch tested?

Added a test and existing tests.
