### PR TITLE
[SPARK-21788][SS]Handle more exceptions when stopping a streaming query

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -412,8 +412,18 @@ class StreamExecution(
   private def isInterruptedByStop(e: Throwable): Boolean = {
     if (state.get == TERMINATED) {
       e match {
+        // InterruptedIOException - thrown when an I/O operation is interrupted
+        // ClosedByInterruptException - thrown when an I/O operation upon a channel is interrupted
         case _: InterruptedException | _: InterruptedIOException | _: ClosedByInterruptException =>
           true
+        // The cause of the following exceptions may be one of the above exceptions:
+        //
+        // UncheckedIOException - thrown by codes that cannot throw a checked IOException, such as
+        //                        BiFunction.apply
+        // ExecutionException - thrown by codes running in a thread pool and these codes throw an
+        //                      exception
+        // UncheckedExecutionException - thrown by codes that cannot throw a checked
+        //                               ExecutionException, such as BiFunction.apply
         case e2 @ (_: UncheckedIOException | _: ExecutionException | _: UncheckedExecutionException)
           if e2.getCause != null =>
           isInterruptedByStop(e2.getCause)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add more cases we should view as a normal query stop rather than a failure.

## How was this patch tested?

The new unit tests.