### PR TITLE
[SPARK-21338][SQL][FOLLOW-UP] Implement isCascadingTruncateTable() method in AggregatedDialect

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -43,6 +43,17 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = {
-    dialects.flatMap(_.isCascadingTruncateTable()).reduceOption(_ || _)
+    // If any dialect claims cascading truncate, this dialect is also cascading truncate.
+    // Otherwise, if any dialect has unknown cascading truncate, this dialect is also unknown.
+    val cascading = dialects.flatMap(_.isCascadingTruncateTable()).reduceOption(_ || _)
+    if (cascading.get) {
+      cascading
+    } else {
+      if (dialects.exists(_.isCascadingTruncateTable().isEmpty)) {
+        None
+      } else {
+        Some(false)
+      }
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -46,7 +46,7 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
     // If any dialect claims cascading truncate, this dialect is also cascading truncate.
     // Otherwise, if any dialect has unknown cascading truncate, this dialect is also unknown.
     val cascading = dialects.flatMap(_.isCascadingTruncateTable()).reduceOption(_ || _)
-    if (cascading.get) {
+    if (cascading.getOrElse(false)) {
       cascading
     } else {
       if (dialects.exists(_.isCascadingTruncateTable().isEmpty)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -45,15 +45,10 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
   override def isCascadingTruncateTable(): Option[Boolean] = {
     // If any dialect claims cascading truncate, this dialect is also cascading truncate.
     // Otherwise, if any dialect has unknown cascading truncate, this dialect is also unknown.
-    val cascading = dialects.flatMap(_.isCascadingTruncateTable()).reduceOption(_ || _)
-    if (cascading.getOrElse(false)) {
-      cascading
-    } else {
-      if (dialects.exists(_.isCascadingTruncateTable().isEmpty)) {
-        None
-      } else {
-        Some(false)
-      }
+    dialects.flatMap(_.isCascadingTruncateTable()).reduceOption(_ || _) match {
+      case Some(true) => Some(true)
+      case _ if dialects.exists(_.isCascadingTruncateTable().isEmpty) => None
+      case _ => Some(false)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -760,21 +760,18 @@ class JDBCSuite extends SparkFunSuite
       override def isCascadingTruncateTable(): Option[Boolean] = cascadingTruncateTable
     }
 
-    val dialectCombination = Seq(
-      List(genDialect(Some(true)), genDialect(Some(false)), genDialect(None)),
-      List(genDialect(Some(true)), genDialect(Some(true)), genDialect(None)),
-      List(genDialect(Some(false)), genDialect(Some(false)), genDialect(None)),
-      List(genDialect(Some(true)), genDialect(Some(true))),
-      List(genDialect(Some(false)), genDialect(Some(false))),
-      List(genDialect(None), genDialect(None))
-    )
-
-    val expectedCascading = Seq(Some(true), Some(true), None, Some(true), Some(false), None)
-
-    dialectCombination.zip(expectedCascading).foreach { case (dialects, cascading) =>
+    def testDialects(cascadings: List[Option[Boolean]], expected: Option[Boolean]): Unit = {
+      val dialects = cascadings.map(genDialect(_))
       val agg = new AggregatedDialect(dialects)
-      assert(agg.isCascadingTruncateTable() === cascading)
+      assert(agg.isCascadingTruncateTable() === expected)
     }
+
+    testDialects(List(Some(true), Some(false), None), Some(true))
+    testDialects(List(Some(true), Some(true), None), Some(true))
+    testDialects(List(Some(false), Some(false), None), None)
+    testDialects(List(Some(true), Some(true)), Some(true))
+    testDialects(List(Some(false), Some(false)), Some(false))
+    testDialects(List(None, None), None)
   }
 
   test("DB2Dialect type mapping") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -747,6 +747,19 @@ class JDBCSuite extends SparkFunSuite
     assert(agg.getCatalystType(0, "", 1, null) === Some(LongType))
     assert(agg.getCatalystType(1, "", 1, null) === Some(StringType))
     assert(agg.isCascadingTruncateTable() === Some(true))
+
+    val agg2 = new AggregatedDialect(List(new JdbcDialect {
+      override def canHandle(url: String) : Boolean = url.startsWith("jdbc:h2:")
+      override def getCatalystType(
+          sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] =
+        if (sqlType % 2 == 0) {
+          Some(LongType)
+        } else {
+          None
+        }
+      override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
+    }, testH2Dialect))
+    assert(agg2.isCascadingTruncateTable() === None)
   }
 
   test("DB2Dialect type mapping") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The implemented `isCascadingTruncateTable` in `AggregatedDialect` is wrong. When no dialect claims cascading, once there is an unknown cascading truncate in the dialects, we should return unknown cascading, instead of false.

## How was this patch tested?

Added test.
