### PR TITLE
[SPARK-22212][SQL][PySpark] Some SQL functions in Python fail with string column name

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -37,7 +37,7 @@ def _create_function(name, doc=""):
     """ Create a function for aggregator by name"""
     def _(col):
         sc = SparkContext._active_spark_context
-        jc = getattr(sc._jvm.functions, name)(col._jc if isinstance(col, Column) else col)
+        jc = getattr(sc._jvm.functions, name)(_to_java_column(col))
         return Column(jc)
     _.__name__ = name
     _.__doc__ = doc

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -33,6 +33,17 @@ from pyspark.sql.column import Column, _to_java_column, _to_seq
 from pyspark.sql.dataframe import DataFrame
 
 
+def _create_function_by_column_name(name, doc=""):
+    """ Create a function for aggregator by name"""
+    def _(col):
+        sc = SparkContext._active_spark_context
+        jc = getattr(sc._jvm.functions, name)(col)
+        return Column(jc)
+    _.__name__ = name
+    _.__doc__ = doc
+    return _
+
+
 def _create_function(name, doc=""):
     """ Create a function for aggregator by name"""
     def _(col):
@@ -67,19 +78,23 @@ def _create_window_function(name, doc=''):
     _.__doc__ = 'Window function: ' + doc
     return _
 
+
 _lit_doc = """
     Creates a :class:`Column` of literal value.
 
     >>> df.select(lit(5).alias('height')).withColumn('spark_user', lit(True)).take(1)
     [Row(height=5, spark_user=True)]
     """
-_functions = {
+
+_functions_by_column_name = {
     'lit': _lit_doc,
     'col': 'Returns a :class:`Column` based on the given column name.',
     'column': 'Returns a :class:`Column` based on the given column name.',
     'asc': 'Returns a sort expression based on the ascending order of the given column name.',
     'desc': 'Returns a sort expression based on the descending order of the given column name.',
+}
 
+_functions = {
     'upper': 'Converts a string expression to upper case.',
     'lower': 'Converts a string expression to upper case.',
     'sqrt': 'Computes the square root of the specified float value.',
@@ -207,6 +222,8 @@ _window_functions = {
         """returns the relative rank (i.e. percentile) of rows within a window partition.""",
 }
 
+for _name, _doc in _functions_by_column_name.items():
+    globals()[_name] = since(1.3)(_create_function_by_column_name(_name, _doc))
 for _name, _doc in _functions.items():
     globals()[_name] = since(1.3)(_create_function(_name, _doc))
 for _name, _doc in _functions_1_4.items():
@@ -220,6 +237,7 @@ for _name, _doc in _functions_1_6.items():
 for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
 del _name, _doc
+
 
 
 @since(1.3)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2583,6 +2583,28 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(df.first(), Row(longarray=[-9223372036854775808, 0, 9223372036854775807]))
 
 
+    def test_create_function_by_column_name(self):
+        import pyspark.sql.functions as func
+
+        # If column name argument is not accepted, exception will be thrown
+        for function_name in func._functions_by_column_name.keys():
+            f = getattr(func, function_name)
+            col = f('text')
+            # We expect to get column as an output
+            self.assertTrue(isinstance(col, Column))
+
+
+    def test_create_function(self):
+        import pyspark.sql.functions as func
+
+        # If column name argument is not accepted, exception will be thrown
+        for function_name in func._functions.keys():
+            f = getattr(func, function_name)
+            col = f('text')
+            # We expect to get column as an output
+            self.assertTrue(isinstance(col, Column))
+
+
 class HiveSparkSubmitTests(SparkSubmitTests):
 
     def test_hivecontext(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

The issue in JIRA: [SPARK-22212](https://issues.apache.org/jira/browse/SPARK-22212)

Most of the functions in `pyspark.sql.functions` allow usage of both column name string and `Column` object. But there are some functions, like `trim`, that require to pass only `Column`. See below code for explanation.

```
>>> import pyspark.sql.functions as func
>>> df = spark.createDataFrame([tuple(l) for l in "abcde"], ["text"])
>>> df.select(func.trim(df["text"])).show()
+----------+
|trim(text)|
+----------+
|         a|
|         b|
|         c|
|         d|
|         e|
+----------+
>>> df.select(func.trim("text")).show()
[...]
Py4JError: An error occurred while calling z:org.apache.spark.sql.functions.trim. Trace:
py4j.Py4JException: Method trim([class java.lang.String]) does not exist
        at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:318)
        at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:339)
        at py4j.Gateway.invoke(Gateway.java:274)
        at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
        at py4j.commands.CallCommand.execute(CallCommand.java:79)
        at py4j.GatewayConnection.run(GatewayConnection.java:214)
        at java.lang.Thread.run(Thread.java:748)
```

This is because most of the Python function calls map column name to `Column` in the Python function mapping, but functions created via `_create_function` pass them as is, if they are not `Column`. On the other hand, few functions that require the column name has been moved `functions_by_column_name`, and are created by `_create_function_by_column_name`.

Note that this is only Python-side fix. Some Scala functions still do not have method to call them by string column name.

## How was this patch tested?

Additional Python tests where written to accommodate this. It was tested via `UnitTest` in IDE and the overall `python\run_tests` script.
