### PR TITLE
[SPARK-22083][CORE] Release locks in MemoryStore.evictBlocksToFreeSpace

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -413,9 +413,12 @@ class MemoryStoreSuite
     // blocks getting evicted.  We'll make the eviction throw an exception, and make sure that
     // all locks are released.
     val ct = implicitly[ClassTag[Array[Byte]]]
-    def testFailureOnNthDrop(failAfterDroppingNBlocks: Int, readLockAfterDrop: Boolean): Unit = {
+    val numInitialBlocks = 10
+    val memStoreSize = 100
+    val bytesPerSmallBlock = memStoreSize / numInitialBlocks
+    def testFailureOnNthDrop(numValidBlocks: Int, readLockAfterDrop: Boolean): Unit = {
       val tc = TaskContext.empty()
-      val memManager = new StaticMemoryManager(conf, Long.MaxValue, 100, numCores = 1)
+      val memManager = new StaticMemoryManager(conf, Long.MaxValue, memStoreSize, numCores = 1)
       val blockInfoManager = new BlockInfoManager
       blockInfoManager.registerTask(tc.taskAttemptId)
       var droppedSoFar = 0
@@ -425,7 +428,7 @@ class MemoryStoreSuite
         override private[storage] def dropFromMemory[T: ClassTag](
             blockId: BlockId,
             data: () => Either[Array[T], ChunkedByteBuffer]): StorageLevel = {
-          if (droppedSoFar < failAfterDroppingNBlocks) {
+          if (droppedSoFar < numValidBlocks) {
             droppedSoFar += 1
             memoryStore.remove(blockId)
             if (readLockAfterDrop) {
@@ -456,18 +459,18 @@ class MemoryStoreSuite
       memManager.setMemoryStore(memoryStore)
 
       // Put in some small blocks to fill up the memory store
-      val initialBlocks = (1 to 10).map { id =>
+      val initialBlocks = (1 to numInitialBlocks).map { id =>
         val blockId = BlockId(s"rdd_1_$id")
         val blockInfo = new BlockInfo(StorageLevel.MEMORY_ONLY, ct, tellMaster = false)
         val initialWriteLock = blockInfoManager.lockNewBlockForWriting(blockId, blockInfo)
         assert(initialWriteLock)
-        val success = memoryStore.putBytes(blockId, 10, MemoryMode.ON_HEAP, () => {
-          new ChunkedByteBuffer(ByteBuffer.allocate(10))
+        val success = memoryStore.putBytes(blockId, bytesPerSmallBlock, MemoryMode.ON_HEAP, () => {
+          new ChunkedByteBuffer(ByteBuffer.allocate(bytesPerSmallBlock))
         })
         assert(success)
         blockInfoManager.unlock(blockId, None)
       }
-      assert(blockInfoManager.size === 10)
+      assert(blockInfoManager.size === numInitialBlocks)
 
 
       // Add one big block, which will require evicting everything in the memorystore.  However our
@@ -476,10 +479,10 @@ class MemoryStoreSuite
       val largeBlockInfo = new BlockInfo(StorageLevel.MEMORY_ONLY, ct, tellMaster = false)
       val initialWriteLock = blockInfoManager.lockNewBlockForWriting(largeBlockId, largeBlockInfo)
       assert(initialWriteLock)
-      if (failAfterDroppingNBlocks < 10) {
+      if (numValidBlocks < numInitialBlocks) {
         val exc = intercept[RuntimeException] {
-          memoryStore.putBytes(largeBlockId, 100, MemoryMode.ON_HEAP, () => {
-            new ChunkedByteBuffer(ByteBuffer.allocate(100))
+          memoryStore.putBytes(largeBlockId, memStoreSize, MemoryMode.ON_HEAP, () => {
+            new ChunkedByteBuffer(ByteBuffer.allocate(memStoreSize))
           })
         }
         assert(exc.getMessage().startsWith("Mock error dropping block"), exc)
@@ -487,17 +490,17 @@ class MemoryStoreSuite
         // testing that here, so do it manually
         blockInfoManager.removeBlock(largeBlockId)
       } else {
-        memoryStore.putBytes(largeBlockId, 100, MemoryMode.ON_HEAP, () => {
-          new ChunkedByteBuffer(ByteBuffer.allocate(100))
+        memoryStore.putBytes(largeBlockId, memStoreSize, MemoryMode.ON_HEAP, () => {
+          new ChunkedByteBuffer(ByteBuffer.allocate(memStoreSize))
         })
         // BlockManager.doPut takes care of releasing the lock for the newly written block -- not
         // testing that here, so do it manually
         blockInfoManager.unlock(largeBlockId)
       }
 
-      val largeBlockInMemory = if (failAfterDroppingNBlocks == 10) 1 else 0
-      val expBlocks = 10 +
-        (if (readLockAfterDrop) 0 else -failAfterDroppingNBlocks) +
+      val largeBlockInMemory = if (numValidBlocks == numInitialBlocks) 1 else 0
+      val expBlocks = numInitialBlocks +
+        (if (readLockAfterDrop) 0 else -numValidBlocks) +
         largeBlockInMemory
       assert(blockInfoManager.size === expBlocks)
 
@@ -513,10 +516,11 @@ class MemoryStoreSuite
           false
         }
       }
-      assert(blocksStillInMemory.size === (10 - failAfterDroppingNBlocks + largeBlockInMemory))
+      assert(blocksStillInMemory.size ===
+        (numInitialBlocks - numValidBlocks + largeBlockInMemory))
     }
 
-    Seq(0, 3, 10).foreach { failAfterDropping =>
+    Seq(0, 3, numInitialBlocks).foreach { failAfterDropping =>
       Seq(true, false).foreach { readLockAfterDropping =>
         testFailureOnNthDrop(failAfterDropping, readLockAfterDropping)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

MemoryStore.evictBlocksToFreeSpace acquires write locks for all the
blocks it intends to evict up front.  If there is a failure to evict
blocks (eg., some failure dropping a block to disk), then we have to
release the lock.  Otherwise the lock is never released and an executor
trying to get the lock will wait forever.

## How was this patch tested?

Added unit test.