### PR TITLE
[SPARK-21846][TEST] Reduce the number of shuffle partition in Hive tests

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -576,7 +576,7 @@ private[hive] object TestHiveContext {
   val overrideConfs: Map[String, String] =
     Map(
       // Fewer shuffle partitions to speed up testing.
-      SQLConf.SHUFFLE_PARTITIONS.key -> "5"
+      SQLConf.SHUFFLE_PARTITIONS.key -> "3"
     )
 
   def makeWarehouseDir(): File = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Jenkins on master branch fails due to timeout ([here](https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-sbt-hadoop-2.7/))

According to [the last successful run](https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-sbt-hadoop-2.7/3396/testReport/), Hive tests takes over 50 mins from 132 mins (in Java/Scala tests)

Package | Test Time
-|-
org.apache.spark.sql.hive.execution  |  30 min
org.apache.spark.sql.hive                    | 11 min
org.apache.spark.sql.hive.client          | 5 min 2 sec
org.apache.spark.sql.hive.thriftserver | 3 min 4 sec
org.apache.spark.sql.hive.orc             | 1 min 25 sec

This PR aims to reduce the test time by reducing the number of shuffle partitions in Hive tests.

## How was this patch tested?

Pass the Jenkins and see the result time.