### PR TITLE
[SPARK-22150][CORE] PeriodicCheckpointer fails in case of dependent RDDs

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.rdd.util
 
-import scala.collection.mutable
 import scala.collection.Set
+import scala.collection.mutable
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -125,5 +125,4 @@ private[spark] object PeriodicRDDCheckpointer {
     }
     deps1.intersect(deps2).exists(_.isCheckpointed)
   }
-
 }

--- a/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
@@ -98,7 +98,7 @@ private[spark] class PeriodicRDDCheckpointer[T](
   override protected def unpersist(data: RDD[T]): Unit = data.unpersist(blocking = false)
 
   override protected def getCheckpointFiles(data: RDD[T]): Iterable[String] = {
-    data.getCheckpointFile.map(x => x)
+    PeriodicRDDCheckpointer.rddDeps(data).flatMap(_.getCheckpointFile)
   }
 
   override protected def haveCommonCheckpoint(newData: RDD[T], oldData: RDD[T]): Boolean = {

--- a/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
@@ -47,7 +47,9 @@ import org.apache.spark.util.PeriodicCheckpointer
  *  - This class should NOT be copied (since copies may conflict on which RDDs should be
  *    checkpointed).
  *  - This class removes checkpoint files once later RDDs have been checkpointed and do not
- *    have dependencies, the files to remove have been created for.
+ *    have dependencies, the files to remove have been created for (removing checkpoint files
+ *    of prior RDDs, the later ones depend on, may fail with `FileNotFoundException` in case
+ *    the later RDDs are not yet materialized).
  *    However, references to the older RDDs will still return isCheckpointed = true.
  *
  * Example usage:

--- a/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/util/PeriodicRDDCheckpointer.scala
@@ -41,12 +41,13 @@ import org.apache.spark.util.PeriodicCheckpointer
  *  - Unpersist RDDs from queue until there are at most 3 persisted RDDs.
  *  - If using checkpointing and the checkpoint interval has been reached,
  *     - Checkpoint the new RDD, and put in a queue of checkpointed RDDs.
- *     - Remove older checkpoints.
+ *     - Remove older checkpoints except for created one and all the checkpoints it depends on.
  *
  * WARNINGS:
  *  - This class should NOT be copied (since copies may conflict on which RDDs should be
  *    checkpointed).
- *  - This class removes checkpoint files once later RDDs have been checkpointed.
+ *  - This class removes checkpoint files once later RDDs have been checkpointed and do not
+ *    have dependencies, the files to remove have been created for.
  *    However, references to the older RDDs will still return isCheckpointed = true.
  *
  * Example usage:

--- a/graphx/src/main/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointer.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointer.scala
@@ -19,6 +19,7 @@ package org.apache.spark.graphx.util
 
 import org.apache.spark.SparkContext
 import org.apache.spark.graphx.Graph
+import org.apache.spark.rdd.util.PeriodicRDDCheckpointer
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.PeriodicCheckpointer
 
@@ -103,4 +104,11 @@ private[spark] class PeriodicGraphCheckpointer[VD, ED](
   override protected def getCheckpointFiles(data: Graph[VD, ED]): Iterable[String] = {
     data.getCheckpointFiles
   }
+
+  override protected def haveCommonCheckpoint(
+      newData: Graph[VD, ED], oldData: Graph[VD, ED]): Boolean = {
+    PeriodicRDDCheckpointer.haveCommonCheckpoint(
+      Set(newData.vertices, newData.edges), Set(oldData.vertices, oldData.edges))
+  }
+
 }

--- a/graphx/src/main/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointer.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointer.scala
@@ -39,12 +39,15 @@ import org.apache.spark.util.PeriodicCheckpointer
  *  - Unpersist graphs from queue until there are at most 3 persisted graphs.
  *  - If using checkpointing and the checkpoint interval has been reached,
  *     - Checkpoint the new graph, and put in a queue of checkpointed graphs.
- *     - Remove older checkpoints.
+ *     - Remove older checkpoints except for created one and all the checkpoints it depends on.
  *
  * WARNINGS:
  *  - This class should NOT be copied (since copies may conflict on which Graphs should be
  *    checkpointed).
- *  - This class removes checkpoint files once later graphs have been checkpointed.
+ *  - This class removes checkpoint files once later graphs have been checkpointed and do not
+ *    have dependencies, the files to remove have been created for (removing checkpoint files
+ *    of prior graphs, the later ones depend on, may fail with `FileNotFoundException` in case
+ *    the later graphs are not yet materialized).
  *    However, references to the older graphs will still return isCheckpointed = true.
  *
  * Example usage:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for [SPARK-22150](https://issues.apache.org/jira/browse/SPARK-22150) JIRA issue.

In case of checkpointing RDDs which depend on previously checkpointed RDDs (for example in iterative algorithms) PeriodicCheckpointer removes already checkpointed materialized RDDs too early leading to FileNotFoundExceptions.

Consider the following snippet

    // create a periodic checkpointer with interval of 2
    val checkpointer = new PeriodicRDDCheckpointer[Double](2, sc)
    
    val rdd1 = createRDD(sc)
    checkpointer.update(rdd1)
    // on the second update rdd1 is checkpointed
    checkpointer.update(rdd1)
    // on action checkpointed rdd is materialized and its lineage is truncated
    rdd1.count() 
    
    // rdd2 depends on rdd1
    val rdd2 = rdd1.filter(_ => true)
    checkpointer.update(rdd2)
    // on the second update rdd2 is checkpointed and checkpoint files of rdd1 are deleted
    checkpointer.update(rdd2)
    // on action it's necessary to read already removed checkpoint files of rdd1
    rdd2.count()

This PR proposes to preserve all the checkpoints the last one depends on to be able to evaluate the final RDD even if the last checkpoint (the final RDD depends on) is not yet materialized.

## How was this patch tested?

Unit tests as well as manually in production jobs which previously were failing until this PR applied.