### PR TITLE
[WIP][SPARK-20628][CORE] Blacklist nodes when they transition to DECOMMISSIONING state in YARN

### DIFF
--- a/core/src/main/scala/org/apache/spark/HostState.scala
+++ b/core/src/main/scala/org/apache/spark/HostState.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.hadoop.yarn.api.records.NodeState
+
+private[spark] object HostState extends Enumeration {
+
+  type HostState = Value
+
+  val New, Running, Unhealthy, Decommissioning, Decommissioned, Lost, Rebooted = Value
+
+  def fromYarnState(state: String): Option[HostState] = {
+    HostState.values.find(_.toString.toUpperCase == state)
+  }
+
+  def toYarnState(state: HostState): Option[String] = {
+    NodeState.values.find(_.name == state.toString.toUpperCase).map(_.name)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -154,6 +154,11 @@ package object config {
     ConfigBuilder("spark.blacklist.application.fetchFailure.enabled")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val BLACKLIST_DECOMMISSIONING_TIMEOUT_CONF =
+    ConfigBuilder("spark.blacklist.decommissioning.timeout")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createOptional
   // End blacklist confs
 
   private[spark] val UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE =

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -155,6 +155,11 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val BLACKLIST_DECOMMISSIONING_ENABLED =
+    ConfigBuilder("spark.blacklist.decommissioning.enabled")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val BLACKLIST_DECOMMISSIONING_TIMEOUT_CONF =
     ConfigBuilder("spark.blacklist.decommissioning.timeout")
       .timeConf(TimeUnit.MILLISECONDS)

--- a/core/src/main/scala/org/apache/spark/scheduler/NodeBlacklistReason.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/NodeBlacklistReason.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import org.apache.spark.annotation.DeveloperApi
+
+/**
+ * Represents an explanation for a Node being blacklisted for task scheduling
+ */
+@DeveloperApi
+private[spark] sealed trait NodeBlacklistReason extends Serializable {
+  def message: String
+}
+
+@DeveloperApi
+private[spark] case class ExecutorFailures(blacklistedExecutors: Set[String])
+  extends NodeBlacklistReason {
+  override def message: String = "Maximum number of executor failures allowed on Node exceeded."
+}
+
+@DeveloperApi
+private[spark] case object NodeDecommissioning extends NodeBlacklistReason {
+  override def message: String = "Node is being decommissioned by Cluster Manager."
+}
+
+@DeveloperApi
+private[spark] case class FetchFailure(host: String) extends NodeBlacklistReason {
+  override def message: String = s"Fetch failure for host $host"
+}
+

--- a/core/src/main/scala/org/apache/spark/scheduler/NodeUnblacklistReason.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/NodeUnblacklistReason.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import org.apache.spark.annotation.DeveloperApi
+
+/**
+ * Represents an explanation for a Node being unblacklisted for task scheduling.
+ */
+@DeveloperApi
+private[spark] sealed trait NodeUnblacklistReason extends Serializable {
+  def message: String
+}
+
+@DeveloperApi
+private[spark] object BlacklistTimedOut extends NodeUnblacklistReason {
+  override def message: String = "Blacklist timeout has reached."
+}
+
+@DeveloperApi
+private[spark] object NodeRunning extends NodeUnblacklistReason {
+  override def message: String = "Node is active and back to Running state."
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -125,11 +125,11 @@ case class SparkListenerExecutorUnblacklisted(time: Long, executorId: String)
 case class SparkListenerNodeBlacklisted(
     time: Long,
     hostId: String,
-    executorFailures: Int)
+    reason: NodeBlacklistReason)
   extends SparkListenerEvent
 
 @DeveloperApi
-case class SparkListenerNodeUnblacklisted(time: Long, hostId: String)
+case class SparkListenerNodeUnblacklisted(time: Long, hostId: String, reason: NodeUnblacklistReason)
   extends SparkListenerEvent
 
 @DeveloperApi

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -656,6 +656,14 @@ private[spark] class TaskSchedulerImpl(
     blacklistTrackerOpt.map(_.nodeBlacklist()).getOrElse(scala.collection.immutable.Set())
   }
 
+  def blacklistExecutorsOnHost(host: String, reason: NodeBlacklistReason): Unit = synchronized {
+    blacklistTrackerOpt.foreach(_.addNodeToBlacklist(host, reason))
+  }
+
+  def unblacklistExecutorsOnHost(host: String, reason: NodeUnblacklistReason): Unit = synchronized {
+    blacklistTrackerOpt.foreach(_.removeNodesFromBlacklist(List((host, reason, None))))
+  }
+
   // By default, rack is unknown
   def getRackForHost(value: String): Option[String] = None
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler.cluster
 
 import java.nio.ByteBuffer
 
+import org.apache.spark.HostState.HostState
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.ExecutorLossReason
@@ -108,6 +109,9 @@ private[spark] object CoarseGrainedClusterMessages {
       localityAwareTasks: Int,
       hostToLocalTaskCount: Map[String, Int],
       nodeBlacklist: Set[String])
+    extends CoarseGrainedClusterMessage
+
+  case class HostStatusUpdate(host: String, hostState: HostState)
     extends CoarseGrainedClusterMessage
 
   // Check if an executor was force-killed but for a reason unrelated to the running tasks.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 
 import org.apache.hadoop.security.UserGroupInformation
 
-import org.apache.spark.{ExecutorAllocationClient, SparkEnv, SparkException, TaskState}
+import org.apache.spark.{ExecutorAllocationClient, HostState, SparkEnv, SparkException, TaskState}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.internal.Logging
@@ -480,6 +480,21 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     driverEndpoint.ask[Boolean](RemoveWorker(workerId, host, message)).onFailure {
       case t => logError(t.getMessage, t)
     }(ThreadUtils.sameThread)
+  }
+
+  protected def handleUpdatedHostState(host: String, hostState: HostState.HostState): Unit = {
+    hostState match {
+      case HostState.Decommissioning =>
+        // TODO: Take action to blacklist executors on the host
+
+      case HostState.Running =>
+        // TODO: Take action to un-blacklist executors on the host
+
+      case HostState.Decommissioned | HostState.Lost =>
+        // TODO: Take action when a node is Decommissioned or Lost
+
+      case _ =>
+    }
   }
 
   def sufficientResourcesRegistered(): Boolean = true

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -482,13 +482,14 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     }(ThreadUtils.sameThread)
   }
 
