### PR TITLE
[SPARK-19256][SQL] Hive bucketing support

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst.plans.physical
 
 import scala.language.existentials
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
@@ -109,7 +108,7 @@ case class ClusteredDistribution(
  */
 case class HashClusteredDistribution(
     expressions: Seq[Expression],
-    requiredNumPartitions: Option[Int],
+    requiredNumPartitions: Option[Int] = None,
     hashingFunctionClass: Class[_ <: HashExpression[Int]] = classOf[Murmur3Hash])
   extends Distribution {
 
@@ -231,8 +230,8 @@ case class HashPartitioning(
     super.satisfies(required) || {
       required match {
         case h: HashClusteredDistribution =>
+          h.hashingFunctionClass == hashingFunctionClass &&
           (h.requiredNumPartitions.isEmpty || h.requiredNumPartitions.get == numPartitions) &&
-            h.hashingFunctionClass == hashingFunctionClass &&
             expressions.length == h.expressions.length &&
             expressions.zip(h.expressions).forall { case (l, r) => l.semanticEquals(r) }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst
 import org.apache.spark.SparkFunSuite
 /* Implicit conversions */
 import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{HiveHash, Murmur3Hash}
 import org.apache.spark.sql.catalyst.plans.physical._
 
 class DistributionSuite extends SparkFunSuite {
@@ -81,6 +82,26 @@ class DistributionSuite extends SparkFunSuite {
 
     checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), Some(classOf[Murmur3Hash])),
+      true)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(12), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('d, 'e), Some(10), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), Some(classOf[HiveHash])),
+      false)
+
+    checkSatisfied(
+      HashPartitioning(Seq('a, 'b, 'c), 10),
       AllTuples,
       false)
 
@@ -127,18 +148,33 @@ class DistributionSuite extends SparkFunSuite {
 
     checkSatisfied(
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('a, 'b, 'c)),
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), None),
       true)
 
     checkSatisfied(
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('c, 'b, 'a)),
+      ClusteredDistribution(Seq('c, 'b, 'a), Some(10), None),
       true)
 
     checkSatisfied(
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('b, 'c, 'a, 'd)),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), None),
       true)
+
+    checkSatisfied(
+      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(12), Some(classOf[Murmur3Hash])),
+      false)
+
+    checkSatisfied(
+      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
+      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), Some(classOf[HiveHash])),
+      false)
 
     // Cases which need an exchange between two data properties.
     // TODO: We can have an optimization to first sort the dataset

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -82,22 +82,22 @@ class DistributionSuite extends SparkFunSuite {
 
     checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
-      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), Some(classOf[Murmur3Hash])),
+      HashClusteredDistribution(Seq('a, 'b, 'c), Some(10), classOf[Murmur3Hash]),
       true)
 
     checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
-      ClusteredDistribution(Seq('a, 'b, 'c), Some(12), Some(classOf[Murmur3Hash])),
+      HashClusteredDistribution(Seq('a, 'b, 'c), Some(12), classOf[Murmur3Hash]),
       false)
 
     checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
-      ClusteredDistribution(Seq('d, 'e), Some(10), Some(classOf[Murmur3Hash])),
+      HashClusteredDistribution(Seq('d, 'e), Some(10), classOf[Murmur3Hash]),
       false)
 
     checkSatisfied(
       HashPartitioning(Seq('a, 'b, 'c), 10),
-      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), Some(classOf[HiveHash])),
+      HashClusteredDistribution(Seq('a, 'b, 'c), Some(10), classOf[HiveHash]),
       false)
 
     checkSatisfied(
@@ -145,36 +145,6 @@ class DistributionSuite extends SparkFunSuite {
       RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
       OrderedDistribution(Seq('a.asc, 'b.asc, 'c.asc, 'd.desc)),
       true)
-
-    checkSatisfied(
-      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('a, 'b, 'c), Some(10), None),
-      true)
-
-    checkSatisfied(
-      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('c, 'b, 'a), Some(10), None),
-      true)
-
-    checkSatisfied(
-      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), None),
-      true)
-
-    checkSatisfied(
-      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), Some(classOf[Murmur3Hash])),
-      false)
-
-    checkSatisfied(
-      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(12), Some(classOf[Murmur3Hash])),
-      false)
-
-    checkSatisfied(
-      RangePartitioning(Seq('a.asc, 'b.asc, 'c.asc), 10),
-      ClusteredDistribution(Seq('b, 'c, 'a, 'd), Some(10), Some(classOf[HiveHash])),
-      false)
 
     // Cases which need an exchange between two data properties.
     // TODO: We can have an optimization to first sort the dataset

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
@@ -21,8 +21,9 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.physical.{Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker
 import org.apache.spark.sql.execution.datasources.FileFormatWriter
@@ -59,6 +60,10 @@ trait DataWritingCommand extends Command {
     val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
     new BasicWriteJobStatsTracker(serializableHadoopConf, metrics)
   }
+
+  def requiredDistribution: Seq[Distribution] = Seq.fill(children.size)(UnspecifiedDistribution)
+
+  def requiredOrdering: Seq[Seq[SortOrder]] = Seq.fill(children.size)(Nil)
 
   def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -23,9 +23,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, SortOrder}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.physical.Distribution
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.debug._
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -43,7 +44,13 @@ trait RunnableCommand extends Command {
   // `ExecutedCommand` during query planning.
   lazy val metrics: Map[String, SQLMetric] = Map.empty
 
-  def run(sparkSession: SparkSession): Seq[Row]
+  def run(sparkSession: SparkSession, children: Seq[SparkPlan]): Seq[Row] = {
+    throw new NotImplementedError
+  }
+
+  def run(sparkSession: SparkSession): Seq[Row] = {
+    throw new NotImplementedError
+  }
 }
 
 /**
@@ -111,6 +118,10 @@ case class DataWritingCommandExec(cmd: DataWritingCommand, child: SparkPlan)
   override def output: Seq[Attribute] = cmd.output
 
   override def nodeName: String = "Execute " + cmd.nodeName
+
+  override def requiredChildDistribution: Seq[Distribution] = cmd.requiredDistribution
+
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] = cmd.requiredOrdering
 
   override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, SortOrder}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
-import org.apache.spark.sql.catalyst.plans.physical.Distribution
+import org.apache.spark.sql.catalyst.plans.physical.{Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.debug._
 import org.apache.spark.sql.execution.metric.SQLMetric

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -33,10 +33,10 @@ import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, ExternalCatalogUtils}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, _}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.execution.{SortExec, SparkPlan, SQLExecution}
@@ -109,7 +109,7 @@ object FileFormatWriter extends Logging {
       outputSpec: OutputSpec,
       hadoopConf: Configuration,
       partitionColumns: Seq[Attribute],
-      bucketSpec: Option[BucketSpec],
+      bucketIdExpression: Option[Expression],
       statsTrackers: Seq[WriteJobStatsTracker],
       options: Map[String, String])
     : Set[String] = {
@@ -121,17 +121,6 @@ object FileFormatWriter extends Logging {
 
     val partitionSet = AttributeSet(partitionColumns)
     val dataColumns = outputSpec.outputColumns.filterNot(partitionSet.contains)
-
-    val bucketIdExpression = bucketSpec.map { spec =>
-      val bucketColumns = spec.bucketColumnNames.map(c => dataColumns.find(_.name == c).get)
-      // Use `HashPartitioning.partitionIdExpression` as our bucket id expression, so that we can
-      // guarantee the data distribution is same between shuffle and bucketed data source, which
-      // enables us to only shuffle one side when join a bucketed table and a normal one.
-      HashPartitioning(bucketColumns, spec.numBuckets).partitionIdExpression
-    }
-    val sortColumns = bucketSpec.toSeq.flatMap {
-      spec => spec.sortColumnNames.map(c => dataColumns.find(_.name == c).get)
-    }
 
     val caseInsensitiveOptions = CaseInsensitiveMap(options)
 
@@ -156,19 +145,6 @@ object FileFormatWriter extends Logging {
       statsTrackers = statsTrackers
     )
 
-    // We should first sort by partition columns, then bucket id, and finally sorting columns.
-    val requiredOrdering = partitionColumns ++ bucketIdExpression ++ sortColumns
-    // the sort order doesn't matter
-    val actualOrdering = plan.outputOrdering.map(_.child)
-    val orderingMatched = if (requiredOrdering.length > actualOrdering.length) {
-      false
-    } else {
-      requiredOrdering.zip(actualOrdering).forall {
-        case (requiredOrder, childOutputOrder) =>
-          requiredOrder.semanticEquals(childOutputOrder)
-      }
-    }
-
     SQLExecution.checkSQLExecutionId(sparkSession)
 
     // This call shouldn't be put into the `try` block below because it only initializes and
@@ -176,20 +152,7 @@ object FileFormatWriter extends Logging {
     committer.setupJob(job)
 
     try {
-      val rdd = if (orderingMatched) {
-        plan.execute()
-      } else {
-        // SPARK-21165: the `requiredOrdering` is based on the attributes from analyzed plan, and
-        // the physical plan may have different attribute ids due to optimizer removing some
-        // aliases. Here we bind the expression ahead to avoid potential attribute ids mismatch.
-        val orderingExpr = requiredOrdering
-          .map(SortOrder(_, Ascending))
-          .map(BindReferences.bindReference(_, outputSpec.outputColumns))
-        SortExec(
-          orderingExpr,
-          global = false,
-          child = plan).execute()
-      }
+      val rdd = plan.execute()
       val ret = new Array[WriteTaskResult](rdd.partitions.length)
       sparkSession.sparkContext.runJob(
         rdd,
@@ -202,7 +165,7 @@ object FileFormatWriter extends Logging {
             committer,
             iterator = iter)
         },
-        0 until rdd.partitions.length,
+        rdd.partitions.indices,
         (index, res: WriteTaskResult) => {
           committer.onTaskCommit(res.commitMsg)
           ret(index) = res
@@ -521,18 +484,18 @@ object FileFormatWriter extends Logging {
       var recordsInFile: Long = 0L
       var fileCounter = 0
       val updatedPartitions = mutable.Set[String]()
-      var currentPartionValues: Option[UnsafeRow] = None
+      var currentPartitionValues: Option[UnsafeRow] = None
       var currentBucketId: Option[Int] = None
 
       for (row <- iter) {
         val nextPartitionValues = if (isPartitioned) Some(getPartitionValues(row)) else None
         val nextBucketId = if (isBucketed) Some(getBucketId(row)) else None
 
-        if (currentPartionValues != nextPartitionValues || currentBucketId != nextBucketId) {
+        if (currentPartitionValues != nextPartitionValues || currentBucketId != nextBucketId) {
           // See a new partition or bucket - write to a new partition dir (or a new bucket file).
-          if (isPartitioned && currentPartionValues != nextPartitionValues) {
-            currentPartionValues = Some(nextPartitionValues.get.copy())
-            statsTrackers.foreach(_.newPartition(currentPartionValues.get))
+          if (isPartitioned && currentPartitionValues != nextPartitionValues) {
+            currentPartitionValues = Some(nextPartitionValues.get.copy())
+            statsTrackers.foreach(_.newPartition(currentPartitionValues.get))
           }
           if (isBucketed) {
             currentBucketId = nextBucketId
@@ -543,7 +506,7 @@ object FileFormatWriter extends Logging {
           fileCounter = 0
 
           releaseResources()
-          newOutputWriter(currentPartionValues, currentBucketId, fileCounter, updatedPartitions)
+          newOutputWriter(currentPartitionValues, currentBucketId, fileCounter, updatedPartitions)
         } else if (desc.maxRecordsPerFile > 0 &&
             recordsInFile >= desc.maxRecordsPerFile) {
           // Exceeded the threshold in terms of the number of records per file.
@@ -554,7 +517,7 @@ object FileFormatWriter extends Logging {
             s"File counter $fileCounter is beyond max value $MAX_FILE_COUNTER")
 
           releaseResources()
-          newOutputWriter(currentPartionValues, currentBucketId, fileCounter, updatedPartitions)
+          newOutputWriter(currentPartitionValues, currentBucketId, fileCounter, updatedPartitions)
         }
         val outputRow = getOutputRow(row)
         currentWriter.write(outputRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -33,13 +33,12 @@ import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, ExternalCatalogUtils}
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, _}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, _}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
-import org.apache.spark.sql.execution.{SortExec, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -25,8 +25,9 @@ import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTablePartition}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSet, Expression, HiveHash, Murmur3Hash, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.internal.SQLConf.PartitionOverwriteMode
@@ -150,6 +151,10 @@ case class InsertIntoHadoopFsRelationCommand(
         }
       }
 
+      val partitionSet = AttributeSet(partitionColumns)
+      val dataColumns = query.output.filterNot(partitionSet.contains)
+      val bucketIdExpression = getBucketIdExpression(dataColumns)
+
       val updatedPartitionPaths =
         FileFormatWriter.write(
           sparkSession = sparkSession,
@@ -160,7 +165,7 @@ case class InsertIntoHadoopFsRelationCommand(
             qualifiedOutputPath.toString, customPartitionLocations, outputColumns),
           hadoopConf = hadoopConf,
           partitionColumns = partitionColumns,
-          bucketSpec = bucketSpec,
+          bucketIdExpression = bucketIdExpression,
           statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
           options = options)
 
@@ -182,6 +187,43 @@ case class InsertIntoHadoopFsRelationCommand(
     }
 
     Seq.empty[Row]
+  }
+
+  private def getBucketIdExpression(dataColumns: Seq[Attribute]): Option[Expression] = {
+    bucketSpec.map { spec =>
+      val bucketColumns = spec.bucketColumnNames.map(c => dataColumns.find(_.name == c).get)
+      // Use `HashPartitioning.partitionIdExpression` as our bucket id expression, so that we can
+      // guarantee the data distribution is same between shuffle and bucketed data source, which
+      // enables us to only shuffle one side when join a bucketed table and a normal one.
+      HashPartitioning(
+        bucketColumns,
+        spec.numBuckets,
+        classOf[Murmur3Hash]
+      ).partitionIdExpression
+    }
+  }
+
+  /**
+   * How is `requiredOrdering` determined ?
+   *
+   *     table type   |            requiredOrdering
+   * -----------------+-------------------------------------------------
+   *   normal table   |             partition columns
+   *   bucketed table | (partition columns + bucketId + sort columns)
+   * -----------------+-------------------------------------------------
+   */
+  override def requiredOrdering: Seq[Seq[SortOrder]] = {
+    val sortExpressions = bucketSpec match {
+      case Some(spec) =>
+        val partitionSet = AttributeSet(partitionColumns)
+        val dataColumns = query.output.filterNot(partitionSet.contains)
+        val bucketIdExpression = getBucketIdExpression(dataColumns)
+        val sortColumns = spec.sortColumnNames.map(c => dataColumns.find(_.name == c).get)
+        partitionColumns ++ bucketIdExpression ++ sortColumns
+
+      case _ => partitionColumns
+    }
+    Seq(sortExpressions.map(SortOrder(_, Ascending)))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -243,13 +243,13 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       rightPartitioning: Partitioning): (Seq[Expression], Seq[Expression]) = {
     if (leftKeys.forall(_.deterministic) && rightKeys.forall(_.deterministic)) {
       leftPartitioning match {
-        case HashPartitioning(leftExpressions, _)
+        case HashPartitioning(leftExpressions, _, _)
           if leftExpressions.length == leftKeys.length &&
             leftKeys.forall(x => leftExpressions.exists(_.semanticEquals(x))) =>
           reorder(leftKeys, rightKeys, leftExpressions, leftKeys)
 
         case _ => rightPartitioning match {
-          case HashPartitioning(rightExpressions, _)
+          case HashPartitioning(rightExpressions, _, _)
             if rightExpressions.length == rightKeys.length &&
               rightKeys.forall(x => rightExpressions.exists(_.semanticEquals(x))) =>
             reorder(leftKeys, rightKeys, rightExpressions, rightKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -204,7 +204,7 @@ object ShuffleExchangeExec {
       serializer: Serializer): ShuffleDependency[Int, InternalRow, InternalRow] = {
     val part: Partitioner = newPartitioning match {
       case RoundRobinPartitioning(numPartitions) => new HashPartitioner(numPartitions)
-      case HashPartitioning(_, n) =>
+      case HashPartitioning(_, n, _) =>
         new Partitioner {
           override def numPartitions: Int = n
           // For HashPartitioning, the partitioning key is already a valid partition ID, as we use

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -128,7 +128,7 @@ class FileStreamSink(
         outputSpec = FileFormatWriter.OutputSpec(path, Map.empty, qe.analyzed.output),
         hadoopConf = hadoopConf,
         partitionColumns = partitionColumns,
-        bucketSpec = None,
+        bucketIdExpression = None,
         statsTrackers = Nil,
         options = options)
     }

--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/BucketizedSparkInputFormat.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/BucketizedSparkInputFormat.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.io;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapred.*;
+import org.apache.hadoop.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR;
+
+/**
+ * A {@link InputFormat} implementation for reading bucketed tables.
+ *
+ * We cannot directly use {@link BucketizedHiveInputFormat} from Hive as it depends on the
+ * map-reduce plan to get required information for split generation.
+ */
+public class BucketizedSparkInputFormat<K extends WritableComparable, V extends Writable>
+        extends BucketizedHiveInputFormat<K, V> {
+
+  private static final String FILE_INPUT_FORMAT = "file.inputformat";
+
+  @Override
+  public RecordReader getRecordReader(
+      InputSplit split,
+      JobConf job,
+      Reporter reporter) throws IOException {
+
+    BucketizedHiveInputSplit hsplit = (BucketizedHiveInputSplit) split;
+    String inputFormatClassName = null;
+    Class inputFormatClass = null;
+
+    try {
+      inputFormatClassName = hsplit.inputFormatClassName();
+      inputFormatClass = job.getClassByName(inputFormatClassName);
+    } catch (ClassNotFoundException e) {
+      throw new IOException("Cannot find class " + inputFormatClassName, e);
+    }
+
+    InputFormat inputFormat = getInputFormatFromCache(inputFormatClass, job);
+    return new BucketizedSparkRecordReader<>(inputFormat, hsplit, job, reporter);
+  }
+
+  @Override
+  public InputSplit[] getSplits(JobConf job, int numBuckets) throws IOException {
+    final String inputFormatClassName = job.get(FILE_INPUT_FORMAT);
+    final String[] inputDirs = job.get(INPUT_DIR).split(StringUtils.COMMA_STR);
+
+    if (inputDirs.length != 1) {
+      throw new IOException(this.getClass().getCanonicalName() +
+        " expects only one input directory. " + inputDirs.length +
+        " directories detected : " + Arrays.toString(inputDirs));
+    }
+
+    final String inputDir = inputDirs[0];
+    final Path inputPath = new Path(inputDir);
+    final JobConf newJob = new JobConf(job);
+    final FileStatus[] listStatus = this.listStatus(newJob, inputPath);
+    final InputSplit[] result = new InputSplit[numBuckets];
+
+    if (listStatus.length != 0 && listStatus.length != numBuckets) {
+      throw new IOException("Bucketed path was expected to have " + numBuckets + " files but " +
+        listStatus.length + " files are present. Path = " + inputPath);
+    }
+
+    try {
+      final Class<?> inputFormatClass = Class.forName(inputFormatClassName);
+      final InputFormat inputFormat = getInputFormatFromCache(inputFormatClass, job);
+      newJob.setInputFormat(inputFormat.getClass());
+
+      for (int i = 0; i < numBuckets; i++) {
+        final FileStatus fileStatus = listStatus[i];
+        FileInputFormat.setInputPaths(newJob, fileStatus.getPath());
+
+        final InputSplit[] inputSplits = inputFormat.getSplits(newJob, 0);
+        if (inputSplits != null && inputSplits.length > 0) {
+          result[i] =
+            new BucketizedHiveInputSplit(inputSplits, inputFormatClass.getName());
+        }
+      }
+    } catch (ClassNotFoundException e) {
+      throw new IOException("Unable to find the InputFormat class " + inputFormatClassName, e);
+    }
+    return result;
+  }
+}

--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/BucketizedSparkRecordReader.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/BucketizedSparkRecordReader.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.io;
+
+import org.apache.hadoop.hive.io.HiveIOExceptionHandlerUtil;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapred.*;
+
+import java.io.IOException;
+
+/**
+ * A {@link RecordReader} implementation for reading {@link BucketizedHiveInputSplit}.
+ * Each {@link BucketizedHiveInputSplit} packs multiple {@link InputSplit} in itself which
+ * correspond to a single bucket. This record reader would open the record reader for those
+ * splits one by one (transparent to the caller) and return records.
+ *
+ * The Hive counterpart for this class is {@link BucketizedHiveRecordReader}. The reason for not
+ * re-using {@link BucketizedHiveRecordReader} in Hive is because it relies on Map-Reduce plan
+ * which is not avaliable while we are running jobs in Spark.
+ */
+public class BucketizedSparkRecordReader<K extends WritableComparable, V extends Writable>
+        implements RecordReader<K, V> {
+
+  protected final BucketizedHiveInputSplit split;
+  protected final InputFormat inputFormat;
+
+  private final Reporter reporter;
+  private long progress;
+  private int index;
+
+  protected RecordReader recordReader;
+  protected JobConf jobConf;
+
+  public BucketizedSparkRecordReader(
+      InputFormat inputFormat,
+      BucketizedHiveInputSplit bucketizedSplit,
+      JobConf jobConf,
+      Reporter reporter) throws IOException {
+    this.recordReader = null;
+    this.jobConf = jobConf;
+    this.split = bucketizedSplit;
+    this.inputFormat = inputFormat;
+    this.reporter = reporter;
+    initNextRecordReader();
+  }
+
+  /**
+   * Get the record reader for the next chunk
+   */
+  private boolean initNextRecordReader() throws IOException {
+    if (recordReader != null) {
+      recordReader.close();
+      recordReader = null;
+      if (index > 0) {
+        progress += split.getLength(index - 1); // done processing so far
+      }
+    }
+
+    // if all chunks have been processed, nothing more to do.
+    if (index == split.getNumSplits()) {
+      return false;
+    }
+
+    try {
+      // get a record reader for the index-th chunk
+      recordReader = inputFormat.getRecordReader(split.getSplit(index), jobConf, reporter);
+    } catch (Exception e) {
+      recordReader = HiveIOExceptionHandlerUtil.handleRecordReaderCreationException(e, jobConf);
+    }
+
+    index++;
+    return true;
+  }
+
+  private boolean doNextWithExceptionHandler(K key, V value) throws IOException {
+    try {
+      return recordReader.next(key,  value);
+    } catch (Exception e) {
+      return HiveIOExceptionHandlerUtil.handleRecordReaderNextException(e, jobConf);
+    }
+  }
+
+  @Override
+  public boolean next(K key, V value) throws IOException {
+    try {
+      while ((recordReader == null) || !doNextWithExceptionHandler(key, value)) {
+        if (!initNextRecordReader()) {
+          return false;
+        }
+      }
+      return true;
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public K createKey() {
+    return (K) recordReader.createKey();
+  }
+
+  @Override
+  public V createValue() {
+    return (V) recordReader.createValue();
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    if (recordReader != null) {
+      return recordReader.getPos();
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (recordReader != null) {
+      recordReader.close();
+      recordReader = null;
+    }
+    index = 0;
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    return Math.min(1.0f, (recordReader == null ?
+            progress : recordReader.getPos()) / (float) (split.getLength()));
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -55,6 +55,8 @@ import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
 
+import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_PROVIDER
+
 /**
  * A class that wraps the HiveClient and converts its responses to externally visible classes.
  * Note that this class is typically loaded with an internal classloader for each instantiation,
@@ -936,7 +938,10 @@ private[hive] object HiveClientImpl {
     }
 
     table.bucketSpec match {
-      case Some(bucketSpec) if DDLUtils.isHiveTable(table) =>
+      case Some(bucketSpec) if DDLUtils.isHiveTable(table) ||
+        (table.tableType != CatalogTableType.VIEW &&
+          table.properties.get(DATASOURCE_PROVIDER).isEmpty) =>
+
         hiveTable.setNumBuckets(bucketSpec.numBuckets)
         hiveTable.setBucketCols(bucketSpec.bucketColumnNames.toList.asJava)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -50,12 +50,11 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX}
+import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_PROVIDER, DATASOURCE_SCHEMA,
+  DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX}
 import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
-
-import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_PROVIDER
 
 /**
  * A class that wraps the HiveClient and converts its responses to externally visible classes.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -304,11 +304,12 @@ case class InsertIntoHiveTable(
       val files =
         fs.listStatus(outputPath)
           .filterNot(_.getPath.getName == "_SUCCESS")
-          .sortBy(_.getPath.getName)
+          .map(_.getPath.getName)
+          .sortBy(_.toString)
 
       var expectedBucketId = 0
       files.foreach { case file =>
-        getBucketIdFromFilename(file.getPath.getName) match {
+        getBucketIdFromFilename(file) match {
           case Some(id) if id == expectedBucketId =>
             expectedBucketId += 1
           case Some(_) =>
@@ -319,7 +320,7 @@ case class InsertIntoHiveTable(
           case None =>
             throw new SparkException(
               s"Invalid file found in temporary bucketed output location. Aborting job. " +
-                s"Output location : $outputPath, bad file : ${file.getPath.getName}")
+                s"Output location : $outputPath, bad file : $file")
         }
       }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.hive.ql.exec.TaskRunner
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.datasources.FileFormatWriter
@@ -52,6 +52,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       fileSinkConf: FileSinkDesc,
       outputLocation: String,
       allColumns: Seq[Attribute],
+      bucketIdExpression: Option[Expression] = None,
       customPartitionLocations: Map[TablePartitionSpec, String] = Map.empty,
       partitionAttributes: Seq[Attribute] = Nil): Set[String] = {
 
@@ -83,7 +84,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
         FileFormatWriter.OutputSpec(outputLocation, customPartitionLocations, allColumns),
       hadoopConf = hadoopConf,
       partitionColumns = partitionAttributes,
-      bucketSpec = None,
+      bucketIdExpression = bucketIdExpression,
       statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
       options = Map.empty)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -512,17 +512,6 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
     }
   }
 
-  test("SPARK-20594: hive.exec.stagingdir was deleted by Hive") {
-    // Set hive.exec.stagingdir under the table directory without start with ".".
-    withSQLConf("hive.exec.stagingdir" -> "./test") {
-      withTable("test_table") {
-        sql("CREATE TABLE test_table (key int)")
-        sql("INSERT OVERWRITE TABLE test_table SELECT 1")
-        checkAnswer(sql("SELECT * FROM test_table"), Row(1))
-      }
-    }
-  }
-
   test("insert overwrite to dir from hive metastore table") {
     withTempDir { dir =>
       val path = dir.toURI.getPath

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveBucketingSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveBucketingSuite.scala
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution
+
+import java.io.File
+import java.net.URI
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, HiveHash, HiveHashFunction}
+import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.execution.joins.SortMergeJoinExec
+import org.apache.spark.sql.hive.test.TestHive.implicits._
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.sql.types.IntegerType
+
+/**
+ * Tests Spark's support for Hive bucketing
+ * https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+ */
+class HiveBucketingSuite extends HiveComparisonTest with SQLTestUtils with TestHiveSingleton {
+  private val (table1, table2, table3) = ("table1", "table2", "table3")
+  private val (partitionedTable1, partitionedTable2) = ("partitionedTable1", "partitionedTable2")
+
+  private val bucketSpec = Some(BucketSpec(8, Seq("key"), Seq("key", "value")))
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      createTable(table1, isPartitioned = false, bucketSpec)
+      createTable(table2, isPartitioned = false, bucketSpec)
+      createTable(table3, isPartitioned = false, None)
+      createTable(partitionedTable1, isPartitioned = true, bucketSpec)
+      createTable(partitionedTable2, isPartitioned = true, bucketSpec)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      Seq(table1, table2, partitionedTable1, partitionedTable2)
+        .foreach(table => sql(s"DROP TABLE IF EXISTS $table"))
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  private def createTable(
+      tableName: String,
+      isPartitioned: Boolean,
+      bucketSpec: Option[BucketSpec]): Unit = {
+
+    val bucketClause =
+      bucketSpec.map(b =>
+        s"CLUSTERED BY (${b.bucketColumnNames.mkString(",")}) " +
+          s"SORTED BY (${b.sortColumnNames.map(_ + " ASC").mkString(" ,")}) " +
+          s"INTO ${b.numBuckets} buckets"
+      ).getOrElse("")
+
+    val partitionClause = if (isPartitioned) "PARTITIONED BY(part STRING)" else ""
+
+    sql(s"""
+           |CREATE TABLE IF NOT EXISTS $tableName (key int, value string) $partitionClause
+           |$bucketClause ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+           |""".stripMargin)
+
+    val data = 0 until 20
+    val df = if (isPartitioned) {
+      (data.map(i => (i, i.toString, "part0")) ++ data.map(i => (i, i.toString, "part1")))
+        .toDF("key", "value", "part")
+    } else {
+      data.map(i => (i, i.toString)).toDF("key", "value")
+    }
+    df.write.mode(SaveMode.Overwrite).insertInto(tableName)
+  }
+
+  case class BucketedTableTestSpec(
+      bucketSpec: Option[BucketSpec] = bucketSpec,
+      expectShuffle: Boolean = false,
+      expectSort: Boolean = false)
+
+  private def testBucketing(
+      queryString: String,
+      bucketedTableTestSpecLeft: BucketedTableTestSpec = BucketedTableTestSpec(),
+      bucketedTableTestSpecRight: BucketedTableTestSpec = BucketedTableTestSpec(),
+      bucketingEnabled: Boolean = true): Unit = {
+
+    def validateChildNode(
+        child: SparkPlan,
+        bucketSpec: Option[BucketSpec],
+        expectedShuffle: Boolean,
+        expectedSort: Boolean): Unit = {
+      val exchange = child.find(_.isInstanceOf[ShuffleExchangeExec])
+      assert(if (expectedShuffle) exchange.isDefined else exchange.isEmpty)
+
+      val sort = child.find(_.isInstanceOf[SortExec])
+      assert(if (expectedSort) sort.isDefined else sort.isEmpty)
+
+      val tableScanNode = child.find(_.isInstanceOf[HiveTableScanExec])
+      assert(tableScanNode.isDefined)
+      val tableScan = tableScanNode.get.asInstanceOf[HiveTableScanExec]
+
+      bucketSpec match {
+        case Some(spec) if bucketingEnabled =>
+          assert(tableScan.outputPartitioning.isInstanceOf[HashPartitioning])
+          val part = tableScan.outputPartitioning.asInstanceOf[HashPartitioning]
+          assert(part.hashingFunctionClass == classOf[HiveHash])
+          assert(part.numPartitions == spec.numBuckets)
+
+          for ((columnName, index) <- spec.bucketColumnNames.zipWithIndex) {
+            part.expressions(index) match {
+              case a: AttributeReference => assert(a.name == columnName)
+            }
+          }
+
+          import org.apache.spark.sql.catalyst.dsl.expressions._
+          part.semanticEquals(HashPartitioning(Seq('key), spec.numBuckets, classOf[HiveHash]))
+
+          val ordering = tableScan.outputOrdering
+          for ((columnName, sortOrder) <- spec.sortColumnNames.zip(ordering)) {
+            assert(sortOrder.direction === Ascending)
+            sortOrder.child match {
+              case a: AttributeReference => assert(a.name == columnName)
+            }
+          }
+        case _ => // do nothing
+      }
+    }
+
+    val BucketedTableTestSpec(bucketSpecLeft, shuffleLeft, sortLeft) = bucketedTableTestSpecLeft
+    val BucketedTableTestSpec(bucketSpecRight, shuffleRight, sortRight) = bucketedTableTestSpecRight
+
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1",
+      SQLConf.BUCKETING_ENABLED.key -> bucketingEnabled.toString) {
+
+      val plan = sql(queryString).queryExecution.executedPlan
+      val joinNode = plan.find(_.isInstanceOf[SortMergeJoinExec])
+      assert(joinNode.isDefined)
+      val joinOperator = joinNode.get.asInstanceOf[SortMergeJoinExec]
+
+      validateChildNode(joinOperator.left, bucketSpecLeft, shuffleLeft, sortLeft)
+      validateChildNode(joinOperator.right, bucketSpecRight, shuffleRight, sortRight)
+    }
+  }
+
+  test("Join two bucketed tables with bucketing enabled") {
+    testBucketing(s"SELECT * FROM $table1 a JOIN $table2 b ON a.key = b.key")
+  }
+
+  test("Join two bucketed tables with bucketing DISABLED") {
+    testBucketing(
+      s"SELECT * FROM $table1 a JOIN $table2 b ON a.key = b.key",
+      BucketedTableTestSpec(expectShuffle = true, expectSort = true),
+      BucketedTableTestSpec(expectShuffle = true, expectSort = true),
+      bucketingEnabled = false)
+  }
+
+  test("Join a regular table with a bucketed table") {
+    testBucketing(
+      s"SELECT * FROM $table3 a JOIN $table1 b ON a.key = b.key",
+      BucketedTableTestSpec(bucketSpec = None, expectShuffle = true, expectSort = true))
+  }
+
+  test("Join two bucketed tables but not over their bucketing column(s)") {
+    testBucketing(
+      s"SELECT a.value, b.value FROM $table1 a JOIN $table2 b ON a.value = b.value",
+      BucketedTableTestSpec(expectShuffle = true, expectSort = true),
+      BucketedTableTestSpec(expectShuffle = true, expectSort = true))
+  }
+
+  test("Join where predicate has other clauses in addition to bucketing column(s)") {
+    testBucketing(
+      s"SELECT a.value, b.value " +
+        s"FROM $table1 a JOIN $table2 b " +
+        s"ON a.key = b.key AND a.value = b.value",
+      BucketedTableTestSpec(expectShuffle = true, expectSort = true),
+      BucketedTableTestSpec(expectShuffle = true, expectSort = true))
+  }
+
+  test("Join two partitioned tables (single partition scan) with bucketing enabled") {
+    testBucketing(
+      s"""
+          SELECT * FROM $partitionedTable1 a JOIN $partitionedTable2 b
+          ON a.key = b.key AND a.part = "part0" AND b.part = "part0"
+        """.stripMargin
+    )
+  }
+
+  test("Join two partitioned tables with single partition scanned on one side and multiple " +
+    "partition scanned on the other one") {
+    testBucketing(
+      s"""
+         SELECT * FROM $partitionedTable1 a JOIN $partitionedTable2 b
+         ON a.key = b.key AND b.part = "part0"
+       """.stripMargin,
+      BucketedTableTestSpec(expectSort = true)
+    )
+  }
+
+  test("Join partitioned tables with non-partitioned table (both bucketed)") {
+    testBucketing(
+      s"""
+         SELECT * FROM $table1 a JOIN $partitionedTable2 b ON a.key = b.key AND b.part = "part0"
+       """.stripMargin
+    )
+  }
+
+  test("Join two partitioned tables (multiple partitions scan) with bucketing enabled") {
+    testBucketing(
+      s"SELECT * FROM $partitionedTable1 a JOIN $partitionedTable2 b ON a.key = b.key",
+      BucketedTableTestSpec(expectSort = true),
+      BucketedTableTestSpec(expectSort = true)
+    )
+  }
+
+  private def validateBucketingAndSorting(numBuckets: Int, dir: URI): Unit = {
+    val bucketFiles = new File(dir).listFiles().filter(_.getName.startsWith("part-"))
+      .sortWith((x, y) => x.getName < y.getName)
+    assert(bucketFiles.length === numBuckets)
+
+    bucketFiles.zipWithIndex.foreach { case(bucketFile, bucketId) =>
+      val rows = spark.read.format("text").load(bucketFile.getAbsolutePath).collect()
+      var prevKey: Option[Int] = None
+      rows.foreach(row => {
+        val key = row.getString(0).split("\t")(0).toInt
+        assert(HiveHashFunction.hash(key, IntegerType, seed = 0) % numBuckets === bucketId)
+
+        if (prevKey.isDefined) {
+          assert(prevKey.get <= key)
+        }
+        prevKey = Some(key)
+      })
+    }
+  }
+
+  test("Write data to a non-partitioned bucketed table") {
+    val numBuckets = 8
+    val tableName = "nonPartitionedBucketed"
+
+    withTable(tableName) {
+      val session = spark.sessionState
+      sql(s"""
+             |CREATE TABLE $tableName (key int, value string)
+             |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+             |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+             |""".stripMargin)
+
+      (0 until 100)
+        .map(i => (i, i.toString)).toDF("key", "value")
+        .write.mode(SaveMode.Overwrite).insertInto(tableName)
+
+      val dir = session.catalog.defaultTablePath(session.sqlParser.parseTableIdentifier(tableName))
+      validateBucketingAndSorting(numBuckets, dir)
+    }
+  }
+
+  test("Write data to a bucketed table with static partition") {
+    val numBuckets = 8
+    val tableName = "bucketizedTable"
+    val sourceTableName = "sourceTable"
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable(tableName, sourceTableName) {
+        sql(s"""
+               |CREATE TABLE $tableName (key int, value string)
+               |PARTITIONED BY(part1 STRING, part2 STRING)
+               |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+               |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+               |""".stripMargin)
+
+        (0 until 100)
+          .map(i => (i, i.toString))
+          .toDF("key", "value")
+          .createOrReplaceTempView(sourceTableName)
+
+        sql(s"""
+               |INSERT OVERWRITE TABLE $tableName PARTITION(part1="val1", part2="val2")
+               |SELECT key, value
+               |FROM $sourceTableName
+               |""".stripMargin)
+
+        val dir = spark.sessionState.catalog.getPartition(
+          spark.sessionState.sqlParser.parseTableIdentifier(tableName),
+          Map("part1" -> "val1", "part2" -> "val2")
+        ).location
+
+        validateBucketingAndSorting(numBuckets, dir)
+      }
+    }
+  }
+
+  test("Write data to a bucketed table with dynamic partitions") {
+    val numBuckets = 7
+    val tableName = "bucketizedTable"
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable(tableName) {
+        sql(s"""
+               |CREATE TABLE $tableName (key int, value string)
+               |PARTITIONED BY(part1 STRING, part2 STRING)
+               |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+               |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+               |""".stripMargin)
+
+        (0 until 100)
+          .map(i => (i, i.toString, (if (i > 50) i % 2 else 2 - i % 2).toString, (i % 3).toString))
+          .toDF("key", "value", "part1", "part2")
+          .write.mode(SaveMode.Overwrite).insertInto(tableName)
+
+        (0 until 2).zip(0 until 3).foreach { case (part1, part2) =>
+          val dir = spark.sessionState.catalog.getPartition(
+            spark.sessionState.sqlParser.parseTableIdentifier(tableName),
+            Map("part1" -> part1.toString, "part2" -> part2.toString)
+          ).location
+
+          validateBucketingAndSorting(numBuckets, dir)
+        }
+      }
+    }
+  }
+
+  test("Write data to a bucketed table with dynamic partitions (along with static partitions)") {
+    val numBuckets = 8
+    val tableName = "bucketizedTable"
+    val sourceTableName = "sourceTable"
+    val part1StaticValue = "0"
+
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable(tableName, sourceTableName) {
+        sql(s"""
+               |CREATE TABLE $tableName (key int, value string)
+               |PARTITIONED BY(part1 STRING, part2 STRING)
+               |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+               |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+               |""".stripMargin)
+
+        (0 until 100)
+          .map(i => (i, i.toString, (i % 3).toString))
+          .toDF("key", "value", "part")
+          .createOrReplaceTempView(sourceTableName)
+
+        sql(s"""
+               |INSERT OVERWRITE TABLE $tableName PARTITION(part1="$part1StaticValue", part2)
+               |SELECT key, value, part
+               |FROM $sourceTableName
+               |""".stripMargin)
+
+        (0 until 3).foreach { case part2 =>
+          val dir = spark.sessionState.catalog.getPartition(
+            spark.sessionState.sqlParser.parseTableIdentifier(tableName),
+            Map("part1" -> part1StaticValue, "part2" -> part2.toString)
+          ).location
+
+          validateBucketingAndSorting(numBuckets, dir)
+        }
+      }
+    }
+  }
+
+  test("Appends to bucketed table should NOT be allowed as it breaks bucketing guarantee") {
+    val numBuckets = 8
+    val tableName = "nonPartitionedBucketed"
+
+    withTable(tableName) {
+      sql(s"""
+             |CREATE TABLE $tableName (key int, value string)
+             |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+             |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+             |""".stripMargin)
+
+      val df = (0 until 100).map(i => (i, i.toString)).toDF("key", "value")
+      val e = intercept[SparkException] {
+        df.write.mode(SaveMode.Append).insertInto(tableName)
+      }
+      assert(e.getMessage.contains("Appending data to hive bucketed table is not allowed"))
+    }
+  }
+
+  test("Fail the query if number of files produced != number of buckets") {
+    val numBuckets = 8
+    val tableName = "nonPartitionedBucketed"
+
+    withTable(tableName) {
+      sql(s"""
+             |CREATE TABLE $tableName (key int, value string)
+             |CLUSTERED BY (key) SORTED BY (key ASC) into $numBuckets buckets
+             |ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+             |""".stripMargin)
+
+      val df = (0 until (numBuckets / 2)).map(i => (i, i.toString)).toDF("key", "value")
+      val e = intercept[SparkException] {
+        df.write.mode(SaveMode.Overwrite).insertInto(tableName)
+      }
+      assert(e.getMessage.contains("Potentially missing bucketed output files"))
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR implements both read and write side changes for supporting hive bucketing in Spark. I had initially created a PR for just the write side changes (https://github.com/apache/spark/pull/18954) for simplicity. If reviewers want to review reader and writer side changes separately, I am happy to wait for the writer side PR to get merged and then send a new PR for reader side changes.

### Semantics for read:
- `outputPartitioning` while scanning hive table would be the set of bucketing columns (whether its partitioned or not, whether you are reading single partition or multiple partitions)
- `outputOrdering` would be the sort columns (actually prefix subset of `sort columns` being read from the table). 
- In case of reading multiple hive partitions of the table, there would be multiple files per bucket so global sorting across buckets is not there. Thus we would have to ignore the sort information.
- See the documentation in `HiveTableScanExec` where the `outputPartitioning` and `outputOrdering` is populated for more nitty gritty details.

### Semantics for write:
- If the Hive table is bucketed, then INSERT node expect the child distribution to be based on the hash of the bucket columns. Else it would be empty. (Just to compare with Spark native bucketing : the required distribution is not enforced even if the table is bucketed or not... this saves the shuffle in comparison with hive).
- Sort ordering for INSERT node over Hive bucketed table is determined as follows:

| Table type   | Normal table | Bucketed table |
| ------------- | ------------- | ------------- |
| non-partitioned insert  | Nil | sort columns |
| static partition   | Nil | sort columns |
| dynamic partitions   | partition columns | (partition columns + bucketId + sort columns) |

Just to compare how sort ordering is expressed for Spark native bucketing:

| Table type   | Normal table | Bucketed table |
| ------------- | ------------- | ------------- |
|  sort ordering | partition columns | (partition columns + bucketId + sort columns) |

Why is there a difference ? With hive, since there bucketed insertions would need a shuffle, sort ordering can be relaxed for both non-partitioned and static partition cases. Every RDD partition would get rows corresponding to a single bucket so those can be written to corresponding output file after sort. In case of dynamic partitions, the rows need to be routed to appropriate partition which makes it similar to Spark's constraints.

- Only `Overwrite` mode is allowed for hive bucketed tables as any other mode will break the bucketing guarantees of the table. This is a difference wrt how Spark bucketing works.
- With the PR, if there are no files created for empty buckets, the query will fail. Will support creation of empty files in coming iteration. This is a difference wrt how Spark bucketing works as it does NOT need files for empty buckets.

### Summary of changes done:
- `ClusteredDistribution` and `HashPartitioning` are modified to store the hashing function used.
- `RunnableCommand`'s' can now express the required distribution and ordering. This is used by `ExecutedCommandExec` which run these commands
  - The good thing about this is that I could remove the logic for enforcing sort ordering inside `FileFormatWriter` which felt out of place. Ideally, this kinda adding of physical nodes should be done within the planner which is what happens with this PR.
- `InsertIntoHiveTable` enforces both distribution and sort ordering
- `InsertIntoHadoopFsRelationCommand` enforces sort ordering ONLY (and not the distribution)
- Fixed a bug due to which any alter commands to bucketed table (eg. updating stats) would wipe out the bucketing spec from metastore. This made insertions to bucketed table non-idempotent operation.
- `HiveTableScanExec` populates `outputPartitioning` and `outputOrdering` based on table's metadata, configs and the query
- `HadoopTableReader` to use `BucketizedSparkInputFormat` for bucketed reads

## How was this patch tested?

- Added new unit tests