### PR TITLE
[SPARK-22162] Executors and the driver should use consistent JobIDs in the RDD commit protocol.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -25,9 +25,9 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.mapred._
-import org.apache.hadoop.mapreduce.{JobContext => NewJobContext,
-OutputFormat => NewOutputFormat, RecordWriter => NewRecordWriter,
-TaskAttemptContext => NewTaskAttemptContext, TaskAttemptID => NewTaskAttemptID, TaskType}
+import org.apache.hadoop.mapreduce.{JobContext => NewJobContext, OutputFormat => NewOutputFormat,
+RecordWriter => NewRecordWriter, TaskAttemptContext => NewTaskAttemptContext,
+TaskAttemptID => NewTaskAttemptID, TaskType}
 import org.apache.hadoop.mapreduce.task.{TaskAttemptContextImpl => NewTaskAttemptContextImpl}
 
 import org.apache.spark.{SerializableWritable, SparkConf, SparkException, TaskContext}
@@ -47,7 +47,9 @@ object SparkHadoopWriter extends Logging {
   /**
    * Basic work flow of this command is:
    * 1. Driver side setup, prepare the data source and hadoop configuration for the write job to
-   *    be issued.
+   *    be issued. To create the configurations we also need stageId. However since info about
+   *    stageId is not available yet at this point of execution, a closure is used to create configs
+   *    that will be executed on the driver when the stageId is available in the DAGScheduler.
    * 2. Issues a write job consists of one or more executor side tasks, each of which writes all
    *    rows within an RDD partition.
    * 3. If no exception is thrown in a task, commits that task, otherwise aborts that task;  If any
@@ -60,41 +62,58 @@ object SparkHadoopWriter extends Logging {
       config: HadoopWriteConfigUtil[K, V]): Unit = {
     // Extract context and configuration from RDD.
     val sparkContext = rdd.context
-    val rddId = rdd.id
+    val stageInfo: StageInfo = new StageInfo
+    stageInfo.rddConf = rdd.conf
+    // Try to write all RDD partitions as a Hadoop OutputFormat.
+    try {
+      val ret = sparkContext.runJob(rdd, createConf( stageInfo, _, config),
+        (context: TaskContext, iter: Iterator[(K, V)]) => {
+          executeTask(
+            context = context,
+            config = config,
+            jobTrackerId = stageInfo.jobTrackerId,
+            sparkStageId = context.stageId,
+            sparkPartitionId = context.partitionId,
+            sparkAttemptNumber = context.attemptNumber,
+            committer = stageInfo.committer.get,
+            iterator = iter)
+        }, 0 until rdd.partitions.length)
 
-    // Set up a job.
+      stageInfo.committer.get.commitJob(stageInfo.jobContext, ret)
+      logInfo(s"Job ${stageInfo.jobContext.getJobID} committed.")
+    } catch {
+      case cause: Throwable =>
+        logError(s"Aborting job ${stageInfo.jobContext.getJobID}.", cause)
+        // This checks whether the aborting was because of assertConf in createConf method
+        if (stageInfo.committer.isDefined) {
+          stageInfo.committer.get.abortJob(stageInfo.jobContext)
+          throw new SparkException("Job aborted.", cause)
+        }
+        else throw cause
+    }
+  }
+
+  /**
+   * This function will be send to DAGScheduler as a closure and gets called on the driver
+   * after the final stage is known. This is because for creating committer, stageId is required.
+   */
+  private def createConf[K, V: ClassTag](
+      stageInfo: StageInfo,
+      stageId: Int,
+      config: HadoopWriteConfigUtil[K, V]): Unit = {
+    stageInfo.stageId = stageId
     val jobTrackerId = createJobTrackerID(new Date())
-    val jobContext = config.createJobContext(jobTrackerId, rddId)
+    val jobContext = config.createJobContext(jobTrackerId, stageId)
+    stageInfo.jobTrackerId = jobTrackerId
+    stageInfo.jobContext = jobContext
     config.initOutputFormat(jobContext)
 
     // Assert the output format/key/value class is set in JobConf.
-    config.assertConf(jobContext, rdd.conf)
+    config.assertConf(stageInfo.jobContext, stageInfo.rddConf)
 
-    val committer = config.createCommitter(rddId)
+    val committer = config.createCommitter(stageId)
+    stageInfo.committer = Some(committer)
     committer.setupJob(jobContext)
-
-    // Try to write all RDD partitions as a Hadoop OutputFormat.
-    try {
-      val ret = sparkContext.runJob(rdd, (context: TaskContext, iter: Iterator[(K, V)]) => {
-        executeTask(
-          context = context,
-          config = config,
-          jobTrackerId = jobTrackerId,
-          sparkRDDId = rddId,
-          sparkPartitionId = context.partitionId,
-          sparkAttemptNumber = context.attemptNumber,
-          committer = committer,
-          iterator = iter)
-      })
-
-      committer.commitJob(jobContext, ret)
-      logInfo(s"Job ${jobContext.getJobID} committed.")
-    } catch {
-      case cause: Throwable =>
-        logError(s"Aborting job ${jobContext.getJobID}.", cause)
-        committer.abortJob(jobContext)
-        throw new SparkException("Job aborted.", cause)
-    }
   }
 
   /** Write a RDD partition out in a single Spark task. */
@@ -102,14 +121,14 @@ object SparkHadoopWriter extends Logging {
       context: TaskContext,
       config: HadoopWriteConfigUtil[K, V],
       jobTrackerId: String,
-      sparkRDDId: Int,
+      sparkStageId: Int,
       sparkPartitionId: Int,
       sparkAttemptNumber: Int,
       committer: FileCommitProtocol,
       iterator: Iterator[(K, V)]): TaskCommitMessage = {
     // Set up a task.
     val taskContext = config.createTaskAttemptContext(
-      jobTrackerId, sparkRDDId, sparkPartitionId, sparkAttemptNumber)
+      jobTrackerId, sparkStageId, sparkPartitionId, sparkAttemptNumber)
     committer.setupTask(taskContext)
 
     val (outputMetrics, callback) = initHadoopOutputMetrics(context)
@@ -387,4 +406,14 @@ class HadoopMapReduceWriteConfigUtil[K, V: ClassTag](conf: SerializableConfigura
       getOutputFormat().checkOutputSpecs(jobContext)
     }
   }
