### PR TITLE
[SPARK-21766][SQL] Convert nullable int columns to float columns in toPandas

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1731,7 +1731,7 @@ class DataFrame(object):
         return DataFrame(jdf, self.sql_ctx)
 
     @since(1.3)
-    def toPandas(self):
+    def toPandas(self, strict=True):
         """
         Returns the contents of this :class:`DataFrame` as Pandas ``pandas.DataFrame``.
 
@@ -1762,7 +1762,7 @@ class DataFrame(object):
         else:
             dtype = {}
             for field in self.schema:
-                pandas_type = _to_corrected_pandas_type(field.dataType)
+                pandas_type = _to_corrected_pandas_type(field, strict)
                 if pandas_type is not None:
                     dtype[field.name] = pandas_type
 
@@ -1810,17 +1810,20 @@ def _to_scala_map(sc, jm):
     return sc._jvm.PythonUtils.toScalaMap(jm)
 
 
-def _to_corrected_pandas_type(dt):
+def _to_corrected_pandas_type(field, strict=True):
     """
     When converting Spark SQL records to Pandas DataFrame, the inferred data type may be wrong.
     This method gets the corrected data type for Pandas if that type may be inferred uncorrectly.
     """
     import numpy as np
+    dt = field.dataType
     if type(dt) == ByteType:
         return np.int8
     elif type(dt) == ShortType:
         return np.int16
     elif type(dt) == IntegerType:
+        if not strict and field.nullable:
+            return np.float32
         return np.int32
     elif type(dt) == FloatType:
         return np.float32

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1761,7 +1761,7 @@ class DataFrame(object):
                 raise ImportError("%s\n%s" % (e.message, msg))
         else:
             dtype = {}
-            columns_with_null_int = {}
+            columns_with_null_int = set()
             def null_handler(rows, columns_with_null_int):
                 for row in rows:
                     row = row.asDict()
@@ -1771,9 +1771,8 @@ class DataFrame(object):
                         if val is not None:
                             if abs(val) > 16777216: # Max value before np.float32 loses precision.
                                 val = np.float64(val)
-                                if np.float64 != dt:
-                                    dt = np.float64
-                                    dtype[column] = np.float64
+                                dt = np.float64
+                                dtype[column] = np.float64
                             else:
                                 val = np.float32(val)
                                 if dt not in (np.float32, np.float64):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1765,6 +1765,7 @@ class DataFrame(object):
             nullable_int_columns = set()
 
             def null_handler(rows, nullable_int_columns):
+                from pyspark.sql import Row
                 requires_double_precision = set()
                 for row in rows:
                     row = row.asDict()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1775,9 +1775,6 @@ class DataFrame(object):
                                 dtype[column] = np.float64
                             else:
                                 val = np.float32(val)
-                                if dt not in (np.float32, np.float64):
-                                    dt = np.float32
-                                    dtype[column] = np.float32
                             row[column] = val
                     row = Row(**row)
                     yield row

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1787,6 +1787,7 @@ class DataFrame(object):
                 if pandas_type in (np.int8, np.int16, np.int32) and field.nullable:
                     columns_with_null_int.add(field.name)
                     row_handler = null_handler
+                    pandas_type = np.float32
                 if pandas_type is not None:
                     dtype[field.name] = pandas_type
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1760,6 +1760,7 @@ class DataFrame(object):
                       "if using spark.sql.execution.arrow.enable=true"
                 raise ImportError("%s\n%s" % (e.message, msg))
         else:
+            import numpy as np
             dtype = {}
             nullable_int_columns = set()
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1791,7 +1791,7 @@ class DataFrame(object):
                     row_handler = null_handler
                 if pandas_type is not None:
                     dtype[field.name] = pandas_type
-            collected_rows = row_handler(self.collect(), columns_with_null_int)
+            collected_rows = row_handler(self.collect(), nullable_int_columns)
             pdf = pd.DataFrame.from_records(collected_rows, columns=self.columns)
 
             for f, t in dtype.items():

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1762,6 +1762,7 @@ class DataFrame(object):
         else:
             dtype = {}
             columns_with_null_int = set()
+
             def null_handler(rows, columns_with_null_int):
                 for row in rows:
                     row = row.asDict()
@@ -1769,7 +1770,7 @@ class DataFrame(object):
                         val = row[column]
                         dt = dtype[column]
                         if val is not None:
-                            if abs(val) > 16777216: # Max value before np.float32 loses precision.
+                            if abs(val) > 16777216:  # Max value before np.float32 loses precision.
                                 val = np.float64(val)
                                 dt = np.float64
                                 dtype[column] = np.float64
@@ -1778,7 +1779,7 @@ class DataFrame(object):
                             row[column] = val
                     row = Row(**row)
                     yield row
-            row_handler = lambda x,y: x
+            row_handler = lambda x, y: x
             for field in self.schema:
                 pandas_type = _to_corrected_pandas_type(field.dataType)
                 if pandas_type in (np.int8, np.int16, np.int32) and field.nullable:
@@ -1787,8 +1788,8 @@ class DataFrame(object):
                     pandas_type = np.float32
                 if pandas_type is not None:
                     dtype[field.name] = pandas_type
-
-            pdf = pd.DataFrame.from_records(row_handler(self.collect(), columns_with_null_int), columns=self.columns)
+            collected_rows = row_handler(self.collect(), columns_with_null_int)
+            pdf = pd.DataFrame.from_records(collected_rows, columns=self.columns)
 
             for f, t in dtype.items():
                 pdf[f] = pdf[f].astype(t, copy=False)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1731,7 +1731,7 @@ class DataFrame(object):
         return DataFrame(jdf, self.sql_ctx)
 
     @since(1.3)
-    def toPandas(self, strict=True):
+    def toPandas(self):
         """
         Returns the contents of this :class:`DataFrame` as Pandas ``pandas.DataFrame``.
 
