### PR TITLE
SPARK-21825: change Set(5, 3) to Seq(5, 3, 5) & Set(2, 3) to Seq(2, 2, 2, 3) in Ex…

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
@@ -421,7 +421,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
 
           case None =>
             assert(exchanges.forall(_.coordinator.isDefined))
-            assert(exchanges.map(_.outputPartitioning.numPartitions).toSet === Set(2, 3))
+            assert(exchanges.map(_.outputPartitioning.numPartitions).toSeq === Seq(2, 2, 2, 3))
         }
       }
 
@@ -473,7 +473,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
 
           case None =>
             assert(exchanges.forall(_.coordinator.isDefined))
-            assert(exchanges.map(_.outputPartitioning.numPartitions).toSet === Set(5, 3))
+            assert(exchanges.map(_.outputPartitioning.numPartitions).toSeq === Seq(5, 3, 5))
         }
       }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?
ExchangeCoordinatorSuite.scala
Line 424: assert(exchanges.map(_.outputPartitioning.numPartitions).toSet === Set(2, 3)) is not so precisely.
change to 
 assert(exchanges.map(_.outputPartitioning.numPartitions).toSeq === Seq(2, 2, 2, 3))

Line 476:             assert(exchanges.map(_.outputPartitioning.numPartitions).toSet === Set(5, 3)) is not so precisely.
change to 
            assert(exchanges.map(_.outputPartitioning.numPartitions).toSeq === Seq(5, 3, 5))
## How was this patch tested?
run ExchangeCoordinatorSuite unit tests. 


Please review http://spark.apache.org/contributing.html before opening a pull request.
