### PR TITLE
[SPARK-21884][SQL][BRANCH-2.2] Fix StackOverflowError on MetadataOnlyQuery

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
@@ -99,7 +99,8 @@ case class OptimizeMetadataOnlyQuery(
           case l @ LogicalRelation(fsRelation: HadoopFsRelation, _, _) =>
             val partAttrs = getPartitionAttrs(fsRelation.partitionSchema.map(_.name), l)
             val partitionData = fsRelation.location.listFiles(Nil, Nil)
-            LocalRelation(partAttrs, partitionData.map(_.values))
+            // `toArray` forces materialization to make the seq serializable
+            LocalRelation(partAttrs, partitionData.map(_.values).toArray)
 
           case relation: HiveTableRelation =>
             val partAttrs = getPartitionAttrs(relation.tableMeta.partitionColumnNames, relation)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -117,4 +117,12 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSQLContext {
     "select partcol1, max(partcol2) from srcpart where partcol1 = 0 group by rollup (partcol1)",
     "select partcol2 from (select partcol2 from srcpart where partcol1 = 0 union all " +
       "select partcol2 from srcpart where partcol1 = 1) t group by partcol2")
+
+  test("SPARK-21884 Fix StackOverflowError on MetadataOnlyQuery") {
+    withTable("t_1000") {
+      sql("CREATE TABLE t_1000 (a INT, p INT) USING PARQUET PARTITIONED BY (p)")
+      (1 to 1000).foreach(p => sql(s"ALTER TABLE t_1000 ADD PARTITION (p=$p)"))
+      sql("SELECT COUNT(DISTINCT p) FROM t_1000").collect()
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to fix StackOverflowError in `branch-2.2`. This happens when `OptimizeMetadataOnlyQuery` returns `LocalRelation` with partition informations without materializations, e.g. for Data source tables (Parquet/ORC) or Hive table stored by Parquet with convertMetastore.
`master` branch has the same logic, but it doesn't throw StackOverflowError due to the other differences.

```scala
scala> spark.version
res0: String = 2.2.0   // 2.2.1-SNAPSHOT is the same.

scala> sql("CREATE TABLE t_1000 (a INT, p INT) USING PARQUET PARTITIONED BY (p)")
res1: org.apache.spark.sql.DataFrame = []

scala> (1 to 1000).foreach(p => sql(s"ALTER TABLE t_1000 ADD PARTITION (p=$p)"))

scala> sql("SELECT COUNT(DISTINCT p) FROM t_1000").collect
java.lang.StackOverflowError
  at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1522)
```

## How was this patch tested?

Pass the Jenkins with a new test case.