### PR TITLE
[SPARK-22266][SQL] The same aggregate function was evaluated multiple times

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -207,9 +207,10 @@ object PhysicalAggregation {
       // In order to avoid evaluating an individual aggregate function multiple times, we'll
       // build a map of the distinct aggregate expressions and build a function which can
       // be used to re-write expressions so that they reference the single copy of the
-      // aggregate function which actually gets computed. Note that aggregate expressions
-      // should always be deterministic, so we can use its canonicalized expression as its
-      // identity in the map.
+      // aggregate function which actually gets computed. Note that identical non-deterministic
+      // aggregate expressions, e.g., FIRST_VALUE, should return the same value within the same
+      // projection, so we use the aggregate expression's canonicalized expression as its key
+      // in the map.
       val aggregateExpressionMap = resultExpressions.flatMap { expr =>
         expr.collect {
           case agg: AggregateExpression => agg.canonicalized -> agg

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.{AccumulatorSuite, SparkException}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.execution.aggregate
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, CartesianProductExec, SortMergeJoinExec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -2676,5 +2677,18 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         """.stripMargin)
       checkAnswer(df, Row(1, 1, 1))
     }
+  }
+
+  test("SRARK-22266: the same aggregate function was calculated multiple times") {
+    val query = "SELECT a, max(b+1), max(b+1) + 1 FROM testData2 GROUP BY a"
+    val df = sql(query)
+    val physical = df.queryExecution.sparkPlan
+    val aggregates = physical.collect {
+      case agg : HashAggregateExec => agg
+    }
+    aggregates.foreach { agg =>
+      assert (agg.aggregateExpressions.size == 1)
+    }
+    checkAnswer(df, Row(1, 3, 4) :: Row(2, 3, 4) :: Row(3, 3, 4) :: Nil)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To let the same aggregate function that appear multiple times in an Aggregate be evaluated only once, we need to deduplicate the aggregate expressions. The original code was trying to use a "distinct" call to get a set of aggregate expressions, but did not work, since the "distinct" did not compare semantic equality. And even if it did, further work should be done in result expression rewriting.
In this PR, I changed the "set" to a map mapping the semantic identity of a aggregate expression to itself. Thus, later on, when rewriting result expressions (i.e., output expressions), the aggregate expression reference can be fixed.

## How was this patch tested?

Added a new test in SQLQuerySuite