### PR TITLE
add MockNetCat

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/util/MockNetCat.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/MockNetCat.scala
@@ -1,0 +1,64 @@
+package org.apache.spark.streaming.util
+
+/**
+ * @author bluejoe2008@gmail.com
+ */
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.io.PrintWriter
+import java.net.ServerSocket
+
+object MockNetCat {
+	def start(port: Int) = new MockNetCat(port);
+}
+
+class MockNetCat(port: Int) {
+	val pout = new PipedOutputStream();
+	val pin = new PipedInputStream(pout);
+	val serverSocket = new ServerSocket(port);
+
+	val listenThread = new Thread() {
+		override def run() {
+			val socket = serverSocket.accept();
+			val sout = socket.getOutputStream();
+			val sin = socket.getInputStream();
+			val thread1 = createSyncThread(pin, sout);
+			val thread2 = createSyncThread(sin, System.out);
+			thread1.start();
+			thread2.start();
+			thread1.join();
+			socket.shutdownOutput();
+			thread2.join();
+		}
+	};
+
+	listenThread.start();
+
+	def writeData(text: String) {
+		pout.write(text.getBytes());
+	}
+
+	def stop() = {
+		serverSocket.close();
+		listenThread.stop();
+	}
+
+	private def createSyncThread(in: InputStream, out: OutputStream) = new Thread() {
+		override def run() {
+			val writer = new PrintWriter(out);
+			val reader = new BufferedReader(new InputStreamReader(in));
+			var line = "";
+			do {
+				line = reader.readLine();
+				if (line != null) {
+					writer.println(line);
+					writer.flush();
+				}
+			} while (line != null)
+		}
+	}
+}

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/MockNetCatTest.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/MockNetCatTest.scala
@@ -1,0 +1,38 @@
+package org.apache.spark.streaming.util
+
+import org.apache.spark.sql.SparkSession
+import org.junit.Test
+
+class MockNetCatTest {
+	var nc: MockNetCat = MockNetCat.start(9999);
+
+	@Test
+	def test() = {
+		val spark = SparkSession.builder.master("local[4]")
+			.getOrCreate();
+		spark.conf.set("spark.sql.streaming.checkpointLocation", "/tmp/");
+		import spark.implicits._
+
+		val lines = spark.readStream
+			.format("socket")
+			.option("host", "localhost")
+			.option("port", 9999)
+			.load()
+
+		// Split the lines into words
+		val words = lines.as[String].flatMap(_.split(" "))
+
+		// Generate running word count
+		val wordCounts = words.groupBy("value").count();
+		val query = wordCounts.writeStream
+			.outputMode("complete")
+			.format("console")
+			.start()
+
+		nc.writeData("hello\r\nworld\r\nbye\r\nworld\r\n");
+		Thread.sleep(2000);
+		nc.writeData("hello\r\nnetcat\r\n");
+		query.awaitTermination();
+	}
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
I add a MockNetCat class, which avoid manually launch `nc -lk 9999` command for test
also I put a MockNetCatTest class, a JUnit 4 test case which test MockNetCat

use of MockNetCat is very simple, like:
`var nc: MockNetCat = MockNetCat.start(9999);`

this starts a NetCat server, and data can be generated using following code:
`nc.writeData("hello\r\nworld\r\nbye\r\nworld\r\n");`

## How was this patch tested?

run MockNetCatTest to test MockNetCat
this class uses a structured streaming example which reads socket data from localhost:9999
