### PR TITLE
[SPARK-22122][SQL] Use analyzed logical plans to count input rows in TPCDSQueryBenchmark

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -66,7 +66,7 @@ object TPCDSQueryBenchmark extends Logging {
       // This is an indirect hack to estimate the size of each query's input by traversing the
       // logical plan and adding up the sizes of all tables that appear in the plan.
       val queryRelations = scala.collection.mutable.HashSet[String]()
-      spark.sql(queryString).queryExecution.analyzed.map {
+      spark.sql(queryString).queryExecution.analyzed.foreach {
         case SubqueryAlias(name, _: LogicalRelation) =>
           queryRelations.add(name)
         case _ =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since the current code ignores WITH clauses to check input relations in TPCDS queries, this leads to inaccurate per-row processing time for benchmark results. For example, in `q2`, this fix could catch all the input relations: `web_sales`, `date_dim`, and `catalog_sales` (the current code catches `date_dim` only). The one-third of the TPCDS queries uses WITH clauses, so I think it is worth fixing this.

## How was this patch tested?
Manually checked.
