### PR TITLE
[SPARK-21790][TESTS][FOLLOW-UP]  Add filter pushdown verification back.

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -22,7 +22,7 @@ import java.util.Properties
 import java.math.BigDecimal
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.execution.{RowDataSourceScanExec, DataSourceScanExec}
+import org.apache.spark.sql.execution.{WholeStageCodegenExec, RowDataSourceScanExec}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
@@ -257,8 +257,8 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
       .filter(dfRead.col("timestamp_type").lt(ts))
 
     val parentPlan = df.queryExecution.executedPlan
-    assert(parentPlan.isInstanceOf[org.apache.spark.sql.execution.WholeStageCodegenExec])
-    val node = parentPlan.asInstanceOf[org.apache.spark.sql.execution.WholeStageCodegenExec]
+    assert(parentPlan.isInstanceOf[WholeStageCodegenExec])
+    val node = parentPlan.asInstanceOf[WholeStageCodegenExec]
     val metadata = node.child.asInstanceOf[RowDataSourceScanExec].metadata
     // The "PushedFilters" part should be exist in Datafrome's
     // physical plan and the existence of right literals in

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -260,11 +260,11 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
     assert(parentPlan.isInstanceOf[WholeStageCodegenExec])
     val node = parentPlan.asInstanceOf[WholeStageCodegenExec]
     val metadata = node.child.asInstanceOf[RowDataSourceScanExec].metadata
-    // The "PushedFilters" part should be exist in Dataframe's
+    // The "PushedFilters" part should exist in Dataframe's
     // physical plan and the existence of right literals in
     // "PushedFilters" is used to prove that the predicates
     // pushing down have been effective.
-    assert(metadata.get("PushedFilters").ne(None))
+    assert(metadata.get("PushedFilters").isDefined)
     assert(metadata("PushedFilters").contains(dt.toString))
     assert(metadata("PushedFilters").contains(ts.toString))
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -260,7 +260,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
     assert(parentPlan.isInstanceOf[WholeStageCodegenExec])
     val node = parentPlan.asInstanceOf[WholeStageCodegenExec]
     val metadata = node.child.asInstanceOf[RowDataSourceScanExec].metadata
-    // The "PushedFilters" part should be exist in Datafrome's
+    // The "PushedFilters" part should be exist in Dataframe's
     // physical plan and the existence of right literals in
     // "PushedFilters" is used to prove that the predicates
     // pushing down have been effective.

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.FilterExec
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{UninterruptibleThread, Utils}
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.FilterExec
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{UninterruptibleThread, Utils}
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The previous PR(https://github.com/apache/spark/pull/19000) removed filter pushdown verification, This PR add them back.

## How was this patch tested?
manual tests
