### PR TITLE
[SPARK-20992][Scheduler] Add links in documentation to Nomad integration.

### DIFF
--- a/docs/cluster-overview.md
+++ b/docs/cluster-overview.md
@@ -58,6 +58,9 @@ for providing container-centric infrastructure. Kubernetes support is being acti
 developed in an [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/) Github organization. 
 For documentation, refer to that project's README.
 
+A third-party project (not supported by the Spark project) exists to add support for
+[Nomad](https://github.com/hashicorp/nomad-spark) as a cluster manager.
+
 # Submitting Applications
 
 Applications can be submitted to a cluster of any type using the `spark-submit` script.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds links to the fork that provides integration with Nomad, in the same places the k8s integration is linked to.

## How was this patch tested?

I clicked on the links to make sure they're correct ;)