### PR TITLE
[SPARK-21817][SQL] Pass FSPermission to LocatedFileStatus from InMemoryFileIndex

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -297,7 +297,7 @@ object InMemoryFileIndex extends Logging {
         // subprocess and parse the stdout).
         val locations = fs.getFileBlockLocations(f, 0, f.getLen)
         val lfs = new LocatedFileStatus(f.getLen, f.isDirectory, f.getReplication, f.getBlockSize,
-          f.getModificationTime, 0, null, null, null, null, f.getPath, locations)
+          f.getModificationTime, 0, f.getPermission, null, null, null, f.getPath, locations)
         if (f.isSymlink) {
           lfs.setSymlink(f.getSymlink)
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pass `FSPermission` to `LocatedFileStatus` as `Hadoop-3.0.0` will use this to pull out the ACL and other information. In 2.6, the API is available to pass in the `FSPermission` but it is not explicitly used. So the `InMemoryFileIndex` was passing `null`

## How was this patch tested?
This was tested using integration tests [here](https://github.com/hortonworks-spark/cloud-integration).
