### PR TITLE
[SPARK-21961][Core] Filter out BlockStatuses Accumulators during replaying history logs in Spark History Server

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -865,10 +865,6 @@ private[spark] object JsonProtocolSuite extends Assertions {
       sw.incWriteTime(b + c + d)
       sw.incRecordsWritten(if (hasRecords) (a + b + c) / 100 else -1)
     }
-    // Make at most 6 blocks
-    t.setUpdatedBlockStatuses((1 to (e % 5 + 1)).map { i =>
-      (RDDBlockId(e % i, f % i), BlockStatus(StorageLevel.MEMORY_AND_DISK_SER_2, a % i, b % i))
-    }.toSeq)
     t
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Filter out BlockStatus update data in logs when replaying. If the accumulable name matches the accumulableBlacklist, they will be filtered out. In this case, no more BlockStatus objects will be created in Spark History Server. SPARK-20084 adds a function called "accumulablesToJson", this patch adds a function called "accumulablesFromJson" to match.

Remove the manual added BlockStatus updates in Unit test to pass the unit test.

## How was this patch tested?
Unit test passed after the unit test change.
Deployed in our production cluster, memory consumption drops a lot. Less than 5 short term Full GC happened when replaying more than 4K history logs, which has logs generated from 1.6.x and 2.1.0. 
