### PR TITLE
[SPARK-22196][Core] Combine multiple input splits into a HadoopPartition

### DIFF
--- a/core/src/main/scala/org/apache/spark/MultipleIterator.scala
+++ b/core/src/main/scala/org/apache/spark/MultipleIterator.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+/**
+ * Iterates over a list of iterators
+ */
+
+class MultipleIterator[T](iterators: List[Iterator[T]]) extends Iterator[T] {
+  private var current = iterators.head
+  private var nextIterators = iterators.tail
+
+  override def hasNext: Boolean = {
+    if (current.hasNext) {
+      true
+    } else if (nextIterators == Nil) {
+      false
+    } else {
+      current = nextIterators.head
+      nextIterators = nextIterators.tail
+      hasNext
+    }
+  }
+
+  override def next: T = {
+    if (!hasNext) {
+      throw new java.util.NoSuchElementException
+    }
+    current.next
+  }
+}

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 import java.util.{Date, Locale}
 
 import scala.collection.immutable.Map
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.reflect.ClassTag
 
 import org.apache.hadoop.conf.{Configurable, Configuration}
@@ -39,33 +40,53 @@ import org.apache.spark.internal.config.IGNORE_CORRUPT_FILES
 import org.apache.spark.rdd.HadoopRDD.HadoopMapPartitionsWithSplitRDD
 import org.apache.spark.scheduler.{HDFSCacheTaskLocation, HostTaskLocation}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.{NextIterator, SerializableConfiguration, ShutdownHookManager}
+import org.apache.spark.util.{NextIterator, SerializableConfiguration, ShutdownHookManager, Utils}
 
 /**
  * A Spark split class that wraps around a Hadoop InputSplit.
  */
