### PR TITLE
Get default Locale

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -268,7 +268,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val hour = minute * 60
     def str: (Long) => String = Utils.msDurationToString(_)
 
-    val sep = new DecimalFormatSymbols(Locale.US).getDecimalSeparator
+    val sep = new DecimalFormatSymbols(Locale.getDefault).getDecimalSeparator
 
     assert(str(123) === "123 ms")
     assert(str(second) === "1" + sep + "0 s")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get default Locale in UtilsSuite.scala in order to make it work with different Locales than US.

## How was this patch tested?

Running UtilsSuite.scala 

Please review http://spark.apache.org/contributing.html before opening a pull request.
