### PR TITLE
[SPARK-22017] Take minimum of all watermark execs in StreamExecution.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -39,7 +39,7 @@ class IncrementalExecution(
     val checkpointLocation: String,
     val runId: UUID,
     val currentBatchId: Long,
-    private[sql] val offsetSeqMetadata: OffsetSeqMetadata)
+    val offsetSeqMetadata: OffsetSeqMetadata)
   extends QueryExecution(sparkSession, logicalPlan) with Logging {
 
   // Modified planner with stateful operations.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -39,7 +39,7 @@ class IncrementalExecution(
     val checkpointLocation: String,
     val runId: UUID,
     val currentBatchId: Long,
-    offsetSeqMetadata: OffsetSeqMetadata)
+    private[sql] val offsetSeqMetadata: OffsetSeqMetadata)
   extends QueryExecution(sparkSession, logicalPlan) with Logging {
 
   // Modified planner with stateful operations.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -132,8 +132,11 @@ class StreamExecution(
 
   /**
    * A map of current watermarks, keyed by the position of the watermark operator in the
-   * physical plan. The minimum watermark timestamp present here will be used and persisted as the
-   * query's watermark when preparing each batch, so it's ok that this val isn't fault-tolerant.
+   * physical plan.
+   *
+   * This state is 'soft state', which does not affect the correctness and semantics of watermarks
+   * and is not persisted across query restarts.
+   * The fault-tolerant watermark state is in offsetSeqMetadata.
    */
   protected val watermarkMsMap: MutableMap[Int, Long] = MutableMap()
 
@@ -573,17 +576,24 @@ class StreamExecution(
           case e: EventTimeWatermarkExec => e
         }.zipWithIndex.foreach {
           case (e, index) if e.eventTimeStats.value.count > 0 =>
-            logDebug(s"Observed event time stats: ${e.eventTimeStats.value}")
-            val newAttributeWatermarkMs = e.eventTimeStats.value.max - e.delayMs
-            val mappedWatermarkMs: Option[Long] = watermarkMsMap.get(index)
-            if (mappedWatermarkMs.isEmpty || newAttributeWatermarkMs > mappedWatermarkMs.get) {
-              watermarkMsMap.put(index, newAttributeWatermarkMs)
+            logDebug(s"Observed event time stats $index: ${e.eventTimeStats.value}")
+            val newWatermarkMs = e.eventTimeStats.value.max - e.delayMs
+            val prevWatermarkMs = watermarkMsMap.get(index)
+            if (prevWatermarkMs.isEmpty || newWatermarkMs > prevWatermarkMs.get) {
+              watermarkMsMap.put(index, newWatermarkMs)
             }
 
-          case _ =>
+          // Populate 0 if we haven't seen any data yet for this watermark node.
+          case (_, index) =>
+            if (!watermarkMsMap.isDefinedAt(index)) {
+              watermarkMsMap.put(index, 0)
+            }
         }
 
-        // Update the query watermark to the minimum of all attribute watermarks.
+        // Update the global watermark to the minimum of all watermark nodes.
+        // This is the safest option, because only the global watermark is fault-tolerant. Making
+        // it the minimum of all individual watermarks guarantees it will never advance past where
+        // any individual watermark operator would be if it were in a plan by itself.
         if(!watermarkMsMap.isEmpty) {
           val newWatermarkMs = watermarkMsMap.minBy(_._2)._2
           if (newWatermarkMs > batchWatermarkMs) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -301,6 +301,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
   }
 
   test("watermark with 2 streams") {
+    import org.apache.spark.sql.functions.sum
     val first = MemoryStream[Int]
 
     val firstDf = first.toDF()
@@ -315,50 +316,66 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
       .withWatermark("eventTime", "5 seconds")
       .select('value)
 
-    val union = firstDf.union(secondDf)
-      .writeStream
-      .format("memory")
-      .queryName("test")
-      .start()
+    withTempDir { checkpointDir =>
+      val unionWriter = firstDf.union(secondDf).agg(sum('value))
+        .writeStream
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .format("memory")
+        .outputMode("complete")
+        .queryName("test")
 
-    def getWatermarkAfterData(
-        firstData: Seq[Int] = Seq.empty,
-        secondData: Seq[Int] = Seq.empty): Long = {
-      if (firstData.nonEmpty) first.addData(firstData)
-      if (secondData.nonEmpty) second.addData(secondData)
-      union.processAllAvailable()
-      // add a dummy batch so lastExecution has the new watermark
-      first.addData(0)
-      union.processAllAvailable()
-      // get last watermark
-      val lastExecution = union.asInstanceOf[StreamingQueryWrapper].streamingQuery.lastExecution
-      lastExecution.offsetSeqMetadata.batchWatermarkMs
+      val union = unionWriter.start()
+
+      def getWatermarkAfterData(
+                                 firstData: Seq[Int] = Seq.empty,
+                                 secondData: Seq[Int] = Seq.empty,
+                                 query: StreamingQuery = union): Long = {
+        if (firstData.nonEmpty) first.addData(firstData)
+        if (secondData.nonEmpty) second.addData(secondData)
+        query.processAllAvailable()
+        // add a dummy batch so lastExecution has the new watermark
+        first.addData(0)
+        query.processAllAvailable()
+        // get last watermark
+        val lastExecution = query.asInstanceOf[StreamingQueryWrapper].streamingQuery.lastExecution
+        lastExecution.offsetSeqMetadata.batchWatermarkMs
+      }
+
+      // Global watermark starts at 0 until we get data from both sides
+      assert(getWatermarkAfterData(firstData = Seq(11)) == 0)
+      assert(getWatermarkAfterData(secondData = Seq(6)) == 1000)
+      // Global watermark stays at left watermark 1 when right watermark moves to 2
+      assert(getWatermarkAfterData(secondData = Seq(8)) == 1000)
+      // Global watermark switches to right side value 2 when left watermark goes higher
+      assert(getWatermarkAfterData(firstData = Seq(21)) == 3000)
+      // Global watermark goes back to left
+      assert(getWatermarkAfterData(secondData = Seq(17, 28, 39)) == 11000)
+      // Global watermark stays on left as long as it's below right
+      assert(getWatermarkAfterData(firstData = Seq(31)) == 21000)
+      assert(getWatermarkAfterData(firstData = Seq(41)) == 31000)
+      // Global watermark switches back to right again
+      assert(getWatermarkAfterData(firstData = Seq(51)) == 34000)
+
+      // Global watermark is updated correctly with simultaneous data from both sides
+      assert(getWatermarkAfterData(firstData = Seq(100), secondData = Seq(100)) == 90000)
+      assert(getWatermarkAfterData(firstData = Seq(120), secondData = Seq(110)) == 105000)
+      assert(getWatermarkAfterData(firstData = Seq(130), secondData = Seq(125)) == 120000)
+
+      // Global watermark doesn't decrement with simultaneous data
+      assert(getWatermarkAfterData(firstData = Seq(100), secondData = Seq(100)) == 120000)
+      assert(getWatermarkAfterData(firstData = Seq(140), secondData = Seq(100)) == 120000)
+      assert(getWatermarkAfterData(firstData = Seq(100), secondData = Seq(135)) == 130000)
+
+      // Global watermark recovers after restart, but left side watermark ahead of it does not.
+      assert(getWatermarkAfterData(firstData = Seq(200), secondData = Seq(190)) == 185000)
+      union.stop()
+      val union2 = unionWriter.start()
+      assert(getWatermarkAfterData(query = union2) == 185000)
+      // Even though the left side was ahead of 185000 in the last execution, the watermark won't
+      // increment until it gets past it in this execution.
+      assert(getWatermarkAfterData(secondData = Seq(200), query = union2) == 185000)
+      assert(getWatermarkAfterData(firstData = Seq(200), query = union2) == 190000)
     }
-
-    // Global watermark starts at 0 until we get data from both sides
-    assert(getWatermarkAfterData(firstData = Seq(11)) == 0)
-    assert(getWatermarkAfterData(secondData = Seq(6)) == 1000)
-    // Global watermark stays at left watermark 1 when right watermark moves to 2
-    assert(getWatermarkAfterData(secondData = Seq(8)) == 1000)
-    // Global watermark switches to right side value 2 when left watermark goes higher
-    assert(getWatermarkAfterData(firstData = Seq(21)) == 3000)
-    // Global watermark goes back to left
-    assert(getWatermarkAfterData(secondData = Seq(17, 28, 39)) == 11000)
-    // Global watermark stays on left as long as it's below right
-    assert(getWatermarkAfterData(firstData = Seq(31)) == 21000)
-    assert(getWatermarkAfterData(firstData = Seq(41)) == 31000)
-    // Global watermark switches back to right again
-    assert(getWatermarkAfterData(firstData = Seq(51)) == 34000)
-
-    // Global watermark is updated correctly with simultaneous data from both sides
-    assert(getWatermarkAfterData(firstData = Seq(100), secondData = Seq(100)) == 90000)
-    assert(getWatermarkAfterData(firstData = Seq(120), secondData = Seq(110)) == 105000)
-    assert(getWatermarkAfterData(firstData = Seq(130), secondData = Seq(125)) == 120000)
-
-    // Global watermark doesn't decrement with simultaneous data
-    assert(getWatermarkAfterData(firstData = Seq(100), secondData = Seq(100)) == 120000)
-    assert(getWatermarkAfterData(firstData = Seq(140), secondData = Seq(100)) == 120000)
-    assert(getWatermarkAfterData(firstData = Seq(100), secondData = Seq(135)) == 130000)
   }
 
   test("complete mode") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -346,7 +346,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
     // Watermark stays on left as long as it's below right
     generateAndAssertNewWatermark(first, Seq(31), 21000)
     generateAndAssertNewWatermark(first, Seq(41), 31000)
-    generateAndAssertNewWatermark(first, Seq(51), 41000)
+    generateAndAssertNewWatermark(first, Seq(51), 32000)
   }
 
   test("complete mode") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -303,19 +303,19 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
   test("watermark with 2 streams") {
     val first = MemoryStream[Int]
 
-    val firstAggregation = first.toDF()
+    val firstDf = first.toDF()
       .withColumn("eventTime", $"value".cast("timestamp"))
       .withWatermark("eventTime", "10 seconds")
       .select('value)
 
     val second = MemoryStream[Int]
 
-    val secondAggregation = second.toDF()
+    val secondDf = second.toDF()
       .withColumn("eventTime", $"value".cast("timestamp"))
       .withWatermark("eventTime", "10 seconds")
       .select('value)
 
-    val union = firstAggregation.union(secondAggregation)
+    val union = firstDf.union(secondDf)
       .writeStream
       .format("memory")
       .queryName("test")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Take the minimum of all watermark exec nodes as the "real" watermark in StreamExecution, rather than picking one arbitrarily.

## How was this patch tested?

new unit test
