### PR TITLE
[SPARK-22172][CORE] Worker hangs when the external shuffle service port is already in use

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -199,7 +199,7 @@ private[deploy] class Worker(
     logInfo(s"Running Spark version ${org.apache.spark.SPARK_VERSION}")
     logInfo("Spark home: " + sparkHome)
     createWorkDir()
-    startExternalShuffleService
+    startExternalShuffleService()
     webUi = new WorkerWebUI(this, workDir, webUiPort)
     webUi.bind()
 
@@ -369,9 +369,11 @@ private[deploy] class Worker(
 
   private def startExternalShuffleService() {
     try {
-      shuffleService.startIfEnabled
+      shuffleService.startIfEnabled()
     } catch {
-      case NonFatal(e) => logError("Failed to start external shuffle service", e)
+      case e: Exception =>
+        logError("Failed to start external shuffle service", e)
+        System.exit(1)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -199,7 +199,7 @@ private[deploy] class Worker(
     logInfo(s"Running Spark version ${org.apache.spark.SPARK_VERSION}")
     logInfo("Spark home: " + sparkHome)
     createWorkDir()
-    shuffleService.startIfEnabled()
+    startExternalShuffleService
     webUi = new WorkerWebUI(this, workDir, webUiPort)
     webUi.bind()
 
@@ -364,6 +364,14 @@ private[deploy] class Worker(
       case Some(_) =>
         logInfo("Not spawning another attempt to register with the master, since there is an" +
           " attempt scheduled already.")
+    }
+  }
+
+  private def startExternalShuffleService() {
+    try {
+      shuffleService.startIfEnabled
+    } catch {
+      case NonFatal(e) => logError("Failed to start external shuffle service", e)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handling the NonFatal exceptions while starting the external shuffle service, if there are any NonFatal exceptions it logs and continues without the external shuffle service.

## How was this patch tested?

I verified it manually, it logs the exception and continues to serve without external shuffle service when BindException occurs.