### PR TITLE
[SPARK-22016][SQL] Add HiveDialect for JDBC connection to Hive

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/HiveDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/HiveDialect.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+object HiveDialect extends JdbcDialect {
+
+  override def canHandle(url: String): Boolean = url.startsWith("jdbc:hive2")
+
+  override def quoteIdentifier(colName: String): String = s"`$colName`"
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -200,6 +200,7 @@ object JdbcDialects {
   registerDialect(DerbyDialect)
   registerDialect(OracleDialect)
   registerDialect(TeradataDialect)
+  registerDialect(HiveDialect)
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1103,6 +1103,17 @@ class JDBCSuite extends SparkFunSuite
        """.stripMargin)
 
       val df3 = sql("SELECT * FROM test_sessionInitStatement")
-      assert(df3.collect() === Array(Row(21519, 1234)))
-    }
+      assert(df3.collect() === Array(Row(21519, 1234))
+    )
+  }
+
+  test("Hive dialect registration") {
+    assert(JdbcDialects.get("jdbc:hive2://127.0.0.1/db") == HiveDialect)
+  }
+
+  test("Hive dialect quoted identifier") {
+    val dialect = JdbcDialects.get("jdbc:hive2://127.0.0.1/db")
+    val quotedIdentifier = dialect.quoteIdentifier("a_column")
+    assert(quotedIdentifier == "`a_column`")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1103,9 +1103,8 @@ class JDBCSuite extends SparkFunSuite
        """.stripMargin)
 
       val df3 = sql("SELECT * FROM test_sessionInitStatement")
-      assert(df3.collect() === Array(Row(21519, 1234))
-    )
-  }
+      assert(df3.collect() === Array(Row(21519, 1234)))
+    }
 
   test("Hive dialect registration") {
     assert(JdbcDialects.get("jdbc:hive2://127.0.0.1/db") == HiveDialect)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1100,11 +1100,11 @@ class JDBCSuite extends SparkFunSuite
          |OPTIONS (url '$urlWithUserAndPass',
          |dbtable '(SELECT NVL(@MYTESTVAR1, -1), NVL(@MYTESTVAR2, -1))',
          |sessionInitStatement 'SET @MYTESTVAR1 21519; SET @MYTESTVAR2 1234')
-       """.stripMargin)
+      """.stripMargin)
 
-      val df3 = sql("SELECT * FROM test_sessionInitStatement")
-      assert(df3.collect() === Array(Row(21519, 1234)))
-    }
+    val df3 = sql("SELECT * FROM test_sessionInitStatement")
+    assert(df3.collect() === Array(Row(21519, 1234)))
+  }
 
   test("Hive dialect registration") {
     assert(JdbcDialects.get("jdbc:hive2://127.0.0.1/db") == HiveDialect)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a HiveDialect for JDBC connection to Hive.
It overrides two methods:
* canHandle
* quoteIdentifier

## How was this patch tested?

It passes the added tests and it was used with a real Hive instance with real data.
