### PR TITLE
[SPARK-21870][SQL] Split aggregation code into small functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions.codegen
 
 import java.io.ByteArrayInputStream
+import java.lang.Character._
 import java.util.{Map => JavaMap}
 
 import scala.collection.JavaConverters._
@@ -1100,6 +1101,29 @@ class CodegenContext {
     } else {
       ""
     }
+  }
+}
+
+object CodegenContext {
+
+  private val javaKeywords = Set(
+    "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+    "continue", "default", "do", "double", "else", "extends", "false", "final", "finally", "float",
+    "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native",
+    "new", "null", "package", "private", "protected", "public", "return", "short", "static",
+    "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true",
+    "try", "void", "volatile", "while"
+  )
+
+  /**
+   * Returns true if the given `str` is a valid java identifier.
+   */
+  def isJavaIdentifier(str: String): Boolean = str match {
+    case null | "" =>
+      false
+    case _ =>
+      !javaKeywords.contains(str) && isJavaIdentifierStart(str.charAt(0)) &&
+        (1 until str.length).forall(i => isJavaIdentifierPart(str.charAt(i)))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -607,6 +607,17 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val MAX_PARAM_NUM_IN_JAVA_METHOD =
+     buildConf("spark.sql.codegen.maxParamNumInJavaMethod")
+      .internal()
+      .doc("The maximum number of parameters in codegened Java functions. When a function " +
+         "exceeds this threshold, the code generator gives up splitting the function code. " +
+         "This default value is 127 because the maximum length of parameters in non-static Java " +
+         "methods is 254 and a parameter of type long or double contributes " +
+         "two units to the length.")
+      .intConf
+      .createWithDefault(127)
+
   val CODEGEN_FALLBACK = buildConf("spark.sql.codegen.fallback")
     .internal()
     .doc("When true, (whole stage) codegen could be temporary disabled for the part of query that" +
@@ -1155,6 +1166,8 @@ class SQLConf extends Serializable with Logging {
   def wholeStageEnabled: Boolean = getConf(WHOLESTAGE_CODEGEN_ENABLED)
 
   def wholeStageMaxNumFields: Int = getConf(WHOLESTAGE_MAX_NUM_FIELDS)
+
+  def maxParamNumInJavaMethod: Int = getConf(MAX_PARAM_NUM_IN_JAVA_METHOD)
 
   def codegenFallback: Boolean = getConf(CODEGEN_FALLBACK)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -394,4 +394,22 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
       Map("add" -> Literal(1))).genCode(ctx)
     assert(ctx.mutableStates.isEmpty)
   }
+
+  test("SPARK-21870 check if CodegenContext.isJavaIdentifier works correctly") {
+    import CodegenContext.isJavaIdentifier
+    // positive cases
+    assert(isJavaIdentifier("agg_value"))
+    assert(isJavaIdentifier("agg_value1"))
+    assert(isJavaIdentifier("bhj_value4"))
+    assert(isJavaIdentifier("smj_value6"))
+    assert(isJavaIdentifier("rdd_value7"))
+    assert(isJavaIdentifier("scan_isNull"))
+    assert(isJavaIdentifier("test"))
+    // negative cases
+    assert(!isJavaIdentifier("true"))
+    assert(!isJavaIdentifier("false"))
+    assert(!isJavaIdentifier("390239"))
+    assert(!isJavaIdentifier(""""literal""""))
+    assert(!isJavaIdentifier(""""double""""))
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -946,7 +946,10 @@ case class HashAggregateExec(
       }
 
       val updateAggValCode = splitAggregateExpressions(
-        ctx, boundUpdateExpr, evalAndUpdateCodes, subExprs.states,
+        ctx,
+        boundUpdateExpr,
+        evalAndUpdateCodes,
+        subExprs.states,
         Seq(("InternalRow", unsafeRowBuffer)))
 
       s"""
@@ -988,7 +991,10 @@ case class HashAggregateExec(
         }
 
         val updateAggValCode = splitAggregateExpressions(
-          ctx, boundUpdateExpr, evalAndUpdateCodes, subExprs.states,
+          ctx,
+          boundUpdateExpr,
+          evalAndUpdateCodes,
+          subExprs.states,
           Seq(("InternalRow", fastRowBuffer)))
 
         // If fast hash map is on, we first generate code to update row in fast hash map, if the

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -211,11 +211,11 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-21871 check if we can get large code size when compiling too long functions") {
     val codeWithShortFunctions = genGroupByCode(3)
-    val (_, maxCodeSize1) = CodeGenerator.compile(codeWithShortFunctions)
-    assert(maxCodeSize1 < SQLConf.WHOLESTAGE_HUGE_METHOD_LIMIT.defaultValue.get)
+    val (_, smallCodeSize) = CodeGenerator.compile(codeWithShortFunctions)
     val codeWithLongFunctions = genGroupByCode(20)
-    val (_, maxCodeSize2) = CodeGenerator.compile(codeWithLongFunctions)
-    assert(maxCodeSize2 > SQLConf.WHOLESTAGE_HUGE_METHOD_LIMIT.defaultValue.get)
+    val (_, largeCodeSize) = CodeGenerator.compile(codeWithLongFunctions)
+    // Just checking if long functions have the large value of max code size
+    assert(largeCodeSize > smallCodeSize)
   }
 
   test("bytecode of batch file scan exceeds the limit of WHOLESTAGE_HUGE_METHOD_LIMIT") {
@@ -234,6 +234,14 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
         assert(fileScan2.asInstanceOf[FileSourceScanExec].supportsBatch)
         checkAnswer(df2, df)
       }
+    }
+  }
+
+  test("SPARK-21870 check the case where the number of parameters goes over the limit") {
+    withSQLConf("spark.sql.codegen.aggregate.maxParamNumInJavaMethod" -> "2") {
+      sql("CREATE OR REPLACE TEMPORARY VIEW t AS SELECT * FROM VALUES (1, 1, 1) AS t(a, b, c)")
+      val df = sql("SELECT SUM(a + b + c) AS sum FROM t")
+      assert(df.collect === Seq(Row(3)))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -238,7 +238,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-21870 check the case where the number of parameters goes over the limit") {
-    withSQLConf("spark.sql.codegen.aggregate.maxParamNumInJavaMethod" -> "2") {
+    withSQLConf("spark.sql.codegen.maxParamNumInJavaMethod" -> "2") {
       sql("CREATE OR REPLACE TEMPORARY VIEW t AS SELECT * FROM VALUES (1, 1, 1) AS t(a, b, c)")
       val df = sql("SELECT SUM(a + b + c) AS sum FROM t")
       assert(df.collect === Seq(Row(3)))


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr proposes to split aggregation code into pieces in `HashAggregateExec`. In #18810, we got performance regression if JVMs didn't compile too long functions (the limit is 8000 in bytecode size). I checked and I found the codegen of `HashAggregateExec` frequently goes over the limit, for example:

```
scala> spark.range(1).selectExpr("id % 1024 AS a", "id AS b").write.saveAsTable("t")
scala> sql("SELECT a, KURTOSIS(b)FROM t GROUP BY a")
```

This query goes over the limit and the actual bytecode size is `12356`.
This pr split the aggregation code into small separate functions and, in a simple example;

```
scala> sql("SELECT SUM(a), AVG(a) FROM VALUES(1) t(a)").debugCodegen
```

- generated  code with this pr:
```
/* 083 */   private void agg_doAggregateWithoutKey() throws java.io.IOException {
/* 084 */     // initialize aggregation buffer
/* 085 */     final long agg_value = -1L;
/* 086 */     agg_bufIsNull = true;
/* 087 */     agg_bufValue = agg_value;
/* 088 */     boolean agg_isNull1 = false;
/* 089 */     double agg_value1 = -1.0;
/* 090 */     if (!false) {
/* 091 */       agg_value1 = (double) 0;
/* 092 */     }
/* 093 */     agg_bufIsNull1 = agg_isNull1;
/* 094 */     agg_bufValue1 = agg_value1;
/* 095 */     agg_bufIsNull2 = false;
/* 096 */     agg_bufValue2 = 0L;
/* 097 */
/* 098 */     while (inputadapter_input.hasNext() && !stopEarly()) {
/* 099 */       InternalRow inputadapter_row = (InternalRow) inputadapter_input.next();
/* 100 */       boolean inputadapter_isNull = inputadapter_row.isNullAt(0);
/* 101 */       long inputadapter_value = inputadapter_isNull ? -1L : (inputadapter_row.getLong(0));
/* 102 */       boolean inputadapter_isNull1 = inputadapter_row.isNullAt(1);
/* 103 */       double inputadapter_value1 = inputadapter_isNull1 ? -1.0 : (inputadapter_row.getDouble(1));
/* 104 */       boolean inputadapter_isNull2 = inputadapter_row.isNullAt(2);
/* 105 */       long inputadapter_value2 = inputadapter_isNull2 ? -1L : (inputadapter_row.getLong(2));
/* 106 */
/* 107 */       // do aggregate
/* 108 */       // copy aggregation buffer to the local
/* 109 */       boolean agg_localBufIsNull = agg_bufIsNull;
/* 110 */       long agg_localBufValue = agg_bufValue;
/* 111 */       boolean agg_localBufIsNull1 = agg_bufIsNull1;
/* 112 */       double agg_localBufValue1 = agg_bufValue1;
/* 113 */       boolean agg_localBufIsNull2 = agg_bufIsNull2;
/* 114 */       long agg_localBufValue2 = agg_bufValue2;
/* 115 */       // common sub-expressions
/* 116 */
/* 117 */       // process aggregate functions to update aggregation buffer
/* 118 */       agg_doAggregateVal_coalesce(agg_localBufIsNull, agg_localBufValue, inputadapter_value, inputadapter_isNull);
/* 119 */       agg_doAggregateVal_add(agg_localBufValue1, inputadapter_isNull1, inputadapter_value1, agg_localBufIsNull1);
/* 120 */       agg_doAggregateVal_add1(inputadapter_isNull2, inputadapter_value2, agg_localBufIsNull2, agg_localBufValue2);
/* 121 */       if (shouldStop()) return;
/* 122 */     }
```

- generated code in the current master
```
/* 083 */   private void agg_doAggregateWithoutKey() throws java.io.IOException {
/* 084 */     // initialize aggregation buffer
/* 085 */     final long agg_value = -1L;
/* 086 */     agg_bufIsNull = true;
/* 087 */     agg_bufValue = agg_value;
/* 088 */     boolean agg_isNull1 = false;
/* 089 */     double agg_value1 = -1.0;
/* 090 */     if (!false) {
/* 091 */       agg_value1 = (double) 0;
/* 092 */     }
/* 093 */     agg_bufIsNull1 = agg_isNull1;
/* 094 */     agg_bufValue1 = agg_value1;
/* 095 */     agg_bufIsNull2 = false;
/* 096 */     agg_bufValue2 = 0L;
/* 097 */
/* 098 */     while (inputadapter_input.hasNext() && !stopEarly()) {
/* 099 */       InternalRow inputadapter_row = (InternalRow) inputadapter_input.next();
/* 100 */       boolean inputadapter_isNull = inputadapter_row.isNullAt(0);
/* 101 */       long inputadapter_value = inputadapter_isNull ? -1L : (inputadapter_row.getLong(0));
/* 102 */       boolean inputadapter_isNull1 = inputadapter_row.isNullAt(1);
/* 103 */       double inputadapter_value1 = inputadapter_isNull1 ? -1.0 : (inputadapter_row.getDouble(1));
/* 104 */       boolean inputadapter_isNull2 = inputadapter_row.isNullAt(2);
/* 105 */       long inputadapter_value2 = inputadapter_isNull2 ? -1L : (inputadapter_row.getLong(2));
/* 106 */
/* 107 */       // do aggregate
/* 108 */       // common sub-expressions
/* 109 */
/* 110 */       // evaluate aggregate function
/* 111 */       boolean agg_isNull12 = true;
/* 112 */       long agg_value12 = -1L;
/* 113 */
/* 114 */       boolean agg_isNull13 = agg_bufIsNull;
/* 115 */       long agg_value13 = agg_bufValue;
/* 116 */       if (agg_isNull13) {
/* 117 */         boolean agg_isNull15 = false;
/* 118 */         long agg_value15 = -1L;
/* 119 */         if (!false) {
/* 120 */           agg_value15 = (long) 0;
/* 121 */         }
/* 122 */         if (!agg_isNull15) {
/* 123 */           agg_isNull13 = false;
/* 124 */           agg_value13 = agg_value15;
/* 125 */         }
/* 126 */       }
/* 127 */
/* 128 */       if (!inputadapter_isNull) {
/* 129 */         agg_isNull12 = false; // resultCode could change nullability.
/* 130 */         agg_value12 = agg_value13 + inputadapter_value;
/* 131 */
/* 132 */       }
/* 133 */       boolean agg_isNull11 = agg_isNull12;
/* 134 */       long agg_value11 = agg_value12;
/* 135 */       if (agg_isNull11) {
/* 136 */         if (!agg_bufIsNull) {
/* 137 */           agg_isNull11 = false;
/* 138 */           agg_value11 = agg_bufValue;
/* 139 */         }
/* 140 */       }
/* 141 */       boolean agg_isNull19 = true;
/* 142 */       double agg_value19 = -1.0;
/* 143 */
/* 144 */       if (!agg_bufIsNull1) {
/* 145 */         if (!inputadapter_isNull1) {
/* 146 */           agg_isNull19 = false; // resultCode could change nullability.
/* 147 */           agg_value19 = agg_bufValue1 + inputadapter_value1;
/* 148 */
/* 149 */         }
/* 150 */
/* 151 */       }
/* 152 */       boolean agg_isNull22 = true;
/* 153 */       long agg_value22 = -1L;
/* 154 */
/* 155 */       if (!agg_bufIsNull2) {
/* 156 */         if (!inputadapter_isNull2) {
/* 157 */           agg_isNull22 = false; // resultCode could change nullability.
/* 158 */           agg_value22 = agg_bufValue2 + inputadapter_value2;
/* 159 */
/* 160 */         }
/* 161 */
/* 162 */       }
/* 163 */       // update aggregation buffer
/* 164 */       agg_bufIsNull = agg_isNull11;
/* 165 */       agg_bufValue = agg_value11;
/* 166 */
/* 167 */       agg_bufIsNull1 = agg_isNull19;
/* 168 */       agg_bufValue1 = agg_value19;
/* 169 */
/* 170 */       agg_bufIsNull2 = agg_isNull22;
/* 171 */       agg_bufValue2 = agg_value22;
/* 172 */       if (shouldStop()) return;
/* 173 */     }
/* 174 */
/* 175 */   }
/* 176 */
/* 177 */ }
```

I did also performance checks;
```
$ ./bin/spark --master=local[1]
scala> sql("SET spark.sql.shuffle.partitions=4")
scala> spark.range(10000000).selectExpr("id % 1024 AS a", "id AS b").write.saveAsTable("t")
scala> timer { sql("SELECT a, KURTOSIS(b)FROM t GROUP BY a").collect }

master w/ this pr, Avg. Elapsed Time: 2.520551837s
master, Avg. Elapsed Time: 54.029893146199996s
```

## How was this patch tested?
Added tests in `WholeStageCodegenSuite`.
