### PR TITLE
[SPARK-21998][SQL] SortMergeJoinExec did not calculate its outputOrdering correctly during physical planning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -101,15 +101,20 @@ object SortOrder {
    * Returns if a sequence of SortOrder satisfies another sequence of SortOrder.
    *
    * SortOrder sequence A satisfies SortOrder sequence B if and only if B is an equivalent of A
-   * or of A's prefix.
+   * or of A's prefix. Here are examples of ordering A satisfying ordering B:
+   * <ul>
+   *   <li>ordering A is [x, y] and ordering B is [x]</li>
+   *   <li>ordering A is [x(sameOrderExpressions=x1)] and ordering B is [x1]</li>
+   *   <li>ordering A is [x(sameOrderExpressions=x1), y] and ordering B is [x1]</li>
+   * </ul>
    */
-  def orderingSatisfies(seq1: Seq[SortOrder], seq2: Seq[SortOrder]): Boolean = {
-    if (seq2.isEmpty) {
+  def orderingSatisfies(ordering1: Seq[SortOrder], ordering2: Seq[SortOrder]): Boolean = {
+    if (ordering2.isEmpty) {
       true
-    } else if (seq2.length > seq1.length) {
+    } else if (ordering2.length > ordering1.length) {
       false
     } else {
-      seq2.zip(seq1).forall {
+      ordering2.zip(ordering1).forall {
         case (o2, o1) => o1.satisfies(o2)
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -96,6 +96,24 @@ object SortOrder {
      sameOrderExpressions: Set[Expression] = Set.empty): SortOrder = {
     new SortOrder(child, direction, direction.defaultNullOrdering, sameOrderExpressions)
   }
+
+  /**
+   * Returns if a sequence of SortOrder satisfies another sequence of SortOrder.
+   *
+   * SortOrder sequence A satisfies SortOrder sequence B if and only if B is an equivalent of A
+   * or of A's prefix.
+   */
+  def orderingSatisfies(seq1: Seq[SortOrder], seq2: Seq[SortOrder]): Boolean = {
+    if (seq2.isEmpty) {
+      true
+    } else if (seq2.length > seq1.length) {
+      false
+    } else {
+      seq2.zip(seq1).forall {
+        case (o2, o1) => o1.satisfies(o2)
+      }
+    }
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -396,26 +396,6 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
 object SparkPlan {
   private[execution] val subqueryExecutionContext = ExecutionContext.fromExecutorService(
     ThreadUtils.newDaemonCachedThreadPool("subquery", 16))
-
-  /**
-   * Returns if the actual ordering satisfies the required ordering.
-   *
-   * Ordering A satisfies ordering B if and only if B is an equivalent of A or of A's prefix.
-   */
-  def orderingSatisfies(actual: Seq[SortOrder], required: Seq[SortOrder]): Boolean = {
-    if (required.nonEmpty) {
-      if (required.length > actual.length) {
-        false
-      } else {
-        required.zip(actual).forall {
-          case (requiredOrder, actualOrder) =>
-            actualOrder.satisfies(requiredOrder)
-        }
-      }
-    } else {
-      true
-    }
-  }
 }
 
 trait LeafExecNode extends SparkPlan {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -396,6 +396,26 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
 object SparkPlan {
   private[execution] val subqueryExecutionContext = ExecutionContext.fromExecutorService(
     ThreadUtils.newDaemonCachedThreadPool("subquery", 16))
+
+  /**
+   * Returns if the actual ordering satisfies the required ordering.
+   *
+   * Ordering A satisfies ordering B if and only if B is an equivalent of A or of A's prefix.
+   */
+  def orderingSatisfies(actual: Seq[SortOrder], required: Seq[SortOrder]): Boolean = {
+    if (required.nonEmpty) {
+      if (required.length > actual.length) {
+        false
+      } else {
+        required.zip(actual).forall {
+          case (requiredOrder, actualOrder) =>
+            actualOrder.satisfies(requiredOrder)
+        }
+      }
+    } else {
+      true
+    }
+  }
 }
 
 trait LeafExecNode extends SparkPlan {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -234,24 +234,11 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
 
     // Now that we've performed any necessary shuffles, add sorts to guarantee output orderings:
     children = children.zip(requiredChildOrderings).map { case (child, requiredOrdering) =>
-      if (requiredOrdering.nonEmpty) {
-        // If child.outputOrdering is [a, b] and requiredOrdering is [a], we do not need to sort.
-        val orderingMatched = if (requiredOrdering.length > child.outputOrdering.length) {
-          false
-        } else {
-          requiredOrdering.zip(child.outputOrdering).forall {
-            case (requiredOrder, childOutputOrder) =>
-              childOutputOrder.satisfies(requiredOrder)
-          }
-        }
-
-        if (!orderingMatched) {
-          SortExec(requiredOrdering, global = false, child = child)
-        } else {
-          child
-        }
-      } else {
+      // If child.outputOrdering already satisfies the requiredOrdering, we do not need to sort.
+      if (SparkPlan.orderingSatisfies(child.outputOrdering, requiredOrdering)) {
         child
+      } else {
+        SortExec(requiredOrdering, global = false, child = child)
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -235,7 +235,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
     // Now that we've performed any necessary shuffles, add sorts to guarantee output orderings:
     children = children.zip(requiredChildOrderings).map { case (child, requiredOrdering) =>
       // If child.outputOrdering already satisfies the requiredOrdering, we do not need to sort.
-      if (SparkPlan.orderingSatisfies(child.outputOrdering, requiredOrdering)) {
+      if (SortOrder.orderingSatisfies(child.outputOrdering, requiredOrdering)) {
         child
       } else {
         SortExec(requiredOrdering, global = false, child = child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -105,9 +105,9 @@ case class SortMergeJoinExec(
    * The utility method to get output ordering for left or right side of the join.
    *
    * Returns the required ordering for left or right child if childOutputOrdering does not
-   * satisfy the required ordering; otherwise, in which case the child will not be re-sorted,
-   * returns the required ordering for this child with extra "sameOrderExpressions" from the
-   * child's outputOrdering.
+   * satisfy the required ordering; otherwise, which means the child does not need to be sorted
+   * again, returns the required ordering for this child with extra "sameOrderExpressions" from
+   * the child's outputOrdering.
    */
   private def getKeyOrdering(keys: Seq[Expression], childOutputOrdering: Seq[SortOrder])
     : Seq[SortOrder] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -101,10 +101,18 @@ case class SortMergeJoinExec(
         s"${getClass.getSimpleName} should not take $x as the JoinType")
   }
 
+  /**
+   * The utility method to get output ordering for left or right side of the join.
+   *
+   * Returns the required ordering for left or right child if childOutputOrdering does not
+   * satisfy the required ordering; otherwise, in which case the child will not be re-sorted,
+   * returns the required ordering for this child with extra "sameOrderExpressions" from the
+   * child's outputOrdering.
+   */
   private def getKeyOrdering(keys: Seq[Expression], childOutputOrdering: Seq[SortOrder])
     : Seq[SortOrder] = {
     val requiredOrdering = requiredOrders(keys)
-    if (SparkPlan.orderingSatisfies(childOutputOrdering, requiredOrdering)) {
+    if (SortOrder.orderingSatisfies(childOutputOrdering, requiredOrdering)) {
       keys.zip(childOutputOrdering).map { case (key, childOrder) =>
         SortOrder(key, Ascending, childOrder.sameOrderExpressions + childOrder.child - key)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{Ascending, SortOrder}
 import org.apache.spark.sql.execution.SortExec
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
@@ -64,42 +63,6 @@ class JoinSuite extends QueryTest with SharedSQLContext {
     assert(operators.size === 1)
     if (operators.head.getClass != c) {
       fail(s"$sqlString expected operator: $c, but got ${operators.head}\n physical: \n$physical")
-    }
-  }
-
-  def assertJoinOrdering(sqlString: String, numOfJoin: Int, numOfSort: Int): Any = {
-    val df = sql(sqlString)
-    val physical = df.queryExecution.sparkPlan
-    val physicalJoins = physical.collect {
-      case j: SortMergeJoinExec => j
-    }
-    val executed = df.queryExecution.executedPlan
-    val executedJoins = executed.collect {
-      case j: SortMergeJoinExec => j
-    }
-    val executedSorts = executed.collect {
-      case s: SortExec => s
-    }
-    assert(executedSorts.size == numOfSort)
-    val joinPairs = physicalJoins.zip(executedJoins)
-    assert(joinPairs.size == numOfJoin)
-
-    joinPairs.foreach {
-      case(join1, join2) =>
-        val leftKeys = join1.leftKeys
-        val rightKeys = join1.rightKeys
-        val outputOrderingPhysical = join1.outputOrdering
-        val outputOrderingExecuted = join2.outputOrdering
-
-        assert(
-          SparkPlan.orderingSatisfies(
-            outputOrderingPhysical, leftKeys.map(SortOrder(_, Ascending))))
-        assert(
-          SparkPlan.orderingSatisfies(
-            outputOrderingPhysical, rightKeys.map(SortOrder(_, Ascending))))
-        assert(outputOrderingPhysical == outputOrderingExecuted,
-          s"Physical operator $join1 did not have the same output ordering as " +
-          s"corresponding executed operator $join2")
     }
   }
 
@@ -828,12 +791,62 @@ class JoinSuite extends QueryTest with SharedSQLContext {
   }
 
   test("test SortMergeJoin output ordering") {
-    assertJoinOrdering("SELECT * FROM testData JOIN testData2 ON key = a", 1, 2)
-    assertJoinOrdering("SELECT * FROM testData t1 JOIN " +
-      "testData2 t2 ON t1.key = t2.a JOIN testData3 t3 ON t2.a = t3.a", 2, 3)
-    assertJoinOrdering("SELECT * FROM testData t1 JOIN " +
-      "testData2 t2 ON t1.key = t2.a JOIN " +
-      "testData3 t3 ON t2.a = t3.a JOIN " +
-      "testData t4 ON t1.key = t4.key", 3, 4)
+    val joinQueries = Seq(
+      "SELECT * FROM testData JOIN testData2 ON key = a",
+      "SELECT * FROM testData t1 JOIN " +
+        "testData2 t2 ON t1.key = t2.a JOIN testData3 t3 ON t2.a = t3.a",
+      "SELECT * FROM testData t1 JOIN " +
+        "testData2 t2 ON t1.key = t2.a JOIN " +
+        "testData3 t3 ON t2.a = t3.a JOIN " +
+        "testData t4 ON t1.key = t4.key")
+
+    def assertJoinOrdering(sqlString: String): Unit = {
+      val df = sql(sqlString)
+      val physical = df.queryExecution.sparkPlan
+      val physicalJoins = physical.collect {
+        case j: SortMergeJoinExec => j
+      }
+      val executed = df.queryExecution.executedPlan
+      val executedJoins = executed.collect {
+        case j: SortMergeJoinExec => j
+      }
+      // This only applies to the above tested queries, in which a child SortMergeJoin always
+      // contains the SortOrder required by its parent SortMergeJoin. Thus, SortExec should never
+      // appear as parent of SortMergeJoin.
+      executed.foreach {
+        case s: SortExec => s.foreach {
+          case j: SortMergeJoinExec => fail(
+            s"No extra sort should be added since $j already satisfies the required ordering"
+          )
+          case _ =>
+        }
+        case _ =>
+      }
+      val joinPairs = physicalJoins.zip(executedJoins)
+      val numOfJoins = sqlString.split(" ").count(_.toUpperCase == "JOIN")
+      assert(joinPairs.size == numOfJoins)
+
+      joinPairs.foreach {
+        case(join1, join2) =>
+          val leftKeys = join1.leftKeys
+          val rightKeys = join1.rightKeys
+          val outputOrderingPhysical = join1.outputOrdering
+          val outputOrderingExecuted = join2.outputOrdering
+
+          // outputOrdering should always contain join keys
+          assert(
+            SortOrder.orderingSatisfies(
+              outputOrderingPhysical, leftKeys.map(SortOrder(_, Ascending))))
+          assert(
+            SortOrder.orderingSatisfies(
+              outputOrderingPhysical, rightKeys.map(SortOrder(_, Ascending))))
+          // outputOrdering should be consistent between physical plan and executed plan
+          assert(outputOrderingPhysical == outputOrderingExecuted,
+            s"Physical operator $join1 did not have the same output ordering as " +
+            s"corresponding executed operator $join2")
+      }
+    }
+
+    joinQueries.foreach(assertJoinOrdering)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -842,8 +842,8 @@ class JoinSuite extends QueryTest with SharedSQLContext {
               outputOrderingPhysical, rightKeys.map(SortOrder(_, Ascending))))
           // outputOrdering should be consistent between physical plan and executed plan
           assert(outputOrderingPhysical == outputOrderingExecuted,
-            s"Physical operator $join1 did not have the same output ordering as " +
-            s"corresponding executed operator $join2")
+            s"Operator $join1 did not have the same output ordering in the physical plan as in " +
+            s"the executed plan.")
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now the calculation of SortMergeJoinExec's outputOrdering relies on the fact that its children have already been sorted on the join keys, while this is often not true until EnsureRequirements has been applied. So we ended up not getting the correct outputOrdering during physical planning stage before Sort nodes are added to the children.

For example, J = {A join B on key1 = key2}
1. if A is NOT ordered on key1 ASC, J's outputOrdering should include "key1 ASC"
2. if A is ordered on key1 ASC, J's outputOrdering should include "key1 ASC"
3. if A is ordered on key1 ASC, with sameOrderExp=c1, J's outputOrdering should include "key1 ASC, sameOrderExp=c1"

So to fix this I changed the  behavior of <code>getKeyOrdering(keys, childOutputOrdering)</code> to:
1. If the childOutputOrdering satisfies (is a superset of) the required child ordering => childOutputOrdering
2. Otherwise => required child ordering

In addition, I organized the logic for deciding the relationship between two orderings into SparkPlan, so that it can be reused by EnsureRequirements and SortMergeJoinExec, and potentially other classes.

## How was this patch tested?

Added new test cases.
Passed all integration tests.
