### PR TITLE
fix openHashSet to actually use quadratic probing instead of linear

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
@@ -147,7 +147,7 @@ class OpenHashSet[@specialized(Long, Int) T: ClassTag](
         return pos
       } else {
         // quadratic probing with values increase by 1, 2, 3, ...
-        pos = (pos + delta) & _mask
+        pos = (pos + delta * delta) & _mask
         delta += 1
       }
     }
@@ -181,7 +181,7 @@ class OpenHashSet[@specialized(Long, Int) T: ClassTag](
         return pos
       } else {
         // quadratic probing with values increase by 1, 2, 3, ...
-        pos = (pos + delta) & _mask
+        pos = (pos + delta * delta) & _mask
         delta += 1
       }
     }
@@ -250,7 +250,7 @@ class OpenHashSet[@specialized(Long, Int) T: ClassTag](
             keepGoing = false
           } else {
             val delta = i
-            newPos = (newPos + delta) & newMask
+            newPos = (newPos + delta * delta) & newMask
             i += 1
           }
         }


### PR DESCRIPTION
The comments in the code state that OpehHashSet uses quadratic probing, but in fact it uses linear probing, which "results in primary clustering, and as the cluster grows larger, the search for those items hashing within the cluster becomes less efficient."
see https://en.wikipedia.org/wiki/Quadratic_probing

OpenHashSetSuite pass with both probing methods.