### PR TITLE
[SPARK-21971][CORE] Too many open files in Spark due to concurrent fi…

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -623,6 +623,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       return iter;
     } else {
       LinkedList<UnsafeSorterIterator> queue = new LinkedList<>();
+      logger.debug("number of spillWriters: {}", spillWriters.size());
       int i = 0;
       for (UnsafeSorterSpillWriter spillWriter : spillWriters) {
         if (i + spillWriter.recordsSpilled() > startIndex) {


### PR DESCRIPTION
…les being opened

## What changes were proposed in this pull request?

In UnsafeExternalSorter::getIterator(), for every spillWriter a file is opened in UnsafeSorterSpillReader and these files get closed later point in time as a part of close() call. 
However, when large number of spill files are present, number of files opened increases to a great extent and ends up throwing "Too many files" open exception.
This can easily be reproduced with TPC-DS Q67 at 1 TB scale in multi node cluster with multiple cores per executor. 

There are ways to reduce the number of spill files that are generated in Q67. E.g, increase "spark.sql.windowExec.buffer.spill.threshold" where 4096 is the default. Another option is to increase ulimit to much higher values.
But those are workarounds. 

This PR reduces the number of files that are kept open at in UnsafeSorterSpillReader.


## How was this patch tested?
Manual testing of Q67 in 1 TB and 10 TB scale on multi node cluster.
