### PR TITLE
[SPARK-21520][SQL][FOLLOW-UP]fix a special case for non-deterministic projects in optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -24,6 +24,24 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 
 /**
+ * A pattern that matches any number of project if fields is deterministic
+ * or child is LeafNode of project on top of another relational operator.
+ */
+object ProjectOperation extends PredicateHelper {
+  type ReturnType = (Seq[NamedExpression], LogicalPlan)
+
+  def unapply(plan: LogicalPlan): Option[ReturnType] = plan match {
+    case Project(fields, child) if fields.forall(_.deterministic) =>
+      Some((fields, child))
+
+    case p @ Project(fields, child: LeafNode) if p.references.nonEmpty =>
+      Some((fields, child))
+
+    case _ => None
+  }
+}
+
+/**
  * A pattern that matches any number of project or filter operations on top of another relational
  * operator.  All filter operators are collected and their conditions are broken up and returned
  * together with the top project operator.
@@ -55,7 +73,7 @@ object PhysicalOperation extends PredicateHelper {
   private def collectProjectsAndFilters(plan: LogicalPlan):
       (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan, Map[Attribute, Expression]) =
     plan match {
-      case Project(fields, child) if fields.forall(_.deterministic) =>
+      case ProjectOperation(fields, child) =>
         val (_, filters, other, aliases) = collectProjectsAndFilters(child)
         val substitutedFields = fields.map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
         (Some(substitutedFields), filters, other, collectAliases(substitutedFields))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2034,6 +2034,28 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("SPARK-21520: the fields of project contains nondeterministic") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+      withTempPath { path =>
+        val p = path.getAbsolutePath
+        Seq((1, 2, 3), (4, 5, 6)).toDF("a", "b", "c").write.partitionBy("a").parquet(p)
+        val df = spark.read.parquet(p)
+
+        val qe = df.select($"a", rand(10).as('rand))
+        // FileScan parquet [a#38]
+        assert(qe.queryExecution.sparkPlan.inputSet.toString.contains("a#"))
+        assert(!qe.queryExecution.sparkPlan.inputSet.toString.contains("b#"))
+        assert(!qe.queryExecution.sparkPlan.inputSet.toString.contains("c#"))
+
+        val qe2 = df.select($"a", $"b", rand(10).as('rand2))
+        // FileScan parquet [b#70,a#72]
+        assert(qe2.queryExecution.sparkPlan.inputSet.toString.contains("a#"))
+        assert(qe2.queryExecution.sparkPlan.inputSet.toString.contains("b#"))
+        assert(!qe2.queryExecution.sparkPlan.inputSet.toString.contains("c#"))
+      }
+    }
+  }
+
   test("order-by ordinal.") {
     checkAnswer(
       testData2.select(lit(7), 'a, 'b).orderBy(lit(1), lit(2), lit(3)),

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -26,8 +26,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoTable, LogicalPlan,
-    ScriptTransformation}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.{CreateTableCommand, DDLUtils}
@@ -239,6 +238,15 @@ private[hive] trait HiveStrategies {
    */
   object HiveTableScans extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      case p @ Project(fields, child)
