### PR TITLE
[SPARK-21990][SQL] QueryPlanConstraints misses some constraints that can be recursively inferred

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -397,6 +397,26 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
         IsNotNull(resolveColumn(tr, "c")))))
   }
 
+  test("Infer recursive constraints") {
+    val tr = LocalRelation('a.int, 'b.int, 'c.int)
+    verifyConstraints(tr
+     .where('a.attr === 'b.attr && 'b.attr === 'c.attr && 'a.attr > 1 && 'b.attr > 5)
+     .analyze.constraints,
+     ExpressionSet(Seq(
+      resolveColumn(tr, "a") > 1,
+      resolveColumn(tr, "b") > 1,
+      resolveColumn(tr, "c") > 1,
+      resolveColumn(tr, "a") > 5,
+      resolveColumn(tr, "b") > 5,
+      resolveColumn(tr, "c") > 5,
+      resolveColumn(tr, "a") === resolveColumn(tr, "b"),
+      resolveColumn(tr, "b") === resolveColumn(tr, "c"),
+      resolveColumn(tr, "a") === resolveColumn(tr, "c"),
+      IsNotNull(resolveColumn(tr, "a")),
+      IsNotNull(resolveColumn(tr, "b")),
+      IsNotNull(resolveColumn(tr, "c")))))
+  }
+
   test("enable/disable constraint propagation") {
     val tr = LocalRelation('a.int, 'b.string, 'c.int)
     val filterRelation = tr.where('a.attr > 10)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I inspected the latest change of SPARK-21979, I found we could miss few constraints that can be recursively inferred.

E.g. consider constraints `a === b && b === c && a > 1 && b > 5`. Currently we only infer `a === c && b > 1 && c > 5`, but `c > 1` can be also inferred from newly inferred constraint `a === c`.

## How was this patch tested?

Added test.
