### PR TITLE
[SPARK-21882][CORE] OutputMetrics doesn't count written bytes correctly in the saveAsHadoopDataset function

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -116,7 +116,8 @@ object SparkHadoopWriter extends Logging {
     config.initWriter(taskContext, sparkPartitionId)
     var recordsWritten = 0L
     
-    // Initialize callback function after the writer.
+    // We must initialize the callback for calculating bytes written after the statistic table 
+    // is initialized in FileSystem which is happened in initWriter.
     val (outputMetrics, callback) = initHadoopOutputMetrics(context)
 
     // Write all rows in RDD partition.

--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -112,11 +112,12 @@ object SparkHadoopWriter extends Logging {
       jobTrackerId, sparkStageId, sparkPartitionId, sparkAttemptNumber)
     committer.setupTask(taskContext)
 
-    val (outputMetrics, callback) = initHadoopOutputMetrics(context)
-
     // Initiate the writer.
     config.initWriter(taskContext, sparkPartitionId)
     var recordsWritten = 0L
+    
+    // Initialize callback function after the writer.
+    val (outputMetrics, callback) = initHadoopOutputMetrics(context)
 
     // Write all rows in RDD partition.
     try {


### PR DESCRIPTION
[SPARK-21882](https://issues.apache.org/jira/browse/SPARK-21882)

## What changes were proposed in this pull request?

The first job called from saveAsHadoopDataset, running in each executor, does not calculate the writtenBytes of OutputMetrics correctly (writtenBytes is 0). The reason is that we did not initialize the callback function called to find bytes written in the right way. As usual, statisticsTable which records statistics in a FileSystem must be initialized at the beginning (this will be triggered when open SparkHadoopWriter). One solution for this issue is to switch the initialization order of HadoopOutputMetrics and SparkHadoopWriter.

## How was this patch tested?

Existing tests
