### PR TITLE
[SPARK-21855][YARN] Should print error when upload same file multiple tim…

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -435,10 +435,10 @@ private[spark] class Client(
       val uriStr = uri.toString()
       val fileName = new File(uri.getPath).getName
       if (distributedUris.contains(uriStr)) {
-        logWarning(s"Same path resource $uri added multiple times to distributed cache.")
+        logError(s"Same path resource $uri added multiple times to distributed cache.")
         false
       } else if (distributedNames.contains(fileName)) {
-        logWarning(s"Same name resource $uri added multiple times to distributed cache")
+        logError(s"Same name resource $uri added multiple times to distributed cache")
         false
       } else {
         distributedUris += uriStr


### PR DESCRIPTION
…es to yarn

## What changes were proposed in this pull request?

Now when submit job with yarn,and upload same file multiple times.We will throw exception but logging level is warn.
This pr change logging level to error,since warning is misleading.

## How was this patch tested?
N/A
