### PR TITLE
[SPARK-22136][SS] Evaluate one-sided conditions early in stream-stream joins.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -124,7 +124,7 @@ class IncrementalExecution(
           eventTimeWatermark = Some(offsetSeqMetadata.batchWatermarkMs),
           stateWatermarkPredicates =
             StreamingSymmetricHashJoinHelper.getStateWatermarkPredicates(
-              j.left.output, j.right.output, j.leftKeys, j.rightKeys, j.condition,
+              j.left.output, j.right.output, j.leftKeys, j.rightKeys, j.condition.full,
               Some(offsetSeqMetadata.batchWatermarkMs))
         )
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -288,9 +288,10 @@ case class StreamingSymmetricHashJoinExec(
       case _ => throwBadJoinTypeException()
     }
 
+    val outputProjection = UnsafeProjection.create(left.output ++ right.output, output)
     val outputIterWithMetrics = outputIter.map { row =>
       numOutputRows += 1
-      row
+      outputProjection(row)
     }
 
     // Function to remove old state after all the input has been consumed and output generated

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -215,13 +215,13 @@ case class StreamingSymmetricHashJoinExec(
 
     val leftSideJoiner = new OneSideHashJoiner(
       LeftSide, left.output, leftKeys, leftInputIter,
-      condition.left, stateWatermarkPredicates.left)
+      condition.leftSideOnly, stateWatermarkPredicates.left)
     val rightSideJoiner = new OneSideHashJoiner(
       RightSide, right.output, rightKeys, rightInputIter,
-      condition.right, stateWatermarkPredicates.right)
+      condition.rightSideOnly, stateWatermarkPredicates.right)
 
     // Filter the joined rows based on the given condition.
