### PR TITLE
[SPARK-21966][SQL]ResolveMissingReference rule should not ignore Union

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1115,6 +1115,8 @@ class Analyzer(
           g.copy(join = true, child = addMissingAttr(g.child, missing))
         case d: Distinct =>
           throw new AnalysisException(s"Can't add $missingAttrs to $d")
+        case u: Union =>
+          u.withNewChildren(u.children.map(addMissingAttr(_, missingAttrs)))
         case u: UnaryNode =>
           u.withNewChildren(addMissingAttr(u.child, missingAttrs) :: Nil)
         case other =>
@@ -1133,6 +1135,8 @@ class Analyzer(
         resolved
       } else {
         plan match {
+          case u: Union if !u.children.head.isInstanceOf[SubqueryAlias] =>
+            resolveExpressionRecursively(resolved, u.children.head)
           case u: UnaryNode if !u.isInstanceOf[SubqueryAlias] =>
             resolveExpressionRecursively(resolved, u.child)
           case other => resolved


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-21966

The problem can be reproduced by following example.

`val df1 = spark.createDataFrame(Seq((1, 1), (2, 1), (2, 2))).toDF("a", "b")
val df2 = spark.createDataFrame(Seq((1, 1), (1, 2), (2, 3))).toDF("a", "b")
val df3 = df1.cube("a").sum("b")
val df4 = df2.cube("a").sum("b")
val df5 = df3.union(df4).filter("grouping_id()=0").show()`

The `org.apache.spark.sql.AnalysisException: cannot resolve '`spark_grouping_id`' given input columns`
is thrown as the ResolveMissingReference rule ignore the Union operator. This PR fix the issue.

## How was this patch tested?
unit tests
