### PR TITLE
[SPARK-22152][SPARK-18855][SQL] Added flatten functions for RDD and Dataset

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -382,6 +382,13 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
+    * Return a new RDD by flattening a traversable collection into a collection itself.
+    */
+  def flatten[U: ClassTag](implicit f: T => TraversableOnce[U]): RDD[U] = withScope {
+    this.flatMap(y => y)
+  }
+
+  /**
    * Return a new RDD containing only the elements that satisfy a predicate.
    */
   def filter(f: T => Boolean): RDD[T] = withScope {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -385,7 +385,7 @@ abstract class RDD[T: ClassTag](
     * Return a new RDD by flattening a traversable collection into a collection itself.
     */
   def flatten[U: ClassTag](implicit f: T => TraversableOnce[U]): RDD[U] = withScope {
-    this.flatMap(y => y)
+    this.flatMap(identity(_))
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -63,6 +63,7 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     assert(nums.map(_.toString).collect().toList === List("1", "2", "3", "4"))
     assert(nums.filter(_ > 2).collect().toList === List(3, 4))
     assert(nums.flatMap(x => 1 to x).collect().toList === List(1, 1, 2, 1, 2, 3, 1, 2, 3, 4))
+    assert(sc.makeRDD(Array(Array(1,2,3,4), Array(1,2,3,4))).flatten == List(1,2,3,4,1,2,3,4))
     assert(nums.union(nums).collect().toList === List(1, 2, 3, 4, 1, 2, 3, 4))
     assert(nums.glom().map(_.toList).collect().toList === List(List(1, 2), List(3, 4)))
     assert(nums.collect({ case i if i >= 3 => i.toString }).collect().toList === List("3", "4"))

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2543,6 +2543,11 @@ class Dataset[T] private[sql](
     mapPartitions(_.flatMap(func))
 
   /**
+    * Returns a new Dataset by by flattening a traversable collection into a collection itself.
+    */
+  def flatten[U: Encoder](implicit func: T => TraversableOnce[U]): Dataset[U] = mapPartitions(_.flatMap(x => x))
+
+  /**
    * :: Experimental ::
    * (Java-specific)
    * Returns a new Dataset by first applying a function to all elements of this Dataset,

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2544,6 +2544,8 @@ class Dataset[T] private[sql](
 
   /**
     * Returns a new Dataset by by flattening a traversable collection into a collection itself.
+    *
+    * @since 2.3.0
     */
   def flatten[U: Encoder](implicit func: T => TraversableOnce[U]): Dataset[U] = mapPartitions(_.flatMap(x => x))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2547,7 +2547,8 @@ class Dataset[T] private[sql](
     *
     * @since 2.3.0
     */
-  def flatten[U: Encoder](implicit func: T => TraversableOnce[U]): Dataset[U] = mapPartitions(_.flatMap(x => x))
+  def flatten[U: Encoder](implicit func: T => TraversableOnce[U]): Dataset[U] =
+    mapPartitions(_.flatMap(x => x))
 
   /**
    * :: Experimental ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1341,6 +1341,17 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       Seq(1).toDS().map(_ => ("", TestForTypeAlias.seqOfTupleTypeAlias)),
       ("", Seq((1, 1), (2, 2))))
   }
+  test("SPARK-22152: a dataset of sequence should be flattened"){
+    val ds: Dataset[Seq[Int]] = Seq(Seq(1, 2, 3)).toDS
+    val out: Dataset[Int] = ds.flatten
+    assert(out.collect.toSeq == Seq(1, 2, 3))
+  }
+
+  test("SPARK-22152: a dataset of option elements should be flattened"){
+    val ds: Dataset[Option[String]] = Seq(Some("a"),None,Some("b")).toDS
+    val out: Dataset[String] = ds.flatten
+    assert(out.collect.toSeq == Seq("a", "b"))
+  }
 }
 
 case class WithImmutableMap(id: String, map_test: scala.collection.immutable.Map[Long, String])


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR creates a _flatten_ function in two places: RDD and Dataset classes. This PR resolves the following issues: SPARK-22152 and SPARK-18855.

Author: Sohum Sachdev <sohum2002@hotmail.com>