### PR TITLE
[SPARK-22139][CORE]Remove the variable which is never used in SparkConf.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -458,11 +458,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     }
 
     val executorOptsKey = "spark.executor.extraJavaOptions"
-    val executorClasspathKey = "spark.executor.extraClassPath"
-    val driverOptsKey = "spark.driver.extraJavaOptions"
-    val driverClassPathKey = "spark.driver.extraClassPath"
     val driverLibraryPathKey = "spark.driver.extraLibraryPath"
-    val sparkExecutorInstances = "spark.executor.instances"
 
     // Used by Yarn in 1.1 and before
     sys.props.get("spark.driver.libraryPath").foreach { value =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the variable which is never used in SparkConf.scala.
val executorClasspathKey = "spark.executor.extraClassPath"
val driverOptsKey = "spark.driver.extraJavaOptions"
val driverClassPathKey = "spark.driver.extraClassPath"
val sparkExecutorInstances = "spark.executor.instances"
They variables are never used. Because the implementation code for the validation rule has been removed in SPARK-17979.

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
