### PR TITLE
[SPARK-22035][SQL]the value of statistical logicalPlan.stats.sizeInBytes which is not expected

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -17,9 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical.statsEstimation
 
-import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.types.LongType
 
 /**
  * An [[LogicalPlanVisitor]] that computes a the statistics used in a cost-based optimizer.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1341,6 +1341,19 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       Seq(1).toDS().map(_ => ("", TestForTypeAlias.seqOfTupleTypeAlias)),
       ("", Seq((1, 1), (2, 2))))
   }
+
+  test ("the calculation precision of sizeInBytes in Statistics") {
+    val N = 1 << 3
+    val df = spark.range(N).selectExpr("id as k1",
+      "cast(id  % 3 as string) as idString1",
+      "cast((id + 1) % 5 as string) as idString2")
+    val sizeInBytes = df.logicalPlan.stats.sizeInBytes
+    // LongType defaultSize: 8
+    // StringType defaultSize: 20
+    // StringType defaultSize: 20
+    // so sizeInBytes is 48 * 8 = 384
+    assert(sizeInBytes == 384)
+  }
 }
 
 case class WithImmutableMap(id: String, map_test: scala.collection.immutable.Map[Long, String])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, assume there will be the same number of rows as child has.  statistics `logicalPlan.stats.SizeInBytes` is calculated based on the percentage of the size of the child's data type and the size of the current data type size.   But there is a problem. Statistics are not very accurate. for example:
 ```
val N = 1 << 3
val df = spark.range(N).selectExpr("id as k1",
      "cast(id  % 3 as string) as idString1",
      "cast((id + 1) % 5 as string) as idString3")
val sizeInBytes = df.logicalPlan.stats.sizeInBytes
println("sizeInBytes : " + sizeInBytes)
```
before modify：
sizeInBytes is 224(8 * 8 * ( (8 + 20 + 20 +8) / (8 + 8))).  
debug information in ` SizeInBytesOnlyStatsPlanVisitor.visitUnaryNode `
```
p.child.dataType: LongType defaultSize: 8
p.dataType: LongType defaultSize: 8
p.dataType: StringType defaultSize: 20
p.dataType: StringType defaultSize: 20
childRowSize: 16 outputRowSize: 56
p.child.stats.sizeInBytes : 64
p.stats.sizeInBytes : 224
sizeInBytes: 224
```

after modify:
sizeInBytes  is 384( 8 * 8 ((8 + 20 + 20) / 8) ).
debug information in ` SizeInBytesOnlyStatsPlanVisitor.visitUnaryNode `
```
p.child.dataType: LongType defaultSize: 8
p.dataType: LongType defaultSize: 8
p.dataType: StringType defaultSize: 20
p.dataType: StringType defaultSize: 20
childRowSize: 8 outputRowSize: 48
p.child.stats.sizeInBytes : 64
p.stats.sizeInBytes : 384
sizeInBytes: 384
```

this PR fix it.

## How was this patch tested?

add new test cases.
