### PR TITLE
[SPARK-21688][ML][MLLIB] make native BLAS the first choice for BLAS level 1 operations for dense data

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -65,7 +65,7 @@ private[spark] object BLAS extends Serializable with Logging {
    */
   private def axpy(a: Double, x: DenseVector, y: DenseVector): Unit = {
     val n = x.size
-    f2jBLAS.daxpy(n, a, x.values, 1, y.values, 1)
+    nativeBLAS.daxpy(n, a, x.values, 1, y.values, 1)
   }
 
   /**
@@ -125,7 +125,7 @@ private[spark] object BLAS extends Serializable with Logging {
    */
   private def dot(x: DenseVector, y: DenseVector): Double = {
     val n = x.size
-    f2jBLAS.ddot(n, x.values, 1, y.values, 1)
+    nativeBLAS.ddot(n, x.values, 1, y.values, 1)
   }
 
   /**
@@ -222,7 +222,7 @@ private[spark] object BLAS extends Serializable with Logging {
       case sx: SparseVector =>
         f2jBLAS.dscal(sx.values.length, a, sx.values, 1)
       case dx: DenseVector =>
-        f2jBLAS.dscal(dx.values.length, a, dx.values, 1)
+        nativeBLAS.dscal(dx.values.length, a, dx.values, 1)
       case _ =>
         throw new IllegalArgumentException(s"scal doesn't support vector type ${x.getClass}.")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this PR, we make native BLAS, if found, the default operations for ddot, daxpy and dscal.

Before this PR, these operations are bound with F2J BLAS, but we found out that with proper setting as we proposed in SPARK-21305, native blas can outperform F2J blas in model training. Moreover, a uni-level test shows these three operations are running faster on native than JVM on different data scale from 10 to 100,000.
## How was this patch tested?
we tested the threes operation on different data scale and got: (we ran 3 times for each test and take the median value)
![image](https://user-images.githubusercontent.com/2673819/29262893-1ada0c5e-8109-11e7-820c-dbbcda2bbfa5.png)

we also tested this PR on SVM and got the result:
![image](https://user-images.githubusercontent.com/2673819/29262694-45fa7488-8108-11e7-857e-04474b4e4592.png)
![image](https://user-images.githubusercontent.com/2673819/29262705-4e6a87b6-8108-11e7-969c-72e0e5359618.png)

With this PR, these operations are more flexible to users that they can choose to run with F2J or native BLAS as they desire.

Signed-off-by: vincent <vincent@localhost.localdomain>