### PR TITLE
[SPARK-19206][yarn]Client and ApplicationMaster resolvePath is inappropriate when use viewfs 

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -150,10 +150,11 @@ private[spark] class ApplicationMaster(
         size: String,
         vis: String): Unit = {
       val uri = new URI(file)
+      val fs = FileSystem.get(uri, yarnConf)
       val amJarRsrc = Records.newRecord(classOf[LocalResource])
       amJarRsrc.setType(rtype)
       amJarRsrc.setVisibility(LocalResourceVisibility.valueOf(vis))
-      amJarRsrc.setResource(ConverterUtils.getYarnUrlFromURI(uri))
+      amJarRsrc.setResource(ConverterUtils.getYarnUrlFromPath(fs.resolvePath(new Path(uri))));
       amJarRsrc.setTimestamp(timestamp.toLong)
       amJarRsrc.setSize(size.toLong)
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientDistributedCacheManager.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientDistributedCacheManager.scala
@@ -73,7 +73,7 @@ private[spark] class ClientDistributedCacheManager() extends Logging {
     amJarRsrc.setType(resourceType)
     val visibility = getVisibility(conf, destPath.toUri(), statCache)
     amJarRsrc.setVisibility(visibility)
-    amJarRsrc.setResource(ConverterUtils.getYarnUrlFromPath(destPath))
+    amJarRsrc.setResource(ConverterUtils.getYarnUrlFromPath(fs.resolvePath(destPath)))    
     amJarRsrc.setTimestamp(destStatus.getModificationTime())
     amJarRsrc.setSize(destStatus.getLen())
     require(link != null && link.nonEmpty, "You must specify a valid link name.")


### PR DESCRIPTION
## What changes were proposed in this pull request?
When HDFS use viewfs and spark construct Executor's and ApplicationMaster's  localResource  Map ( the list of localized files ) ,can't covert viewfs:// path to the real hdfs:// path . Therefore , when NodeManager download the local Resource, will throw java.io.IOException: ViewFs: Cannot initialize: Empty Mount table in config for viewfs://clusterName/ 

Exception stack：

java.io.IOException: ViewFs: Cannot initialize: Empty Mount table in config for viewfs://ns-view/ 
at org.apache.hadoop.fs.viewfs.InodeTree.<init>(InodeTree.java:337) 
at org.apache.hadoop.fs.viewfs.ViewFileSystem$1.<init>(ViewFileSystem.java:167) 
at org.apache.hadoop.fs.viewfs.ViewFileSystem.initialize(ViewFileSystem.java:167) 
at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2669) 
at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:94) 
at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2703) 
at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2685) 
at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:373) 
at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295) 
at org.apache.hadoop.yarn.util.FSDownload.copy(FSDownload.java:251) 
at org.apache.hadoop.yarn.util.FSDownload.access$000(FSDownload.java:63) 
at org.apache.hadoop.yarn.util.FSDownload$2.run(FSDownload.java:361) 
at org.apache.hadoop.yarn.util.FSDownload$2.run(FSDownload.java:359) 
at java.security.AccessController.doPrivileged(Native Method) 
at javax.security.auth.Subject.doAs(Subject.java:422) 
at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1700) 
at org.apache.hadoop.yarn.util.FSDownload.call(FSDownload.java:358) 
at org.apache.hadoop.yarn.util.FSDownload.call(FSDownload.java:62) 
at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) 
at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) 
at java.lang.Thread.run(Thread.java:748) 
Failing this attempt. Failing the application

## How was this patch tested?
manual tests