### PR TITLE
[SPARK-22185] : Classpath cannot be set for jobs running on Spark Standalone Mode

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -201,6 +201,9 @@ abstract class AbstractCommandBuilder {
     addToClassPath(cp, getenv("HADOOP_CONF_DIR"));
     addToClassPath(cp, getenv("YARN_CONF_DIR"));
     addToClassPath(cp, getenv("SPARK_DIST_CLASSPATH"));
+    if (getenv("SPARK_DAEMON_CLASSPATH") != null) {
+      addToClassPath(cp, getenv("SPARK_DAEMON_CLASSPATH"));
+    }
     return new ArrayList<>(cp);
   }
 


### PR DESCRIPTION
Refer https://issues.apache.org/jira/browse/SPARK-21798.
Basically, the environment variable SPARK_DAEMON_CLASSPATH was added to replace SPARK_CLASSPATH for launching daemons. However, Spark Standalone mode is unable to run spark jobs accessing hdfs cluster as the jars required by hadoop like hadoop-gpl-compression jar exported with SPARK_DAEMON_CLASSPATH are not available in the executor launched by worker process.

## How was this patch tested?
Ran HDFS Job on Spark Standalone Mode and verified that the job properly ran.
