### PR TITLE
[SPARK-21568][CORE] ConsoleProgressBar should only be enabled in shells

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -434,7 +434,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _statusTracker = new SparkStatusTracker(this)
 
     _progressBar =
-      if (_conf.getBoolean(UI_SHOW_CONSOLE_PROGRESS.key, false) && !log.isInfoEnabled) {
+      if (_conf.get(UI_SHOW_CONSOLE_PROGRESS) && !log.isInfoEnabled) {
         Some(new ConsoleProgressBar(this))
       } else {
         None

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -434,7 +434,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _statusTracker = new SparkStatusTracker(this)
 
     _progressBar =
-      if (_conf.getBoolean("spark.ui.showConsoleProgress", false) && !log.isInfoEnabled) {
+      if (_conf.getBoolean(UI_SHOW_CONSOLE_PROGRESS.key, false) && !log.isInfoEnabled) {
         Some(new ConsoleProgressBar(this))
       } else {
         None

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -434,7 +434,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _statusTracker = new SparkStatusTracker(this)
 
     _progressBar =
-      if (_conf.getBoolean("spark.ui.showConsoleProgress", true) && !log.isInfoEnabled) {
+      if (_conf.getBoolean("spark.ui.showConsoleProgress", false) && !log.isInfoEnabled) {
         Some(new ConsoleProgressBar(this))
       } else {
         None

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -599,7 +599,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
     }
 
     // In case of shells, spark.ui.showConsoleProgress can be true by default or by user.
-    if (isShell(args.primaryResource) && !sparkConf.contains(UI_SHOW_CONSOLE_PROGRESS.key)) {
+    if (isShell(args.primaryResource) && !sparkConf.contains(UI_SHOW_CONSOLE_PROGRESS)) {
       sysProps(UI_SHOW_CONSOLE_PROGRESS.key) = "true"
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -598,6 +598,15 @@ object SparkSubmit extends CommandLineUtils with Logging {
       }
     }
 
+    // In case of shells, spark.ui.showConsoleProgress can be true by default or by user.
+    if (isShell(args.primaryResource)) {
+      if (!sparkConf.contains("spark.ui.showConsoleProgress")) {
+        sysProps("spark.ui.showConsoleProgress") = "true"
+      }
+    } else {
+      sysProps("spark.ui.showConsoleProgress") = "false"
+    }
+
     // Add the application jar automatically so the user doesn't have to call sc.addJar
     // For YARN cluster mode, the jar is already distributed on each node as "app.jar"
     // For python and R files, the primary resource is already distributed as a regular file

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -599,12 +599,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
     }
 
     // In case of shells, spark.ui.showConsoleProgress can be true by default or by user.
-    if (isShell(args.primaryResource)) {
-      if (!sparkConf.contains("spark.ui.showConsoleProgress")) {
-        sysProps("spark.ui.showConsoleProgress") = "true"
-      }
-    } else {
-      sysProps("spark.ui.showConsoleProgress") = "false"
+    if (isShell(args.primaryResource) && !sparkConf.contains(UI_SHOW_CONSOLE_PROGRESS.key)) {
+      sysProps(UI_SHOW_CONSOLE_PROGRESS.key) = "true"
     }
 
     // Add the application jar automatically so the user doesn't have to call sc.addJar

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -204,6 +204,7 @@ package object config {
     ConfigBuilder("spark.history.ui.maxApplications").intConf.createWithDefault(Integer.MAX_VALUE)
 
   private[spark] val UI_SHOW_CONSOLE_PROGRESS = ConfigBuilder("spark.ui.showConsoleProgress")
+    .doc("When true, show the progress bar in the console.")
     .booleanConf
     .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -203,6 +203,10 @@ package object config {
   private[spark] val HISTORY_UI_MAX_APPS =
     ConfigBuilder("spark.history.ui.maxApplications").intConf.createWithDefault(Integer.MAX_VALUE)
 
+  private[spark] val UI_SHOW_CONSOLE_PROGRESS = ConfigBuilder("spark.ui.showConsoleProgress")
+    .booleanConf
+    .createOptional
+
   private[spark] val IO_ENCRYPTION_ENABLED = ConfigBuilder("spark.io.encryption.enabled")
     .booleanConf
     .createWithDefault(false)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -205,7 +205,7 @@ package object config {
 
   private[spark] val UI_SHOW_CONSOLE_PROGRESS = ConfigBuilder("spark.ui.showConsoleProgress")
     .booleanConf
-    .createOptional
+    .createWithDefault(false)
 
   private[spark] val IO_ENCRYPTION_ENABLED = ConfigBuilder("spark.io.encryption.enabled")
     .booleanConf

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -325,7 +325,7 @@ class SparkSubmitSuite
       mainClass should be ("org.apache.spark.deploy.Client")
     }
     classpath should have size 0
-    sysProps should have size 10
+    sysProps should have size 9
     sysProps.keys should contain ("SPARK_SUBMIT")
     sysProps.keys should contain ("spark.master")
     sysProps.keys should contain ("spark.app.name")
@@ -336,7 +336,6 @@ class SparkSubmitSuite
     sysProps.keys should contain ("spark.ui.enabled")
     sysProps.keys should contain ("spark.submit.deployMode")
     sysProps("spark.ui.enabled") should be ("false")
-    sysProps("spark.ui.showConsoleProgress") should be ("false")
   }
 
   test("handles standalone client mode") {
@@ -401,16 +400,15 @@ class SparkSubmitSuite
   }
 
   test("SPARK-21568 ConsoleProgressBar should be enabled only in shells") {
-    val clArgs = Seq(
-      "--master", "yarn",
-      "--conf", "spark.ui.showConsoleProgress=true",
-      "--class", "org.SomeClass",
-      "thejar.jar"
-    )
-    val appArgs = new SparkSubmitArguments(clArgs)
-    val (_, _, sysProps, _) = prepareSubmitEnvironment(appArgs)
+    val clArgs1 = Seq("--class", "org.apache.spark.repl.Main", "spark-shell")
+    val appArgs1 = new SparkSubmitArguments(clArgs1)
+    val (_, _, sysProps1, _) = prepareSubmitEnvironment(appArgs1)
+    sysProps1("spark.ui.showConsoleProgress") should be ("true")
 
-    sysProps("spark.ui.showConsoleProgress") should be("false")
+    val clArgs2 = Seq("--class", "org.SomeClass", "thejar.jar")
+    val appArgs2 = new SparkSubmitArguments(clArgs2)
+    val (_, _, sysProps2, _) = prepareSubmitEnvironment(appArgs2)
+    sysProps2.keys should not contain "spark.ui.showConsoleProgress"
   }
 
   test("launch simple application with spark-submit") {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -325,7 +325,7 @@ class SparkSubmitSuite
       mainClass should be ("org.apache.spark.deploy.Client")
     }
     classpath should have size 0
-    sysProps should have size 9
+    sysProps should have size 10
     sysProps.keys should contain ("SPARK_SUBMIT")
     sysProps.keys should contain ("spark.master")
     sysProps.keys should contain ("spark.app.name")
@@ -336,6 +336,7 @@ class SparkSubmitSuite
     sysProps.keys should contain ("spark.ui.enabled")
     sysProps.keys should contain ("spark.submit.deployMode")
     sysProps("spark.ui.enabled") should be ("false")
+    sysProps("spark.ui.showConsoleProgress") should be ("false")
   }
 
   test("handles standalone client mode") {
@@ -397,6 +398,19 @@ class SparkSubmitSuite
     sysProps("spark.master") should be ("yarn")
     sysProps("spark.submit.deployMode") should be ("cluster")
     mainClass should be ("org.apache.spark.deploy.yarn.Client")
+  }
+
+  test("SPARK-21568 ConsoleProgressBar should be enabled only in shells") {
+    val clArgs = Seq(
+      "--master", "yarn",
+      "--conf", "spark.ui.showConsoleProgress=true",
+      "--class", "org.SomeClass",
+      "thejar.jar"
+    )
+    val appArgs = new SparkSubmitArguments(clArgs)
+    val (_, _, sysProps, _) = prepareSubmitEnvironment(appArgs)
+
+    sysProps("spark.ui.showConsoleProgress") should be("false")
   }
 
   test("launch simple application with spark-submit") {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -403,12 +403,12 @@ class SparkSubmitSuite
     val clArgs1 = Seq("--class", "org.apache.spark.repl.Main", "spark-shell")
     val appArgs1 = new SparkSubmitArguments(clArgs1)
     val (_, _, sysProps1, _) = prepareSubmitEnvironment(appArgs1)
-    sysProps1("spark.ui.showConsoleProgress") should be ("true")
+    sysProps1(UI_SHOW_CONSOLE_PROGRESS.key) should be ("true")
 
     val clArgs2 = Seq("--class", "org.SomeClass", "thejar.jar")
     val appArgs2 = new SparkSubmitArguments(clArgs2)
     val (_, _, sysProps2, _) = prepareSubmitEnvironment(appArgs2)
-    sysProps2.keys should not contain "spark.ui.showConsoleProgress"
+    sysProps2.keys should not contain UI_SHOW_CONSOLE_PROGRESS.key
   }
 
   test("launch simple application with spark-submit") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR disables console progress bar feature in non-shell environment by overriding the configuration.

## How was this patch tested?

Manual. Run the following examples with and without `spark.ui.showConsoleProgress` in order to see progress bar on master branch and this PR.

**Scala Shell**
```scala
spark.range(1000000000).map(_ + 1).count
```

**PySpark**
```python
spark.range(10000000).rdd.map(lambda x: len(x)).count()
```

**Spark Submit**
```python
from pyspark.sql import SparkSession

if __name__ == "__main__":
    spark = SparkSession.builder.getOrCreate()
    spark.range(2000000).rdd.map(lambda row: len(row)).count()
    spark.stop()
```