### PR TITLE
[SPARK-22131][MESOS] Mesos driver secrets

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -493,33 +493,44 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td><code>(none)</code></td>
   <td>
-    A secret is specified by its contents and destination. These properties
-    specify a secret's contents. To specify a secret's destination, see the cell below.
-
-    You can specify a secret's contents either (1) by value or (2) by reference.
-    (1) To specify a secret by value, set the
-    <code>spark.mesos.[driver|executor].secret.values</code>
-    property, to make the secret available in the driver or executors.
-    For example, to make a secret password "guessme" available to the driver process, set:
+    <p>
+      A secret is specified by its contents and destination. These properties
+      specify a secret's contents. To specify a secret's destination, see the cell below.
+    </p>
+    <p>
+      You can specify a secret's contents either (1) by value or (2) by reference.
+    </p>
+    <p>
+      (1) To specify a secret by value, set the
+      <code>spark.mesos.[driver|executor].secret.values</code>
+      property, to make the secret available in the driver or executors.
+      For example, to make a secret password "guessme" available to the driver process, set:
     
-    <pre>spark.mesos.driver.secret.values=guessme</pre>
-    
-    (2) To specify a secret that has been placed in a secret store
-    by reference, specify its name within the secret store
-    by setting the <code>spark.mesos.[driver|executor].secret.names</code>
-    property. For example, to make a secret password named "password" in a secret store
-    available to the driver process, set:
+      <pre>spark.mesos.driver.secret.values=guessme</pre>
+    </p>
+    <p>
+      (2) To specify a secret that has been placed in a secret store
+      by reference, specify its name within the secret store
+      by setting the <code>spark.mesos.[driver|executor].secret.names</code>
+      property. For example, to make a secret password named "password" in a secret store
+      available to the driver process, set:
 
-    <pre>spark.mesos.driver.secret.names=password</pre>
+      <pre>spark.mesos.driver.secret.names=password</pre>
+    </p>
+    <p>
+      Note: To use a secret store, make sure one has been integrated with Mesos via a custom
+      <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
+      module</a>.
+    </p>
+    <p>
+      To specify multiple secrets, provide a comma-separated list:
 
-    To specify multiple secrets, provide a comma-separated list:
+      <pre>spark.mesos.driver.secret.values=guessme,passwd123</pre>
 
-    <pre>spark.mesos.driver.secret.values=guessme,passwd123</pre>
+      or
 
-    or
-
-    <pre>spark.mesos.driver.secret.names=password1,password2</pre>
-    
+      <pre>spark.mesos.driver.secret.names=password1,password2</pre>
+    </p>
   </td>
 </tr>
 
@@ -532,40 +543,48 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td><code>(none)</code></td>
   <td>
-    A secret is specified by its contents and destination. These properties
-    specify a secret's destination. To specify a secret's contents, see the cell above.
+    <p>
+      A secret is specified by its contents and destination. These properties
+      specify a secret's destination. To specify a secret's contents, see the cell above.
+    </p>
+    <p>
+      You can specify a secret's destination in the driver or
+      executors as either (1) an environment variable or (2) as a file.
+    </p>
+    <p>
+      (1) To make an environment-based secret, set the
+      <code>spark.mesos.[driver|executor].secret.envkeys</code> property.
+      The secret will appear as an environment variable with the
+      given name in the driver or executors. For example, to make a secret password available
+      to the driver process as $PASSWORD, set:
 
-    You can specify a secret's destination in the driver or
-    executors as either (1) an environment variable or (2) as a file.
-    (1) To make an environment-based secret, set the
-    <code>spark.mesos.[driver|executor].secret.envkeys</code> property.
-    The secret will appear as an environment variable with the
-    given name in the driver or executors. For example, to make a secret password available
-    to the driver process as $PASSWORD, set:
+      <pre>spark.mesos.driver.secret.envkeys=PASSWORD</pre>
+    </p>
+    <p>
+      (2) To make a file-based secret, set the
+      <code>spark.mesos.[driver|executor].secret.filenames</code> property.
+      The secret will appear in the contents of a file with the given file name in
+      the driver or executors. For example, to make a secret password available in a
+      file named "pwdfile" in the driver process, set:
 
-    <pre>spark.mesos.driver.secret.envkeys=PASSWORD</pre>
+      <pre>spark.mesos.driver.secret.filenames=pwdfile</pre>
+    </p>
+    <p>
+      Paths are relative to the container's work directory. Absolute paths must
+      already exist. Note: File-based secrets require a custom
+      <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
+      module</a>.
+    </p>
+    <p>
+      To specify env vars or file names corresponding to multiple secrets,
+      provide a comma-separated list:
 
-    (2) To make a file-based secret, set the
-    <code>spark.mesos.[driver|executor].secret.filenames</code> property.
-    The secret will appear in the contents of a file with the given file name in
-    the driver or executors. For example, to make a secret password available in a
-    file named "pwdfile" in the driver process, set:
-
-    <pre>spark.mesos.driver.secret.filenames=pwdfile</pre>
-
-    Paths are relative to the container's work directory. Absolute paths must
-    already exist. Note: File-based secrets require a custom
-    <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
-    module</a>.
+      <pre>spark.mesos.driver.secret.envkeys=PASSWORD1,PASSWORD2</pre>
     
-    To specify env vars or file names corresponding to multiple secrets,
-    provide a comma-separated list:
-
-    <pre>spark.mesos.driver.secret.envkeys=PASSWORD1,PASSWORD2</pre>
+      or
     
-    or
-    
-    <pre>spark.mesos.driver.secret.filenames=pwdfile1,pwdfile2</pre>
+      <pre>spark.mesos.driver.secret.filenames=pwdfile1,pwdfile2</pre>
+    </p>
   </td>
 </tr>
 

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -522,6 +522,43 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 
 <tr>
+  <td><code>spark.mesos.executor.secret.envkeys</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    A comma-separated list that, if set, the contents of the secret referenced
+    by spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
+    set to the provided environment variable in the executor's process.
+  </td>
+  </tr>
+  <tr>
+<td><code>spark.mesos.executor.secret.filenames</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    A comma-separated list that, if set, the contents of the secret referenced by
+    spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
+    written to the provided file. Paths are relative to the container's work
+    directory.  Absolute paths must already exist.  Consult the Mesos Secret
+    protobuf for more information.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.secret.names</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    A comma-separated list of secret references. Consult the Mesos Secret
+    protobuf for more information.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.secret.values</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    A comma-separated list of secret values. Consult the Mesos Secret
+    protobuf for more information.
+  </td>
+</tr>
+
+<tr>
   <td><code>spark.mesos.driverEnv.[EnvironmentVariableName]</code></td>
   <td><code>(none)</code></td>
   <td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -490,7 +490,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
     A comma-separated list that, if set, the contents of the secret referenced
     by spark.mesos.driver.secret.names or spark.mesos.driver.secret.values will be
-    set to the provided environment variable in the driver's process.
+    set to the provided environment variable in the driver's process. Example:
+    
+    <pre>ENVKEY1,ENVKEY2</pre>
   </td>
   </tr>
   <tr>
@@ -501,7 +503,9 @@ See the [configuration page](configuration.html) for information on Spark config
     spark.mesos.driver.secret.names or spark.mesos.driver.secret.values will be
     written to the provided file. Paths are relative to the container's work
     directory.  Absolute paths must already exist.  Consult the Mesos Secret
-    protobuf for more information.
+    protobuf for more information. Example:
+    
+    <pre>filename1,filename2</pre>
   </td>
 </tr>
 <tr>
@@ -509,7 +513,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>(none)</code></td>
   <td>
     A comma-separated list of secret references. Consult the Mesos Secret
-    protobuf for more information.
+    protobuf for more information. Example:
+    
+    <pre>secretname1,secretname2</pre>
   </td>
 </tr>
 <tr>
@@ -517,7 +523,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>(none)</code></td>
   <td>
     A comma-separated list of secret values. Consult the Mesos Secret
-    protobuf for more information.
+    protobuf for more information. Example:
+    
+    <pre>secretvalue1,secretvalue2</pre>
   </td>
 </tr>
 
@@ -527,7 +535,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
     A comma-separated list that, if set, the contents of the secret referenced
     by spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
