### PR TITLE
[SPARK-22243][DStreams]spark.yarn.jars reload from config when Checkpoint recovery

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -53,6 +53,7 @@ class Checkpoint(ssc: StreamingContext, val checkpointTime: Time)
       "spark.driver.host",
       "spark.driver.port",
       "spark.master",
+      "spark.yarn.jars",
       "spark.yarn.keytab",
       "spark.yarn.principal",
       "spark.yarn.credentials.file",


### PR DESCRIPTION
add spark.yarn.jars to the checkpoint reload configs.