### PR TITLE
[SPARK-21774][SQL] The rule PromoteStrings should cast a string to double type when compare with a int/long

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -127,10 +127,10 @@ object TypeCoercion {
     case (DateType, TimestampType) => Some(StringType)
     case (StringType, NullType) => Some(StringType)
     case (NullType, StringType) => Some(StringType)
-    case (StringType, IntegerType) => Some(DoubleType)
-    case (IntegerType, StringType) => Some(DoubleType)
-    case (l: StringType, r: AtomicType) if r != StringType => Some(r)
-    case (l: AtomicType, r: StringType) if l != StringType => Some(l)
+    case (l: StringType, r: AtomicType) if r != StringType =>
+      if (r == IntegerType || r == LongType) Some(DoubleType) else Some(r)
+    case (l: AtomicType, r: StringType) if l != StringType =>
+      if (l == IntegerType || l == LongType) Some(DoubleType) else Some(l)
     case (l, r) => None
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -127,8 +127,10 @@ object TypeCoercion {
     case (DateType, TimestampType) => Some(StringType)
     case (StringType, NullType) => Some(StringType)
     case (NullType, StringType) => Some(StringType)
+    case (StringType, IntegerType) => Some(DoubleType)
+    case (IntegerType, StringType) => Some(DoubleType)
     case (l: StringType, r: AtomicType) if r != StringType => Some(r)
-    case (l: AtomicType, r: StringType) if (l != StringType) => Some(l)
+    case (l: AtomicType, r: StringType) if l != StringType => Some(l)
     case (l, r) => None
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -127,10 +127,10 @@ object TypeCoercion {
     case (DateType, TimestampType) => Some(StringType)
     case (StringType, NullType) => Some(StringType)
     case (NullType, StringType) => Some(StringType)
-    case (l: StringType, r: AtomicType) if r != StringType =>
-      if (r == IntegerType || r == LongType) Some(DoubleType) else Some(r)
-    case (l: AtomicType, r: StringType) if l != StringType =>
-      if (l == IntegerType || l == LongType) Some(DoubleType) else Some(l)
+    case (StringType, r: NumericType) => Some(DoubleType)
+    case (l: NumericType, StringType) => Some(DoubleType)
+    case (l: StringType, r: AtomicType) if r != StringType => Some(r)
+    case (l: AtomicType, r: StringType) if l != StringType => Some(l)
     case (l, r) => None
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1103,6 +1103,9 @@ class TypeCoercionSuite extends AnalysisTest {
       GreaterThan(Literal("123"), Literal(1)),
       GreaterThan(Cast(Literal("123"), DoubleType), Cast(Literal(1), DoubleType)))
     ruleTest(PromoteStrings,
+      GreaterThan(Literal("123"), Literal(1L)),
+      GreaterThan(Cast(Literal("123"), DoubleType), Cast(Literal(1L), DoubleType)))
+    ruleTest(PromoteStrings,
       GreaterThan(Literal("123"), Literal(0.1)),
       GreaterThan(Cast(Literal("123"), DoubleType), Literal(0.1)))
     ruleTest(PromoteStrings,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1101,7 +1101,10 @@ class TypeCoercionSuite extends AnalysisTest {
   test("binary comparison with string promotion") {
     ruleTest(PromoteStrings,
       GreaterThan(Literal("123"), Literal(1)),
-      GreaterThan(Cast(Literal("123"), IntegerType), Literal(1)))
+      GreaterThan(Cast(Literal("123"), DoubleType), Cast(Literal(1), DoubleType)))
+    ruleTest(PromoteStrings,
+      GreaterThan(Literal("123"), Literal(0.1)),
+      GreaterThan(Cast(Literal("123"), DoubleType), Literal(0.1)))
     ruleTest(PromoteStrings,
       LessThan(Literal(true), Literal("123")),
       LessThan(Literal(true), Cast(Literal("123"), BooleanType)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2668,6 +2668,10 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     withTempView("src") {
       Seq(("0", 1), ("-0.4", 2)).toDF("a", "b").createOrReplaceTempView("src")
       checkAnswer(sql("SELECT a FROM src WHERE a=0"), Seq(Row("0")))
+      checkAnswer(sql("SELECT a FROM src WHERE a=0L"), Seq(Row("0")))
+      checkAnswer(sql("SELECT a FROM src WHERE a=0.0"), Seq(Row("0")))
+      checkAnswer(sql("SELECT a FROM src WHERE a=-0.4"), Seq(Row("-0.4")))
+      checkAnswer(sql("SELECT a FROM src WHERE a=0.0"), Seq(Row("0")))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2671,7 +2671,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       checkAnswer(sql("SELECT a FROM src WHERE a=0L"), Seq(Row("0")))
       checkAnswer(sql("SELECT a FROM src WHERE a=0.0"), Seq(Row("0")))
       checkAnswer(sql("SELECT a FROM src WHERE a=-0.4"), Seq(Row("-0.4")))
-      checkAnswer(sql("SELECT a FROM src WHERE a=0.0"), Seq(Row("0")))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2663,4 +2663,11 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     // In unit test, Spark will fail the query if memory leak detected.
     spark.range(100).groupBy("id").count().limit(1).collect()
   }
+
+  test("SPARK-21774: should cast a string to double type when compare with a int") {
+    withTempView("src") {
+      Seq(("0", 1), ("-0.4", 2)).toDF("a", "b").createOrReplaceTempView("src")
+      checkAnswer(sql("SELECT a FROM src WHERE a=0"), Seq(Row("0")))
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The rule PromoteStrings should cast a string to double type when compare with a int.

This PR fixed this.

## How was this patch tested?

Origin test cases updated.