### PR TITLE
[SPARK-22121][SQL] Correct database location for namenode HA.

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -119,7 +119,10 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
       "hdfs://foo-1.xyz.com/some/path" -> "hdfs://foo-1.xyz.com/some/path",
       "hdfs://foo-2.xyz.com:1234/some/path" -> "hdfs://ns1/some/path",
       "hdfs://blah-1.bar.com:8020/another/path" -> "hdfs://ns2/another/path",
-      "hdfs://another.cluster.com:8020/my/path" -> "hdfs://another.cluster.com:8020/my/path"
+      "hdfs://another.cluster.com:8020/my/path" -> "hdfs://another.cluster.com:8020/my/path",
+      "file:/some/local/path/spark-warehouse" ->
+        "file:/some/local/path/spark-warehouse",
+      "/bare/path" -> "/bare/path"
     ).foreach { case (orig, exp) =>
       val convertedName = HiveExternalCatalog.convertNamenodeToNameservice(
           namenodeToNameservice,


### PR DESCRIPTION
## What changes were proposed in this pull request?

If hdfs HA is turned on after a hive database is already created, the db
location may still reference just one namenode, instead of the
nameservice, if users do not properly follow all upgrade instructions.
After this change, spark detects the misconfiguration and tries to
auto-adjust for it, since this is the behavior from hive as well.

## How was this patch tested?

Added unit tests.  Also deployed on a cluster with hdfs ha, with the database location set to only one instance, and then I failed over the namenode so the other instance was the active one.  After this change, things worked without a problem.