@@ -1762,7 +1762,7 @@ class DataFrame(object):
         else:
             dtype = {}
             for field in self.schema:
-                pandas_type = _to_corrected_pandas_type(field, strict)
+                pandas_type = _to_corrected_pandas_type(field.dataType)
                 if pandas_type is not None:
                     dtype[field.name] = pandas_type
 
@@ -1810,20 +1810,17 @@ def _to_scala_map(sc, jm):
     return sc._jvm.PythonUtils.toScalaMap(jm)
 
 
-def _to_corrected_pandas_type(field, strict=True):
+def _to_corrected_pandas_type(dt):
     """
     When converting Spark SQL records to Pandas DataFrame, the inferred data type may be wrong.
     This method gets the corrected data type for Pandas if that type may be inferred uncorrectly.
     """
     import numpy as np
-    dt = field.dataType
     if type(dt) == ByteType:
         return np.int8
     elif type(dt) == ShortType:
         return np.int16
     elif type(dt) == IntegerType:
-        if not strict and field.nullable:
-            return np.float32
         return np.int32
     elif type(dt) == FloatType:
         return np.float32

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2495,10 +2495,12 @@ class SQLTests(ReusedPySparkTestCase):
     def test_to_pandas(self):
         import numpy as np
         schema = StructType().add("a", IntegerType()).add("b", StringType())\
-                             .add("c", BooleanType()).add("d", FloatType())
+                             .add("c", BooleanType()).add("d", FloatType())\
+                             .add("e", IntegerType()).add("f", IntegerType())\
+                             .add("g", IntegerType())
         data = [
-            (1, "foo", True, 3.0), (2, "foo", True, 5.0),
-            (3, "bar", False, -1.0), (4, "bar", False, 6.0),
+            (1, "foo", True, 3.0, 1, 16777218, None), (2, "foo", True, 5.0, 2, 16777220, None),
+            (3, "bar", False, -1.0, 3, 1, None), (4, "bar", False, 6.0, None, None, None),
         ]
         df = self.spark.createDataFrame(data, schema)
         types = df.toPandas().dtypes
@@ -2506,6 +2508,9 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEquals(types[1], np.object)
         self.assertEquals(types[2], np.bool)
         self.assertEquals(types[3], np.float32)
+        self.assertEquals(types[4], np.float32)
+        self.assertEquals(types[5], np.float64)
+        self.assertEquals(types[6], np.float32)
 
     def test_create_dataframe_from_array_of_long(self):
         import array


### PR DESCRIPTION
…as to prevent needless Exceptions during routine use.

Add the `strict=True` kwarg to DataFrame.toPandas to allow for a non-strict interpretation of the schema of a dataframe. This is currently limited to allowing a nullable int column to being interpreted as a float column (because that is the only way Pandas supports nullable int columns and actually crashes without this).

I consider this small change to be a massive quality of life improvement for DataFrames with lots of nullable int columns, which would otherwise need a litany of `df.withColumn(name, F.col(name).cast(DoubleType()))`, etc, just to view them easily or interact with them in-memory.

**Possible Objections**
* I foresee concerns with the name of the kwarg, of which I am open to suggestions.
* I also foresee possible objections due to the potential for needless conversion of nullable int columns to floats when there are actually no null values. I would counter those objections by noting that it only occurs when strict=False, which is not the default, and can be avoided on a per-column basis by setting the `nullable` property of the schema to False. 

**Alternatives**
* Rename the kwarg to be specific to the current change. i.e., `nullable_int_to_float` instead of `strict` or some other, similar name.
* Fix Pandas to allow nullable int columns. (Very difficult, per Wes McKinney, due to lack of NumPy support. https://stackoverflow.com/questions/11548005/numpy-or-pandas-keeping-array-type-as-integer-while-having-a-nan-value)
