### PR TITLE
[SPARK-14878][SQL] Adding examples for Trim characters string function 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -533,17 +533,17 @@ object StringTrim {
 @ExpressionDescription(
   usage = """
     _FUNC_(str) - Removes the leading and trailing space characters from `str`.
-    _FUNC_(BOTH trimStr FROM str) - Remove the leading and trailing trimStr characters from `str`
-    _FUNC_(LEADING trimStr FROM str) - Remove the leading trimStr characters from `str`
-    _FUNC_(TRAILING trimStr FROM str) - Remove the trailing trimStr characters from `str`
+    _FUNC_(BOTH trimStr FROM str) - Remove the leading and trailing `trimStr` characters from `str`
+    _FUNC_(LEADING trimStr FROM str) - Remove the leading `trimStr` characters from `str`
+    _FUNC_(TRAILING trimStr FROM str) - Remove the trailing `trimStr` characters from `str`
   """,
   arguments = """
     Arguments:
       * str - a string expression
       * trimStr - the trim string characters to trim, the default value is a single space
-      * BOTH, FROM - these are keywords to specify for trim string characters from both ends of the string
-      * LEADING, FROM - these are keywords to specify for trim string characters from left end of the string
-      * TRAILING, FROM - these are keywords to specify for trim string characters from right end of the string
+      * BOTH, FROM - these are keywords to specify trimming string characters from both ends of the string
+      * LEADING, FROM - these are keywords to specify trimming string characters from the left end of the string
+      * TRAILING, FROM - these are keywords to specify trimming string characters from the right end of the string
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -533,20 +533,30 @@ object StringTrim {
 @ExpressionDescription(
   usage = """
     _FUNC_(str) - Removes the leading and trailing space characters from `str`.
-    _FUNC_(BOTH trimStr FROM str) - Remove the leading and trailing trimString from `str`
+    _FUNC_(BOTH trimStr FROM str) - Remove the leading and trailing trimStr characters from `str`
+    _FUNC_(LEADING trimStr FROM str) - Remove the leading trimStr characters from `str`
+    _FUNC_(TRAILING trimStr FROM str) - Remove the trailing trimStr characters from `str`
   """,
   arguments = """
     Arguments:
       * str - a string expression
-      * trimString - the trim string
-      * BOTH, FROM - these are keyword to specify for trim string from both ends of the string
+      * trimStr - the trim string characters to trim, the default value is a single space
+      * BOTH, FROM - these are keywords to specify for trim string characters from both ends of the string
+      * LEADING, FROM - these are keywords to specify for trim string characters from left end of the string
+      * TRAILING, FROM - these are keywords to specify for trim string characters from right end of the string
   """,
   examples = """
     Examples:
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
+      > SELECT _FUNC_('SL', 'SSparkSQLS');
+       parkSQ
       > SELECT _FUNC_(BOTH 'SL' FROM 'SSparkSQLS');
        parkSQ
+      > SELECT _FUNC_(LEADING 'SL' FROM 'SSparkSQLS');
+       parkSQLS
+      > SELECT _FUNC_(TRAILING 'SL' FROM 'SSparkSQLS');
+       SSparkSQ
   """)
 case class StringTrim(
     srcStr: Expression,
@@ -634,8 +644,7 @@ object StringTrimLeft {
   arguments = """
     Arguments:
       * str - a string expression
-      * trimString - the trim string
-      * BOTH, FROM - these are keyword to specify for trim string from both ends of the string
+      * trimStr - the trim string characters to trim, the default value is a single space
   """,
   examples = """
     Examples:
@@ -731,8 +740,7 @@ object StringTrimRight {
   arguments = """
     Arguments:
       * str - a string expression
-      * trimString - the trim string
-      * BOTH, FROM - these are keyword to specify for trim string from both ends of the string
+      * trimStr - the trim string characters to trim, the default value is a single space
   """,
   examples = """
     Examples:


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr is a follow-up PR for this merged trim function pr: [Support Trim characters in the string trim function](https://github.com/apache/spark/pull/12646).

I am adding examples in the `ExpressionDescription` session for `stringTrim` function


## How was this patch tested?

This is documentation pr, and it passed all sql testing locally. 