-private[spark] class HadoopPartition(rddId: Int, override val index: Int, s: InputSplit)
+private[spark] class HadoopPartition(rddId: Int, override val index: Int,
+                                     s: ArrayBuffer[InputSplit])
   extends Partition {
 
-  val inputSplit = new SerializableWritable[InputSplit](s)
+  val inputSplits = createInputSplits(s)
 
   override def hashCode(): Int = 31 * (31 + rddId) + index
 
   override def equals(other: Any): Boolean = super.equals(other)
 
+  def createInputSplits(splits: ArrayBuffer[InputSplit]):
+  ArrayBuffer[SerializableWritable[InputSplit]] = {
+    val serializableInputSplits = new ArrayBuffer[SerializableWritable[InputSplit]]()
+    for (split <- splits) {
+      serializableInputSplits += new SerializableWritable[InputSplit](split)
+    }
+    serializableInputSplits
+  }
+
   /**
-   * Get any environment variables that should be added to the users environment when running pipes
+   * Get any environment variables that should be added to the users environment when running pipes.
+   * Since a Hadoop Partition can now have multiple input splits, map_input_file or
+   * mapreduce_map_input_file has the list of comma separated input split paths.
+   *
    * @return a Map with the environment variables and corresponding values, it could be empty
    */
   def getPipeEnvVars(): Map[String, String] = {
-    val envVars: Map[String, String] = if (inputSplit.value.isInstanceOf[FileSplit]) {
-      val is: FileSplit = inputSplit.value.asInstanceOf[FileSplit]
-      // map_input_file is deprecated in favor of mapreduce_map_input_file but set both
-      // since it's not removed yet
-      Map("map_input_file" -> is.getPath().toString(),
-        "mapreduce_map_input_file" -> is.getPath().toString())
-    } else {
-      Map()
+    val envVars: Map[String, String] = {
+      val filePaths = new ArrayBuffer[String]()
+      for (split <- inputSplits) {
+        if (split.value.isInstanceOf[FileSplit]) {
+          val is: FileSplit = split.value.asInstanceOf[FileSplit]
+          filePaths.append(is.getPath.toString)
+        }
+      }
+      if (filePaths.size > 0) {
+        val concatenatedFilePaths = filePaths.mkString(",")
+        Map("map_input_file" -> concatenatedFilePaths,
+          "mapreduce_map_input_file" -> concatenatedFilePaths)
+      } else {
+        Map()
+      }
     }
     envVars
   }
@@ -192,122 +213,167 @@ class HadoopRDD[K, V](
     SparkHadoopUtil.get.addCredentials(jobConf)
     val inputFormat = getInputFormat(jobConf)
     val inputSplits = inputFormat.getSplits(jobConf, minPartitions)
-    val array = new Array[Partition](inputSplits.size)
-    for (i <- 0 until inputSplits.size) {
-      array(i) = new HadoopPartition(id, i, inputSplits(i))
+    val hadoopPartitions = new ArrayBuffer[Partition]
+
+    val defaultMaxSplitBytes = Utils.getMaxPartitionBytes(sparkContext.conf)
+    val openCostInBytes = Utils.getFileOpenCostBytes(sparkContext.conf)
+    val defaultParallelism = sparkContext.defaultParallelism
+    val totalBytes = inputSplits.map(_.getLength + openCostInBytes).sum
+    val bytesPerCore = totalBytes / defaultParallelism
+
+    val maxSplitBytes = Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+    logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+      s"open cost is considered as scanning $openCostInBytes bytes.")
+
+    val partitions = new ArrayBuffer[ArrayBuffer[InputSplit]]()
+    var currentPartitionSplits = new ArrayBuffer[InputSplit]
+    var currentSize = 0L
+
+    inputSplits.sortBy(_.getLength)(implicitly[Ordering[Long]].reverse)
+
+    /** Close the current partition and move to the next. */
+    def closePartition(): Unit = {
+      if (currentPartitionSplits.nonEmpty) {
+        partitions += currentPartitionSplits
+      }
+      currentPartitionSplits = new ArrayBuffer[InputSplit]
+      currentSize = 0
     }
-    array
+
+    // Assign files to partitions using "First Fit Decreasing" (FFD)
+    inputSplits.foreach { split =>
+      if (currentSize + split.getLength > maxSplitBytes) {
+        closePartition()
+      }
+      // Add the given file to the current partition.
+      currentSize += split.getLength + openCostInBytes
+      currentPartitionSplits += split
+    }
+    closePartition()
+
+    // Create Hadoop Partitions from InputSplits
+    for (i <- 0 until partitions.size) {
+      hadoopPartitions.append(new HadoopPartition(id, i, partitions(i)))
+    }
+    hadoopPartitions.toArray
+
   }
 
-  override def compute(theSplit: Partition, context: TaskContext): InterruptibleIterator[(K, V)] = {
-    val iter = new NextIterator[(K, V)] {
+  override def compute(partition: Partition, context: TaskContext): MultipleIterator[(K, V)] = {
+    val splits = partition.asInstanceOf[HadoopPartition].inputSplits
+    val iterators = new ListBuffer[Iterator[(K, V)]]
+    val partitionIndex = partition.index
+    for (singleSplit <- splits) {
+      val theSplit = singleSplit.value
+      val iter = new NextIterator[(K, V)] {
+        logInfo("Input split: " + theSplit)
+        private val jobConf = getJobConf()
 
-      private val split = theSplit.asInstanceOf[HadoopPartition]
-      logInfo("Input split: " + split.inputSplit)
-      private val jobConf = getJobConf()
+        private val inputMetrics = context.taskMetrics().inputMetrics
+        private val existingBytesRead = inputMetrics.bytesRead
 
-      private val inputMetrics = context.taskMetrics().inputMetrics
-      private val existingBytesRead = inputMetrics.bytesRead
-
-      // Sets InputFileBlockHolder for the file block's information
-      split.inputSplit.value match {
-        case fs: FileSplit =>
-          InputFileBlockHolder.set(fs.getPath.toString, fs.getStart, fs.getLength)
-        case _ =>
-          InputFileBlockHolder.unset()
-      }
-
-      // Find a function that will return the FileSystem bytes read by this thread. Do this before
-      // creating RecordReader, because RecordReader's constructor might read some bytes
-      private val getBytesReadCallback: Option[() => Long] = split.inputSplit.value match {
-        case _: FileSplit | _: CombineFileSplit =>
-          Some(SparkHadoopUtil.get.getFSBytesReadOnThreadCallback())
-        case _ => None
-      }
-
-      // We get our input bytes from thread-local Hadoop FileSystem statistics.
-      // If we do a coalesce, however, we are likely to compute multiple partitions in the same
-      // task and in the same thread, in which case we need to avoid override values written by
-      // previous partitions (SPARK-13071).
-      private def updateBytesRead(): Unit = {
-        getBytesReadCallback.foreach { getBytesRead =>
-          inputMetrics.setBytesRead(existingBytesRead + getBytesRead())
+        // Sets InputFileBlockHolder for the file block's information
+        theSplit match {
+          case fs: FileSplit =>
+            InputFileBlockHolder.set(fs.getPath.toString, fs.getStart, fs.getLength)
+          case _ =>
+            InputFileBlockHolder.unset()
         }
-      }
 
-      private var reader: RecordReader[K, V] = null
-      private val inputFormat = getInputFormat(jobConf)
-      HadoopRDD.addLocalConfiguration(
-        new SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(createTime),
-        context.stageId, theSplit.index, context.attemptNumber, jobConf)
-
-      reader =
-        try {
-          inputFormat.getRecordReader(split.inputSplit.value, jobConf, Reporter.NULL)
-        } catch {
-          case e: IOException if ignoreCorruptFiles =>
-            logWarning(s"Skipped the rest content in the corrupted file: ${split.inputSplit}", e)
-            finished = true
-            null
+        // Find a function that will return the FileSystem bytes read by this thread. Do this before
+        // creating RecordReader, because RecordReader's constructor might read some bytes
+        private val getBytesReadCallback: Option[() => Long] = theSplit match {
+          case _: FileSplit | _: CombineFileSplit =>
+            Some(SparkHadoopUtil.get.getFSBytesReadOnThreadCallback())
+          case _ => None
         }
-      // Register an on-task-completion callback to close the input stream.
-      context.addTaskCompletionListener { context =>
-        // Update the bytes read before closing is to make sure lingering bytesRead statistics in
-        // this thread get correctly added.
-        updateBytesRead()
-        closeIfNeeded()
-      }
 
-      private val key: K = if (reader == null) null.asInstanceOf[K] else reader.createKey()
-      private val value: V = if (reader == null) null.asInstanceOf[V] else reader.createValue()
-
-      override def getNext(): (K, V) = {
-        try {
-          finished = !reader.next(key, value)
-        } catch {
-          case e: IOException if ignoreCorruptFiles =>
-            logWarning(s"Skipped the rest content in the corrupted file: ${split.inputSplit}", e)
-            finished = true
-        }
-        if (!finished) {
-          inputMetrics.incRecordsRead(1)
-        }
-        if (inputMetrics.recordsRead % SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
-          updateBytesRead()
-        }
-        (key, value)
-      }
-
-      override def close(): Unit = {
-        if (reader != null) {
-          InputFileBlockHolder.unset()
-          try {
-            reader.close()
-          } catch {
-            case e: Exception =>
-              if (!ShutdownHookManager.inShutdown()) {
-                logWarning("Exception in RecordReader.close()", e)
-              }
-          } finally {
-            reader = null
+        // We get our input bytes from thread-local Hadoop FileSystem statistics.
+        // If we do a coalesce, however, we are likely to compute multiple partitions in the same
+        // task and in the same thread, in which case we need to avoid override values written by
+        // previous partitions (SPARK-13071).
+        private def updateBytesRead(): Unit = {
+          getBytesReadCallback.foreach { getBytesRead =>
+            inputMetrics.setBytesRead(existingBytesRead + getBytesRead())
           }
-          if (getBytesReadCallback.isDefined) {
+        }
+
+        private var reader: RecordReader[K, V] = null
+        private val inputFormat = getInputFormat(jobConf)
+        HadoopRDD.addLocalConfiguration(
+          new SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(createTime),
+          context.stageId, partitionIndex, context.attemptNumber, jobConf)
+
+        reader =
+          try {
+            inputFormat.getRecordReader(theSplit, jobConf, Reporter.NULL)
+          } catch {
+            case e: IOException if ignoreCorruptFiles =>
+              logWarning(s"Skipped the rest content in the corrupted file: ${theSplit}", e)
+              finished = true
+              null
+          }
+        // Register an on-task-completion callback to close the input stream.
+        context.addTaskCompletionListener { context =>
+          // Update the bytes read before closing is to make sure lingering bytesRead statistics in
+          // this thread get correctly added.
+          updateBytesRead()
+          closeIfNeeded()
+        }
+
+        private val key: K = if (reader == null) null.asInstanceOf[K] else reader.createKey()
+        private val value: V = if (reader == null) null.asInstanceOf[V] else reader.createValue()
+
+        override def getNext(): (K, V) = {
+          try {
+            finished = !reader.next(key, value)
+          } catch {
+            case e: IOException if ignoreCorruptFiles =>
+              logWarning(s"Skipped the rest content in the corrupted file: ${theSplit}", e)
+              finished = true
+          }
+          if (!finished) {
+            inputMetrics.incRecordsRead(1)
+          }
+          if (inputMetrics.recordsRead %
+            SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
             updateBytesRead()
-          } else if (split.inputSplit.value.isInstanceOf[FileSplit] ||
-                     split.inputSplit.value.isInstanceOf[CombineFileSplit]) {
-            // If we can't get the bytes read from the FS stats, fall back to the split size,
-            // which may be inaccurate.
+          }
+          (key, value)
+        }
+
+        override def close(): Unit = {
+          if (reader != null) {
+            InputFileBlockHolder.unset()
             try {
-              inputMetrics.incBytesRead(split.inputSplit.value.getLength)
+              reader.close()
             } catch {
-              case e: java.io.IOException =>
-                logWarning("Unable to get input size to set InputMetrics for task", e)
+              case e: Exception =>
+                if (!ShutdownHookManager.inShutdown()) {
+                  logWarning("Exception in RecordReader.close()", e)
+                }
+            } finally {
+              reader = null
+            }
+            if (getBytesReadCallback.isDefined) {
+              updateBytesRead()
+            } else if (theSplit.isInstanceOf[FileSplit] ||
+              theSplit.isInstanceOf[CombineFileSplit]) {
+              // If we can't get the bytes read from the FS stats, fall back to the split size,
+              // which may be inaccurate.
+              try {
+                inputMetrics.incBytesRead(theSplit.getLength)
+              } catch {
+                case e: java.io.IOException =>
+                  logWarning("Unable to get input size to set InputMetrics for task", e)
+              }
             }
           }
         }
       }
+      iterators.append(new InterruptibleIterator[(K, V)](context, iter))
     }
-    new InterruptibleIterator[(K, V)](context, iter)
+    new MultipleIterator[(K, V)](iterators.toList)
   }
 
   /** Maps over a partition, providing the InputSplit that was used as the base of the partition. */
@@ -318,14 +384,19 @@ class HadoopRDD[K, V](
     new HadoopMapPartitionsWithSplitRDD(this, f, preservesPartitioning)
   }
 
-  override def getPreferredLocations(split: Partition): Seq[String] = {
-    val hsplit = split.asInstanceOf[HadoopPartition].inputSplit.value
-    val locs = hsplit match {
-      case lsplit: InputSplitWithLocationInfo =>
-        HadoopRDD.convertSplitLocationInfo(lsplit.getLocationInfo)
-      case _ => None
+  override def getPreferredLocations(partition: Partition): Seq[String] = {
+    val hPartition = partition.asInstanceOf[HadoopPartition]
+    val hSplits = hPartition.inputSplits
+    val prefLocs = new ArrayBuffer[Seq[String]]
+    for (hsplit <- hSplits) {
+      val locs = hsplit match {
+        case lsplit: InputSplitWithLocationInfo =>
+          HadoopRDD.convertSplitLocationInfo(lsplit.getLocationInfo)
+        case _ => None
+      }
+      prefLocs.append(locs.getOrElse(hsplit.value.getLocations.filter(_ != "localhost")))
     }
-    locs.getOrElse(hsplit.getLocations.filter(_ != "localhost"))
+    prefLocs.flatten
   }
 
   override def checkpoint() {
@@ -392,10 +463,16 @@ private[spark] object HadoopRDD extends Logging {
 
     override def getPartitions: Array[Partition] = firstParent[T].partitions
 
-    override def compute(split: Partition, context: TaskContext): Iterator[U] = {
-      val partition = split.asInstanceOf[HadoopPartition]
-      val inputSplit = partition.inputSplit.value
-      f(inputSplit, firstParent[T].iterator(split, context))
+    override def compute(partition: Partition, context: TaskContext): MultipleIterator[U] = {
+      val hPartition = partition.asInstanceOf[HadoopPartition]
+      val hSplits = hPartition.inputSplits
+      val iterators = new ListBuffer[Iterator[(U)]]
+      for (hSplit <- hSplits) {
+        val inputSplit = hSplit.value
+        iterators.append(f(inputSplit, firstParent[T].iterator(partition, context)))
+      }
+      new MultipleIterator[(U)](iterators.toList)
+
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2363,6 +2363,26 @@ private[spark] object Utils extends Logging {
     memoryStringToMb(conf.get("spark.driver.maxResultSize", "1g")).toLong << 20
   }
 
+  // The maximum number of bytes to pack into a single partition when reading files.
+  // Default is 128MB (parquet.block.size).
+  // Note: The defaults for this parameter are also defined in the sql module. The
+  // default values here should be kept in sync with the defaults in the sql module.
+  def getMaxPartitionBytes(conf: SparkConf): Long = {
+    val maxPartitionBytesDefault = 128*1024*1024L
+    conf.getLong("spark.sql.files.maxPartitionBytes", maxPartitionBytesDefault)
+  }
+
+  // The estimated cost to open a file, measured by the number of bytes could be scanned in
+  // the same time. This is used when putting multiple files into a partition. It's better to
+  // over estimated, then the partitions with small files will be faster than partitions with
+  // bigger files (which is scheduled first. Default is 4MB
+  // Note: The defaults for this parameter are also defined in the sql module. The
+  // default values here should be kept in sync with the defaults in the sql module.
+  def getFileOpenCostBytes(conf: SparkConf): Long = {
+    val fileOpenCostBytesDefault = 4*1024*1024L;
+    conf.getLong("spark.sql.files.openCostInBytes", fileOpenCostBytesDefault)
+  }
+
   /**
    * Return the current system LD_LIBRARY_PATH name
    */

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.rdd
 import java.io.File
 
 import scala.collection.Map
+import scala.collection.mutable.ArrayBuffer
 import scala.io.Codec
 
 import org.apache.hadoop.fs.Path
@@ -215,8 +216,9 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
       override val getDependencies = List[Dependency[_]]()
 
       override def compute(theSplit: Partition, context: TaskContext) = {
-        new InterruptibleIterator[(LongWritable, Text)](context, Iterator((new LongWritable(1),
-          new Text("b"))))
+        val iterator = new InterruptibleIterator[(LongWritable, Text)](context,
+          Iterator((new LongWritable(1), new Text("b"))))
+        new MultipleIterator[(LongWritable, Text)](List(iterator))
       }
     }
     val hadoopPart1 = generateFakeHadoopPartition()
@@ -241,7 +243,7 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
   def generateFakeHadoopPartition(): HadoopPartition = {
     val split = new FileSplit(new Path("/some/path"), 0, 1,
       Array[String]("loc1", "loc2", "loc3", "loc4", "loc5"))
-    new HadoopPartition(sc.newRddId(), 1, split)
+    new HadoopPartition(sc.newRddId(), 1, ArrayBuffer(split))
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark native read path allows tuning the partition size based on spark.sql.files.maxPartitionBytes and spark.sql.files.openCostInBytes. It would be useful to add a similar functionality/behavior to HadoopRDD, i.e, pack multiple input splits into a single partition based on maxPartitionBytes and openCostInBytes. We have had several use-cases to merge small files by coalescing them by size to reduce the number of tasks launched.

## How was this patch tested?
Added a unit test. It was also tested manually in a few production jobs. 
