### PR TITLE
[SPARK-21932][SQL][TEST]Add  test CartesianProduct join case and BroadcastNestedLoop join case in JoinBenchmark

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -91,7 +91,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
         leftPlan: SparkPlan,
         rightPlan: SparkPlan,
         side: BuildSide) = {
-      val broadcastJoin = joins.BroadcastHashJoinExec(
+      val broadcastJoin = BroadcastHashJoinExec(
         leftKeys,
         rightKeys,
         Inner,
@@ -109,7 +109,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
         leftPlan: SparkPlan,
         rightPlan: SparkPlan,
         side: BuildSide) = {
-      val shuffledHashJoin = joins.ShuffledHashJoinExec(leftKeys, rightKeys, Inner,
+      val shuffledHashJoin = ShuffledHashJoinExec(leftKeys, rightKeys, Inner,
         side, None, leftPlan, rightPlan)
       val filteredJoin =
         boundCondition.map(FilterExec(_, shuffledHashJoin)).getOrElse(shuffledHashJoin)
@@ -122,7 +122,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
         boundCondition: Option[Expression],
         leftPlan: SparkPlan,
         rightPlan: SparkPlan) = {
-      val sortMergeJoin = joins.SortMergeJoinExec(leftKeys, rightKeys, Inner, boundCondition,
+      val sortMergeJoin = SortMergeJoinExec(leftKeys, rightKeys, Inner, boundCondition,
         leftPlan, rightPlan)
       EnsureRequirements(spark.sessionState.conf).apply(sortMergeJoin)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
this PR  describe add new two test case. test CartesianProduct join and BroadcastNestedLoop join. We understand the effect of CodeGen on them. and through these two test cases, we can know Per Row (NS),  is much more delayed than our previous hash join.

## How was this patch tested?

add new test case.
