### PR TITLE
[SPARK-21906][YARN][Spark Core]Don't runAsSparkUser to switch UserGroupInformation in YARN mode

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -775,10 +775,8 @@ object ApplicationMaster extends Logging {
         sys.props(k) = v
       }
     }
-    SparkHadoopUtil.get.runAsSparkUser { () =>
-      master = new ApplicationMaster(amArgs, new YarnRMClient)
-      System.exit(master.run())
-    }
+    master = new ApplicationMaster(amArgs, new YarnRMClient)
+    System.exit(master.run())
   }
 
   private[spark] def sparkContextInitialized(sc: SparkContext): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1、The Yarn application‘s ugi is determined by the ugi launching it
2、 runAsSparkUser is used to switch a ugi as same as itself, because we have already set
 `env("SPARK_USER") = UserGroupInformation.getCurrentUser().getShortUserName() `
in the am container context
```scala
 def runAsSparkUser(func: () => Unit) {
    val user = Utils.getCurrentUserName()  // get the user itself
    logDebug("running as user: " + user)
    val ugi = UserGroupInformation.createRemoteUser(user) // create a new ugi use itself
    transferCredentials(UserGroupInformation.getCurrentUser(), ugi) // transfer its own credentials 
    ugi.doAs(new PrivilegedExceptionAction[Unit] { // doAs as itseft
      def run: Unit = func()
    })
  }
```

## How was this patch tested?
 manual tests

cc @vanzin 