### PR TITLE
[SPARK-22215][SQL] Add configuration to set the threshold for generated class

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -279,11 +279,13 @@ class CodegenContext {
       inlineToOuterClass: Boolean = false): String = {
     // The number of named constants that can exist in the class is limited by the Constant Pool
     // limit, 65,536. We cannot know how many constants will be inserted for a class, so we use a
-    // threshold of 1600k bytes to determine when a function should be inlined to a private, nested
-    // sub-class.
+    // threshold to determine when a function should be inlined to a private, nested sub-class
+    val generatedClassLengthThreshold = SparkEnv.get.conf.getInt(
+      SQLConf.GENERATED_CLASS_LENGTH_THRESHOLD.key,
+      SQLConf.GENERATED_CLASS_LENGTH_THRESHOLD.defaultValue.get)
     val (className, classInstance) = if (inlineToOuterClass) {
       outerClassName -> ""
-    } else if (currClassSize > 1600000) {
+    } else if (currClassSize > generatedClassLengthThreshold) {
       val className = freshName("NestedClass")
       val classInstance = freshName("nestedClassInstance")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -280,9 +280,7 @@ class CodegenContext {
     // The number of named constants that can exist in the class is limited by the Constant Pool
     // limit, 65,536. We cannot know how many constants will be inserted for a class, so we use a
     // threshold to determine when a function should be inlined to a private, nested sub-class
-    val generatedClassLengthThreshold = SparkEnv.get.conf.getInt(
-      SQLConf.GENERATED_CLASS_LENGTH_THRESHOLD.key,
-      SQLConf.GENERATED_CLASS_LENGTH_THRESHOLD.defaultValue.get)
+    val generatedClassLengthThreshold = SQLConf.get.generatedClassLengthThreshold
     val (className, classInstance) = if (inlineToOuterClass) {
       outerClassName -> ""
     } else if (currClassSize > generatedClassLengthThreshold) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -934,6 +934,15 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val GENERATED_CLASS_LENGTH_THRESHOLD =
+    buildConf("spark.sql.codegen.generatedClass.size.threshold")
+      .doc("Threshold in bytes for the size of a generated class. If the generated class " +
+        "size is higher of this value, a private nested class is created and used." +
+        "This is useful to limit the number of named constants in the class " +
+        "and therefore its Constant Pool. The default is 1600k.")
+      .intConf
+      .createWithDefault(1600000)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1223,6 +1223,8 @@ class SQLConf extends Serializable with Logging {
 
   def arrowMaxRecordsPerBatch: Int = getConf(ARROW_EXECUTION_MAX_RECORDS_PER_BATCH)
 
+  def generatedClassLengthThreshold: Int = getConf(GENERATED_CLASS_LENGTH_THRESHOLD)
+
   /** ********************** SQLConf functionality methods ************ */
 
   /** Set Spark SQL configuration properties. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -936,11 +936,14 @@ object SQLConf {
 
   val GENERATED_CLASS_LENGTH_THRESHOLD =
     buildConf("spark.sql.codegen.generatedClass.size.threshold")
+      .internal()
       .doc("Threshold in bytes for the size of a generated class. If the generated class " +
         "size is higher of this value, a private nested class is created and used." +
         "This is useful to limit the number of named constants in the class " +
         "and therefore its Constant Pool. The default is 1600k.")
       .intConf
+      .checkValue(bytes => bytes > 0, "The maximum size of a generated class " +
+        "in bytes must be a positive number.")
       .createWithDefault(1600000)
 
   object Deprecated {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-18016 introduced an arbitrary threshold for the size of a generated class (https://github.com/apache/spark/blob/83488cc3180ca18f829516f550766efb3095881e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala#L286). This value is hardcoded.
In some cases making it smaller can help avoiding the error of exceeding the maximum number of entries in the Constant Pool.
This PR introduces a new configuration parameter, which defaults to the previous value, but it allows to set this to a smaller one if needed.

## How was this patch tested?
manual tests