### PR TITLE
[SPARK-22029][PySpark] Add lru_cache to _parse_datatype_json_string

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -24,12 +24,14 @@ import json
 import re
 import base64
 from array import array
-from functools import lru_cache
 import ctypes
 
 if sys.version >= "3":
     long = int
     basestring = unicode = str
+
+if sys.version_info >= (3, 3):
+    from functools import lru_cache
 
 from py4j.protocol import register_input_converter
 from py4j.java_gateway import JavaClass
@@ -845,7 +847,13 @@ def _parse_datatype_string(s):
                 raise e
 
 
-@lru_cache(maxsize=None)
+if sys.version_info >= (3, 3):
+    decorator = lru_cache(maxsize=None)
+else:
+    decorator = lambda f: f
+
+
+@decorator
 def _parse_datatype_json_string(json_string):
     """Parses the given data type JSON string.
     >>> import pickle

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -24,6 +24,7 @@ import json
 import re
 import base64
 from array import array
+from functools import lru_cache
 import ctypes
 
 if sys.version >= "3":
@@ -844,6 +845,7 @@ def _parse_datatype_string(s):
                 raise e
 
 
+@lru_cache(maxsize=None)
 def _parse_datatype_json_string(json_string):
     """Parses the given data type JSON string.
     >>> import pickle


### PR DESCRIPTION
## What changes were proposed in this pull request?

_parse_datatype_json_string is called many times for the same datatypes.
By cacheing its result we can speed up pySpark internals.
Speed up is bigger for complicated SQL schemas.

Test
```
import time
from pyspark.sql import SparkSession
spark = SparkSession.builder.getOrCreate()

df = spark.range(1000000).selectExpr("struct(struct(id, id), id) as id0", "struct(struct(id, id), id) as id1", "struct(struct(id, id), id) as id2", "struct(struct(id, id), id) as id3", "struct(struct(id, id), id) as id4", "struct(struct(id, id), id) as id5", "struct(struct(id, id), id) as id6", "struct(struct(id, id), id) as id7", "struct(struct(id, id), id) as id8", "struct(struct(id, id), id) as id9").cache()
df.count()
for i in range(10):
  start = time.time()
  df.rdd.map(lambda x: x).count()
  print(i, time.time() - start)
```

Before:
```
0 12.123183250427246
1 11.405049562454224
2 11.22128415107727
3 11.24196171760559
4 11.492472410202026
5 11.242795705795288
6 11.167386531829834
7 11.119175672531128
8 11.130866765975952
9 11.13940691947937
```

After:
```
0 11.548425674438477
1 10.786834239959717
2 10.491389751434326
3 10.409717082977295
4 10.756452083587646
5 10.595868825912476
6 10.374756097793579
7 10.407423257827759
8 10.379964113235474
9 10.382996797561646
```


## How was this patch tested?

Existing tests.
Performance benchmark.