### PR TITLE
[SPARK-21916][SQL] Set isolationOn=true when create hive client for metadata.

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveCliSessionStateSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveCliSessionStateSuite.scala
@@ -43,7 +43,7 @@ class HiveCliSessionStateSuite extends SparkFunSuite {
       val sparkConf = new SparkConf()
       val hadoopConf = SparkHadoopUtil.get.newConfiguration(sparkConf)
       val s2 = HiveUtils.newClientForMetadata(sparkConf, hadoopConf).getState
-      assert(s1 === s2)
+      assert(s1 != s2)
       assert(s2.isInstanceOf[CliSessionState])
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -330,7 +330,7 @@ private[spark] object HiveUtils extends Logging {
         hadoopConf = hadoopConf,
         execJars = jars.toSeq,
         config = configurations,
-        isolationOn = !isCliSessionState(),
+        isolationOn = true,
         barrierPrefixes = hiveMetastoreBarrierPrefixes,
         sharedPrefixes = hiveMetastoreSharedPrefixes)
     } else if (hiveMetastoreJars == "maven") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current code, we set `isolationOn=!isCliSession()` when create hive client for metadata. However conf of `CliSessionState` points to local dummy metastore(https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala#L416). Using `CliSessionState`, we fail to get metadata from remote hive metastore. We can always set `isolationOn=true` when create hive clietnt for metadata

## How was this patch tested?

Existing.