+}
+
+private[spark]
+class StageInfo extends Serializable {
+  var committer: Option[HadoopMapReduceCommitProtocol] = None
+  @transient
+  var jobContext: NewJobContext = null
+  var stageId: Integer = 0
+  var rddConf: SparkConf = null
+  var jobTrackerId: String = ""
 }

--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -60,17 +60,17 @@ object SparkHadoopWriter extends Logging {
       config: HadoopWriteConfigUtil[K, V]): Unit = {
     // Extract context and configuration from RDD.
     val sparkContext = rdd.context
-    val stageId = rdd.id
+    val rddId = rdd.id
 
     // Set up a job.
     val jobTrackerId = createJobTrackerID(new Date())
-    val jobContext = config.createJobContext(jobTrackerId, stageId)
+    val jobContext = config.createJobContext(jobTrackerId, rddId)
     config.initOutputFormat(jobContext)
 
     // Assert the output format/key/value class is set in JobConf.
     config.assertConf(jobContext, rdd.conf)
 
-    val committer = config.createCommitter(stageId)
+    val committer = config.createCommitter(rddId)
     committer.setupJob(jobContext)
 
     // Try to write all RDD partitions as a Hadoop OutputFormat.
@@ -80,7 +80,7 @@ object SparkHadoopWriter extends Logging {
           context = context,
           config = config,
           jobTrackerId = jobTrackerId,
-          sparkStageId = context.stageId,
+          sparkRDDId = rddId,
           sparkPartitionId = context.partitionId,
           sparkAttemptNumber = context.attemptNumber,
           committer = committer,
@@ -102,14 +102,14 @@ object SparkHadoopWriter extends Logging {
       context: TaskContext,
       config: HadoopWriteConfigUtil[K, V],
       jobTrackerId: String,
-      sparkStageId: Int,
+      sparkRDDId: Int,
       sparkPartitionId: Int,
       sparkAttemptNumber: Int,
       committer: FileCommitProtocol,
       iterator: Iterator[(K, V)]): TaskCommitMessage = {
     // Set up a task.
     val taskContext = config.createTaskAttemptContext(
-      jobTrackerId, sparkStageId, sparkPartitionId, sparkAttemptNumber)
+      jobTrackerId, sparkRDDId, sparkPartitionId, sparkAttemptNumber)
     committer.setupTask(taskContext)
 
     val (outputMetrics, callback) = initHadoopOutputMetrics(context)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -37,6 +37,7 @@ private[scheduler] sealed trait DAGSchedulerEvent
 private[scheduler] case class JobSubmitted(
     jobId: Int,
     finalRDD: RDD[_],
+    jobSetupFunction: Int => Unit,
     func: (TaskContext, Iterator[_]) => _,
     partitions: Array[Int],
     callSite: CallSite,
@@ -97,4 +98,3 @@ private[scheduler] case object ResubmitFailedStages extends DAGSchedulerEvent
 
 private[scheduler]
 case class SpeculativeTaskSubmitted(task: Task[_]) extends DAGSchedulerEvent
-

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -529,7 +529,6 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     // Create more than one rdd to mimic stageId not equal to rddId
     val pairs = sc.parallelize(Array((1, 2), (2, 3)), 2).
       map { p => (new Integer(p._1 + 1), new Integer(p._2 + 1)) }.filter { p => p._1 > 0 }
-    RDDID.rddid = pairs.id
     pairs.saveAsNewAPIHadoopFile[YetAnotherFakeFormat]("ignored")
   }
 
@@ -881,9 +880,8 @@ class YetAnotherFakeCommitter extends NewOutputCommitter with Assertions {
   def needsTaskCommit(t: NewTaskAttempContext): Boolean = false
 
   def setupTask(t: NewTaskAttempContext): Unit = {
-    val rddid = t.getTaskAttemptID().getJobID().getId
-    assert(rddid === RDDID.rddid )
-    assert(rddid === JobID.jobid)
+    val jobId = t.getTaskAttemptID().getJobID().getId
+    assert(jobId === JobID.jobid)
   }
 
   def commitTask(t: NewTaskAttempContext): Unit = {}
@@ -902,10 +900,6 @@ class YetAnotherFakeFormat() extends NewOutputFormat[Integer, Integer]() {
   def getOutputCommitter(t: NewTaskAttempContext): NewOutputCommitter = {
     new YetAnotherFakeCommitter()
   }
-}
-
-object RDDID {
-  var rddid = -1
 }
 
 object JobID {

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -22,8 +22,6 @@ import java.io.IOException
 import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.util.Random
 
-import org.scalatest.Assertions
-
 import org.apache.commons.math3.distribution.{BinomialDistribution, PoissonDistribution}
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.fs.FileSystem
@@ -32,6 +30,7 @@ import org.apache.hadoop.mapreduce.{JobContext => NewJobContext,
   OutputCommitter => NewOutputCommitter, OutputFormat => NewOutputFormat,
   RecordWriter => NewRecordWriter, TaskAttemptContext => NewTaskAttempContext}
 import org.apache.hadoop.util.Progressable
+import org.scalatest.Assertions
 
 import org.apache.spark._
 import org.apache.spark.Partitioner

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -526,8 +526,9 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   test("The JobId on driver and executor should be the same during the commit") {
-    val pairs = sc.parallelize(Array((new Integer(1), new Integer(2))), 1).
-      map( p => (new Integer(p._1 + 1), new Integer(p._2 + 1))).filter( p => p._1 > 0)
+    // Create more than one rdd to mimic stageId not equal to rddId
+    val pairs = sc.parallelize(Array((1, 2), (2, 3)), 2).
+      map { p => (new Integer(p._1 + 1), new Integer(p._2 + 1)) }.filter { p => p._1 > 0 }
     RDDID.rddid = pairs.id
     pairs.saveAsNewAPIHadoopFile[YetAnotherFakeFormat]("ignored")
   }
@@ -875,7 +876,6 @@ class NewFakeFormatWithCallback() extends NewFakeFormat {
 class YetAnotherFakeCommitter extends NewOutputCommitter with Assertions {
   def setupJob(j: NewJobContext): Unit = {
     JobID.jobid = j.getJobID().getId
-    ()
   }
 
   def needsTaskCommit(t: NewTaskAttempContext): Boolean = false
@@ -884,17 +884,16 @@ class YetAnotherFakeCommitter extends NewOutputCommitter with Assertions {
     val rddid = t.getTaskAttemptID().getJobID().getId
     assert(rddid === RDDID.rddid )
     assert(rddid === JobID.jobid)
-    ()
   }
 
-  def commitTask(t: NewTaskAttempContext): Unit = ()
+  def commitTask(t: NewTaskAttempContext): Unit = {}
 
-  def abortTask(t: NewTaskAttempContext): Unit = ()
+  def abortTask(t: NewTaskAttempContext): Unit = {}
 }
 
 class YetAnotherFakeFormat() extends NewOutputFormat[Integer, Integer]() {
 
-  def checkOutputSpecs(j: NewJobContext): Unit = ()
+  def checkOutputSpecs(j: NewJobContext): Unit = {}
 
   def getRecordWriter(t: NewTaskAttempContext): NewRecordWriter[Integer, Integer] = {
     new NewFakeWriter()

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -312,7 +312,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       listener: JobListener = jobListener,
       properties: Properties = null): Int = {
     val jobId = scheduler.nextJobId.getAndIncrement()
-    runEvent(JobSubmitted(jobId, rdd, func, partitions, CallSite("", ""), listener, properties))
+    runEvent(JobSubmitted(jobId, rdd, (_: Int) => {}, func, partitions, CallSite("", ""), listener,
+      properties))
     jobId
   }
 


### PR DESCRIPTION
I have modified SparkHadoopWriter so that executors and the driver always use consistent JobIds during the hadoop commit. Before SPARK-18191, spark always used the rddId, it just incorrectly named the variable stageId. After SPARK-18191, it used the rddId in the driver, and the stageId in the executors. With this change, spark uses a closure to create configs that will be called as soon as stageId is available in DAGScheduler. This way executors and the river will consistently uses stageId.
 In addition to the existing unit tests, a test has been added to check whether executors and the driver are using the same JobId. The test failed before this change and passed after applying this fix.