### PR TITLE
[SPARK-22056][Streaming] Add subconcurrency for KafkaRDDPartition

### DIFF
--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -57,29 +57,35 @@ class KafkaRDD[
     messageHandler: MessageAndMetadata[K, V] => R
   ) extends RDD[R](sc, Nil) with Logging with HasOffsetRanges {
   override def getPartitions: Array[Partition] = {
+
     val subconcurrency = if (kafkaParams.contains("topic.partition.subconcurrency"))
-                              kafkaParams.get("topic.partition.subconcurrency").asInstanceOf[String].toInt
-                         else 1
+      kafkaParams.getOrElse("topic.partition.subconcurrency","1").toInt
+    else 1
     val numPartitions = offsetRanges.length
-    val kafkaRDDPartitionArray = new Array[Partition](subconcurrency * numPartitions)
+
+    val subOffsetRanges: Array[OffsetRange] = new Array[OffsetRange](subconcurrency * numPartitions)
     for (i <- 0 until numPartitions) {
       val offsetRange = offsetRanges(i)
-      val (host, port) = leaders(TopicAndPartition(offsetRange.topic, offsetRange.partition))
       val step = (offsetRange.untilOffset - offsetRange.fromOffset) / subconcurrency
 
       var from = -1L
       var until = -1L
+
       for (j <- 0 until subconcurrency) {
         from = offsetRange.fromOffset + j * step
-        until = offsetRange.fromOffset + (j + 1) * step - 1
+        until = offsetRange.fromOffset + (j + 1) * step -1
         if (j == subconcurrency) {
           until = offsetRange.untilOffset
         }
-        kafkaRDDPartitionArray(i * subconcurrency + j) = new KafkaRDDPartition(i,
-          offsetRange.topic, offsetRange.partition, from, until, host, port)
+        subOffsetRanges(i * subconcurrency + j) = OffsetRange.create(offsetRange.topic, offsetRange.partition, from, until)
       }
     }
-    kafkaRDDPartitionArray
+
+    subOffsetRanges.zipWithIndex.map{ case (o, i) =>
+      val (host, port) = leaders(TopicAndPartition(o.topic, o.partition))
+      new KafkaRDDPartition(i, o.topic, o.partition, o.fromOffset, o.untilOffset, host, port)
+    }.toArray
+
   }
 
   override def count(): Long = offsetRanges.map(_.count).sum


### PR DESCRIPTION
JIRA Issue：https://issues.apache.org/jira/browse/SPARK-22056

When spark streaming consuming data from Kafka in direct way , partition in Kafka and KafkaRDDPartition in spark streaming are now bijection. To enhance the computing ability of spark streaming, we always to increase the number of partitions in Kafka , but too many increments may lead problems in Kafka like leader selection. 
So , we introduce a new mechanism that change bijection to one-to-many which controls by a new parameter named "topic.partition.subconcurrency". This mechanism will divide one KafkaRDDPartition to many according to the parameter in spark streaming side , thus will make spark streaming use computing resources more efficient  and avoid the problems caused by increasing the Kafka partitions.  

we test this in production , the processing capacity of spark streaming improves apparently.
