### PR TITLE
[SPARK-21770][ML] ProbabilisticClassificationModel fix corner case: normalization of all-zero raw predictions

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -230,12 +230,15 @@ private[ml] object ProbabilisticClassificationModel {
    * Normalize a vector of raw predictions to be a multinomial probability vector, in place.
    *
    * The input raw predictions should be nonnegative.
-   * The output vector sums to 1, when the input vector is all-0, exception will be thrown.
+   * The output vector sums to 1.
    *
    * NOTE: This is NOT applicable to all models, only ones which effectively use class
    *       instance counts for raw predictions.
    */
+  @throws[IllegalArgumentException]("If the input vector is all-0 or including negative values")
   def normalizeToProbabilitiesInPlace(v: DenseVector): Unit = {
+    v.values.foreach(value => require(value >= 0,
+      "The input raw predictions should be nonnegative."))
     val sum = v.values.sum
     require(sum > 0, "All-0 vector is not allowed normalizing.")
     var i = 0

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import java.util.Arrays
-
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.linalg.{DenseVector, Vector, VectorUDT}
 import org.apache.spark.ml.param.shared._
@@ -232,8 +230,7 @@ private[ml] object ProbabilisticClassificationModel {
    * Normalize a vector of raw predictions to be a multinomial probability vector, in place.
    *
    * The input raw predictions should be nonnegative.
-   * The output vector sums to 1, when the input vector is all-0, the output values will be all
-   * equal to 1 / size.
+   * The output vector sums to 1, when the input vector is all-0, exception will be thrown.
    *
    * NOTE: This is NOT applicable to all models, only ones which effectively use class
    *       instance counts for raw predictions.
@@ -248,7 +245,7 @@ private[ml] object ProbabilisticClassificationModel {
         i += 1
       }
     } else {
-      Arrays.fill(v.values, 1.0 / v.size)
+      throw new IllegalArgumentException("All-0 vector is not allowed normalizing.")
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -237,15 +237,12 @@ private[ml] object ProbabilisticClassificationModel {
    */
   def normalizeToProbabilitiesInPlace(v: DenseVector): Unit = {
     val sum = v.values.sum
-    if (sum != 0) {
-      var i = 0
-      val size = v.size
-      while (i < size) {
-        v.values(i) /= sum
-        i += 1
-      }
-    } else {
-      throw new IllegalArgumentException("All-0 vector is not allowed normalizing.")
+    require(sum > 0, "All-0 vector is not allowed normalizing.")
+    var i = 0
+    val size = v.size
+    while (i < size) {
+      v.values(i) /= sum
+      i += 1
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -248,8 +248,9 @@ private[ml] object ProbabilisticClassificationModel {
     } else {
       var i = 0
       val size = v.size
+      val value = 1.0 / size
       while (i < size) {
-        v.values(i) = 1.0 / size
+        v.values(i) = value
         i += 1
       }
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -234,13 +234,14 @@ private[ml] object ProbabilisticClassificationModel {
    *
    * NOTE: This is NOT applicable to all models, only ones which effectively use class
    *       instance counts for raw predictions.
+   *
+   * @throws IllegalArgumentException if the input vector is all-0 or including negative values
    */
-  @throws[IllegalArgumentException]("If the input vector is all-0 or including negative values")
   def normalizeToProbabilitiesInPlace(v: DenseVector): Unit = {
     v.values.foreach(value => require(value >= 0,
       "The input raw predictions should be nonnegative."))
     val sum = v.values.sum
-    require(sum > 0, "All-0 vector is not allowed normalizing.")
+    require(sum > 0, "Can't normalize the 0-vector.")
     var i = 0
     val size = v.size
     while (i < size) {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification
 
+import java.util.Arrays
+
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.linalg.{DenseVector, Vector, VectorUDT}
 import org.apache.spark.ml.param.shared._
@@ -246,9 +248,7 @@ private[ml] object ProbabilisticClassificationModel {
         i += 1
       }
     } else {
-      var i = 0
-      val size = v.size
-      java.util.Arrays.fill(v.values, 1.0 / size)
+      Arrays.fill(v.values, 1.0 / v.size)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -230,8 +230,8 @@ private[ml] object ProbabilisticClassificationModel {
    * Normalize a vector of raw predictions to be a multinomial probability vector, in place.
    *
    * The input raw predictions should be nonnegative.
-   * The output vector sums to 1, unless the input vector is all-0 (in which case the output is
-   * all-0 too).
+   * The output vector sums to 1, when the input vector is all-0, the output values will be all
+   * equal to 1 / size.
    *
    * NOTE: This is NOT applicable to all models, only ones which effectively use class
    *       instance counts for raw predictions.
@@ -243,6 +243,13 @@ private[ml] object ProbabilisticClassificationModel {
       val size = v.size
       while (i < size) {
         v.values(i) /= sum
+        i += 1
+      }
+    } else {
+      var i = 0
+      val size = v.size
+      while (i < size) {
+        v.values(i) = 1.0 / size
         i += 1
       }
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -248,11 +248,7 @@ private[ml] object ProbabilisticClassificationModel {
     } else {
       var i = 0
       val size = v.size
-      val value = 1.0 / size
-      while (i < size) {
-        v.values(i) = value
-        i += 1
-      }
+      java.util.Arrays.fill(v.values, 1.0 / size)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
@@ -91,6 +91,12 @@ class ProbabilisticClassifierSuite extends SparkFunSuite {
     intercept[IllegalArgumentException] {
       ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec2)
     }
+
+    // negative input test
+    val vec3 = Vectors.dense(1.0, -1.0, 2.0).toDense
+    intercept[IllegalArgumentException] {
+      ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec3)
+    }
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.sql.{Dataset, Row}
 
-
 final class TestProbabilisticClassificationModel(
     override val uid: String,
     override val numFeatures: Int,

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.sql.{Dataset, Row}
 
+
 final class TestProbabilisticClassificationModel(
     override val uid: String,
     override val numFeatures: Int,
@@ -78,6 +79,19 @@ class ProbabilisticClassifierSuite extends SparkFunSuite {
     }
     intercept[IllegalArgumentException] {
       new TestProbabilisticClassificationModel("myuid", 2, 2).setThresholds(Array(-0.1, 0.1))
+    }
+  }
+
+  test("normalizeToProbabilitiesInPlace") {
+    val vec1 = Vectors.dense(1.0, 2.0, 3.0).toDense
+    ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec1)
+    assert(vec1 ~== Vectors.dense(1.0 / 6, 2.0 / 6, 3.0 / 6) relTol 1e-3)
+
+    // all-0 input test
+    val vec2 = Vectors.dense(0.0, 0.0, 0.0).toDense
+    ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec2)
+    vec2.toArray.foreach { v =>
+      assert(v ~== 1.0 / 3 relTol 1e-3)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
@@ -88,9 +88,8 @@ class ProbabilisticClassifierSuite extends SparkFunSuite {
 
     // all-0 input test
     val vec2 = Vectors.dense(0.0, 0.0, 0.0).toDense
-    ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec2)
-    vec2.toArray.foreach { v =>
-      assert(v ~== 1.0 / 3 relTol 1e-3)
+    intercept[IllegalArgumentException] {
+      ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec2)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix probabilisticClassificationModel corner case: normalization of all-zero raw predictions, throw IllegalArgumentException with description.

## How was this patch tested?

Test case added.
