### PR TITLE
[SPARK-3181] [ML] Implement huber loss for LinearRegression.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -26,7 +26,7 @@ import org.apache.spark.ml.linalg.Vector
  *
  * The huber loss function based on:
  * Art B. Owen (2006), A robust hybrid of lasso and ridge regression.
- * ([[http://statweb.stanford.edu/~owen/reports/hhu.pdf]])
+ * (http://statweb.stanford.edu/~owen/reports/hhu.pdf)
  *
  * Two HuberAggregator can be merged together to have a summary of loss and gradient of
  * the corresponding joint dataset.
@@ -48,7 +48,7 @@ import org.apache.spark.ml.linalg.Vector
  *   $$
  *   \begin{align}
  *   H_m(z) = \begin{cases}
- *            z^2, & \text {if } |z| < \epsilon, \\
+ *            z^2, & \text {if } |z| <= \epsilon, \\
  *            2\epsilon|z| - \epsilon^2, & \text{otherwise}
  *            \end{cases}
  *   \end{align}

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -37,7 +37,7 @@ import org.apache.spark.ml.linalg.Vector
  *   $$
  *   \begin{align}
  *   \min_{w, \sigma}\frac{1}{2n}{\sum_{i=1}^n\left(\sigma +
- *   H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \frac{1}{2}\alpha {||w||_2}^2}
+ *   H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \frac{1}{2}\lambda {||w||_2}^2}
  *   \end{align}
  *   $$
  * </blockquote>

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -112,11 +112,11 @@ private[ml] class HuberAggregator(
         features.foreachActive { (index, value) =>
           if (featuresStd(index) != 0.0 && value != 0.0) {
             gradientSumArray(index) +=
-              0.5 * weight * -2.0 * linearLoss / sigma * (value / featuresStd(index))
+              -1.0 * weight * linearLoss / sigma * (value / featuresStd(index))
           }
         }
         if (fitIntercept) {
-          gradientSumArray(dim - 2) += 0.5 * weight * -2.0 * linearLoss / sigma
+          gradientSumArray(dim - 2) += -1.0 * weight * linearLoss / sigma
         }
         gradientSumArray(dim - 1) += 0.5 * weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
       } else {
@@ -125,11 +125,11 @@ private[ml] class HuberAggregator(
 
         features.foreachActive { (index, value) =>
           if (featuresStd(index) != 0.0 && value != 0.0) {
-            gradientSumArray(index) += 0.5 * weight * sign * 2.0 * m * (value / featuresStd(index))
+            gradientSumArray(index) += weight * sign * m * (value / featuresStd(index))
           }
         }
         if (fitIntercept) {
-          gradientSumArray(dim - 2) += 0.5 * weight * (sign * 2.0 * m)
+          gradientSumArray(dim - 2) += weight * sign * m
         }
         gradientSumArray(dim - 1) += 0.5 * weight * (1.0 - m * m)
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -36,8 +36,8 @@ import org.apache.spark.ml.linalg.Vector
  * <blockquote>
  *   $$
  *   \begin{align}
- *   {min\,} {\sum_{i=1}^n\left(\sigma +
- *   H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \alpha {||w||_2}^2}
+ *   \min_{w, \sigma}\frac{1}{2n}{\sum_{i=1}^n\left(\sigma +
+ *   H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \frac{1}{2}\alpha {||w||_2}^2}
  *   \end{align}
  *   $$
  * </blockquote>

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -113,7 +113,7 @@ private[ml] class HuberAggregator(
       val linearLoss = label - margin
 
       if (math.abs(linearLoss) <= sigma * epsilon) {
-        lossSum += 0.5 * weight * (sigma +  math.pow(linearLoss, 2.0) / sigma)
+        lossSum += 0.5 * weight * (sigma + math.pow(linearLoss, 2.0) / sigma)
         val linearLossDivSigma = linearLoss / sigma
 
         features.foreachActive { (index, value) =>

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -25,8 +25,8 @@ import org.apache.spark.ml.linalg.Vector
  * as used in robust regression for samples in sparse or dense vector in an online fashion.
  *
  * The huber loss function based on:
- * Art B. Owen (2006), A robust hybrid of lasso and ridge regression.
- * (http://statweb.stanford.edu/~owen/reports/hhu.pdf)
+ * <a href="http://statweb.stanford.edu/~owen/reports/hhu.pdf">Art B. Owen (2006),
+ * A robust hybrid of lasso and ridge regression</a>.
  *
  * Two HuberAggregator can be merged together to have a summary of loss and gradient of
  * the corresponding joint dataset.
@@ -55,7 +55,10 @@ import org.apache.spark.ml.linalg.Vector
  *   $$
  * </blockquote>
  *
- * It is advised to set the parameter $\epsilon$ to 1.35 to achieve 95% statistical efficiency.
+ * It is advised to set the parameter $\epsilon$ to 1.35 to achieve 95% statistical efficiency
+ * for normally distributed data. Please refer to chapter 2 of
+ * <a href="http://statweb.stanford.edu/~owen/reports/hhu.pdf">
+ * A robust hybrid of lasso and ridge regression</a> for more detail.
  *
  * @param fitIntercept Whether to fit an intercept term.
  * @param epsilon The shape parameter to control the amount of robustness.
@@ -112,11 +115,11 @@ private[ml] class HuberAggregator(
         features.foreachActive { (index, value) =>
           if (featuresStd(index) != 0.0 && value != 0.0) {
             gradientSumArray(index) +=
-              -1.0 * weight * linearLoss / sigma * (value / featuresStd(index))
+              -1.0 * weight * (linearLoss / sigma) * (value / featuresStd(index))
           }
         }
         if (fitIntercept) {
-          gradientSumArray(dim - 2) += -1.0 * weight * linearLoss / sigma
+          gradientSumArray(dim - 2) += -1.0 * weight * (linearLoss / sigma)
         }
         gradientSumArray(dim - 1) += 0.5 * weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -107,31 +107,31 @@ private[ml] class HuberAggregator(
       val linearLoss = label - margin
 
       if (math.abs(linearLoss) <= sigma * m) {
-        lossSum += weight * (sigma +  math.pow(linearLoss, 2.0) / sigma)
+        lossSum += 0.5 * weight * (sigma +  math.pow(linearLoss, 2.0) / sigma)
 
         features.foreachActive { (index, value) =>
           if (featuresStd(index) != 0.0 && value != 0.0) {
             gradientSumArray(index) +=
-              weight * -2.0 * linearLoss / sigma * (value / featuresStd(index))
+              0.5 * weight * -2.0 * linearLoss / sigma * (value / featuresStd(index))
           }
         }
         if (fitIntercept) {
-          gradientSumArray(dim - 2) += weight * -2.0 * linearLoss / sigma
+          gradientSumArray(dim - 2) += 0.5 * weight * -2.0 * linearLoss / sigma
         }
-        gradientSumArray(dim - 1) += weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
+        gradientSumArray(dim - 1) += 0.5 * weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
       } else {
         val sign = if (linearLoss >= 0) -1.0 else 1.0
-        lossSum += weight * (sigma + 2.0 * m * math.abs(linearLoss) - sigma * m * m)
+        lossSum += 0.5 * weight * (sigma + 2.0 * m * math.abs(linearLoss) - sigma * m * m)
 
         features.foreachActive { (index, value) =>
           if (featuresStd(index) != 0.0 && value != 0.0) {
-            gradientSumArray(index) += weight * sign * 2.0 * m * (value / featuresStd(index))
+            gradientSumArray(index) += 0.5 * weight * sign * 2.0 * m * (value / featuresStd(index))
           }
         }
         if (fitIntercept) {
-          gradientSumArray(dim - 2) += weight * (sign * 2.0 * m)
+          gradientSumArray(dim - 2) += 0.5 * weight * (sign * 2.0 * m)
         }
-        gradientSumArray(dim - 1) += weight * (1.0 - m * m)
+        gradientSumArray(dim - 1) += 0.5 * weight * (1.0 - m * m)
       }
 
       weightSum += weight

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml.optim.aggregator
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.feature.Instance
+import org.apache.spark.ml.linalg.Vector
+
+/**
+ * HuberAggregator computes the gradient and loss for a huber loss function,
+ * as used in robust regression for samples in sparse or dense vector in an online fashion.
+ *
+ * The huber loss function based on:
+ * Art B. Owen (2006), A robust hybrid of lasso and ridge regression.
+ * ([[http://statweb.stanford.edu/~owen/reports/hhu.pdf]])
+ *
+ * Two HuberAggregator can be merged together to have a summary of loss and gradient of
+ * the corresponding joint dataset.
+ *
+ * The huber loss function is given by
+ *
+ * <blockquote>
+ *   $$
+ *   \begin{align}
+ *   {min\,} {\sum_{i=1}^n\left(\sigma +
+ *   H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \alpha {||w||_2}^2}
+ *   \end{align}
+ *   $$
+ * </blockquote>
+ *
+ * where
+ *
+ * <blockquote>
+ *   $$
+ *   \begin{align}
+ *   H_m(z) = \begin{cases}
+ *            z^2, & \text {if } |z| < \epsilon, \\
+ *            2\epsilon|z| - \epsilon^2, & \text{otherwise}
+ *            \end{cases}
+ *   \end{align}
+ *   $$
+ * </blockquote>
+ *
+ * It is advised to set the parameter $\epsilon$ to 1.35 to achieve 95% statistical efficiency.
+ *
+ * @param fitIntercept Whether to fit an intercept term.
+ * @param m The shape parameter to control the amount of robustness.
+ * @param bcFeaturesStd The broadcast standard deviation values of the features.
+ * @param bcParameters including three parts: the regression coefficients corresponding
+ *                     to the features, the intercept (if fitIntercept is ture)
+ *                     and the scale parameter (sigma).
+ */
+private[ml] class HuberAggregator(
+    fitIntercept: Boolean,
+    m: Double,
+    bcFeaturesStd: Broadcast[Array[Double]])(bcParameters: Broadcast[Vector])
+  extends DifferentiableLossAggregator[Instance, HuberAggregator] {
+
+  protected override val dim: Int = bcParameters.value.size
+  private val numFeatures: Int = if (fitIntercept) dim - 2 else dim - 1
+
+  @transient private lazy val coefficients: Array[Double] =
+    bcParameters.value.toArray.slice(0, numFeatures)
+  private val sigma: Double = bcParameters.value(dim - 1)
+
+  @transient private lazy val featuresStd = bcFeaturesStd.value
+
+  /**
+   * Add a new training instance to this HuberAggregator, and update the loss and gradient
+   * of the objective function.
+   *
+   * @param instance The instance of data point to be added.
+   * @return This HuberAggregator object.
+   */
+  def add(instance: Instance): HuberAggregator = {
+    instance match { case Instance(label, weight, features) =>
+      require(numFeatures == features.size, s"Dimensions mismatch when adding new sample." +
+        s" Expecting $numFeatures but got ${features.size}.")
+      require(weight >= 0.0, s"instance weight, $weight has to be >= 0.0")
+
+      if (weight == 0.0) return this
+
+      val margin = {
+        var sum = 0.0
+        features.foreachActive { (index, value) =>
+          if (featuresStd(index) != 0.0 && value != 0.0) {
+            sum += coefficients(index) * (value / featuresStd(index))
+          }
+        }
+        if (fitIntercept) sum += bcParameters.value(dim - 2)
+        sum
+      }
+      val linearLoss = label - margin
+
+      if (math.abs(linearLoss) <= sigma * m) {
+        lossSum += weight * (sigma +  math.pow(linearLoss, 2.0) / sigma)
+
+        features.foreachActive { (index, value) =>
+          if (featuresStd(index) != 0.0 && value != 0.0) {
+            gradientSumArray(index) +=
+              weight * -2.0 * linearLoss / sigma * (value / featuresStd(index))
+          }
+        }
+        if (fitIntercept) {
+          gradientSumArray(dim - 2) += weight * -2.0 * linearLoss / sigma
+        }
+        gradientSumArray(dim - 1) += weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
+      } else {
+        val sign = if (linearLoss >= 0) -1.0 else 1.0
+        lossSum += weight * (sigma + 2.0 * m * math.abs(linearLoss) - sigma * m * m)
+
+        features.foreachActive { (index, value) =>
+          if (featuresStd(index) != 0.0 && value != 0.0) {
+            gradientSumArray(index) += weight * sign * 2.0 * m * (value / featuresStd(index))
+          }
+        }
+        if (fitIntercept) {
+          gradientSumArray(dim - 2) += weight * (sign * 2.0 * m)
+        }
+        gradientSumArray(dim - 1) += weight * (1.0 - m * m)
+      }
+
+      weightSum += weight
+      this
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberAggregator.scala
@@ -48,7 +48,7 @@ import org.apache.spark.ml.linalg.Vector
  *   $$
  *   \begin{align}
  *   H_m(z) = \begin{cases}
- *            z^2, & \text {if } |z| <= \epsilon, \\
+ *            z^2, & \text {if } |z| &lt; \epsilon, \\
  *            2\epsilon|z| - \epsilon^2, & \text{otherwise}
  *            \end{cases}
  *   \end{align}

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
@@ -88,7 +88,8 @@ private[shared] object SharedParamsCodeGen {
         "during tuning. If set to false, then only the single best sub-model will be available " +
         "after fitting. If set to true, then all sub-models will be available. Warning: For " +
         "large models, collecting all sub-models can cause OOMs on the Spark driver",
-        Some("false"), isExpertParam = true)
+        Some("false"), isExpertParam = true),
+      ParamDesc[String]("loss", "the loss function to be optimized", finalFields = false)
     )
 
     val code = genSharedParams(params)

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -487,4 +487,21 @@ trait HasCollectSubModels extends Params {
   /** @group expertGetParam */
   final def getCollectSubModels: Boolean = $(collectSubModels)
 }
+
+/**
+ * Trait for shared param loss. This trait may be changed or
+ * removed between minor versions.
+ */
+@DeveloperApi
+trait HasLoss extends Params {
+
+  /**
+   * Param for the loss function to be optimized.
+   * @group param
+   */
+  val loss: Param[String] = new Param[String](this, "loss", "the loss function to be optimized")
+
+  /** @group getParam */
+  final def getLoss: String = $(loss)
+}
 // scalastyle:on

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -84,19 +84,19 @@ private[regression] trait LinearRegressionParams extends PredictorParams
 
   /**
    * The shape parameter to control the amount of robustness. Must be &gt; 1.0.
-   * At larger values of M, the huber criterion becomes more similar to least squares regression;
-   * for small values of M, the criterion is more similar to L1 regression.
+   * At larger values of epsilon, the huber criterion becomes more similar to least squares
+   * regression; for small values of epsilon, the criterion is more similar to L1 regression.
    * Default is 1.35 to get as much robustness as possible while retaining
    * 95% statistical efficiency for normally distributed data.
    * Only valid when "loss" is "huber".
    */
   @Since("2.3.0")
-  final val m = new DoubleParam(this, "m", "The shape parameter to control the amount of " +
-    "robustness. Must be > 1.0.", ParamValidators.gt(1.0))
+  final val epsilon = new DoubleParam(this, "epsilon", "The shape parameter to control the " +
+    "amount of robustness. Must be > 1.0.", ParamValidators.gt(1.0))
 
   /** @group getParam */
   @Since("2.3.0")
-  def getM: Double = $(m)
+  def getEpsilon: Double = $(epsilon)
 
   override protected def validateAndTransformSchema(
       schema: StructType,
@@ -262,14 +262,14 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   setDefault(loss -> LeastSquares)
 
   /**
-   * Sets the value of param [[m]].
+   * Sets the value of param [[epsilon]].
    * Default is 1.35.
    *
    * @group setParam
    */
   @Since("2.3.0")
-  def setM(value: Double): this.type = set(m, value)
-  setDefault(m -> 1.35)
+  def setEpsilon(value: Double): this.type = set(epsilon, value)
+  setDefault(epsilon -> 1.35)
 
   override protected def train(dataset: Dataset[_]): LinearRegressionModel = {
     // Extract the number of features before deciding optimization solver.
@@ -415,7 +415,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
           bcFeaturesStd, bcFeaturesMean)(_)
         new RDDLossFunction(instances, getAggregatorFunc, regularization, $(aggregationDepth))
       case Huber =>
-        val getAggregatorFunc = new HuberAggregator($(fitIntercept), $(m), bcFeaturesStd)(_)
+        val getAggregatorFunc = new HuberAggregator($(fitIntercept), $(epsilon), bcFeaturesStd)(_)
         new RDDLossFunction(instances, getAggregatorFunc, regularization, $(aggregationDepth))
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -83,7 +83,7 @@ private[regression] trait LinearRegressionParams extends PredictorParams
     ParamValidators.inArray[String](supportedLosses))
 
   /**
-   * The shape parameter to control the amount of robustness. Must be > 1.0.
+   * The shape parameter to control the amount of robustness. Must be &gt; 1.0.
    * At larger values of M, the huber criterion becomes more similar to least squares regression;
    * for small values of M, the criterion is more similar to L1 regression.
    * Default is 1.35 to get as much robustness as possible while retaining

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -119,15 +119,53 @@ private[regression] trait LinearRegressionParams extends PredictorParams
  * Linear regression.
  *
  * The learning objective is to minimize the specified loss function, with regularization.
- * This supports two loss functions:
+ * This supports two kinds of loss:
  *  - squaredError (a.k.a squared loss)
- *  - huber
+ *  - huber (a hybrid of squared error for relatively small errors and absolute error for
+ *  relatively large ones, and we estimate the scale parameter from training data)
  *
  * This supports multiple types of regularization:
  *  - none (a.k.a. ordinary least squares)
  *  - L2 (ridge regression)
  *  - L1 (Lasso)
  *  - L2 + L1 (elastic net)
+ *
+ * The squared error objective function is:
+ *
+ * <blockquote>
+ *   $$
+ *   \begin{align}
+ *   \min_{w}\frac{1}{2n}{\sum_{i=1}^n(X_{i}w - y_{i})^{2} +
+ *   \lambda\left[\frac{1-\alpha}{2}{||w||_{2}}^{2} + \alpha{||w||_{1}}\right]}
+ *   \end{align}
+ *   $$
+ * </blockquote>
+ *
+ * The huber objective function is:
+ *
+ * <blockquote>
+ *   $$
+ *   \begin{align}
+ *   \min_{w, \sigma}\frac{1}{2n}{\sum_{i=1}^n\left(\sigma +
+ *   H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \frac{1}{2}\lambda {||w||_2}^2}
+ *   \end{align}
+ *   $$
+ * </blockquote>
+ *
+ * where
+ *
+ * <blockquote>
+ *   $$
+ *   \begin{align}
+ *   H_m(z) = \begin{cases}
+ *            z^2, & \text {if } |z| &lt; \epsilon, \\
+ *            2\epsilon|z| - \epsilon^2, & \text{otherwise}
+ *            \end{cases}
+ *   \end{align}
+ *   $$
+ * </blockquote>
+ *
+ * Note: Fitting with huber loss only supports none and L2 regularization.
  */
 @Since("1.3.0")
 class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -88,7 +88,9 @@ private[regression] trait LinearRegressionParams extends PredictorParams
    * At larger values of epsilon, the huber criterion becomes more similar to least squares
    * regression; for small values of epsilon, the criterion is more similar to L1 regression.
    * Default is 1.35 to get as much robustness as possible while retaining
-   * 95% statistical efficiency for normally distributed data.
+   * 95% statistical efficiency for normally distributed data. It matches sklearn
+   * HuberRegressor and is "M" from <a href="http://statweb.stanford.edu/~owen/reports/hhu.pdf">
+   * A robust hybrid of lasso and ridge regression</a>.
    * Only valid when "loss" is "huber".
    *
    * @group expertParam
@@ -221,7 +223,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * For alpha in (0,1), the penalty is a combination of L1 and L2.
    * Default is 0.0 which is an L2 penalty.
    *
-   * Note: Fitting with huber loss only supports L2 regularization,
+   * Note: Fitting with huber loss only supports None and L2 regularization,
    * so throws exception if this param is non-zero value.
    *
    * @group setParam

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/HuberAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/HuberAggregatorSuite.scala
@@ -131,9 +131,9 @@ class HuberAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
       if (math.abs(linearLoss) <= sigma * epsilon) {
         features.toArray.indices.foreach { i =>
           gradientCoef(i) +=
-            -1.0 * weight * linearLoss / sigma * (features(i) / featuresStd(i))
+            -1.0 * weight * (linearLoss / sigma) * (features(i) / featuresStd(i))
         }
-        gradientCoef(2) += -1.0 * weight * linearLoss / sigma
+        gradientCoef(2) += -1.0 * weight * (linearLoss / sigma)
         gradientCoef(3) += 0.5 * weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
       } else {
         val sign = if (linearLoss >= 0) -1.0 else 1.0

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/HuberAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/HuberAggregatorSuite.scala
@@ -162,7 +162,7 @@ class HuberAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
     // constant features should not affect gradient
     def validateGradient(grad: Vector, gradFiltered: Vector): Unit = {
       assert(grad(0) === 0.0)
-      assert(grad(1) === gradFiltered(0))
+      assert(grad(1) ~== gradFiltered(0) relTol 0.01)
     }
 
     validateGradient(aggConstantFeature.gradient, aggConstantFeatureFiltered.gradient)

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/HuberAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/HuberAggregatorSuite.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml.optim.aggregator
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.feature.Instance
+import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors}
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+class HuberAggregatorSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  import DifferentiableLossAggregatorSuite.getRegressionSummarizers
+
+  @transient var instances: Array[Instance] = _
+  @transient var instancesConstantFeature: Array[Instance] = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    instances = Array(
+      Instance(0.0, 0.1, Vectors.dense(1.0, 2.0)),
+      Instance(1.0, 0.5, Vectors.dense(1.5, 1.0)),
+      Instance(2.0, 0.3, Vectors.dense(4.0, 0.5))
+    )
+    instancesConstantFeature = Array(
+      Instance(0.0, 0.1, Vectors.dense(1.0, 2.0)),
+      Instance(1.0, 0.5, Vectors.dense(1.0, 1.0)),
+      Instance(2.0, 0.3, Vectors.dense(1.0, 0.5))
+    )
+  }
+
+  /** Get summary statistics for some data and create a new HuberAggregator. */
+  private def getNewAggregator(
+      instances: Array[Instance],
+      parameters: Vector,
+      fitIntercept: Boolean,
+      m: Double): HuberAggregator = {
+    val (featuresSummarizer, _) = getRegressionSummarizers(instances)
+    val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
+    val bcFeaturesStd = spark.sparkContext.broadcast(featuresStd)
+    val bcParameters = spark.sparkContext.broadcast(parameters)
+    new HuberAggregator(fitIntercept, m, bcFeaturesStd)(bcParameters)
+  }
+
+  test("aggregator add method should check input size") {
+    val parameters = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    val agg = getNewAggregator(instances, parameters, fitIntercept = true, m = 1.35)
+    withClue("HuberAggregator features dimension must match parameters dimension") {
+      intercept[IllegalArgumentException] {
+        agg.add(Instance(1.0, 1.0, Vectors.dense(2.0)))
+      }
+    }
+  }
+
+  test("negative weight") {
+    val parameters = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    val agg = getNewAggregator(instances, parameters, fitIntercept = true, m = 1.35)
+    withClue("HuberAggregator does not support negative instance weights.") {
+      intercept[IllegalArgumentException] {
+        agg.add(Instance(1.0, -1.0, Vectors.dense(2.0, 1.0)))
+      }
+    }
+  }
+
+  test("check sizes") {
+    val paramWithIntercept = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    val paramWithoutIntercept = Vectors.dense(1.0, 2.0, 4.0)
+    val aggIntercept = getNewAggregator(instances, paramWithIntercept,
+      fitIntercept = true, m = 1.35)
+    val aggNoIntercept = getNewAggregator(instances, paramWithoutIntercept,
+      fitIntercept = false, m = 1.35)
+    instances.foreach(aggIntercept.add)
+    instances.foreach(aggNoIntercept.add)
+
+    assert(aggIntercept.gradient.size === 4)
+    assert(aggNoIntercept.gradient.size === 3)
+  }
+
+  test("check correctness") {
+    val parameters = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    val numFeatures = 2
+    val (featuresSummarizer, _) = getRegressionSummarizers(instances)
+    val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
+    val m = 1.35
+    val weightSum = instances.map(_.weight).sum
+
+    val agg = getNewAggregator(instances, parameters, fitIntercept = true, m)
+    instances.foreach(agg.add)
+
+    // compute expected loss sum
+    val coefficients = parameters.toArray.slice(0, 2)
+    val intercept = parameters(2)
+    val sigma = parameters(3)
+    val stdCoef = coefficients.indices.map(i => coefficients(i) / featuresStd(i)).toArray
+    val lossSum = instances.map { case Instance(label, weight, features) =>
+      val margin = BLAS.dot(Vectors.dense(stdCoef), features) + intercept
+      val linearLoss = label - margin
+      if (math.abs(linearLoss) <= sigma * m) {
+        weight * (sigma +  math.pow(linearLoss, 2.0) / sigma)
+      } else {
+        weight * (sigma + 2.0 * m * math.abs(linearLoss) - sigma * m * m)
+      }
+    }.sum
+    val loss = lossSum / weightSum
+
+    // compute expected gradients
+    val gradientCoef = new Array[Double](numFeatures + 2)
+    instances.foreach { case Instance(label, weight, features) =>
+      val margin = BLAS.dot(Vectors.dense(stdCoef), features) + intercept
+      val linearLoss = label - margin
+      if (math.abs(linearLoss) <= sigma * m) {
+        features.toArray.indices.foreach { i =>
+          gradientCoef(i) += weight * -2.0 * linearLoss / sigma * (features(i) / featuresStd(i))
+        }
+        gradientCoef(2) += weight * -2.0 * linearLoss / sigma
+        gradientCoef(3) += weight * (1.0 - math.pow(linearLoss / sigma, 2.0))
+      } else {
+        val sign = if (linearLoss >= 0) -1.0 else 1.0
+        features.toArray.indices.foreach { i =>
+          gradientCoef(i) += weight * sign * 2.0 * m * (features(i) / featuresStd(i))
+        }
+        gradientCoef(2) += weight * (sign * 2.0 * m)
+        gradientCoef(3) += weight * (1.0 - m * m)
+      }
+    }
+    val gradient = Vectors.dense(gradientCoef.map(_ / weightSum))
+
+    assert(loss ~== agg.loss relTol 0.01)
+    assert(gradient ~== agg.gradient relTol 0.01)
+  }
+
+  test("check with zero standard deviation") {
+    val parameters = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    val aggConstantFeature = getNewAggregator(instancesConstantFeature, parameters,
+      fitIntercept = true, m = 1.35)
+    instances.foreach(aggConstantFeature.add)
+    // constant features should not affect gradient
+    assert(aggConstantFeature.gradient(0) === 0.0)
+    assert(!aggConstantFeature.gradient(1).isNaN && !aggConstantFeature.gradient(1).isInfinity)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -285,6 +285,9 @@ class LinearRegressionSuite
     val model2 = trainer2.fit(datasetWithOutlier)
 
     /*
+      Using the following Python code to load the data and train the model using
+      scikit-learn package.
+
       import pandas as pd
       import numpy as np
       from sklearn.linear_model import HuberRegressor
@@ -298,8 +301,6 @@ class LinearRegressionSuite
       array([ 4.68998007,  7.19429011])
       >>> huber.intercept_
       6.3002404351083037
-      >>> huber.scale_
-      0.077810159205220747
      */
     val coefficientsPy = Vectors.dense(4.68998007, 7.19429011)
     val interceptPy = 6.30024044
@@ -368,6 +369,9 @@ class LinearRegressionSuite
     val model2 = trainer2.fit(datasetWithOutlier)
 
     /*
+      Using the following Python code to load the data and train the model using
+      scikit-learn package.
+
       import pandas as pd
       import numpy as np
       from sklearn.linear_model import HuberRegressor
@@ -381,8 +385,6 @@ class LinearRegressionSuite
       array([ 6.71756703,  5.08873222])
       >>> huber.intercept_
       0.0
-      >>> huber.scale_
-      2.5560209922722317
      */
     val coefficientsPy = Vectors.dense(6.71756703, 5.08873222)
     val interceptPy = 0.0
@@ -558,6 +560,9 @@ class LinearRegressionSuite
     val model = trainer.fit(datasetWithOutlier)
 
     /*
+      Using the following Python code to load the data and train the model using
+      scikit-learn package.
+
       import pandas as pd
       import numpy as np
       from sklearn.linear_model import HuberRegressor
@@ -571,8 +576,6 @@ class LinearRegressionSuite
       array([ 4.68836213,  7.19283181])
       >>> huber.intercept_
       6.2997900552575956
-      >>> huber.scale_
-      0.078078316418777688
      */
     val coefficientsPy = Vectors.dense(4.68836213, 7.19283181)
     val interceptPy = 6.29979006
@@ -640,6 +643,9 @@ class LinearRegressionSuite
     val model = trainer.fit(datasetWithOutlier)
 
     /*
+      Using the following Python code to load the data and train the model using
+      scikit-learn package.
+
       import pandas as pd
       import numpy as np
       from sklearn.linear_model import HuberRegressor
@@ -653,8 +659,6 @@ class LinearRegressionSuite
       array([ 6.65843427,  5.05270876])
       >>> huber.intercept_
       0.0
-      >>> huber.scale_
-      2.5699129758439119
      */
     val coefficientsPy = Vectors.dense(6.65843427, 5.05270876)
     val interceptPy = 0.0
@@ -1005,6 +1009,7 @@ class LinearRegressionSuite
       (1.0, 0.21, true, true)
     )
 
+    // For leastSquares loss
     for (solver <- Seq("auto", "l-bfgs", "normal");
          (elasticNetParam, regParam, fitIntercept, standardization) <- testParams) {
       val estimator = new LinearRegression()
@@ -1019,6 +1024,22 @@ class LinearRegressionSuite
         outlierRatio = 3)
       MLTestingUtils.testOversamplingVsWeighting[LinearRegressionModel, LinearRegression](
         datasetWithStrongNoise.as[LabeledPoint], estimator, modelEquals, seed)
+    }
+
+    // For huber loss
+    for ((_, regParam, fitIntercept, standardization) <- testParams) {
+      val estimator = new LinearRegression()
+        .setLoss("huber")
+        .setFitIntercept(fitIntercept)
+        .setStandardization(standardization)
+        .setRegParam(regParam)
+      MLTestingUtils.testArbitrarilyScaledWeights[LinearRegressionModel, LinearRegression](
+        datasetWithOutlier.as[LabeledPoint], estimator, modelEquals)
+      MLTestingUtils.testOutliersWithSmallWeights[LinearRegressionModel, LinearRegression](
+        datasetWithOutlier.as[LabeledPoint], estimator, numClasses, modelEquals,
+        outlierRatio = 3)
+      MLTestingUtils.testOversamplingVsWeighting[LinearRegressionModel, LinearRegression](
+        datasetWithOutlier.as[LabeledPoint], estimator, modelEquals, seed)
     }
   }
 
@@ -1171,6 +1192,15 @@ class LinearRegressionSuite
         assert(expected.coefficients === actual.coefficients)
       }
     }
+  }
+
+  test("huber loss model match leastSquares loss for large m") {
+    val trainer1 = new LinearRegression().setLoss("huber").setM(1E5)
+    val model1 = trainer1.fit(datasetWithOutlier)
+    val trainer2 = new LinearRegression()
+    val model2 = trainer2.fit(datasetWithOutlier)
+    assert(model1.coefficients ~== model2.coefficients relTol 1E-3)
+    assert(model1.intercept ~== model2.intercept relTol 1E-3)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -161,7 +161,7 @@ class LinearRegressionSuite
     assert(lir.getFitIntercept)
     assert(lir.getStandardization)
     assert(lir.getSolver === "auto")
-    assert(lir.getLoss === "leastSquares")
+    assert(lir.getLoss === "squaredError")
     assert(lir.getEpsilon === 1.35)
     val model = lir.fit(datasetWithDenseFeature)
 
@@ -869,7 +869,7 @@ class LinearRegressionSuite
       (1.0, 0.21, true, true)
     )
 
-    // For leastSquares loss
+    // For squaredError loss
     for (solver <- Seq("auto", "l-bfgs", "normal");
          (elasticNetParam, regParam, fitIntercept, standardization) <- testParams) {
       val estimator = new LinearRegression()
@@ -1211,7 +1211,7 @@ class LinearRegressionSuite
     assert(model2.intercept === interceptPy2)
   }
 
-  test("huber loss model match leastSquares loss for large m") {
+  test("huber loss model match squared error for large m") {
     val trainer1 = new LinearRegression().setLoss("huber").setEpsilon(1E5)
     val model1 = trainer1.fit(datasetWithOutlier)
     val trainer2 = new LinearRegression()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -178,6 +178,7 @@ class LinearRegressionSuite
     assert(model.getFeaturesCol === "features")
     assert(model.getPredictionCol === "prediction")
     assert(model.intercept !== 0.0)
+    assert(model.scale === 1.0)
     assert(model.hasParent)
     val numFeatures = datasetWithDenseFeature.select("features").first().getAs[Vector](0).size
     assert(model.numFeatures === numFeatures)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -161,6 +161,8 @@ class LinearRegressionSuite
     assert(lir.getFitIntercept)
     assert(lir.getStandardization)
     assert(lir.getSolver == "auto")
+    assert(lir.getLoss == "leastSquares")
+    assert(lir.getM == 1.35)
     val model = lir.fit(datasetWithDenseFeature)
 
     MLTestingUtils.checkCopyAndUids(lir, model)
@@ -179,6 +181,21 @@ class LinearRegressionSuite
     assert(model.hasParent)
     val numFeatures = datasetWithDenseFeature.select("features").first().getAs[Vector](0).size
     assert(model.numFeatures === numFeatures)
+  }
+
+  test("linear regression: illegal params") {
+    withClue("LinearRegression with huber loss only supports L2 regularization") {
+      intercept[IllegalArgumentException] {
+        new LinearRegression().setLoss("huber").setElasticNetParam(0.5)
+          .fit(datasetWithDenseFeature)
+      }
+    }
+
+    withClue("LinearRegression with huber loss doesn't support normal solver") {
+      intercept[IllegalArgumentException] {
+        new LinearRegression().setLoss("huber").setSolver("normal").fit(datasetWithDenseFeature)
+      }
+    }
   }
 
   test("linear regression handles singular matrices") {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -160,9 +160,9 @@ class LinearRegressionSuite
     assert(lir.getElasticNetParam === 0.0)
     assert(lir.getFitIntercept)
     assert(lir.getStandardization)
-    assert(lir.getSolver == "auto")
-    assert(lir.getLoss == "leastSquares")
-    assert(lir.getM == 1.35)
+    assert(lir.getSolver === "auto")
+    assert(lir.getLoss === "leastSquares")
+    assert(lir.getM === 1.35)
     val model = lir.fit(datasetWithDenseFeature)
 
     MLTestingUtils.checkCopyAndUids(lir, model)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -275,44 +275,6 @@ class LinearRegressionSuite
     }
   }
 
-  test("linear regression (huber loss) with intercept without regularization") {
-    val trainer1 = (new LinearRegression).setLoss("huber")
-      .setFitIntercept(true).setStandardization(true)
-    val trainer2 = (new LinearRegression).setLoss("huber")
-      .setFitIntercept(true).setStandardization(false)
-
-    val model1 = trainer1.fit(datasetWithOutlier)
-    val model2 = trainer2.fit(datasetWithOutlier)
-
-    /*
-      Using the following Python code to load the data and train the model using
-      scikit-learn package.
-
-      import pandas as pd
-      import numpy as np
-      from sklearn.linear_model import HuberRegressor
-      df = pd.read_csv("path", header = None)
-      X = df[df.columns[1:3]]
-      y = np.array(df[df.columns[0]])
-      huber = HuberRegressor(fit_intercept=True, alpha=0.0, max_iter=100, epsilon=1.35)
-      huber.fit(X, y)
-
-      >>> huber.coef_
-      array([ 4.68998007,  7.19429011])
-      >>> huber.intercept_
-      6.3002404351083037
-     */
-    val coefficientsPy = Vectors.dense(4.68998007, 7.19429011)
-    val interceptPy = 6.30024044
-
-    assert(model1.coefficients ~= coefficientsPy relTol 1E-3)
-    assert(model1.intercept ~== interceptPy relTol 1E-3)
-
-    // Without regularization, with or without standardization will converge to the same solution.
-    assert(model2.coefficients ~= coefficientsPy relTol 1E-3)
-    assert(model2.intercept ~== interceptPy relTol 1E-3)
-  }
-
   test("linear regression without intercept without regularization") {
     Seq("auto", "l-bfgs", "normal").foreach { solver =>
       val trainer1 = (new LinearRegression).setFitIntercept(false).setSolver(solver)
@@ -357,44 +319,6 @@ class LinearRegressionSuite
       assert(modelWithoutIntercept2.intercept ~== 0 absTol 1E-3)
       assert(modelWithoutIntercept2.coefficients ~= coefficientsWithoutInterceptR relTol 1E-3)
     }
-  }
-
-  test("linear regression (huber loss) without intercept without regularization") {
-    val trainer1 = (new LinearRegression).setLoss("huber")
-      .setFitIntercept(false).setStandardization(true)
-    val trainer2 = (new LinearRegression).setLoss("huber")
-      .setFitIntercept(false).setStandardization(false)
-
-    val model1 = trainer1.fit(datasetWithOutlier)
-    val model2 = trainer2.fit(datasetWithOutlier)
-
-    /*
-      Using the following Python code to load the data and train the model using
-      scikit-learn package.
-
-      import pandas as pd
-      import numpy as np
-      from sklearn.linear_model import HuberRegressor
-      df = pd.read_csv("path", header = None)
-      X = df[df.columns[1:3]]
-      y = np.array(df[df.columns[0]])
-      huber = HuberRegressor(fit_intercept=False, alpha=0.0, max_iter=100, epsilon=1.35)
-      huber.fit(X, y)
-
-      >>> huber.coef_
-      array([ 6.71756703,  5.08873222])
-      >>> huber.intercept_
-      0.0
-     */
-    val coefficientsPy = Vectors.dense(6.71756703, 5.08873222)
-    val interceptPy = 0.0
-
-    assert(model1.coefficients ~= coefficientsPy relTol 1E-3)
-    assert(model1.intercept === interceptPy)
-
-    // Without regularization, with or without standardization will converge to the same solution.
-    assert(model2.coefficients ~= coefficientsPy relTol 1E-3)
-    assert(model2.intercept === interceptPy)
   }
 
   test("linear regression with intercept with L1 regularization") {
@@ -552,38 +476,6 @@ class LinearRegressionSuite
     }
   }
 
-  test("linear regression (huber loss) with intercept with L2 regularization") {
-    // Since Python scikit-learn does not support standardization, we can not compare that case.
-    val trainer = (new LinearRegression).setLoss("huber")
-      .setFitIntercept(true).setRegParam(2.1 / 1000).setStandardization(false)
-
-    val model = trainer.fit(datasetWithOutlier)
-
-    /*
-      Using the following Python code to load the data and train the model using
-      scikit-learn package.
-
-      import pandas as pd
-      import numpy as np
-      from sklearn.linear_model import HuberRegressor
-      df = pd.read_csv("path", header = None)
-      X = df[df.columns[1:3]]
-      y = np.array(df[df.columns[0]])
-      huber = HuberRegressor(fit_intercept=True, alpha=2.1, max_iter=100, epsilon=1.35)
-      huber.fit(X, y)
-
-      >>> huber.coef_
-      array([ 4.68836213,  7.19283181])
-      >>> huber.intercept_
-      6.2997900552575956
-     */
-    val coefficientsPy = Vectors.dense(4.68836213, 7.19283181)
-    val interceptPy = 6.29979006
-
-    assert(model.coefficients ~= coefficientsPy relTol 1E-3)
-    assert(model.intercept ~== interceptPy relTol 1E-3)
-  }
-
   test("linear regression without intercept with L2 regularization") {
     Seq("auto", "l-bfgs", "normal").foreach { solver =>
       val trainer1 = (new LinearRegression).setElasticNetParam(0.0).setRegParam(2.3)
@@ -633,38 +525,6 @@ class LinearRegressionSuite
           assert(prediction1 ~== prediction2 relTol 1E-5)
       }
     }
-  }
-
-  test("linear regression (huber loss) without intercept with L2 regularization") {
-    // Since Python scikit-learn does not support standardization, we can not compare that case.
-    val trainer = (new LinearRegression).setLoss("huber")
-      .setFitIntercept(false).setRegParam(2.1 / 1000).setStandardization(false)
-
-    val model = trainer.fit(datasetWithOutlier)
-
-    /*
-      Using the following Python code to load the data and train the model using
-      scikit-learn package.
-
-      import pandas as pd
-      import numpy as np
-      from sklearn.linear_model import HuberRegressor
-      df = pd.read_csv("path", header = None)
-      X = df[df.columns[1:3]]
-      y = np.array(df[df.columns[0]])
-      huber = HuberRegressor(fit_intercept=False, alpha=2.1, max_iter=100, epsilon=1.35)
-      huber.fit(X, y)
-
-      >>> huber.coef_
-      array([ 6.65843427,  5.05270876])
-      >>> huber.intercept_
-      0.0
-     */
-    val coefficientsPy = Vectors.dense(6.65843427, 5.05270876)
-    val interceptPy = 0.0
-
-    assert(model.coefficients ~= coefficientsPy relTol 1E-3)
-    assert(model.intercept === interceptPy)
   }
 
   test("linear regression with intercept with ElasticNet regularization") {
@@ -1192,6 +1052,163 @@ class LinearRegressionSuite
         assert(expected.coefficients === actual.coefficients)
       }
     }
+  }
+
+  test("linear regression (huber loss) with intercept without regularization") {
+    val trainer1 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(true).setStandardization(true)
+    val trainer2 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(true).setStandardization(false)
+
+    val model1 = trainer1.fit(datasetWithOutlier)
+    val model2 = trainer2.fit(datasetWithOutlier)
+
+    /*
+      Using the following Python code to load the data and train the model using
+      scikit-learn package.
+
+      import pandas as pd
+      import numpy as np
+      from sklearn.linear_model import HuberRegressor
+      df = pd.read_csv("path", header = None)
+      X = df[df.columns[1:3]]
+      y = np.array(df[df.columns[0]])
+      huber = HuberRegressor(fit_intercept=True, alpha=0.0, max_iter=100, epsilon=1.35)
+      huber.fit(X, y)
+
+      >>> huber.coef_
+      array([ 4.68998007,  7.19429011])
+      >>> huber.intercept_
+      6.3002404351083037
+     */
+    val coefficientsPy = Vectors.dense(4.68998007, 7.19429011)
+    val interceptPy = 6.30024044
+
+    assert(model1.coefficients ~= coefficientsPy relTol 1E-3)
+    assert(model1.intercept ~== interceptPy relTol 1E-3)
+
+    // Without regularization, with or without standardization will converge to the same solution.
+    assert(model2.coefficients ~= coefficientsPy relTol 1E-3)
+    assert(model2.intercept ~== interceptPy relTol 1E-3)
+  }
+
+  test("linear regression (huber loss) without intercept without regularization") {
+    val trainer1 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(false).setStandardization(true)
+    val trainer2 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(false).setStandardization(false)
+
+    val model1 = trainer1.fit(datasetWithOutlier)
+    val model2 = trainer2.fit(datasetWithOutlier)
+
+    /*
+      huber = HuberRegressor(fit_intercept=False, alpha=0.0, max_iter=100, epsilon=1.35)
+      huber.fit(X, y)
+
+      >>> huber.coef_
+      array([ 6.71756703,  5.08873222])
+      >>> huber.intercept_
+      0.0
+     */
+    val coefficientsPy = Vectors.dense(6.71756703, 5.08873222)
+    val interceptPy = 0.0
+
+    assert(model1.coefficients ~= coefficientsPy relTol 1E-3)
+    assert(model1.intercept === interceptPy)
+
+    // Without regularization, with or without standardization will converge to the same solution.
+    assert(model2.coefficients ~= coefficientsPy relTol 1E-3)
+    assert(model2.intercept === interceptPy)
+  }
+
+  test("linear regression (huber loss) with intercept with L2 regularization") {
+    val trainer1 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(true).setRegParam(0.21).setStandardization(true)
+    val trainer2 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(true).setRegParam(0.21).setStandardization(false)
+
+    val model1 = trainer1.fit(datasetWithOutlier)
+    val model2 = trainer2.fit(datasetWithOutlier)
+
+    /*
+      Since scikit-learn HuberRegressor does not support standardization,
+      we do it manually out of the estimator.
+
+      xStd = np.std(X, axis=0)
+      scaledX = X / xStd
+      huber = HuberRegressor(fit_intercept=True, alpha=210, max_iter=100, epsilon=1.35)
+      huber.fit(scaledX, y)
+
+      >>> np.array(huber.coef_ / xStd)
+      array([ 1.97732633,  3.38816722])
+      >>> huber.intercept_
+      3.7527581430531227
+     */
+    val coefficientsPy1 = Vectors.dense(1.97732633, 3.38816722)
+    val interceptPy1 = 3.75275814
+
+    assert(model1.coefficients ~= coefficientsPy1 relTol 1E-2)
+    assert(model1.intercept ~== interceptPy1 relTol 1E-2)
+
+    /*
+      huber = HuberRegressor(fit_intercept=True, alpha=210, max_iter=100, epsilon=1.35)
+      huber.fit(X, y)
+
+      >>> huber.coef_
+      array([ 1.73346444,  3.63746999])
+      >>> huber.intercept_
+      4.3017134790781739
+     */
+    val coefficientsPy2 = Vectors.dense(1.73346444, 3.63746999)
+    val interceptPy2 = 4.30171347
+
+    assert(model2.coefficients ~= coefficientsPy2 relTol 1E-3)
+    assert(model2.intercept ~== interceptPy2 relTol 1E-3)
+  }
+
+  test("linear regression (huber loss) without intercept with L2 regularization") {
+    val trainer1 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(false).setRegParam(0.21).setStandardization(true)
+    val trainer2 = (new LinearRegression).setLoss("huber")
+      .setFitIntercept(false).setRegParam(0.21).setStandardization(false)
+
+    val model1 = trainer1.fit(datasetWithOutlier)
+    val model2 = trainer2.fit(datasetWithOutlier)
+
+    /*
+      Since scikit-learn HuberRegressor does not support standardization,
+      we do it manually out of the estimator.
+
+      xStd = np.std(X, axis=0)
+      scaledX = X / xStd
+      huber = HuberRegressor(fit_intercept=False, alpha=210, max_iter=100, epsilon=1.35)
+      huber.fit(scaledX, y)
+
+      >>> np.array(huber.coef_ / xStd)
+      array([ 2.59679008,  2.26973102])
+      >>> huber.intercept_
+      0.0
+     */
+    val coefficientsPy1 = Vectors.dense(2.59679008, 2.26973102)
+    val interceptPy1 = 0.0
+
+    assert(model1.coefficients ~= coefficientsPy1 relTol 1E-2)
+    assert(model1.intercept === interceptPy1)
+
+    /*
+      huber = HuberRegressor(fit_intercept=False, alpha=210, max_iter=100, epsilon=1.35)
+      huber.fit(X, y)
+
+      >>> huber.coef_
+      array([ 2.28423908,  2.25196887])
+      >>> huber.intercept_
+      0.0
+     */
+    val coefficientsPy2 = Vectors.dense(2.28423908, 2.25196887)
+    val interceptPy2 = 0.0
+
+    assert(model2.coefficients ~= coefficientsPy2 relTol 1E-3)
+    assert(model2.intercept === interceptPy2)
   }
 
   test("huber loss model match leastSquares loss for large m") {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -1080,16 +1080,21 @@ class LinearRegressionSuite
       array([ 4.68998007,  7.19429011])
       >>> huber.intercept_
       6.3002404351083037
+      >>> huber.scale_
+      0.077810159205220747
      */
     val coefficientsPy = Vectors.dense(4.68998007, 7.19429011)
     val interceptPy = 6.30024044
+    val scalePy = 0.07781016
 
     assert(model1.coefficients ~= coefficientsPy relTol 1E-3)
     assert(model1.intercept ~== interceptPy relTol 1E-3)
+    assert(model1.scale ~== scalePy relTol 1E-3)
 
     // Without regularization, with or without standardization will converge to the same solution.
     assert(model2.coefficients ~= coefficientsPy relTol 1E-3)
     assert(model2.intercept ~== interceptPy relTol 1E-3)
+    assert(model2.scale ~== scalePy relTol 1E-3)
   }
 
   test("linear regression (huber loss) without intercept without regularization") {
@@ -1109,16 +1114,21 @@ class LinearRegressionSuite
       array([ 6.71756703,  5.08873222])
       >>> huber.intercept_
       0.0
+      >>> huber.scale_
+      2.5560209922722317
      */
     val coefficientsPy = Vectors.dense(6.71756703, 5.08873222)
     val interceptPy = 0.0
+    val scalePy = 2.55602099
 
     assert(model1.coefficients ~= coefficientsPy relTol 1E-3)
     assert(model1.intercept === interceptPy)
+    assert(model1.scale ~== scalePy relTol 1E-3)
 
     // Without regularization, with or without standardization will converge to the same solution.
     assert(model2.coefficients ~= coefficientsPy relTol 1E-3)
     assert(model2.intercept === interceptPy)
+    assert(model2.scale ~== scalePy relTol 1E-3)
   }
 
   test("linear regression (huber loss) with intercept with L2 regularization") {
@@ -1143,12 +1153,16 @@ class LinearRegressionSuite
       array([ 1.97732633,  3.38816722])
       >>> huber.intercept_
       3.7527581430531227
+      >>> huber.scale_
+      3.787363673371801
      */
     val coefficientsPy1 = Vectors.dense(1.97732633, 3.38816722)
     val interceptPy1 = 3.75275814
+    val scalePy1 = 3.78736367
 
     assert(model1.coefficients ~= coefficientsPy1 relTol 1E-2)
     assert(model1.intercept ~== interceptPy1 relTol 1E-2)
+    assert(model1.scale ~== scalePy1 relTol 1E-2)
 
     /*
       huber = HuberRegressor(fit_intercept=True, alpha=210, max_iter=100, epsilon=1.35)
@@ -1158,12 +1172,16 @@ class LinearRegressionSuite
       array([ 1.73346444,  3.63746999])
       >>> huber.intercept_
       4.3017134790781739
+      >>> huber.scale_
+      3.6472742809286793
      */
     val coefficientsPy2 = Vectors.dense(1.73346444, 3.63746999)
     val interceptPy2 = 4.30171347
+    val scalePy2 = 3.64727428
 
     assert(model2.coefficients ~= coefficientsPy2 relTol 1E-3)
     assert(model2.intercept ~== interceptPy2 relTol 1E-3)
+    assert(model2.scale ~== scalePy2 relTol 1E-3)
   }
 
   test("linear regression (huber loss) without intercept with L2 regularization") {
@@ -1188,12 +1206,16 @@ class LinearRegressionSuite
       array([ 2.59679008,  2.26973102])
       >>> huber.intercept_
       0.0
+      >>> huber.scale_
+      4.5766311924091791
      */
     val coefficientsPy1 = Vectors.dense(2.59679008, 2.26973102)
     val interceptPy1 = 0.0
+    val scalePy1 = 4.57663119
 
     assert(model1.coefficients ~= coefficientsPy1 relTol 1E-2)
     assert(model1.intercept === interceptPy1)
+    assert(model1.scale ~== scalePy1 relTol 1E-2)
 
     /*
       huber = HuberRegressor(fit_intercept=False, alpha=210, max_iter=100, epsilon=1.35)
@@ -1203,12 +1225,16 @@ class LinearRegressionSuite
       array([ 2.28423908,  2.25196887])
       >>> huber.intercept_
       0.0
+      >>> huber.scale_
+      4.5979643506051753
      */
     val coefficientsPy2 = Vectors.dense(2.28423908, 2.25196887)
     val interceptPy2 = 0.0
+    val scalePy2 = 4.59796435
 
     assert(model2.coefficients ~= coefficientsPy2 relTol 1E-3)
     assert(model2.intercept === interceptPy2)
+    assert(model2.scale ~== scalePy2 relTol 1E-3)
   }
 
   test("huber loss model match squared error for large m") {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -1237,7 +1237,7 @@ class LinearRegressionSuite
     assert(model2.scale ~== scalePy2 relTol 1E-3)
   }
 
-  test("huber loss model match squared error for large m") {
+  test("huber loss model match squared error for large epsilon") {
     val trainer1 = new LinearRegression().setLoss("huber").setEpsilon(1E5)
     val model1 = trainer1.fit(datasetWithOutlier)
     val trainer2 = new LinearRegression()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -162,7 +162,7 @@ class LinearRegressionSuite
     assert(lir.getStandardization)
     assert(lir.getSolver === "auto")
     assert(lir.getLoss === "leastSquares")
-    assert(lir.getM === 1.35)
+    assert(lir.getEpsilon === 1.35)
     val model = lir.fit(datasetWithDenseFeature)
 
     MLTestingUtils.checkCopyAndUids(lir, model)
@@ -1212,7 +1212,7 @@ class LinearRegressionSuite
   }
 
   test("huber loss model match leastSquares loss for large m") {
-    val trainer1 = new LinearRegression().setLoss("huber").setM(1E5)
+    val trainer1 = new LinearRegression().setLoss("huber").setEpsilon(1E5)
     val model1 = trainer1.fit(datasetWithOutlier)
     val trainer2 = new LinearRegression()
     val model2 = trainer2.fit(datasetWithOutlier)

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -1065,6 +1065,11 @@ object MimaExcludes {
       // [SPARK-21680][ML][MLLIB]optimzie Vector coompress
       ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.mllib.linalg.Vector.toSparseWithSize"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.linalg.Vector.toSparseWithSize")
+    ) ++ Seq(
+      // [SPARK-3181][ML]Implement huber loss for LinearRegression.
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.param.shared.HasLoss.org$apache$spark$ml$param$shared$HasLoss$_setter_$loss_="),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.param.shared.HasLoss.getLoss"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.param.shared.HasLoss.loss")
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
MLlib ```LinearRegression``` supports _huber_ loss addition to _leastSquares_ loss. The huber loss objective function is:
![image](https://user-images.githubusercontent.com/1962026/29554124-9544d198-8750-11e7-8afa-33579ec419d5.png)
Refer Eq.(6) and Eq.(8) in [A robust hybrid of lasso and ridge regression](http://statweb.stanford.edu/~owen/reports/hhu.pdf). This objective is jointly convex as a function of (w, σ) ∈ R × (0,∞), we can use L-BFGS-B to solve it.

The current implementation is a straight forward porting for Python scikit-learn [```HuberRegressor```](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.HuberRegressor.html). There are some differences:
* We use mean loss (```lossSum/weightSum```), but sklearn uses total loss (```lossSum```).
* We multiply the loss function and L2 regularization by 1/2. It does not affect the result if we multiply the whole formula by a factor, we just keep consistent with _leastSquares_ loss.

So if fitting w/o regularization, MLlib and sklearn produce the same output. If fitting w/ regularization, MLlib should set ```regParam``` divide by the number of instances to match the output of sklearn.

## How was this patch tested?
Unit tests.