-  protected def handleUpdatedHostState(host: String, hostState: HostState.HostState): Unit = {
+  private[scheduler] def handleUpdatedHostState(host: String,
+                                                hostState: HostState.HostState): Unit = {
     hostState match {
       case HostState.Decommissioning =>
-        // TODO: Take action to blacklist executors on the host
+        scheduler.blacklistExecutorsOnHost(host, NodeDecommissioning)
 
       case HostState.Running =>
-        // TODO: Take action to un-blacklist executors on the host
+        scheduler.unblacklistExecutorsOnHost(host, NodeRunning)
 
       case HostState.Decommissioned | HostState.Lost =>
         // TODO: Take action when a node is Decommissioned or Lost

--- a/core/src/test/resources/spark-events/app-20161115172038-0000
+++ b/core/src/test/resources/spark-events/app-20161115172038-0000
@@ -68,8 +68,8 @@
 {"Event":"SparkListenerJobEnd","Job ID":0,"Completion Time":1479252044931,"Job Result":{"Result":"JobSucceeded"}}
 {"Event":"org.apache.spark.scheduler.SparkListenerExecutorBlacklisted","time":1479252044930,"executorId":"2","taskFailures":4}
 {"Event":"org.apache.spark.scheduler.SparkListenerExecutorBlacklisted","time":1479252044930,"executorId":"0","taskFailures":4}
-{"Event":"org.apache.spark.scheduler.SparkListenerNodeBlacklisted","time":1479252044930,"hostId":"172.22.0.111","executorFailures":2}
+{"Event":"SparkListenerNodeBlacklisted","time":1479252044930,"hostId":"172.22.0.111","blacklistReason":{"reason":"ExecutorFailures","blacklistedExecutors":["exec1","exec2","exec3"]}}
 {"Event":"org.apache.spark.scheduler.SparkListenerExecutorUnblacklisted","time":1479252055635,"executorId":"2"}
 {"Event":"org.apache.spark.scheduler.SparkListenerExecutorUnblacklisted","time":1479252055635,"executorId":"0"}
-{"Event":"org.apache.spark.scheduler.SparkListenerNodeUnblacklisted","time":1479252055635,"hostId":"172.22.0.111"}
+{"Event":"SparkListenerNodeUnblacklisted","time":1479252055635,"hostId":"172.22.0.111","unblacklistReason":{"reason":"BlacklistTimedOut"}}
 {"Event":"SparkListenerApplicationEnd","Timestamp":1479252138874}

--- a/core/src/test/resources/spark-events/app-20161116163331-0000
+++ b/core/src/test/resources/spark-events/app-20161116163331-0000
@@ -64,5 +64,5 @@
 {"Event":"SparkListenerJobEnd","Job ID":0,"Completion Time":1479335617480,"Job Result":{"Result":"JobSucceeded"}}
 {"Event":"org.apache.spark.scheduler.SparkListenerExecutorBlacklisted","time":1479335617478,"executorId":"2","taskFailures":4}
 {"Event":"org.apache.spark.scheduler.SparkListenerExecutorBlacklisted","time":1479335617478,"executorId":"0","taskFailures":4}
-{"Event":"org.apache.spark.scheduler.SparkListenerNodeBlacklisted","time":1479335617478,"hostId":"172.22.0.167","executorFailures":2}
+{"Event":"SparkListenerNodeBlacklisted","time":1479335617478,"hostId":"172.22.0.167","blacklistReason":{"reason":"ExecutorFailures","blacklistedExecutors":["exec1","exec2","exec3"]}}
 {"Event":"SparkListenerApplicationEnd","Timestamp":1479335620587}

--- a/core/src/test/scala/org/apache/spark/HostStateSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HostStateSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.scalatest.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks.{forAll, Table}
+
+import org.apache.spark.HostState.HostState
+
+class HostStateSuite extends SparkFunSuite with Matchers {
+
+  test("Contract for the conversion between YARN NodeState and HostState") {
+    val mappings =
+      Table(
+        ("yarnNodeState", "hostState"),
+        (HostState.toYarnState(HostState.New), HostState.New),
+        (HostState.toYarnState(HostState.Running), HostState.Running),
+        (HostState.toYarnState(HostState.Decommissioned), HostState.Decommissioned),
+        (HostState.toYarnState(HostState.Decommissioning), HostState.Decommissioning),
+        (HostState.toYarnState(HostState.Unhealthy), HostState.Unhealthy),
+        (HostState.toYarnState(HostState.Rebooted), HostState.Rebooted))
+
+    forAll (mappings) { (yarnNodeState: Option[String], hostState: HostState) =>
+      assert(yarnNodeState.isDefined)
+      val hostStateOpt = HostState.fromYarnState(yarnNodeState.get)
+      assert(hostStateOpt.isDefined)
+      hostStateOpt.get should be (hostState)
+    }
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistIntegrationSuite.scala
@@ -44,7 +44,8 @@ class BlacklistIntegrationSuite extends SchedulerIntegrationSuite[MultiExecutorM
   // according to locality preferences, and so the job fails
   testScheduler("If preferred node is bad, without blacklist job will fail",
     extraConfs = Seq(
-      config.BLACKLIST_ENABLED.key -> "false"
+      config.BLACKLIST_ENABLED.key -> "false",
+      config.BLACKLIST_DECOMMISSIONING_ENABLED.key -> "true"
   )) {
     val rdd = new MockRDDWithLocalityPrefs(sc, 10, Nil, badHost)
     withBackend(badHostBackend _) {
@@ -58,6 +59,7 @@ class BlacklistIntegrationSuite extends SchedulerIntegrationSuite[MultiExecutorM
     "With default settings, job can succeed despite multiple bad executors on node",
     extraConfs = Seq(
       config.BLACKLIST_ENABLED.key -> "true",
+      config.BLACKLIST_DECOMMISSIONING_ENABLED.key -> "false",
       config.MAX_TASK_FAILURES.key -> "4",
       "spark.testing.nHosts" -> "2",
       "spark.testing.nExecutorsPerHost" -> "5",
@@ -84,6 +86,7 @@ class BlacklistIntegrationSuite extends SchedulerIntegrationSuite[MultiExecutorM
     "Bad node with multiple executors, job will still succeed with the right confs",
     extraConfs = Seq(
        config.BLACKLIST_ENABLED.key -> "true",
+       config.BLACKLIST_DECOMMISSIONING_ENABLED.key -> "false",
       // just to avoid this test taking too long
       "spark.locality.wait" -> "10ms"
     )
@@ -103,6 +106,7 @@ class BlacklistIntegrationSuite extends SchedulerIntegrationSuite[MultiExecutorM
     "SPARK-15865 Progress with fewer executors than maxTaskFailures",
     extraConfs = Seq(
       config.BLACKLIST_ENABLED.key -> "true",
+      config.BLACKLIST_DECOMMISSIONING_ENABLED.key -> "false",
       "spark.testing.nHosts" -> "2",
       "spark.testing.nExecutorsPerHost" -> "1",
       "spark.testing.nCoresPerExecutor" -> "1"

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -85,6 +85,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     blacklist = mock[BlacklistTracker]
     val conf = new SparkConf().setMaster("local").setAppName("TaskSchedulerImplSuite")
     conf.set(config.BLACKLIST_ENABLED, true)
+        .set(config.BLACKLIST_DECOMMISSIONING_ENABLED, false)
     sc = new SparkContext(conf)
     taskScheduler =
       new TaskSchedulerImpl(sc, sc.conf.getInt("spark.task.maxFailures", 4)) {
@@ -621,7 +622,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // schedulable on another executor.  However, that executor may fail later on, leaving the
     // first task with no place to run.
     val taskScheduler = setupScheduler(
-      config.BLACKLIST_ENABLED.key -> "true"
+      config.BLACKLIST_ENABLED.key -> "true",
+      config.BLACKLIST_DECOMMISSIONING_ENABLED.key -> "false"
     )
 
     val taskSet = FakeTask.createTaskSet(2)
@@ -672,7 +674,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // available and not bail on the job
 
     val taskScheduler = setupScheduler(
-      config.BLACKLIST_ENABLED.key -> "true"
+      config.BLACKLIST_ENABLED.key -> "true",
+      config.BLACKLIST_DECOMMISSIONING_ENABLED.key -> "false"
     )
 
     val taskSet = FakeTask.createTaskSet(2, (0 until 2).map { _ => Seq(TaskLocation("host0")) }: _*)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetBlacklistSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetBlacklistSuite.scala
@@ -25,6 +25,7 @@ class TaskSetBlacklistSuite extends SparkFunSuite {
   test("Blacklisting tasks, executors, and nodes") {
     val conf = new SparkConf().setAppName("test").setMaster("local")
       .set(config.BLACKLIST_ENABLED.key, "true")
+      .set(config.BLACKLIST_DECOMMISSIONING_ENABLED.key, "false")
     val clock = new ManualClock
 
     val taskSetBlacklist = new TaskSetBlacklist(conf, stageId = 0, clock = clock)
@@ -146,6 +147,7 @@ class TaskSetBlacklistSuite extends SparkFunSuite {
     // lead to any node blacklisting
     val conf = new SparkConf().setAppName("test").setMaster("local")
       .set(config.BLACKLIST_ENABLED.key, "true")
+      .set(config.BLACKLIST_DECOMMISSIONING_ENABLED.key, "false")
     val taskSetBlacklist = new TaskSetBlacklist(conf, stageId = 0, new SystemClock())
     taskSetBlacklist.updateBlacklistForFailedTask("hostA", exec = "1", index = 0)
     taskSetBlacklist.updateBlacklistForFailedTask("hostA", exec = "1", index = 1)

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerDistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerDistributedSuite.scala
@@ -32,6 +32,7 @@ class KryoSerializerDistributedSuite extends SparkFunSuite with LocalSparkContex
       .set("spark.kryo.registrator", classOf[AppJarRegistrator].getName)
       .set(config.MAX_TASK_FAILURES, 1)
       .set(config.BLACKLIST_ENABLED, false)
+      .set(config.BLACKLIST_DECOMMISSIONING_ENABLED, false)
 
     val jar = TestUtils.createJarWithClasses(List(AppJarRegistrator.customClassName))
     conf.setJars(List(jar.getPath))

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -264,6 +264,10 @@ private[spark] abstract class YarnSchedulerBackend(
       case AddWebUIFilter(filterName, filterParams, proxyBase) =>
         addWebUIFilter(filterName, filterParams, proxyBase)
 
+      case HostStatusUpdate(host, hostState) =>
+        logDebug("Received updated state %s for host %s".format(host, hostState))
+        handleUpdatedHostState(host, hostState)
+
       case r @ RemoveExecutor(executorId, reason) =>
         logWarning(reason.toString)
         driverEndpoint.ask[Boolean](r).onFailure {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnDecommissioningSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnDecommissioningSuite.scala
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files => JFiles, Paths}
+import java.util.concurrent.{Executors, TimeUnit}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.io.Source
+import scala.language.postfixOps
+import scala.util.Try
+
+import com.google.common.io.Files
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.scalatest.{BeforeAndAfter, Matchers}
+import org.scalatest.exceptions.TestFailedDueToTimeoutException
+
+import org.apache.spark.{HostState, SparkConf, SparkContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.tags.ExtendedYarnTest
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Integration test for YARN's graceful decommission mechanism; these tests use a mini
+ * Yarn cluster to run Spark-on-YARN applications, and require the Spark assembly to be built
+ * before they can be successfully run.
+ * Tests trigger the decommission of the only node in the mini Yarn cluster, and then check
+ * in the Yarn container logs that the Yarn node transitions were received at the driver.
+ */
+@ExtendedYarnTest
+class YarnDecommissioningSuite extends BaseYarnClusterSuite with BeforeAndAfter {
+
+  private val (excludedHostsFile, syncFile) = {
+    val (excludedHostsFile, syncFile) = (File.createTempFile("yarn-excludes", null, tempDir),
+                                         File.createTempFile("syncFile", null, tempDir))
+    excludedHostsFile.deleteOnExit()
+    syncFile.deleteOnExit()
+    logInfo(s"Using YARN excludes file ${excludedHostsFile.getAbsolutePath}")
+    logInfo(s"Using sync file ${syncFile.getAbsolutePath}")
+    (excludedHostsFile, syncFile)
+  }
+  // used to avoid restarting the MiniYARNCluster on the first test run
+  private var fistTestRun = true
+  private val executorService = Executors.newSingleThreadScheduledExecutor()
+  private implicit val ec = ExecutionContext.fromExecutorService(executorService)
+
+  override val newYarnConfig: YarnConfiguration = {
+    val conf = new YarnConfiguration()
+    conf.set("yarn.resourcemanager.nodes.exclude-path", excludedHostsFile.getAbsolutePath)
+    conf
+  }
+
+  private val decommissionStates = Set(HostState.Decommissioning,
+                                       HostState.Decommissioned).map{ state =>
+    val yarnStateOpt = HostState.toYarnState(state)
+    assert(yarnStateOpt.isDefined,
+           s"Spark host state $state should have a translation to YARN state")
+    yarnStateOpt.get
+  }
+
+  before {
+    if (!fistTestRun) {
+      Files.write("", excludedHostsFile, StandardCharsets.UTF_8)
+      Files.write("", syncFile, StandardCharsets.UTF_8)
+      restartCluster()
+    }
+    fistTestRun = false
+  }
+
+  test("Spark application master gets notified on node decommissioning when running in" +
+    " cluster mode") {
+    val excludedHostStateUpdates = testNodeDecommission(clientMode = false)
+    excludedHostStateUpdates shouldEqual(decommissionStates)
+  }
+
+  test("Spark application master gets notified on node decommissioning when running in" +
+    " client mode") {
+    val excludedHostStateUpdates = testNodeDecommission(clientMode = true)
+    // In client mode the node doesn't always have time to reach the decommissioned state
+    assert(excludedHostStateUpdates.subsetOf(decommissionStates))
+    assert(excludedHostStateUpdates
+             .contains(HostState.toYarnState(HostState.Decommissioning).get))
+  }
+
+  /**
+   * @return a set of strings for the Yarn decommission related states the only node in
+   *         the MiniYARNCluster has transitioned to after the Spark job has started.
+   */
+  private def testNodeDecommission(clientMode: Boolean): Set[String] = {
+    val excludedHostPromise = Promise[String]
+    scheduleDecommissionRunnable(excludedHostPromise)
+
+    // surface exceptions in the executor service
+    val excludedHostFuture = excludedHostPromise.future
+    excludedHostFuture.onFailure { case t => throw t  }
+    // we expect a timeout exception because the job will fail when the only available node
+    // is decommissioned after its timeout
+    intercept[TestFailedDueToTimeoutException] {
+      runSpark(clientMode, mainClassName(YarnDecommissioningDriver.getClass),
+        appArgs = Seq(syncFile.getAbsolutePath),
+        extraConf = Map(),
+        numExecutors = 2,
+        executionTimeout = 2 minutes)
+    }
+    assert(excludedHostPromise.isCompleted, "graceful decommission was not launched for any node")
+    val excludedHost = ThreadUtils.awaitResult(excludedHostFuture, 1 millisecond)
+    assert(excludedHost.length > 0)
+    getExcludedHostStateUpdate(excludedHost)
+  }
+
+  /**
+   * This method repeatedly schedules a task that checks the contents of the syncFile used to
+   * synchronize with the Spark driver. When the syncFile is updated with the sync text then
+   * YARN's graceful decommission mechanism is triggered, and the excluded host is returned
+   * by completing excludedHostPromise.
+   */
+  private def scheduleDecommissionRunnable(excludedHostPromise: Promise[String]): Unit = {
+    def decommissionRunnable(): Runnable = new Runnable() {
+      override def run() {
+        if (syncFile.exists() &&
+          Files.toString(syncFile, StandardCharsets.UTF_8)
+            .equals(YarnDecommissioningDriver.SYNC_TEXT)) {
+          excludedHostPromise.complete(Try{
+            logInfo("Launching graceful decommission of a node in YARN")
+            gracefullyDecommissionNode(newYarnConfig, excludedHostsFile,
+              decommissionTimeout = 10 seconds)
+          })
+        } else {
+          logDebug("Waiting for sync file to be updated by the driver")
+          executorService.schedule(decommissionRunnable(), 100, TimeUnit.MILLISECONDS)
+        }
+      }
+    }
+    executorService.schedule(decommissionRunnable(), 1, TimeUnit.SECONDS)
+  }
+
+  /**
+   * This method should be called after the Spark application has completed, to parse
+   * the container logs for messages about Yarn decommission related states involving
+   * the node that was decommissioned.
+   */
+  private def getExcludedHostStateUpdate(excludedHost: String): Set[String] = {
+    val stateChangeRe = {
+      val decommissionStateRe = decommissionStates.mkString("|")
+      "(?:%s.*(%s))|(?:(%s).*%s)".format(excludedHost, decommissionStateRe,
+        decommissionStateRe, excludedHost).r
+    }
+    (for {
+      file <- JFiles.walk(Paths.get(getClusterWorkDir.getAbsolutePath))
+                    .iterator().asScala
+      if file.getFileName.toString == "stderr"
+      line <- Source.fromFile(file.toFile).getLines()
+      matchingSubgroups <- stateChangeRe.findFirstMatchIn(line)
+                                        .map(_.subgroups.filter(_ != null)).toSeq
+      group <- matchingSubgroups
+    } yield group).toSet
+  }
+}
+
+private object YarnDecommissioningDriver extends Logging with Matchers {
+
+  val SYNC_TEXT = "First action completed. Start decommissioning."
+  val WAIT_TIMEOUT_MILLIS = 10000
+  val DECOMMISSION_WAIT_TIME_MILLIS = 500000
+
+  def main(args: Array[String]): Unit = {
+    if (args.length != 1) {
+      // scalastyle:off println
+      System.err.println(
+        s"""
+           |Invalid command line: ${args.mkString(" ")}
+           |
+        |Usage: YarnDecommissioningDriver [sync file]
+        """.stripMargin)
+      // scalastyle:on println
+      System.exit(1)
+    }
+    val sc = new SparkContext(new SparkConf()
+        .setAppName("Yarn Decommissioning Test"))
+    try {
+      logInfo("Starting YarnDecommissioningDriver")
+      val counts = sc.parallelize(1 to 10, 4)
+                      .map{ x => (x%7, x)}
+                      .reduceByKey(_ + _).collect
+      sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
+      logInfo(s"Got ${counts.mkString(",")}")
+
+      val syncFile = new File(args(0))
+      Files.append(SYNC_TEXT, syncFile, StandardCharsets.UTF_8)
+      logInfo(s"Sync file ${syncFile} written")
+
+      // Wait for decommissioning and then for decommissioned, the timeout in
+      // the corresponding call to runSpark will interrupt this
+      Thread.sleep(DECOMMISSION_WAIT_TIME_MILLIS)
+    } catch {
+      case e =>
+        logError(s"Driver exception: ${e.getMessage}")
+    }
+    finally {
+      sc.stop()
+    }
+  }
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request? 
Dynamic cluster configurations where cluster nodes are added and removed frequently are common in public cloud environments, so this has become a [problem for Spark users](https://www.trulia.com/blog/tech/aws-emr-ad-hoc-spark-development-environme... ). To cope with this we propose implementing a mechanism in the line of YARN’s support for [graceful node decommission](https://issues.apache.org/jira/browse/YARN-914 ) or [Mesos maintenance primitives](https://mesos.apache.org/documentation/latest/maintenance/ ). These changes allow cluster nodes to be transitioned to a ‘decommissioning’ state, at which point no more tasks will be scheduled on the executors running on those nodes. After a configurable drain time, nodes in the ‘decommissioning’ state will transition to a ‘decommissioned’ state, where shuffle blocks are not available anymore. Shuffle blocks stored on nodes in the ‘decommissioning’ state are available to other executors. By preventing more tasks from running on nodes in the ‘decommissioning’ state we avoid creating more shuffle blocks on those nodes, as those blocks won’t be available when nodes eventually transition to the ‘decommissioned’ state. 

We have implemented a first version of this proposal for YARN, using Spark’s [blacklisting mechanism for task scheduling](https://issues.apache.org/jira/browse/SPARK-8425 ) ─available at the node level since Spark 2.2.0─ to ensure tasks are not scheduled on nodes in the ‘decommissioning’ state. With this solution it is the cluster manager, not the Spark application, that tracks the status of the node, and handles the transition from ‘decommissioning’ to ‘decommissioned’. The Spark driver simply reacts to the node state transitions. 

## How was this patch tested? 
All functionality has been tested with unit tests, with an integration test based on the BaseYarnClusterSuite, and with manual testing on a cluster 