### PR TITLE
[SPARK-21822][SQL]When insert Hive Table is finished, it is better to clean out the tmpLocation dir

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -435,6 +435,18 @@ case class InsertIntoHiveTable(
         logWarning(s"Unable to delete staging directory: $stagingDir.\n" + e)
     }
 
+    //delete the tmpLocation dir
+    try {
+      val fs = tmpLocation.getFileSystem(hadoopConf)
+      if (fs.delete(tmpLocation, true)) {
+        // If we successfully delete the tmpLocation dir, remove it from FileSystem's cache.
+        fs.cancelDeleteOnExit(tmpLocation)
+      }
+    } catch {
+      case NonFatal(e) =>
+        logWarning(s"Unable to delete tmpLocation directory:" + tmpLocation.toString + "\n" + e)
+    }
+
     // un-cache this table.
     sparkSession.catalog.uncacheTable(table.identifier.quotedString)
     sparkSession.sessionState.catalog.refreshTable(table.identifier)


### PR DESCRIPTION

## What changes were proposed in this pull request?

When insert Hive Table is finished, it is better to clean out the tmpLocation dir(the temp directories like ".hive-staging_hive_2017-08-19_10-56-01_540_5448395226195533570-9/-ext-10000" or "/tmp/hive/..." for an old spark version).
Otherwise, when lots of spark job are executed, millions of temporary directories are left in HDFS. And these temporary directories can only be deleted by the maintainer through the shell script.

## How was this patch tested?

