### PR TITLE
[SPARK-22264][DEPLOY] Add timeout for eventlog replaying to avoid time-cons…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -97,7 +97,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private val CLEAN_INTERVAL_S = conf.getTimeAsSeconds("spark.history.fs.cleaner.interval", "1d")
 
   // Timeout for event log replaying
-  private val REPLAY_TIMEOUT = conf.getTimeAsSeconds("spark.history.fs.replay.timeout", "5m")
+  private val REPLAY_TIMEOUT = conf.getTimeAsSeconds("spark.history.fs.replay.timeout", "30m")
 
   // Number of threads used to replay event logs.
   private val NUM_PROCESSING_THREADS = conf.getInt(SPARK_HISTORY_FS_NUM_REPLAY_THREADS,


### PR DESCRIPTION
…uming replaying which will cause historyserver unavailable

## What changes were proposed in this pull request?

History server will be unavailable if there is an event log file with large size.Large size here means the replaying time is too long.
We can fix this to add a timeout for event log replaying.
More details attached in [SPARK-22264](https://issues.apache.org/jira/browse/SPARK-22264)

## How was this patch tested?
Exsisted unit tests.
