### PR TITLE
[SPARK-22102][SQL] Set ConfVars.METASTOREWAREHOUSE before constructor CliSessionState

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -45,16 +45,11 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   // Load hive-site.xml into hadoopConf and determine the warehouse path we want to use, based on
   // the config from both hive and Spark SQL. Finally set the warehouse config value to sparkConf.
   val warehousePath: String = {
-    // hive.metastore.warehouse.dir only stay in hadoopConf
     sparkContext.conf.remove("hive.metastore.warehouse.dir")
-    val path = SQLUtils.warehousePath(sparkContext.getConf)
-    sparkContext.conf.set(WAREHOUSE_PATH.key, path)
-    sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", path)
-    path
+    SQLUtils.warehousePath(sparkContext.getConf, sparkContext.hadoopConfiguration, sparkContext)
   }
 
   logInfo(s"Warehouse path is '$warehousePath'.")
-
 
   /**
    * Class for caching query results reused in future executions.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -28,12 +28,12 @@ import org.apache.hadoop.fs.FsUrlStreamHandlerFactory
 
 import org.apache.spark.{SparkConf, SparkContext, SparkException}
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.sql.{SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.execution.CacheManager
 import org.apache.spark.sql.execution.ui.{SQLListener, SQLTab}
 import org.apache.spark.sql.internal.StaticSQLConf._
+import org.apache.spark.sql.util.SQLUtils
 import org.apache.spark.util.{MutableURLClassLoader, Utils}
 
 
@@ -45,36 +45,14 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   // Load hive-site.xml into hadoopConf and determine the warehouse path we want to use, based on
   // the config from both hive and Spark SQL. Finally set the warehouse config value to sparkConf.
   val warehousePath: String = {
-    val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
-    if (configFile != null) {
-      logInfo(s"loading hive config file: $configFile")
-      sparkContext.hadoopConfiguration.addResource(configFile)
-    }
-
     // hive.metastore.warehouse.dir only stay in hadoopConf
     sparkContext.conf.remove("hive.metastore.warehouse.dir")
-    // Set the Hive metastore warehouse path to the one we use
-    val hiveWarehouseDir = sparkContext.hadoopConfiguration.get("hive.metastore.warehouse.dir")
-    if (hiveWarehouseDir != null && !sparkContext.conf.contains(WAREHOUSE_PATH.key)) {
-      // If hive.metastore.warehouse.dir is set and spark.sql.warehouse.dir is not set,
-      // we will respect the value of hive.metastore.warehouse.dir.
-      sparkContext.conf.set(WAREHOUSE_PATH.key, hiveWarehouseDir)
-      logInfo(s"${WAREHOUSE_PATH.key} is not set, but hive.metastore.warehouse.dir " +
-        s"is set. Setting ${WAREHOUSE_PATH.key} to the value of " +
-        s"hive.metastore.warehouse.dir ('$hiveWarehouseDir').")
-      hiveWarehouseDir
-    } else {
-      // If spark.sql.warehouse.dir is set, we will override hive.metastore.warehouse.dir using
-      // the value of spark.sql.warehouse.dir.
-      // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
-      // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
-      val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
-      logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
-        s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
-      sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
-      sparkWarehouseDir
-    }
+    val path = SQLUtils.warehousePath(sparkContext.getConf)
+    sparkContext.conf.set(WAREHOUSE_PATH.key, path)
+    sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", path)
+    path
   }
+
   logInfo(s"Warehouse path is '$warehousePath'.")
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/util/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/SQLUtils.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
+import org.apache.spark.util.{Utils => CoreUtils}
+/**
+ * Various utility methods used by Spark SQL.
+ */
+private[spark] object SQLUtils extends Logging {
+
+  def warehousePath(sparkConf: SparkConf = new SparkConf(loadDefaults = true)): String = {
+    val configFile = CoreUtils.getContextOrSparkClassLoader.getResource("hive-site.xml")
+    val hadoopConf = SparkHadoopUtil.get.newConfiguration(sparkConf)
+    if (configFile != null) {
+      logInfo(s"loading hive config file: $configFile")
+      hadoopConf.addResource(configFile)
+    }
+
+    // Set the Hive metastore warehouse path to the one we use
+    val hiveWarehouseDir = hadoopConf.get("hive.metastore.warehouse.dir")
+    if (hiveWarehouseDir != null && !sparkConf.contains(WAREHOUSE_PATH.key)) {
+      // If hive.metastore.warehouse.dir is set and spark.sql.warehouse.dir is not set,
+      // we will respect the value of hive.metastore.warehouse.dir.
+      logInfo(s"${WAREHOUSE_PATH.key} is not set, but hive.metastore.warehouse.dir " +
+        s"is set. Setting ${WAREHOUSE_PATH.key} to the value of " +
+        s"hive.metastore.warehouse.dir ('$hiveWarehouseDir').")
+      hiveWarehouseDir
+    } else {
+      // If spark.sql.warehouse.dir is set, we will override hive.metastore.warehouse.dir using
+      // the value of spark.sql.warehouse.dir.
+      // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
+      // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
+      val sparkWarehouseDir = sparkConf.get(WAREHOUSE_PATH)
+      logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
+        s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
+      sparkWarehouseDir
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/util/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/SQLUtils.scala
@@ -17,19 +17,20 @@
 
 package org.apache.spark.sql.util
 
-import org.apache.spark.SparkConf
-import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
-import org.apache.spark.util.{Utils => CoreUtils}
+import org.apache.spark.util.Utils
 /**
  * Various utility methods used by Spark SQL.
  */
 private[spark] object SQLUtils extends Logging {
 
-  def warehousePath(sparkConf: SparkConf = new SparkConf(loadDefaults = true)): String = {
-    val configFile = CoreUtils.getContextOrSparkClassLoader.getResource("hive-site.xml")
-    val hadoopConf = SparkHadoopUtil.get.newConfiguration(sparkConf)
+  def warehousePath(sparkConf: SparkConf, hadoopConf: Configuration, sc: SparkContext): String = {
+    // hive.metastore.warehouse.dir only stay in hadoopConf
+    val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
       logInfo(s"loading hive config file: $configFile")
       hadoopConf.addResource(configFile)
@@ -38,20 +39,26 @@ private[spark] object SQLUtils extends Logging {
     // Set the Hive metastore warehouse path to the one we use
     val hiveWarehouseDir = hadoopConf.get("hive.metastore.warehouse.dir")
     if (hiveWarehouseDir != null && !sparkConf.contains(WAREHOUSE_PATH.key)) {
-      // If hive.metastore.warehouse.dir is set and spark.sql.warehouse.dir is not set,
-      // we will respect the value of hive.metastore.warehouse.dir.
-      logInfo(s"${WAREHOUSE_PATH.key} is not set, but hive.metastore.warehouse.dir " +
-        s"is set. Setting ${WAREHOUSE_PATH.key} to the value of " +
-        s"hive.metastore.warehouse.dir ('$hiveWarehouseDir').")
+      if (sc != null) {
+        // If hive.metastore.warehouse.dir is set and spark.sql.warehouse.dir is not set,
+        // we will respect the value of hive.metastore.warehouse.dir.
+        logInfo(s"${WAREHOUSE_PATH.key} is not set, but hive.metastore.warehouse.dir " +
+          s"is set. Setting ${WAREHOUSE_PATH.key} to the value of " +
+          s"hive.metastore.warehouse.dir ('$hiveWarehouseDir').")
+        sc.conf.set(WAREHOUSE_PATH.key, hiveWarehouseDir)
+      }
       hiveWarehouseDir
     } else {
-      // If spark.sql.warehouse.dir is set, we will override hive.metastore.warehouse.dir using
-      // the value of spark.sql.warehouse.dir.
-      // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
-      // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
       val sparkWarehouseDir = sparkConf.get(WAREHOUSE_PATH)
-      logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
-        s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
+      if (sc != null) {
+        // If spark.sql.warehouse.dir is set, we will override hive.metastore.warehouse.dir using
+        // the value of spark.sql.warehouse.dir.
+        // When neither spark.sql.warehouse.dir nor hive.metastore.warehouse.dir is set,
+        // we will set hive.metastore.warehouse.dir to the default value of spark.sql.warehouse.dir.
+        logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
+          s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
+        sc.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
+      }
       sparkWarehouseDir
     }
   }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -96,7 +96,7 @@ private[hive] object SparkSQLCLIDriver extends Logging {
         cliConf.set(k, v)
     }
 
-    cliConf.setVar(ConfVars.METASTOREWAREHOUSE, SQLUtils.warehousePath(sparkConf))
+    cliConf.setVar(ConfVars.METASTOREWAREHOUSE, SQLUtils.warehousePath(sparkConf, hadoopConf, null))
 
     val sessionState = new CliSessionState(cliConf)
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.cli.{CliDriver, CliSessionState, OptionsProcessor}
 import org.apache.hadoop.hive.common.{HiveInterruptCallback, HiveInterruptUtils}
 import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hadoop.hive.ql.Driver
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.processors._
@@ -42,6 +43,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hive.HiveUtils
+import org.apache.spark.sql.util.SQLUtils
 import org.apache.spark.util.ShutdownHookManager
 
 /**
@@ -93,6 +95,8 @@ private[hive] object SparkSQLCLIDriver extends Logging {
       case (k, v) =>
         cliConf.set(k, v)
     }
+
+    cliConf.setVar(ConfVars.METASTOREWAREHOUSE, SQLUtils.warehousePath(sparkConf))
 
     val sessionState = new CliSessionState(cliConf)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -107,8 +107,8 @@ private[hive] class HiveClientImpl(
 
   // Create an internal session state for this HiveClientImpl.
   val state: SessionState = {
-    val original = Thread.currentThread().getContextClassLoader
     if (clientLoader.isolationOn) {
+      val original = Thread.currentThread().getContextClassLoader
       // Switch to the initClassLoader.
       Thread.currentThread().setContextClassLoader(initClassLoader)
       // Set up kerberos credentials for UserGroupInformation.loginUser within current class loader
@@ -133,17 +133,7 @@ private[hive] class HiveClientImpl(
       // in hive jars, which will turn off isolation, if SessionSate.detachSession is
       // called to remove the current state after that, hive client created later will initialize
       // its own state by newState()
-      val ret = SessionState.get
-      if (ret != null) {
-        // hive.metastore.warehouse.dir is determined in SharedState after the CliSessionState
-        // instance constructed, we need to follow that change here.
-        Option(hadoopConf.get(ConfVars.METASTOREWAREHOUSE.varname)).foreach { dir =>
-          ret.getConf.setVar(ConfVars.METASTOREWAREHOUSE, dir)
-        }
-        ret
-      } else {
-        newState()
-      }
+      Option(SessionState.get).getOrElse(newState())
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -69,10 +69,8 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
             .asInstanceOf[HiveTableRelation]
 
           val properties = relation.tableMeta.ignoredProperties
-          assert(properties(StatsSetupConst.TOTAL_SIZE).toLong <= 0,
-            "external table totalSize must be <= 0")
-          assert(properties(StatsSetupConst.RAW_DATA_SIZE).toLong <= 0,
-            "external table rawDataSize must be <= 0")
+          assert(properties("totalSize").toLong <= 0, "external table totalSize must be <= 0")
+          assert(properties("rawDataSize").toLong <= 0, "external table rawDataSize must be <= 0")
 
           val sizeInBytes = relation.stats.sizeInBytes
           assert(sizeInBytes === BigInt(file1.length() + file2.length()))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -69,8 +69,10 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
             .asInstanceOf[HiveTableRelation]
 
           val properties = relation.tableMeta.ignoredProperties
-          assert(properties("totalSize").toLong <= 0, "external table totalSize must be <= 0")
-          assert(properties("rawDataSize").toLong <= 0, "external table rawDataSize must be <= 0")
+          assert(properties(StatsSetupConst.TOTAL_SIZE).toLong <= 0,
+            "external table totalSize must be <= 0")
+          assert(properties(StatsSetupConst.RAW_DATA_SIZE).toLong <= 0,
+            "external table rawDataSize must be <= 0")
 
           val sizeInBytes = relation.stats.sizeInBytes
           assert(sizeInBytes === BigInt(file1.length() + file2.length()))


### PR DESCRIPTION
## What changes were proposed in this pull request? 

As described in [SPARK-22102](https://issues.apache.org/jira/browse/SPARK-22102). spark-sql shows the warehouse dir is `file:/root/create/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse`, but actually the warehouse dir is `/user/hive/warehouse` when create table. the reason is that set `ConfVars.METASTOREWAREHOUSE` after constructor CliSessionState is invalid.

This PR set `ConfVars.METASTOREWAREHOUSE` before constructor CliSessionState



## How was this patch tested?

manual tests, seems didn't have a good way to do unit test.

```
Yumings-MacBook-Pro:spark-2.3.0-SNAPSHOT-bin-2.6.5 ming$ bin/spark-sql
17/09/22 21:59:59 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
log4j:WARN No appenders could be found for logger (org.apache.hadoop.conf.Configuration).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
17/09/22 22:00:00 INFO SQLUtils: Setting hive.metastore.warehouse.dir ('null') to the value of spark.sql.warehouse.dir ('file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse').
17/09/22 22:00:00 INFO HiveMetaStore: 0: Opening raw store with implemenation class:org.apache.hadoop.hive.metastore.ObjectStore
17/09/22 22:00:00 INFO ObjectStore: ObjectStore, initialize called
17/09/22 22:00:00 INFO Persistence: Property hive.metastore.integral.jdo.pushdown unknown - will be ignored
17/09/22 22:00:00 INFO Persistence: Property datanucleus.cache.level2 unknown - will be ignored
17/09/22 22:00:02 INFO ObjectStore: Setting MetaStore object pin classes with hive.metastore.cache.pinobjtypes="Table,StorageDescriptor,SerDeInfo,Partition,Database,Type,FieldSchema,Order"
17/09/22 22:00:03 INFO Datastore: The class "org.apache.hadoop.hive.metastore.model.MFieldSchema" is tagged as "embedded-only" so does not have its own datastore table.
17/09/22 22:00:03 INFO Datastore: The class "org.apache.hadoop.hive.metastore.model.MOrder" is tagged as "embedded-only" so does not have its own datastore table.
17/09/22 22:00:03 INFO Datastore: The class "org.apache.hadoop.hive.metastore.model.MFieldSchema" is tagged as "embedded-only" so does not have its own datastore table.
17/09/22 22:00:03 INFO Datastore: The class "org.apache.hadoop.hive.metastore.model.MOrder" is tagged as "embedded-only" so does not have its own datastore table.
17/09/22 22:00:03 INFO MetaStoreDirectSql: Using direct SQL, underlying DB is DERBY
17/09/22 22:00:03 INFO ObjectStore: Initialized ObjectStore
17/09/22 22:00:03 WARN ObjectStore: Version information not found in metastore. hive.metastore.schema.verification is not enabled so recording the schema version 1.2.0
17/09/22 22:00:04 WARN ObjectStore: Failed to get database default, returning NoSuchObjectException
17/09/22 22:00:04 INFO HiveMetaStore: Added admin role in metastore
17/09/22 22:00:04 INFO HiveMetaStore: Added public role in metastore
17/09/22 22:00:04 INFO HiveMetaStore: No user is added in admin role, since config is empty
17/09/22 22:00:04 INFO HiveMetaStore: 0: get_all_databases
17/09/22 22:00:04 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_all_databases   
17/09/22 22:00:04 INFO HiveMetaStore: 0: get_functions: db=default pat=*
17/09/22 22:00:04 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_functions: db=default pat=*     
17/09/22 22:00:04 INFO Datastore: The class "org.apache.hadoop.hive.metastore.model.MResourceUri" is tagged as "embedded-only" so does not have its own datastore table.
17/09/22 22:00:04 INFO SessionState: Created local directory: /var/folders/gl/xfd53h993834l25kxpnjksy40000gn/T/a202faad-8ea0-4019-8051-f31828db413a_resources
17/09/22 22:00:04 INFO SessionState: Created HDFS directory: /tmp/hive/ming/a202faad-8ea0-4019-8051-f31828db413a
17/09/22 22:00:04 INFO SessionState: Created local directory: /var/folders/gl/xfd53h993834l25kxpnjksy40000gn/T/ming/a202faad-8ea0-4019-8051-f31828db413a
17/09/22 22:00:04 INFO SessionState: Created HDFS directory: /tmp/hive/ming/a202faad-8ea0-4019-8051-f31828db413a/_tmp_space.db
17/09/22 22:00:04 INFO SparkContext: Running Spark version 2.3.0-SNAPSHOT
17/09/22 22:00:04 INFO SparkContext: Submitted application: SparkSQL::10.8.44.55
17/09/22 22:00:04 INFO SecurityManager: Changing view acls to: ming
17/09/22 22:00:04 INFO SecurityManager: Changing modify acls to: ming
17/09/22 22:00:04 INFO SecurityManager: Changing view acls groups to: 
17/09/22 22:00:04 INFO SecurityManager: Changing modify acls groups to: 
17/09/22 22:00:04 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users  with view permissions: Set(ming); groups with view permissions: Set(); users  with modify permissions: Set(ming); groups with modify permissions: Set()
17/09/22 22:00:04 INFO Utils: Successfully started service 'sparkDriver' on port 57139.
17/09/22 22:00:04 INFO SparkEnv: Registering MapOutputTracker
17/09/22 22:00:05 INFO SparkEnv: Registering BlockManagerMaster
17/09/22 22:00:05 INFO BlockManagerMasterEndpoint: Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information
17/09/22 22:00:05 INFO BlockManagerMasterEndpoint: BlockManagerMasterEndpoint up
17/09/22 22:00:05 INFO DiskBlockManager: Created local directory at /private/var/folders/gl/xfd53h993834l25kxpnjksy40000gn/T/blockmgr-d3520e8e-9879-4329-8dfb-71a429dec945
17/09/22 22:00:05 INFO MemoryStore: MemoryStore started with capacity 366.3 MB
17/09/22 22:00:05 INFO SparkEnv: Registering OutputCommitCoordinator
17/09/22 22:00:05 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.
17/09/22 22:00:05 WARN Utils: Service 'SparkUI' could not bind on port 4041. Attempting port 4042.
17/09/22 22:00:05 INFO Utils: Successfully started service 'SparkUI' on port 4042.
17/09/22 22:00:05 INFO SparkUI: Bound SparkUI to 0.0.0.0, and started at http://10.8.44.55:4042
17/09/22 22:00:05 INFO Executor: Starting executor ID driver on host localhost
17/09/22 22:00:05 INFO Utils: Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 57140.
17/09/22 22:00:05 INFO NettyBlockTransferService: Server created on 10.8.44.55:57140
17/09/22 22:00:05 INFO BlockManager: Using org.apache.spark.storage.RandomBlockReplicationPolicy for block replication policy
17/09/22 22:00:05 INFO BlockManagerMaster: Registering BlockManager BlockManagerId(driver, 10.8.44.55, 57140, None)
17/09/22 22:00:05 INFO BlockManagerMasterEndpoint: Registering block manager 10.8.44.55:57140 with 366.3 MB RAM, BlockManagerId(driver, 10.8.44.55, 57140, None)
17/09/22 22:00:05 INFO BlockManagerMaster: Registered BlockManager BlockManagerId(driver, 10.8.44.55, 57140, None)
17/09/22 22:00:05 INFO BlockManager: Initialized BlockManager: BlockManagerId(driver, 10.8.44.55, 57140, None)
17/09/22 22:00:05 INFO SQLUtils: Setting hive.metastore.warehouse.dir ('null') to the value of spark.sql.warehouse.dir ('file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse').
17/09/22 22:00:05 INFO SharedState: Warehouse path is 'file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse'.
17/09/22 22:00:05 INFO HiveUtils: Initializing HiveMetastoreConnection version 1.2.1 using Spark classes.
17/09/22 22:00:05 INFO HiveClientImpl: Warehouse location for Hive client (version 1.2.2) is file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse
17/09/22 22:00:05 INFO HiveMetaStore: 0: get_database: default
17/09/22 22:00:05 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_database: default       
17/09/22 22:00:05 INFO HiveClientImpl: Warehouse location for Hive client (version 1.2.2) is file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse
17/09/22 22:00:06 INFO StateStoreCoordinatorRef: Registered StateStoreCoordinator endpoint
spark-sql> create table t(id int);
17/09/22 22:00:32 INFO HiveMetaStore: 0: get_database: global_temp
17/09/22 22:00:32 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_database: global_temp   
17/09/22 22:00:32 WARN ObjectStore: Failed to get database global_temp, returning NoSuchObjectException
17/09/22 22:00:32 INFO HiveClientImpl: Warehouse location for Hive client (version 1.2.2) is file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse
17/09/22 22:00:33 INFO HiveMetaStore: 0: get_database: default
17/09/22 22:00:33 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_database: default       
17/09/22 22:00:33 INFO HiveMetaStore: 0: get_database: default
17/09/22 22:00:33 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_database: default       
17/09/22 22:00:33 INFO HiveMetaStore: 0: get_table : db=default tbl=t
17/09/22 22:00:33 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_table : db=default tbl=t        
17/09/22 22:00:33 INFO HiveMetaStore: 0: get_database: default
17/09/22 22:00:33 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=get_database: default       
17/09/22 22:00:34 INFO HiveMetaStore: 0: create_table: Table(tableName:t, dbName:default, owner:ming, createTime:1506088832, lastAccessTime:0, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:id, type:int, comment:null)], location:file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse/t, inputFormat:org.apache.hadoop.mapred.TextInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat, compressed:false, numBuckets:-1, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, parameters:{serialization.format=1}), bucketCols:[], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], skewedColValueLocationMaps:{})), partitionKeys:[], parameters:{spark.sql.sources.schema.part.0={"type":"struct","fields":[{"name":"id","type":"integer","nullable":true,"metadata":{}}]}, spark.sql.sources.schema.numParts=1, spark.sql.create.version=2.3.0-SNAPSHOT}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, privileges:PrincipalPrivilegeSet(userPrivileges:{}, groupPrivileges:null, rolePrivileges:null))
17/09/22 22:00:34 INFO audit: ugi=ming  ip=unknown-ip-addr      cmd=create_table: Table(tableName:t, dbName:default, owner:ming, createTime:1506088832, lastAccessTime:0, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:id, type:int, comment:null)], location:file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse/t, inputFormat:org.apache.hadoop.mapred.TextInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat, compressed:false, numBuckets:-1, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, parameters:{serialization.format=1}), bucketCols:[], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], skewedColValueLocationMaps:{})), partitionKeys:[], parameters:{spark.sql.sources.schema.part.0={"type":"struct","fields":[{"name":"id","type":"integer","nullable":true,"metadata":{}}]}, spark.sql.sources.schema.numParts=1, spark.sql.create.version=2.3.0-SNAPSHOT}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, privileges:PrincipalPrivilegeSet(userPrivileges:{}, groupPrivileges:null, rolePrivileges:null))       
17/09/22 22:00:34 WARN HiveMetaStore: Location: file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse/t specified for non-external table:t
17/09/22 22:00:34 INFO FileUtils: Creating directory if it doesn't exist: file:/Users/ming/tmp/spark/spark-2.3.0-SNAPSHOT-bin-2.6.5/spark-warehouse/t
Time taken: 2.156 seconds
17/09/22 22:00:34 INFO SparkSQLCLIDriver: Time taken: 2.156 seconds
spark-sql> 
```