### PR TITLE
[SPARK-21652][SQL] Fix rule confliction between InferFiltersFromConstraints and ConstantPropagation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -80,6 +80,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       ReorderJoin,
       EliminateOuterJoin,
       InferFiltersFromConstraints,
+      BooleanSimplification,
       PushPredicateThroughJoin,
       PushDownPredicate,
       LimitPushDown,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -79,11 +79,11 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PushProjectionThroughUnion,
       ReorderJoin,
       EliminateOuterJoin,
+      InferFiltersFromConstraints,
       PushPredicateThroughJoin,
       PushDownPredicate,
       LimitPushDown,
       ColumnPruning,
-      InferFiltersFromConstraints,
       // Operator combine
       CollapseRepartition,
       CollapseProject,

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2666,29 +2666,16 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-21652: rule confliction of InferFiltersFromConstraints and ConstantPropagation") {
-    // Under test environment, throws Exception if the max iteration number is reached for an
-    // optimization batch.
-    val isTesting = Utils.isTesting
-    try {
-      if (!isTesting) {
-        System.setProperty("spark.testing", "true")
-      }
-
-      withTempView("t1", "t2") {
-        Seq((1, 1)).toDF("col1", "col2").createOrReplaceTempView("t1")
-        Seq(1, 2).toDF("col").createOrReplaceTempView("t2")
-        val df = sql(
-          """
-            |SELECT *
-            |FROM t1, t2
-            |WHERE t1.col1 = 1 AND 1 = t1.col2 AND t1.col1 = t2.col AND t1.col2 = t2.col
-          """.stripMargin)
-        checkAnswer(df, Row(1, 1, 1))
-      }
-    } finally {
-      if (!isTesting) {
-        System.clearProperty("spark.testing")
-      }
+    withTempView("t1", "t2") {
+      Seq((1, 1)).toDF("col1", "col2").createOrReplaceTempView("t1")
+      Seq(1, 2).toDF("col").createOrReplaceTempView("t2")
+      val df = sql(
+        """
+          |SELECT *
+          |FROM t1, t2
+          |WHERE t1.col1 = 1 AND 1 = t1.col2 AND t1.col1 = t2.col AND t1.col2 = t2.col
+        """.stripMargin)
+      checkAnswer(df, Row(1, 1, 1))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
 import org.apache.spark.sql.test.SQLTestData._
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 class SQLQuerySuite extends QueryTest with SharedSQLContext {
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
 import org.apache.spark.sql.test.SQLTestData._
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 class SQLQuerySuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -2662,5 +2663,32 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   test("SPARK-21743: top-most limit should not cause memory leak") {
     // In unit test, Spark will fail the query if memory leak detected.
     spark.range(100).groupBy("id").count().limit(1).collect()
+  }
+
+  test("SPARK-21652: rule confliction of InferFiltersFromConstraints and ConstantPropagation") {
+    // Under test environment, throws Exception if the max iteration number is reached for an
+    // optimization batch.
+    val isTesting = Utils.isTesting
+    try {
+      if (!isTesting) {
+        System.setProperty("spark.testing", "true")
+      }
+
+      withTempView("t1", "t2") {
+        Seq((1, 1)).toDF("col1", "col2").createOrReplaceTempView("t1")
+        Seq(1, 2).toDF("col").createOrReplaceTempView("t2")
+        val df = sql(
+          """
+            |SELECT *
+            |FROM t1, t2
+            |WHERE t1.col1 = 1 AND 1 = t1.col2 AND t1.col1 = t2.col AND t1.col2 = t2.col
+          """.stripMargin)
+        checkAnswer(df, Row(1, 1, 1))
+      }
+    } finally {
+      if (!isTesting) {
+        System.clearProperty("spark.testing")
+      }
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the given example below, the predicate added by `InferFiltersFromConstraints` is folded by `ConstantPropagation` later, this leads to unconverged optimize iteration:
```
Seq((1, 1)).toDF("col1", "col2").createOrReplaceTempView("t1")
Seq(1, 2).toDF("col").createOrReplaceTempView("t2")
sql("SELECT * FROM t1, t2 WHERE t1.col1 = 1 AND 1 = t1.col2 AND t1.col1 = t2.col AND t1.col2 = t2.col")
```

We can fix this by adjusting the indent of the optimize rules.

## How was this patch tested?

Add test case that would have failed in `SQLQuerySuite`.