### PR TITLE
[SPARK-22079][SQL] Serializer in HiveOutputWriter miss loading job co…

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
@@ -116,7 +116,7 @@ class HiveOutputWriter(
 
   private val serializer = {
     val serializer = tableDesc.getDeserializerClass.newInstance().asInstanceOf[Serializer]
-    serializer.initialize(null, tableDesc.getProperties)
+    serializer.initialize(jobConf, tableDesc.getProperties)
     serializer
   }
 
@@ -130,7 +130,7 @@ class HiveOutputWriter(
 
   private val standardOI = ObjectInspectorUtils
     .getStandardObjectInspector(
-      tableDesc.getDeserializer.getObjectInspector,
+      tableDesc.getDeserializer(jobConf).getObjectInspector,
       ObjectInspectorCopyOption.JAVA)
     .asInstanceOf[StructObjectInspector]
 


### PR DESCRIPTION
…nfiguration

## What changes were proposed in this pull request?

Serializer in HiveOutputWriter misses loading job configuration. It will failed the customized SerDe object which extends org.apache.hadoop.hive.serde2.AbstractSerDe and overrides its initialize(Configuration,...) method.

## How was this patch tested?

If need, I can provide a UT.

Please review http://spark.apache.org/contributing.html before opening a pull request.
