### PR TITLE
[SPARK-20711][ML]MultivariateOnlineSummarizer/Summarizer incorrect min/max for NaN value

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -143,7 +143,7 @@ class MinMaxScaler @Since("1.5.0") (@Since("1.5.0") override val uid: String)
           while (i < numFeatures) {
             nnz1(i) += nnz2(i)
             min1(i) = math.min(min1(i), min2(i))
-            max1(i) = math.max(max1(i), max1(i))
+            max1(i) = math.max(max1(i), max2(i))
             i += 1
           }
           (count1 + count2, nnz1, min1, max1)

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -299,11 +299,11 @@ private[ml] object SummaryBuilderImpl extends Logging {
       val localCurrMin = currMin
       instance.foreachActive { (index, value) =>
         if (value != 0.0) {
-          if (localCurrMax != null && localCurrMax(index) < value) {
-            localCurrMax(index) = value
+          if (localCurrMax != null) {
+            localCurrMax(index) = math.max(localCurrMax(index), value)
           }
-          if (localCurrMin != null && localCurrMin(index) > value) {
-            localCurrMin(index) = value
+          if (localCurrMin != null) {
+            localCurrMin(index) = math.min(localCurrMin(index), value)
           }
 
           if (localWeightSum != null) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -97,13 +97,8 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
     val localCurrMin = currMin
     instance.foreachActive { (index, value) =>
       if (value != 0.0) {
-        if (localCurrMax(index) < value) {
-          localCurrMax(index) = value
-        }
-        if (localCurrMin(index) > value) {
-          localCurrMin(index) = value
-        }
-
+        localCurrMax(index) = math.max(localCurrMax(index), value)
+        localCurrMin(index) = math.min(localCurrMin(index), value)
         val prevMean = localCurrMean(index)
         val diff = value - prevMean
         localCurrMean(index) = prevMean + weight * diff / (localWeightSum(index) + weight)

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
@@ -501,12 +501,20 @@ class SummarizerSuite extends SparkFunSuite with MLlibTestSparkContext {
     }
     summarizer3.add(Vectors.dense(10.0, -10.0), 1e10)
 
+    val summarizer4 = new SummarizerBuffer()
+    summarizer4.add(Vectors.dense(10.0, Double.NaN), 1)
+    summarizer4.add(Vectors.dense(Double.NaN, Double.NaN), 1)
+
     assert(summarizer1.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer1.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
     assert(summarizer2.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer2.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
     assert(summarizer3.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer3.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
+    assert(summarizer4.max(0).isNaN)
+    assert(summarizer4.max(1).isNaN)
+    assert(summarizer4.min(0).isNaN)
+    assert(summarizer4.min(1).isNaN)
   }
 
   ignore("performance test") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
@@ -263,12 +263,20 @@ class MultivariateOnlineSummarizerSuite extends SparkFunSuite {
     }
     summarizer3.add(Vectors.dense(10.0, -10.0), 1e10)
 
+    val summarizer4 = new MultivariateOnlineSummarizer()
+    summarizer4.add(Vectors.dense(10.0, Double.NaN), 1)
+    summarizer4.add(Vectors.dense(Double.NaN, Double.NaN), 1)
+
     assert(summarizer1.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer1.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
     assert(summarizer2.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer2.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
     assert(summarizer3.max ~== Vectors.dense(10.0, 0.0) absTol 1e-14)
     assert(summarizer3.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
+    assert(summarizer4.max(0).isNaN)
+    assert(summarizer4.max(1).isNaN)
+    assert(summarizer4.min(0).isNaN)
+    assert(summarizer4.min(1).isNaN)
   }
 
   test ("test zero variance (SPARK-21818)") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

current impl of min/max ignore `NaN`
for a column only containing `NaN`, `Double.MaxValue` will be returned for `min` and `Double.MinValue` will be returned for `max`

min/max for column containing `NaN` should return `NaN`

## How was this patch tested?
existing tests
