### PR TITLE
[SPARK-21874][SQL] Support changing database when rename table.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -131,13 +131,21 @@ abstract class ExternalCatalog
       ignoreIfNotExists: Boolean,
       purge: Boolean): Unit
 
-  final def renameTable(db: String, oldName: String, newName: String): Unit = {
-    postToAll(RenameTablePreEvent(db, oldName, newName))
-    doRenameTable(db, oldName, newName)
-    postToAll(RenameTableEvent(db, oldName, newName))
+  final def renameTable(
+      oldDb: String,
+      oldName: String,
+      newDb: String,
+      newName: String): Unit = {
+    postToAll(RenameTablePreEvent(oldDb, oldName, newDb, newName))
+    doRenameTable(oldDb, oldName, newDb, newName)
+    postToAll(RenameTableEvent(oldDb, oldName, newDb, newName))
   }
 
-  protected def doRenameTable(db: String, oldName: String, newName: String): Unit
+  protected def doRenameTable(
+      oldDb: String,
+      oldName: String,
+      newDb: String,
+      newName: String): Unit
 
   /**
    * Alter a table whose database and name match the ones specified in `tableDefinition`, assuming

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -272,6 +272,8 @@ class InMemoryCatalog(
     requireTableExists(oldDb, oldName)
     requireTableNotExists(newDb, newName)
     val oldDesc = catalog(oldDb).tables(oldName)
+    // Update description of old table with information of new table.
+    // Put the description into catalog finally.
     oldDesc.table = oldDesc.table.copy(identifier = TableIdentifier(newName, Some(newDb)))
     if (oldDesc.table.tableType == CatalogTableType.MANAGED) {
       assert(oldDesc.table.storage.locationUri.isDefined,
@@ -289,6 +291,7 @@ class InMemoryCatalog(
       }
       oldDesc.table = oldDesc.table.withNewStorage(locationUri = Some(newDir.toUri))
     }
+
     catalog(newDb).tables.put(newName, oldDesc)
     catalog(oldDb).tables.remove(oldName)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -570,11 +570,12 @@ class SessionCatalog(
    * Rename a table.
    *
    * If the database specified in `newName` is different from the one specified in `oldName`,
-   * It will result in moving table across databases.
+   * It results in moving table across databases.
    *
-   * If no database is specified, this will first attempt to rename a temporary table with
-   * the same name, then, if that does not exist, current database will be used for locating
-   * `oldName` or `newName`.
+   * If no database is specified in `oldName`, this will first attempt to rename a temporary table
+   * with the same name, then, if that does not exist, rename the table in the current database.
+   *
+   * If no database is specified in `newName`, current database will be used.
    *
    */
   def renameTable(oldName: TableIdentifier, newName: TableIdentifier): Unit = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -97,6 +97,7 @@ case class DropTableEvent(database: String, name: String) extends TableEvent
 case class RenameTablePreEvent(
     database: String,
     name: String,
+    newDb: String,
     newName: String)
   extends TableEvent
 
@@ -106,6 +107,7 @@ case class RenameTablePreEvent(
 case class RenameTableEvent(
     database: String,
     name: String,
+    newDb: String,
     newName: String)
   extends TableEvent
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
@@ -120,15 +120,15 @@ class ExternalCatalogEventSuite extends SparkFunSuite {
     checkEvents(CreateTablePreEvent("db5", "tbl1") :: Nil)
 
     // RENAME
-    catalog.renameTable("db5", "tbl1", "tbl2")
+    catalog.renameTable("db5", "tbl1", "db5", "tbl2")
     checkEvents(
-      RenameTablePreEvent("db5", "tbl1", "tbl2") ::
-      RenameTableEvent("db5", "tbl1", "tbl2") :: Nil)
+      RenameTablePreEvent("db5", "tbl1", "db5", "tbl2") ::
+      RenameTableEvent("db5", "tbl1", "db5", "tbl2") :: Nil)
 
     intercept[AnalysisException] {
-      catalog.renameTable("db5", "tbl1", "tbl2")
+      catalog.renameTable("db5", "tbl1", "db5", "tbl2")
     }
-    checkEvents(RenameTablePreEvent("db5", "tbl1", "tbl2") :: Nil)
+    checkEvents(RenameTablePreEvent("db5", "tbl1", "db5", "tbl2") :: Nil)
 
     // DROP
     intercept[AnalysisException] {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -385,18 +385,18 @@ abstract class SessionCatalogSuite extends AnalysisTest {
       assert(catalog.externalCatalog.listTables("db2").toSet == Set("table_two"))
 
       // Renaming "db2.tblone" to "db1.tblones" should fail because table cannot be found.
-      val thrown1 = intercept[AnalysisException] {
+      val except1 = intercept[AnalysisException] {
         catalog.renameTable(
           TableIdentifier("tblone", Some("db2")), TableIdentifier("tblones", Some("db1")))
-      }
-      assert(thrown1.getMessage.contains("Table or view 'tblone' not found in database 'db2'"))
+      }.getMessage
+      assert(except1.contains("Table or view 'tblone' not found in database 'db2'"))
       // The new table already exists
-      val thrown2 = intercept[TableAlreadyExistsException] {
+      val except2 = intercept[TableAlreadyExistsException] {
         catalog.renameTable(
           TableIdentifier("tblone", Some("db1")),
           TableIdentifier("table_two", Some("db2")))
-      }
-      assert(thrown2.getMessage.contains(
+      }.getMessage
+      assert(except2.contains(
         "Table or view 'table_two' already exists in database 'db2'"))
     }
   }
@@ -447,26 +447,26 @@ abstract class SessionCatalogSuite extends AnalysisTest {
       assert(catalog.externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
       // If database is not specified, global temp view will not be renamed
       catalog.setCurrentDatabase("db1")
-      val thrown1 = intercept[AnalysisException] {
+      val except1 = intercept[AnalysisException] {
         catalog.renameTable(TableIdentifier("tbl1"), TableIdentifier("tblone"))
-      }
-      assert(thrown1.getMessage.contains("Table or view 'tbl1' not found in database 'db1'"))
+      }.getMessage
+      assert(except1.contains("Table or view 'tbl1' not found in database 'db1'"))
       catalog.setCurrentDatabase("db2")
       catalog.renameTable(TableIdentifier("tbl1"), TableIdentifier("tblone"))
       assert(catalog.getGlobalTempView("tbl1") == Option(globalTempTable))
       assert(catalog.externalCatalog.listTables("db2").toSet == Set("tblone", "tbl2"))
       // Moving global temp view to another database is forbidden
-      val thrown2 = intercept[AnalysisException] {
+      val except2 = intercept[AnalysisException] {
         catalog.renameTable(
           TableIdentifier("tbl1", Some("global_temp")), TableIdentifier("tbl3", Some("db2")))
-      }
-      assert(thrown2.getMessage.contains("Cannot change database of table 'tbl1'"))
+      }.getMessage
+      assert(except2.contains("Cannot change database of table 'tbl1'"))
       // Moving table from regular database to be a global temp view is forbidden
-      val thrown3 = intercept[AnalysisException] {
+      val except3 = intercept[AnalysisException] {
         catalog.renameTable(
           TableIdentifier("tbl2", Some("db2")), TableIdentifier("tbltwo", Some("global_temp")))
-      }
-      assert(thrown3.getMessage.contains("Cannot change database of table 'tbl2'"))
+      }.getMessage
+      assert(except3.contains("Cannot change database of table 'tbl2'"))
       catalog.renameTable(
         TableIdentifier("tbl1", Some("global_temp")),
         TableIdentifier("tblone", Some("global_temp")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -58,7 +58,7 @@ class GlobalTempViewSuite extends QueryTest with SharedSQLContext {
       checkAnswer(spark.table(s"$globalTempDB.src"), Row(1, "a"))
 
       // Use qualified name to rename a global temp view.
-      sql(s"ALTER VIEW $globalTempDB.src RENAME TO src2")
+      sql(s"ALTER VIEW $globalTempDB.src RENAME TO $globalTempDB.src2")
       intercept[NoSuchTableException](spark.table(s"$globalTempDB.src"))
       checkAnswer(spark.table(s"$globalTempDB.src2"), Row(1, "a"))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -760,7 +760,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
     // The database in destination table name can be omitted, and we will use the database of source
     // table for it.
-    sql("ALTER TABLE dbx.tab2 RENAME TO tab1")
+    sql("ALTER TABLE dbx.tab2 RENAME TO dbx.tab1")
     assert(catalog.listTables("dbx") == Seq(tableIdent1))
 
     catalog.setCurrentDatabase("dbx")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogBackwardCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogBackwardCompatibilitySuite.scala
@@ -241,7 +241,8 @@ class HiveExternalCatalogBackwardCompatibilitySuite extends QueryTest
   test("make sure we can rename table created by old version of Spark") {
     for ((tbl, expectedSchema) <- rawTablesAndExpectations) {
       val newName = tbl.identifier.table + "_renamed"
-      sql(s"ALTER TABLE ${tbl.identifier} RENAME TO $newName")
+      val dbName = tbl.identifier.database.get
+      sql(s"ALTER TABLE ${tbl.identifier} RENAME TO $dbName.$newName")
 
       val readBack = getTableMetadata(newName)
       assert(readBack.schema.sameType(expectedSchema))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support changing database of table by `alter table dbA.XXX rename to dbB.YYY`. Details as below:
I have to databases: `test` and `jin`; there's a table `test_student` under `test` database;
In Hive:
```
  hive> alter table test.test_student rename to jin.jin_student;
  hive> use jin;
  hive> show tables;
  OK
  jin_student
```
In Spark:
```
  spark-sql> alter table jin.jin_student rename to test.test_student;
  Error in query: RENAME TABLE source and destination databases do not match: 'jin' != 'test';
```
## How was this patch tested?

Updated existing unit test.