### PR TITLE
[SPARK-22174][CORE]Support to automatically create the directory where the event logs go (`spark.eventLog.dir`)

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -94,7 +94,10 @@ private[spark] class EventLoggingListener(
    * Creates the log file in the configured log directory.
    */
   def start() {
-    if (!fileSystem.getFileStatus(new Path(logBaseDir)).isDirectory) {
+    val logBasePath = new Path(logBaseDir)
+    if(!fileSystem.exists(logBasePath) && !fileSystem.mkdirs(logBasePath)) {
+      throw new IOException(s"Failed to create log directory $logBaseDir." )
+    } else if (!fileSystem.getFileStatus(logBasePath).isDirectory) {
       throw new IllegalArgumentException(s"Log directory $logBaseDir is not a directory.")
     }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -51,7 +51,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
   private var testDirPath: Path = _
 
   before {
-    testDir = Utils.createTempDir(namePrefix = s"history log")
+    testDir = new File(System.getProperty("java.io.tmpdir") + "/history log")
     testDir.deleteOnExit()
     testDirPath = new Path(testDir.getAbsolutePath())
   }
@@ -109,6 +109,9 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
   }
 
   test("Log overwriting") {
+    val conf = getLoggingConf(testDirPath)
+    val eventLogger = new EventLoggingListener("test", None, testDirPath.toUri(), conf)
+    eventLogger.start()
     val logUri = EventLoggingListener.getLogPath(testDir.toURI, "test", None)
     val logPath = new Path(logUri).toUri.getPath
     // Create file before writing the event log


### PR DESCRIPTION

## What changes were proposed in this pull request?

`2017-09-30 09:47:44,721 ERROR org.apache.spark.SparkContext: Error initializing SparkContext.
java.io.FileNotFoundException: File file:/tmp/spark-events does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:611)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:824)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:601)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:421)
	at org.apache.spark.scheduler.EventLoggingListener.start(EventLoggingListener.scala:93)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:516)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2258)
	at org.apache.spark.sql.SparkSession$Builder$$anonfun$8.apply(SparkSession.scala:846)
	at org.apache.spark.sql.SparkSession$Builder$$anonfun$8.apply(SparkSession.scala:838)
	at scala.Option.getOrElse(Option.scala:121)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:838)
	at org.apache.spark.examples.SparkPi$.main(SparkPi.scala:31)
	at org.apache.spark.examples.SparkPi.main(SparkPi.scala)`

Currently, if our applications are using event logging, the directory where the event logs go (`spark.eventLog.dir`) should be manually created.
I suggest to create the event log directory automatically in source code, this will make spark more convenient to use.

## How was this patch tested?

update existing tests
