### PR TITLE
[SPARK-22040] Add current_date function with timezone id

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -793,12 +793,12 @@ def ntile(n):
 # ---------------------- Date/Timestamp functions ------------------------------
 
 @since(1.5)
-def current_date():
+def current_date(timeZone=None):
     """
-    Returns the current date as a :class:`DateType` column.
+    Returns the current date in the given timezone as a :class:`DateType` column.
     """
     sc = SparkContext._active_spark_context
-    return Column(sc._jvm.functions.current_date())
+    return Column(sc._jvm.functions.current_date(timeZone))
 
 
 def current_timestamp():

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2508,6 +2508,14 @@ object functions {
   def current_date(): Column = withExpr { CurrentDate() }
 
   /**
+   * Returns the current date in the given timezone as a date column.
+   *
+   * @group datetime_funcs
+   * @since 2.3.0
+   */
+  def current_date(timeZone: String): Column = withExpr { CurrentDate(Option(timeZone)) }
+
+  /**
    * Returns the current timestamp as a timestamp column.
    *
    * @group datetime_funcs


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add current_date function with timezone id.

## How was this patch tested?

Manual test on spark-shell and pyspark.
