### PR TITLE
[SPARK-22175][WEB-UI] Add status column to history page

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -54,6 +54,11 @@
       </th>
       {{/showCompletedColumns}}
       <th>
+        <span data-toggle="tooltip" data-placement="right" title="The status of this application">
+           Status
+        </span>
+      </th>
+      <th>
         <span data-toggle="tooltip" data-placement="top" title="The Spark user of this application">
           Spark User
         </span>
@@ -83,6 +88,7 @@
       <td>{{endTime}}</td>
       <td><span title="{{durationMillisec}}">{{duration}}</span></td>
       {{/showCompletedColumns}}
+      <td>{{status}}</td>
       <td>{{sparkUser}}</td>
       <td>{{lastUpdated}}</td>
       <td><a href="{{log}}" class="btn btn-info btn-mini">Download</a></td>

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -132,6 +132,7 @@ $(document).ready(function() {
           attempt["startTime"] = formatDate(attempt["startTime"]);
           attempt["endTime"] = formatDate(attempt["endTime"]);
           attempt["lastUpdated"] = formatDate(attempt["lastUpdated"]);
+          attempt["status"] = attempt["status"];
           attempt["log"] = uiRoot + "/api/v1/applications/" + id + "/" +
             (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "logs";
           attempt["durationMillisec"] = attempt["duration"];
@@ -167,6 +168,7 @@ $(document).ready(function() {
             {name: startedColumnName},
             {name: completedColumnName},
             {name: durationColumnName, type: "title-numeric"},
+            {name: 'status'},
             {name: 'user'},
             {name: 'lastUpdated'},
             {name: 'eventLog'},

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -26,6 +26,7 @@ import org.apache.spark.ui.SparkUI
 
 private[spark] case class ApplicationAttemptInfo(
     attemptId: Option[String],
+    status: String,
     startTime: Long,
     endTime: Long,
     lastUpdated: Long,

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -712,6 +712,10 @@ private[history] object FsHistoryProvider {
 
   private val LOG_START_EVENT_PREFIX = "{\"Event\":\"SparkListenerLogStart\""
 
+  private val JOB_START_EVENT_PREFIX = "{\"Event\":\"SparkListenerJobStart\""
+
+  private val JOB_END_EVENT_PREFIX = "{\"Event\":\"SparkListenerJobEnd\""
+
   /**
    * Current version of the data written to the listing database. When opening an existing
    * db, if the version does not match this value, the FsHistoryProvider will throw away
@@ -746,7 +750,7 @@ private[history] class AttemptInfoWrapper(
     val fileSize: Long) {
 
   def toAppAttemptInfo(): ApplicationAttemptInfo = {
-    ApplicationAttemptInfo(info.attemptId, info.startTime.getTime(),
+    ApplicationAttemptInfo(info.attemptId, info.status, info.startTime.getTime(),
       info.endTime.getTime(), info.lastUpdated.getTime(), info.sparkUser,
       info.completed, info.appSparkVersion)
   }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -487,8 +487,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   protected def mergeApplicationListing(fileStatus: FileStatus): Unit = {
     val eventsFilter: ReplayEventsFilter = { eventString =>
       eventString.startsWith(APPL_START_EVENT_PREFIX) ||
-        eventString.startsWith(APPL_END_EVENT_PREFIX) ||
-        eventString.startsWith(LOG_START_EVENT_PREFIX)
+      eventString.startsWith(APPL_END_EVENT_PREFIX) ||
+      eventString.startsWith(LOG_START_EVENT_PREFIX) ||
+      eventString.startsWith(JOB_START_EVENT_PREFIX) ||
+      eventString.startsWith(JOB_END_EVENT_PREFIX)
     }
 
     val logPath = fileStatus.getPath()
@@ -798,6 +800,17 @@ private[history] class AppListingListener(log: FileStatus, clock: Clock) extends
     attempt.completed = true
   }
 
+  override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+    attempt.jobToStatus(jobStart.jobId) = "Started"
+  }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+    attempt.jobToStatus(jobEnd.jobId) = jobEnd.jobResult match {
+      case JobSucceeded => "Succeeded"
+      case JobFailed(_) => "Failed"
+    }
+  }
+
   override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
     case SparkListenerLogStart(sparkVersion) =>
       attempt.appSparkVersion = sparkVersion
@@ -837,10 +850,12 @@ private[history] class AppListingListener(log: FileStatus, clock: Clock) extends
     var sparkUser: String = null
     var completed = false
     var appSparkVersion = ""
+    val jobToStatus = new mutable.HashMap[Int, String]
 
     def toView(): AttemptInfoWrapper = {
       val apiInfo = new v1.ApplicationAttemptInfo(
         attemptId,
+        applicationStatus.get,
         startTime,
         endTime,
         lastUpdated,
@@ -852,6 +867,18 @@ private[history] class AppListingListener(log: FileStatus, clock: Clock) extends
         apiInfo,
         logPath,
         fileSize)
+    }
+
+    def applicationStatus : Option[String] = {
+      if (startTime.getTime == -1) {
+        Some("<Not Started>")
+      } else if (endTime.getTime == -1) {
+        Some("<In Progress>")
+      } else if (jobToStatus.isEmpty || jobToStatus.exists(_._2 != "Succeeded")) {
+        Some("Failed")
+      } else {
+        Some("Succeeded")
+      }
     }
 
   }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
@@ -80,6 +80,7 @@ private[spark] object ApplicationsListResource {
       attempts = app.attempts.map { internalAttemptInfo =>
         new ApplicationAttemptInfo(
           attemptId = internalAttemptInfo.attemptId,
+          status = internalAttemptInfo.status,
           startTime = new Date(internalAttemptInfo.startTime),
           endTime = new Date(internalAttemptInfo.endTime),
           duration =

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -38,6 +38,7 @@ class ApplicationInfo private[spark](
   allowGetters = true)
 class ApplicationAttemptInfo private[spark](
     val attemptId: Option[String],
+    val status: String,
     val startTime: Date,
     val endTime: Date,
     val lastUpdated: Date,

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -118,6 +118,7 @@ private[spark] class SparkUI private (
       memoryPerExecutorMB = None,
       attempts = Seq(new ApplicationAttemptInfo(
         attemptId = None,
+        status = "",
         startTime = new Date(startTime),
         endTime = new Date(-1),
         duration = 0,

--- a/core/src/test/resources/HistoryServerExpectations/application_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/application_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "app-20161116163331-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status": "Succeeded",
     "startTime" : "2016-11-16T22:33:29.916GMT",
     "endTime" : "2016-11-16T22:33:40.587GMT",
     "lastUpdated" : "",
@@ -17,6 +18,7 @@
   "id" : "app-20161115172038-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-15T23:20:37.079GMT",
     "endTime" : "2016-11-15T23:22:18.874GMT",
     "lastUpdated" : "",
@@ -32,6 +34,7 @@
   "id" : "local-1430917381534",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:11.398GMT",
     "lastUpdated" : "",
@@ -48,6 +51,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -60,6 +64,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",
@@ -76,6 +81,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -88,6 +94,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",
@@ -103,6 +110,7 @@
   "id" : "local-1425081759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-28T00:02:38.277GMT",
     "endTime" : "2015-02-28T00:02:46.912GMT",
     "lastUpdated" : "",
@@ -118,6 +126,7 @@
   "id" : "local-1422981780767",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Failed",
     "startTime" : "2015-02-03T16:42:59.720GMT",
     "endTime" : "2015-02-03T16:43:08.731GMT",
     "lastUpdated" : "",
@@ -133,6 +142,7 @@
   "id" : "local-1422981759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-03T16:42:38.277GMT",
     "endTime" : "2015-02-03T16:42:46.912GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/completed_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/completed_app_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "app-20161116163331-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-16T22:33:29.916GMT",
     "endTime" : "2016-11-16T22:33:40.587GMT",
     "lastUpdated" : "",
@@ -17,6 +18,7 @@
   "id" : "app-20161115172038-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-15T23:20:37.079GMT",
     "endTime" : "2016-11-15T23:22:18.874GMT",
     "lastUpdated" : "",
@@ -32,6 +34,7 @@
   "id" : "local-1430917381534",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:11.398GMT",
     "lastUpdated" : "",
@@ -48,6 +51,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -60,6 +64,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",
@@ -76,6 +81,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -88,6 +94,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",
@@ -103,6 +110,7 @@
   "id" : "local-1425081759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-28T00:02:38.277GMT",
     "endTime" : "2015-02-28T00:02:46.912GMT",
     "lastUpdated" : "",
@@ -119,6 +127,7 @@
   "id" : "local-1422981780767",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Failed",
     "startTime" : "2015-02-03T16:42:59.720GMT",
     "endTime" : "2015-02-03T16:43:08.731GMT",
     "lastUpdated" : "",
@@ -134,6 +143,7 @@
   "id" : "local-1422981759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-03T16:42:38.277GMT",
     "endTime" : "2015-02-03T16:42:46.912GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/limit_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/limit_app_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "app-20161116163331-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-16T22:33:29.916GMT",
     "endTime" : "2016-11-16T22:33:40.587GMT",
     "lastUpdated" : "",
@@ -17,6 +18,7 @@
   "id" : "app-20161115172038-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-15T23:20:37.079GMT",
     "endTime" : "2016-11-15T23:22:18.874GMT",
     "lastUpdated" : "",
@@ -32,6 +34,7 @@
   "id" : "local-1430917381534",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:11.398GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/maxDate2_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/maxDate2_app_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "local-1422981759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-03T16:42:38.277GMT",
     "endTime" : "2015-02-03T16:42:46.912GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/maxDate_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/maxDate_app_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "local-1422981780767",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Failed",
     "startTime" : "2015-02-03T16:42:59.720GMT",
     "endTime" : "2015-02-03T16:43:08.731GMT",
     "lastUpdated" : "",
@@ -17,6 +18,7 @@
   "id" : "local-1422981759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-03T16:42:38.277GMT",
     "endTime" : "2015-02-03T16:42:46.912GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/maxEndDate_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/maxEndDate_app_list_json_expectation.json
@@ -3,6 +3,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -15,6 +16,7 @@
     "endTimeEpoch" : 1430917380950
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",
@@ -31,6 +33,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -43,6 +46,7 @@
     "endTimeEpoch" : 1426633945177
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",
@@ -58,6 +62,7 @@
   "id" : "local-1425081759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-28T00:02:38.277GMT",
     "endTime" : "2015-02-28T00:02:46.912GMT",
     "lastUpdated" : "",
@@ -73,6 +78,7 @@
   "id" : "local-1422981780767",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Failed",
     "startTime" : "2015-02-03T16:42:59.720GMT",
     "endTime" : "2015-02-03T16:43:08.731GMT",
     "lastUpdated" : "",
@@ -88,6 +94,7 @@
   "id" : "local-1422981759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-03T16:42:38.277GMT",
     "endTime" : "2015-02-03T16:42:46.912GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/minDate_and_maxEndDate_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/minDate_and_maxEndDate_app_list_json_expectation.json
@@ -3,6 +3,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -15,6 +16,7 @@
     "endTimeEpoch" : 1430917380950
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",
@@ -31,6 +33,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -43,6 +46,7 @@
     "endTimeEpoch" : 1426633945177
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/minDate_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/minDate_app_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "app-20161116163331-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-16T22:33:29.916GMT",
     "endTime" : "2016-11-16T22:33:40.587GMT",
     "lastUpdated" : "",
@@ -17,6 +18,7 @@
   "id" : "app-20161115172038-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-15T23:20:37.079GMT",
     "endTime" : "2016-11-15T23:22:18.874GMT",
     "lastUpdated" : "",
@@ -32,6 +34,7 @@
   "id" : "local-1430917381534",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:11.398GMT",
     "lastUpdated" : "",
@@ -48,6 +51,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -60,6 +64,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",
@@ -76,6 +81,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -88,6 +94,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",
@@ -103,6 +110,7 @@
   "id" : "local-1425081759269",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-02-28T00:02:38.277GMT",
     "endTime" : "2015-02-28T00:02:46.912GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/minEndDate_and_maxEndDate_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/minEndDate_and_maxEndDate_app_list_json_expectation.json
@@ -3,6 +3,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -15,6 +16,7 @@
     "endTimeEpoch" : 1430917380950
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",
@@ -31,6 +33,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -43,6 +46,7 @@
     "endTimeEpoch" : 1426633945177
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/minEndDate_app_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/minEndDate_app_list_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "app-20161116163331-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-16T22:33:29.916GMT",
     "endTime" : "2016-11-16T22:33:40.587GMT",
     "lastUpdated" : "",
@@ -17,6 +18,7 @@
   "id" : "app-20161115172038-0000",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2016-11-15T23:20:37.079GMT",
     "endTime" : "2016-11-15T23:22:18.874GMT",
     "lastUpdated" : "",
@@ -32,6 +34,7 @@
   "id" : "local-1430917381534",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Succeeded",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:11.398GMT",
     "lastUpdated" : "",
@@ -48,6 +51,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.893GMT",
     "endTime" : "2015-05-06T13:03:00.950GMT",
     "lastUpdated" : "",
@@ -60,6 +64,7 @@
     "endTimeEpoch" : 1430917380950
   }, {
     "attemptId" : "1",
+    "status" : "Failed",
     "startTime" : "2015-05-06T13:03:00.880GMT",
     "endTime" : "2015-05-06T13:03:00.890GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/one_app_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/one_app_json_expectation.json
@@ -2,6 +2,7 @@
   "id" : "local-1422981780767",
   "name" : "Spark shell",
   "attempts" : [ {
+    "status" : "Failed",
     "startTime" : "2015-02-03T16:42:59.720GMT",
     "endTime" : "2015-02-03T16:43:08.731GMT",
     "lastUpdated" : "",

--- a/core/src/test/resources/HistoryServerExpectations/one_app_multi_attempt_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/one_app_multi_attempt_json_expectation.json
@@ -3,6 +3,7 @@
   "name" : "Spark shell",
   "attempts" : [ {
     "attemptId" : "2",
+    "status" : "Succeeded",
     "startTime" : "2015-03-17T23:11:50.242GMT",
     "endTime" : "2015-03-17T23:12:25.177GMT",
     "lastUpdated" : "",
@@ -15,6 +16,7 @@
     "lastUpdatedEpoch" : 0
   }, {
     "attemptId" : "1",
+    "status" : "Succeeded",
     "startTime" : "2015-03-16T19:25:10.242GMT",
     "endTime" : "2015-03-16T19:25:45.177GMT",
     "lastUpdated" : "",

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -176,7 +176,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
       started: Long,
       ended: Long): SparkUI = {
     val info = new ApplicationInfo(name, name, Some(1), Some(1), Some(1), Some(64),
-      Seq(new AttemptInfo(attemptId, new Date(started), new Date(ended),
+      Seq(new AttemptInfo(attemptId, "Succeeded", new Date(started), new Date(ended),
         new Date(ended), ended - started, "user", completed, org.apache.spark.SPARK_VERSION)))
     val ui = mock[SparkUI]
     when(ui.getApplicationInfoList).thenReturn(List(info).iterator)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the history page has no status column which represent the status of application.
This patch add status column to history page.
Before modifying:
![before](https://user-images.githubusercontent.com/26762018/31041854-c1c71946-a5ce-11e7-8f96-dcab28f8faf0.png)
After modifying:
![after](https://user-images.githubusercontent.com/26762018/31041857-c772699a-a5ce-11e7-9ae4-43e00d926e72.png)

## How was this patch tested?
Pass related unit test and manually test.
