### PR TITLE
[SPARK-21783][SQL]Turn on ORC filter push-down by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -325,7 +325,7 @@ object SQLConf {
   val ORC_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.orc.filterPushdown")
     .doc("When true, enable filter pushdown for ORC files.")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   val HIVE_VERIFY_PARTITION_PATH = buildConf("spark.sql.hive.verifyPartitionPath")
     .doc("When true, check all the partition paths under the table\'s root directory " +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcHadoopFsRelationSuite.scala
@@ -65,19 +65,17 @@ class OrcHadoopFsRelationSuite extends HadoopFsRelationTest {
   test("SPARK-12218: 'Not' is included in ORC filter pushdown") {
     import testImplicits._
 
-    withSQLConf(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key -> "true") {
-      withTempPath { dir =>
-        val path = s"${dir.getCanonicalPath}/table1"
-        (1 to 5).map(i => (i, (i % 2).toString)).toDF("a", "b").write.orc(path)
+    withTempPath { dir =>
+      val path = s"${dir.getCanonicalPath}/table1"
+      (1 to 5).map(i => (i, (i % 2).toString)).toDF("a", "b").write.orc(path)
 
-        checkAnswer(
-          spark.read.orc(path).where("not (a = 2) or not(b in ('1'))"),
-          (1 to 5).map(i => Row(i, (i % 2).toString)))
+      checkAnswer(
+        spark.read.orc(path).where("not (a = 2) or not(b in ('1'))"),
+        (1 to 5).map(i => Row(i, (i % 2).toString)))
 
-        checkAnswer(
-          spark.read.orc(path).where("not (a = 2 and b in ('1'))"),
-          (1 to 5).map(i => Row(i, (i % 2).toString)))
-      }
+      checkAnswer(
+        spark.read.orc(path).where("not (a = 2 and b in ('1'))"),
+        (1 to 5).map(i => Row(i, (i % 2).toString)))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Turned on ORC filter push-down option by default, spark.sql.orc.filterPushdown was turned off by default from the beginning. 

## How was this patch tested?
Updated existing test cases

