### PR TITLE
[SPARK-22010][PySpark] Change fromInternal method of TimestampType

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -19,6 +19,7 @@ import sys
 import decimal
 import time
 import datetime
+import dateutil
 import calendar
 import json
 import re
@@ -178,6 +179,9 @@ class DateType(AtomicType):
             return datetime.date.fromordinal(v + self.EPOCH_ORDINAL)
 
 
+_is_utc = datetime.datetime.now(dateutil.tz.tzlocal()).tzname() == "UTC"
+
+
 class TimestampType(AtomicType):
     """Timestamp (datetime.datetime) data type.
     """
@@ -196,7 +200,8 @@ class TimestampType(AtomicType):
     def fromInternal(self, ts):
         if ts is not None:
             # using int to avoid precision loss in float
-            return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
+            y, m, d, hh, mm, ss, _, _, _ = time.gmtime(ts // 1000000) if _is_utc else time.localtime(ts // 1000000)
+            datetime.datetime(y, m, d, hh, mm, ss, ts % 1000000)
 
 
 class DecimalType(FractionalType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -19,7 +19,7 @@ import sys
 import decimal
 import time
 import datetime
-import dateutil
+import dateutil.tz
 import calendar
 import json
 import re

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -201,7 +201,7 @@ class TimestampType(AtomicType):
         if ts is not None:
             # using int to avoid precision loss in float
             y, m, d, hh, mm, ss, _, _, _ = time.gmtime(ts // 1000000) if _is_utc else time.localtime(ts // 1000000)
-            datetime.datetime(y, m, d, hh, mm, ss, ts % 1000000)
+            return datetime.datetime(y, m, d, hh, mm, ss, ts % 1000000)
 
 
 class DecimalType(FractionalType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -19,7 +19,6 @@ import sys
 import decimal
 import time
 import datetime
-import dateutil.tz
 import calendar
 import json
 import re
@@ -179,7 +178,7 @@ class DateType(AtomicType):
             return datetime.date.fromordinal(v + self.EPOCH_ORDINAL)
 
 
-_is_utc = datetime.datetime.now(dateutil.tz.tzlocal()).tzname() == "UTC"
+_is_utc = time.tzname[time.daylight] == "UTC"
 
 
 class TimestampType(AtomicType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -201,6 +201,7 @@ class TimestampType(AtomicType):
             # using int to avoid precision loss in float
             y, m, d, hh, mm, ss, _, _, _ = (time.gmtime(ts // 1000000) if _is_utc
                                             else time.localtime(ts // 1000000))
+            ss = min(ss, 59)  # leap seconds support
             return datetime.datetime(y, m, d, hh, mm, ss, ts % 1000000)
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -200,7 +200,8 @@ class TimestampType(AtomicType):
     def fromInternal(self, ts):
         if ts is not None:
             # using int to avoid precision loss in float
-            y, m, d, hh, mm, ss, _, _, _ = time.gmtime(ts // 1000000) if _is_utc else time.localtime(ts // 1000000)
+            y, m, d, hh, mm, ss, _, _, _ = (time.gmtime(ts // 1000000) if _is_utc
+                                            else time.localtime(ts // 1000000))
             return datetime.datetime(y, m, d, hh, mm, ss, ts % 1000000)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes the way pySpark converts Timestamp format from internal to Python representation.

The code is based on Python datetime and udatetime library.
https://github.com/python/cpython/blob/018d353c1c8c87767d2335cd884017c2ce12e045/Lib/datetime.py#L1425-L1458
https://github.com/freach/udatetime/blob/08f95c233188a6a3d316e9905cfb3379278376f5/udatetime/_pure.py#L30-L42

**Benchmarks**
Before change:
4.58 µs ± 558 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

After change:
System with UTC timezone
1.49 µs ± 142 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

Other timezones:
3.15 µs ± 388 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

## How was this patch tested?

Existing tests.
Performance benchmarks.