### PR TITLE
[SPARK-22080][SQL] Adds support for allowing user to add pre-optimization rules

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/ExperimentalMethods.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ExperimentalMethods.scala
@@ -44,11 +44,14 @@ class ExperimentalMethods private[sql]() {
    */
   @volatile var extraStrategies: Seq[Strategy] = Nil
 
+  @volatile var extraPreOptimizations: Seq[Rule[LogicalPlan]] = Nil
+
   @volatile var extraOptimizations: Seq[Rule[LogicalPlan]] = Nil
 
   override def clone(): ExperimentalMethods = {
     val result = new ExperimentalMethods
     result.extraStrategies = extraStrategies
+    result.extraPreOptimizations = extraPreOptimizations
     result.extraOptimizations = extraOptimizations
     result
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -28,14 +28,14 @@ class SparkOptimizer(
     experimentalMethods: ExperimentalMethods)
   extends Optimizer(catalog) {
 
-  val experimentalPreOptimizations: Seq[Batch] = Seq(Batch(
-    "User Provided Pre Optimizers", fixedPoint, experimentalMethods.extraPreOptimizations: _*))
+  val experimentalPreOptimizations: Batch = Batch(
+    "User Provided Pre Optimizers", fixedPoint, experimentalMethods.extraPreOptimizations: _*)
 
   val experimentalPostOptimizations: Batch = Batch(
     "User Provided Post Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*)
 
-  override def batches: Seq[Batch] = experimentalPreOptimizations ++
-    (preOptimizationBatches ++ super.batches :+
+  override def batches: Seq[Batch] =
+    ((experimentalPreOptimizations +: preOptimizationBatches) ++ super.batches :+
     Batch("Optimize Metadata Only Query", Once, OptimizeMetadataOnlyQuery(catalog)) :+
     Batch("Extract Python UDF from Aggregate", Once, ExtractPythonUDFFromAggregate) :+
     Batch("Prune File Source Table Partitions", Once, PruneFileSourcePartitions)) ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -28,12 +28,18 @@ class SparkOptimizer(
     experimentalMethods: ExperimentalMethods)
   extends Optimizer(catalog) {
 
-  override def batches: Seq[Batch] = (preOptimizationBatches ++ super.batches :+
+  val experimentalPreOptimizations: Seq[Batch] = Seq(Batch(
+    "User Provided Pre Optimizers", fixedPoint, experimentalMethods.extraPreOptimizations: _*))
+
+  val experimentalPostOptimizations: Batch = Batch(
+    "User Provided Post Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*)
+
+  override def batches: Seq[Batch] = experimentalPreOptimizations ++
+    (preOptimizationBatches ++ super.batches :+
     Batch("Optimize Metadata Only Query", Once, OptimizeMetadataOnlyQuery(catalog)) :+
     Batch("Extract Python UDF from Aggregate", Once, ExtractPythonUDFFromAggregate) :+
     Batch("Prune File Source Table Partitions", Once, PruneFileSourcePartitions)) ++
-    postHocOptimizationBatches :+
-    Batch("User Provided Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*)
+    postHocOptimizationBatches :+ experimentalPostOptimizations
 
   /**
    * Optimization batches that are executed before the regular optimization batches (also before

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLContextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLContextSuite.scala
@@ -86,7 +86,7 @@ class SQLContextSuite extends SparkFunSuite with SharedSparkContext {
     sqlContext.experimental.extraPreOptimizations = Seq(DummyPreOptimizationRule)
 
     val firstBatch = sqlContext.sessionState.optimizer.batches.head
-    val lastBatch = sqlContext.sessionState.optimizer.batches.last // .flatMap(_.rules)
+    val lastBatch = sqlContext.sessionState.optimizer.batches.last
 
     assert(firstBatch.rules == Seq(DummyPreOptimizationRule))
     assert(lastBatch.rules == Seq(DummyPostOptimizationRule))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the user provided custom rules that are added via `sparkSession.experimental.extraOptimizations = Seq(..)` are applied only after all the spark's native rules are applied. 

After this PR, users can add custom pre-optimization rules via:
`sparkSession.experimental.extraPreOptimizations = Seq(MyCustomPreOptimization)`
And custom post-optimization rules via:
`sparkSession.experimental.extraOptimizations = Seq(MyCustomPostOptimization)` 

## How was this patch tested?

The changes are unit tested and also locally test using spark shell.