-    set to the provided environment variable in the executor's process.
+    set to the provided environment variable in the executor's process. Example:
+    
+    <pre>ENVKEY1,ENVKEY2</pre>
   </td>
   </tr>
   <tr>
@@ -538,7 +548,9 @@ See the [configuration page](configuration.html) for information on Spark config
     spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
     written to the provided file. Paths are relative to the container's work
     directory.  Absolute paths must already exist.  Consult the Mesos Secret
-    protobuf for more information.
+    protobuf for more information. Example:
+    
+    <pre>filename1,filename2</pre>
   </td>
 </tr>
 <tr>
@@ -546,7 +558,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>(none)</code></td>
   <td>
     A comma-separated list of secret references. Consult the Mesos Secret
-    protobuf for more information.
+    protobuf for more information. Example:
+    
+    <pre>secretname1,secretname2</pre>
   </td>
 </tr>
 <tr>
@@ -554,7 +568,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>(none)</code></td>
   <td>
     A comma-separated list of secret values. Consult the Mesos Secret
-    protobuf for more information.
+    protobuf for more information. Example:
+    
+    <pre>secretvalue1,secretvalue2</pre>
   </td>
 </tr>
 

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -485,96 +485,87 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 
 <tr>
-  <td><code>spark.mesos.driver.secret.envkeys</code></td>
-  <td><code>(none)</code></td>
   <td>
-    A comma-separated list that, if set, the contents of the secret referenced
-    by spark.mesos.driver.secret.names or spark.mesos.driver.secret.values will be
-    set to the provided environment variable in the driver's process. Example:
-    
-    <pre>ENVKEY1,ENVKEY2</pre>
+    <code>spark.mesos.driver.secret.values</code>,
+    <code>spark.mesos.driver.secret.names</code>,
+    <code>spark.mesos.executor.secret.values</code>,
+    <code>spark.mesos.executor.secret.names</code>,
   </td>
-  </tr>
-  <tr>
-<td><code>spark.mesos.driver.secret.filenames</code></td>
   <td><code>(none)</code></td>
   <td>
-    A comma-separated list that, if set, the contents of the secret referenced by
-    spark.mesos.driver.secret.names or spark.mesos.driver.secret.values will be
-    written to the provided file. Paths are relative to the container's work
-    directory.  Absolute paths must already exist.  Consult the Mesos Secret
-    protobuf for more information. Note: File-based secrets require a custom
-    <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
-    module</a>. Example:
+    A secret is specified by its contents and destination. These properties
+    specify a secret's contents. To specify a secret's destination, see the cell below.
+
+    You can specify a secret's contents either (1) by value or (2) by reference.
+    (1) To specify a secret by value, set the
+    <code>spark.mesos.[driver|executor].secret.values</code>
+    property, to make the secret available in the driver or executors.
+    For example, to make a secret password "guessme" available to the driver process, set:
     
-    <pre>filename1,filename2</pre>
-  </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.driver.secret.names</code></td>
-  <td><code>(none)</code></td>
-  <td>
-    A comma-separated list of secret references. Consult the Mesos Secret
-    protobuf for more information. Example:
+    <pre>spark.mesos.driver.secret.values=guessme</pre>
     
-    <pre>secretname1,secretname2</pre>
-  </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.driver.secret.values</code></td>
-  <td><code>(none)</code></td>
-  <td>
-    A comma-separated list of secret values. Consult the Mesos Secret
-    protobuf for more information. Example:
+    (2) To specify a secret that has been placed in a secret store
+    by reference, specify its name within the secret store
+    by setting the <code>spark.mesos.[driver|executor].secret.names</code>
+    property. For example, to make a secret password named "password" in a secret store
+    available to the driver process, set:
+
+    <pre>spark.mesos.driver.secret.names=password</pre>
+
+    To specify multiple secrets, provide a comma-separated list:
+
+    <pre>spark.mesos.driver.secret.values=guessme,passwd123</pre>
+
+    or
+
+    <pre>spark.mesos.driver.secret.names=password1,password2</pre>
     
-    <pre>secretvalue1,secretvalue2</pre>
   </td>
 </tr>
 
 <tr>
-  <td><code>spark.mesos.executor.secret.envkeys</code></td>
-  <td><code>(none)</code></td>
   <td>
-    A comma-separated list that, if set, the contents of the secret referenced
-    by spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
-    set to the provided environment variable in the executor's process. Example:
-    
-    <pre>ENVKEY1,ENVKEY2</pre>
+    <code>spark.mesos.driver.secret.envkeys</code>,
+    <code>spark.mesos.driver.secret.filenames</code>,
+    <code>spark.mesos.executor.secret.envkeys</code>,
+    <code>spark.mesos.executor.secret.filenames</code>,
   </td>
-  </tr>
-  <tr>
-<td><code>spark.mesos.executor.secret.filenames</code></td>
   <td><code>(none)</code></td>
   <td>
-    A comma-separated list that, if set, the contents of the secret referenced by
-    spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
-    written to the provided file. Paths are relative to the container's work
-    directory.  Absolute paths must already exist.  Consult the Mesos Secret
-    protobuf for more information. Note: File-based secrets require a custom
+    A secret is specified by its contents and destination. These properties
+    specify a secret's destination. To specify a secret's contents, see the cell above.
+
+    You can specify a secret's destination in the driver or
+    executors as either (1) an environment variable or (2) as a file.
+    (1) To make an environment-based secret, set the
+    <code>spark.mesos.[driver|executor].secret.envkeys</code> property.
+    The secret will appear as an environment variable with the
+    given name in the driver or executors. For example, to make a secret password available
+    to the driver process as $PASSWORD, set:
+
+    <pre>spark.mesos.driver.secret.envkeys=PASSWORD</pre>
+
+    (2) To make a file-based secret, set the
+    <code>spark.mesos.[driver|executor].secret.filenames</code> property.
+    The secret will appear in the contents of a file with the given file name in
+    the driver or executors. For example, to make a secret password available in a
+    file named "pwdfile" in the driver process, set:
+
+    <pre>spark.mesos.driver.secret.filenames=pwdfile</pre>
+
+    Paths are relative to the container's work directory. Absolute paths must
+    already exist. Note: File-based secrets require a custom
     <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
-    module</a>. Example:
+    module</a>.
     
-    <pre>filename1,filename2</pre>
-  </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.executor.secret.names</code></td>
-  <td><code>(none)</code></td>
-  <td>
-    A comma-separated list of secret references. Consult the Mesos Secret
-    protobuf for more information. Example:
+    To specify env vars or file names corresponding to multiple secrets,
+    provide a comma-separated list:
+
+    <pre>spark.mesos.driver.secret.envkeys=PASSWORD1,PASSWORD2</pre>
     
-    <pre>secretname1,secretname2</pre>
-  </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.executor.secret.values</code></td>
-  <td><code>(none)</code></td>
-  <td>
-    A comma-separated list of secret values. Consult the Mesos Secret
-    protobuf for more information. Example:
+    or
     
-    <pre>secretvalue1,secretvalue2</pre>
+    <pre>spark.mesos.driver.secret.filenames=pwdfile1,pwdfile2</pre>
   </td>
 </tr>
 

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -503,7 +503,9 @@ See the [configuration page](configuration.html) for information on Spark config
     spark.mesos.driver.secret.names or spark.mesos.driver.secret.values will be
     written to the provided file. Paths are relative to the container's work
     directory.  Absolute paths must already exist.  Consult the Mesos Secret
-    protobuf for more information. Example:
+    protobuf for more information. Note: File-based secrets require a custom
+    <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
+    module</a>. Example:
     
     <pre>filename1,filename2</pre>
   </td>
@@ -548,7 +550,9 @@ See the [configuration page](configuration.html) for information on Spark config
     spark.mesos.executor.secret.names or spark.mesos.executor.secret.values will be
     written to the provided file. Paths are relative to the container's work
     directory.  Absolute paths must already exist.  Consult the Mesos Secret
