### PR TITLE
[SPARK-22233] [core] Allow user to filter out empty split in HadoopRDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -270,12 +270,9 @@ package object config {
     .longConf
     .createWithDefault(4 * 1024 * 1024)
 
-  private [spark] val FILTER_OUT_EMPTY_SPLIT = ConfigBuilder("spark.files.filterOutEmptySplit")
-    .doc("If set to true, HadoopRDD/NewHadoopRDD will not handle the split which its length is 0." +
-      "Maybe you will read an empty hive table but has many empty files. If set to false, Spark " +
-      "generates many tasks to handle these empty files. Sometimes, users maybe want to use " +
-      "SparkContext#textFile to handle a file stored in hadoop, and they don't want to generate " +
-      "any task when this file is empty, they can set this configuration to true.")
+  private[spark] val IGNORE_EMPTY_SPLITS = ConfigBuilder("spark.files.ignoreEmptySplits")
+    .doc("If true, methods like that use HadoopRDD and NewHadoopRDD such as " +
+      "SparkContext.textFiles will not create a partition for input splits that are empty.")
     .booleanConf
     .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -270,6 +270,15 @@ package object config {
     .longConf
     .createWithDefault(4 * 1024 * 1024)
 
+  private [spark] val FILTER_OUT_EMPTY_SPLIT = ConfigBuilder("spark.files.filterOutEmptySplit")
+    .doc("If set to true, HadoopRDD/NewHadoopRDD will not handle the split which its length is 0." +
+      "Maybe you will read an empty hive table but has many empty files. If set to false, Spark " +
+      "generates many tasks to handle these empty files. Sometimes, users maybe want to use " +
+      "SparkContext#textFile to handle a file stored in hadoop, and they don't want to generate " +
+      "any task when this file is empty, they can set this configuration to true.")
+    .booleanConf
+    .createWithDefault(false)
+
   private[spark] val SECRET_REDACTION_PATTERN =
     ConfigBuilder("spark.redaction.regex")
       .doc("Regex to decide which Spark configuration properties and environment variables in " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -271,7 +271,7 @@ package object config {
     .createWithDefault(4 * 1024 * 1024)
 
   private[spark] val IGNORE_EMPTY_SPLITS = ConfigBuilder("spark.files.ignoreEmptySplits")
-    .doc("If true, methods like that use HadoopRDD and NewHadoopRDD such as " +
+    .doc("If true, methods that use HadoopRDD and NewHadoopRDD such as " +
       "SparkContext.textFiles will not create a partition for input splits that are empty.")
     .booleanConf
     .createWithDefault(false)

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -196,7 +196,10 @@ class HadoopRDD[K, V](
     // add the credentials here as this can be called before SparkContext initialized
     SparkHadoopUtil.get.addCredentials(jobConf)
     val inputFormat = getInputFormat(jobConf)
-    val inputSplits = inputFormat.getSplits(jobConf, minPartitions)
+    var inputSplits = inputFormat.getSplits(jobConf, minPartitions)
+    if (sparkContext.getConf.getBoolean("spark.hadoop.filterOutEmptySplit", false)) {
+      inputSplits = inputSplits.filter(_.getLength>0)
+    }
     val array = new Array[Partition](inputSplits.size)
     for (i <- 0 until inputSplits.size) {
       array(i) = new HadoopPartition(id, i, inputSplits(i))

--- a/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
@@ -122,7 +122,10 @@ class NewHadoopRDD[K, V](
       case _ =>
     }
     val jobContext = new JobContextImpl(_conf, jobId)
-    val rawSplits = inputFormat.getSplits(jobContext).toArray
+    var rawSplits = inputFormat.getSplits(jobContext).toArray(Array.empty[InputSplit])
+    if (sparkContext.getConf.getBoolean("spark.hadoop.filterOutEmptySplit", false)) {
+      rawSplits = rawSplits.filter(_.getLength>0)
+    }
     val result = new Array[Partition](rawSplits.size)
     for (i <- 0 until rawSplits.size) {
       result(i) = new NewHadoopPartition(id, i, rawSplits(i).asInstanceOf[InputSplit with Writable])

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -564,9 +564,11 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
       for (i <- 0 until actualPartitionNum) {
         assert(new File(output, s"part-r-0000$i").exists() === true)
       }
-      val hadoopRDD = sc.newAPIHadoopFile(new File(output, "part-r-*").getPath,
-        classOf[NewTextInputFormat], classOf[LongWritable], classOf[Text])
-        .asInstanceOf[NewHadoopRDD[_, _]]
+      val hadoopRDD = sc.newAPIHadoopFile(
+        new File(output, "part-r-*").getPath,
+        classOf[NewTextInputFormat],
+        classOf[LongWritable],
+        classOf[Text]).asInstanceOf[NewHadoopRDD[_, _]]
       assert(hadoopRDD.partitions.length === expectedPartitionNum)
       Utils.deleteRecursively(output)
     }

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -561,7 +561,10 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
       val output = new File(tempDir, "output" + outputSuffix)
       dataRDD.saveAsNewAPIHadoopFile[NewTextOutputFormat[String, String]](output.getPath)
       assert(new File(output, checkPart).exists() === true)
-      val hadoopRDD = sc.textFile(new File(output, "part-r-*").getPath)
+
+      val hadoopRDD = sc.newAPIHadoopFile(new File(output, "part-r-*").getPath,
+        classOf[NewTextInputFormat], classOf[LongWritable], classOf[Text])
+        .asInstanceOf[NewHadoopRDD[_, _]]
       assert(hadoopRDD.partitions.length === expectedPartitionNum)
     }
 
@@ -575,7 +578,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
 
     // Ensure that if no split is empty, we don't lose any splits
     testIgnoreEmptySplits(
-      data = Array(("key1", "a"), ("key2", "a"), ("key3", "b")),
+      data = Array(("1", "a"), ("2", "a"), ("3", "b")),
       numSlices = 2,
       outputSuffix = 1,
       checkPart = "part-r-00001",
@@ -583,7 +586,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
 
     // Ensure that if part of the splits are empty, we remove the splits correctly
     testIgnoreEmptySplits(
-      data = Array(("key1", "a"), ("key2", "a")),
+      data = Array(("1", "a"), ("2", "b")),
       numSlices = 5,
       outputSuffix = 2,
       checkPart = "part-r-00004",

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -516,23 +516,38 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext(conf)
 
     def testIgnoreEmptySplits(data: Array[Tuple2[String, String]], numSlices: Int,
-                              outputSuffix: Int, checkPart: String, partitionLength: Int): Unit = {
+      outputSuffix: Int, checkPart: String, expectedPartitionNum: Int): Unit = {
       val dataRDD = sc.parallelize(data, numSlices)
       val output = new File(tempDir, "output" + outputSuffix)
       dataRDD.saveAsHadoopFile[TextOutputFormat[String, String]](output.getPath)
       assert(new File(output, checkPart).exists() === true)
       val hadoopRDD = sc.textFile(new File(output, "part-*").getPath)
-      assert(hadoopRDD.partitions.length === partitionLength)
+      assert(hadoopRDD.partitions.length === expectedPartitionNum)
     }
 
     // Ensure that if all of the splits are empty, we remove the splits correctly
-    testIgnoreEmptySplits(Array.empty[Tuple2[String, String]], 1, 0, "part-00000", 0)
+    testIgnoreEmptySplits(
+      data = Array.empty[Tuple2[String, String]],
+      numSlices = 1,
+      outputSuffix = 0,
+      checkPart = "part-00000",
+      expectedPartitionNum = 0)
 
     // Ensure that if no split is empty, we don't lose any splits
-    testIgnoreEmptySplits(Array(("key1", "a"), ("key2", "a"), ("key3", "b")), 2, 1, "part-00001", 2)
+    testIgnoreEmptySplits(
+      data = Array(("key1", "a"), ("key2", "a"), ("key3", "b")),
+      numSlices = 2,
+      outputSuffix = 1,
+      checkPart = "part-00001",
+      expectedPartitionNum = 2)
 
     // Ensure that if part of the splits are empty, we remove the splits correctly
-    testIgnoreEmptySplits(Array(("key1", "a"), ("key2", "a")), 5, 2, "part-00004", 2)
+    testIgnoreEmptySplits(
+      data = Array(("key1", "a"), ("key2", "a")),
+      numSlices = 5,
+      outputSuffix = 2,
+      checkPart = "part-00004",
+      expectedPartitionNum = 2)
   }
 
   test("spark.files.ignoreEmptySplits work correctly (new Hadoop API)") {
@@ -541,23 +556,37 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext(conf)
 
     def testIgnoreEmptySplits(data: Array[Tuple2[String, String]], numSlices: Int,
-                              outputSuffix: Int, checkPart: String, partitionLength: Int): Unit = {
+      outputSuffix: Int, checkPart: String, expectedPartitionNum: Int): Unit = {
       val dataRDD = sc.parallelize(data, numSlices)
       val output = new File(tempDir, "output" + outputSuffix)
       dataRDD.saveAsNewAPIHadoopFile[NewTextOutputFormat[String, String]](output.getPath)
       assert(new File(output, checkPart).exists() === true)
       val hadoopRDD = sc.textFile(new File(output, "part-r-*").getPath)
-      assert(hadoopRDD.partitions.length === partitionLength)
+      assert(hadoopRDD.partitions.length === expectedPartitionNum)
     }
 
     // Ensure that if all of the splits are empty, we remove the splits correctly
-    testIgnoreEmptySplits(Array.empty[Tuple2[String, String]], 1, 0, "part-r-00000", 0)
+    testIgnoreEmptySplits(
+      data = Array.empty[Tuple2[String, String]],
+      numSlices = 1,
+      outputSuffix = 0,
+      checkPart = "part-r-00000",
+      expectedPartitionNum = 0)
 
     // Ensure that if no split is empty, we don't lose any splits
-    testIgnoreEmptySplits(Array(("key1", "a"), ("key2", "a"), ("key3", "b")), 2, 1, "part-r-00001",
-      2)
+    testIgnoreEmptySplits(
+      data = Array(("key1", "a"), ("key2", "a"), ("key3", "b")),
+      numSlices = 2,
+      outputSuffix = 1,
+      checkPart = "part-r-00001",
+      expectedPartitionNum = 2)
 
     // Ensure that if part of the splits are empty, we remove the splits correctly
-    testIgnoreEmptySplits(Array(("key1", "a"), ("key2", "a")), 5, 2, "part-r-00004", 2)
+    testIgnoreEmptySplits(
+      data = Array(("key1", "a"), ("key2", "a")),
+      numSlices = 5,
+      outputSuffix = 2,
+      checkPart = "part-r-00004",
+      expectedPartitionNum = 2)
   }
 }

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -510,4 +510,16 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  test("spark.hadoop.filterOutEmptySplit") {
+    val sf = new SparkConf()
+    sf.setAppName("test").setMaster("local").set("spark.hadoop.filterOutEmptySplit", "true")
+    sc = new SparkContext(sf)
+    val emptyRDD = sc.parallelize(Array.empty[Tuple2[String, String]], 1)
+    emptyRDD.saveAsHadoopFile[TextOutputFormat[String, String]](tempDir.getPath + "/output")
+    assert(new File(tempDir.getPath + "/output/part-00000").exists() === true)
+
+    val hadoopRDD = sc.textFile(tempDir.getPath + "/output/part-00000")
+    assert(hadoopRDD.partitions.length === 0)
+  }
+
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1211,6 +1211,14 @@ Apart from these, the following properties are also available, and may be useful
     data may need to be rewritten to pre-existing output directories during checkpoint recovery.</td>
 </tr>
 <tr>
+    <td><code>spark.hadoop.filterOutEmptySplit</code></td>
+    <td>false</td>
+    <td>If set to true, HadoopRDD will not handle the split which its lenghth is 0. Maybe you will read an empty
+    hive table but has many empty files. If set to false, Spark generates many tasks to handle these empty files.
+    Sometimes, users maybe want to use SparkContext#textFile to handle a file stored in hadoop, and they don't 
+    want to generate any task when this file is empty, they can set this configuration to true.</td>
+</tr>
+<tr>
   <td><code>spark.storage.memoryMapThreshold</code></td>
   <td>2m</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1192,14 +1192,6 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-    <td><code>spark.files.filterOutEmptySplit</code></td>
-    <td>false</td>
-    <td>If set to true, HadoopRDD/NewHadoopRDD will not handle the split which its length is 0. Maybe you will read an empty
-    hive table but has many empty files. If set to false, Spark generates many tasks to handle these empty files.
-    Sometimes, users maybe want to use SparkContext#textFile to handle a file stored in hadoop, and they don't
-    want to generate any task when this file is empty, they can set this configuration to true.</td>
-</tr>
-<tr>
     <td><code>spark.hadoop.cloneConf</code></td>
     <td>false</td>
     <td>If set to true, clones a new Hadoop <code>Configuration</code> object for each task.  This

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1192,6 +1192,14 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+    <td><code>spark.files.filterOutEmptySplit</code></td>
+    <td>false</td>
+    <td>If set to true, HadoopRDD/NewHadoopRDD will not handle the split which its length is 0. Maybe you will read an empty
+    hive table but has many empty files. If set to false, Spark generates many tasks to handle these empty files.
+    Sometimes, users maybe want to use SparkContext#textFile to handle a file stored in hadoop, and they don't
+    want to generate any task when this file is empty, they can set this configuration to true.</td>
+</tr>
+<tr>
     <td><code>spark.hadoop.cloneConf</code></td>
     <td>false</td>
     <td>If set to true, clones a new Hadoop <code>Configuration</code> object for each task.  This
@@ -1209,14 +1217,6 @@ Apart from these, the following properties are also available, and may be useful
     previous versions of Spark. Simply use Hadoop's FileSystem API to delete output directories by hand.
     This setting is ignored for jobs generated through Spark Streaming's StreamingContext, since
     data may need to be rewritten to pre-existing output directories during checkpoint recovery.</td>
-</tr>
-<tr>
-    <td><code>spark.hadoop.filterOutEmptySplit</code></td>
-    <td>false</td>
-    <td>If set to true, HadoopRDD will not handle the split which its lenghth is 0. Maybe you will read an empty
-    hive table but has many empty files. If set to false, Spark generates many tasks to handle these empty files.
-    Sometimes, users maybe want to use SparkContext#textFile to handle a file stored in hadoop, and they don't 
-    want to generate any task when this file is empty, they can set this configuration to true.</td>
 </tr>
 <tr>
   <td><code>spark.storage.memoryMapThreshold</code></td>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a flag spark.files.ignoreEmptySplits. When true, methods like that use HadoopRDD and NewHadoopRDD such as SparkContext.textFiles will not create a partition for input splits that are empty.