### PR TITLE
[SPARK-21993][SQL] Close sessionState when finish

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -360,4 +360,6 @@ abstract class ExternalCatalog
       event: ExternalCatalogEvent): Unit = {
     listener.onEvent(event)
   }
+
+  def close(): Unit = { }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -114,8 +114,11 @@ class SparkSession private(
   @InterfaceStability.Unstable
   @transient
   lazy val sharedState: SharedState = {
+    sharedStateInitialized = true
     existingSharedState.getOrElse(new SharedState(sparkContext))
   }
+
+  var sharedStateInitialized: Boolean = false
 
   /**
    * Initial options for session. This options are applied once when sessionState is created.
@@ -706,6 +709,9 @@ class SparkSession private(
    */
   def stop(): Unit = {
     sparkContext.stop()
+    if (sharedStateInitialized) {
+      sharedState.close()
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -87,6 +87,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
    */
   val listener: SQLListener = createListenerAndUI(sparkContext)
 
+  var externalCatalogInitialized: Boolean = false
   /**
    * A catalog that interacts with external systems.
    */
@@ -115,6 +116,7 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       }
     })
 
+    externalCatalogInitialized = true
     externalCatalog
   }
 
@@ -153,6 +155,12 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
       }
     }
     SparkSession.sqlListener.get()
+  }
+
+  def close(): Unit = {
+    if (externalCatalogInitialized) {
+      externalCatalog.close()
+    }
   }
 }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/CLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/CLIService.java
@@ -126,6 +126,11 @@ public class CLIService extends CompositeService implements ICLIService {
     ss.setIsHiveServerQuery(true);
     SessionState.start(ss);
     ss.applyAuthorizationPolicy();
+    try {
+      ss.close();
+    } catch (IOException e) {
+      LOG.error("Failed closing Hive session state.", e);
+    }
   }
 
   private void setupBlockedUdfs() {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -109,6 +109,8 @@ object HiveThriftServer2 extends Logging {
       case e: Exception =>
         logError("Error starting HiveThriftServer2", e)
         System.exit(-1)
+    } finally {
+      executionHive.close()
     }
   }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -124,7 +124,10 @@ private[hive] object SparkSQLCLIDriver extends Logging {
     SessionState.start(sessionState)
 
     // Clean up after we exit
-    ShutdownHookManager.addShutdownHook { () => SparkSQLEnv.stop() }
+    ShutdownHookManager.addShutdownHook { () =>
+      sessionState.close()
+      SparkSQLEnv.stop()
+    }
 
     val remoteMode = isRemoteMode(sessionState)
     // "-h" option has been passed, so connect to Hive thrift server.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1267,6 +1267,11 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.listFunctions(db, pattern)
   }
 
+  override def close(): Unit = {
+    super.close()
+    client.close()
+  }
+
 }
 
 object HiveExternalCatalog {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -42,7 +42,7 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
    * Create a Hive aware resource loader.
    */
   override protected lazy val resourceLoader: HiveSessionResourceLoader = {
-    val client: HiveClient = externalCatalog.client.newSession()
+    val client: HiveClient = externalCatalog.client
     new HiveSessionResourceLoader(session, client)
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -278,4 +278,6 @@ private[hive] trait HiveClient {
   /** Used for testing only.  Removes all metadata from this instance of Hive. */
   def reset(): Unit
 
+  /** Close this client. */
+  def close(): Unit
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -838,6 +838,10 @@ private[hive] class HiveClientImpl(
         client.dropDatabase(db, true, false, true)
       }
   }
+
+  def close(): Unit = {
+    state.close()
+  }
 }
 
 private[hive] object HiveClientImpl {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -198,7 +198,7 @@ private[hive] class TestHiveSparkSession(
     new TestHiveSessionStateBuilder(this, parentSessionState).build()
   }
 
-  lazy val metadataHive: HiveClient = sharedState.externalCatalog.client.newSession()
+  lazy val metadataHive: HiveClient = sharedState.externalCatalog.client
 
   override def newSession(): TestHiveSparkSession = {
     new TestHiveSparkSession(sc, Some(sharedState), None, loadTestTables)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -578,11 +578,6 @@ class VersionsSuite extends SparkFunSuite with Logging {
       client.setError(new PrintStream(new ByteArrayOutputStream()))
     }
 
-    test(s"$version: newSession") {
-      val newClient = client.newSession()
-      assert(newClient != null)
-    }
-
     test(s"$version: withHiveState and addJar") {
       val newClassPath = "."
       client.addJar(newClassPath)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current code, `SessionState` in `SparkSQLCLIDriver` is not guaranteed to be closed. As a result, some tmp files/dirs are not removed when job finished. We can close `SessionState` in shutdown hook.
