### PR TITLE
Update quickstart python dataset example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -153,7 +153,7 @@ This first maps a line to an integer value and aliases it as "numWords", creatin
 One common data flow pattern is MapReduce, as popularized by Hadoop. Spark can implement MapReduce flows easily:
 
 {% highlight python %}
->>> wordCounts = textFile.select(explode(split(textFile.value, "\s+")).as("word")).groupBy("word").count()
+>>> wordCounts = textFile.select(explode(split(textFile.value, "\s+")).name("word")).groupBy("word").count()
 {% endhighlight %}
 
 Here, we use the `explode` function in `select`, to transfrom a Dataset of lines to a Dataset of words, and then combine `groupBy` and `count` to compute the per-word counts in the file as a DataFrame of 2 columns: "word" and "count". To collect the word counts in our shell, we can call `collect`:


### PR DESCRIPTION
The python spark datasets example for the mapreduce was returning error, when using .select().as() function.
Replaces the error to use the .select().name() function, that does the same thing and works

## What changes were proposed in this pull request?

no changes

## How was this patch tested?

no significant changes were made to the spark code. Just documentation changes. The change I implemented was tested manually over spark 2.2.0

Please review http://spark.apache.org/contributing.html before opening a pull request.
