### PR TITLE
[WIP][SPARK-22096][ML] use aggregateByKeyLocally in feature frequency calc…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -159,7 +159,7 @@ class NaiveBayes @Since("1.5.0") (
     // TODO: similar to reduceByKeyLocally to save one stage.
     val aggregated = dataset.select(col($(labelCol)), w, col($(featuresCol))).rdd
       .map { row => (row.getDouble(0), (row.getDouble(1), row.getAs[Vector](2)))
-      }.aggregateByKey[(Double, DenseVector)]((0.0, Vectors.zeros(numFeatures).toDense))(
+      }.aggregateByKeyLocally[(Double, DenseVector)]((0.0, Vectors.zeros(numFeatures).toDense))(
       seqOp = {
          case ((weightSum: Double, featureSum: DenseVector), (weight, features)) =>
            requireValues(features)
@@ -170,7 +170,7 @@ class NaiveBayes @Since("1.5.0") (
          case ((weightSum1, featureSum1), (weightSum2, featureSum2)) =>
            BLAS.axpy(1.0, featureSum2, featureSum1)
            (weightSum1 + weightSum2, featureSum1)
-      }).collect().sortBy(_._1)
+      }).toArray.sortBy(_._1)
 
     val numLabels = aggregated.length
     instr.logNumClasses(numLabels)


### PR DESCRIPTION
## What changes were proposed in this pull request?

NaiveBayes currently takes aggreateByKey followed by a collect to calculate frequency for each feature/label. We can implement a new function 'aggregateByKeyLocally' in RDD that merges locally on each mapper before sending results to a reducer to save one stage.

We tested on NaiveBayes and see ~16% performance gain on training with these changes.

Signed-off-by: Vincent Xie <vincent.xie@intel.com>
## How was this patch tested?
existing test