### PR TITLE
[SPARK-21862][ML] Add overflow check in PCA

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -49,7 +49,8 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
       + math.max(math.max(k, numFeatures), 4 * math.min(k, numFeatures)
       * math.min(k, numFeatures) + 4 * math.min(k, numFeatures))
       )
-    require(workSize < (1 << 31), "The param K and numFeatures is too large for SVD computation.")
+    require(workSize <= Int.MaxValue,
+      "The param K and numFeatures is too large for SVD computation.")
 
     val mat = new RowMatrix(sources)
     val (pc, explainedVariance) = mat.computePrincipalComponentsAndExplainedVariance(k)

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -44,8 +44,8 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
     require(k <= numFeatures,
       s"source vector size $numFeatures must be no less than k=$k")
 
-    require(PCAUtil.memoryCost(k, numFeatures) <= Int.MaxValue,
-      "The param k and numFeatures is too large for SVD computation." +
+    require(PCAUtil.memoryCost(k, numFeatures) < Int.MaxValue,
+      "The param k and numFeatures is too large for SVD computation. " +
       "Try reducing the parameter k for PCA, or reduce the input feature " +
       "vector dimension to make this tractable.")
 
@@ -116,7 +116,7 @@ class PCAModel private[spark] (
   }
 }
 
-object PCAUtil {
+private[feature] object PCAUtil {
 
   // This memory cost formula is from breeze code:
   // https://github.com/scalanlp/breeze/blob/

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -44,6 +44,13 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
     require(k <= numFeatures,
       s"source vector size $numFeatures must be no less than k=$k")
 
+    val workSize = ( 3
+      * math.min(k, numFeatures) * math.min(k, numFeatures)
+      + math.max(math.max(k, numFeatures), 4 * math.min(k, numFeatures)
+      * math.min(k, numFeatures) + 4 * math.min(k, numFeatures))
+      )
+    require(workSize < (1 << 31), "The param K and numFeatures exceed limit in SVD.")
+
     val mat = new RowMatrix(sources)
     val (pc, explainedVariance) = mat.computePrincipalComponentsAndExplainedVariance(k)
     val densePC = pc match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -49,7 +49,7 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
       + math.max(math.max(k, numFeatures), 4 * math.min(k, numFeatures)
       * math.min(k, numFeatures) + 4 * math.min(k, numFeatures))
       )
-    require(workSize < (1 << 31), "The param K and numFeatures exceed limit in SVD.")
+    require(workSize < (1 << 31), "The param K and numFeatures is too large for SVD computation.")
 
     val mat = new RowMatrix(sources)
     val (pc, explainedVariance) = mat.computePrincipalComponentsAndExplainedVariance(k)

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -44,13 +44,10 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
     require(k <= numFeatures,
       s"source vector size $numFeatures must be no less than k=$k")
 
-    val workSize = ( 3
-      * math.min(k, numFeatures) * math.min(k, numFeatures)
-      + math.max(math.max(k, numFeatures), 4 * math.min(k, numFeatures)
-      * math.min(k, numFeatures) + 4 * math.min(k, numFeatures))
-      )
-    require(workSize <= Int.MaxValue,
-      "The param K and numFeatures is too large for SVD computation.")
+    require(PCAUtil.memoryCost(k, numFeatures) <= Int.MaxValue,
+      "The param k and numFeatures is too large for SVD computation." +
+      "Try reducing the parameter k for PCA, or reduce the input feature " +
+      "vector dimension to make this tractable.")
 
     val mat = new RowMatrix(sources)
     val (pc, explainedVariance) = mat.computePrincipalComponentsAndExplainedVariance(k)
@@ -117,4 +114,18 @@ class PCAModel private[spark] (
           s"SparseVector or DenseVector. Instead got: ${vector.getClass}")
     }
   }
+}
+
+object PCAUtil {
+
+  // This memory cost formula is from breeze code:
+  // https://github.com/scalanlp/breeze/blob/
+  // 6e541be066d547a097f5089165cd7c38c3ca276d/math/src/main/scala/breeze/linalg/
+  // functions/svd.scala#L87
+  def memoryCost(k: Int, numFeatures: Int): Long = {
+    3L * math.min(k, numFeatures) * math.min(k, numFeatures)
+    + math.max(math.max(k, numFeatures), 4L * math.min(k, numFeatures)
+    * math.min(k, numFeatures) + 4L * math.min(k, numFeatures))
+  }
+
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/PCASuite.scala
@@ -48,4 +48,10 @@ class PCASuite extends SparkFunSuite with MLlibTestSparkContext {
     }
     assert(pca.explainedVariance ~== explainedVariance relTol 1e-8)
   }
+
+  test("memory cost computation") {
+    assert(PCAUtil.memoryCost(10, 100) < Int.MaxValue)
+    // check overflowing
+    assert(PCAUtil.memoryCost(40000, 60000) > Int.MaxValue)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

add overflow check in PCA, otherwise it is possible to throw `NegativeArraySizeException` when `k` and `numFeatures` are too large.
The overflow checking formula is here:
https://github.com/scalanlp/breeze/blob/master/math/src/main/scala/breeze/linalg/functions/svd.scala#L87

## How was this patch tested?

N/A