### PR TITLE
Quote table names in JDBC queries

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -86,11 +86,11 @@ abstract class JdbcDialect extends Serializable {
   def getJDBCType(dt: DataType): Option[JdbcType] = None
 
   /**
-   * Quotes the identifier. This is used to put quotes around the identifier in case the column
+   * Quotes the identifier. This is used to put quotes around the identifier in case the column/table
    * name is a reserved keyword, or in case it contains characters that require quotes (e.g. space).
    */
-  def quoteIdentifier(colName: String): String = {
-    s""""$colName""""
+  def quoteIdentifier(identifier: String): String = {
+    s"\"$identifier\""
   }
 
   /**
@@ -100,7 +100,7 @@ abstract class JdbcDialect extends Serializable {
    * @return The SQL query to use for checking the table.
    */
   def getTableExistsQuery(table: String): String = {
-    s"SELECT * FROM $table WHERE 1=0"
+    s"SELECT * FROM ${quoteIdentifier(table)} WHERE 1=0"
   }
 
   /**
@@ -113,7 +113,7 @@ abstract class JdbcDialect extends Serializable {
    */
   @Since("2.1.0")
   def getSchemaQuery(table: String): String = {
-    s"SELECT * FROM $table WHERE 1=0"
+    s"SELECT * FROM ${quoteIdentifier(table)} WHERE 1=0"
   }
 
   /**


### PR DESCRIPTION
In MySQL table names sometimes need to be quoted. This should fix that, although I haven't tested (I really don't want to go through the build and everything).

Also, four quotes in a row is not readable.
