### PR TITLE
[SPARK-21772] Fix staging parent directory for InsertIntoHiveTable

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -171,8 +171,11 @@ case class InsertIntoHiveTable(
     // Have to pass the TableDesc object to RDD.mapPartitions and then instantiate new serializer
     // instances within the closure, since Serializer is not serializable while TableDesc is.
     val tableDesc = table.tableDesc
-    val tableLocation = table.hiveQlTable.getDataLocation
-    val tmpLocation = getExternalTmpPath(tableLocation, hadoopConf)
+    // val tableLocation = table.hiveQlTable.getDataLocation
+    val stagingParentDir = Option(stagingDir).filter(_.startsWith("/")).map(new Path(_))
+      .getOrElse(Option(FileSystem.get(hadoopConf).getHomeDirectory)
+        .map(new Path(_, ".sqlStaging")).get)
+    val tmpLocation = getExternalTmpPath(stagingParentDir, hadoopConf)
     val fileSinkConf = new FileSinkDesc(tmpLocation.toString, tableDesc, false)
     val isCompressed = hadoopConf.get("hive.exec.compress.output", "false").toBoolean
 


### PR DESCRIPTION
Summary: 
Due to the incorrect tmpLocation in InsertIntoHiveTable is set. SQL queries like create table as select
or insert into would all run in error. 

## What changes were proposed in this pull request?

Fix the sql staging parent directory for InsertIntoHiveTable

(Please fill in changes proposed in this fix)

## How was this patch tested?

manual tests
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