+        if !fields.forall(_.deterministic) && p.references.nonEmpty =>
+        collectHiveTableSource(Project(child.output.filter(p.references.contains), child))
+          .map(p => ProjectExec(fields, p)).toList
+
+      case _ => collectHiveTableSource(plan)
+    }
+
+    private def collectHiveTableSource(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case PhysicalOperation(projectList, predicates, relation: HiveTableRelation) =>
         // Filter out all predicates that only deal with partition keys, these are given to the
         // hive table scan operator to be used for partition pruning.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up of #18892 :
Currently, Did a lot of special handling for non-deterministic projects in optimizer. but not good enough. this patch add a new special case for non-deterministic projects. the application logic is as follows, in my spark-shell, Simple creates a 22 column Orc data table.
```
val df = (0 until 50).map(i => (i % 2, i % 3, i % 4, i % 5, i % 6, i % 7, i % 8, i % 9, i % 10, i % 11,(i % 2).toString, (i % 3).toString, (i % 4).toString, (i % 5).toString, (i % 6).toString, (i % 7).toString, (i % 2).toDouble, (i % 3).toDouble, (i % 4).toDouble, (i % 5).toDouble, (i % 6).toDouble, (i % 7).toDouble)).toDF("i2","i3","i4","i5","i6","i7","i8","i9","i10","i11","s2","s3","s4","s5","s6","s7","d2","d3","d4","d5","d6","d7")
df.write.format("orc").partitionBy("i2").bucketBy(8, "i3","i4","i5","i6","i7","i8","i9","i10","i11","s2","s3","s4","s5","s6","s7","d2","d3","d4","d5","d6","d7").saveAsTable("tableorc")
```
sql Query statement:
```
val df_sql = spark.sql("SELECT i2,i3,i4,CASE WHEN i5 < 3 then i5 else ceil(rand(100)*100) end as i5 from tableorc")
println("executed Plan:" + df_sql.queryExecution.executedPlan)
df_sql.show(500)
```
**Before modifiy, executed Plan:**
```
*Project [i2#100, i3#79, i4#80, CASE WHEN (i5#81 < 3) THEN cast(i5#81 as bigint) ELSE CEIL((rand(100) * 100.0)) END AS i5#78L]
+- *FileScan orc default.tableorc[i3#79,i4#80,i5#81,i6#82,i7#83,i8#84,i9#85,i10#86,i11#87,s2#88,s3#89,s4#90,s5#91,s6#92,s7#93,d2#94,d3#95,d4#96,d5#97,d6#98,d7#99,i2#100] Batched: false, Format: ORC, Location: CatalogFileIndex[file:/home/cxw/spark/bin/spark-warehouse/tableorc], PartitionCount: 2, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<i3:int,i4:int,i5:int,i6:int,i7:int,i8:int,i9:int,i10:int,i11:int,s2:string,s3:string,s4:st...
```
FileScanRDD read  a row of userdata: _[0,0,2,3,0,4,2,0,8,7,b800000001,c000000001,c800000001,d000000001,d800000001,e000000001,0,0,4000000000000000,4008000000000000,0,4010000000000000,0,30,30,32,33,30,34]_
we read all columns of userdata from orc table. there is such a change, Because the fields of projects is non-deterministic, contains nondeterministic function(rand function).  _PhysicalOperation_ excluded that the fields of projects is non-deterministic.

**After modifiy, executed Plan:**
```
*Project [i2#87, i3#66, i4#67, CASE WHEN (i5#68 < 3) THEN cast(i5#68 as bigint) ELSE CEIL((rand(100) * 100.0)) END AS i5#65L]
+- *FileScan orc default.tableorc[i3#66,i4#67,i5#68,i2#87] Batched: false, Format: ORC, Location: CatalogFileIndex[file:/home/cxw/spark/bin/spark-warehouse/tableorc], PartitionCount: 2, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<i3:int,i4:int,i5:int>
```
FileScanRDD read  a row of userdata: _[0,0,2,3,0]_
we read only need to userdata from orc table.

 In addition, HiveTableScans also scan more columns according to the execution plan:
```
*HashAggregate(keys=[k#403L], functions=[partial_sum(cast(id#402 as bigint))], output=[k#403L, sum#800L])
+- Project [d004#607 AS id#402, FLOOR((rand(8828525941469309371) * 10000.0)) AS k#403L]
   +- HiveTableScan [c030#606L, d004#607, d005#608, d025#609, c002#610, d023#611, d024#612, c005#613L, c008#614, c009#615, c010#616, d021#617, d022#618, c017#619, c018#620, c019#621, c020#622, c021#623, c022#624, c023#625, c024#626, c025#627, c026#628, c027#629, ... 169 more fields], MetastoreRelation XXX_database, XXX_table
```
and it will affect the performance of task.
Similar query statements as follows:
`select k,k,sum(id) from (select d004 as id, floor(rand() * 10000) as k, ceil(c010) as cceila from t054) a group by k,k;`

In a spark cluster environment with 1 master and 2 work nodes, the performance before and after modification is 556s vs 5996s.

this PR describe ways to solve the problem.

## How was this patch tested?
Should be covered existing test cases and add test cases.