### PR TITLE
[SPARK-22227][CORE] DiskBlockManager.getAllBlocks now tolerates temp files

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -104,27 +104,43 @@ object BlockId {
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
+  val TEMP_LOCAL = "temp_local_([A-Fa-f-]+)".r
+  val TEMP_SHUFFLE = "temp_shuffle_([A-Fa-f-]+)".r
   val TEST = "test_(.*)".r
 
-  /** Converts a BlockId "name" String back into a BlockId. */
-  def apply(id: String): BlockId = id match {
-    case RDD(rddId, splitIndex) =>
-      RDDBlockId(rddId.toInt, splitIndex.toInt)
-    case SHUFFLE(shuffleId, mapId, reduceId) =>
-      ShuffleBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
-    case SHUFFLE_DATA(shuffleId, mapId, reduceId) =>
-      ShuffleDataBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
-    case SHUFFLE_INDEX(shuffleId, mapId, reduceId) =>
-      ShuffleIndexBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
-    case BROADCAST(broadcastId, field) =>
-      BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
-    case TASKRESULT(taskId) =>
-      TaskResultBlockId(taskId.toLong)
-    case STREAM(streamId, uniqueId) =>
-      StreamBlockId(streamId.toInt, uniqueId.toLong)
-    case TEST(value) =>
-      TestBlockId(value)
-    case _ =>
-      throw new IllegalStateException("Unrecognized BlockId: " + id)
+  def apply(name: String): BlockId = {
+    guess(name).getOrElse {
+      throw new IllegalStateException("Unrecognized BlockId: " + name)
+    }
+  }
+
+  /** Tries to guess block ID type by [[BlockId.name]]. */
+  private[storage] def guess(name: String): Option[BlockId] = {
+    val blockId = name match {
+      case RDD(rddId, splitIndex) =>
+        RDDBlockId(rddId.toInt, splitIndex.toInt)
+      case SHUFFLE(shuffleId, mapId, reduceId) =>
+        ShuffleBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
+      case SHUFFLE_DATA(shuffleId, mapId, reduceId) =>
+        ShuffleDataBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
+      case SHUFFLE_INDEX(shuffleId, mapId, reduceId) =>
+        ShuffleIndexBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
+      case BROADCAST(broadcastId, field) =>
+        BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
+      case TASKRESULT(taskId) =>
+        TaskResultBlockId(taskId.toLong)
+      case STREAM(streamId, uniqueId) =>
+        StreamBlockId(streamId.toInt, uniqueId.toLong)
+      case TEMP_LOCAL(uuid) =>
+        TempShuffleBlockId(UUID.fromString(uuid))
+      case TEMP_SHUFFLE(uuid) =>
+        TempShuffleBlockId(UUID.fromString(uuid))
+      case TEST(value) =>
+        TestBlockId(value)
+      case _ =>
+        null
+    }
+
+    Option(blockId)
   }
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -96,6 +96,7 @@ private[spark] case class TestBlockId(id: String) extends BlockId {
   override def name: String = "test_" + id
 }
 
+@DeveloperApi
 class UnrecognizedBlockId(name: String)
     extends SparkException(s"Failed to parse $name into a block ID")
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -19,6 +19,7 @@ package org.apache.spark.storage
 
 import java.util.UUID
 
+import org.apache.spark.SparkException
 import org.apache.spark.annotation.DeveloperApi
 
 /**
@@ -95,7 +96,8 @@ private[spark] case class TestBlockId(id: String) extends BlockId {
   override def name: String = "test_" + id
 }
 
-class UnrecognizedBlockId(name: String) extends Exception
+class UnrecognizedBlockId(name: String)
+    extends SparkException(s"Failed to parse $name into a block ID")
 
 @DeveloperApi
 object BlockId {

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -109,8 +109,8 @@ object BlockId {
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
-  val TEMP_LOCAL = "temp_local_([A-Fa-f-]+)".r
-  val TEMP_SHUFFLE = "temp_shuffle_([A-Fa-f-]+)".r
+  val TEMP_LOCAL = "temp_local_([-A-Fa-f0-9]+)".r
+  val TEMP_SHUFFLE = "temp_shuffle_([-A-Fa-f0-9]+)".r
   val TEST = "test_(.*)".r
 
   def apply(name: String): BlockId = name match {
@@ -129,7 +129,7 @@ object BlockId {
     case STREAM(streamId, uniqueId) =>
       StreamBlockId(streamId.toInt, uniqueId.toLong)
     case TEMP_LOCAL(uuid) =>
-      TempShuffleBlockId(UUID.fromString(uuid))
+      TempLocalBlockId(UUID.fromString(uuid))
     case TEMP_SHUFFLE(uuid) =>
       TempShuffleBlockId(UUID.fromString(uuid))
     case TEST(value) =>

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -101,14 +101,15 @@ private[spark] class DiskBlockManager(conf: SparkConf, deleteFilesOnStop: Boolea
   /** List all the blocks currently stored on disk by the disk manager. */
   def getAllBlocks(): Seq[BlockId] = {
     getAllFiles().flatMap { f =>
-      val blockId = BlockId.guess(f.getName)
-      if (blockId.isEmpty) {
-        // This does not handle a special-case of a temporary file
-        // created by [[SortShuffleWriter]].
-        log.warn(s"Encountered an unexpected file in a managed directory: $f")
+      try {
+        Some(BlockId(f.getName))
+      } catch {
+        case _: UnrecognizedBlockId =>
+          // This does not handle a special-case of a temporary file
+          // created by [[SortShuffleWriter]].
+          log.warn(s"Encountered an unexpected file in a managed directory: $f")
+          None
       }
-
-      blockId
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -105,9 +105,8 @@ private[spark] class DiskBlockManager(conf: SparkConf, deleteFilesOnStop: Boolea
         Some(BlockId(f.getName))
       } catch {
         case _: UnrecognizedBlockId =>
-          // This does not handle a special-case of a temporary file
-          // created by [[SortShuffleWriter]].
-          log.warn(s"Encountered an unexpected file in a managed directory: $f")
+          // Skip files which do not correspond to blocks, for example temporary
+          // files created by [[SortShuffleWriter]].
           None
       }
     }

--- a/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -35,13 +35,8 @@ class BlockIdSuite extends SparkFunSuite {
   }
 
   test("test-bad-deserialization") {
-    try {
-      // Try to deserialize an invalid block id.
+    intercept[UnrecognizedBlockId] {
       BlockId("myblock")
-      fail()
-    } catch {
-      case e: IllegalStateException => // OK
-      case _: Throwable => fail()
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -134,6 +134,7 @@ class BlockIdSuite extends SparkFunSuite {
     assert(id.id.getMostSignificantBits() === 5)
     assert(id.id.getLeastSignificantBits() === 2)
     assert(!id.isShuffle)
+    assertSame(id, BlockId(id.toString))
   }
 
   test("temp shuffle") {
@@ -146,6 +147,7 @@ class BlockIdSuite extends SparkFunSuite {
     assert(id.id.getMostSignificantBits() === 1)
     assert(id.id.getLeastSignificantBits() === 2)
     assert(!id.isShuffle)
+    assertSame(id, BlockId(id.toString))
   }
 
   test("test") {

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -81,8 +81,7 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
   }
 
   test("SPARK-22227: non-block files are skipped") {
-    val blockId = TempShuffleBlockId(UUID.randomUUID())
-    val file = diskBlockManager.getFile(blockId)
+    val file = diskBlockManager.getFile("unmanaged_file")
     writeToFile(file, 10)
     assert(diskBlockManager.getAllBlocks().isEmpty)
   }

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.storage
 
 import java.io.{File, FileWriter}
+import java.util.UUID
 
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
@@ -77,6 +78,13 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
     val files = ids.map(id => diskBlockManager.getFile(id))
     files.foreach(file => writeToFile(file, 10))
     assert(diskBlockManager.getAllBlocks.toSet === ids.toSet)
+  }
+
+  test("SPARK-22227: non-block files are skipped") {
+    val blockId = TempShuffleBlockId(UUID.randomUUID())
+    val file = diskBlockManager.getFile(blockId)
+    writeToFile(file, 10)
+    assert(diskBlockManager.getAllBlocks().isEmpty)
   }
 
   def writeToFile(file: File, numBytes: Int) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prior to this commit getAllBlocks implicitly assumed that the directories
managed by the DiskBlockManager contain only the files corresponding to
valid block IDs. In reality, this assumption was violated during shuffle,
which produces temporary files in the same directory as the resulting
blocks. As a result, calls to getAllBlocks during shuffle were unreliable.

The fix could be made more efficient, but this is probably good enough.

## How was this patch tested?

`DiskBlockManagerSuite`