### PR TITLE
[SPARK] Misleading error message for missing --proxy-user value

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -625,7 +625,7 @@ public class SparkLauncher {
     @Override
     protected boolean handle(String opt, String value) {
       if (value == null && hasValue) {
-        throw new IllegalArgumentException(String.format("'%s' does not expect a value.", opt));
+        throw new IllegalArgumentException(String.format("'%s' expects a value.", opt));
       }
       return true;
     }


### PR DESCRIPTION
Fix misleading error message when argument is expected.

## What changes were proposed in this pull request?

Change message to be accurate.

## How was this patch tested?

Messaging change, was tested manually.