### PR TITLE
[SPARK-21859][CORE] Fix SparkFiles.get failed on driver in yarn-cluster and yarn-client mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -393,7 +393,7 @@ object SparkEnv extends Logging {
     // Add a reference to tmp dir created by driver, we will delete this tmp dir when stop() is
     // called, and we only need to do it for driver. Because driver may run as a service, and if we
     // don't delete this tmp dir when sc is stopped, then will create too many tmp dirs.
-    if (isDriver) {
+    if (isDriver && conf.get("spark.submit.deployMode", "client") == "client") {
       val sparkFilesDir = Utils.createTempDir(Utils.getLocalDir(conf), "userFiles").getAbsolutePath
       envInstance.driverTmpDir = Some(sparkFilesDir)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -481,7 +481,7 @@ object SparkSubmit extends CommandLineUtils {
         sysProp = "spark.executor.memory"),
       OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS, ALL_DEPLOY_MODES,
         sysProp = "spark.cores.max"),
-      OptionAssigner(args.files, LOCAL | STANDALONE | MESOS, ALL_DEPLOY_MODES,
+      OptionAssigner(args.files, ALL_CLUSTER_MGRS, ALL_DEPLOY_MODES,
         sysProp = "spark.files"),
       OptionAssigner(args.jars, LOCAL, CLIENT, sysProp = "spark.jars"),
       OptionAssigner(args.jars, STANDALONE | MESOS, ALL_DEPLOY_MODES, sysProp = "spark.jars"),


### PR DESCRIPTION
## What changes were proposed in this pull request?
when use SparkFiles.get a file on driver in yarn-client or yarn-cluster, it will report file not found exception.
This exception only happens on driver, getting files on executor is ok.

we can reproduce the bug as follows:

Scala Test
```scala
def testOnDriver(fileName: String) = {
    val file = new File(SparkFiles.get(fileName))
    if (!file.exists()) {
        logging.info(s"$file not exist")
    } else {
        // print file content on driver
        val content = Source.fromFile(file).getLines().mkString("\n")
        logging.info(s"File content: ${content}")
    }
}
// the output will be file not exist
```
Pyspark Test

```python
conf = SparkConf().setAppName("test files")
sc = SparkContext(appName="spark files test")

def test_on_driver(filename):
    file = SparkFiles.get(filename)
    print("file path: {}".format(file))
    if os.path.exists(file):
        with open(file) as f:
        lines = f.readlines()
        print(lines)
    else:
        print("file doesn't exist")
        run_command("ls .")
```
## How was this patch tested?
tested in integration tests and manual tests
submit the demo case in yarn-cluster and yarn-client mode, verify the test result
the integration tests commands are as follows:

```shell
./bin/spark-submit --master yarn-cluster --files README.md --class "testing.SparkFilesTest" testing.jar
./bin/spark-submit --master yarn-client --files README.md --class "testing.SparkFilesTest" testing.jar
./bin/spark-submit --master yarn-cluster --files README.md test_get_files.py
./bin/spark-submit --master yarn-client --files README.md test_get_files.py
```