### PR TITLE
[SPARK-21956][CORE] Fetch up to max bytes when buf really been released

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -445,6 +445,8 @@ final class ShuffleBlockFetcherIterator(
                   fetchRequests += FetchRequest(address, Array((blockId, size)))
                   result = null
                 }
+                bytesInFlight -= size
+                fetchUpToMaxBytes()
             } finally {
               // TODO: release the buf here to free memory earlier
               originalInput.close()

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -156,16 +156,14 @@ final class ShuffleBlockFetcherIterator(
   // The currentResult is set to null to prevent releasing the buffer again on cleanup()
   private[storage] def releaseCurrentResultBuffer(): Unit = {
     // Release the current buffer if necessary
-    if (currentResult != null) {
-      currentResult match {
-        case SuccessFetchResult(_, _, size, buf, _) =>
-          buf.release()
-          bytesInFlight -= size
-          // Send fetch requests up to maxBytesInFlight
-          fetchUpToMaxBytes()
-        case _ =>
-      }
-    }
+    currentResult match {
+       case SuccessFetchResult(_, _, size, buf, _) =>
+         buf.release()
+         bytesInFlight -= size
+         // Send fetch requests up to maxBytesInFlight
+         fetchUpToMaxBytes()
+       case _ =>
+     }
     currentResult = null
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now,ShuffleBlockFetcherIterator will decrease bytesInFlight immediatily when take from results queue.But currentresult's bytebuf has not been released at that time.Then direct memory may be a little out of control.
We should decrease bytesInFlight when currentresult's bytebuf really been released.

## How was this patch tested?

Exsisted Unit test
