### PR TITLE
[SPARK-22097][CORE]Request an accurate memory after we unrolled the block

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -387,7 +387,7 @@ private[spark] class MemoryStore(
     // the block's actual memory usage has exceeded the unroll memory by a small amount, so we
     // perform one final call to attempt to allocate additional memory if necessary.
     if (keepUnrolling) {
-      serializationStream.flush()
+      serializationStream.close()
       if (bbos.size > unrollMemoryUsedByThisBlock) {
         val amountToRequest = bbos.size - unrollMemoryUsedByThisBlock
         keepUnrolling = reserveUnrollMemoryForThisTask(blockId, amountToRequest, memoryMode)
@@ -398,7 +398,6 @@ private[spark] class MemoryStore(
     }
 
     if (keepUnrolling) {
-      serializationStream.close()
       val entry = SerializedMemoryEntry[T](bbos.toChunkedByteBuffer, memoryMode, classTag)
       // Synchronize so that transfer is atomic
       memoryManager.synchronized {


### PR DESCRIPTION
## What changes were proposed in this pull request?


We only need request `bbos.size - unrollMemoryUsedByThisBlock` after unrolled the block.

## How was this patch tested?

Existing UT.
