### PR TITLE
[SPARK-21917][CORE][YARN] Supporting adding http(s) resources in yarn mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
@@ -121,6 +121,11 @@ private[deploy] object DependencyUtils {
 
     uri.getScheme match {
       case "file" | "local" => path
+      case "http" | "https" | "ftp" if Utils.isTesting =>
+        // This is only used for SparkSubmitSuite unit test. Instead of downloading file remotely,
+        // return a dummy local path instead.
+        val file = new File(uri.getPath)
+        new File(targetDir, file.getName).toURI.toString
       case _ =>
         val fname = new Path(uri).getName()
         val localFile = Utils.doFetchFile(uri.toString(), targetDir, fname, sparkConf, secMgr,

--- a/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
@@ -94,7 +94,7 @@ private[deploy] object DependencyUtils {
       hadoopConf: Configuration,
       secMgr: SecurityManager): String = {
     require(fileList != null, "fileList cannot be null.")
-    fileList.split(",")
+    Utils.stringToSeq(fileList)
       .map(downloadFile(_, targetDir, sparkConf, hadoopConf, secMgr))
       .mkString(",")
   }
@@ -136,7 +136,7 @@ private[deploy] object DependencyUtils {
 
   def resolveGlobPaths(paths: String, hadoopConf: Configuration): String = {
     require(paths != null, "paths cannot be null.")
-    paths.split(",").map(_.trim).filter(_.nonEmpty).flatMap { path =>
+    Utils.stringToSeq(paths).flatMap { path =>
       val uri = Utils.resolveURI(path)
       uri.getScheme match {
         case "local" | "http" | "https" | "ftp" => Array(path)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -373,7 +373,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
     //   2. We explicitly bypass Hadoop FileSystem with "spark.yarn.dist.forceDownloadSchemes".
     // We will download them to local disk prior to add to YARN's distributed cache.
     // For yarn client mode, since we already download them with above code, so we only need to
-    // gifure out the local path to replace the remote one.
+    // figure out the local path and replace the remote one.
     if (clusterManager == YARN) {
       sparkConf.setIfMissing(SecurityManager.SPARK_AUTH_SECRET_CONF, "unused")
       val secMgr = new SecurityManager(sparkConf)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -381,7 +381,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
 
       def shouldDownload(scheme: String): Boolean = {
         forceDownloadSchemes.contains(scheme) ||
-          Try { FileSystem.getFileSystemClass(scheme, hadoopConf) }.isSuccess
+          Try { FileSystem.getFileSystemClass(scheme, hadoopConf) }.isFailure
       }
 
       def downloadResource(resource: String): String = {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -403,16 +403,16 @@ object SparkSubmit extends CommandLineUtils with Logging {
 
       args.primaryResource = Option(args.primaryResource).map { downloadResource }.orNull
       args.files = Option(args.files).map { files =>
-        files.split(",").map(_.trim).filter(_.nonEmpty).map { downloadResource }.mkString(",")
+        Utils.stringToSeq(files).map { downloadResource }.mkString(",")
       }.orNull
-      args.pyFiles = Option(args.pyFiles).map { files =>
-        files.split(",").map(_.trim).filter(_.nonEmpty).map { downloadResource }.mkString(",")
+      args.pyFiles = Option(args.pyFiles).map { pyFiles =>
+        Utils.stringToSeq(pyFiles).map { downloadResource }.mkString(",")
       }.orNull
-      args.jars = Option(args.jars).map { files =>
-        files.split(",").map(_.trim).filter(_.nonEmpty).map { downloadResource }.mkString(",")
+      args.jars = Option(args.jars).map { jars =>
+        Utils.stringToSeq(jars).map { downloadResource }.mkString(",")
       }.orNull
-      args.archives = Option(args.archives).map { files =>
-        files.split(",").map(_.trim).filter(_.nonEmpty).map { downloadResource }.mkString(",")
+      args.archives = Option(args.archives).map { archives =>
+        Utils.stringToSeq(archives).map { downloadResource }.mkString(",")
       }.orNull
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -380,10 +380,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
       val forceDownloadSchemes = sparkConf.get(FORCE_DOWNLOAD_SCHEMES)
 
       def shouldDownload(scheme: String): Boolean = {
-        val isFsAvailable = () => {
+        forceDownloadSchemes.contains(scheme) ||
           Try { FileSystem.getFileSystemClass(scheme, hadoopConf) }.isSuccess
-        }
-        forceDownloadSchemes.contains(scheme) || !isFsAvailable()
       }
 
       def downloadResource(resource: String): String = {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -403,16 +403,16 @@ object SparkSubmit extends CommandLineUtils with Logging {
 
       args.primaryResource = Option(args.primaryResource).map { downloadResource }.orNull
       args.files = Option(args.files).map { files =>
-        Utils.stringToSeq(files).map { downloadResource }.mkString(",")
+        Utils.stringToSeq(files).map(downloadResource).mkString(",")
       }.orNull
       args.pyFiles = Option(args.pyFiles).map { pyFiles =>
-        Utils.stringToSeq(pyFiles).map { downloadResource }.mkString(",")
+        Utils.stringToSeq(pyFiles).map(downloadResource).mkString(",")
       }.orNull
       args.jars = Option(args.jars).map { jars =>
-        Utils.stringToSeq(jars).map { downloadResource }.mkString(",")
+        Utils.stringToSeq(jars).map(downloadResource).mkString(",")
       }.orNull
       args.archives = Option(args.archives).map { archives =>
-        Utils.stringToSeq(archives).map { downloadResource }.mkString(",")
+        Utils.stringToSeq(archives).map(downloadResource).mkString(",")
       }.orNull
     }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -406,7 +406,7 @@ package object config {
       .doc("Comma-separated list of schemes for which files will be downloaded to the " +
         "local disk prior to being added to YARN's distributed cache. For use in cases " +
         "where the YARN service does not support schemes that are supported by Spark, like http, " +
-        "https, ftp.")
+        "https and ftp.")
       .stringConf
       .toSequence
       .createWithDefault(Nil)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -403,8 +403,9 @@ package object config {
 
   private[spark] val FORCE_DOWNLOAD_SCHEMES =
     ConfigBuilder("spark.yarn.dist.forceDownloadSchemes")
-      .doc("Comma-separated list of schemes in which remote resources have to download to local " +
-        "disk and upload to Hadoop FS.")
+      .doc("Comma-separated list of schemes for which files will be downloaded to the " +
+        "local disk prior to being added to YARN's distributed cache. For use in cases " +
+        "where the YARN service does not support schemes that are supported by Spark.")
       .stringConf
       .toSequence
       .createWithDefault(Nil)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -405,7 +405,8 @@ package object config {
     ConfigBuilder("spark.yarn.dist.forceDownloadSchemes")
       .doc("Comma-separated list of schemes for which files will be downloaded to the " +
         "local disk prior to being added to YARN's distributed cache. For use in cases " +
-        "where the YARN service does not support schemes that are supported by Spark.")
+        "where the YARN service does not support schemes that are supported by Spark, like http, " +
+        "https, ftp.")
       .stringConf
       .toSequence
       .createWithDefault(Nil)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -401,11 +401,11 @@ package object config {
       .doubleConf
       .createWithDefault(1.5)
 
-  private[spark] val FORCE_DOWNLOAD_RESOURCES =
-    ConfigBuilder("spark.yarn.dist.forceDownloadResources")
-      .doc("Whether to download remote HTTP(s) resources to local and upload to Hadoop FS. " +
-        "This is only honored in Hadoop 2.9+ environment to bypass the build-in HTTP(s) " +
-        "FileSystem and use Spark's own logic to handle remote HTTP(s) resources")
-      .booleanConf
-      .createWithDefault(false)
+  private[spark] val FORCE_DOWNLOAD_SCHEMES =
+    ConfigBuilder("spark.yarn.dist.forceDownloadSchemes")
+      .doc("Comma-separated list of schemes in which remote resources have to download to local " +
+        "disk and upload to Hadoop FS.")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -400,4 +400,12 @@ package object config {
       .doc("Memory to request as a multiple of the size that used to unroll the block.")
       .doubleConf
       .createWithDefault(1.5)
+
+  private[spark] val FORCE_DOWNLOAD_RESOURCES =
+    ConfigBuilder("spark.yarn.dist.forceDownloadResources")
+      .doc("Whether to download remote HTTP(s) resources to local and upload to Hadoop FS. " +
+        "This is only honored in Hadoop 2.9+ environment to bypass the build-in HTTP(s) " +
+        "FileSystem and use Spark's own logic to handle remote HTTP(s) resources")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2684,6 +2684,9 @@ private[spark] object Utils extends Logging {
     redact(redactionPattern, kvs.toArray)
   }
 
+  def stringToSeq(str: String): Seq[String] = {
+    str.split(",").map(_.trim()).filter(_.nonEmpty)
+  }
 }
 
 private[util] object CallerContext extends Logging {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -954,7 +954,7 @@ class SparkSubmitSuite
 
     val args2 = Seq(
       "--class", UserClasspathFirstTest.getClass.getName.stripPrefix("$"),
-      "--conf", "spark.yarn.dist.forceDownloadResources=true",
+      "--conf", "spark.yarn.dist.forceDownloadSchemes=http,https",
       "--name", "testApp",
       "--master", "yarn",
       "--deploy-mode", "client",

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -897,78 +897,74 @@ class SparkSubmitSuite
     sysProps("spark.submit.pyFiles") should (startWith("/"))
   }
 
-  test("handle remote http(s) resources in yarn mode") {
+  test("download remote resource if it is not supported by yarn service") {
+    testRemoteResources(isHttpSchemeBlacklisted = false, supportMockHttpFs = false)
+  }
+
+  test("avoid downloading remote resource if it is supported by yarn service") {
+    testRemoteResources(isHttpSchemeBlacklisted = false, supportMockHttpFs = true)
+  }
+
+  test("force downloading remote resource if it's scheme is configured") {
+    testRemoteResources(isHttpSchemeBlacklisted = true, supportMockHttpFs = true)
+  }
+
+  private def testRemoteResources(
+      isHttpSchemeBlacklisted: Boolean, supportMockHttpFs: Boolean): Unit = {
     val hadoopConf = new Configuration()
     updateConfWithFakeS3Fs(hadoopConf)
+    if (supportMockHttpFs) {
+      hadoopConf.set("fs.http.impl", classOf[TestFileSystem].getCanonicalName)
+      hadoopConf.set("fs.http.impl.disable.cache", "true")
+    }
 
     val tmpDir = Utils.createTempDir()
     val mainResource = File.createTempFile("tmpPy", ".py", tmpDir)
-    val tmpJar = TestUtils.createJarWithFiles(Map("test.resource" -> "USER"), tmpDir)
-    val tmpJarPath = s"s3a://${new File(tmpJar.toURI).getAbsolutePath}"
-    // This assumes UT environment could access external network.
-    val remoteHttpJar =
-      "http://central.maven.org/maven2/io/dropwizard/metrics/metrics-core/" +
-        "3.2.4/metrics-core-3.2.4.jar"
+    val tmpS3Jar = TestUtils.createJarWithFiles(Map("test.resource" -> "USER"), tmpDir)
+    val tmpS3JarPath = s"s3a://${new File(tmpS3Jar.toURI).getAbsolutePath}"
+    val tmpHttpJar = TestUtils.createJarWithFiles(Map("test.resource" -> "USER"), tmpDir)
+    val tmpHttpJarPath = s"http://${new File(tmpHttpJar.toURI).getAbsolutePath}"
 
     val args = Seq(
       "--class", UserClasspathFirstTest.getClass.getName.stripPrefix("$"),
       "--name", "testApp",
       "--master", "yarn",
       "--deploy-mode", "client",
-      "--jars", s"$tmpJarPath,$remoteHttpJar",
+      "--jars", s"$tmpS3JarPath,$tmpHttpJarPath",
       s"s3a://$mainResource"
+    ) ++ (
+      if (isHttpSchemeBlacklisted) {
+        Seq("--conf", "spark.yarn.dist.forceDownloadSchemes=http,https")
+      } else {
+        Nil
+      }
     )
 
-    val appArgs = new SparkSubmitArguments(args)
-    val sysProps = SparkSubmit.prepareSubmitEnvironment(appArgs, Some(hadoopConf))._3
+    sys.props.put("spark.testing", "1")
+    try {
+      val appArgs = new SparkSubmitArguments(args)
+      val sysProps = SparkSubmit.prepareSubmitEnvironment(appArgs, Some(hadoopConf))._3
 
-    // Resources in S3 should still be remote path, but remote http resource will be downloaded
-    // to local.
-    val jars = sysProps("spark.yarn.dist.jars").split(",").toSet
-    jars.contains(tmpJarPath) should be (true)
-    val metricsJar = jars.filter(_.contains("metrics"))
-    metricsJar.size should be (1)
-    metricsJar.head should startWith("file:")
+      val jars = sysProps("spark.yarn.dist.jars").split(",").toSet
 
-    val hadoopConf1 = new Configuration()
-    updateConfWithFakeS3Fs(hadoopConf1)
-    hadoopConf1.set("fs.http.impl", classOf[TestFileSystem].getCanonicalName)
-    hadoopConf1.set("fs.http.impl.disable.cache", "true")
+      // The URI of remote S3 resource should still be remote.
+      assert(jars.contains(tmpS3JarPath))
 
-    val args1 = Seq(
-      "--class", UserClasspathFirstTest.getClass.getName.stripPrefix("$"),
-      "--name", "testApp",
-      "--master", "yarn",
-      "--deploy-mode", "client",
-      "--jars", s"$tmpJarPath,$remoteHttpJar",
-      s"s3a://$mainResource"
-    )
-
-    val appArgs1 = new SparkSubmitArguments(args1)
-    val sysProps1 = SparkSubmit.prepareSubmitEnvironment(appArgs1, Some(hadoopConf1))._3
-
-    // If Hadoop FileSystem supports remote HTTP(S) resoures, we will still keep HTTP
-    // resource URI, not the local one.
-    val jars1 = sysProps1("spark.yarn.dist.jars").split(",").toSet
-    jars1.contains(remoteHttpJar) should be (true)
-
-    val args2 = Seq(
-      "--class", UserClasspathFirstTest.getClass.getName.stripPrefix("$"),
-      "--conf", "spark.yarn.dist.forceDownloadSchemes=http,https",
-      "--name", "testApp",
-      "--master", "yarn",
-      "--deploy-mode", "client",
-      "--jars", s"$tmpJarPath,$remoteHttpJar",
-      s"s3a://$mainResource"
-    )
-
-    val appArgs2 = new SparkSubmitArguments(args2)
-    val sysProps2 = SparkSubmit.prepareSubmitEnvironment(appArgs2, Some(hadoopConf1))._3
-
-    // We explicitly disable using HTTP(S) FileSystem, force downloading remote HTTP(s)
-    // resources, so the URI should be local one.
-    val jars2 = sysProps2("spark.yarn.dist.jars").split(",").toSet
-    jars.filter(_.contains("metrics")).head should startWith("file:")
+      if (supportMockHttpFs) {
+        // If Http FS is supported by yarn service, the URI of remote http resource should
+        // still be remote.
+        assert(jars.contains(tmpHttpJarPath))
+      } else {
+        // If Http FS is not supported by yarn service, or http scheme is configured to be force
+        // downloading, the URI of remote http resource should be changed to a local one.
+        val jarName = new File(tmpHttpJar.toURI).getName
+        val localHttpJar = jars.filter(_.contains(jarName))
+        localHttpJar.size should be(1)
+        localHttpJar.head should startWith("file:")
+      }
+    } finally {
+      sys.props.remove("spark.testing")
+    }
   }
 
   // NOTE: This is an expensive operation in terms of time (10 seconds+). Use sparingly.

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -215,8 +215,9 @@ To use a custom metrics.properties for the application master and executors, upd
   <td><code>spark.yarn.dist.forceDownloadSchemes</code></td>
   <td><code>(none)</code></td>
   <td>
-    Comma-separated schemes in which remote resources have to download to local disk and upload 
-    to Hadoop FS.
+    Comma-separated list of schemes for which files will be downloaded to the local disk prior to 
+    being added to YARN's distributed cache. For use in cases where the YARN service does not 
+    support schemes that are supported by Spark.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -212,6 +212,15 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
 </tr>
 <tr>
+  <td><code>spark.yarn.dist.forceDownloadResources</code></td>
+  <td><code>false</code></td>
+  <td>
+    Whether to download remote HTTP(s) resources to local and upload to Hadoop FS. This is only 
+    honored in Hadoop 2.9+ environment to bypass the build-in HTTP(s) FileSystem and use Spark's 
+    own logic to handle remote HTTP(s) resources"
+  </td>
+</tr>
+<tr>
  <td><code>spark.executor.instances</code></td>
   <td><code>2</code></td>
   <td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -212,12 +212,11 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
 </tr>
 <tr>
-  <td><code>spark.yarn.dist.forceDownloadResources</code></td>
-  <td><code>false</code></td>
+  <td><code>spark.yarn.dist.forceDownloadSchemes</code></td>
+  <td><code>(none)</code></td>
   <td>
-    Whether to download remote HTTP(s) resources to local and upload to Hadoop FS. This is only 
-    honored in Hadoop 2.9+ environment to bypass the build-in HTTP(s) FileSystem and use Spark's 
-    own logic to handle remote HTTP(s) resources"
+    Comma-separated schemes in which remote resources have to download to local disk and upload 
+    to Hadoop FS.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -217,7 +217,7 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>
     Comma-separated list of schemes for which files will be downloaded to the local disk prior to 
     being added to YARN's distributed cache. For use in cases where the YARN service does not 
-    support schemes that are supported by Spark.
+    support schemes that are supported by Spark, like http, https and ftp.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the current Spark, when submitting application on YARN with remote resources `./bin/spark-shell --jars http://central.maven.org/maven2/com/github/swagger-akka-http/swagger-akka-http_2.11/0.10.1/swagger-akka-http_2.11-0.10.1.jar --master yarn-client -v`, Spark will be failed with:

```
java.io.IOException: No FileSystem for scheme: http
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:2586)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2593)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:91)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2632)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2614)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:370)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296)
	at org.apache.spark.deploy.yarn.Client.copyFileToRemote(Client.scala:354)
	at org.apache.spark.deploy.yarn.Client.org$apache$spark$deploy$yarn$Client$$distribute$1(Client.scala:478)
	at org.apache.spark.deploy.yarn.Client$$anonfun$prepareLocalResources$11$$anonfun$apply$6.apply(Client.scala:600)
	at org.apache.spark.deploy.yarn.Client$$anonfun$prepareLocalResources$11$$anonfun$apply$6.apply(Client.scala:599)
	at scala.collection.mutable.ArraySeq.foreach(ArraySeq.scala:74)
	at org.apache.spark.deploy.yarn.Client$$anonfun$prepareLocalResources$11.apply(Client.scala:599)
	at org.apache.spark.deploy.yarn.Client$$anonfun$prepareLocalResources$11.apply(Client.scala:598)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.apache.spark.deploy.yarn.Client.prepareLocalResources(Client.scala:598)
	at org.apache.spark.deploy.yarn.Client.createContainerLaunchContext(Client.scala:848)
	at org.apache.spark.deploy.yarn.Client.submitApplication(Client.scala:173)
```

This is because `YARN#client` assumes resources are on the Hadoop compatible FS. To fix this problem, here propose to download remote http(s) resources to local and add this local downloaded resources to dist cache. This solution has one downside: remote resources are downloaded and uploaded again, but it only restricted to only remote http(s) resources, also the overhead is not so big. The advantages of this solution is that it is simple and the code changes restricts to only `SparkSubmit`.

## How was this patch tested?

Unit test added, also verified in local cluster.
