### PR TITLE
[SPARK-21829][CORE] Enable config to permanently blacklist a list of nodes

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -154,6 +154,11 @@ package object config {
     ConfigBuilder("spark.blacklist.application.fetchFailure.enabled")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val BLACKLIST_ALWAYSBLACKLISTEDNODES_CONF =
+    ConfigBuilder("spark.blacklist.alwaysBlacklistedNodes")
+      .stringConf
+      .createOptional
   // End blacklist confs
 
   private[spark] val UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE =

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -97,8 +97,7 @@ private[scheduler] class BlacklistTracker (
    * Blacklists permanently the nodes listed in spark.blacklist.alwaysBlacklistedNodes
    * The blacklist timeout is set to a large value, effectively never expiring.
    */
-  private val permanentlyBlacklistedNodes: Seq[String] =
-    conf.get("spark.blacklist.alwaysBlacklistedNodes", "").split(',').map(_.trim).filter(_ != "")
+  private val permanentlyBlacklistedNodes = BlacklistTracker.getBlacklistedNodes(conf)
   if (permanentlyBlacklistedNodes.nonEmpty) {
     val now = clock.getTimeMillis()
     for (nodeName <- permanentlyBlacklistedNodes) {
@@ -422,6 +421,15 @@ private[scheduler] object BlacklistTracker extends Logging {
       conf.get(config.BLACKLIST_LEGACY_TIMEOUT_CONF).getOrElse {
         Utils.timeStringAsMs(DEFAULT_TIMEOUT)
       }
+    }
+  }
+
+  // Return a set of node names from the config spark.blacklist.alwaysBlacklistedNodes
+  def getBlacklistedNodes(conf: SparkConf): Set[String] = {
+    val listNodes = conf.get(config.BLACKLIST_ALWAYSBLACKLISTEDNODES_CONF)
+    listNodes match {
+      case Some(nodes) => (nodes + ",").split(',').map(_.trim).toSet
+      case None => Set()
     }
   }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1529,6 +1529,17 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.blacklist.alwaysBlacklistedNodes</code></td>
+  <td>(none)</td>
+  <td>
+    A comma-separated list of cluster nodes that will be put in the scheduler blacklist at the start of the Spark Context.
+    These nodes are permanently blacklisted and are exempt from the spark.blacklist.timeout mechanism.
+    If the cluster manager allocates executors on nodes in the blacklist, they will be rejected by the scheduler.
+    This feature can be used to prevent running executors/tasks on a user-specified list of cluster nodes.
+    Dependency: requires spark.blacklist.enabled=true
+  </td>
+</tr>
+<tr>
   <td><code>spark.speculation</code></td>
   <td>false</td>
   <td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

With this new feature I propose to introduce a mechanism to allow users to specify a list of nodes in the cluster where executors/tasks should not run for a specific job.
The proposed implementation that I tested (see PR) uses the Spark blacklist mechanism. With the parameter spark.blacklist.alwaysBlacklistedNodes, a list of user-specified nodes is added to the blacklist at the start of the Spark Context and it is never expired. 
I have tested this on a YARN cluster on a case taken from the original production problem and I confirm a performance improvement of about 5x for the specific test case I have. I imagine that there can be other cases where Spark users may want to blacklist a set of nodes. This can be used for troubleshooting, including cases where certain nodes/executors are slow for a given workload and this is caused by external agents, so the anomaly is not picked up by the cluster manager.
See also SPARK-21829

## How was this patch tested?

A test has been added to the BlackListTrackerSuite.
The patch has also been successfully tested manually on a YARN cluster.
