### PR TITLE
[SPARK-21784][SQL] Adds support for defining informational primary key and foreign key constraints using ALTER TABLE DDL.

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -120,6 +120,7 @@ statement
         DROP (IF EXISTS)? partitionSpec (',' partitionSpec)*           #dropTablePartitions
     | ALTER TABLE tableIdentifier partitionSpec? SET locationSpec      #setTableLocation
     | ALTER TABLE tableIdentifier RECOVER PARTITIONS                   #recoverPartitions
+    | ALTER TABLE tableIdentifier ADD tableConstraint                  #addTableConstraint
     | DROP TABLE (IF EXISTS)? tableIdentifier PURGE?                   #dropTable
     | DROP VIEW (IF EXISTS)? tableIdentifier                           #dropTable
     | CREATE (OR REPLACE)? (GLOBAL? TEMPORARY)?
@@ -237,6 +238,20 @@ skewSpec
 locationSpec
     : LOCATION STRING
     ;
+
+tableConstraint
+    : (CONSTRAINT identifier)?
+      (PRIMARY KEY keyColNames=identifierList
+        | FOREIGN KEY keyColNames=identifierList referenceClause) constraintState
+    ;
+
+constraintState
+    : (VALIDATE | NOVALIDATE)? (RELY | NORELY)?
+    ;
+
+referenceClause
+   : REFERENCES tableIdentifier (referenceColNames = identifierList)?
+   ;
 
 query
     : ctes? queryNoWith
@@ -753,6 +768,7 @@ nonReserved
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT
     | DIRECTORY
     | BOTH | LEADING | TRAILING
+    | CONSTRAINT | PRIMARY | FOREIGN | KEY | REFERENCES | VALIDATE | NOVALIDATE | RELY | NORELY
     ;
 
 SELECT: 'SELECT';
@@ -986,6 +1002,15 @@ OPTION: 'OPTION';
 ANTI: 'ANTI';
 LOCAL: 'LOCAL';
 INPATH: 'INPATH';
+CONSTRAINT: 'CONSTRAINT';
+PRIMARY: 'PRIMARY';
+FOREIGN: 'FOREIGN';
+KEY: 'KEY';
+REFERENCES: 'REFERENCES';
+VALIDATE: 'VALIDATE';
+NOVALIDATE: 'NOVALIDATE';
+RELY: 'RELY';
+NORELY: 'NORELY';
 
 STRING
     : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
