### PR TITLE
Add the validation of spark.cores.max under Streaming

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -144,6 +144,13 @@ class StreamingContext private[streaming] (
     }
   }
 
+  if (sc.conf.contains("spark.cores.max")) {
+    val totalCores = sc.conf.getInt("spark.cores.max", 1)
+    if (totalCores <= 1) {
+      throw new SparkException(" Total executor cores (spark.cores.max) must greater than 1")
+    }
+  }
+
   if (sc.conf.get("spark.master") == "local" || sc.conf.get("spark.master") == "local[1]") {
     logWarning("spark.master should be set as local[n], n > 1 in local mode if you have receivers" +
       " to get data, otherwise Spark jobs will not get resources to process the received data.")


### PR DESCRIPTION
## What changes were proposed in this pull request?
By using spark streaming, --total-executor-cores must greater than 1.
This pull requst add the validation of spark.cores.max.


## How was this patch tested?
manual tests:
--total-executor-cores 1
--total-executor-cores 2

Please review http://spark.apache.org/contributing.html before opening a pull request.
