### PR TITLE
[SPARK-22103][FOLLOWUP] Rename addExtraCode to addInnerClass

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -243,7 +243,7 @@ class CodegenContext {
     mutable.Map(outerClassName -> mutable.Map.empty[String, String])
 
   // Verbatim extra code to be added to the OuterClass.
-  private val extraCode: mutable.ListBuffer[String] = mutable.ListBuffer[String]()
+  private val extraClasses: mutable.ListBuffer[String] = mutable.ListBuffer[String]()
 
   // Returns the size of the most recently added class.
   private def currClassSize(): Int = classSize(classes.head._1)
@@ -335,16 +335,15 @@ class CodegenContext {
    * Emits any source code added with addExtraCode
    */
   def emitExtraCode(): String = {
-    extraCode.mkString("\n")
+    extraClasses.mkString("\n")
   }
 
   /**
    * Add extra source code to the outermost generated class.
-   * @param code verbatim source code to be added.
+   * @param code verbatim source code of the inner class to be added.
    */
-  def addExtraCode(code: String): Unit = {
-    extraCode.append(code)
-    classSize(outerClassName) += code.length
+  def addInnerClass(code: String): Unit = {
+    extraClasses.append(code)
   }
 
   final val JAVA_BOOLEAN = "boolean"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -332,7 +332,7 @@ class CodegenContext {
   }
 
   /**
-   * Emits any source code added with addExtraCode
+   * Emits extra inner classes added with addExtraCode
    */
   def emitExtraCode(): String = {
     extraClasses.mkString("\n")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -621,7 +621,7 @@ case class HashAggregateExec(
         }
       } else ""
     }
-    ctx.addExtraCode(generateGenerateCode())
+    ctx.addInnerClass(generateGenerateCode())
 
     val doAgg = ctx.freshName("doAggregateWithKeys")
     val peakMemory = metricTerm(ctx, "peakMemory")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address PR comments that appeared post-merge, to rename `addExtraCode` to `addInnerClass`,
and not count the size of the inner class to the size of the outer class.

## How was this patch tested?

YOLO.