-    protobuf for more information. Example:
+    protobuf for more information. Note: File-based secrets require a custom
+    <a href="http://mesos.apache.org/documentation/latest/secrets/">SecretResolver
+    module</a>. Example:
     
     <pre>filename1,filename2</pre>
   </td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.internal.config.ConfigBuilder
 
 private[spark] class MesosSecretConfig(taskType: String) {
-  private[spark] val SECRET_NAME =
+  private[spark] val SECRET_NAMES =
     ConfigBuilder(s"spark.mesos.$taskType.secret.names")
       .doc("A comma-separated list of secret reference names. Consult the Mesos Secret " +
         "protobuf for more information.")
@@ -30,14 +30,14 @@ private[spark] class MesosSecretConfig(taskType: String) {
       .toSequence
       .createOptional
 
-  private[spark] val SECRET_VALUE =
+  private[spark] val SECRET_VALUES =
     ConfigBuilder(s"spark.mesos.$taskType.secret.values")
       .doc("A comma-separated list of secret values.")
       .stringConf
       .toSequence
       .createOptional
 
-  private[spark] val SECRET_ENVKEY =
+  private[spark] val SECRET_ENVKEYS =
     ConfigBuilder(s"spark.mesos.$taskType.secret.envkeys")
       .doc("A comma-separated list of the environment variables to contain the secrets." +
         "The environment variable will be set on the driver.")
@@ -45,7 +45,7 @@ private[spark] class MesosSecretConfig(taskType: String) {
       .toSequence
       .createOptional
 
-  private[spark] val SECRET_FILENAME =
+  private[spark] val SECRET_FILENAMES =
     ConfigBuilder(s"spark.mesos.$taskType.secret.filenames")
       .doc("A comma-separated list of file paths secret will be written to.  Consult the Mesos " +
         "Secret protobuf for more information.")

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -21,40 +21,40 @@ import java.util.concurrent.TimeUnit
 
 import org.apache.spark.internal.config.ConfigBuilder
 
-private[spark] class MesosSecretConfig(taskType: String) {
-  private[spark] val SECRET_NAMES =
-    ConfigBuilder(s"spark.mesos.$taskType.secret.names")
-      .doc("A comma-separated list of secret reference names. Consult the Mesos Secret " +
-        "protobuf for more information.")
-      .stringConf
-      .toSequence
-      .createOptional
-
-  private[spark] val SECRET_VALUES =
-    ConfigBuilder(s"spark.mesos.$taskType.secret.values")
-      .doc("A comma-separated list of secret values.")
-      .stringConf
-      .toSequence
-      .createOptional
-
-  private[spark] val SECRET_ENVKEYS =
-    ConfigBuilder(s"spark.mesos.$taskType.secret.envkeys")
-      .doc("A comma-separated list of the environment variables to contain the secrets." +
-        "The environment variable will be set on the driver.")
-      .stringConf
-      .toSequence
-      .createOptional
-
-  private[spark] val SECRET_FILENAMES =
-    ConfigBuilder(s"spark.mesos.$taskType.secret.filenames")
-      .doc("A comma-separated list of file paths secret will be written to.  Consult the Mesos " +
-        "Secret protobuf for more information.")
-      .stringConf
-      .toSequence
-      .createOptional
-}
-
 package object config {
+
+  private[spark] class MesosSecretConfig private[config](taskType: String) {
+    private[spark] val SECRET_NAMES =
+      ConfigBuilder(s"spark.mesos.$taskType.secret.names")
+        .doc("A comma-separated list of secret reference names. Consult the Mesos Secret " +
+          "protobuf for more information.")
+        .stringConf
+        .toSequence
+        .createOptional
+
+    private[spark] val SECRET_VALUES =
+      ConfigBuilder(s"spark.mesos.$taskType.secret.values")
+        .doc("A comma-separated list of secret values.")
+        .stringConf
+        .toSequence
+        .createOptional
+
+    private[spark] val SECRET_ENVKEYS =
+      ConfigBuilder(s"spark.mesos.$taskType.secret.envkeys")
+        .doc("A comma-separated list of the environment variables to contain the secrets." +
+          "The environment variable will be set on the driver.")
+        .stringConf
+        .toSequence
+        .createOptional
+
+    private[spark] val SECRET_FILENAMES =
+      ConfigBuilder(s"spark.mesos.$taskType.secret.filenames")
+        .doc("A comma-separated list of file paths secret will be written to.  Consult the Mesos " +
+          "Secret protobuf for more information.")
+        .stringConf
+        .toSequence
+        .createOptional
+  }
 
   /* Common app configuration. */
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -21,6 +21,39 @@ import java.util.concurrent.TimeUnit
 
 import org.apache.spark.internal.config.ConfigBuilder
 
+private[spark] class MesosSecretConfig(taskType: String) {
+  private[spark] val SECRET_NAME =
+    ConfigBuilder(s"spark.mesos.$taskType.secret.names")
+      .doc("A comma-separated list of secret reference names. Consult the Mesos Secret " +
+        "protobuf for more information.")
+      .stringConf
+      .toSequence
+      .createOptional
+
+  private[spark] val SECRET_VALUE =
+    ConfigBuilder(s"spark.mesos.$taskType.secret.values")
+      .doc("A comma-separated list of secret values.")
+      .stringConf
+      .toSequence
+      .createOptional
+
+  private[spark] val SECRET_ENVKEY =
+    ConfigBuilder(s"spark.mesos.$taskType.secret.envkeys")
+      .doc("A comma-separated list of the environment variables to contain the secrets." +
+        "The environment variable will be set on the driver.")
+      .stringConf
+      .toSequence
+      .createOptional
+
+  private[spark] val SECRET_FILENAME =
+    ConfigBuilder(s"spark.mesos.$taskType.secret.filenames")
+      .doc("A comma-separated list of file paths secret will be written to.  Consult the Mesos " +
+        "Secret protobuf for more information.")
+      .stringConf
+      .toSequence
+      .createOptional
+}
+
 package object config {
 
   /* Common app configuration. */
@@ -64,36 +97,9 @@ package object config {
       .stringConf
       .createOptional
 
-  private[spark] val SECRET_NAME =
-    ConfigBuilder("spark.mesos.driver.secret.names")
-      .doc("A comma-separated list of secret reference names. Consult the Mesos Secret protobuf " +
-        "for more information.")
-      .stringConf
-      .toSequence
-      .createOptional
+  private[spark] val driverSecretConfig = new MesosSecretConfig("driver")
 
-  private[spark] val SECRET_VALUE =
-    ConfigBuilder("spark.mesos.driver.secret.values")
-      .doc("A comma-separated list of secret values.")
-      .stringConf
-      .toSequence
-      .createOptional
-
-  private[spark] val SECRET_ENVKEY =
-    ConfigBuilder("spark.mesos.driver.secret.envkeys")
-      .doc("A comma-separated list of the environment variables to contain the secrets." +
-        "The environment variable will be set on the driver.")
-      .stringConf
-      .toSequence
-      .createOptional
-
-  private[spark] val SECRET_FILENAME =
-    ConfigBuilder("spark.mesos.driver.secret.filenames")
-      .doc("A comma-seperated list of file paths secret will be written to.  Consult the Mesos " +
-        "Secret protobuf for more information.")
-      .stringConf
-      .toSequence
-      .createOptional
+  private[spark] val executorSecretConfig = new MesosSecretConfig("executor")
 
   private[spark] val DRIVER_FAILOVER_TIMEOUT =
     ConfigBuilder("spark.mesos.driver.failoverTimeout")

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -395,13 +395,13 @@ private[spark] class MesosClusterScheduler(
     // add secret environment variables
     MesosSchedulerBackendUtil.getSecretEnvVar(desc.conf, config.driverSecretConfig)
       .foreach { variable =>
-      if (variable.getSecret.getReference.isInitialized) {
-        logInfo(s"Setting reference secret ${variable.getSecret.getReference.getName} " +
-          s"on file ${variable.getName}")
-      } else {
-        logInfo(s"Setting secret on environment variable name=${variable.getName}")
-      }
-      envBuilder.addVariables(variable)
+        if (variable.getSecret.getReference.isInitialized) {
+          logInfo(s"Setting reference secret ${variable.getSecret.getReference.getName} " +
+            s"on file ${variable.getName}")
+        } else {
+          logInfo(s"Setting secret on environment variable name=${variable.getName}")
+        }
+        envBuilder.addVariables(variable)
     }
 
     envBuilder.build()
@@ -425,13 +425,13 @@ private[spark] class MesosClusterScheduler(
 
     MesosSchedulerBackendUtil.getSecretVolume(desc.conf, config.driverSecretConfig)
       .foreach { volume =>
-      if (volume.getSource.getSecret.getReference.isInitialized) {
-        logInfo(s"Setting reference secret ${volume.getSource.getSecret.getReference.getName} " +
-          s"on file ${volume.getContainerPath}")
-      } else {
-        logInfo(s"Setting secret on file name=${volume.getContainerPath}")
-      }
-      containerInfo.addVolumes(volume)
+        if (volume.getSource.getSecret.getReference.isInitialized) {
+          logInfo(s"Setting reference secret ${volume.getSource.getSecret.getReference.getName} " +
+            s"on file ${volume.getContainerPath}")
+        } else {
+          logInfo(s"Setting secret on file name=${volume.getContainerPath}")
+        }
+        containerInfo.addVolumes(volume)
     }
 
     containerInfo

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -28,7 +28,6 @@ import org.apache.mesos.{Scheduler, SchedulerDriver}
 import org.apache.mesos.Protos.{TaskState => MesosTaskState, _}
 import org.apache.mesos.Protos.Environment.Variable
 import org.apache.mesos.Protos.TaskStatus.Reason
-import org.apache.mesos.protobuf.ByteString
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException, TaskState}
 import org.apache.spark.deploy.mesos.MesosDriverDescription
@@ -394,37 +393,9 @@ private[spark] class MesosClusterScheduler(
     }
 
     // add secret environment variables
-    getSecretEnvVar(desc).foreach { variable =>
-      if (variable.getSecret.getReference.isInitialized) {
-        logInfo(s"Setting reference secret ${variable.getSecret.getReference.getName}" +
-          s"on file ${variable.getName}")
-      } else {
-        logInfo(s"Setting secret on environment variable name=${variable.getName}")
-      }
-      envBuilder.addVariables(variable)
-    }
+    MesosSchedulerBackendUtil.addSecretEnvVar(envBuilder, desc.conf, config.driverSecretConfig)
 
     envBuilder.build()
-  }
-
-  private def getSecretEnvVar(desc: MesosDriverDescription): List[Variable] = {
-    val secrets = getSecrets(desc)
-    val secretEnvKeys = desc.conf.get(config.SECRET_ENVKEY).getOrElse(Nil)
-    if (illegalSecretInput(secretEnvKeys, secrets)) {
-      throw new SparkException(
-        s"Need to give equal numbers of secrets and environment keys " +
-          s"for environment-based reference secrets got secrets $secrets, " +
-          s"and keys $secretEnvKeys")
-    }
-
-    secrets.zip(secretEnvKeys).map {
-      case (s, k) =>
-        Variable.newBuilder()
-          .setName(k)
-          .setType(Variable.Type.SECRET)
-          .setSecret(s)
-          .build
-    }.toList
   }
 
   private def getDriverUris(desc: MesosDriverDescription): List[CommandInfo.URI] = {
@@ -572,94 +543,11 @@ private[spark] class MesosClusterScheduler(
       .setName(s"Driver for ${appName}")
       .setSlaveId(offer.offer.getSlaveId)
       .setCommand(buildDriverCommand(desc))
-      .setContainer(getContainerInfo(desc))
+      .setContainer(MesosSchedulerBackendUtil.containerInfo(desc.conf, config.driverSecretConfig))
       .addAllResources(cpuResourcesToUse.asJava)
       .addAllResources(memResourcesToUse.asJava)
       .setLabels(driverLabels)
       .build
-  }
-
-  private def getContainerInfo(desc: MesosDriverDescription): ContainerInfo.Builder = {
-    val containerInfo = MesosSchedulerBackendUtil.containerInfo(desc.conf)
-
-    getSecretVolume(desc).foreach { volume =>
-      if (volume.getSource.getSecret.getReference.isInitialized) {
-        logInfo(s"Setting reference secret ${volume.getSource.getSecret.getReference.getName}" +
-          s"on file ${volume.getContainerPath}")
-      } else {
-        logInfo(s"Setting secret on file name=${volume.getContainerPath}")
-      }
-      containerInfo.addVolumes(volume)
-    }
-
-    containerInfo
-  }
-
-
-  private def getSecrets(desc: MesosDriverDescription): Seq[Secret] = {
-    def createValueSecret(data: String): Secret = {
-      Secret.newBuilder()
-        .setType(Secret.Type.VALUE)
-        .setValue(Secret.Value.newBuilder().setData(ByteString.copyFrom(data.getBytes)))
-        .build()
-    }
-
-    def createReferenceSecret(name: String): Secret = {
-      Secret.newBuilder()
-        .setReference(Secret.Reference.newBuilder().setName(name))
-        .setType(Secret.Type.REFERENCE)
-        .build()
-    }
-
-    val referenceSecrets: Seq[Secret] =
-      desc.conf.get(config.SECRET_NAME).getOrElse(Nil).map(s => createReferenceSecret(s))
-
-    val valueSecrets: Seq[Secret] = {
-      desc.conf.get(config.SECRET_VALUE).getOrElse(Nil).map(s => createValueSecret(s))
-    }
-
-    if (valueSecrets.nonEmpty && referenceSecrets.nonEmpty) {
-      throw new SparkException("Cannot specify VALUE type secrets and REFERENCE types ones")
-    }
-
-    if (referenceSecrets.nonEmpty) referenceSecrets else valueSecrets
-  }
-
-  private def illegalSecretInput(dest: Seq[String], s: Seq[Secret]): Boolean = {
-    if (dest.isEmpty) {  // no destination set (ie not using secrets of this type
-      return false
-    }
-    if (dest.nonEmpty && s.nonEmpty) {
-      // make sure there is a destination for each secret of this type
-      if (dest.length != s.length) {
-        return true
-      }
-    }
-    false
-  }
-
-  private def getSecretVolume(desc: MesosDriverDescription): List[Volume] = {
-    val secrets = getSecrets(desc)
-    val secretPaths: Seq[String] =
-      desc.conf.get(config.SECRET_FILENAME).getOrElse(Nil)
-
-    if (illegalSecretInput(secretPaths, secrets)) {
-      throw new SparkException(
-        s"Need to give equal numbers of secrets and file paths for file-based " +
-          s"reference secrets got secrets $secrets, and paths $secretPaths")
-    }
-
-    secrets.zip(secretPaths).map {
-      case (s, p) =>
-        val source = Volume.Source.newBuilder()
-          .setType(Volume.Source.Type.SECRET)
-          .setSecret(s)
-        Volume.newBuilder()
-          .setContainerPath(p)
-          .setSource(source)
-          .setMode(Volume.Mode.RO)
-          .build
-    }.toList
   }
 
   /**

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -543,7 +543,8 @@ private[spark] class MesosClusterScheduler(
       .setName(s"Driver for ${appName}")
       .setSlaveId(offer.offer.getSlaveId)
       .setCommand(buildDriverCommand(desc))
-      .setContainer(MesosSchedulerBackendUtil.containerInfo(desc.conf, config.driverSecretConfig))
+      .setContainer(MesosSchedulerBackendUtil.buildContainerInfo(
+        desc.conf, config.driverSecretConfig))
       .addAllResources(cpuResourcesToUse.asJava)
       .addAllResources(memResourcesToUse.asJava)
       .setLabels(driverLabels)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -460,7 +460,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             .setName(s"${sc.appName} $taskId")
             .setLabels(MesosProtoUtils.mesosLabels(taskLabels))
             .addAllResources(resourcesToUse.asJava)
-            .setContainer(MesosSchedulerBackendUtil.containerInfo(sc.conf, executorSecretConfig))
+            .setContainer(MesosSchedulerBackendUtil.buildContainerInfo(
+              sc.conf, executorSecretConfig))
 
           tasks(offer.getId) ::= taskBuilder.build()
           remainingResources(offerId) = resourcesLeft.asJava

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -28,7 +28,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.Future
 
-import org.apache.spark.{SecurityManager, SparkContext, SparkException, TaskState}
+import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkException, TaskState}
 import org.apache.spark.deploy.mesos.config._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.internal.config
@@ -233,7 +233,15 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         .build())
     }
 
-    MesosSchedulerBackendUtil.addSecretEnvVar(environment, conf, executorSecretConfig)
+    MesosSchedulerBackendUtil.getSecretEnvVar(conf, executorSecretConfig).foreach { variable =>
+      if (variable.getSecret.getReference.isInitialized) {
+        logInfo(s"Setting reference secret ${variable.getSecret.getReference.getName} " +
+          s"on file ${variable.getName}")
+      } else {
+        logInfo(s"Setting secret on environment variable name=${variable.getName}")
+      }
+      environment.addVariables(variable)
+    }
 
     val command = CommandInfo.newBuilder()
       .setEnvironment(environment)
@@ -409,6 +417,22 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     }
   }
 
+  private def getContainerInfo(conf: SparkConf): ContainerInfo.Builder = {
+    val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(conf)
+
+    MesosSchedulerBackendUtil.getSecretVolume(conf, executorSecretConfig).foreach { volume =>
+      if (volume.getSource.getSecret.getReference.isInitialized) {
+        logInfo(s"Setting reference secret ${volume.getSource.getSecret.getReference.getName} " +
+          s"on file ${volume.getContainerPath}")
+      } else {
+        logInfo(s"Setting secret on file name=${volume.getContainerPath}")
+      }
+      containerInfo.addVolumes(volume)
+    }
+
+    containerInfo
+  }
+
   /**
    * Returns a map from OfferIDs to the tasks to launch on those offers.  In order to maximize
    * per-task memory and IO, tasks are round-robin assigned to offers.
@@ -460,8 +484,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             .setName(s"${sc.appName} $taskId")
             .setLabels(MesosProtoUtils.mesosLabels(taskLabels))
             .addAllResources(resourcesToUse.asJava)
-            .setContainer(MesosSchedulerBackendUtil.buildContainerInfo(
-              sc.conf, executorSecretConfig))
+            .setContainer(getContainerInfo(sc.conf))
 
           tasks(offer.getId) ::= taskBuilder.build()
           remainingResources(offerId) = resourcesLeft.asJava

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -232,6 +232,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         .setValue(value)
         .build())
     }
+
+    MesosSchedulerBackendUtil.addSecretEnvVar(environment, conf, executorSecretConfig)
+
     val command = CommandInfo.newBuilder()
       .setEnvironment(environment)
 
@@ -457,7 +460,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             .setName(s"${sc.appName} $taskId")
             .setLabels(MesosProtoUtils.mesosLabels(taskLabels))
             .addAllResources(resourcesToUse.asJava)
-            .setContainer(MesosSchedulerBackendUtil.containerInfo(sc.conf))
+            .setContainer(MesosSchedulerBackendUtil.containerInfo(sc.conf, executorSecretConfig))
 
           tasks(offer.getId) ::= taskBuilder.build()
           remainingResources(offerId) = resourcesLeft.asJava

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -161,7 +161,7 @@ private[spark] class MesosFineGrainedSchedulerBackend(
       .setData(ByteString.copyFrom(createExecArg()))
 
     executorInfo.setContainer(
-      MesosSchedulerBackendUtil.buildContainerInfo(sc.conf, config.executorSecretConfig))
+      MesosSchedulerBackendUtil.buildContainerInfo(sc.conf))
     (executorInfo.build(), resourcesAfterMem.asJava)
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -28,6 +28,7 @@ import org.apache.mesos.SchedulerDriver
 import org.apache.mesos.protobuf.ByteString
 
 import org.apache.spark.{SparkContext, SparkException, TaskState}
+import org.apache.spark.deploy.mesos.config
 import org.apache.spark.executor.MesosExecutorBackend
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
@@ -159,7 +160,8 @@ private[spark] class MesosFineGrainedSchedulerBackend(
       .setCommand(command)
       .setData(ByteString.copyFrom(createExecArg()))
 
-    executorInfo.setContainer(MesosSchedulerBackendUtil.containerInfo(sc.conf))
+    executorInfo.setContainer(
+      MesosSchedulerBackendUtil.containerInfo(sc.conf, config.executorSecretConfig))
     (executorInfo.build(), resourcesAfterMem.asJava)
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackend.scala
@@ -161,7 +161,7 @@ private[spark] class MesosFineGrainedSchedulerBackend(
       .setData(ByteString.copyFrom(createExecArg()))
 
     executorInfo.setContainer(
-      MesosSchedulerBackendUtil.containerInfo(sc.conf, config.executorSecretConfig))
+      MesosSchedulerBackendUtil.buildContainerInfo(sc.conf, config.executorSecretConfig))
     (executorInfo.build(), resourcesAfterMem.asJava)
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -126,7 +126,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
     .toList
   }
 
-  def buildContainerInfo(conf: SparkConf, secretConfig: MesosSecretConfig):
+  def buildContainerInfo(conf: SparkConf):
   ContainerInfo.Builder = {
     val containerType = if (conf.contains("spark.mesos.executor.docker.image") &&
       conf.get("spark.mesos.containerizer", "docker") == "docker") {
@@ -175,32 +175,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
       containerInfo.addNetworkInfos(info)
     }
 
-    getSecretVolume(conf, secretConfig).foreach { volume =>
-      if (volume.getSource.getSecret.getReference.isInitialized) {
-        logInfo(s"Setting reference secret ${volume.getSource.getSecret.getReference.getName}" +
-          s"on file ${volume.getContainerPath}")
-      } else {
-        logInfo(s"Setting secret on file name=${volume.getContainerPath}")
-      }
-      containerInfo.addVolumes(volume)
-    }
-
     containerInfo
-  }
-
-  def addSecretEnvVar(
-      envBuilder: Environment.Builder,
-      conf: SparkConf,
-      secretConfig: MesosSecretConfig): Unit = {
-    getSecretEnvVar(conf, secretConfig).foreach { variable =>
-      if (variable.getSecret.getReference.isInitialized) {
-        logInfo(s"Setting reference secret ${variable.getSecret.getReference.getName}" +
-          s"on file ${variable.getName}")
-      } else {
-        logInfo(s"Setting secret on environment variable name=${variable.getName}")
-      }
-      envBuilder.addVariables(variable)
-    }
   }
 
   private def getSecrets(conf: SparkConf, secretConfig: MesosSecretConfig):
@@ -243,7 +218,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
     false
   }
 
-  private def getSecretVolume(conf: SparkConf, secretConfig: MesosSecretConfig): List[Volume] = {
+  def getSecretVolume(conf: SparkConf, secretConfig: MesosSecretConfig): List[Volume] = {
     val secrets = getSecrets(conf, secretConfig)
     val secretPaths: Seq[String] =
       conf.get(secretConfig.SECRET_FILENAMES).getOrElse(Nil)
@@ -267,7 +242,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
     }.toList
   }
 
-  private def getSecretEnvVar(conf: SparkConf, secretConfig: MesosSecretConfig):
+  def getSecretEnvVar(conf: SparkConf, secretConfig: MesosSecretConfig):
   List[Variable] = {
     val secrets = getSecrets(conf, secretConfig)
     val secretEnvKeys = conf.get(secretConfig.SECRET_ENVKEYS).getOrElse(Nil)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -178,8 +178,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
     containerInfo
   }
 
-  private def getSecrets(conf: SparkConf, secretConfig: MesosSecretConfig):
-  Seq[Secret] = {
+  private def getSecrets(conf: SparkConf, secretConfig: MesosSecretConfig): Seq[Secret] = {
     def createValueSecret(data: String): Secret = {
       Secret.newBuilder()
         .setType(Secret.Type.VALUE)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -127,7 +127,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
   }
 
   def buildContainerInfo(conf: SparkConf):
-  ContainerInfo.Builder = {
+    ContainerInfo.Builder = {
     val containerType = if (conf.contains("spark.mesos.executor.docker.image") &&
       conf.get("spark.mesos.containerizer", "docker") == "docker") {
       ContainerInfo.Type.DOCKER
@@ -242,7 +242,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
   }
 
   def getSecretEnvVar(conf: SparkConf, secretConfig: MesosSecretConfig):
-  List[Variable] = {
+    List[Variable] = {
     val secrets = getSecrets(conf, secretConfig)
     val secretEnvKeys = conf.get(secretConfig.SECRET_ENVKEYS).getOrElse(Nil)
     if (illegalSecretInput(secretEnvKeys, secrets)) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -24,8 +24,8 @@ import org.apache.mesos.protobuf.ByteString
 
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
-import org.apache.spark.deploy.mesos.MesosSecretConfig
 import org.apache.spark.deploy.mesos.config.{NETWORK_LABELS, NETWORK_NAME}
+import org.apache.spark.deploy.mesos.config.MesosSecretConfig
 import org.apache.spark.internal.Logging
 
 /**
@@ -126,8 +126,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
     .toList
   }
 
-  def buildContainerInfo(conf: SparkConf):
-    ContainerInfo.Builder = {
+  def buildContainerInfo(conf: SparkConf): ContainerInfo.Builder = {
     val containerType = if (conf.contains("spark.mesos.executor.docker.image") &&
       conf.get("spark.mesos.containerizer", "docker") == "docker") {
       ContainerInfo.Type.DOCKER
@@ -228,16 +227,15 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
           s"reference secrets got secrets $secrets, and paths $secretPaths")
     }
 
-    secrets.zip(secretPaths).map {
-      case (s, p) =>
-        val source = Volume.Source.newBuilder()
-          .setType(Volume.Source.Type.SECRET)
-          .setSecret(s)
-        Volume.newBuilder()
-          .setContainerPath(p)
-          .setSource(source)
-          .setMode(Volume.Mode.RO)
-          .build
+    secrets.zip(secretPaths).map { case (s, p) =>
+      val source = Volume.Source.newBuilder()
+        .setType(Volume.Source.Type.SECRET)
+        .setSecret(s)
+      Volume.newBuilder()
+        .setContainerPath(p)
+        .setSource(source)
+        .setMode(Volume.Mode.RO)
+        .build
     }.toList
   }
 
@@ -252,13 +250,12 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
           s"and keys $secretEnvKeys")
     }
 
-    secrets.zip(secretEnvKeys).map {
-      case (s, k) =>
-        Variable.newBuilder()
-          .setName(k)
-          .setType(Variable.Type.SECRET)
-          .setSecret(s)
-          .build
+    secrets.zip(secretEnvKeys).map { case (s, k) =>
+      Variable.newBuilder()
+        .setName(k)
+        .setType(Variable.Type.SECRET)
+        .setSecret(s)
+        .build
     }.toList
   }
 

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -193,14 +193,14 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
     }
 
     val referenceSecrets: Seq[Secret] =
-      conf.get(secretConfig.SECRET_NAMES).getOrElse(Nil).map(s => createReferenceSecret(s))
+      conf.get(secretConfig.SECRET_NAMES).getOrElse(Nil).map { s => createReferenceSecret(s) }
 
     val valueSecrets: Seq[Secret] = {
-      conf.get(secretConfig.SECRET_VALUES).getOrElse(Nil).map(s => createValueSecret(s))
+      conf.get(secretConfig.SECRET_VALUES).getOrElse(Nil).map { s => createValueSecret(s) }
     }
 
     if (valueSecrets.nonEmpty && referenceSecrets.nonEmpty) {
-      throw new SparkException("Cannot specify VALUE type secrets and REFERENCE types ones")
+      throw new SparkException("Cannot specify both value-type and reference-type secrets.")
     }
 
     if (referenceSecrets.nonEmpty) referenceSecrets else valueSecrets

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -24,7 +24,6 @@ import scala.collection.JavaConverters._
 import org.apache.mesos.Protos.{Environment, Secret, TaskState => MesosTaskState, _}
 import org.apache.mesos.Protos.Value.{Scalar, Type}
 import org.apache.mesos.SchedulerDriver
-import org.apache.mesos.protobuf.ByteString
 import org.mockito.{ArgumentCaptor, Matchers}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -32,6 +31,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
+import org.apache.spark.deploy.mesos.config
 
 class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext with MockitoSugar {
 
@@ -341,132 +341,33 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
   }
 
   test("Creates an env-based reference secrets.") {
-    setScheduler()
-
-    val mem = 1000
-    val cpu = 1
-    val secretName = "/path/to/secret,/anothersecret"
-    val envKey = "SECRET_ENV_KEY,PASSWORD"
-    val driverDesc = new MesosDriverDescription(
-      "d1",
-      "jar",
-      mem,
-      cpu,
-      true,
-      command,
-      Map("spark.mesos.executor.home" -> "test",
-        "spark.app.name" -> "test",
-        "spark.mesos.driver.secret.names" -> secretName,
-        "spark.mesos.driver.secret.envkeys" -> envKey),
-      "s1",
-      new Date())
-    val response = scheduler.submitDriver(driverDesc)
-    assert(response.success)
-    val offer = Utils.createOffer("o1", "s1", mem, cpu)
-    scheduler.resourceOffers(driver, Collections.singletonList(offer))
-    val launchedTasks = Utils.verifyTaskLaunched(driver, "o1")
-    assert(launchedTasks.head
-      .getCommand
-      .getEnvironment
-      .getVariablesCount == 3)  // SPARK_SUBMIT_OPS and the secret
-    val variableOne = launchedTasks.head.getCommand.getEnvironment
-      .getVariablesList.asScala.filter(_.getName == "SECRET_ENV_KEY").head
-    assert(variableOne.getSecret.isInitialized)
-    assert(variableOne.getSecret.getType == Secret.Type.REFERENCE)
-    assert(variableOne.getSecret.getReference.getName == "/path/to/secret")
-    assert(variableOne.getType == Environment.Variable.Type.SECRET)
-    val variableTwo = launchedTasks.head.getCommand.getEnvironment
-      .getVariablesList.asScala.filter(_.getName == "PASSWORD").head
-    assert(variableTwo.getSecret.isInitialized)
-    assert(variableTwo.getSecret.getType == Secret.Type.REFERENCE)
-    assert(variableTwo.getSecret.getReference.getName == "/anothersecret")
-    assert(variableTwo.getType == Environment.Variable.Type.SECRET)
+    val launchedTasks = launchDriverTask(
+      Utils.configEnvBasedRefSecrets(config.driverSecretConfig))
+    Utils.verifyEnvBasedRefSecrets(launchedTasks)
   }
 
   test("Creates an env-based value secrets.") {
-    setScheduler()
-    val mem = 1000
-    val cpu = 1
-    val secretValues = "user,password"
-    val envKeys = "USER,PASSWORD"
-    val driverDesc = new MesosDriverDescription(
-      "d1",
-      "jar",
-      mem,
-      cpu,
-      true,
-      command,
-      Map("spark.mesos.executor.home" -> "test",
-        "spark.app.name" -> "test",
-        "spark.mesos.driver.secret.values" -> secretValues,
-        "spark.mesos.driver.secret.envkeys" -> envKeys),
-      "s1",
-      new Date())
-    val response = scheduler.submitDriver(driverDesc)
-    assert(response.success)
-    val offer = Utils.createOffer("o1", "s1", mem, cpu)
-    scheduler.resourceOffers(driver, Collections.singletonList(offer))
-    val launchedTasks = Utils.verifyTaskLaunched(driver, "o1")
-    assert(launchedTasks.head
-      .getCommand
-      .getEnvironment
-      .getVariablesCount == 3)  // SPARK_SUBMIT_OPS and the secret
-    val variableOne = launchedTasks.head.getCommand.getEnvironment
-      .getVariablesList.asScala.filter(_.getName == "USER").head
-    assert(variableOne.getSecret.isInitialized)
-    assert(variableOne.getSecret.getType == Secret.Type.VALUE)
-    assert(variableOne.getSecret.getValue.getData == ByteString.copyFrom("user".getBytes))
-    assert(variableOne.getType == Environment.Variable.Type.SECRET)
-    val variableTwo = launchedTasks.head.getCommand.getEnvironment
-      .getVariablesList.asScala.filter(_.getName == "PASSWORD").head
-    assert(variableTwo.getSecret.isInitialized)
-    assert(variableTwo.getSecret.getType == Secret.Type.VALUE)
-    assert(variableTwo.getSecret.getValue.getData == ByteString.copyFrom("password".getBytes))
-    assert(variableTwo.getType == Environment.Variable.Type.SECRET)
+    val launchedTasks = launchDriverTask(
+      Utils.configEnvBasedValueSecrets(config.driverSecretConfig))
+    Utils.verifyEnvBasedValueSecrets(launchedTasks)
   }
 
   test("Creates file-based reference secrets.") {
-    setScheduler()
-    val mem = 1000
-    val cpu = 1
-    val secretName = "/path/to/secret,/anothersecret"
-    val secretPath = "/topsecret,/mypassword"
-    val driverDesc = new MesosDriverDescription(
-      "d1",
-      "jar",
-      mem,
-      cpu,
-      true,
-      command,
-      Map("spark.mesos.executor.home" -> "test",
-        "spark.app.name" -> "test",
-        "spark.mesos.driver.secret.names" -> secretName,
-        "spark.mesos.driver.secret.filenames" -> secretPath),
-      "s1",
-      new Date())
-    val response = scheduler.submitDriver(driverDesc)
-    assert(response.success)
-    val offer = Utils.createOffer("o1", "s1", mem, cpu)
-    scheduler.resourceOffers(driver, Collections.singletonList(offer))
-    val launchedTasks = Utils.verifyTaskLaunched(driver, "o1")
-    val volumes = launchedTasks.head.getContainer.getVolumesList
-    assert(volumes.size() == 2)
-    val secretVolOne = volumes.get(0)
-    assert(secretVolOne.getContainerPath == "/topsecret")
-    assert(secretVolOne.getSource.getSecret.getType == Secret.Type.REFERENCE)
-    assert(secretVolOne.getSource.getSecret.getReference.getName == "/path/to/secret")
-    val secretVolTwo = volumes.get(1)
-    assert(secretVolTwo.getContainerPath == "/mypassword")
-    assert(secretVolTwo.getSource.getSecret.getType == Secret.Type.REFERENCE)
-    assert(secretVolTwo.getSource.getSecret.getReference.getName == "/anothersecret")
+    val launchedTasks = launchDriverTask(
+      Utils.configFileBasedRefSecrets(config.driverSecretConfig))
+    Utils.verifyFileBasedRefSecrets(launchedTasks)
   }
 
   test("Creates a file-based value secrets.") {
+    val launchedTasks = launchDriverTask(
+      Utils.configFileBasedValueSecrets(config.driverSecretConfig))
+    Utils.verifyFileBasedValueSecrets(launchedTasks)
+  }
+
+  private def launchDriverTask(addlSparkConfVars: Map[String, String]): List[TaskInfo] = {
     setScheduler()
     val mem = 1000
     val cpu = 1
-    val secretValues = "user,password"
-    val secretPath = "/whoami,/mypassword"
     val driverDesc = new MesosDriverDescription(
       "d1",
       "jar",
@@ -475,27 +376,14 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       true,
       command,
       Map("spark.mesos.executor.home" -> "test",
-        "spark.app.name" -> "test",
-        "spark.mesos.driver.secret.values" -> secretValues,
-        "spark.mesos.driver.secret.filenames" -> secretPath),
+        "spark.app.name" -> "test") ++
+        addlSparkConfVars,
       "s1",
       new Date())
     val response = scheduler.submitDriver(driverDesc)
     assert(response.success)
     val offer = Utils.createOffer("o1", "s1", mem, cpu)
     scheduler.resourceOffers(driver, Collections.singletonList(offer))
-    val launchedTasks = Utils.verifyTaskLaunched(driver, "o1")
-    val volumes = launchedTasks.head.getContainer.getVolumesList
-    assert(volumes.size() == 2)
-    val secretVolOne = volumes.get(0)
-    assert(secretVolOne.getContainerPath == "/whoami")
-    assert(secretVolOne.getSource.getSecret.getType == Secret.Type.VALUE)
-    assert(secretVolOne.getSource.getSecret.getValue.getData ==
-      ByteString.copyFrom("user".getBytes))
-    val secretVolTwo = volumes.get(1)
-    assert(secretVolTwo.getContainerPath == "/mypassword")
-    assert(secretVolTwo.getSource.getSecret.getType == Secret.Type.VALUE)
-    assert(secretVolTwo.getSource.getSecret.getValue.getData ==
-      ByteString.copyFrom("password".getBytes))
+    Utils.verifyTaskLaunched(driver, "o1")
   }
 }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.mesos.config
 
 class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
 
@@ -26,7 +27,7 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     conf.set("spark.mesos.executor.docker.parameters", "a,b")
     conf.set("spark.mesos.executor.docker.image", "test")
 
-    val containerInfo = MesosSchedulerBackendUtil.containerInfo(conf)
+    val containerInfo = MesosSchedulerBackendUtil.containerInfo(conf, config.executorSecretConfig)
     val params = containerInfo.getDocker.getParametersList
 
     assert(params.size() == 0)
@@ -37,7 +38,7 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     conf.set("spark.mesos.executor.docker.parameters", "a=1,b=2,c=3")
     conf.set("spark.mesos.executor.docker.image", "test")
 
-    val containerInfo = MesosSchedulerBackendUtil.containerInfo(conf)
+    val containerInfo = MesosSchedulerBackendUtil.containerInfo(conf, config.executorSecretConfig)
     val params = containerInfo.getDocker.getParametersList
     assert(params.size() == 3)
     assert(params.get(0).getKey == "a")

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
@@ -28,7 +28,7 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     conf.set("spark.mesos.executor.docker.image", "test")
 
     val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(
-      conf, config.executorSecretConfig)
+      conf)
     val params = containerInfo.getDocker.getParametersList
 
     assert(params.size() == 0)
@@ -40,7 +40,7 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     conf.set("spark.mesos.executor.docker.image", "test")
 
     val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(
-      conf, config.executorSecretConfig)
+      conf)
     val params = containerInfo.getDocker.getParametersList
     assert(params.size() == 3)
     assert(params.get(0).getKey == "a")

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtilSuite.scala
@@ -27,7 +27,8 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     conf.set("spark.mesos.executor.docker.parameters", "a,b")
     conf.set("spark.mesos.executor.docker.image", "test")
 
-    val containerInfo = MesosSchedulerBackendUtil.containerInfo(conf, config.executorSecretConfig)
+    val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(
+      conf, config.executorSecretConfig)
     val params = containerInfo.getDocker.getParametersList
 
     assert(params.size() == 0)
@@ -38,7 +39,8 @@ class MesosSchedulerBackendUtilSuite extends SparkFunSuite {
     conf.set("spark.mesos.executor.docker.parameters", "a=1,b=2,c=3")
     conf.set("spark.mesos.executor.docker.image", "test")
 
-    val containerInfo = MesosSchedulerBackendUtil.containerInfo(conf, config.executorSecretConfig)
+    val containerInfo = MesosSchedulerBackendUtil.buildContainerInfo(
+      conf, config.executorSecretConfig)
     val params = containerInfo.getDocker.getParametersList
     assert(params.size() == 3)
     assert(params.get(0).getKey == "a")

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -28,7 +28,7 @@ import org.apache.mesos.protobuf.ByteString
 import org.mockito.{ArgumentCaptor, Matchers}
 import org.mockito.Mockito._
 
-import org.apache.spark.deploy.mesos.MesosSecretConfig
+import org.apache.spark.deploy.mesos.config.MesosSecretConfig
 
 object Utils {
 

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -113,8 +113,8 @@ object Utils {
     val secretName = "/path/to/secret,/anothersecret"
     val envKey = "SECRET_ENV_KEY,PASSWORD"
     Map(
-      secretConfig.SECRET_NAME.key -> secretName,
-      secretConfig.SECRET_ENVKEY.key -> envKey
+      secretConfig.SECRET_NAMES.key -> secretName,
+      secretConfig.SECRET_ENVKEYS.key -> envKey
     )
   }
 
@@ -125,7 +125,7 @@ object Utils {
       .getVariablesList
       .asScala
     assert(envVars
-      .filter(!_.getName.startsWith("SPARK_")).length == 2)  // user-defined secret env vars
+      .count(!_.getName.startsWith("SPARK_")) == 2)  // user-defined secret env vars
     val variableOne = envVars.filter(_.getName == "SECRET_ENV_KEY").head
     assert(variableOne.getSecret.isInitialized)
     assert(variableOne.getSecret.getType == Secret.Type.REFERENCE)
@@ -142,8 +142,8 @@ object Utils {
     val secretValues = "user,password"
     val envKeys = "USER,PASSWORD"
     Map(
-      secretConfig.SECRET_VALUE.key -> secretValues,
-      secretConfig.SECRET_ENVKEY.key -> envKeys
+      secretConfig.SECRET_VALUES.key -> secretValues,
+      secretConfig.SECRET_ENVKEYS.key -> envKeys
     )
   }
 
@@ -154,7 +154,7 @@ object Utils {
       .getVariablesList
       .asScala
     assert(envVars
-      .filter(!_.getName.startsWith("SPARK_")).length == 2)  // user-defined secret env vars
+      .count(!_.getName.startsWith("SPARK_")) == 2)  // user-defined secret env vars
     val variableOne = envVars.filter(_.getName == "USER").head
     assert(variableOne.getSecret.isInitialized)
     assert(variableOne.getSecret.getType == Secret.Type.VALUE)
@@ -171,8 +171,8 @@ object Utils {
     val secretName = "/path/to/secret,/anothersecret"
     val secretPath = "/topsecret,/mypassword"
     Map(
-      secretConfig.SECRET_NAME.key -> secretName,
-      secretConfig.SECRET_FILENAME.key -> secretPath
+      secretConfig.SECRET_NAMES.key -> secretName,
+      secretConfig.SECRET_FILENAMES.key -> secretPath
     )
   }
 
@@ -193,8 +193,8 @@ object Utils {
     val secretValues = "user,password"
     val secretPath = "/whoami,/mypassword"
     Map(
-      secretConfig.SECRET_VALUE.key -> secretValues,
-      secretConfig.SECRET_FILENAME.key -> secretPath
+      secretConfig.SECRET_VALUES.key -> secretValues,
+      secretConfig.SECRET_FILENAMES.key -> secretPath
     )
   }
 

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -24,8 +24,11 @@ import scala.collection.JavaConverters._
 import org.apache.mesos.Protos._
 import org.apache.mesos.Protos.Value.{Range => MesosRange, Ranges, Scalar}
 import org.apache.mesos.SchedulerDriver
+import org.apache.mesos.protobuf.ByteString
 import org.mockito.{ArgumentCaptor, Matchers}
 import org.mockito.Mockito._
+
+import org.apache.spark.deploy.mesos.MesosSecretConfig
 
 object Utils {
 
@@ -104,5 +107,109 @@ object Utils {
 
   def createTaskId(taskId: String): TaskID = {
     TaskID.newBuilder().setValue(taskId).build()
+  }
+
+  def configEnvBasedRefSecrets(secretConfig: MesosSecretConfig): Map[String, String] = {
+    val secretName = "/path/to/secret,/anothersecret"
+    val envKey = "SECRET_ENV_KEY,PASSWORD"
+    Map(
+      secretConfig.SECRET_NAME.key -> secretName,
+      secretConfig.SECRET_ENVKEY.key -> envKey
+    )
+  }
+
+  def verifyEnvBasedRefSecrets(launchedTasks: List[TaskInfo]): Unit = {
+    val envVars = launchedTasks.head
+      .getCommand
+      .getEnvironment
+      .getVariablesList
+      .asScala
+    assert(envVars
+      .filter(!_.getName.startsWith("SPARK_")).length == 2)  // user-defined secret env vars
+    val variableOne = envVars.filter(_.getName == "SECRET_ENV_KEY").head
+    assert(variableOne.getSecret.isInitialized)
+    assert(variableOne.getSecret.getType == Secret.Type.REFERENCE)
+    assert(variableOne.getSecret.getReference.getName == "/path/to/secret")
+    assert(variableOne.getType == Environment.Variable.Type.SECRET)
+    val variableTwo = envVars.filter(_.getName == "PASSWORD").head
+    assert(variableTwo.getSecret.isInitialized)
+    assert(variableTwo.getSecret.getType == Secret.Type.REFERENCE)
+    assert(variableTwo.getSecret.getReference.getName == "/anothersecret")
+    assert(variableTwo.getType == Environment.Variable.Type.SECRET)
+  }
+
+  def configEnvBasedValueSecrets(secretConfig: MesosSecretConfig): Map[String, String] = {
+    val secretValues = "user,password"
+    val envKeys = "USER,PASSWORD"
+    Map(
+      secretConfig.SECRET_VALUE.key -> secretValues,
+      secretConfig.SECRET_ENVKEY.key -> envKeys
+    )
+  }
+
+  def verifyEnvBasedValueSecrets(launchedTasks: List[TaskInfo]): Unit = {
+    val envVars = launchedTasks.head
+      .getCommand
+      .getEnvironment
+      .getVariablesList
+      .asScala
+    assert(envVars
+      .filter(!_.getName.startsWith("SPARK_")).length == 2)  // user-defined secret env vars
+    val variableOne = envVars.filter(_.getName == "USER").head
+    assert(variableOne.getSecret.isInitialized)
+    assert(variableOne.getSecret.getType == Secret.Type.VALUE)
+    assert(variableOne.getSecret.getValue.getData == ByteString.copyFrom("user".getBytes))
+    assert(variableOne.getType == Environment.Variable.Type.SECRET)
+    val variableTwo = envVars.filter(_.getName == "PASSWORD").head
+    assert(variableTwo.getSecret.isInitialized)
+    assert(variableTwo.getSecret.getType == Secret.Type.VALUE)
+    assert(variableTwo.getSecret.getValue.getData == ByteString.copyFrom("password".getBytes))
+    assert(variableTwo.getType == Environment.Variable.Type.SECRET)
+  }
+
+  def configFileBasedRefSecrets(secretConfig: MesosSecretConfig): Map[String, String] = {
+    val secretName = "/path/to/secret,/anothersecret"
+    val secretPath = "/topsecret,/mypassword"
+    Map(
+      secretConfig.SECRET_NAME.key -> secretName,
+      secretConfig.SECRET_FILENAME.key -> secretPath
+    )
+  }
+
+  def verifyFileBasedRefSecrets(launchedTasks: List[TaskInfo]): Unit = {
+    val volumes = launchedTasks.head.getContainer.getVolumesList
+    assert(volumes.size() == 2)
+    val secretVolOne = volumes.get(0)
+    assert(secretVolOne.getContainerPath == "/topsecret")
+    assert(secretVolOne.getSource.getSecret.getType == Secret.Type.REFERENCE)
+    assert(secretVolOne.getSource.getSecret.getReference.getName == "/path/to/secret")
+    val secretVolTwo = volumes.get(1)
+    assert(secretVolTwo.getContainerPath == "/mypassword")
+    assert(secretVolTwo.getSource.getSecret.getType == Secret.Type.REFERENCE)
+    assert(secretVolTwo.getSource.getSecret.getReference.getName == "/anothersecret")
+  }
+
+  def configFileBasedValueSecrets(secretConfig: MesosSecretConfig): Map[String, String] = {
+    val secretValues = "user,password"
+    val secretPath = "/whoami,/mypassword"
+    Map(
+      secretConfig.SECRET_VALUE.key -> secretValues,
+      secretConfig.SECRET_FILENAME.key -> secretPath
+    )
+  }
+
+  def verifyFileBasedValueSecrets(launchedTasks: List[TaskInfo]): Unit = {
+    val volumes = launchedTasks.head.getContainer.getVolumesList
+    assert(volumes.size() == 2)
+    val secretVolOne = volumes.get(0)
+    assert(secretVolOne.getContainerPath == "/whoami")
+    assert(secretVolOne.getSource.getSecret.getType == Secret.Type.VALUE)
+    assert(secretVolOne.getSource.getSecret.getValue.getData ==
+      ByteString.copyFrom("user".getBytes))
+    val secretVolTwo = volumes.get(1)
+    assert(secretVolTwo.getContainerPath == "/mypassword")
+    assert(secretVolTwo.getSource.getSecret.getType == Secret.Type.VALUE)
+    assert(secretVolTwo.getSource.getSecret.getValue.getData ==
+      ByteString.copyFrom("password".getBytes))
   }
 }


### PR DESCRIPTION
## Background

In #18837 , @ArtRand added Mesos secrets support to the dispatcher. **This PR is to add the same secrets support to the drivers.** This means if the secret configs are set, the driver will launch executors that have access to either env or file-based secrets.

One use case for this is to support TLS in the driver <=> executor communication.

## What changes were proposed in this pull request?

Most of the changes are a refactor of the dispatcher secrets support (#18837) - moving it to a common place that can be used by both the dispatcher and drivers. The same goes for the unit tests.

## How was this patch tested?

There are four config combinations: [env or file-based] x [value or reference secret]. For each combination:
- Added a unit test.
- Tested in DC/OS.
