### PR TITLE
[WIP][SPARK-21190][SQL][PYTHON] Vectorized UDFs in Python

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -573,6 +573,39 @@ class UTF8Deserializer(Serializer):
         return "UTF8Deserializer(%s)" % self.use_unicode
 
 
+class VectorizedSerializer(Serializer):
+
+    """
+    (De)serializes a vectorized(Apache Arrow) stream.
+    """
+
+    def load_stream(self, stream):
+        import pyarrow as pa
+        reader = pa.open_stream(stream)
+        for batch in reader:
+            vectors = [batch[col].to_pandas() for col in xrange(batch.num_columns)]
+            yield [batch.num_rows] + vectors
+
+    def dump_stream(self, iterator, stream):
+        import pandas as pd
+        import pyarrow as pa
+        # the schema is set at worker.py#read_vectorized_udfs
+        writer = pa.RecordBatchStreamWriter(stream, self.schema)
+        names = self.schema.names
+        types = [f.type for f in self.schema]
+        # todo: verify the type of the arrays returned by UDF.
+        try:
+            for arrays in iterator:
+                vectors = [pa.Array.from_pandas(array.astype(t.to_pandas_dtype(), copy=False),
+                                                mask=pd.isnull(array), type=t)
+                           for array, t in zip(arrays, types)]
+                batch = pa.RecordBatch.from_arrays(vectors, names)
+                writer.write_batch(batch)
+        finally:
+            # todo: does arrow close the socket?
+            writer.close()
+
+
 def read_long(stream):
     length = stream.read(8)
     if not length:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -30,7 +30,13 @@ try:
     import pandas
     _have_pandas = True
 except:
-    # No Pandas, but that's okay, we'll skip those tests
+    pass
+
+_have_arrow = False
+try:
+    import pyarrow
+    _have_arrow = True
+except:
     pass
 
 from pyspark import since, SparkContext
@@ -2125,7 +2131,7 @@ def _udf(f, returnType, vectorized):
     return udf_obj._wrapped()
 
 
-if _have_pandas:
+if _have_pandas and _have_arrow:
 
     @since(2.3)
     def pandas_udf(f=None, returnType=StringType()):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2032,7 +2032,7 @@ class UserDefinedFunction(object):
 
     .. versionadded:: 1.3
     """
-    def __init__(self, func, returnType, name=None):
+    def __init__(self, func, returnType, name=None, vectorized=False):
         if not callable(func):
             raise TypeError(
                 "Not a function or callable (__call__ is not defined): "
@@ -2046,6 +2046,7 @@ class UserDefinedFunction(object):
         self._name = name or (
             func.__name__ if hasattr(func, '__name__')
             else func.__class__.__name__)
+        self._vectorized = vectorized
 
     @property
     def returnType(self):
@@ -2077,7 +2078,7 @@ class UserDefinedFunction(object):
         wrapped_func = _wrap_function(sc, self.func, self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())
         judf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonFunction(
-            self._name, wrapped_func, jdt)
+            self._name, wrapped_func, jdt, self._vectorized)
         return judf
 
     def __call__(self, *cols):
@@ -2111,8 +2112,40 @@ class UserDefinedFunction(object):
         return wrapper
 
 
+@since(2.3)
+def pandas_udf(f=None, returnType=None):
+    """Creates a :class:`Column` expression representing a vectorized user defined function (UDF).
+
+    .. note:: The vectorized user-defined functions must be deterministic. Due to optimization,
+        duplicate invocations may be eliminated or the function may even be invoked more times than
+        it is present in the query.
+
+    :param f: python function if used as a standalone function
+    :param returnType: a :class:`pyspark.sql.types.DataType` object
+
+    >>> from pyspark.sql.types import LongType
+    >>> add = pandas_udf(lambda x, y: x + y, LongType())
+    >>> @pandas_udf(returnType=LongType())
+    ... def mul(x, y):
+    ...     return x * y
+    ...
+    >>> import pandas as pd
+    >>> ones = pandas_udf(lambda size: pd.Series(1).repeat(size), LongType())
+
+    >>> df = spark.createDataFrame([(1, 2), (3, 4)], ("a", "b"))
+    >>> df.select(add("a", "b").alias("add(a, b)"), mul("a", "b"), ones().alias("ones")).show()
+    +---------+---------+----+
+    |add(a, b)|mul(a, b)|ones|
+    +---------+---------+----+
+    |        3|        2|   1|
+    |        7|       12|   1|
+    +---------+---------+----+
+    """
+    return udf(f, returnType, vectorized=True)
+
+
 @since(1.3)
-def udf(f=None, returnType=StringType()):
+def udf(f=None, returnType=StringType(), vectorized=False):
     """Creates a :class:`Column` expression representing a user defined function (UDF).
 
     .. note:: The user-defined functions must be deterministic. Due to optimization,