@@ -143,7 +143,7 @@ object TableConstraint {
     keyColFields.map(_.dataType).foreach {
       case ByteType | ShortType | IntegerType | LongType | FloatType |
            DoubleType | BooleanType | _: DecimalType | TimestampType |
-           DateType | StringType =>
+           DateType | StringType | BinaryType =>
       case otherType => throw new UnsupportedOperationException(
         s"Constraints are not supported for ${otherType.simpleString} data type.")
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import java.util.UUID
+
+import org.json4s._
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.SchemaUtils
+
+/**
+ * A container class to hold all the constraints defined on a table. Scope of the
+ * constraint names are at the table level.
+ */
+case class TableConstraints(
+    primaryKey: Option[PrimaryKey] = None,
+    foreignKeys: Seq[ForeignKey] = Seq.empty) {
+
+  /**
+   * Adds the given constraint to the existing table constraints, after verifying the
+   * constraint name is not a duplicate.
+   */
+  def addConstraint(constraint: TableConstraint, resolver: Resolver): TableConstraints = {
+    if ((primaryKey.exists(pk => resolver(pk.constraintName, constraint.constraintName))
+      || foreignKeys.exists(fk => resolver(fk.constraintName, constraint.constraintName)))) {
+      throw new AnalysisException(
+        s"Failed to add constraint, duplicate constraint name '${constraint.constraintName}'")
+    }
+    constraint match {
+      case pk: PrimaryKey =>
+        if (primaryKey.nonEmpty) {
+          throw new AnalysisException(
+            s"Primary key '${primaryKey.get.constraintName}' already exists.")
+        }
+        this.copy(primaryKey = Option(pk))
+      case fk: ForeignKey => this.copy(foreignKeys = foreignKeys :+ fk)
+    }
+  }
+}
+
+object TableConstraints {
+  /**
+   * Returns a [[TableConstraints]] containing [[PrimaryKey]] or [[ForeignKey]]
+   */
+  def apply(tableConstraint: TableConstraint): TableConstraints = {
+    tableConstraint match {
+      case pk: PrimaryKey => TableConstraints(primaryKey = Option(pk))
+      case fk: ForeignKey => TableConstraints(foreignKeys = Seq(fk))
+    }
+  }
+
+  /**
+   * Converts constraints represented in Json strings to [[TableConstraints]].
+   */
+  def fromJson(pkJson: Option[String], fksJson: Seq[String]): TableConstraints = {
+    val pk = pkJson.map(pk => PrimaryKey.fromJson(parse(pk)))
+    val fks = fksJson.map(fk => ForeignKey.fromJson(parse(fk)))
+    TableConstraints(pk, fks)
+  }
+}
+
+/**
+ * Common type representing a table constraint.
+ */
+sealed trait TableConstraint {
+  val constraintName : String
+  val keyColumnNames : Seq[String]
+}
+
+object TableConstraint {
+  private[TableConstraint] val curId = new java.util.concurrent.atomic.AtomicLong(0L)
+  private[TableConstraint] val jvmId = UUID.randomUUID()
+
+  /**
+   * Generates unique constraint name to use when adding table constraints,
+   * if user does not specify a name. The `curId` field is unique within a given JVM,
+   * while the `jvmId` is used to uniquely identify JVMs.
+   */
+  def generateConstraintName(constraintType: String = "constraint"): String = {
+    s"${constraintType}_${jvmId}_${curId.getAndIncrement()}"
+  }
+
+  def parseColumn(json: JValue): String = json match {
+    case JString(name) => name
+    case _ => json.toString
+  }
+
+  object JSortedObject {
+    def unapplySeq(value: JValue): Option[List[(String, JValue)]] = value match {
+      case JObject(seq) => Some(seq.toList.sortBy(_._1))
+      case _ => None
+    }
+  }
+
+  /**
+   * Returns [[StructField]] for the given column name if it exists in the given schema.
+   */
+  def findColumnByName(
+    schema: StructType, name: String, resolver: Resolver): StructField = {
+    schema.fields.collectFirst {
+      case field if resolver(field.name, name) => field
+    }.getOrElse(throw new AnalysisException(
+      s"Invalid column reference '$name', table data schema is '${schema}'"))
+  }
+
+  /**
+   * Verify the user input constraint information, and add the missing information
+   * like the unspecified reference columns that defaults to reference table's primary key.
+   */
+  def verifyAndBuildConstraint(
+      inputConstraint: TableConstraint,
+      table: CatalogTable,
+      catalog: SessionCatalog,
+      resolver: Resolver): TableConstraint = {
+    SchemaUtils.checkColumnNameDuplication(
+      inputConstraint.keyColumnNames, "in the constraint key definition", resolver)
+    // check if the column names are valid non-partition columns.
+    val keyColFields = inputConstraint.keyColumnNames
+      .map(findColumnByName(table.dataSchema, _, resolver))
+    // Constraints are only supported for basic sql types, throw error for any other data types.
+    keyColFields.map(_.dataType).foreach {
+      case ByteType | ShortType | IntegerType | LongType | FloatType |
+           DoubleType | BooleanType | _: DecimalType | TimestampType |
+           DateType | StringType =>
+      case otherType => throw new UnsupportedOperationException(
+        s"Constraints are not supported for ${otherType.simpleString} data type.")
+    }
+    inputConstraint match {
+      case pk: PrimaryKey => pk
+      case fk: ForeignKey => ForeignKey.verifyAndBuildForeignKey(fk, table, catalog, resolver)
+    }
+  }
+}
+
+/**
+ * A Primary key constraint defined on a table.
+ */
+case class PrimaryKey(
+  constraintName: String,
+  keyColumnNames: Seq[String],
+  isValidated: Boolean = false,
+  isRely: Boolean = false) extends TableConstraint {
+
+  def json: String = compact(render(jsonValue))
+
+  private def jsonValue: JValue = {
+    ("id" -> constraintName) ~
+      ("keyCols" -> keyColumnNames) ~
+      ("rely" -> isRely) ~
+      ("validate" -> isValidated)
+  }
+}
+
+object PrimaryKey {
+  import TableConstraint._
+
+  /**
+   * Converts the primary key represented in Json string to [[PrimaryKey]].
+   */
+  def fromJson(json: JValue): PrimaryKey = json match {
+    case JSortedObject(
+    ("id", JString(id)),
+    ("keyCols", JArray(keyCols)),
+    ("rely", JBool(rely)),
+    ("validate", JBool(validate))
+    ) =>
+      PrimaryKey(
+        constraintName = id,
+        keyColumnNames = keyCols.map(parseColumn),
+        isValidated = validate,
+        isRely = rely)
+  }
+}
+
+/**
+ * A Foreign key defined on a table.
+ */
+case class ForeignKey(
+  constraintName: String,
+  keyColumnNames: Seq[String],
+  referenceTableIdentifier: TableIdentifier,
+  referenceColumnNames: Seq[String] = Seq.empty,
+  isValidated: Boolean = false,
+  isRely: Boolean = false) extends TableConstraint {
+
+  def json: String = compact(render(jsonValue))
+
+  private def jsonValue: JValue = {
+    ("id" -> constraintName) ~
+      ("keyCols" -> keyColumnNames) ~
+      ("refCols" -> referenceColumnNames) ~
+      ("refDb" -> referenceTableIdentifier.database.get) ~
+      ("refTable" -> referenceTableIdentifier.table) ~
+      ("rely" -> isRely) ~
+      ("validate" -> isValidated)
+  }
+}
+
+object ForeignKey {
+  import TableConstraint._
+  /**
+   * Converts a foreign key represented in Json string to [[ForeignKey]].
+   */
+  def fromJson(json: JValue): ForeignKey = json match {
+    case JSortedObject(
+    ("id", JString(id)),
+    ("keyCols", JArray(keyCols)),
+    ("refCols", JArray(referenceCols)),
+    ("refDb", JString(referenceDb)),
+    ("refTable", JString(referenceTable)),
+    ("rely", JBool(rely)),
+    ("validate", JBool(validate))
+    ) =>
+      ForeignKey(
+        constraintName = id,
+        keyColumnNames = keyCols.map(parseColumn),
+        referenceTableIdentifier = TableIdentifier(referenceTable, Option(referenceDb)),
+        referenceColumnNames = referenceCols.map(parseColumn),
+        isValidated = validate,
+        isRely = rely)
+  }
+
+  /**
+   * Verify the user specified foreign key information, and add the missing information
+   * such as the the unspecified reference columns and the database of the reference table.
+   * When user does not specify reference columns, they are set to reference table's
+   * primary key columns.
+   */
+  def verifyAndBuildForeignKey(
+      inputFk: ForeignKey,
+      table: CatalogTable,
+      catalog: SessionCatalog,
+      resolver: Resolver): TableConstraint = {
+    SchemaUtils.checkColumnNameDuplication(
+      inputFk.referenceColumnNames, "in the foreign key references clause", resolver)
+    // verify the reference table has a primary key on the foreign key reference columns.
+    val refTable = catalog.getTableMetadata(inputFk.referenceTableIdentifier)
+    val refPk = refTable.tableConstraints.flatMap(_.primaryKey).getOrElse(
+      throw new AnalysisException(
+        "Primary key is not defined on the reference table:" + refTable.identifier)
+    )
+    // Set the reference column names to the referenced table primary key columns,
+    // when user does not specify reference column names using references clause.
+    val referenceColumnNames = if (inputFk.referenceColumnNames.isEmpty) {
+      refPk.keyColumnNames
+    } else {
+      // size of the reference columns list and the reference table
+      // primary key column list should be same
+      if (inputFk.referenceColumnNames.size != refPk.keyColumnNames.size) {
+        throw new AnalysisException(
+          s"""
+            |Referencing columns list size ${inputFk.referenceColumnNames.size}
+            |is not same as referenced table primary key columns list
+            |size ${refPk.keyColumnNames.size}")
+           """.stripMargin.replace("\n", " ").trim())
+      }
+
+      // reference column names should match primary key columns in the same order
+      for ((refColumn, refPkColumn) <- (inputFk.referenceColumnNames zip refPk.keyColumnNames)) {
+        if (!resolver(refColumn, refPkColumn)) {
+          throw new AnalysisException(
+            s"""
+              |Referencing columns ${inputFk.referenceColumnNames.mkString("(", ",", ")")} does not
+              |match reference table primary key
+              |columns ${refPk.keyColumnNames.mkString("(", ",", ")")}
+             """.stripMargin.replace("\n", " ").trim())
+        }
+      }
+      inputFk.referenceColumnNames
+    }
+
+    // size foreign key columns list and reference key column list should be same
+    if (inputFk.keyColumnNames.size != referenceColumnNames.size) {
+      throw new AnalysisException(
+        s"""
+          |Foreign key columns list size ${inputFk.keyColumnNames.size}
+          |is not same as referencing columns list size ${referenceColumnNames.size}")
+         """.stripMargin.replace("\n", " ").trim())
+    }
+
+    // Foreign key columns and referenced primary key columns data types should match
+    val keyColFields = inputFk.keyColumnNames.map(findColumnByName(table.dataSchema, _, resolver))
+    val refKeyColFields = referenceColumnNames
+      .map(findColumnByName(refTable.dataSchema, _, resolver))
+
+    for ((keyField, refKeyField) <- (keyColFields zip refKeyColFields)) {
+      if (!keyField.dataType.sameType(refKeyField.dataType)) {
+        throw new AnalysisException(
+          s"""
+            |Foreign key column data type ${keyField.name}:${keyField.dataType.simpleString}
+            |does not match with referencing column
+            |data type ${refKeyField.name}:${refKeyField.dataType.simpleString}.
+           """.stripMargin.replace("\n", " ").trim())
+      }
+    }
+    inputFk.copy(
+      referenceColumnNames = referenceColumnNames,
+      referenceTableIdentifier = refTable.identifier)
+  }
+}
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -231,7 +231,8 @@ case class CatalogTable(
     unsupportedFeatures: Seq[String] = Seq.empty,
     tracksPartitionsInCatalog: Boolean = false,
     schemaPreservesCase: Boolean = true,
-    ignoredProperties: Map[String, String] = Map.empty) {
+    ignoredProperties: Map[String, String] = Map.empty,
+    tableConstraints: Option[TableConstraints] = None) {
 
   import CatalogTable._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -165,6 +165,15 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSQLContext with Befo
       assert(e.message.contains("It doesn't match the specified format"))
     }
   }
+  test("alter table add constraint") {
+    withTable("t") {
+      sql("create table t (c1 int) using parquet")
+      val e = intercept[UnsupportedOperationException] {
+        sql("ALTER TABLE t ADD PRIMARY KEY(c1)")
+      }.getMessage
+      assert(e.contains("Hive support is required to add table constraints."))
+    }
+  }
 }
 
 abstract class DDLSuite extends QueryTest with SQLTestUtils {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -451,7 +451,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       }
       val fks = tableConstraints.foreignKeys
       if (fks.nonEmpty) {
-        constraintProperties += TABLE_NUM_FK_CONSTRAINTS -> fks.size.toString()
+        constraintProperties += TABLE_CONSTRAINT_NUM_FOREIGN_KEYS -> fks.size.toString()
         fks.zipWithIndex.foreach { case (fk, index) =>
           constraintProperties += (s"$TABLE_CONSTRAINT_FOREIGNKEY_PREFIX$index" -> fk.json)
         }
@@ -1322,9 +1322,9 @@ object HiveExternalCatalog {
   val CREATED_SPARK_VERSION = SPARK_SQL_PREFIX + "create.version"
 
   val TABLE_CONSTRAINT_PREFIX = SPARK_SQL_PREFIX + "constraint."
-  val TABLE_CONSTRAINT_PRIMARY_KEY = SPARK_SQL_PREFIX + TABLE_CONSTRAINT_PREFIX + "pk"
-  val TABLE_NUM_FK_CONSTRAINTS = SPARK_SQL_PREFIX + "numFkConstraints"
-  val TABLE_CONSTRAINT_FOREIGNKEY_PREFIX = SPARK_SQL_PREFIX + TABLE_CONSTRAINT_PREFIX + "fk."
+  val TABLE_CONSTRAINT_PRIMARY_KEY = TABLE_CONSTRAINT_PREFIX + "pk"
+  val TABLE_CONSTRAINT_NUM_FOREIGN_KEYS = TABLE_CONSTRAINT_PREFIX + "numForeignKeys"
+  val TABLE_CONSTRAINT_FOREIGNKEY_PREFIX = TABLE_CONSTRAINT_PREFIX + "fk."
 
   // When storing data source tables in hive metastore, we need to set data schema to empty if the
   // schema is hive-incompatible. However we need a hack to preserve existing behavior. Before
@@ -1412,7 +1412,7 @@ object HiveExternalCatalog {
    */
   private def getConstraintsFromTableProperties(table: CatalogTable): Option[TableConstraints] = {
     val primaryKeyJson = table.properties.get(TABLE_CONSTRAINT_PRIMARY_KEY)
-    val numFkConstraints = table.properties.get(TABLE_NUM_FK_CONSTRAINTS)
+    val numFkConstraints = table.properties.get(TABLE_CONSTRAINT_NUM_FOREIGN_KEYS)
     val foreignKeysJson: Seq[String] = if (numFkConstraints.isDefined) {
       (0 until numFkConstraints.get.toInt).flatMap { index =>
         val key = s"$TABLE_CONSTRAINT_FOREIGNKEY_PREFIX$index"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2165,4 +2165,351 @@ class HiveDDLSuite
       checkAnswer(spark.table("t4"), Row(0, 0))
     }
   }
+
+  /**
+   * Helper method to compare expected and actual primary key.
+   */
+  private def checkPrimaryKey(
+      expectedPk: PrimaryKey,
+      tableName: String,
+      db: Option[String] = None) = {
+    val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName, db))
+    assert(table.tableConstraints.flatMap(_.primaryKey) == Some(expectedPk))
+  }
+
+  /**
+   * Helper method to compare expected and actual foreign keys.
+   */
+  private def checkForeignKeys(
+      expectedFks: Seq[ForeignKey],
+      tableName: String,
+      db: Option[String] = None) = {
+    val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName, db))
+    val actualFks = table.tableConstraints.map(_.foreignKeys).get
+    assert(actualFks.size == expectedFks.size)
+    assert(expectedFks.forall(actualFks.contains(_)))
+  }
+
+  test("alter table add primary key") {
+    withTable("t1") {
+      sql("CREATE TABLE t1(c1 int, c2 int, c3 string) using parquet")
+      sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (c1) novalidate rely")
+      val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t1"))
+      checkPrimaryKey(PrimaryKey("pk1", Seq("c1"), false, true), "t1")
+    }
+    // composite primary key
+    withTable("t1") {
+      sql("CREATE TABLE t1(c1 int, c2 int, c3 string) using parquet")
+      sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (c1, c3) novalidate norely")
+      checkPrimaryKey(PrimaryKey("pk1", Seq("c1", "c3")), "t1")
+    }
+  }
+
+  test("alter table add foreign key") {
+    withTable("parent1", "parent2", "child") {
+      sql("CREATE TABLE parent1(c1 int, c2 int, c3 string) using parquet")
+      sql("ALTER TABLE parent1 ADD CONSTRAINT pk1 primary key (c1) novalidate rely")
+      sql("CREATE TABLE child(c1 int, c2 int, c3 string) using parquet")
+      sql("ALTER TABLE child ADD CONSTRAINT fk1 foreign key (c1)" +
+        " references parent1(c1) novalidate rely")
+
+      checkPrimaryKey(PrimaryKey("pk1", Seq("c1"), false, true), "parent1")
+      checkForeignKeys(
+        Seq(
+          ForeignKey("fk1",
+          Seq("c1"),
+          TableIdentifier("parent1", Option("default")),
+          Seq("c1"),
+          false,
+          true)),
+        "child")
+
+      // composite foreign key, and more than one foreign key on a table
+      sql("CREATE TABLE parent2(c1 int, c2 int, c3 string) using parquet")
+      sql("ALTER TABLE parent2 ADD CONSTRAINT pk1 primary key (c1, c3) novalidate norely")
+      sql("ALTER TABLE child ADD CONSTRAINT fk2 foreign key (c1, c3)" +
+        " references parent2(c1, c3) novalidate norely")
+
+      checkPrimaryKey(PrimaryKey("pk1", Seq("c1", "c3"), false, false), "parent2")
+      checkForeignKeys(
+        Seq(
+          ForeignKey(
+            "fk1",
+            Seq("c1"),
+            TableIdentifier("parent1", Option("default")),
+            Seq("c1"),
+            false,
+            true),
+          ForeignKey(
+            "fk2",
+            Seq("c1", "c3"),
+            TableIdentifier("parent2", Option("default")),
+            Seq("c1", "c3"),
+            false,
+            false)),
+        "child")
+    }
+  }
+
+  test("alter table add self-referencing foreign key") {
+    withTable("t1") {
+      sql("CREATE TABLE t1(c1 int, c2 int, c3 string)")
+      sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (c1)")
+      sql("ALTER TABLE t1 ADD CONSTRAINT fk1 foreign key (c1) REFERENCES t1")
+      checkForeignKeys(Seq(ForeignKey("fk1", Seq("c1"),
+          TableIdentifier("t1", Option("default")), Seq("c1"), false)), "t1")
+
+      // type mismatch in self-referencing foreign key
+      val e = intercept[AnalysisException] {
+        sql("ALTER TABLE t1 ADD CONSTRAINT fk2 FOREIGN key (c3) REFERENCES t1 (c1)")
+      }.getMessage
+      assert(e.contains("Foreign key column data type c3:string does not " +
+        "match with referencing column data type c1:int."))
+    }
+  }
+
+  test("alter table add foreign key with no reference columns specified") {
+    withTable("parent", "child") {
+      sql("CREATE TABLE parent(c1 int, c2 int, c3 string)")
+      sql("ALTER TABLE parent ADD CONSTRAINT pk1 primary key (c1)")
+      sql("CREATE TABLE child(c1 int, c2 int, c3 string)")
+      sql("ALTER TABLE child ADD CONSTRAINT fk1 foreign key (c1) REFERENCES parent NOVALIDATE")
+      checkForeignKeys(Seq(ForeignKey("fk1", Seq("c1"),
+        TableIdentifier("parent", Option("default")), Seq("c1"), false)), "child")
+    }
+  }
+
+  test("alter table add constraint with generated constraint names") {
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1(c1 int, c2 int, c3 string) using parquet")
+      // generated constraint name for primary key
+      sql("ALTER TABLE t1 ADD primary key (c1)")
+      val pk = spark.sessionState.catalog
+        .getTableMetadata(TableIdentifier("t1")).tableConstraints.flatMap(_.primaryKey).get
+      assert(pk.constraintName.matches("""pk_.*_\d+"""))
+      assert(pk.keyColumnNames == Seq("c1"))
+      // generated constraint name for foreign key
+      sql("CREATE TABLE t2(x int, y int, z string) using parquet")
+      sql("ALTER TABLE t2 ADD foreign key (y) references t1(c1)")
+      val fk = spark.sessionState.catalog
+        .getTableMetadata(TableIdentifier("t2")).tableConstraints.map(_.foreignKeys).get.head
+      assert(fk.constraintName.matches("""fk_.*_\d+"""))
+      assert(fk.keyColumnNames == Seq("y"))
+    }
+  }
+
+  test("alter table add constraint with database name") {
+    val db1 = "mydb1"
+    // non default database
+    withDatabase(s"$db1") {
+      sql(s"CREATE DATABASE $db1")
+      sql(s"USE $db1")
+      withTable("t1", "t2") {
+        sql("CREATE TABLE t1 (c1 int, c2 int, c3 string) using parquet")
+        sql("ALTER TABLE t1 ADD CONSTRAINT pk1 PRIMARY KEY (c1)")
+        sql("CREATE TABLE t2(x int, y int, z string) using parquet")
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (y) references t1(c1)")
+        checkPrimaryKey(PrimaryKey("pk1", Seq("c1"), false, false), "t1", Option(s"$db1"))
+        checkForeignKeys(
+          Seq(
+            ForeignKey("fk1",
+              Seq("y"),
+              TableIdentifier("t1", Option(s"$db1")),
+              Seq("c1"))),
+          "t2", Option(s"$db1"))
+      }
+    }
+
+    // create a foreign key constraint that reference table table different databases
+    val db2 = "mydb2"
+    withDatabase(s"$db1", s"$db2") {
+      withTable(s"${db1}.t1", s"${db2}.t2") {
+        sql(s"CREATE DATABASE $db1")
+        sql(s"CREATE DATABASE $db2")
+
+        sql(s"CREATE TABLE ${db1}.t1(c1 int, c2 int, c3 string) using parquet")
+        sql(s"ALTER TABLE ${db1}.t1 ADD CONSTRAINT pk1 PRIMARY KEY (c1)")
+
+        sql(s"CREATE TABLE ${db2}.t2(x int, y int, z string) using parquet")
+        sql(s"ALTER TABLE ${db2}.t2 ADD CONSTRAINT fk1 FOREIGN KEY (y) references ${db1}.t1(c1)")
+
+        checkPrimaryKey(PrimaryKey("pk1", Seq("c1"), false, false), "t1", Option(s"$db1"))
+        checkForeignKeys(
+          Seq(
+            ForeignKey("fk1",
+              Seq("y"),
+              TableIdentifier("t1", Option(s"$db1")),
+              Seq("c1"),
+              false,
+              false)),
+          "t2", Option(s"$db2"))
+      }
+    }
+  }
+
+  test("invalid add primary key") {
+    withTable("t1") {
+      sql("CREATE TABLE t1(col1 int, col2 int, col3 string)")
+      sql("INSERT INTO t1 VALUES (1, 2, 'abcd')")
+
+      // invalid table name
+      val e = intercept[AnalysisException] {
+        sql("ALTER TABLE xct1 ADD CONSTRAINT pk1 primary key (col1, col2)")
+      }.getMessage
+      assert(e.contains("Table or view 'xct1' not found in database"))
+      // invalid column names
+      val e1 = intercept[AnalysisException] {
+        sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (xcol1, col2)")
+      }.getMessage
+      assert(e1.contains("Invalid column reference 'xcol1'"))
+
+      // more than one primary key not allowed.
+      val e2 = intercept[AnalysisException] {
+        sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (col1, col2)")
+        sql("ALTER TABLE t1 ADD CONSTRAINT pk2 primary key (col1, col2)")
+      }.getMessage
+      assert(e2.contains("Primary key 'pk1' already exists."))
+
+      // duplicate constraint name
+      val e4 = intercept[AnalysisException] {
+        sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (col3)")
+      }.getMessage
+      assert(e4.contains("duplicate constraint name 'pk1'"))
+    }
+  }
+
+  test("invalid alter table add foreign keys.") {
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t2(c1 int, c2 string, c3 decimal)")
+      // reference table does not exist
+      val e = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 " +
+          "FOREIGN key (c1, c3) REFERENCES t1 (col1, col3)")
+      }.getMessage
+      assert(e.contains("Table or view 't1' not found in database"))
+
+      sql("CREATE TABLE t1(c1 int, c2 String, c3 decimal)")
+
+      // primary key does not exists, no constraints on the table
+      val e2 = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 " +
+          "FOREIGN key (c1, c3) REFERENCES t1 (c1, c3)")
+      }.getMessage
+      assert(e2.contains("Primary key is not defined on the reference table:`default`.`t1`"))
+
+      sql("CREATE TABLE t3(c1 int, c2 string, c3 decimal)")
+      sql("alter table t3 add primary key(c1, c3)")
+      sql("alter table t1 add foreign key(c1, c3) references t3(c1, c3)")
+
+      // primary key does not exist for reference table, but it has foreign key
+      val e21 = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN key (c2, c3) REFERENCES t1 (c1, c3)")
+      }.getMessage
+      assert(e21.contains("Primary key is not defined on the reference table:`default`.`t1`"))
+
+      sql("ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (c2, c3)")
+
+      // invalid column name
+      val e1 = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 " +
+          "FOREIGN key (xyz, c3) REFERENCES t1 (col1, col3)")
+      }.getMessage
+      assert(e1.contains("Invalid column reference 'xyz'"))
+
+      // duplicate constraint name for foreign keys
+      val e4 = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN key (c1, c3) REFERENCES t3 (c1, c3)")
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN key (c2, c3) REFERENCES t1 (c2, c3)")
+      }.getMessage
+      assert(e4.contains("duplicate constraint name 'fk1'"))
+    }
+  }
+
+  test("alter table add constraint duplicate columns check") {
+    withTable("t1") {
+      sql("CREATE TABLE t1(c1 int, c2 string, c3 decimal)")
+      val e1 = intercept[AnalysisException] {
+        sql("alter table t1 add primary key(c1, c2, c1)")
+      }.getMessage
+      assert(e1.contains("Found duplicate column(s) in the constraint key definition: `c1`"))
+
+      val e2 = intercept[AnalysisException] {
+        sql("alter table t1 add foreign key(c1, c2, c1) references t1 (c1, c2)")
+      }.getMessage
+      assert(e2.contains("Found duplicate column(s) in the constraint key definition: `c1`"))
+
+      val e3 = intercept[AnalysisException] {
+        sql("alter table t1 add foreign key(c1, c2) references t1 (c1, c2, c1)")
+      }.getMessage
+      assert(e3.contains("Found duplicate column(s) in the foreign key references clause: `c1`"))
+    }
+  }
+
+  test("alter table add foreign key columns mismatch") {
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1(c1 int, c2 string, c3 decimal)")
+      sql("CREATE TABLE t2(c1 int, c2 string, c3 decimal)")
+      sql("alter table t1 add primary key(c1, c3)")
+      val e1 = intercept[AnalysisException] {
+        sql("alter table t2 add foreign key(c1, c3) references t1(c1)")
+      }.getMessage
+      assert(e1.contains("Referencing columns list size 1 is not" +
+        " same as referenced table primary key columns list size 2"))
+      val e2 = intercept[AnalysisException] {
+        sql("alter table t2 add foreign key(c1) references t1(c1, c3)")
+      }.getMessage
+      assert(e2.contains(
+        "Foreign key columns list size 1 is not same as referencing columns list size 2"))
+      val e3 = intercept[AnalysisException] {
+        sql("alter table t2 add foreign key(c1) references t1(c1, xyz)")
+      }.getMessage
+      assert(e3.contains(
+        "Referencing columns (c1,xyz) does not match reference table primary key columns (c1,c3)"))
+
+      // Foreign key and primary key columns data types does not match
+      val e4 = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN key (c2, c3) REFERENCES t1 (c1, c3)")
+      }.getMessage
+      assert(e4.contains("Foreign key column data type c2:string does not " +
+        "match with referencing column data type c1:int."))
+    }
+  }
+
+  test("alter table add constraint on partition columns not supported") {
+    withTable("t1", "t2") {
+      sql("create table t1 (a int) partitioned by (b int)")
+      sql("create table t2 (x int) partitioned by (y int)")
+
+      val e1 = intercept[AnalysisException] {
+        sql("ALTER TABLE t1 ADD PRIMARY KEY (b)")
+      }.getMessage
+      assert(e1.contains("Invalid column reference 'b'"))
+      sql("ALTER TABLE t1 ADD PRIMARY KEY(a)")
+      val e2 = intercept[AnalysisException] {
+        sql("ALTER TABLE t2 ADD FOREIGN KEY(y) references t1(a)")
+      }.getMessage
+      assert(e2.contains("Invalid column reference 'y'"))
+    }
+  }
+
+  test("alter table add constraint unsupported data types") {
+    Seq("array<int>", "map<int,string>", "struct<f1:int,f2:string>")
+      .foreach { unsupportedType =>
+        withTable("t1", "t2") {
+          sql(s"CREATE TABLE t1(c1 int, c2 $unsupportedType)")
+          // test primary key
+          val e1 = intercept[UnsupportedOperationException] {
+            sql("ALTER TABLE t1 ADD CONSTRAINT pk PRIMARY KEY(c2)")
+          }.getMessage
+          assert(e1.contains(s"Constraints are not supported for $unsupportedType data type"))
+          // test foreign key
+          sql("ALTER TABLE t1 ADD CONSTRAINT pk PRIMARY KEY(c1)")
+          sql(s"CREATE TABLE t2(c1 int, c2 $unsupportedType)")
+          val e2 = intercept[UnsupportedOperationException] {
+            sql("ALTER TABLE t2 ADD FOREIGN KEY (c2) REFERENCES t1")
+          }.getMessage
+          assert(e2.contains(s"Constraints are not supported for $unsupportedType data type"))
+        }
+      }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR implements ALTER TABLE DDL ADD CONSTRAINT  to  add  informational primary key and foreign key (referential integrity) constraints in Spark. These constraints will be used in query optimization and you can find more details about this in the spec in  [SPARK-19842](https://issues.apache.org/jira/browse/SPARK-19842)
 
The proposed syntax of the constraints DDL is similar to the Hive  2.1 referential integrity constraints  support (https://issues.apache.org/jira/browse/HIVE-13076) which is aligned to Oracle's semantics.
 
Syntax:
```sql
ALTER TABLE [db_name.]table_name ADD [CONSTRAINT constraintName]
  (PRIMARY KEY (col_names) |
  FOREIGN KEY (col_names) REFERENCES [db_name.]table_name [(col_names)])
  [VALIDATE | NOVALIDATE] [RELY | NORELY]
```
Examples :
 ```sql
ALTER TABLE employee ADD CONSTRANT pk  PRIMARY KEY(empno) VALIDATE RELY
ALTER TABLE department ADD CONSTRAINT emp_fk FOREIGN KEY (mgrno) REFERENCES employee(empno) NOVALIDATE NORELY
ALTER TABLE department ADD PRIMARY KEY(deptno) VALIDATE RELY
ALTER TABLE employee ADD FOREIGN KEY (workdept) REFERENCES department(deptno) VALIDATE RELY;
 ```
The constraint information is stored in the table properties as JSON string for each constraint. 
One of the advantages of  storing constraints in the table properties is that this functionality  will work in all the supported Hive metastore versions. 
 
An alternative approach  that we considered was to store the constraints information using the hive metastore API that stores the constraints in a separate table.  The problem with this approach is this feature will only work in Spark installations that use **Hive 2.1 metastore**, and also this version is NOT the current  spark default.  More details are in the spec document.
 
**This PR implements the  ALTER TABLE constraint DDL using table properties because it is important to work with default hive metastore version of the spark.** 
 
The syntax to define the  constraints as part of _create table_  definition will be implemented in a follow-up Jira.


## How was this patch tested?
Added  new unit test cases to HiveDDLSuite, and SparkSqlParserSuite
