### PR TITLE
[WEB-UI]Add the 'master' column to identify the type of resource management for the spark job, in the history server web ui.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -29,6 +29,11 @@
           App Name
         </span>
       </th>
+      <th>
+        <span data-toggle="tooltip" data-placement="top" title="Master of the application.">
+          Master
+        </span>
+       </th>
       {{#hasMultipleAttempts}}
       <th>
         <span data-toggle="tooltip" data-placement="top" title="The attempt ID of this application since one application might be launched several times">
@@ -75,6 +80,7 @@
       <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}><span title="{{id}}"><a href="{{uiroot}}/history/{{id}}/{{num}}/jobs/">{{id}}</a></span></td>
       <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}>{{name}}</td>
       {{#attempts}}
+      <td>{{master}}</td>
       {{#hasMultipleAttempts}}
       <td><a href="{{uiroot}}/history/{{id}}/{{attemptId}}/jobs/">{{attemptId}}</a></td>
       {{/hasMultipleAttempts}}

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -136,6 +136,16 @@ $(document).ready(function() {
             (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "logs";
           attempt["durationMillisec"] = attempt["duration"];
           attempt["duration"] = formatDuration(attempt["duration"]);
+          var idStr = id.toString();
+          if(idStr.indexOf("application_") > -1) {
+            attempt["master"] = "yarn";
+          } else if(idStr.indexOf("app-") > -1) {
+            attempt["master"] = "standalone";
+          } else if(idStr.indexOf("local-") > -1) {
+            attempt["master"] = "local";
+          } else {
+            attempt["master"] = "mesos";
+          }
           var app_clone = {"id" : id, "name" : name, "num" : num, "attempts" : [attempt]};
           array.push(app_clone);
         }
@@ -163,6 +173,7 @@ $(document).ready(function() {
           "columns": [
             {name: 'appId', type: "appid-numeric"},
             {name: 'appName'},
+            {name: 'master'},
             {name: attemptIdColumnName},
             {name: startedColumnName},
             {name: completedColumnName},


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add the 'master' column to identify the type of resource management for the spark job, in the history server web ui.

such as:
      --master yarn, which means that the resource type of the blurs job is yarn.
      --master ip: 7077, that the spark resource management type is standalone.
      --master local, which indicates that the resource type of the blurs job is local.

Screenshots are as follows:
![1](https://user-images.githubusercontent.com/26266482/29700661-329e3516-8999-11e7-8ebc-479b7986c489.png)

(Please fill in changes proposed in this fix)

## How was this patch tested?

manual tests
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
