### PR TITLE
[SPARK-21942][CORE] Fix DiskBlockManager crashing when a root local folder has been externally deleted

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -66,7 +66,7 @@ private[spark] class DiskBlockManager(conf: SparkConf, deleteFilesOnStop: Boolea
         old
       } else {
         val newDir = new File(localDirs(dirId), "%02x".format(subDirId))
-        if (!newDir.exists() && !newDir.mkdir()) {
+        if (!newDir.exists() && !newDir.mkdirs()) {
           throw new IOException(s"Failed to create local dir in $newDir.")
         }
         subDirs(dirId)(subDirId) = newDir

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -79,6 +79,16 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
     assert(diskBlockManager.getAllBlocks.toSet === ids.toSet)
   }
 
+  test("working correctly if local dirs are deleted") {
+    //  DisckBlockManager's local dirs deletion can happen externally,
+    //  for example when they are located in the '/tmp' folder (which is default)
+    diskBlockManager.localDirs.foreach(Utils.deleteRecursively(_))
+    val blockId = new TestBlockId("test")
+    val newFile = diskBlockManager.getFile(blockId)
+    writeToFile(newFile, 10)
+    assert(diskBlockManager.containsBlock(blockId))
+  }
+
   def writeToFile(file: File, numBytes: Int) {
     val writer = new FileWriter(file, true)
     for (i <- 0 until numBytes) writer.write(i)


### PR DESCRIPTION
## What changes were proposed in this pull request?

**The problem:** 

`DiskBlockManager` has a notion of a "scratch" local folder(s), which can be configured via `spark.local.dir` option, and which defaults to the system's `/tmp`. The hierarchy is two-level, e.g. `/blockmgr-XXX.../YY`, where the `YY` part is a hash bit, to spread files evenly. 

Function `DiskBlockManager.getFile` _expects_ the top level directories (`blockmgr-XXX...`) to always exist (they get created once, when the spark context is first created), otherwise it would fail with a message like:

```
... java.io.IOException: Failed to create local dir in /tmp/blockmgr-XXX.../YY
```

However, this may not always be the case, in particular if it's the default `/tmp` folder - on certain operating systems it can be cleaned on a regular basis (e.g. once per day via a system cron job). 

The symptom is that after the process using spark is running for a while (a few days), it may not be able to load files anymore, since the top-level scratch directories are not there and `DiskBlockManager.getFile` crashes.

The change/mitigation is simple: use `File.mkdirs` instead of `File.mkdir` inside `getFile`, so that we create the _full path_ there, which will handle the case that parent directory is not there anymore.

## How was this patch tested?

I have added a falsifying unit test inside `DiskBlockManagerSuite`, which gets fixed via this patch.