### PR TITLE
[SPARK-21964][SQL]Enable splitting the Aggregate (on Expand) into a number of Aggregates for grouing analytics

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1298,20 +1298,18 @@ object SplitAggregateWithExpand extends Rule[LogicalPlan] {
    * Split [[Expand]] operator to a number of [[Expand]] operators
    */
   private def splitExpand(expand: Expand): Seq[Expand] = {
-    val len = expand.projections.length
-    val allProjections = expand.projections
-    Seq.tabulate(len)(
-      i => Expand(Seq(allProjections(i)), expand.output, expand.child)
-    )
+    val expands: Seq[Expand] = expand.projections.map { projection =>
+      Expand(Seq(projection), expand.output, expand.child)
+    }
+    expands
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case a @ Aggregate(_, _, e @ Expand(projections, _, _)) =>
       if (SQLConf.get.groupingWithUnion && projections.length > 1) {
-        val expands = splitExpand(e)
-        val aggregates: Seq[Aggregate] = Seq.tabulate(expands.length)(
-          i => Aggregate(a.groupingExpressions, a.aggregateExpressions, expands(i))
-        )
+        val aggregates: Seq[Aggregate] = splitExpands(e).map { expand =>
+          Aggregate(a.groupingExpressions, a.aggregateExpressions, expand)
+        }
         Union(aggregates)
       } else {
         a

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1307,7 +1307,7 @@ object SplitAggregateWithExpand extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case a @ Aggregate(_, _, e @ Expand(projections, _, _)) =>
       if (SQLConf.get.groupingWithUnion && projections.length > 1) {
-        val aggregates: Seq[Aggregate] = splitExpands(e).map { expand =>
+        val aggregates: Seq[Aggregate] = splitExpand(e).map { expand =>
           Aggregate(a.groupingExpressions, a.aggregateExpressions, expand)
         }
         Union(aggregates)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -481,6 +481,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val GROUPING_WITH_UNION = buildConf("spark.sql.grouping.union.enabled")
+    .doc("When true, the grouping analytics (i.e., cube, rollup, grouping sets) will be " +
+      "implemented by Union with a number of aggregates for each group. " +
+      "When false, the grouping analytics will be implemented by a single aggregate on Expand.")
+    .booleanConf
+    .createWithDefault(false)
+
   // The output committer class used by data sources. The specified class needs to be a
   // subclass of org.apache.hadoop.mapreduce.OutputCommitter.
   val OUTPUT_COMMITTER_CLASS = buildConf("spark.sql.sources.outputCommitterClass")
@@ -1156,6 +1163,8 @@ class SQLConf extends Serializable with Logging {
   def groupByOrdinal: Boolean = getConf(GROUP_BY_ORDINAL)
 
   def groupByAliases: Boolean = getConf(GROUP_BY_ALIASES)
+
+  def groupingWithUnion: Boolean = getConf(GROUPING_WITH_UNION)
 
   def crossJoinEnabled: Boolean = getConf(SQLConf.CROSS_JOINS_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -488,6 +488,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val GROUPING_EXPAND_PROJECTIONS = buildConf("spark.sql.grouping.projectionsPerExpand")
+    .doc("The number of projections in each Expand operator when the grouping analytics is " +
+      "implemented using a union with aggregates for each group."
+    .intConf
+    .checkValue(projections => projections >= 1, "The number of projections for each Expand " +
+      "operator must be positive.")
+    .createWithDefault(1)
+
   // The output committer class used by data sources. The specified class needs to be a
   // subclass of org.apache.hadoop.mapreduce.OutputCommitter.
   val OUTPUT_COMMITTER_CLASS = buildConf("spark.sql.sources.outputCommitterClass")
@@ -1165,6 +1173,8 @@ class SQLConf extends Serializable with Logging {
   def groupByAliases: Boolean = getConf(GROUP_BY_ALIASES)
 
   def groupingWithUnion: Boolean = getConf(GROUPING_WITH_UNION)
+
+  def groupingExpandProjections: Int = getConf(GROUPING_EXPAND_PROJECTIONS)
 
   def crossJoinEnabled: Boolean = getConf(SQLConf.CROSS_JOINS_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -490,7 +490,7 @@ object SQLConf {
 
   val GROUPING_EXPAND_PROJECTIONS = buildConf("spark.sql.grouping.projectionsPerExpand")
     .doc("The number of projections in each Expand operator when the grouping analytics is " +
-      "implemented using a union with aggregates for each group."
+      "implemented using a union with aggregates for each group.")
     .intConf
     .checkValue(projections => projections >= 1, "The number of projections for each Expand " +
       "operator must be positive.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -489,8 +489,8 @@ object SQLConf {
     .createWithDefault(false)
 
   val GROUPING_EXPAND_PROJECTIONS = buildConf("spark.sql.grouping.projectionsPerExpand")
-    .doc("The number of projections in each Expand operator when the grouping analytics is " +
-      "implemented using a union with aggregates for each group.")
+    .doc("The number of projections in each Expand when implementing grouping analytics " +
+      "using a union with aggregates for each group.")
     .intConf
     .checkValue(projections => projections >= 1, "The number of projections for each Expand " +
       "operator must be positive.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -484,7 +484,7 @@ object SQLConf {
   val GROUPING_WITH_UNION = buildConf("spark.sql.grouping.union.enabled")
     .doc("When true, the grouping analytics (i.e., cube, rollup, grouping sets) will be " +
       "implemented by Union with a number of aggregates for each group. " +
-      "When false, the grouping analytics will be implemented by a single aggregate on Expand.")
+      "When false, the grouping analytics will be implemented by one aggregate on Expand.")
     .booleanConf
     .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -483,8 +483,8 @@ object SQLConf {
 
   val GROUPING_WITH_UNION = buildConf("spark.sql.grouping.union.enabled")
     .doc("When true, the grouping analytics (i.e., cube, rollup, grouping sets) will be " +
-      "implemented by Union with a number of aggregates for each group. " +
-      "When false, the grouping analytics will be implemented by one aggregate on Expand.")
+      "implemented using a union with aggregates for each group. " +
+      "When false, the grouping analytics will be implemented using one aggregate on Expand.")
     .booleanConf
     .createWithDefault(false)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, GROUP_BY_ORDINAL, GROUPING_WITH_UNION}
+import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, GROUP_BY_ORDINAL, GROUPING_EXPAND_PROJECTIONS, GROUPING_WITH_UNION}
 import org.apache.spark.sql.types.IntegerType
 
 class AggregateOptimizeSuite extends PlanTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-21964

Current implementation for grouping analytics (i.e., cube, rollup and grouping sets) is "heavyweight" for many scenarios (e.g., high dimensions cube), as the Expand operator produces a large number of projections, resulting vast shuffle write.  It may result into low performance or even OOM issues for direct buffer memory.

This PR provides another choice which enables splitting the heavyweight aggregate into a number of lightweight aggregates for each group. Actually, it implements the grouping analytics as Union and executes the aggregates one by one. 

This optimization is opposite to the general sense of "avoding redundant data scan". However, it can achieve overall high performance for many cases. In our production environment, about 500+ queries can get benefit from it. 

The current splitting strategy is simple as one aggregation for one group. In future, we may figure out more intelligent splitting stategies (e.g., cost-based method).

## How was this patch tested?
Unit tests
Manual tests in production environment
