### PR TITLE
[SPARK-21985][PySpark] PairDeserializer is broken for double-zipped RDDs

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -343,6 +343,7 @@ class PairDeserializer(Serializer):
         key_batch_stream = self.key_ser._load_stream_without_unbatching(stream)
         val_batch_stream = self.val_ser._load_stream_without_unbatching(stream)
         for (key_batch, val_batch) in zip(key_batch_stream, val_batch_stream):
+            # the batch is an iterable, we need to check lengths so we convert to list if needed.
             key_batch = key_batch if hasattr(key_batch, '__len__') else list(key_batch)
             val_batch = val_batch if hasattr(val_batch, '__len__') else list(val_batch)
             if len(key_batch) != len(val_batch):

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -97,7 +97,7 @@ class Serializer(object):
 
     def _load_stream_without_unbatching(self, stream):
         """
-        Return an iterator of deserialized batches (lists) of objects from the input stream.
+        Return an iterator of deserialized batches (iterable) of objects from the input stream.
         if the serializer does not operate on batches the default implementation returns an
         iterator of single element lists.
         """

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -343,7 +343,8 @@ class PairDeserializer(Serializer):
         key_batch_stream = self.key_ser._load_stream_without_unbatching(stream)
         val_batch_stream = self.val_ser._load_stream_without_unbatching(stream)
         for (key_batch, val_batch) in zip(key_batch_stream, val_batch_stream):
-            # the batch is an iterable, we need to check lengths so we convert to list if needed.
+            # For double-zipped RDDs, the batches can be iterators from other PairDeserializer,
+            # instead of lists. We need to convert them to lists if needed.
             key_batch = key_batch if hasattr(key_batch, '__len__') else list(key_batch)
             val_batch = val_batch if hasattr(val_batch, '__len__') else list(val_batch)
             if len(key_batch) != len(val_batch):

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -343,8 +343,8 @@ class PairDeserializer(Serializer):
         key_batch_stream = self.key_ser._load_stream_without_unbatching(stream)
         val_batch_stream = self.val_ser._load_stream_without_unbatching(stream)
         for (key_batch, val_batch) in zip(key_batch_stream, val_batch_stream):
-            key_batch = list(key_batch)
-            val_batch = list(val_batch)
+            key_batch = key_batch if hasattr(key_batch, '__len__') else list(key_batch)
+            val_batch = val_batch if hasattr(val_batch, '__len__') else list(val_batch)
             if len(key_batch) != len(val_batch):
                 raise ValueError("Can not deserialize PairRDD with different number of items"
                                  " in batches: (%d, %d)" % (len(key_batch), len(val_batch)))

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -333,6 +333,9 @@ class PairDeserializer(Serializer):
     Deserializes the JavaRDD zip() of two PythonRDDs.
     Due to pyspark batching we cannot simply use the result of the Java RDD zip,
     we additionally need to do the zip within each pair of batches.
+
+    It is the responsibility of the user of this class to ensure the batch sizes of the key and
+    value serializer are the same size. If they are not this will give incorrect results.
     """
 
     def __init__(self, key_ser, val_ser):
@@ -343,9 +346,6 @@ class PairDeserializer(Serializer):
         key_batch_stream = self.key_ser._load_stream_without_unbatching(stream)
         val_batch_stream = self.val_ser._load_stream_without_unbatching(stream)
         for (key_batch, val_batch) in zip(key_batch_stream, val_batch_stream):
-            if len(key_batch) != len(val_batch):
-                raise ValueError("Can not deserialize PairRDD with different number of items"
-                                 " in batches: (%d, %d)" % (len(key_batch), len(val_batch)))
             # for correctness with repeated cartesian/zip this must be returned as one batch
             yield zip(key_batch, val_batch)
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -646,7 +646,7 @@ class RDDTests(ReusedPySparkTestCase):
 
     def test_zip_chaining(self):
         # Tests for SPARK-21985
-        rdd = self.sc.parallelize('abc')
+        rdd = self.sc.parallelize('abc',2)
         self.assertSetEqual(
             set(rdd.zip(rdd).zip(rdd).collect()),
             set([((x, x), x) for x in 'abc'])

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -653,7 +653,7 @@ class RDDTests(ReusedPySparkTestCase):
         )
         self.assertSetEqual(
             set(rdd.zip(rdd.zip(rdd)).collect()),
-            set([((x, (x, x)) for x in range(10)])
+            set([(x, (x, x)) for x in range(10)])
         )
 
     def test_deleting_input_files(self):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -646,7 +646,7 @@ class RDDTests(ReusedPySparkTestCase):
 
     def test_zip_chaining(self):
         # Tests for SPARK-21985
-        rdd = self.sc.parallelize('abc',2)
+        rdd = self.sc.parallelize('abc', 2)
         self.assertSetEqual(
             set(rdd.zip(rdd).zip(rdd).collect()),
             set([((x, x), x) for x in 'abc'])

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -646,14 +646,14 @@ class RDDTests(ReusedPySparkTestCase):
 
     def test_zip_chaining(self):
         # Tests for SPARK-21985
-        rdd = self.sc.parallelize(range(10), 2)
+        rdd = self.sc.parallelize('abc')
         self.assertSetEqual(
             set(rdd.zip(rdd).zip(rdd).collect()),
-            set([((x, x), x) for x in range(10)])
+            set([((x, x), x) for x in 'abc'])
         )
         self.assertSetEqual(
             set(rdd.zip(rdd.zip(rdd)).collect()),
-            set([(x, (x, x)) for x in range(10)])
+            set([(x, (x, x)) for x in 'abc'])
         )
 
     def test_deleting_input_files(self):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -644,6 +644,18 @@ class RDDTests(ReusedPySparkTestCase):
             set([(x, (y, y)) for x in range(10) for y in range(10)])
         )
 
+    def test_zip_chaining(self):
+        # Tests for SPARK-21985
+        rdd = self.sc.parallelize(range(10), 2)
+        self.assertSetEqual(
+            set(rdd.zip(rdd).zip(rdd).collect()),
+            set([((x, x), x) for x in range(10)])
+        )
+        self.assertSetEqual(
+            set(rdd.zip(rdd.zip(rdd)).collect()),
+            set([((x, (x, x)) for x in range(10)])
+        )
+
     def test_deleting_input_files(self):
         # Regression test for SPARK-1025
         tempFile = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
## What changes were proposed in this pull request?
(edited)
Fixes a bug introduced in #16121 

In PairDeserializer convert each batch of keys and values to lists (if they do not have `__len__` already) so that we can check that they are the same size. Normally they already are lists so this should not have a performance impact, but this is needed when repeated `zip`'s are done.

## How was this patch tested?

Additional unit test