### PR TITLE
[SPARK-22025][PySpark] Speeding up fromInternal for StructField

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -413,6 +413,21 @@ class StructField(DataType):
         self.needConversion = dataType.needConversion
         self.toInternal = dataType.toInternal
         self.fromInternal = dataType.fromInternal
+ 
+    def __getstate__(self):
+        """Return state values to be pickled."""
+        return (self.name, self.dataType, self.nullable, self.metadata)
+
+    def __setstate__(self, state):
+        """Restore state from the unpickled state values."""
+        name, dataType, nullable, metadata = state
+        self.name = name
+        self.dataType = dataType
+        self.nullable = nullable
+        self.metadata = metadata
+        self.needConversion = dataType.needConversion
+        self.toInternal = dataType.toInternal
+        self.fromInternal = dataType.fromInternal
 
     def simpleString(self):
         return '%s:%s' % (self.name, self.dataType.simpleString())

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -410,6 +410,9 @@ class StructField(DataType):
         self.dataType = dataType
         self.nullable = nullable
         self.metadata = metadata or {}
+        self.needConversion = dataType.needConversion
+        self.toInternal = dataType.toInternal
+        self.fromInternal = dataType.fromInternal
 
     def simpleString(self):
         return '%s:%s' % (self.name, self.dataType.simpleString())
@@ -430,15 +433,6 @@ class StructField(DataType):
                            _parse_datatype_json_value(json["type"]),
                            json["nullable"],
                            json["metadata"])
-
-    def needConversion(self):
-        return self.dataType.needConversion()
-
-    def toInternal(self, obj):
-        return self.dataType.toInternal(obj)
-
-    def fromInternal(self, obj):
-        return self.dataType.fromInternal(obj)
 
     def typeName(self):
         raise TypeError(

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -413,7 +413,7 @@ class StructField(DataType):
         self.needConversion = dataType.needConversion
         self.toInternal = dataType.toInternal
         self.fromInternal = dataType.fromInternal
- 
+
     def __getstate__(self):
         """Return state values to be pickled."""
         return (self.name, self.dataType, self.nullable, self.metadata)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change function call to references can greatly speed up function calling.

Benchmark
```
df = spark.range(10000000).selectExpr("id as id0", "id as id1", "id as id2", "id as id3", "id as id4", "id as id5", "id as id6", "id as id7", "id as id8", "id as id9", "struct(id) as s").cache()
df.count()
df.rdd.map(lambda x: x).count()
```

Before:
```
420274688 function calls (410272560 primitive calls) in 1710.883 seconds

Ordered by: internal time, cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
110000000  412.988    0.000  648.632    0.000 types.py:442(fromInternal)
 10000000  250.461    0.000  899.093    0.000 types.py:629(<listcomp>)
 30000000  188.816    0.000 1409.060    0.000 types.py:622(fromInternal)
100000000  177.706    0.000  177.706    0.000 types.py:88(fromInternal)
```
After
```
310274584 function calls (300272456 primitive calls) in 1308.709 seconds

Ordered by: internal time, cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 10000000  251.018    0.000  483.316    0.000 types.py:619(<listcomp>)
 30000000  190.364    0.000 1001.505    0.000 types.py:612(fromInternal)
100000000  175.242    0.000  175.242    0.000 types.py:88(fromInternal)
 20000000  155.427    0.000  325.382    0.000 types.py:1471(_create_row)
```

The change is 110 millions function calls less in types.py:442(fromInternal) and about 25% performance gain.

## How was this patch tested?

Existing tests.
Performance benchmark.

