### PR TITLE
[SPARK-22027] Add missing explanation of default value of `GBTRegressor`'s `maxIter` in API document

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -44,7 +44,7 @@ private[ml] trait HasRegParam extends Params {
 private[ml] trait HasMaxIter extends Params {
 
   /**
-   * Param for maximum number of iterations (&gt;= 0).
+   * Param for maximum number of iterations (&gt;= 0). (default = 20)
    * @group param
    */
   final val maxIter: IntParam = new IntParam(this, "maxIter", "maximum number of iterations (>= 0)", ParamValidators.gtEq(0))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the explanation of the default value of `GBTRegressor`'s `maxIter` parameter in the API document.

## How was this patch tested?

Check the default value of `GBTRegressor`'s `maxIter` parameter via the source code (https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala#L498).