### PR TITLE
[SPARK-22278][SS] Expose current event time watermark and current processing time in GroupState

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
-import org.apache.spark.sql.catalyst.plans.logical.{FunctionUtils, LogicalGroupState}
+import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, FunctionUtils, LogicalGroupState}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.streaming.GroupStateImpl
 import org.apache.spark.sql.streaming.GroupStateTimeout
@@ -361,8 +361,12 @@ object MapGroupsExec {
       outputObjAttr: Attribute,
       timeoutConf: GroupStateTimeout,
       child: SparkPlan): MapGroupsExec = {
+    val watermarkPresent = child.output.exists {
+      case a: Attribute if a.metadata.contains(EventTimeWatermark.delayKey) => true
+      case _ => false
+    }
     val f = (key: Any, values: Iterator[Any]) => {
-      func(key, values, GroupStateImpl.createForBatch(timeoutConf))
+      func(key, values, GroupStateImpl.createForBatch(timeoutConf, watermarkPresent))
     }
     new MapGroupsExec(f, keyDeserializer, valueDeserializer,
       groupingAttributes, dataAttributes, outputObjAttr, child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -61,6 +61,10 @@ case class FlatMapGroupsWithStateExec(
 
   private val isTimeoutEnabled = timeoutConf != NoTimeout
   val stateManager = new FlatMapGroupsWithState_StateManager(stateEncoder, isTimeoutEnabled)
+  val watermarkPresent = child.output.exists {
+    case a: Attribute if a.metadata.contains(EventTimeWatermark.delayKey) => true
+    case _ => false
+  }
 
   /** Distribute by grouping attributes */
   override def requiredChildDistribution: Seq[Distribution] =
@@ -190,7 +194,8 @@ case class FlatMapGroupsWithStateExec(
         batchTimestampMs.getOrElse(NO_TIMESTAMP),
         eventTimeWatermark.getOrElse(NO_TIMESTAMP),
         timeoutConf,
-        hasTimedOut)
+        hasTimedOut,
+        watermarkPresent)
 
       // Call function, get the returned objects and convert them to rows
       val mappedIterator = func(keyObj, valueObjIter, groupState).map { obj =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
@@ -145,6 +145,15 @@ private[sql] class GroupStateImpl[S] private(
     setTimeoutTimestamp(timestamp.getTime + parseDuration(additionalDuration))
   }
 
+  override def getEventTimeWatermark(): Long = {
+    if (timeoutConf != EventTimeTimeout) {
+      throw new UnsupportedOperationException(
+        "Cannot get event time watermark timestamp without enabling event time timeout in " +
+          "map/flatMapGroupsWithState")
+    }
+    eventTimeWatermarkMs
+  }
+
   override def toString: String = {
     s"GroupState(${getOption.map(_.toString).getOrElse("<undefined>")})"
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
@@ -143,7 +143,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != ProcessingTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot get processing time timestamp without enabling processing time timeout in " +
-          "map|flatMap]GroupsWithState")
+          "[map|flatMap]GroupsWithState")
     }
     batchProcessingTimeMs
   }
