### PR TITLE
[MINOR] Fix a typo in the method name `UserDefinedFunction.asNonNullabe`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
@@ -82,7 +82,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
    * Registers a user-defined function (UDF), for a UDF that's already defined using the Dataset
    * API (i.e. of type UserDefinedFunction). To change a UDF to nondeterministic, call the API
    * `UserDefinedFunction.asNondeterministic()`. To change a UDF to nonNullable, call the API
-   * `UserDefinedFunction.asNonNullabe()`.
+   * `UserDefinedFunction.asNonNullable()`.
    *
    * Example:
    * {{{
@@ -90,7 +90,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
    *   spark.udf.register("random", foo.asNondeterministic())
    *
    *   val bar = udf(() => "bar")
-   *   spark.udf.register("stringLit", bar.asNonNullabe())
+   *   spark.udf.register("stringLit", bar.asNonNullable())
    * }}}
    *
    * @param name the name of the UDF.
@@ -130,7 +130,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
           }
           functionRegistry.createOrReplaceTempFunction(name, builder)
           val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-          if (nullable) udf else udf.asNonNullabe()
+          if (nullable) udf else udf.asNonNullable()
         }""")
     }
 
@@ -175,7 +175,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -194,7 +194,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -213,7 +213,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -232,7 +232,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -251,7 +251,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -270,7 +270,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -289,7 +289,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -308,7 +308,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -327,7 +327,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -346,7 +346,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -365,7 +365,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -384,7 +384,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -403,7 +403,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -422,7 +422,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -441,7 +441,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -460,7 +460,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -479,7 +479,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -498,7 +498,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -517,7 +517,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -536,7 +536,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -555,7 +555,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -574,7 +574,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -593,7 +593,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
     }
     functionRegistry.createOrReplaceTempFunction(name, builder)
     val udf = UserDefinedFunction(func, dataType, inputTypes).withName(name)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
@@ -101,7 +101,7 @@ case class UserDefinedFunction protected[sql] (
    *
    * @since 2.3.0
    */
-  def asNonNullabe(): UserDefinedFunction = {
+  def asNonNullable(): UserDefinedFunction = {
     if (!nullable) {
       this
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3226,7 +3226,7 @@ object functions {
       val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
       val inputTypes = Try($inputTypes).toOption
       val udf = UserDefinedFunction(f, dataType, inputTypes)
-      if (nullable) udf else udf.asNonNullabe()
+      if (nullable) udf else udf.asNonNullable()
     }""")
   }
 
@@ -3245,7 +3245,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3261,7 +3261,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3277,7 +3277,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3293,7 +3293,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3309,7 +3309,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3325,7 +3325,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: ScalaReflection.schemaFor(typeTag[A5]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3341,7 +3341,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: ScalaReflection.schemaFor(typeTag[A5]).dataType :: ScalaReflection.schemaFor(typeTag[A6]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3357,7 +3357,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: ScalaReflection.schemaFor(typeTag[A5]).dataType :: ScalaReflection.schemaFor(typeTag[A6]).dataType :: ScalaReflection.schemaFor(typeTag[A7]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3373,7 +3373,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: ScalaReflection.schemaFor(typeTag[A5]).dataType :: ScalaReflection.schemaFor(typeTag[A6]).dataType :: ScalaReflection.schemaFor(typeTag[A7]).dataType :: ScalaReflection.schemaFor(typeTag[A8]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3389,7 +3389,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: ScalaReflection.schemaFor(typeTag[A5]).dataType :: ScalaReflection.schemaFor(typeTag[A6]).dataType :: ScalaReflection.schemaFor(typeTag[A7]).dataType :: ScalaReflection.schemaFor(typeTag[A8]).dataType :: ScalaReflection.schemaFor(typeTag[A9]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   /**
@@ -3405,7 +3405,7 @@ object functions {
     val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[RT]
     val inputTypes = Try(ScalaReflection.schemaFor(typeTag[A1]).dataType :: ScalaReflection.schemaFor(typeTag[A2]).dataType :: ScalaReflection.schemaFor(typeTag[A3]).dataType :: ScalaReflection.schemaFor(typeTag[A4]).dataType :: ScalaReflection.schemaFor(typeTag[A5]).dataType :: ScalaReflection.schemaFor(typeTag[A6]).dataType :: ScalaReflection.schemaFor(typeTag[A7]).dataType :: ScalaReflection.schemaFor(typeTag[A8]).dataType :: ScalaReflection.schemaFor(typeTag[A9]).dataType :: ScalaReflection.schemaFor(typeTag[A10]).dataType :: Nil).toOption
     val udf = UserDefinedFunction(f, dataType, inputTypes)
-    if (nullable) udf else udf.asNonNullabe()
+    if (nullable) udf else udf.asNonNullable()
   }
 
   // scalastyle:on parameter.number


### PR DESCRIPTION
## What changes were proposed in this pull request?

The method name `asNonNullabe` should be `asNonNullable`.

## How was this patch tested?

N/A