### PR TITLE
[SPARK-21583][HOTFIX] Removed intercept in test causing failures

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1308,10 +1308,6 @@ class ColumnarBatchSuite extends SparkFunSuite {
       }
     }
 
-    intercept[java.lang.AssertionError] {
-      batch.getRow(100)
-    }
-
     batch.close()
     allocator.close()
   }


### PR DESCRIPTION
Removing a check in the ColumnarBatchSuite that depended on a Java assertion.  This assertion is being compiled out in the Maven builds causing the test to fail.  This part of the test is not specifically from to the functionality that is being tested here.