### PR TITLE
[SPARK-18067] Avoid shuffling child if join keys are superset of child's partitioning keys

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -225,21 +225,23 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
            && muchSmaller(right, left) ||
            !RowOrdering.isOrderable(leftKeys) =>
         Seq(joins.ShuffledHashJoinExec(
-          leftKeys, rightKeys, joinType, BuildRight, condition, planLater(left), planLater(right)))
+          leftKeys, rightKeys, leftKeys, rightKeys, joinType, BuildRight, condition,
+          planLater(left), planLater(right)))
 
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
          if !conf.preferSortMergeJoin && canBuildLeft(joinType) && canBuildLocalHashMap(left)
            && muchSmaller(left, right) ||
            !RowOrdering.isOrderable(leftKeys) =>
         Seq(joins.ShuffledHashJoinExec(
-          leftKeys, rightKeys, joinType, BuildLeft, condition, planLater(left), planLater(right)))
+          leftKeys, rightKeys, leftKeys, rightKeys, joinType, BuildLeft, condition, planLater(left),
+          planLater(right)))
 
       // --- SortMergeJoin ------------------------------------------------------------
 
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
         if RowOrdering.isOrderable(leftKeys) =>
-        joins.SortMergeJoinExec(
-          leftKeys, rightKeys, joinType, condition, planLater(left), planLater(right)) :: Nil
+        joins.SortMergeJoinExec(leftKeys, rightKeys, leftKeys, rightKeys, joinType, condition,
+          planLater(left), planLater(right)) :: Nil
 
       // --- Without joining keys ------------------------------------------------------------
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 case class ShuffledHashJoinExec(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
+    leftDistributionKeys: Seq[Expression],
+    rightDistributionKeys: Seq[Expression],
     joinType: JoinType,
     buildSide: BuildSide,
     condition: Option[Expression],
@@ -46,7 +48,9 @@ case class ShuffledHashJoinExec(
     "avgHashProbe" -> SQLMetrics.createAverageMetric(sparkContext, "avg hash probe"))
 
   override def requiredChildDistribution: Seq[Distribution] =
-    HashClusteredDistribution(leftKeys) :: HashClusteredDistribution(rightKeys) :: Nil
+    HashClusteredDistribution(leftDistributionKeys) ::
+      HashClusteredDistribution(rightDistributionKeys) ::
+      Nil
 
   private def buildHashedRelation(iter: Iterator[InternalRow]): HashedRelation = {
     val buildDataSize = longMetric("buildDataSize")

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -836,8 +836,8 @@ class JoinSuite extends QueryTest with SharedSQLContext {
 
       joinPairs.foreach {
         case(join1, join2) =>
-          val leftKeys = join1.leftKeys
-          val rightKeys = join1.rightKeys
+          val leftKeys = join1.leftJoinKeys
+          val rightKeys = join1.rightJoinKeys
           val outputOrderingPhysical = join1.outputOrdering
           val outputOrderingExecuted = join2.outputOrdering
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -422,6 +422,8 @@ class PlannerSuite extends SharedSQLContext {
     val inputPlan = SortMergeJoinExec(
       Literal(1) :: Nil,
       Literal(1) :: Nil,
+      Literal(1) :: Nil,
+      Literal(1) :: Nil,
       Inner,
       None,
       shuffle,
@@ -437,6 +439,8 @@ class PlannerSuite extends SharedSQLContext {
 
     // nested exchanges
     val inputPlan2 = SortMergeJoinExec(
+      Literal(1) :: Nil,
+      Literal(1) :: Nil,
       Literal(1) :: Nil,
       Literal(1) :: Nil,
       Inner,
@@ -496,7 +500,9 @@ class PlannerSuite extends SharedSQLContext {
 
   test("EnsureRequirements skips sort when either side of join keys is required after inner SMJ") {
     Seq(Inner, Cross).foreach { joinType =>
-      val innerSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, joinType, None, planA, planB)
+      val innerSmj =
+        SortMergeJoinExec(exprA :: Nil, exprB :: Nil, exprA :: Nil, exprB :: Nil, joinType, None,
+          planA, planB)
       // Both left and right keys should be sorted after the SMJ.
       Seq(orderingA, orderingB).foreach { ordering =>
         assertSortRequirementsAreSatisfied(
@@ -510,8 +516,13 @@ class PlannerSuite extends SharedSQLContext {
   test("EnsureRequirements skips sort when key order of a parent SMJ is propagated from its " +
     "child SMJ") {
     Seq(Inner, Cross).foreach { joinType =>
-      val childSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, joinType, None, planA, planB)
-      val parentSmj = SortMergeJoinExec(exprB :: Nil, exprC :: Nil, joinType, None, childSmj, planC)
+      val childSmj =
+        SortMergeJoinExec(exprA :: Nil, exprB :: Nil, exprA :: Nil, exprB :: Nil, joinType, None,
+          planA, planB)
+
+      val parentSmj =
+        SortMergeJoinExec(exprB :: Nil, exprC :: Nil, exprB :: Nil, exprC :: Nil, joinType, None,
+          childSmj, planC)
       // After the second SMJ, exprA, exprB and exprC should all be sorted.
       Seq(orderingA, orderingB, orderingC).foreach { ordering =>
         assertSortRequirementsAreSatisfied(
@@ -524,7 +535,8 @@ class PlannerSuite extends SharedSQLContext {
 
   test("EnsureRequirements for sort operator after left outer sort merge join") {
     // Only left key is sorted after left outer SMJ (thus doesn't need a sort).
-    val leftSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, LeftOuter, None, planA, planB)
+    val leftSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, exprA :: Nil, exprB :: Nil,
+      LeftOuter, None, planA, planB)
     Seq((orderingA, false), (orderingB, true)).foreach { case (ordering, needSort) =>
       assertSortRequirementsAreSatisfied(
         childPlan = leftSmj,
@@ -535,7 +547,8 @@ class PlannerSuite extends SharedSQLContext {
 
   test("EnsureRequirements for sort operator after right outer sort merge join") {
     // Only right key is sorted after right outer SMJ (thus doesn't need a sort).
-    val rightSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, RightOuter, None, planA, planB)
+    val rightSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, exprA :: Nil, exprB :: Nil,
+      RightOuter, None, planA, planB)
     Seq((orderingA, true), (orderingB, false)).foreach { case (ordering, needSort) =>
       assertSortRequirementsAreSatisfied(
         childPlan = rightSmj,
@@ -546,7 +559,8 @@ class PlannerSuite extends SharedSQLContext {
 
   test("EnsureRequirements adds sort after full outer sort merge join") {
     // Neither keys is sorted after full outer SMJ, so they both need sorts.
-    val fullSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, FullOuter, None, planA, planB)
+    val fullSmj = SortMergeJoinExec(exprA :: Nil, exprB :: Nil, exprA :: Nil, exprB :: Nil,
+      FullOuter, None, planA, planB)
     Seq(orderingA, orderingB).foreach { ordering =>
       assertSortRequirementsAreSatisfied(
         childPlan = fullSmj,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
@@ -106,14 +106,14 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSQLContext {
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
             EnsureRequirements(left.sqlContext.sessionState.conf).apply(
-              ShuffledHashJoinExec(
-                leftKeys, rightKeys, joinType, BuildRight, boundCondition, left, right)),
+              ShuffledHashJoinExec(leftKeys, rightKeys, leftKeys, rightKeys, joinType, BuildRight,
+                boundCondition, left, right)),
             expectedAnswer,
             sortAnswers = true)
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
             EnsureRequirements(left.sqlContext.sessionState.conf).apply(
-              createLeftSemiPlusJoin(ShuffledHashJoinExec(
-                leftKeys, rightKeys, leftSemiPlus, BuildRight, boundCondition, left, right))),
+              createLeftSemiPlusJoin(ShuffledHashJoinExec(leftKeys, rightKeys, leftKeys, rightKeys,
+                leftSemiPlus, BuildRight, boundCondition, left, right))),
             expectedAnswer,
             sortAnswers = true)
         }
@@ -144,13 +144,14 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSQLContext {
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
             EnsureRequirements(left.sqlContext.sessionState.conf).apply(
-              SortMergeJoinExec(leftKeys, rightKeys, joinType, boundCondition, left, right)),
+              SortMergeJoinExec(leftKeys, rightKeys, leftKeys, rightKeys, joinType, boundCondition,
+                left, right)),
             expectedAnswer,
             sortAnswers = true)
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
             EnsureRequirements(left.sqlContext.sessionState.conf).apply(
-              createLeftSemiPlusJoin(SortMergeJoinExec(
-                leftKeys, rightKeys, leftSemiPlus, boundCondition, left, right))),
+              createLeftSemiPlusJoin(SortMergeJoinExec(leftKeys, rightKeys, leftKeys, rightKeys,
+                leftSemiPlus, boundCondition, left, right))),
             expectedAnswer,
             sortAnswers = true)
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -109,8 +109,8 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
         leftPlan: SparkPlan,
         rightPlan: SparkPlan,
         side: BuildSide) = {
-      val shuffledHashJoin = joins.ShuffledHashJoinExec(leftKeys, rightKeys, Inner,
-        side, None, leftPlan, rightPlan)
+      val shuffledHashJoin = joins.ShuffledHashJoinExec(leftKeys, rightKeys, leftKeys, rightKeys,
+        Inner, side, None, leftPlan, rightPlan)
       val filteredJoin =
         boundCondition.map(FilterExec(_, shuffledHashJoin)).getOrElse(shuffledHashJoin)
       EnsureRequirements(spark.sessionState.conf).apply(filteredJoin)
@@ -122,8 +122,8 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
         boundCondition: Option[Expression],
         leftPlan: SparkPlan,
         rightPlan: SparkPlan) = {
-      val sortMergeJoin = joins.SortMergeJoinExec(leftKeys, rightKeys, Inner, boundCondition,
-        leftPlan, rightPlan)
+      val sortMergeJoin = joins.SortMergeJoinExec(leftKeys, rightKeys, leftKeys, rightKeys, Inner,
+        boundCondition, leftPlan, rightPlan)
       EnsureRequirements(spark.sessionState.conf).apply(sortMergeJoin)
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -83,8 +83,8 @@ class OuterJoinSuite extends SparkPlanTest with SharedSQLContext {
             val buildSide = if (joinType == LeftOuter) BuildRight else BuildLeft
             checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
               EnsureRequirements(spark.sessionState.conf).apply(
-                ShuffledHashJoinExec(
-                  leftKeys, rightKeys, joinType, buildSide, boundCondition, left, right)),
+                ShuffledHashJoinExec(leftKeys, rightKeys, leftKeys, rightKeys, joinType, buildSide,
+                  boundCondition, left, right)),
               expectedAnswer.map(Row.fromTuple),
               sortAnswers = true)
           }
@@ -116,7 +116,8 @@ class OuterJoinSuite extends SparkPlanTest with SharedSQLContext {
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
             EnsureRequirements(spark.sessionState.conf).apply(
-              SortMergeJoinExec(leftKeys, rightKeys, joinType, boundCondition, left, right)),
+              SortMergeJoinExec(leftKeys, rightKeys, leftKeys, rightKeys, joinType, boundCondition,
+                left, right)),
             expectedAnswer.map(Row.fromTuple),
             sortAnswers = true)
         }


### PR DESCRIPTION
Jira : https://issues.apache.org/jira/browse/SPARK-18067

## What problem is being addressed in this PR ?

Currently shuffle based joins require its children to be shuffled over all the columns in the join condition. In case the child node is already distributed over a subset of columns in the join condition, this shuffle is not needed (eg. if the input is bucketed, if the input is output of a subquery). Avoiding the shuffle makes the join run faster and more stably as its single stage.

To dive deeper, lets look at this example. Both input tables `table1` and `table2` are bucketed on columns `i` and `j` and have 8 buckets. The query is joining the 2 tables over `i,j,k`. With bucketing, all the rows with the same values of `i` and `j` should reside in the same bucket of both the inputs. So, if we simply sort the corresponding buckets over the join columns and perform the join, that would suffice the requirements.

| partitions  | table1 (i,j,k) values | table2 (i,j,k) values  |
| ------------- | ------------- | ------------- |
| bucket 0  | (0,0,1)  (0,0,2)  (1,0,4) | (0,0,1)  (0,0,3) |
| bucket 1  | (1,0,2) (1,1,1) | (1,0,1) (1,0,2) (1,1,2) |
| bucket 2  | (0,1,8) (0,1,6) | (0,1,1) |

## What changes were proposed in this pull request?

Both shuffled hash join and sort merge join would not keep track of `which keys should the children be distributed on ?`. To start off, this is same as the join keys. The rule `ReorderJoinPredicates` is modified to detect if the child's output partitioning is over a subset of join keys and based on that the distribution keys for the join operator are revised.

## How was this patch tested?

- Added unit test.
- manual test:

Query:
```
-- both the input tables are bucketed over columns `i` and `j`
SELECT * FROM table1 a JOIN table2 b ON a.i = b.i AND a.j = b.j AND a.k = b.k
```

BEFORE
```
SortMergeJoin [i#5, j#6, k#7], [i#8, j#9, k#10], Inner
:- *Sort [i#5 ASC NULLS FIRST, j#6 ASC NULLS FIRST, k#7 ASC NULLS FIRST], false, 0
:  +- Exchange hashpartitioning(i#5, j#6, k#7, 200)
:     +- *FileScan orc default.table1[i#5,j#6,k#7] Batched: false, Format: ORC, Location: InMemoryFileIndex[file:warehouse/table1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<i:int,j:int,k:string>
+- *Sort [i#8 ASC NULLS FIRST, j#9 ASC NULLS FIRST, k#10 ASC NULLS FIRST], false, 0
   +- Exchange hashpartitioning(i#8, j#9, k#10, 200)
      +- *FileScan orc default.table2[i#8,j#9,k#10] Batched: false, Format: ORC, Location: InMemoryFileIndex[file:warehouse/table2], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<i:int,j:int,k:string>
```

AFTER
```
SortMergeJoin [i#5, j#6, k#7], [i#8, j#9, k#10], [i#5, j#6], [i#8, j#9], Inner
:- *Sort [i#5 ASC NULLS FIRST, j#6 ASC NULLS FIRST, k#7 ASC NULLS FIRST], false, 0
:  +- *FileScan orc default.table1[i#5,j#6,k#7] Batched: false, Format: ORC, Location: InMemoryFileIndex[file:warehouse/table1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<i:int,j:int,k:string>
+- *Sort [i#8 ASC NULLS FIRST, j#9 ASC NULLS FIRST, k#10 ASC NULLS FIRST], false, 0
   +- *FileScan orc default.table2[i#8,j#9,k#10] Batched: false, Format: ORC, Location: InMemoryFileIndex[file:warehouse/table2], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<i:int,j:int,k:string>
```