-    val joinedFilter = newPredicate(condition.joined.getOrElse(Literal(true)), output).eval _
+    val joinedFilter = newPredicate(condition.bothSides.getOrElse(Literal(true)), output).eval _
 
     //  Join one side input using the other side's buffered/state rows. Here is how it is done.
     //

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -187,6 +187,7 @@ case class StreamingSymmetricHashJoinExec(
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
+    print(this)
     val stateStoreCoord = sqlContext.sessionState.streamingQueryManager.stateStoreCoordinator
     val stateStoreNames = SymmetricHashJoinStateManager.allStateStoreNames(LeftSide, RightSide)
     left.execute().stateStoreAwareZipPartitions(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -377,7 +377,8 @@ case class StreamingSymmetricHashJoinExec(
     // Filter the joined rows based on the given condition.
     val preJoinFilter =
       newPredicate(preJoinFilterExpr.getOrElse(Literal(true)), inputAttributes).eval _
-    val postJoinFilter = newPredicate(postJoinFilterExpr.getOrElse(Literal(true)), output).eval _
+    val postJoinFilter =
+      newPredicate(postJoinFilterExpr.getOrElse(Literal(true)), left.output ++ right.output).eval _
 
     private val joinStateManager = new SymmetricHashJoinStateManager(
       joinSide, inputAttributes, joinKeys, stateInfo, storeConf, hadoopConfBcast.value.value)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -187,7 +187,6 @@ case class StreamingSymmetricHashJoinExec(
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
-    print(this)
     val stateStoreCoord = sqlContext.sessionState.streamingQueryManager.stateStoreCoordinator
     val stateStoreNames = SymmetricHashJoinStateManager.allStateStoreNames(LeftSide, RightSide)
     left.execute().stateStoreAwareZipPartitions(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -75,15 +75,15 @@ object StreamingSymmetricHashJoinHelper extends Logging {
    * their condition. Any conjuncts after the first nondeterministic one are treated as
    * nondeterministic for purposes of the split.
    *
-   * @param left Deterministic conjuncts which reference only the left side of the join.
-   * @param right Deterministic conjuncts which reference only the right side of the join.
-   * @param joined Conjuncts which are in neither left nor right.
+   * @param leftSideOnly Deterministic conjuncts which reference only the left side of the join.
+   * @param rightSideOnly Deterministic conjuncts which reference only the right side of the join.
+   * @param bothSides Conjuncts which are in neither left nor right.
    * @param full The full join condition.
    */
   case class JoinConditionSplitPredicates(
-    left: Option[Expression],
-    right: Option[Expression],
-    joined: Option[Expression],
+    leftSideOnly: Option[Expression],
+    rightSideOnly: Option[Expression],
+    bothSides: Option[Expression],
     full: Option[Expression]) {}
 
   object JoinConditionSplitPredicates extends PredicateHelper {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -82,10 +82,17 @@ object StreamingSymmetricHashJoinHelper extends Logging {
    * @param full The full join condition.
    */
   case class JoinConditionSplitPredicates(
-    leftSideOnly: Option[Expression],
-    rightSideOnly: Option[Expression],
-    bothSides: Option[Expression],
-    full: Option[Expression]) {}
+      leftSideOnly: Option[Expression],
+      rightSideOnly: Option[Expression],
+      bothSides: Option[Expression],
+      full: Option[Expression]) {
+    override def toString(): String = {
+      s"condition = [ leftOnly = ${leftSideOnly.map(_.toString).getOrElse("null")}, " +
+        s"rightOnly = ${rightSideOnly.map(_.toString).getOrElse("null")}, " +
+        s"both = ${bothSides.map(_.toString).getOrElse("null")}, " +
+        s"full = ${full.map(_.toString).getOrElse("null")} ]"
+    }
+  }
 
   object JoinConditionSplitPredicates extends PredicateHelper {
     def apply(condition: Option[Expression], left: SparkPlan, right: SparkPlan):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -88,7 +88,7 @@ object StreamingSymmetricHashJoinHelper extends Logging {
 
   object JoinConditionSplitPredicates extends PredicateHelper {
     def apply(condition: Option[Expression], left: SparkPlan, right: SparkPlan):
-    JoinConditionSplitPredicates = {
+        JoinConditionSplitPredicates = {
       // Split the condition into 3 parts:
       // * Conjuncts that can be applied to the left before storing.
       // * Conjuncts that can be applied to the right before storing.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -120,7 +120,7 @@ object StreamingSymmetricHashJoinHelper extends Logging {
           (
             leftConjuncts.reduceOption(And),
             rightConjuncts.reduceOption(And),
-            (nonDeterministicConjuncts ++ remainingConjuncts).reduceOption(And)
+            (remainingConjuncts ++ nonDeterministicConjuncts).reduceOption(And)
           )
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -365,6 +365,24 @@ class StreamingInnerJoinSuite extends StreamTest with StateStoreMetricsTest with
       }
     }
   }
+
+  test("join between three streams") {
+    val input1 = MemoryStream[Int]
+    val input2 = MemoryStream[Int]
+    val input3 = MemoryStream[Int]
+
+    val df1 = input1.toDF.select('value as "leftKey", ('value * 2) as "leftValue")
+    val df2 = input2.toDF.select('value as "middleKey", ('value * 3) as "middleValue")
+    val df3 = input3.toDF.select('value as "rightKey", ('value * 5) as "rightValue")
+
+    val joined = df1.join(df2, expr("leftKey = middleKey")).join(df3, expr("rightKey = middleKey"))
+
+    testStream(joined)(
+      AddData(input1, 1, 5),
+      AddData(input2, 1, 5, 10),
+      AddData(input3, 5, 10),
+      CheckLastBatch((5, 10, 5, 15, 5, 25)))
+  }
 }
 
 class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with BeforeAndAfter {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSymmetricHashJoinHelperSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSymmetricHashJoinHelperSuite.scala
@@ -55,7 +55,7 @@ class StreamingSymmetricHashJoinHelperSuite extends StreamTest {
     val split = JoinConditionSplitPredicates(Some(predicate), left, right)
 
     assert(split.leftSideOnly.contains(predicate))
-    assert(split.rightSideOnly.isEmpty)
+    assert(split.rightSideOnly.contains(predicate))
     assert(split.bothSides.isEmpty)
     assert(split.full.contains(predicate))
   }
@@ -89,7 +89,7 @@ class StreamingSymmetricHashJoinHelperSuite extends StreamTest {
     val split = JoinConditionSplitPredicates(Some(predicate), left, right)
 
     assert(split.leftSideOnly.contains((leftColA > leftColB && lit(1) === lit(1)).expr))
-    assert(split.rightSideOnly.contains((rightColC > rightColD).expr))
+    assert(split.rightSideOnly.contains((rightColC > rightColD && lit(1) === lit(1)).expr))
     assert(split.bothSides.contains((leftColA === rightColC).expr))
     assert(split.full.contains(predicate))
   }
@@ -123,7 +123,7 @@ class StreamingSymmetricHashJoinHelperSuite extends StreamTest {
     val split = JoinConditionSplitPredicates(Some(predicate), left, right)
 
     assert(split.leftSideOnly.contains((leftColA > leftColB && lit(1) === lit(1)).expr))
-    assert(split.rightSideOnly.contains((rightColC > rightColD).expr))
+    assert(split.rightSideOnly.contains((rightColC > rightColD && lit(1) === lit(1)).expr))
     assert(split.bothSides.contains((leftColA === rightColC && randCol > lit(0)).expr))
     assert(split.full.contains(predicate))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSymmetricHashJoinHelperSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSymmetricHashJoinHelperSuite.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.{LeafExecNode, LocalTableScanExec, SparkPlan}
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
+import org.apache.spark.sql.execution.streaming.StreamingSymmetricHashJoinHelper.JoinConditionSplitPredicates
+import org.apache.spark.sql.types.DataTypes
+
+class StreamingSymmetricHashJoinHelperSuite extends StreamTest {
+  import org.apache.spark.sql.functions._
+
+  val attributeA = AttributeReference("a", DataTypes.IntegerType)()
+  val attributeB = AttributeReference("b", DataTypes.IntegerType)()
+  val attributeC = AttributeReference("c", DataTypes.IntegerType)()
+  val attributeD = AttributeReference("d", DataTypes.IntegerType)()
+  val colA = new Column(attributeA)
+  val colB = new Column(attributeB)
+  val colC = new Column(attributeC)
+  val colD = new Column(attributeD)
+
+  val left = new LocalTableScanExec(Seq(attributeA, attributeB), Seq())
+  val right = new LocalTableScanExec(Seq(attributeC, attributeD), Seq())
+
+  test("empty") {
+    val split = JoinConditionSplitPredicates(None, left, right)
+    assert(split.leftSideOnly.isEmpty)
+    assert(split.rightSideOnly.isEmpty)
+    assert(split.bothSides.isEmpty)
+    assert(split.full.isEmpty)
+  }
+
+  test("only literals") {
+    // Literal-only conjuncts end up on the left side because that's the first bucket they fit in.
+    // There's no semantic reason they couldn't be in any bucket.
+    val predicate = (lit(1) < lit(5) && lit(6) < lit(7) && lit(0) === lit(-1)).expr
+    val split = JoinConditionSplitPredicates(Some(predicate), left, right)
+
+    assert(split.leftSideOnly.contains(predicate))
+    assert(split.rightSideOnly.isEmpty)
+    assert(split.bothSides.isEmpty)
+    assert(split.full.contains(predicate))
+  }
+
+  test("only left") {
+    val predicate = (colA > lit(1) && colB > lit(5) && colA < colB).expr
+    val split = JoinConditionSplitPredicates(Some(predicate), left, right)
+
+    assert(split.leftSideOnly.contains(predicate))
+    assert(split.rightSideOnly.isEmpty)
+    assert(split.bothSides.isEmpty)
+    assert(split.full.contains(predicate))
+  }
+
+  test("only right") {
+    val predicate = (colC > lit(1) && colD > lit(5) && colD < colC).expr
+    val split = JoinConditionSplitPredicates(Some(predicate), left, right)
+
+    assert(split.leftSideOnly.isEmpty)
+    assert(split.rightSideOnly.contains(predicate))
+    assert(split.bothSides.isEmpty)
+    assert(split.full.contains(predicate))
+  }
+
+  test("mixed conjuncts") {
+    val predicate = (colA > colB && colC > colD && colA === colC && lit(1) === lit(1)).expr
+    val split = JoinConditionSplitPredicates(Some(predicate), left, right)
+
+    assert(split.leftSideOnly.contains((colA > colB && lit(1) === lit(1)).expr))
+    assert(split.rightSideOnly.contains((colC > colD).expr))
+    assert(split.bothSides.contains((colA === colC).expr))
+    assert(split.full.contains(predicate))
+  }
+
+  test("conjuncts after nondeterministic") {
+    // All conjuncts after a nondeterministic conjunct shouldn't be split because they don't
+    // commute across it.
+    val predicate =
+      (rand() > lit(0) && colA > colB && colC > colD && colA === colC && lit(1) === lit(1)).expr
+    val split = JoinConditionSplitPredicates(Some(predicate), left, right)
+
+    assert(split.leftSideOnly.isEmpty)
+    assert(split.rightSideOnly.isEmpty)
+    assert(split.bothSides.contains(predicate))
+    assert(split.full.contains(predicate))
+  }
+
+
+  test("conjuncts before nondeterministic") {
+    val randCol = rand()
+    val predicate =
+      (colA > colB && colC > colD && colA === colC && lit(1) === lit(1) && randCol > lit(0)).expr
+    val split = JoinConditionSplitPredicates(Some(predicate), left, right)
+
+    assert(split.leftSideOnly.contains((colA > colB && lit(1) === lit(1)).expr))
+    assert(split.rightSideOnly.contains((colC > colD).expr))
+    assert(split.bothSides.contains((colA === colC && randCol > lit(0)).expr))
+    assert(split.full.contains(predicate))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Evaluate one-sided conditions early in stream-stream joins.

This is in addition to normal filter pushdown, because integrating it with the join logic allows it to take place in outer join scenarios. This means that rows which can never satisfy the join condition won't clog up the state. 

## How was this patch tested?
new unit tests
