### PR TITLE
[SPARK-22237] [CORE] Fix spark submit file download for standalone client mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -367,7 +367,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
         downloadFileList(_, targetDir, sparkConf, hadoopConf, secMgr)
       }.orNull
 
-      if (clusterManager == STANDALONE) {
+      if (clusterManager == STANDALONE || clusterManager == LOCAL) {
         // Use local files for standalone client mode.
         args.primaryResource = localPrimaryResource
         args.jars = localJars

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -372,6 +372,9 @@ object SparkSubmit extends CommandLineUtils with Logging {
         args.primaryResource = localPrimaryResource
         args.jars = localJars
         args.pyFiles = localPyFiles
+        args.files = Option(args.files).map {
+          downloadFileList(_, targetDir, sparkConf, hadoopConf, secMgr)
+        }.orNull
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -366,6 +366,13 @@ object SparkSubmit extends CommandLineUtils with Logging {
       localPyFiles = Option(args.pyFiles).map {
         downloadFileList(_, targetDir, sparkConf, hadoopConf, secMgr)
       }.orNull
+
+      if (clusterManager == STANDALONE) {
+        // Use local files for standalone client mode.
+        args.primaryResource = localPrimaryResource
+        args.jars = localJars
+        args.pyFiles = localPyFiles
+      }
     }
 
     // When running in YARN, for some remote resources with scheme:


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes spark-submit script to use downloaded files in local/standalone client mode.

## How was this patch tested?

Unit tests and manual tests.
