### PR TITLE
[SPARK-21849][Core]Make the serializer function more robust

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
@@ -97,8 +97,11 @@ private[spark] class JavaSerializerInstance(
   override def serialize[T: ClassTag](t: T): ByteBuffer = {
     val bos = new ByteBufferOutputStream()
     val out = serializeStream(bos)
-    out.writeObject(t)
-    out.close()
+    try {
+      out.writeObject(t)
+    } finally {
+      out.close()
+    }
     bos.toByteBuffer
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -138,8 +138,11 @@ private[spark] object Utils extends Logging {
   def serialize[T](o: T): Array[Byte] = {
     val bos = new ByteArrayOutputStream()
     val oos = new ObjectOutputStream(bos)
-    oos.writeObject(o)
-    oos.close()
+    try {
+      oos.writeObject(o)
+    } finally {
+      oos.close()
+    }
     bos.toByteArray
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

make sure the `close` function is called in the `finally` block.

## How was this patch tested?

No Test, just compile.
