### PR TITLE
SPARK-22015: Remove usage of non-used private field isAuthenticated from org.apache.spark.network.sasl.SaslRpcHandler.java

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
@@ -59,7 +59,6 @@ public class SaslRpcHandler extends RpcHandler {
 
   private SparkSaslServer saslServer;
   private boolean isComplete;
-  private boolean isAuthenticated;
 
   public SaslRpcHandler(
       TransportConf conf,
@@ -72,7 +71,6 @@ public class SaslRpcHandler extends RpcHandler {
     this.secretKeyHolder = secretKeyHolder;
     this.saslServer = null;
     this.isComplete = false;
-    this.isAuthenticated = false;
   }
 
   @Override


### PR DESCRIPTION
SPARK-22015: Remove usage of non-used private field isAuthenticated from org.apache.spark.network.sasl.SaslRpcHandler.java

Code does not adhere to code conventions.