### PR TITLE
[SPARK-22228][SQL] Add support for array<primitive_type> to from_json

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -552,15 +552,12 @@ case class JsonToStructs(
 
   // This converts parsed rows to the desired output by the given schema.
   @transient
-  lazy val converter = (rows: Seq[Any]) =>
-    (schema, rows) match {
-      case (_: StructType, rows: Seq[InternalRow]) =>
-         if (rows.length == 1) rows.head else null
-      case (ArrayType(_: StructType, _), rows: Seq[InternalRow]) =>
-        new GenericArrayData(rows)
-      case (ArrayType(_: AtomicType, _), rows: Seq[AtomicType]) =>
-        new GenericArrayData(rows)
-    }
+  lazy val converter = schema match {
+    case _: StructType =>
+      (rows: Seq[Any]) => if (rows.length == 1) rows.head else null
+    case ArrayType(_: StructType| _: AtomicType, _) =>
+      (rows: Seq[Any]) => new GenericArrayData(rows)
+  }
 
   @transient
   lazy val parser =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -359,7 +359,11 @@ class JacksonParser private (
   }
 
   /**
-   * Parse the JSON input to the set of [[InternalRow]]s.
+   * Parse the JSON input to the set of [[InternalRow]]s. This function can be safely
+   * used when a [[StructType]] is passed as schema. This means that it can parse JSON
+   * objects and array of JSON objects.
+   * If you need to support array of primitive types too (ie. when the schema is a
+   * [[ArrayType]]), then use [[parseWithArrayOfPrimitiveSupport]] instead.
    *
    * @param recordLiteral an optional function that will be used to generate
    *   the corrupt record text instead of record.toString
@@ -379,8 +383,8 @@ class JacksonParser private (
 
   /**
    * Parse the JSON input. This function can return a set of [[InternalRow]]s
-   * if a [[StructType]] is defined as schema, otherwise it returns a set of
-   * objects.
+   * if a [[StructType]] is defined as schema, meanwhile it returns a set of
+   * objects if an [[ArrayType]] is defined as schema.
    *
    * @param recordLiteral an optional function that will be used to generate
    *   the corrupt record text instead of record.toString

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -36,7 +36,7 @@ import org.apache.spark.util.Utils
  * Constructs a parser for a given schema that translates a json string to a [[Seq]]
  * of [[InternalRow]]s or [[AtomicType]]s.
  */
-private[sql] class JacksonParser(
+class JacksonParser private (
     schema: DataType,
     val options: JSONOptions) extends Logging {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -371,7 +371,9 @@ class JacksonParser private (
     parseWithArrayOfPrimitiveSupport(record, createParser, recordLiteral) match {
       case rows: Seq[InternalRow] => rows
       case _: Seq[_] => throw BadRecordException(() => recordLiteral(record), () => None,
-        new RuntimeException("Conversion of array of primitive data is not yet supported here."))
+        new RuntimeException("`parse` is only used to parse the JSON input to a set of " +
+          "`InternalRow`s. It can parse JSON obejcts and array of JSON objects. Use " +
+          "`parseWithArrayOfPrimitiveSupport` when parsing array of primitive data is needed."))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3037,8 +3037,8 @@ object functions {
 
   /**
    * (Scala-specific) Parses a column containing a JSON string into a `StructType` or `ArrayType`
-   * of `StructType`s with the specified schema. Returns `null`, in the case of an unparseable
-   * string.
+   * of `StructType`s or primitive types with the specified schema. Returns `null`, in the case of
+   * an unparseable string.
    *
    * @param e a string column containing JSON data.
    * @param schema the schema to use when parsing the json string
@@ -3069,8 +3069,8 @@ object functions {
 
   /**
    * (Java-specific) Parses a column containing a JSON string into a `StructType` or `ArrayType`
-   * of `StructType`s with the specified schema. Returns `null`, in the case of an unparseable
-   * string.
+   * of `StructType`s or primitive types with the specified schema. Returns `null`, in the case of
+   * an unparseable string.
    *
    * @param e a string column containing JSON data.
    * @param schema the schema to use when parsing the json string
@@ -3098,7 +3098,8 @@ object functions {
 
   /**
    * Parses a column containing a JSON string into a `StructType` or `ArrayType` of `StructType`s
-   * with the specified schema. Returns `null`, in the case of an unparseable string.
+   * of `StructType`s or primitive types with the specified schema. Returns `null`, in the case of
+   * an unparseable string.
    *
    * @param e a string column containing JSON data.
    * @param schema the schema to use when parsing the json string

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -133,7 +133,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null) :: Nil)
   }
 
-
   test("from_json array support") {
     val df = Seq("""[{"a": 1, "b": "a"}, {"a": 2}, { }]""").toDS()
     val schema = ArrayType(

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -183,6 +183,16 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       dfEmpty.select(from_json($"value", ArrayType(StringType))),
       Row(Nil):: Nil)
+
+    val dfBadType = Seq("[1]", "[2, 3]", """["a string"]""").toDS()
+    checkAnswer(
+      dfBadType.select(from_json($"value", ArrayType(IntegerType))),
+      Row(Seq(1)) :: Row(Seq(2, 3)) :: Row(null) :: Nil)
+
+    val dfInvalidJson = Seq("[invalid]").toDS()
+    checkAnswer(
+      dfInvalidJson.select(from_json($"value", ArrayType(StringType))),
+      Row(null) :: Nil)
   }
 
   test("to_json - struct") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The fix introduces support for parsing array of primitive types in the `from_json` function. Currently, it supports only array of struct, which is equivalent to array of JSON objects, but it doesn't allow to parse array of simple types, like array of strings (eg. `["this is a valid JSON", "we cannot parse before the PR"]`).

## How was this patch tested?

Added UTs.
