### PR TITLE
[WIP][SPARK-21896][SQL] Fix Stack Overflow when window function is nested inside an aggregate function

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.TestUtils.assertSpilled
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{max, rank}
 import org.apache.spark.sql.test.SharedSQLContext
 
 case class WindowData(month: Int, area: String, product: Int)
@@ -485,5 +487,11 @@ class SQLWindowFunctionSuite extends QueryTest with SharedSQLContext {
     }
 
     spark.catalog.dropTempView("nums")
+  }
+
+  test("[SPARK-21896] nested window functions in aggregations") {
+    val df = Seq((1, 2), (1, 3), (2, 4), (5, 5)).toDF("a", "b")
+    val window = Window.orderBy('a)
+    checkAnswer(df.groupBy().agg(max(rank().over(window))), Seq(Row(4)))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This WIP PR contains an idea how to fix ``StackOverflowError`` in ``Analyzer``.  There are open questions that have to be clarified.

### General Info

Currently, Spark cannot handle window expressions inside aggregate functions. There is a ``StackOverflowError`` error due to a bug in ``ExtractWindowExpressions``. There are two options:
- prohibit window expressions inside aggregate functions and throw a descriptive error
- improve ``ExtractWindowExpressions`` (what this PR tries to do)

### Implementation

One reason why I introduced a separate case clause in ``ExtractWindowExpressions`` rather than trying to fix the existing one (i.e., lines 1958-1972 in ``ExtractWindowExpressions``) is the relative order of window and aggregate operations. The existing case always puts an aggregation first, which might be incorrect in some situations. For instance, the example below requires a window operation to be computed first:

```
    val df = Seq((1, 2), (1, 3), (2, 4), (5, 5)).toDF("a", "b")
    val window = Window.orderBy("a")
    df.groupBy().agg(max(rank().over(window)).show(false)
```

The added part extracts window expressions only from children of aggregate functions while keeping all other window expressions untouched. Consider the following example:

```
    val window1 = Window.orderBy("a")
    val window2 = Window.orderBy(max('a))
    df.groupBy().agg(sum('a), max(rank().over(window1)), rank().over(window2))
```

First, the new part will extract ``rank().over(window1)`` and add a separate window node to the plan. All other expressions will stay as they are. Next, the existing case will add another window operation to the plan based on ``rank().over(window2)``. The result will look like: 

```
== Analyzed Logical Plan ==
sum(a): bigint, max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$())): int, RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$()): int
Project [sum(a)#20L, max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$()))#21, RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$())#22]
+- Project [sum(a)#20L, max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$()))#21, _w0#59, _w1#63, RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$())#22, RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$())#22]
   +- Window [rank(_w1#63) windowspecdefinition(_w1#63 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$())#22], [_w1#63 ASC NULLS FIRST]
      +- Aggregate [sum(cast(a#5 as bigint)) AS sum(a)#20L, max(_we0#52) AS max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$()))#21, max(a#5) AS _w0#59, max(a#5) AS _w1#63]
         +- Project [a#5, b#6, _we0#52, _we0#52]
            +- Window [rank(a#5) windowspecdefinition(a#5 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS _we0#52], [a#5 ASC NULLS FIRST]
               +- Project [_1#2 AS a#5, _2#3 AS b#6]
                  +- LocalRelation [_1#2, _2#3]

== Optimized Logical Plan ==
Project [sum(a)#20L, max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$()))#21, RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$())#22]
+- Window [rank(_w1#63) windowspecdefinition(_w1#63 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS RANK() OVER (ORDER BY max(a) ASC NULLS FIRST unspecifiedframe$())#22], [_w1#63 ASC NULLS FIRST]
   +- Aggregate [sum(cast(a#5 as bigint)) AS sum(a)#20L, max(_we0#52) AS max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$()))#21, max(a#5) AS _w1#63]
      +- Project [a#5, _we0#52, _we0#52]
         +- Window [rank(a#5) windowspecdefinition(a#5 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS _we0#52], [a#5 ASC NULLS FIRST]
            +- LocalRelation [a#5]
```

### Open Questions

There is a question about the logical meaning and expected result of the next query:

```
    val df = Seq((1, 2), (1, 3), (2, 4), (5, 5)).toDF("a", "b")
    val window = Window.orderBy("a")
    df.groupBy('a).agg(sum('a), max('a), max(rank().over(window))).show(false)

+---+------+------+-----------------------------------------------------------------+
|a  |sum(a)|max(a)|max(RANK() OVER (ORDER BY a ASC NULLS FIRST unspecifiedframe$()))|
+---+------+------+-----------------------------------------------------------------+
|1  |2     |1     |1                                                                |
|2  |2     |2     |3                                                                |
|5  |5     |5     |4                                                                |
+---+------+------+-----------------------------------------------------------------+
```

Currently, the new part will ignore the grouping to compute ``max(rank().over(window))``, which feels like a mistake. Am I right? What is expected in this case?

## How was this patch tested?

This PR represents a prototype and contains a test that did not work previously.