@@ -190,7 +190,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != EventTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot set timeout timestamp without enabling event time timeout in " +
-          "map|flatMapGroupsWithState")
+          "[map|flatMapGroupsWithState")
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
@@ -134,7 +134,7 @@ private[sql] class GroupStateImpl[S] private(
   override def getCurrentWatermarkMs(): Long = {
     if (!watermarkPresent) {
       throw new UnsupportedOperationException(
-        "Cannot get event time watermark timestamp without enabling setting watermark before " +
+        "Cannot get event time watermark timestamp without setting watermark before " +
           "[map|flatMap]GroupsWithState")
     }
     eventTimeWatermarkMs
@@ -213,7 +213,7 @@ private[sql] object GroupStateImpl {
       watermarkPresent: Boolean): GroupStateImpl[Any] = {
     new GroupStateImpl[Any](
       optionalValue = None,
-      batchProcessingTimeMs = NO_TIMESTAMP,
+      batchProcessingTimeMs = System.currentTimeMillis,
       eventTimeWatermarkMs = NO_TIMESTAMP,
       timeoutConf,
       hasTimedOut = false,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
@@ -90,7 +90,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != ProcessingTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot set timeout duration without enabling processing time timeout in " +
-          "map/flatMapGroupsWithState")
+          "[map/flatMap]GroupsWithState")
     }
     if (durationMs <= 0) {
       throw new IllegalArgumentException("Timeout duration must be positive")
@@ -102,10 +102,6 @@ private[sql] class GroupStateImpl[S] private(
     setTimeoutDuration(parseDuration(duration))
   }
 
-  @throws[IllegalArgumentException]("if 'timestampMs' is not positive")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
   override def setTimeoutTimestamp(timestampMs: Long): Unit = {
     checkTimeoutTimestampAllowed()
     if (timestampMs <= 0) {
@@ -119,39 +115,37 @@ private[sql] class GroupStateImpl[S] private(
     timeoutTimestamp = timestampMs
   }
 
-  @throws[IllegalArgumentException]("if 'additionalDuration' is invalid")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
   override def setTimeoutTimestamp(timestampMs: Long, additionalDuration: String): Unit = {
     checkTimeoutTimestampAllowed()
     setTimeoutTimestamp(parseDuration(additionalDuration) + timestampMs)
   }
 
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
   override def setTimeoutTimestamp(timestamp: Date): Unit = {
     checkTimeoutTimestampAllowed()
     setTimeoutTimestamp(timestamp.getTime)
   }
 
-  @throws[IllegalArgumentException]("if 'additionalDuration' is invalid")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
   override def setTimeoutTimestamp(timestamp: Date, additionalDuration: String): Unit = {
     checkTimeoutTimestampAllowed()
     setTimeoutTimestamp(timestamp.getTime + parseDuration(additionalDuration))
   }
 
-  override def getEventTimeWatermark(): Long = {
+  override def getCurrentWatermarkMs(): Long = {
     if (timeoutConf != EventTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot get event time watermark timestamp without enabling event time timeout in " +
-          "map/flatMapGroupsWithState")
+          "[map/flatMap]GroupsWithState")
     }
     eventTimeWatermarkMs
+  }
+
+  override def getCurrentProcessingTimeMs(): Long = {
+    if (timeoutConf != ProcessingTimeTimeout) {
+      throw new UnsupportedOperationException(
+        "Cannot get processing time timestamp without enabling processing time timeout in " +
+          "map/flatMap]GroupsWithState")
+    }
+    batchProcessingTimeMs
   }
 
   override def toString: String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/GroupStateImpl.scala
@@ -90,7 +90,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != ProcessingTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot set timeout duration without enabling processing time timeout in " +
-          "[map/flatMap]GroupsWithState")
+          "[map|flatMap]GroupsWithState")
     }
     if (durationMs <= 0) {
       throw new IllegalArgumentException("Timeout duration must be positive")
@@ -134,7 +134,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != EventTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot get event time watermark timestamp without enabling event time timeout in " +
-          "[map/flatMap]GroupsWithState")
+          "[map|flatMap]GroupsWithState")
     }
     eventTimeWatermarkMs
   }
@@ -143,7 +143,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != ProcessingTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot get processing time timestamp without enabling processing time timeout in " +
-          "map/flatMap]GroupsWithState")
+          "map|flatMap]GroupsWithState")
     }
     batchProcessingTimeMs
   }
