### PR TITLE
[SPARK-14387][SPARK-16628][SPARK-18355][SQL] Use Spark schema to read ORC table instead of ORC file schema

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2051,57 +2051,61 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
-  test("SPARK-18355 Use Spark schema to read ORC table instead of ORC file schema") {
-    val client = spark.sharedState.externalCatalog.asInstanceOf[HiveExternalCatalog].client
+  Seq("orc", "parquet").foreach { format =>
+    test(s"SPARK-18355 Read data from a hive table with a new column - $format") {
+      val client = spark.sharedState.externalCatalog.asInstanceOf[HiveExternalCatalog].client
 
-    Seq("true", "false").foreach { value =>
-      withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> value) {
-        withTempDatabase { db =>
-          client.runSqlHive(
-            s"""
-               |CREATE TABLE $db.t(
-               |  click_id string,
-               |  search_id string,
-               |  uid bigint)
-               |PARTITIONED BY (
-               |  ts string,
-               |  hour string)
-               |STORED AS ORC
-             """.stripMargin)
+      Seq("true", "false").foreach { value =>
+        withSQLConf(
+          HiveUtils.CONVERT_METASTORE_ORC.key -> value,
+          HiveUtils.CONVERT_METASTORE_PARQUET.key -> value) {
+          withTempDatabase { db =>
+            client.runSqlHive(
+              s"""
+                 |CREATE TABLE $db.t(
+                 |  click_id string,
+                 |  search_id string,
+                 |  uid bigint)
+                 |PARTITIONED BY (
+                 |  ts string,
+                 |  hour string)
+                 |STORED AS $format
+              """.stripMargin)
 
-          client.runSqlHive(
-            s"""
-               |INSERT INTO TABLE $db.t
-               |PARTITION (ts = '98765', hour = '01')
-               |VALUES (12, 2, 12345)
-             """.stripMargin
-          )
+            client.runSqlHive(
+              s"""
+                 |INSERT INTO TABLE $db.t
+                 |PARTITION (ts = '98765', hour = '01')
+                 |VALUES (12, 2, 12345)
+              """.stripMargin
+            )
 
-          checkAnswer(
-            sql(s"SELECT click_id, search_id, uid, ts, hour FROM $db.t"),
-            Row("12", "2", 12345, "98765", "01"))
+            checkAnswer(
+              sql(s"SELECT click_id, search_id, uid, ts, hour FROM $db.t"),
+              Row("12", "2", 12345, "98765", "01"))
 
-          client.runSqlHive(s"ALTER TABLE $db.t ADD COLUMNS (dummy string)")
+            client.runSqlHive(s"ALTER TABLE $db.t ADD COLUMNS (dummy string)")
 
-          checkAnswer(
-            sql(s"SELECT click_id, search_id FROM $db.t"),
-            Row("12", "2"))
+            checkAnswer(
+              sql(s"SELECT click_id, search_id FROM $db.t"),
+              Row("12", "2"))
 
-          checkAnswer(
-            sql(s"SELECT search_id, click_id FROM $db.t"),
-            Row("2", "12"))
+            checkAnswer(
+              sql(s"SELECT search_id, click_id FROM $db.t"),
+              Row("2", "12"))
 
-          checkAnswer(
-            sql(s"SELECT search_id FROM $db.t"),
-            Row("2"))
+            checkAnswer(
+              sql(s"SELECT search_id FROM $db.t"),
+              Row("2"))
 
-          checkAnswer(
-            sql(s"SELECT dummy, click_id FROM $db.t"),
-            Row(null, "12"))
+            checkAnswer(
+              sql(s"SELECT dummy, click_id FROM $db.t"),
+              Row(null, "12"))
 
-          checkAnswer(
-            sql(s"SELECT click_id, search_id, uid, dummy, ts, hour FROM $db.t"),
-            Row("12", "2", 12345, null, "98765", "01"))
+            checkAnswer(
+              sql(s"SELECT click_id, search_id, uid, dummy, ts, hour FROM $db.t"),
+              Row("12", "2", 12345, null, "98765", "01"))
+          }
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.hive.HiveUtils
+import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
@@ -2046,6 +2046,62 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
             sql(s"ALTER TABLE t21912 ADD COLUMNS(`col$name` INT)")
           }.getMessage
           assert(m.contains(s"contains invalid character(s)"))
+        }
+      }
+    }
+  }
+
+  test("SPARK-18355 Use Spark schema to read ORC table instead of ORC file schema") {
+    val client = spark.sharedState.externalCatalog.asInstanceOf[HiveExternalCatalog].client
+
+    Seq("true", "false").foreach { value =>
+      withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> value) {
+        withTempDatabase { db =>
+          client.runSqlHive(
+            s"""
+               |CREATE TABLE $db.t(
+               |  click_id string,
+               |  search_id string,
+               |  uid bigint)
+               |PARTITIONED BY (
+               |  ts string,
+               |  hour string)
+               |STORED AS ORC
+             """.stripMargin)
+
+          client.runSqlHive(
+            s"""
+               |INSERT INTO TABLE $db.t
+               |PARTITION (ts = '98765', hour = '01')
+               |VALUES (12, 2, 12345)
+             """.stripMargin
+          )
+
+          checkAnswer(
+            sql(s"SELECT * FROM $db.t"),
+            Row("12", "2", 12345, "98765", "01"))
+
+          client.runSqlHive(s"ALTER TABLE $db.t ADD COLUMNS (dummy string)")
+
+          checkAnswer(
+            sql(s"SELECT click_id, search_id FROM $db.t"),
+            Row("12", "2"))
+
+          checkAnswer(
+            sql(s"SELECT search_id, click_id FROM $db.t"),
+            Row("2", "12"))
+
+          checkAnswer(
+            sql(s"SELECT search_id FROM $db.t"),
+            Row("2"))
+
+          checkAnswer(
+            sql(s"SELECT dummy, click_id FROM $db.t"),
+            Row(null, "12"))
+
+          checkAnswer(
+            sql(s"SELECT * FROM $db.t"),
+            Row("12", "2", 12345, null, "98765", "01"))
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2106,4 +2106,24 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       }
     }
   }
+
+  // This test case is added to prevent regression.
+  test("SPARK-22267 Spark SQL incorrectly reads ORC files when column order is different") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+
+      Seq(1 -> 2).toDF("c1", "c2").write.format("orc").mode("overwrite").save(path)
+      checkAnswer(spark.read.orc(path), Row(1, 2))
+
+      Seq("true", "false").foreach { value =>
+        withTable("t") {
+          withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> value) {
+            sql(s"CREATE EXTERNAL TABLE t(c2 INT, c1 INT) STORED AS ORC LOCATION '$path'")
+            // The correct answer is Row(2, 1). SPARK-22267 should fix this later.
+            checkAnswer(spark.table("t"), if (value == "true") Row(2, 1) else Row(1, 2))
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before Hive 2.0, ORC File schema has invalid column names like `_col1` and `_col2`. This is a well-known limitation and there are several Apache Spark issues with `spark.sql.hive.convertMetastoreOrc=true`. This PR ignores ORC File schema and use Spark schema.

## How was this patch tested?

Pass the newly added test case.