### PR TITLE
[SPARK-22127][CORE]The Master Register Application Function requires an warn log to increase the waiting status

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -265,6 +265,9 @@ private[deploy] class Master(
         val app = createApplication(description, driver)
         registerApplication(app)
         logInfo("Registered app " + description.name + " with ID " + app.id)
+        if(app.state == ApplicationState.WAITING) {
+          logWarning("App need to wait Launch executor, there is no resources, can not execute")
+        }
         persistenceEngine.addApplication(app)
         driver.send(RegisteredApplication(app.id, self))
         schedule()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Master register application function requires an alarm log to increase the waiting status.

When I create a spark application, I apply for the resources to reach the ceiling, the current Worker does not have enough resources to allocate Executor, this time spark application state is waiting.
But I can not know from the spark master log this situation, which led to my positioning problems difficult, I mistakenly thought that the master or worker process dead.

All that I added to the warting state of the warn log, which better helps us locate this kind of problem.

1.WAITING  app:
![1](https://user-images.githubusercontent.com/26266482/30858530-a3f3c5e2-a2f2-11e7-9899-041cf3eac118.png)

2.master log:
![2](https://user-images.githubusercontent.com/26266482/30858550-bd07ed38-a2f2-11e7-91db-952101976502.png)


## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
