### PR TITLE
[SPARK-17654] [SQL] Enable populating hive bucketed tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.plans.physical
 
+import scala.language.existentials
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
@@ -49,12 +51,18 @@ case object AllTuples extends Distribution
  * can mean such tuples are either co-located in the same partition or they will be contiguous
  * within a single partition.
  */
-case class ClusteredDistribution(clustering: Seq[Expression]) extends Distribution {
+case class ClusteredDistribution(
+    clustering: Seq[Expression],
+    numClusters: Option[Int] = None,
+    hashingFunctionClass: Option[Class[_ <: HashExpression[Int]]] = None)
+  extends Distribution {
   require(
     clustering != Nil,
     "The clustering expressions of a ClusteredDistribution should not be Nil. " +
       "An AllTuples should be used to represent a distribution that only has " +
       "a single partition.")
+  require(numClusters.isEmpty || numClusters.get > 0,
+    "Number of cluster (if set) should only be a positive integer")
 }
 
 /**
@@ -234,7 +242,10 @@ case object SinglePartition extends Partitioning {
  * of `expressions`.  All rows where `expressions` evaluate to the same values are guaranteed to be
  * in the same partition.
  */
-case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
+case class HashPartitioning(
+    expressions: Seq[Expression],
+    numPartitions: Int,
+    hashingFunctionClass: Class[_ <: HashExpression[Int]] = classOf[Murmur3Hash])
   extends Expression with Partitioning with Unevaluable {
 
   override def children: Seq[Expression] = expressions
@@ -243,8 +254,10 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
 
   override def satisfies(required: Distribution): Boolean = required match {
     case UnspecifiedDistribution => true
-    case ClusteredDistribution(requiredClustering) =>
-      expressions.forall(x => requiredClustering.exists(_.semanticEquals(x)))
+    case ClusteredDistribution(requiredClustering, numClusters, hashingFunctionClazz) =>
+      (numClusters.isEmpty || numClusters.get == numPartitions) &&
+        (hashingFunctionClazz.isEmpty || hashingFunctionClazz.get == hashingFunctionClass) &&
+        expressions.forall(x => requiredClustering.exists(_.semanticEquals(x)))
     case _ => false
   }
 
@@ -260,9 +273,16 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
 
   /**
    * Returns an expression that will produce a valid partition ID(i.e. non-negative and is less
-   * than numPartitions) based on hashing expressions.
+   * than numPartitions) based on hashing expression(s) and the hashing function.
    */
-  def partitionIdExpression: Expression = Pmod(new Murmur3Hash(expressions), Literal(numPartitions))
+  def partitionIdExpression: Expression = {
+    val hashExpression = hashingFunctionClass match {
+      case m if m == classOf[Murmur3Hash] => new Murmur3Hash(expressions)
+      case h if h == classOf[HiveHash] => HiveHash(expressions)
+      case _ => throw new Exception(s"Unsupported hashingFunction: $hashingFunctionClass")
+    }
+    Pmod(hashExpression, Literal(numPartitions))
+  }
 }
 
 /**
@@ -289,8 +309,9 @@ case class RangePartitioning(ordering: Seq[SortOrder], numPartitions: Int)
     case OrderedDistribution(requiredOrdering) =>
       val minSize = Seq(requiredOrdering.size, ordering.size).min
       requiredOrdering.take(minSize) == ordering.take(minSize)
-    case ClusteredDistribution(requiredClustering) =>
-      ordering.map(_.child).forall(x => requiredClustering.exists(_.semanticEquals(x)))
+    case ClusteredDistribution(requiredClustering, numClusters, hashingFunctionClass) =>
+      (numClusters.isEmpty || numClusters.get == numPartitions) && hashingFunctionClass.isEmpty &&
+        ordering.map(_.child).forall(x => requiredClustering.exists(_.semanticEquals(x)))
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -32,7 +32,10 @@ import org.apache.spark.sql.types.{DataType, IntegerType}
  *  - Intra-partition ordering of data: In this case the distribution describes guarantees made
  *    about how tuples are distributed within a single partition.
  */
-sealed trait Distribution
+sealed trait Distribution {
+  /** If defined, then represents how many partitions are expected by the distribution */
+  def numPartitions: Option[Int] = None
+}
 
 /**
  * Represents a distribution where no promises are made about co-location of data.
@@ -63,6 +66,8 @@ case class ClusteredDistribution(
       "a single partition.")
   require(numClusters.isEmpty || numClusters.get > 0,
     "Number of cluster (if set) should only be a positive integer")
+
+  override def numPartitions: Option[Int] = numClusters
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst
 import org.apache.spark.SparkFunSuite
 /* Implicit conversions */
 import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{HiveHash, Murmur3Hash}
 import org.apache.spark.sql.catalyst.plans.physical._
 
 class DistributionSuite extends SparkFunSuite {
@@ -81,6 +82,26 @@ class DistributionSuite extends SparkFunSuite {
 
     checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), Some(classOf[Murmur3Hash])),
+      true)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(12), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('d, 'e), Some(10), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), Some(classOf[HiveHash])),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
       AllTuples,
       false)
 