@@ -2142,8 +2175,8 @@ def udf(f=None, returnType=StringType()):
     |         8|      JOHN DOE|          22|
     +----------+--------------+------------+
     """
-    def _udf(f, returnType=StringType()):
-        udf_obj = UserDefinedFunction(f, returnType)
+    def _udf(f, returnType=StringType(), vectorized=False):
+        udf_obj = UserDefinedFunction(f, returnType, vectorized=vectorized)
         return udf_obj._wrapped()
 
     # decorator @udf, @udf() or @udf(dataType())
@@ -2151,9 +2184,9 @@ def udf(f=None, returnType=StringType()):
         # If DataType has been passed as a positional argument
         # for decorator use it as a returnType
         return_type = f or returnType
-        return functools.partial(_udf, returnType=return_type)
+        return functools.partial(_udf, returnType=return_type, vectorized=vectorized)
     else:
-        return _udf(f=f, returnType=returnType)
+        return _udf(f=f, returnType=returnType, vectorized=vectorized)
 
 
 blacklist = ['map', 'since', 'ignore_unicode_prefix']

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -63,10 +63,12 @@ from pyspark.sql.types import UserDefinedType, _infer_type, _make_type_verifier
 from pyspark.sql.types import _array_signed_int_typecode_ctype_mappings, _array_type_mappings
 from pyspark.sql.types import _array_unsigned_int_typecode_ctype_mappings
 from pyspark.tests import QuietTest, ReusedPySparkTestCase, SparkSubmitTests
-from pyspark.sql.functions import UserDefinedFunction, sha2, lit, col, expr, pandas_udf
+from pyspark.sql.functions import UserDefinedFunction, sha2, lit, col, expr
 from pyspark.sql.window import Window
 from pyspark.sql.utils import AnalysisException, ParseException, IllegalArgumentException
 
+if _have_pandas:
+    from pyspark.sql.functions import pandas_udf
 
 _have_arrow = False
 try:

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3226,6 +3226,13 @@ class VectorizedUDFTests(ReusedPySparkTestCase):
         res = df.select(f0())
         self.assertEquals(df.select(lit(1)).collect(), res.collect())
 
+    def test_vectorized_udf_datatype_string(self):
+        import pandas as pd
+        df = self.spark.range(100000)
+        f0 = pandas_udf(lambda size: pd.Series(1).repeat(size), "long")
+        res = df.select(f0())
+        self.assertEquals(df.select(lit(1)).collect(), res.collect())
+
     def test_vectorized_udf_complex(self):
         df = self.spark.range(10).select(
             col('id').cast('int').alias('a'),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3264,6 +3264,15 @@ class VectorizedUDFTests(ReusedPySparkTestCase):
                     'The length of returned value should be the same as input value'):
                 df.select(raise_exception()).collect()
 
+    def test_vectorized_udf_mix_udf(self):
+        from pyspark.sql.functions import udf
+        df = self.spark.range(10)
+        row_by_row_udf = udf(lambda x: x, LongType())
+        pd_udf = pandas_udf(lambda x: x, LongType())
+        with QuietTest(self.sc):
+            with self.assertRaisesRegexp(Exception, 'cannot mix vectorized udf and normal udf'):
+                df.select(row_by_row_udf(col('id')), pd_udf(col('id'))).collect()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests import *

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -67,9 +67,6 @@ from pyspark.sql.functions import UserDefinedFunction, sha2, lit, col, expr
 from pyspark.sql.window import Window
 from pyspark.sql.utils import AnalysisException, ParseException, IllegalArgumentException
 
-if _have_pandas:
-    from pyspark.sql.functions import pandas_udf
-
 _have_arrow = False
 try:
     import pyarrow
@@ -77,6 +74,9 @@ try:
 except:
     # No Arrow, but that's okay, we'll skip those tests
     pass
+
+if _have_pandas and _have_arrow:
+    from pyspark.sql.functions import pandas_udf
 
 
 class UTCOffsetTimezone(datetime.tzinfo):
@@ -3124,7 +3124,7 @@ class ArrowTests(ReusedPySparkTestCase):
         self.assertTrue(pdf.empty)
 
 
-@unittest.skipIf(not _have_arrow, "Arrow not installed")
+@unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")
 class VectorizedUDFTests(ReusedPySparkTestCase):
 
     @classmethod

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3245,6 +3245,15 @@ class VectorizedUDFTests(ReusedPySparkTestCase):
             with self.assertRaisesRegexp(Exception, 'division( or modulo)? by zero'):
                 df.select(raise_exception(col('id'))).collect()
 
+    def test_vectorized_udf_invalid_length(self):
+        import pandas as pd
+        df = self.spark.range(10)
+        raise_exception = pandas_udf(lambda size: pd.Series(1), LongType())
+        with QuietTest(self.sc):
+            with self.assertRaisesRegexp(Exception,
+                    'The length of returned value should be the same as input value'):
+                df.select(raise_exception()).collect()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests import *

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3250,7 +3250,8 @@ class VectorizedUDFTests(ReusedPySparkTestCase):
         df = self.spark.range(10)
         raise_exception = pandas_udf(lambda size: pd.Series(1), LongType())
         with QuietTest(self.sc):
-            with self.assertRaisesRegexp(Exception,
+            with self.assertRaisesRegexp(
+                    Exception,
                     'The length of returned value should be the same as input value'):
                 df.select(raise_exception()).collect()
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1582,6 +1582,35 @@ register_input_converter(DatetimeConverter())
 register_input_converter(DateConverter())
 
 
+def toArrowType(dt):
+    import pyarrow as pa
+    if type(dt) == BooleanType:
+        arrow_type = pa.bool_()
+    elif type(dt) == ByteType:
+        arrow_type = pa.int8()
+    elif type(dt) == ShortType:
+        arrow_type = pa.int16()
+    elif type(dt) == IntegerType:
+        arrow_type = pa.int32()
+    elif type(dt) == LongType:
+        arrow_type = pa.int64()
+    elif type(dt) == FloatType:
+        arrow_type = pa.float32()
+    elif type(dt) == DoubleType:
+        arrow_type = pa.float64()
+    elif type(dt) == DecimalType:
+        arrow_type = pa.decimal(dt.precision, dt.scale)
+    elif type(dt) == StringType:
+        arrow_type = pa.string()
+    return arrow_type
+
+
+def toArrowSchema(types):
+    import pyarrow as pa
+    fields = [pa.field("c_" + str(i), toArrowType(types[i])) for i in range(len(types))]
+    return pa.schema(fields)
+
+
 def _test():
     import doctest
     from pyspark.context import SparkContext

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -138,11 +138,13 @@ def read_vectorized_udfs(pickleSer, infile):
         else:
             args = ["a[0]"]
         call_udfs.append("f%d(%s)" % (i, ", ".join(args)))
+
     def chk_len(v, size):
         if len(v) == size:
             return v
         else:
             raise Exception("The length of returned value should be the same as input value")
+
     call_and_chk_len = ['chk_len(%s, a[0])' % call_udf for call_udf in call_udfs]
     udfs['chk_len'] = chk_len
     # Create function like this:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExec.scala
@@ -62,6 +62,7 @@ import org.apache.spark.util.Utils
  */
 case class BatchEvalPythonExec(udfs: Seq[PythonUDF], output: Seq[Attribute], child: SparkPlan)
   extends SparkPlan {
+  assert(udfs.map(_.vectorized).distinct.length == 1, "cannot mix vectorized udf and normal udf")
 
   def children: Seq[SparkPlan] = child :: Nil
 
@@ -84,86 +85,138 @@ case class BatchEvalPythonExec(udfs: Seq[PythonUDF], output: Seq[Attribute], chi
     val bufferSize = inputRDD.conf.getInt("spark.buffer.size", 65536)
     val reuseWorker = inputRDD.conf.getBoolean("spark.python.worker.reuse", defaultValue = true)
 
-    inputRDD.mapPartitions { iter =>
-      EvaluatePython.registerPicklers()  // register pickler for Row
+    if (udfs.head.vectorized) {
+      inputRDD.mapPartitions { iter =>
+        val context = TaskContext.get()
 
-      // The queue used to buffer input rows so we can drain it to
-      // combine input with output from Python.
-      val queue = HybridRowQueue(TaskContext.get().taskMemoryManager(),
-        new File(Utils.getLocalDir(SparkEnv.get.conf)), child.output.length)
-      TaskContext.get().addTaskCompletionListener({ ctx =>
-        queue.close()
-      })
+        // The queue used to buffer input rows so we can drain it to
+        // combine input with output from Python.
+        val queue = HybridRowQueue(context.taskMemoryManager(),
+          new File(Utils.getLocalDir(SparkEnv.get.conf)), child.output.length)
+        context.addTaskCompletionListener({ ctx =>
+          queue.close()
+        })
 
-      val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
+        val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
 
-      // flatten all the arguments
-      val allInputs = new ArrayBuffer[Expression]
-      val dataTypes = new ArrayBuffer[DataType]
-      val argOffsets = inputs.map { input =>
-        input.map { e =>
-          if (allInputs.exists(_.semanticEquals(e))) {
-            allInputs.indexWhere(_.semanticEquals(e))
-          } else {
-            allInputs += e
-            dataTypes += e.dataType
-            allInputs.length - 1
-          }
+        // flatten all the arguments
+        val allInputs = new ArrayBuffer[Expression]
+        val dataTypes = new ArrayBuffer[DataType]
+        val argOffsets = inputs.map { input =>
+          input.map { e =>
+            if (allInputs.exists(_.semanticEquals(e))) {
+              allInputs.indexWhere(_.semanticEquals(e))
+            } else {
+              allInputs += e
+              dataTypes += e.dataType
+              allInputs.length - 1
+            }
+          }.toArray
         }.toArray
-      }.toArray
-      val projection = newMutableProjection(allInputs, child.output)
-      val schema = StructType(dataTypes.map(dt => StructField("", dt)))
-      val needConversion = dataTypes.exists(EvaluatePython.needConversionInPython)
+        val projection = newMutableProjection(allInputs, child.output)
+        val schema = StructType(dataTypes.zipWithIndex.map {
+          case (dt, index) => StructField(s"c_$index", dt)
+        })
 
-      // enable memo iff we serialize the row with schema (schema and class should be memorized)
-      val pickle = new Pickler(needConversion)
-      // Input iterator to Python: input rows are grouped so we send them in batches to Python.
-      // For each row, add it to the queue.
-      val inputIterator = iter.map { inputRow =>
-        queue.add(inputRow.asInstanceOf[UnsafeRow])
-        val row = projection(inputRow)
-        if (needConversion) {
-          EvaluatePython.toJava(row, schema)
-        } else {
-          // fast path for these types that does not need conversion in Python
-          val fields = new Array[Any](row.numFields)
-          var i = 0
-          while (i < row.numFields) {
-            val dt = dataTypes(i)
-            fields(i) = EvaluatePython.toJava(row.get(i, dt), dt)
-            i += 1
-          }
-          fields
+        // For each row, add it to the queue.
+
+        val inputIterator = iter.map { inputRow =>
+          queue.add(inputRow.asInstanceOf[UnsafeRow])
+          projection(inputRow)
         }
-      }.grouped(100).map(x => pickle.dumps(x.toArray))
 
-      val context = TaskContext.get()
-
-      // Output iterator for results from Python.
-      val outputIterator = new PythonRunner(pyFuncs, bufferSize, reuseWorker, true, argOffsets)
-        .compute(inputIterator, context.partitionId(), context)
-
-      val unpickle = new Unpickler
-      val mutableRow = new GenericInternalRow(1)
-      val joined = new JoinedRow
-      val resultType = if (udfs.length == 1) {
-        udfs.head.dataType
-      } else {
-        StructType(udfs.map(u => StructField("", u.dataType, u.nullable)))
+        // Output iterator for results from Python.
+        val outputIterator =
+          new VectorizedPythonRunner(pyFuncs, 10000, bufferSize, reuseWorker, argOffsets)
+            .compute(inputIterator, schema, context.partitionId(), context)
+        val joined = new JoinedRow
+        val resultProj = UnsafeProjection.create(output, output)
+        outputIterator.map { row =>
+          resultProj(joined(queue.remove(), row))
+        }
       }
-      val resultProj = UnsafeProjection.create(output, output)
-      outputIterator.flatMap { pickedResult =>
-        val unpickledBatch = unpickle.loads(pickedResult)
-        unpickledBatch.asInstanceOf[java.util.ArrayList[Any]].asScala
-      }.map { result =>
-        val row = if (udfs.length == 1) {
-          // fast path for single UDF
-          mutableRow(0) = EvaluatePython.fromJava(result, resultType)
-          mutableRow
+    } else {
+      inputRDD.mapPartitions { iter =>
+        val context = TaskContext.get()
+
+        EvaluatePython.registerPicklers()  // register pickler for Row
+
+        // The queue used to buffer input rows so we can drain it to
+        // combine input with output from Python.
+        val queue = HybridRowQueue(context.taskMemoryManager(),
+          new File(Utils.getLocalDir(SparkEnv.get.conf)), child.output.length)
+        context.addTaskCompletionListener({ ctx =>
+          queue.close()
+        })
+
+        val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
+
+        // flatten all the arguments
+        val allInputs = new ArrayBuffer[Expression]
+        val dataTypes = new ArrayBuffer[DataType]
+        val argOffsets = inputs.map { input =>
+          input.map { e =>
+            if (allInputs.exists(_.semanticEquals(e))) {
+              allInputs.indexWhere(_.semanticEquals(e))
+            } else {
+              allInputs += e
+              dataTypes += e.dataType
+              allInputs.length - 1
+            }
+          }.toArray
+        }.toArray
+        val projection = newMutableProjection(allInputs, child.output)
+        val schema = StructType(dataTypes.map(dt => StructField("", dt)))
+        val needConversion = dataTypes.exists(EvaluatePython.needConversionInPython)
+
+        // enable memo iff we serialize the row with schema (schema and class should be memorized)
+        val pickle = new Pickler(needConversion)
+        // Input iterator to Python: input rows are grouped so we send them in batches to Python.
+        // For each row, add it to the queue.
+        val inputIterator = iter.map { inputRow =>
+          queue.add(inputRow.asInstanceOf[UnsafeRow])
+          val row = projection(inputRow)
+          if (needConversion) {
+            EvaluatePython.toJava(row, schema)
+          } else {
+            // fast path for these types that does not need conversion in Python
+            val fields = new Array[Any](row.numFields)
+            var i = 0
+            while (i < row.numFields) {
+              val dt = dataTypes(i)
+              fields(i) = EvaluatePython.toJava(row.get(i, dt), dt)
+              i += 1
+            }
+            fields
+          }
+        }.grouped(100).map(x => pickle.dumps(x.toArray))
+
+        // Output iterator for results from Python.
+        val outputIterator = new PythonRunner(pyFuncs, bufferSize, reuseWorker, true, argOffsets)
+          .compute(inputIterator, context.partitionId(), context)
+
+        val unpickle = new Unpickler
+        val mutableRow = new GenericInternalRow(1)
+        val joined = new JoinedRow
+        val resultType = if (udfs.length == 1) {
+          udfs.head.dataType
         } else {
-          EvaluatePython.fromJava(result, resultType).asInstanceOf[InternalRow]
+          StructType(udfs.map(u => StructField("", u.dataType, u.nullable)))
         }
-        resultProj(joined(queue.remove(), row))
+        val resultProj = UnsafeProjection.create(output, output)
+        outputIterator.flatMap { pickedResult =>
+          val unpickledBatch = unpickle.loads(pickedResult)
+          unpickledBatch.asInstanceOf[java.util.ArrayList[Any]].asScala
+        }.map { result =>
+          val row = if (udfs.length == 1) {
+            // fast path for single UDF
+            mutableRow(0) = EvaluatePython.fromJava(result, resultType)
+            mutableRow
+          } else {
+            EvaluatePython.fromJava(result, resultType).asInstanceOf[InternalRow]
+          }
+          resultProj(joined(queue.remove(), row))
+        }
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDF.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDF.scala
@@ -28,7 +28,8 @@ case class PythonUDF(
     name: String,
     func: PythonFunction,
     dataType: DataType,
-    children: Seq[Expression])
+    children: Seq[Expression],
+    vectorized: Boolean = false)
   extends Expression with Unevaluable with NonSQLExpression with UserDefinedExpression {
 
   override def toString: String = s"$name(${children.mkString(", ")})"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -28,10 +28,11 @@ import org.apache.spark.sql.types.DataType
 case class UserDefinedPythonFunction(
     name: String,
     func: PythonFunction,
-    dataType: DataType) {
+    dataType: DataType,
+    vectorized: Boolean = false) {
 
   def builder(e: Seq[Expression]): PythonUDF = {
-    PythonUDF(name, func, dataType, e)
+    PythonUDF(name, func, dataType, e, vectorized)
   }
 
   /** Returns a [[Column]] that will evaluate to calling this UDF with the given input. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/VectorizedPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/VectorizedPythonRunner.scala
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.stream.{ArrowStreamReader, ArrowStreamWriter}
+
+import org.apache.spark.{SparkEnv, SparkFiles, TaskContext}
+import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType, PythonException, PythonRDD, SpecialLengths}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.arrow.{ArrowUtils, ArrowWriter}
+import org.apache.spark.sql.execution.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
+
+/**
+ * Similar to `PythonRunner`, but exchange data with Python worker via columnar format.
+ */
+class VectorizedPythonRunner(
+    funcs: Seq[ChainedPythonFunctions],
+    batchSize: Int,
+    bufferSize: Int,
+    reuse_worker: Boolean,
+    argOffsets: Array[Array[Int]]) extends Logging {
+
+  require(funcs.length == argOffsets.length, "argOffsets should have the same length as funcs")
+
+  // All the Python functions should have the same exec, version and envvars.
+  private val envVars = funcs.head.funcs.head.envVars
+  private val pythonExec = funcs.head.funcs.head.pythonExec
+  private val pythonVer = funcs.head.funcs.head.pythonVer
+
+  // TODO: support accumulator in multiple UDF
+  private val accumulator = funcs.head.funcs.head.accumulator
+
+  // todo: return column batch?
+  def compute(
+      inputRows: Iterator[InternalRow],
+      schema: StructType,
+      partitionIndex: Int,
+      context: TaskContext): Iterator[InternalRow] = {
+    val startTime = System.currentTimeMillis
+    val env = SparkEnv.get
+    val localdir = env.blockManager.diskBlockManager.localDirs.map(f => f.getPath()).mkString(",")
+    envVars.put("SPARK_LOCAL_DIRS", localdir) // it's also used in monitor thread
+    if (reuse_worker) {
+      envVars.put("SPARK_REUSE_WORKER", "1")
+    }
+    val worker: Socket = env.createPythonWorker(pythonExec, envVars.asScala.toMap)
+    // Whether is the worker released into idle pool
+    @volatile var released = false
+
+    // Start a thread to feed the process input from our parent's iterator
+    val writerThread = new WriterThread(
+      env, worker, inputRows, schema, partitionIndex, context)
+
+    context.addTaskCompletionListener { context =>
+      writerThread.shutdownOnTaskCompletion()
+      if (!reuse_worker || !released) {
+        try {
+          worker.close()
+        } catch {
+          case e: Exception =>
+            logWarning("Failed to close worker socket", e)
+        }
+      }
+    }
+
+    writerThread.start()
+
+    val stream = new DataInputStream(new BufferedInputStream(worker.getInputStream, bufferSize))
+
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator(
+      s"stdin reader for $pythonExec", 0, Long.MaxValue)
+    val reader = new ArrowStreamReader(stream, allocator)
+
+    new Iterator[InternalRow] {
+      private val root = reader.getVectorSchemaRoot
+      private val vectors = root.getFieldVectors.asScala.map { vector =>
+        new ArrowColumnVector(vector)
+      }.toArray[ColumnVector]
+
+      var closed = false
+
+      context.addTaskCompletionListener { _ =>
+        // todo: we need something like `read.end()`, which release all the resources, but leave
+        // the input stream open. `reader.close` will close the socket and we can't reuse worker.
+        // So here we simply not close the reader, which is problematic.
+        if (!closed) {
+          root.close()
+          allocator.close()
+        }
+      }
+
+      private[this] var batchLoaded = true
+      private[this] var currentIter: Iterator[InternalRow] = Iterator.empty
+
+      override def hasNext: Boolean = batchLoaded && (currentIter.hasNext || loadNextBatch()) || {
+        root.close()
+        allocator.close()
+        closed = true
+        false
+      }
+
+      private def loadNextBatch(): Boolean = {
+        batchLoaded = reader.loadNextBatch()
+        if (batchLoaded) {
+          val batch = new ColumnarBatch(schema, vectors, root.getRowCount)
+          batch.setNumRows(root.getRowCount)
+          currentIter = batch.rowIterator().asScala
+        } else {
+          // end of arrow batches, handle some special signal
+          val signal = stream.readInt()
+          if (signal == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
+            val exLength = stream.readInt()
+            val obj = new Array[Byte](exLength)
+            stream.readFully(obj)
+            throw new PythonException(new String(obj, StandardCharsets.UTF_8),
+              writerThread.exception.getOrElse(null))
+          }
+
+          assert(signal == SpecialLengths.TIMING_DATA)
+          // Timing data from worker
+          val bootTime = stream.readLong()
+          val initTime = stream.readLong()
+          val finishTime = stream.readLong()
+          val boot = bootTime - startTime
+          val init = initTime - bootTime
+          val finish = finishTime - initTime
+          val total = finishTime - startTime
+          logInfo("Times: total = %s, boot = %s, init = %s, finish = %s".format(total, boot,
+            init, finish))
+          val memoryBytesSpilled = stream.readLong()
+          val diskBytesSpilled = stream.readLong()
+          context.taskMetrics.incMemoryBytesSpilled(memoryBytesSpilled)
+          context.taskMetrics.incDiskBytesSpilled(diskBytesSpilled)
+
+          assert(stream.readInt() == SpecialLengths.END_OF_DATA_SECTION)
+          // We've finished the data section of the output, but we can still
+          // read some accumulator updates:
+          val numAccumulatorUpdates = stream.readInt()
+          (1 to numAccumulatorUpdates).foreach { _ =>
+            val updateLen = stream.readInt()
+            val update = new Array[Byte](updateLen)
+            stream.readFully(update)
+            accumulator.add(update)
+          }
+          // Check whether the worker is ready to be re-used.
+          if (stream.readInt() == SpecialLengths.END_OF_STREAM) {
+            if (reuse_worker) {
+              env.releasePythonWorker(pythonExec, envVars.asScala.toMap, worker)
+              released = true
+            }
+          }
+        }
+        hasNext // skip empty batches if any
+      }
+
+      override def next(): InternalRow = {
+        currentIter.next()
+      }
+    }
+  }
+
+  class WriterThread(
+      env: SparkEnv,
+      worker: Socket,
+      inputRows: Iterator[InternalRow],
+      schema: StructType,
+      partitionIndex: Int,
+      context: TaskContext)
+    extends Thread(s"stdout writer for $pythonExec") {
+
+    @volatile private var _exception: Exception = null
+
+    private val pythonIncludes = funcs.flatMap(_.funcs.flatMap(_.pythonIncludes.asScala)).toSet
+    private val broadcastVars = funcs.flatMap(_.funcs.flatMap(_.broadcastVars.asScala))
+
+    setDaemon(true)
+
+    /** Contains the exception thrown while writing the parent iterator to the Python process. */
+    def exception: Option[Exception] = Option(_exception)
+
+    /** Terminates the writer thread, ignoring any exceptions that may occur due to cleanup. */
+    def shutdownOnTaskCompletion() {
+      assert(context.isCompleted)
+      this.interrupt()
+    }
+
+    override def run(): Unit = Utils.logUncaughtExceptions {
+      try {
+        TaskContext.setTaskContext(context)
+
+        val stream = new BufferedOutputStream(worker.getOutputStream, bufferSize)
+        val dataOut = new DataOutputStream(stream)
+        // Partition index
+        dataOut.writeInt(partitionIndex)
+        // Python version of driver
+        PythonRDD.writeUTF(pythonVer, dataOut)
+        // Write out the TaskContextInfo
+        dataOut.writeInt(context.stageId())
+        dataOut.writeInt(context.partitionId())
+        dataOut.writeInt(context.attemptNumber())
+        dataOut.writeLong(context.taskAttemptId())
+        // sparkFilesDir
+        PythonRDD.writeUTF(SparkFiles.getRootDirectory(), dataOut)
+        // Python includes (*.zip and *.egg files)
+        dataOut.writeInt(pythonIncludes.size)
+        for (include <- pythonIncludes) {
+          PythonRDD.writeUTF(include, dataOut)
+        }
+        // Broadcast variables
+        val oldBids = PythonRDD.getWorkerBroadcasts(worker)
+        val newBids = broadcastVars.map(_.id).toSet
+        // number of different broadcasts
+        val toRemove = oldBids.diff(newBids)
+        val cnt = toRemove.size + newBids.diff(oldBids).size
+        dataOut.writeInt(cnt)
+        for (bid <- toRemove) {
+          // remove the broadcast from worker
+          dataOut.writeLong(- bid - 1)  // bid >= 0
+          oldBids.remove(bid)
+        }
+        for (broadcast <- broadcastVars) {
+          if (!oldBids.contains(broadcast.id)) {
+            // send new broadcast
+            dataOut.writeLong(broadcast.id)
+            PythonRDD.writeUTF(broadcast.value.path, dataOut)
+            oldBids.add(broadcast.id)
+          }
+        }
+        dataOut.flush()
+
+        // SQL_VECTORIZED_UDF means arrow mode
+        dataOut.writeInt(PythonEvalType.SQL_VECTORIZED_UDF)
+        dataOut.writeInt(funcs.length)
+        funcs.zip(argOffsets).foreach { case (chained, offsets) =>
+          dataOut.writeInt(offsets.length)
+          offsets.foreach(dataOut.writeInt)
+          dataOut.writeInt(chained.funcs.length)
+          chained.funcs.foreach { f =>
+            dataOut.writeInt(f.command.length)
+            dataOut.write(f.command)
+          }
+        }
+        dataOut.flush()
+
+        val arrowSchema = ArrowUtils.toArrowSchema(schema)
+        val allocator = ArrowUtils.rootAllocator.newChildAllocator(
+          s"stdout writer for $pythonExec", 0, Long.MaxValue)
+
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        val arrowWriter = ArrowWriter.create(root)
+
+        var closed = false
+
+        context.addTaskCompletionListener { _ =>
+          if (!closed) {
+            root.close()
+            allocator.close()
+          }
+        }
+
+        // TODO: does ArrowStreamWriter buffer data?
+        // TODO: who decides the dictionary?
+        val writer = new ArrowStreamWriter(root, null, dataOut)
+        writer.start()
+
+        Utils.tryWithSafeFinally {
+          while (inputRows.hasNext) {
+            var rowCount = 0
+            while (inputRows.hasNext && rowCount < batchSize) {
+              val row = inputRows.next()
+              arrowWriter.write(row)
+              rowCount += 1
+            }
+            arrowWriter.finish()
+            writer.writeBatch()
+            arrowWriter.reset()
+          }
+        } {
+          writer.end()
+          root.close()
+          allocator.close()
+          closed = true
+        }
+
+        dataOut.writeInt(SpecialLengths.END_OF_STREAM)
+        dataOut.flush()
+      } catch {
+        case e: Exception if context.isCompleted || context.isInterrupted =>
+          logDebug("Exception thrown after task completion (likely due to cleanup)", e)
+          if (!worker.isClosed) {
+            Utils.tryLog(worker.shutdownOutput())
+          }
+
+        case e: Exception =>
+          // We must avoid throwing exceptions here, because the thread uncaught exception handler
+          // will kill the whole executor (see org.apache.spark.executor.Executor).
+          _exception = e
+          if (!worker.isClosed) {
+            Utils.tryLog(worker.shutdownOutput())
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr introduces vectorized UDFs in Python.
Note that this pr should focus on APIs for vectorized UDFs, not APIs for vectorized UDAFs or Window operations.

**Proposed API**

We introduce a `@pandas_udf` decorator (or annotation) to define vectorized UDFs which takes one or more `pandas.Series` or one integer value meaning the length of the input value for 0-parameter UDFs. The return value should be `pandas.Series` of the specified type and the length of the returned value should be the same as input value.

We can define vectorized UDFs as:

```python
  @pandas_udf(DoubleType())
  def plus(v1, v2):
      return v1 + v2
```

or we can define as:

```python
  plus = pandas_udf(lambda v1, v2: v1 + v2, DoubleType())
```

We can use it similar to row-by-row UDFs:

```python
  df.withColumn('sum', plus(df.v1, df.v2))
```

As for 0-parameter UDFs, we can define and use as:

```python
  @pandas_udf(LongType())
  def f0(size):
      return pd.Series(1).repeat(size)

  df.select(f0())
```

## How was this patch tested?

Added tests and existing tests.

## TBD

- [ ] the way to specify the size hint to 0-parameter UDF (or for more parameter UDFs to be consistent)