@@ -190,7 +190,7 @@ private[sql] class GroupStateImpl[S] private(
     if (timeoutConf != EventTimeTimeout) {
       throw new UnsupportedOperationException(
         "Cannot set timeout timestamp without enabling event time timeout in " +
-          "map/flatMapGroupsWithState")
+          "map|flatMapGroupsWithState")
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
@@ -213,85 +213,119 @@ trait GroupState[S] extends LogicalGroupState[S] {
 
   /**
    * Whether the function has been called because the key has timed out.
-   * @note This can return true only when timeouts are enabled in `[map/flatmap]GroupsWithStates`.
+   * @note This can return true only when timeouts are enabled in `[map/flatmap]GroupsWithState`.
    */
   def hasTimedOut: Boolean
+
 
   /**
    * Set the timeout duration in ms for this key.
    *
-   * @note ProcessingTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
+   * @note [[GroupStateTimeout Processing time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method has no effect when used in a batch query.
    */
   @throws[IllegalArgumentException]("if 'durationMs' is not positive")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
   @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+    "if processing time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def setTimeoutDuration(durationMs: Long): Unit
+
 
   /**
    * Set the timeout duration for this key as a string. For example, "1 hour", "2 days", etc.
    *
-   * @note ProcessingTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
+   * @note [[GroupStateTimeout Processing time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method has no effect when used in a batch query.
    */
   @throws[IllegalArgumentException]("if 'duration' is not a valid duration")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
   @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+    "if processing time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def setTimeoutDuration(duration: String): Unit
 
-  @throws[IllegalArgumentException]("if 'timestampMs' is not positive")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+
   /**
    * Set the timeout timestamp for this key as milliseconds in epoch time.
    * This timestamp cannot be older than the current watermark.
    *
-   * @note EventTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
+   * @note [[GroupStateTimeout Event time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method has no effect when used in a batch query.
    */
+  @throws[IllegalArgumentException](
+    "if 'timestampMs' is not positive or less than the current watermark in a streaming query")
+  @throws[UnsupportedOperationException](
+    "if processing time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def setTimeoutTimestamp(timestampMs: Long): Unit
 
-  @throws[IllegalArgumentException]("if 'additionalDuration' is invalid")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+
   /**
    * Set the timeout timestamp for this key as milliseconds in epoch time and an additional
    * duration as a string (e.g. "1 hour", "2 days", etc.).
    * The final timestamp (including the additional duration) cannot be older than the
    * current watermark.
    *
-   * @note EventTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
+   * @note [[GroupStateTimeout Event time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method has no side effect when used in a batch query.
    */
+  @throws[IllegalArgumentException](
+    "if 'additionalDuration' is invalid or the final timeout timestamp is less than " +
+      "the current watermark in a streaming query")
+  @throws[UnsupportedOperationException](
+    "if event time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def setTimeoutTimestamp(timestampMs: Long, additionalDuration: String): Unit
 
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+
   /**
    * Set the timeout timestamp for this key as a java.sql.Date.
    * This timestamp cannot be older than the current watermark.
    *
-   * @note EventTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
+   * @note [[GroupStateTimeout Event time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method has no side effect when used in a batch query.
    */
+  @throws[UnsupportedOperationException](
+    "if event time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def setTimeoutTimestamp(timestamp: java.sql.Date): Unit
 
-  @throws[IllegalArgumentException]("if 'additionalDuration' is invalid")
-  @throws[IllegalStateException]("when state is either not initialized, or already removed")
-  @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+
   /**
    * Set the timeout timestamp for this key as a java.sql.Date and an additional
    * duration as a string (e.g. "1 hour", "2 days", etc.).
    * The final timestamp (including the additional duration) cannot be older than the
    * current watermark.
    *
-   * @note EventTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
+   * @note [[GroupStateTimeout Event time timeout]] must be enabled in
+   *      `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method has no side effect when used in a batch query.
    */
+  @throws[IllegalArgumentException]("if 'additionalDuration' is invalid")
+  @throws[UnsupportedOperationException](
+    "if event time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def setTimeoutTimestamp(timestamp: java.sql.Date, additionalDuration: String): Unit
 
+
+  /**
+   * Get the current event time watermark as milliseconds in epoch time.
+   *
+   * @note [[GroupStateTimeout Event time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method returns -1 when calling inside a batch query.
+   */
   @throws[UnsupportedOperationException](
-    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
-  /** */
-  def getEventTimeWatermark(): Long
+    "if event time timeout has not been enabled in [map|flatMap]GroupsWithState")
+  def getCurrentWatermarkMs(): Long
+
+
+  /**
+   * Get the current event time watermark.
+   *
+   * @note [[GroupStateTimeout Processing time timeout]] must be enabled in
+   *       `[map/flatmap]GroupsWithState` for calling this method.
+   * @note This method returns -1 when calling inside a batch query.
+   */
+  @throws[UnsupportedOperationException](
+    "if processing time timeout has not been enabled in [map|flatMap]GroupsWithState")
+  def getCurrentProcessingTimeMs(): Long
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
@@ -309,8 +309,8 @@ trait GroupState[S] extends LogicalGroupState[S] {
   /**
    * Get the current event time watermark as milliseconds in epoch time.
    *
-   * @note In a streaming query, this can be called only when watermark is enabled. In a batch
-   *       query, this method always returns -1.
+   * @note In a streaming query, this can be called only when watermark is set before calling
+   *       `[map/flatmap]GroupsWithState`. In a batch query, this method always returns -1.
    */
   @throws[UnsupportedOperationException](
     "if watermark has not been set before in [map|flatMap]GroupsWithState")

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
@@ -309,23 +309,18 @@ trait GroupState[S] extends LogicalGroupState[S] {
   /**
    * Get the current event time watermark as milliseconds in epoch time.
    *
-   * @note [[GroupStateTimeout Event time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
-   * @note This method returns -1 when calling inside a batch query.
+   * @note In a streaming query, this can be called only when watermark is enabled. In a batch
+   *       query, this method always returns -1.
    */
   @throws[UnsupportedOperationException](
-    "if event time timeout has not been enabled in [map|flatMap]GroupsWithState")
+    "if watermark has not been set before in [map|flatMap]GroupsWithState")
   def getCurrentWatermarkMs(): Long
 
 
   /**
    * Get the current event time watermark.
    *
-   * @note [[GroupStateTimeout Processing time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
    * @note This method returns -1 when calling inside a batch query.
    */
-  @throws[UnsupportedOperationException](
-    "if processing time timeout has not been enabled in [map|flatMap]GroupsWithState")
   def getCurrentProcessingTimeMs(): Long
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
@@ -205,11 +205,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
   /** Get the state value as a scala Option. */
   def getOption: Option[S]
 
-  /**
-   * Update the value of the state. Note that `null` is not a valid value, and it throws
-   * IllegalArgumentException.
-   */
-  @throws[IllegalArgumentException]("when updating with null")
+  /** Update the value of the state. */
   def update(newState: S): Unit
 
   /** Remove this state. */
@@ -293,4 +289,9 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * @note EventTimeTimeout must be enabled in `[map/flatmap]GroupsWithStates`.
    */
   def setTimeoutTimestamp(timestamp: java.sql.Date, additionalDuration: String): Unit
+
+  @throws[UnsupportedOperationException](
+    "if 'timeout' has not been enabled in [map|flatMap]GroupsWithState in a streaming query")
+  /** */
+  def getEventTimeWatermark(): Long
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
@@ -213,7 +213,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
 
   /**
    * Whether the function has been called because the key has timed out.
-   * @note This can return true only when timeouts are enabled in `[map/flatmap]GroupsWithState`.
+   * @note This can return true only when timeouts are enabled in `[map/flatMap]GroupsWithState`.
    */
   def hasTimedOut: Boolean
 
@@ -222,7 +222,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * Set the timeout duration in ms for this key.
    *
    * @note [[GroupStateTimeout Processing time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
+   *       `[map/flatMap]GroupsWithState` for calling this method.
    * @note This method has no effect when used in a batch query.
    */
   @throws[IllegalArgumentException]("if 'durationMs' is not positive")
@@ -235,7 +235,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * Set the timeout duration for this key as a string. For example, "1 hour", "2 days", etc.
    *
    * @note [[GroupStateTimeout Processing time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
+   *       `[map/flatMap]GroupsWithState` for calling this method.
    * @note This method has no effect when used in a batch query.
    */
   @throws[IllegalArgumentException]("if 'duration' is not a valid duration")
@@ -249,7 +249,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * This timestamp cannot be older than the current watermark.
    *
    * @note [[GroupStateTimeout Event time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
+   *       `[map/flatMap]GroupsWithState` for calling this method.
    * @note This method has no effect when used in a batch query.
    */
   @throws[IllegalArgumentException](
@@ -266,7 +266,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * current watermark.
    *
    * @note [[GroupStateTimeout Event time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
+   *       `[map/flatMap]GroupsWithState` for calling this method.
    * @note This method has no side effect when used in a batch query.
    */
   @throws[IllegalArgumentException](
@@ -282,7 +282,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * This timestamp cannot be older than the current watermark.
    *
    * @note [[GroupStateTimeout Event time timeout]] must be enabled in
-   *       `[map/flatmap]GroupsWithState` for calling this method.
+   *       `[map/flatMap]GroupsWithState` for calling this method.
    * @note This method has no side effect when used in a batch query.
    */
   @throws[UnsupportedOperationException](
@@ -297,7 +297,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * current watermark.
    *
    * @note [[GroupStateTimeout Event time timeout]] must be enabled in
-   *      `[map/flatmap]GroupsWithState` for calling this method.
+   *      `[map/flatMap]GroupsWithState` for calling this method.
    * @note This method has no side effect when used in a batch query.
    */
   @throws[IllegalArgumentException]("if 'additionalDuration' is invalid")
@@ -310,7 +310,7 @@ trait GroupState[S] extends LogicalGroupState[S] {
    * Get the current event time watermark as milliseconds in epoch time.
    *
    * @note In a streaming query, this can be called only when watermark is set before calling
-   *       `[map/flatmap]GroupsWithState`. In a batch query, this method always returns -1.
+   *       `[map/flatMap]GroupsWithState`. In a batch query, this method always returns -1.
    */
   @throws[UnsupportedOperationException](
     "if watermark has not been set before in [map|flatMap]GroupsWithState")
@@ -318,9 +318,9 @@ trait GroupState[S] extends LogicalGroupState[S] {
 
 
   /**
-   * Get the current event time watermark.
-   *
-   * @note This method returns -1 when calling inside a batch query.
+   * Get the current processing time as milliseconds in epoch time.
+   * @note In a streaming query, this will return a constant value throughout the duration of a
+   *       trigger, even if the trigger is re-executed.
    */
   def getCurrentProcessingTimeMs(): Long
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
@@ -312,7 +312,7 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest with BeforeAndAf
       GroupStateImpl.createForBatch(timeoutConf)
     }
 
-    // Tests for getCurrentWatermarkMs in streaming queries
+    // Tests for getCurrentProcessingTimeMs in streaming queries
     assertWrongTimeoutError { streamingState(NoTimeout, 1000).getCurrentProcessingTimeMs() }
     assertWrongTimeoutError { streamingState(EventTimeTimeout, 1000).getCurrentProcessingTimeMs() }
     assert(streamingState(ProcessingTimeTimeout, 1000).getCurrentProcessingTimeMs() === 1000)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Complex state-updating and/or timeout-handling logic in mapGroupsWithState functions may require taking decisions based on the current event-time watermark and/or processing time. Currently, you can use the SQL function `current_timestamp` to get the current processing time, but it needs to be passed inserted in every row with a select, and then passed through the encoder, which isn't efficient. Furthermore, there is no way to get the current watermark.

This PR exposes both of them through the GroupState API. 
Additionally, it also cleans up some of the GroupState docs. 

## How was this patch tested?

New unit tests