@@ -127,18 +148,33 @@ class DistributionSuite extends SparkFunSuite {
 
     checkSatisfied(
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('a, 'b, 'c)),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), None),
       true)
 
     checkSatisfied(
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('c, 'b, 'a)),
+      ClusteredDistribution(Seq('c, 'b, 'a), Some(10), None),
       true)
 
     checkSatisfied(
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('b, 'c, 'a, 'd)),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), None),
       true)
+
+    checkSatisfied(
+      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(12), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), Some(classOf[HiveHash])),
+      false)
 
     // Cases which need an exchange between two data properties.
     // TODO: We can have an optimization to first sort the dataset

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -44,8 +44,9 @@ trait RunnableCommand extends logical.Command {
   // `ExecutedCommand` during query planning.
   lazy val metrics: Map[String, SQLMetric] = Map.empty
 
-  def requiredDistribution: Seq[Distribution] =
-    Seq.fill(children.size)(UnspecifiedDistribution)
+  def requiredDistribution: Seq[Distribution] = Seq.fill(children.size)(UnspecifiedDistribution)
+
+  def requiredOrdering: Seq[Seq[SortOrder]] = Seq.fill(children.size)(Nil)
 
   def run(sparkSession: SparkSession, children: Seq[SparkPlan]): Seq[Row] = {
     throw new NotImplementedError
@@ -99,6 +100,8 @@ case class ExecutedCommandExec(cmd: RunnableCommand, children: Seq[SparkPlan]) e
   override def executeTake(limit: Int): Array[InternalRow] = sideEffectResult.take(limit).toArray
 
   override def requiredChildDistribution: Seq[Distribution] = cmd.requiredDistribution
+
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] = cmd.requiredOrdering
 
   protected override def doExecute(): RDD[InternalRow] = {
     sqlContext.sparkContext.parallelize(sideEffectResult, 1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -50,7 +50,9 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       numPartitions: Int): Partitioning = {
     requiredDistribution match {
       case AllTuples => SinglePartition
-      case ClusteredDistribution(clustering) => HashPartitioning(clustering, numPartitions)
+      case ClusteredDistribution(clustering, numClusters, hashingFunctionClass) =>
+        HashPartitioning(clustering, numClusters.getOrElse(numPartitions),
+          hashingFunctionClass.getOrElse(classOf[Murmur3Hash]))
       case OrderedDistribution(ordering) => RangePartitioning(ordering, numPartitions)
       case dist => sys.error(s"Do not know how to satisfy distribution $dist")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchange.scala
@@ -203,7 +203,7 @@ object ShuffleExchange {
       serializer: Serializer): ShuffleDependency[Int, InternalRow, InternalRow] = {
     val part: Partitioner = newPartitioning match {
       case RoundRobinPartitioning(numPartitions) => new HashPartitioner(numPartitions)
-      case HashPartitioning(_, n) =>
+      case HashPartitioning(_, n, _) =>
         new Partitioner {
           override def numPartitions: Int = n
           // For HashPartitioning, the partitioning key is already a valid partition ID, as we use

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ReorderJoinPredicates.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ReorderJoinPredicates.scala
@@ -54,13 +54,13 @@ class ReorderJoinPredicates extends Rule[SparkPlan] {
 
     if (leftKeys.forall(_.deterministic) && rightKeys.forall(_.deterministic)) {
       leftPartitioning match {
-        case HashPartitioning(leftExpressions, _)
+        case HashPartitioning(leftExpressions, _, _)
           if leftExpressions.length == leftKeys.length &&
             leftKeys.forall(x => leftExpressions.exists(_.semanticEquals(x))) =>
           reorder(leftExpressions, leftKeys)
 
         case _ => rightPartitioning match {
-          case HashPartitioning(rightExpressions, _)
+          case HashPartitioning(rightExpressions, _, _)
             if rightExpressions.length == rightKeys.length &&
               rightKeys.forall(x => rightExpressions.exists(_.semanticEquals(x))) =>
             reorder(rightExpressions, rightKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -127,7 +127,7 @@ class FileStreamSink(
         outputSpec = FileFormatWriter.OutputSpec(path, Map.empty),
         hadoopConf = hadoopConf,
         partitionColumns = partitionColumns,
-        bucketSpec = None,
+        bucketIdExpression = None,
         statsTrackers = Nil,
         options = options)
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -55,6 +55,8 @@ import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
 
+import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_PROVIDER
+
 /**
  * A class that wraps the HiveClient and converts its responses to externally visible classes.
  * Note that this class is typically loaded with an internal classloader for each instantiation,
@@ -918,7 +920,10 @@ private[hive] object HiveClientImpl {
     }
 
     table.bucketSpec match {
-      case Some(bucketSpec) if DDLUtils.isHiveTable(table) =>
+      case Some(bucketSpec) if DDLUtils.isHiveTable(table) ||
+        (table.tableType != CatalogTableType.VIEW &&
+          table.properties.get(DATASOURCE_PROVIDER).isEmpty) =>
+
         hiveTable.setNumBuckets(bucketSpec.numBuckets)
         hiveTable.setBucketCols(bucketSpec.bucketColumnNames.toList.asJava)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -51,11 +51,10 @@ import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.hive.HiveExternalCatalog
+import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_PROVIDER
 import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
-
-import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_PROVIDER
 
 /**
  * A class that wraps the HiveClient and converts its responses to externally visible classes.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -478,34 +478,35 @@ case class InsertIntoHiveTable(
 
     outputPaths.foreach(outputPath => {
       val fs = outputPath.getFileSystem(conf)
-      val files =
-        fs.listStatus(outputPath)
-          .filterNot(_.getPath.getName == "_SUCCESS")
+      val allFiles = fs.listStatus(outputPath)
+      if (allFiles != null && allFiles.nonEmpty) {
+        val files = allFiles.filterNot(_.getPath.getName == "_SUCCESS")
           .map(_.getPath.getName)
           .sortBy(_.toString)
 
-      var expectedBucketId = 0
-      files.foreach { case file =>
-        getBucketIdFromFilename(file) match {
-          case Some(id) if id == expectedBucketId =>
-            expectedBucketId += 1
-          case Some(_) =>
-            throw new SparkException(
-              s"Potentially missing bucketed output files in temporary bucketed output location. " +
-                s"Aborting job. Output location : $outputPath, files found : " +
-                files.mkString("[", ",", "]"))
-          case None =>
-            throw new SparkException(
-              s"Invalid file found in temporary bucketed output location. Aborting job. " +
-                s"Output location : $outputPath, bad file : $file")
+        var expectedBucketId = 0
+        files.foreach { case file =>
+          getBucketIdFromFilename(file) match {
+            case Some(id) if id == expectedBucketId =>
+              expectedBucketId += 1
+            case Some(_) =>
+              throw new SparkException(
+                s"Potentially missing bucketed output files in temporary bucketed output " +
+                  s"location. Aborting job. Output location : $outputPath, files found : " +
+                  files.mkString("[", ",", "]"))
+            case None =>
+              throw new SparkException(
+                s"Invalid file found in temporary bucketed output location. Aborting job. " +
+                  s"Output location : $outputPath, bad file : $file")
+          }
         }
-      }
 
-      if (expectedBucketId != numBuckets) {
-        throw new SparkException(
-          s"Potentially missing bucketed output files in temporary bucketed output location. " +
-            s"Aborting job. Output location : $outputPath, files found : " +
-            files.mkString("[", ",", "]"))
+        if (expectedBucketId != numBuckets) {
+          throw new SparkException(
+            s"Potentially missing bucketed output files in temporary bucketed output location. " +
+              s"Aborting job. Output location : $outputPath, files found : " +
+              files.mkString("[", ",", "]"))
+        }
       }
     })
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -481,11 +481,12 @@ case class InsertIntoHiveTable(
       val files =
         fs.listStatus(outputPath)
           .filterNot(_.getPath.getName == "_SUCCESS")
-          .sortBy(_.getPath.getName)
+          .map(_.getPath.getName)
+          .sortBy(_.toString)
 
       var expectedBucketId = 0
       files.foreach { case file =>
-        getBucketIdFromFilename(file.getPath.getName) match {
+        getBucketIdFromFilename(file) match {
           case Some(id) if id == expectedBucketId =>
             expectedBucketId += 1
           case Some(_) =>
@@ -496,7 +497,7 @@ case class InsertIntoHiveTable(
           case None =>
             throw new SparkException(
               s"Invalid file found in temporary bucketed output location. Aborting job. " +
-                s"Output location : $outputPath, bad file : ${file.getPath.getName}")
+                s"Output location : $outputPath, bad file : $file")
         }
       }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -35,8 +35,9 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, HiveHash}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.{CommandUtils, DataWritingCommand}
 import org.apache.spark.sql.execution.datasources.FileFormatWriter
@@ -311,25 +312,10 @@ case class InsertIntoHiveTable(
       }
     }
 
-    table.bucketSpec match {
-      case Some(bucketSpec) =>
-        // Writes to bucketed hive tables are allowed only if user does not care about maintaining
-        // table's bucketing ie. both "hive.enforce.bucketing" and "hive.enforce.sorting" are
-        // set to false
-        val enforceBucketingConfig = "hive.enforce.bucketing"
-        val enforceSortingConfig = "hive.enforce.sorting"
-
-        val message = s"Output Hive table ${table.identifier} is bucketed but Spark" +
-          "currently does NOT populate bucketed output which is compatible with Hive."
-
-        if (hadoopConf.get(enforceBucketingConfig, "true").toBoolean ||
-          hadoopConf.get(enforceSortingConfig, "true").toBoolean) {
-          throw new AnalysisException(message)
-        } else {
-          logWarning(message + s" Inserting data anyways since both $enforceBucketingConfig and " +
-            s"$enforceSortingConfig are set to false.")
-        }
-      case _ => // do nothing since table has no bucketing
+    if (!overwrite && table.bucketSpec.isDefined) {
+      throw new AnalysisException(s"Appending data to hive bucketed table ${table.qualifiedName} " +
+        s"is not allowed as it will break the table's bucketing guarantee. Consider overwriting " +
+        s"instead.")
     }
 
     val committer = FileCommitProtocol.instantiate(
@@ -352,9 +338,19 @@ case class InsertIntoHiveTable(
       outputSpec = FileFormatWriter.OutputSpec(tmpLocation.toString, Map.empty),
       hadoopConf = hadoopConf,
       partitionColumns = partitionAttributes,
-      bucketSpec = None,
+      bucketSpec = table.bucketSpec,
       statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
       options = Map.empty)
+
+    // TODO(tejasp) validate bucketing based on number of files before loading data into metastore
+    if (table.bucketSpec.isDefined) {
+      if (partition.nonEmpty && numDynamicPartitions > 0) {
+        // TODO(tejasp) goto to leaf partition dir
+        // validateBucketing(hadoopConf, Seq(tmpLocation), table.bucketSpec.get.numBuckets)
+      } else {
+        validateBucketing(hadoopConf, Seq(tmpLocation), table.bucketSpec.get.numBuckets)
+      }
+    }
 
     if (partition.nonEmpty) {
       if (numDynamicPartitions > 0) {
@@ -446,5 +442,60 @@ case class InsertIntoHiveTable(
     // does not return anything for insert operations.
     // TODO: implement hive compatibility as rules.
     Seq.empty[Row]
+  }
+
+  def validateBucketing(conf: Configuration, outputPaths: Seq[Path], numBuckets: Int): Unit = {
+    val bucketedFilePattern = """part-(\d+)(?:.*)?$""".r
+
+    def getBucketIdFromFilename(fileName : String): Option[Int] =
+      fileName match {
+        case bucketedFilePattern(bucketId) => Some(bucketId.toInt)
+        case _ => None
+      }
+
+    outputPaths.foreach(outputPath => {
+      val fs = outputPath.getFileSystem(conf)
+      val files = fs.listStatus(outputPath).sortBy(_.getPath.getName)
+      var expectedBucketId = 0
+
+      files.foreach(f => {
+        val fileName = f.getPath.getName
+        getBucketIdFromFilename(fileName) match {
+          case Some(bucketId) if bucketId == expectedBucketId =>
+            expectedBucketId += 1
+          case Some(bucketId) if bucketId > expectedBucketId =>
+            // TODO(tejasp) Tasks which do not produce any data would still have to create an
+            // empty file so that we are in par with Hive's support of matching the output
+            // files produced
+            throw new AnalysisException(
+              s"Invalid bucketed output: Missing output file for bucket $expectedBucketId " +
+                s"in temporary output location $outputPath, expected buckets = ${files.length}")
+          case None if fileName == "_SUCCESS" =>
+            // do nothing
+          case _ =>
+            // In case there is any other file in the output directory, fail the job because we
+            // strict guarantee about all files in a bucketed output directory
+            throw new AnalysisException(
+              s"Invalid bucketed output: Output file $fileName does not match with table's " +
+                s"bucketing spec. Temporary output location : $outputPath")
+        }
+      })
+    })
+  }
+
+  override def requiredDistribution: Seq[Distribution] = {
+    val allColumns = query.output
+    val partitionColumnNames = partition.keySet
+    val dataColumns = allColumns.filterNot(c => partitionColumnNames.contains(c.name))
+
+    table.bucketSpec match {
+      case Some(bucketSpec) if bucketSpec.numBuckets > 1 =>
+        val bucketSpec = table.bucketSpec.get
+        val bucketColumns = bucketSpec.bucketColumnNames.map(b => dataColumns.find(_.name == b).get)
+        Seq(ClusteredDistribution(bucketColumns, Option(bucketSpec.numBuckets),
+          Some(classOf[HiveHash])))
+
+      case _ => Seq(UnspecifiedDistribution)
+    }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -22,11 +22,12 @@ import java.net.URI
 import java.text.SimpleDateFormat
 import java.util.{Date, Locale, Random}
 
+import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.hadoop.hive.common.FileUtils
+import org.apache.hadoop.hive.common.{FileUtils, HiveStatsUtils}
 import org.apache.hadoop.hive.ql.ErrorMsg
 import org.apache.hadoop.hive.ql.exec.TaskRunner
 import org.apache.hadoop.hive.ql.plan.TableDesc
@@ -35,9 +36,9 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Attribute, HiveHash}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Expression, HiveHash, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, UnspecifiedDistribution}
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, HashPartitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.{CommandUtils, DataWritingCommand}
 import org.apache.spark.sql.execution.datasources.FileFormatWriter
@@ -313,9 +314,9 @@ case class InsertIntoHiveTable(
     }
 
     if (!overwrite && table.bucketSpec.isDefined) {
-      throw new AnalysisException(s"Appending data to hive bucketed table ${table.qualifiedName} " +
-        s"is not allowed as it will break the table's bucketing guarantee. Consider overwriting " +
-        s"instead.")
+      throw new SparkException("Appending data to hive bucketed table is not allowed as it " +
+        "will break the table's bucketing guarantee. Consider overwriting instead. Table = " +
+        table.qualifiedName)
     }
 
     val committer = FileCommitProtocol.instantiate(
@@ -330,6 +331,9 @@ case class InsertIntoHiveTable(
       }.asInstanceOf[Attribute]
     }
 
+    val (_, dataColumns) = getPartitionAndDataColumns
+    val bucketIdExpression = getBucketIdExpression(dataColumns)
+
     FileFormatWriter.write(
       sparkSession = sparkSession,
       plan = children.head,
@@ -338,17 +342,18 @@ case class InsertIntoHiveTable(
       outputSpec = FileFormatWriter.OutputSpec(tmpLocation.toString, Map.empty),
       hadoopConf = hadoopConf,
       partitionColumns = partitionAttributes,
-      bucketSpec = table.bucketSpec,
+      bucketIdExpression = bucketIdExpression,
       statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
       options = Map.empty)
 
-    // TODO(tejasp) validate bucketing based on number of files before loading data into metastore
-    if (table.bucketSpec.isDefined) {
+    // validate bucketing based on number of files before loading to metastore
+    table.bucketSpec.foreach { spec =>
       if (partition.nonEmpty && numDynamicPartitions > 0) {
-        // TODO(tejasp) goto to leaf partition dir
-        // validateBucketing(hadoopConf, Seq(tmpLocation), table.bucketSpec.get.numBuckets)
+        val validPartitionPaths =
+          getValidPartitionPaths(hadoopConf, tmpLocation, numDynamicPartitions)
+        validateBuckets(hadoopConf, validPartitionPaths, table.bucketSpec.get.numBuckets)
       } else {
-        validateBucketing(hadoopConf, Seq(tmpLocation), table.bucketSpec.get.numBuckets)
+        validateBuckets(hadoopConf, Seq(tmpLocation), table.bucketSpec.get.numBuckets)
       }
     }
 
@@ -367,10 +372,10 @@ case class InsertIntoHiveTable(
         // https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries
         // scalastyle:on
         val oldPart =
-          externalCatalog.getPartitionOption(
-            table.database,
-            table.identifier.table,
-            partitionSpec)
+        externalCatalog.getPartitionOption(
+          table.database,
+          table.identifier.table,
+          partitionSpec)
 
         var doHiveOverwrite = overwrite
 
@@ -444,7 +449,25 @@ case class InsertIntoHiveTable(
     Seq.empty[Row]
   }
 
-  def validateBucketing(conf: Configuration, outputPaths: Seq[Path], numBuckets: Int): Unit = {
+  private def getValidPartitionPaths(
+      conf: Configuration,
+      outputPath: Path,
+      numDynamicPartitions: Int): Seq[Path] = {
+    val validPartitionPaths = mutable.HashSet[Path]()
+    try {
+      val fs = outputPath.getFileSystem(conf)
+      HiveStatsUtils.getFileStatusRecurse(outputPath, numDynamicPartitions, fs)
+        .filter(_.isDirectory)
+        .foreach(d => validPartitionPaths.add(d.getPath))
+    } catch {
+      case e: IOException =>
+        throw new SparkException("Unable to extract partition paths from temporary output " +
+          s"location $outputPath due to : ${e.getMessage}", e)
+    }
+    validPartitionPaths.toSeq
+  }
+
+  private def validateBuckets(conf: Configuration, outputPaths: Seq[Path], numBuckets: Int) = {
     val bucketedFilePattern = """part-(\d+)(?:.*)?$""".r
 
     def getBucketIdFromFilename(fileName : String): Option[Int] =
@@ -455,47 +478,100 @@ case class InsertIntoHiveTable(
 
     outputPaths.foreach(outputPath => {
       val fs = outputPath.getFileSystem(conf)
-      val files = fs.listStatus(outputPath).sortBy(_.getPath.getName)
-      var expectedBucketId = 0
+      val files =
+        fs.listStatus(outputPath)
+          .filterNot(_.getPath.getName == "_SUCCESS")
+          .sortBy(_.getPath.getName)
 
-      files.foreach(f => {
-        val fileName = f.getPath.getName
-        getBucketIdFromFilename(fileName) match {
-          case Some(bucketId) if bucketId == expectedBucketId =>
+      var expectedBucketId = 0
+      files.foreach { case file =>
+        getBucketIdFromFilename(file.getPath.getName) match {
+          case Some(id) if id == expectedBucketId =>
             expectedBucketId += 1
-          case Some(bucketId) if bucketId > expectedBucketId =>
-            // TODO(tejasp) Tasks which do not produce any data would still have to create an
-            // empty file so that we are in par with Hive's support of matching the output
-            // files produced
-            throw new AnalysisException(
-              s"Invalid bucketed output: Missing output file for bucket $expectedBucketId " +
-                s"in temporary output location $outputPath, expected buckets = ${files.length}")
-          case None if fileName == "_SUCCESS" =>
-            // do nothing
-          case _ =>
-            // In case there is any other file in the output directory, fail the job because we
-            // strict guarantee about all files in a bucketed output directory
-            throw new AnalysisException(
-              s"Invalid bucketed output: Output file $fileName does not match with table's " +
-                s"bucketing spec. Temporary output location : $outputPath")
+          case Some(_) =>
+            throw new SparkException(
+              s"Potentially missing bucketed output files in temporary bucketed output location. " +
+                s"Aborting job. Output location : $outputPath, files found : " +
+                files.mkString("[", ",", "]"))
+          case None =>
+            throw new SparkException(
+              s"Invalid file found in temporary bucketed output location. Aborting job. " +
+                s"Output location : $outputPath, bad file : ${file.getPath.getName}")
         }
-      })
+      }
+
+      if (expectedBucketId != numBuckets) {
+        throw new SparkException(
+          s"Potentially missing bucketed output files in temporary bucketed output location. " +
+            s"Aborting job. Output location : $outputPath, files found : " +
+            files.mkString("[", ",", "]"))
+      }
     })
   }
 
-  override def requiredDistribution: Seq[Distribution] = {
+  private def getPartitionAndDataColumns: (Seq[Attribute], Seq[Attribute]) = {
     val allColumns = query.output
     val partitionColumnNames = partition.keySet
-    val dataColumns = allColumns.filterNot(c => partitionColumnNames.contains(c.name))
+    allColumns.partition(c => partitionColumnNames.contains(c.name))
+  }
 
-    table.bucketSpec match {
-      case Some(bucketSpec) if bucketSpec.numBuckets > 1 =>
-        val bucketSpec = table.bucketSpec.get
-        val bucketColumns = bucketSpec.bucketColumnNames.map(b => dataColumns.find(_.name == b).get)
-        Seq(ClusteredDistribution(bucketColumns, Option(bucketSpec.numBuckets),
-          Some(classOf[HiveHash])))
-
-      case _ => Seq(UnspecifiedDistribution)
+  /**
+   * Use `HashPartitioning.partitionIdExpression` as our bucket id expression, so that we can
+   * guarantee the data distribution is same between shuffle and bucketed data source, which
+   * enables us to only shuffle one side when join a bucketed table and a normal one.
+   */
+  private def getBucketIdExpression(dataColumns: Seq[Attribute]): Option[Expression] =
+    table.bucketSpec.map { spec =>
+      HashPartitioning(
+        spec.bucketColumnNames.map(c => dataColumns.find(_.name == c).get),
+        spec.numBuckets,
+        classOf[HiveHash]
+      ).partitionIdExpression
     }
+
+  /**
+   * If the table is bucketed, then requiredDistribution would be the bucket columns.
+   * Else it would be empty
+   */
+  override def requiredDistribution: Seq[Distribution] = table.bucketSpec match {
+    case Some(bucketSpec) =>
+      val (_, dataColumns) = getPartitionAndDataColumns
+      Seq(ClusteredDistribution(
+        bucketSpec.bucketColumnNames.map(b => dataColumns.find(_.name == b).get),
+        Option(bucketSpec.numBuckets),
+        Some(classOf[HiveHash])
+      ))
+
+    case _ => Seq(UnspecifiedDistribution)
+  }
+
+  /**
+   * How is `requiredOrdering` determined ?
+   *
+   *     table type      |    normal table    |              bucketed table
+   * --------------------+--------------------+-----------------------------------------------
+   *   non-partitioned   |        Nil         |               sort columns
+   *   static partition  |        Nil         |               sort columns
+   *   dynamic partition |  partition columns | (partition columns + bucketId + sort columns)
+   * --------------------+--------------------+-----------------------------------------------
+   */
+  override def requiredOrdering: Seq[Seq[SortOrder]] = {
+    val (partitionColumns, dataColumns) = getPartitionAndDataColumns
+    val isDynamicPartitioned =
+      table.partitionColumnNames.nonEmpty && partition.values.exists(_.isEmpty)
+
+    val sortExpressions = table.bucketSpec match {
+      case Some(bucketSpec) =>
+        val sortColumns = bucketSpec.sortColumnNames.map(c => dataColumns.find(_.name == c).get)
+        if (isDynamicPartitioned) {
+          partitionColumns ++ getBucketIdExpression(dataColumns) ++ sortColumns
+        } else {
+          sortColumns
+        }
+
+      case _ => if (isDynamicPartitioned) partitionColumns else Nil
+    }
+
+    Seq(sortExpressions.map(SortOrder(_, Ascending)))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.hive
 
 import java.io.File
+import java.net.URI
+import java.util
 
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, _}
-import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.InsertIntoTable
+import org.apache.spark.sql.catalyst.expressions.HiveHashFunction
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
@@ -497,33 +498,6 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
     }
   }
 
-  testBucketedTable("INSERT should NOT fail if strict bucketing is NOT enforced") {
-    tableName =>
-      withSQLConf("hive.enforce.bucketing" -> "false", "hive.enforce.sorting" -> "false") {
-        sql(s"INSERT INTO TABLE $tableName SELECT 1, 4, 2 AS c, 3 AS b")
-        checkAnswer(sql(s"SELECT a, b, c, d FROM $tableName"), Row(1, 2, 3, 4))
-      }
-  }
-
-  testBucketedTable("INSERT should fail if strict bucketing / sorting is enforced") {
-    tableName =>
-      withSQLConf("hive.enforce.bucketing" -> "true", "hive.enforce.sorting" -> "false") {
-        intercept[AnalysisException] {
-          sql(s"INSERT INTO TABLE $tableName SELECT 1, 2, 3, 4")
-        }
-      }
-      withSQLConf("hive.enforce.bucketing" -> "false", "hive.enforce.sorting" -> "true") {
-        intercept[AnalysisException] {
-          sql(s"INSERT INTO TABLE $tableName SELECT 1, 2, 3, 4")
-        }
-      }
-      withSQLConf("hive.enforce.bucketing" -> "true", "hive.enforce.sorting" -> "true") {
-        intercept[AnalysisException] {
-          sql(s"INSERT INTO TABLE $tableName SELECT 1, 2, 3, 4")
-        }
-      }
-  }
-
   test("SPARK-20594: hive.exec.stagingdir was deleted by Hive") {
     // Set hive.exec.stagingdir under the table directory without start with ".".
     withSQLConf("hive.exec.stagingdir" -> "./test") {
@@ -531,6 +505,104 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
         sql("CREATE TABLE test_table (key int)")
         sql("INSERT OVERWRITE TABLE test_table SELECT 1")
         checkAnswer(sql("SELECT * FROM test_table"), Row(1))
+      }
+    }
+  }
+
+  private def validateBucketingAndSorting(numBuckets: Int, dir: URI): Unit = {
+    val bucketFiles = new File(dir).listFiles().filter(_.getName.startsWith("part-"))
+      .sortWith((x, y) => x.getName < y.getName)
+    assert(bucketFiles.length === numBuckets)
+
+    bucketFiles.zipWithIndex.foreach { case(bucketFile, bucketId) =>
+      val rows = spark.read.format("text").load(bucketFile.getAbsolutePath).collect()
+      var prevKey: Option[Int] = None
+      rows.foreach(row => {
+        val key = row.getString(0).split("\t")(0).toInt
+        assert(HiveHashFunction.hash(key, IntegerType, seed = 0) % numBuckets === bucketId)
+
+        if (prevKey.isDefined) {
+          assert(prevKey.get <= key)
+        }
+        prevKey = Some(key)
+      })
+    }
+  }
+
+  test("Write data to a non-partitioned bucketed table") {
+    val numBuckets = 8
+    val tableName = "nonPartitionedBucketed"
+
+    withTable(tableName) {
+      val session = spark.sessionState
+      sql(s"""
+             |CREATE TABLE $tableName (key int, value string)
+             |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+             |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+             |""".stripMargin)
+
+      (0 until 100)
+        .map(i => (i, i.toString)).toDF("key", "value")
+        .write.mode(SaveMode.Overwrite).insertInto(tableName)
+
+      val dir = session.catalog.defaultTablePath(session.sqlParser.parseTableIdentifier(tableName))
+      validateBucketingAndSorting(numBuckets, dir)
+    }
+  }
+
+  test("Write data to a bucketed table with static partition") {
+    val numBuckets = 8
+    val tableName = "bucketizedTable"
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable(tableName) {
+        sql(s"""
+              |CREATE TABLE $tableName (key int, value string)
+              |PARTITIONED BY(part1 STRING, part2 STRING)
+              |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+              |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+              |""".stripMargin)
+
+        (0 until 100)
+          .map(i => (i, i.toString, "val1", "val2")).toDF("key", "value", "part1", "part2")
+          .write.mode(SaveMode.Overwrite).insertInto(tableName)
+
+        val dir = spark.sessionState.catalog.getPartition(
+          spark.sessionState.sqlParser.parseTableIdentifier(tableName),
+          Map("part1" -> "val1", "part2" -> "val2")
+        ).location
+
+        validateBucketingAndSorting(numBuckets, dir)
+      }
+    }
+  }
+
+  test("Write data to a bucketed table with dynamic partitions") {
+    val numBuckets = 7
+    val tableName = "bucketizedTable"
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable(tableName) {
+        sql(s"""
+               |CREATE TABLE $tableName (key int, value string)
+               |PARTITIONED BY(part1 STRING, part2 STRING)
+               |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+               |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+               |""".stripMargin)
+
+        (0 until 1000)
+          .map(i => (i, i.toString, (if (i > 50) i % 2 else 2 - i % 2).toString, (i % 3).toString))
+          .toDF("key", "value", "part1", "part2")
+          .write.mode(SaveMode.Overwrite).insertInto(tableName)
+
+        val identifier = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
+        (0 until 2).zip(0 until 3).foreach { case (part1, part2) =>
+          val dir = spark.sessionState.catalog.getPartition(
+            identifier, Map("part1" -> part1.toString, "part2" -> part2.toString)
+          ).location
+
+          validateBucketingAndSorting(numBuckets, dir)
+        }
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.hive
 
 import java.io.File
 import java.net.URI
-import java.util
 
 import org.scalatest.BeforeAndAfter
 
@@ -498,17 +497,6 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
     }
   }
 
-  test("SPARK-20594: hive.exec.stagingdir was deleted by Hive") {
-    // Set hive.exec.stagingdir under the table directory without start with ".".
-    withSQLConf("hive.exec.stagingdir" -> "./test") {
-      withTable("test_table") {
-        sql("CREATE TABLE test_table (key int)")
-        sql("INSERT OVERWRITE TABLE test_table SELECT 1")
-        checkAnswer(sql("SELECT * FROM test_table"), Row(1))
-      }
-    }
-  }
-
   private def validateBucketingAndSorting(numBuckets: Int, dir: URI): Unit = {
     val bucketFiles = new File(dir).listFiles().filter(_.getName.startsWith("part-"))
       .sortWith((x, y) => x.getName < y.getName)
@@ -553,9 +541,10 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
   test("Write data to a bucketed table with static partition") {
     val numBuckets = 8
     val tableName = "bucketizedTable"
+    val sourceTableName = "sourceTable"
 
     withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
-      withTable(tableName) {
+      withTable(tableName, sourceTableName) {
         sql(s"""
               |CREATE TABLE $tableName (key int, value string)
               |PARTITIONED BY(part1 STRING, part2 STRING)
@@ -564,8 +553,15 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
               |""".stripMargin)
 
         (0 until 100)
-          .map(i => (i, i.toString, "val1", "val2")).toDF("key", "value", "part1", "part2")
-          .write.mode(SaveMode.Overwrite).insertInto(tableName)
+          .map(i => (i, i.toString))
+          .toDF("key", "value")
+          .createOrReplaceTempView(sourceTableName)
+
+        sql(s"""
+              |INSERT OVERWRITE TABLE $tableName PARTITION(part1="val1", part2="val2")
+              |SELECT key, value
+              |FROM $sourceTableName
+              |""".stripMargin)
 
         val dir = spark.sessionState.catalog.getPartition(
           spark.sessionState.sqlParser.parseTableIdentifier(tableName),
@@ -595,14 +591,101 @@ class InsertIntoHiveTableSuite extends QueryTest with TestHiveSingleton with Bef
           .toDF("key", "value", "part1", "part2")
           .write.mode(SaveMode.Overwrite).insertInto(tableName)
 
-        val identifier = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
         (0 until 2).zip(0 until 3).foreach { case (part1, part2) =>
           val dir = spark.sessionState.catalog.getPartition(
-            identifier, Map("part1" -> part1.toString, "part2" -> part2.toString)
+            spark.sessionState.sqlParser.parseTableIdentifier(tableName),
+            Map("part1" -> part1.toString, "part2" -> part2.toString)
           ).location
 
           validateBucketingAndSorting(numBuckets, dir)
         }
+      }
+    }
+  }
+
+  test("Write data to a bucketed table with dynamic partitions (along with static partitions)") {
+    val numBuckets = 8
+    val tableName = "bucketizedTable"
+    val sourceTableName = "sourceTable"
+    val part1StaticValue = "0"
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable(tableName, sourceTableName) {
+        sql(s"""
+               |CREATE TABLE $tableName (key int, value string)
+               |PARTITIONED BY(part1 STRING, part2 STRING)
+               |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+               |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+               |""".stripMargin)
+
+        (0 until 100)
+          .map(i => (i, i.toString, (i % 3).toString))
+          .toDF("key", "value", "part")
+          .createOrReplaceTempView(sourceTableName)
+
+        sql(s"""
+               |INSERT OVERWRITE TABLE $tableName PARTITION(part1="$part1StaticValue", part2)
+               |SELECT key, value, part
+               |FROM $sourceTableName
+               |""".stripMargin)
+
+        (0 until 3).foreach { case part2 =>
+          val dir = spark.sessionState.catalog.getPartition(
+            spark.sessionState.sqlParser.parseTableIdentifier(tableName),
+            Map("part1" -> part1StaticValue, "part2" -> part2.toString)
+          ).location
+
+          validateBucketingAndSorting(numBuckets, dir)
+        }
+      }
+    }
+  }
+
+  test("Appends to bucketed table should NOT be allowed as it breaks bucketing guarantee") {
+    val numBuckets = 8
+    val tableName = "nonPartitionedBucketed"
+
+    withTable(tableName) {
+      sql(s"""
+             |CREATE TABLE $tableName (key int, value string)
+             |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+             |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+             |""".stripMargin)
+
+      val df = (0 until 100).map(i => (i, i.toString)).toDF("key", "value")
+      val e = intercept[SparkException] {
+        df.write.mode(SaveMode.Append).insertInto(tableName)
+      }
+      assert(e.getMessage.contains("Appending data to hive bucketed table is not allowed"))
+    }
+  }
+
+  test("Fail the query if number of files produced != number of buckets") {
+    val numBuckets = 8
+    val tableName = "nonPartitionedBucketed"
+
+    withTable(tableName) {
+      sql(s"""
+             |CREATE TABLE $tableName (key int, value string)
+             |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+             |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+             |""".stripMargin)
+
+      val df = (0 until (numBuckets / 2)).map(i => (i, i.toString)).toDF("key", "value")
+      val e = intercept[SparkException] {
+        df.write.mode(SaveMode.Overwrite).insertInto(tableName)
+      }
+      assert(e.getMessage.contains("Potentially missing bucketed output files"))
+    }
+  }
+
+  test("SPARK-20594: hive.exec.stagingdir was deleted by Hive") {
+    // Set hive.exec.stagingdir under the table directory without start with ".".
+    withSQLConf("hive.exec.stagingdir" -> "./test") {
+      withTable("test_table") {
+        sql("CREATE TABLE test_table (key int)")
+        sql("INSERT OVERWRITE TABLE test_table SELECT 1")
+        checkAnswer(sql("SELECT * FROM test_table"), Row(1))
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Semantics:
- If the Hive table is bucketed, then INSERT node expect the child distribution to be based on the hash of the bucket columns. Else it would be empty. (Just to compare with Spark native bucketing : the required distribution is not enforced even if the table is bucketed or not... this saves the shuffle in comparison with hive).
- Sort ordering for INSERT node over Hive bucketed table is determined as follows:

| Table type   | Normal table | Bucketed table |
| ------------- | ------------- | ------------- |
| non-partitioned insert  | Nil | sort columns |
| static partition   | Nil | sort columns |
| dynamic partitions   | partition columns | (partition columns + bucketId + sort columns) |

Just to compare how sort ordering is expressed for Spark native bucketing:

| Table type   | Normal table | Bucketed table |
| ------------- | ------------- | ------------- |
|  sort ordering | partition columns | (partition columns + bucketId + sort columns) |

Why is there a difference ? With hive, since there bucketed insertions would need a shuffle, sort ordering can be relaxed for both non-partitioned and static partition cases. Every RDD partition would get rows corresponding to a single bucket so those can be written to corresponding output file after sort. In case of dynamic partitions, the rows need to be routed to appropriate partition which makes it similar to Spark's constraints.

- Only `Overwrite` mode is allowed for hive bucketed tables as any other mode will break the bucketing guarantees of the table. This is a difference wrt how Spark bucketing works.
- With the PR, if there are no files created for empty buckets, the query will fail. Will support creation of empty files in coming iteration. This is a difference wrt how Spark bucketing works as it does NOT need files for empty buckets.

### Summary of changes done:
- `ClusteredDistribution` and `HashPartitioning` are modified to store the hashing function used.
- `RunnableCommand`'s' can now express the required distribution and ordering. This is used by `ExecutedCommandExec` which run these commands
  - The good thing about this is that I could remove the logic for enforcing sort ordering inside `FileFormatWriter` which felt out of place. Ideally, this kinda adding of physical nodes should be done within the planner which is what happens with this PR.
- `InsertIntoHiveTable` enforces both distribution and sort ordering
- `InsertIntoHadoopFsRelationCommand` enforces sort ordering ONLY (and not the distribution)
- Fixed a bug due to which any alter commands to bucketed table (eg. updating stats) would wipe out the bucketing spec from metastore. This made insertions to bucketed table non-idempotent operation.

## How was this patch tested?

- Added new unit tests