### PR TITLE
[SPARK-22146] FileNotFoundException while reading ORC files containing special characters

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -58,7 +58,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     OrcFileOperator.readSchema(
-      files.map(_.getPath.toUri.toString),
+      files.map(_.getPath.toString),
       Some(sparkSession.sessionState.newHadoopConf())
     )
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1344,7 +1344,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
     }
   }
 
-  Seq("orc", "parquet").foreach { format =>
+  Seq("orc", "parquet", "csv", "json", "text").foreach { format =>
     test(s"SPARK-22146: read files containing special characters using $format") {
       val nameWithSpecialChars = s"sp&cial%chars"
       withTempDir { dir =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -993,7 +993,6 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
     spark.sql("""drop database if exists testdb8156 CASCADE""")
   }
 
-
   test("skip hive metadata on table creation") {
     withTempDir { tempPath =>
       val schema = StructType((1 to 5).map(i => StructField(s"c_$i", StringType)))
@@ -1341,6 +1340,17 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
           sql(s"INSERT OVERWRITE TABLE $tableName SELECT 1")
           checkAnswer(spark.table(tableName), Row(1))
         }
+      }
+    }
+  }
+
+  Seq("orc", "parquet").foreach { format =>
+    test(s"SPARK-22146: read files containing special characters using $format") {
+      val nameWithSpecialChars = s"sp&cial%chars"
+      withTempDir { dir =>
+        val tmpFile = s"$dir/$nameWithSpecialChars"
+        spark.createDataset(Seq("a", "b")).write.format(format).save(tmpFile)
+        spark.read.format(format).load(tmpFile)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcSourceSuite.scala
@@ -274,16 +274,4 @@ class OrcSourceSuite extends OrcSuite {
       )).get.toString
     }
   }
-
-  test("SPARK-22146: read ORC files containing special characters") {
-    val dir = Utils.createTempDir().getCanonicalFile
-    import spark.implicits._
-    try {
-      val nameWithSpecialChars = s"$dir/a%3Abad name.orc"
-      spark.createDataset(Seq("a", "b")).write.format("orc").save(nameWithSpecialChars)
-      spark.read.format("orc").load(nameWithSpecialChars)
-    } finally {
-      Utils.deleteRecursively(dir)
-    }
-  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcSourceSuite.scala
@@ -274,4 +274,16 @@ class OrcSourceSuite extends OrcSuite {
       )).get.toString
     }
   }
+
+  test("SPARK-22146: read ORC files containing special characters") {
+    val dir = Utils.createTempDir().getCanonicalFile
+    import spark.implicits._
+    try {
+      val nameWithSpecialChars = s"$dir/a%3Abad name.orc"
+      spark.createDataset(Seq("a", "b")).write.format("orc").save(nameWithSpecialChars)
+      spark.read.format("orc").load(nameWithSpecialChars)
+    } finally {
+      Utils.deleteRecursively(dir)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reading ORC files containing special characters like '%' fails with a FileNotFoundException.
This PR aims to fix the problem.

## How was this patch tested?

Added UT.