### PR TITLE
[SPARK-22280][SQL][TEST] Improve StatisticsSuite to test `convertMetastore` properly

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -946,9 +946,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
             sql(s"CREATE TABLE $format (key STRING, value STRING) STORED AS $format")
             sql(s"INSERT INTO TABLE $format SELECT * FROM src")
 
-            val hasHiveStats = !isConverted
-            checkTableStats(format, hasSizeInBytes = hasHiveStats, expectedRowCounts = None)
-
+            checkTableStats(format, hasSizeInBytes = !isConverted, expectedRowCounts = None)
             sql(s"ANALYZE TABLE $format COMPUTE STATISTICS")
             checkTableStats(format, hasSizeInBytes = true, expectedRowCounts = Some(500))
           }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -937,26 +937,22 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
   }
 
   test("test statistics of LogicalRelation converted from Hive serde tables") {
-    val parquetTable = "parquetTable"
-    val orcTable = "orcTable"
-    withTable(parquetTable, orcTable) {
-      sql(s"CREATE TABLE $parquetTable (key STRING, value STRING) STORED AS PARQUET")
-      sql(s"CREATE TABLE $orcTable (key STRING, value STRING) STORED AS ORC")
-      sql(s"INSERT INTO TABLE $parquetTable SELECT * FROM src")
-      sql(s"INSERT INTO TABLE $orcTable SELECT * FROM src")
+    Seq("orc", "parquet").foreach { format =>
+      Seq("true", "false").foreach { isConverted =>
+        withSQLConf(
+          HiveUtils.CONVERT_METASTORE_ORC.key -> isConverted,
+          HiveUtils.CONVERT_METASTORE_PARQUET.key -> isConverted) {
+          withTable(format) {
+            sql(s"CREATE TABLE $format (key STRING, value STRING) STORED AS $format")
+            sql(s"INSERT INTO TABLE $format SELECT * FROM src")
 
-      // the default value for `spark.sql.hive.convertMetastoreParquet` is true, here we just set it
-      // for robustness
-      withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "true") {
-        checkTableStats(parquetTable, hasSizeInBytes = false, expectedRowCounts = None)
-        sql(s"ANALYZE TABLE $parquetTable COMPUTE STATISTICS")
-        checkTableStats(parquetTable, hasSizeInBytes = true, expectedRowCounts = Some(500))
-      }
-      withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> "true") {
-        // We still can get tableSize from Hive before Analyze
-        checkTableStats(orcTable, hasSizeInBytes = true, expectedRowCounts = None)
-        sql(s"ANALYZE TABLE $orcTable COMPUTE STATISTICS")
-        checkTableStats(orcTable, hasSizeInBytes = true, expectedRowCounts = Some(500))
+            val hasHiveStats = !isConverted.toBoolean
+            checkTableStats(format, hasSizeInBytes = hasHiveStats, expectedRowCounts = None)
+
+            sql(s"ANALYZE TABLE $format COMPUTE STATISTICS")
+            checkTableStats(format, hasSizeInBytes = true, expectedRowCounts = Some(500))
+          }
+        }
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -938,15 +938,15 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
 
   test("test statistics of LogicalRelation converted from Hive serde tables") {
     Seq("orc", "parquet").foreach { format =>
-      Seq("true", "false").foreach { isConverted =>
+      Seq(true, false).foreach { isConverted =>
         withSQLConf(
-          HiveUtils.CONVERT_METASTORE_ORC.key -> isConverted,
-          HiveUtils.CONVERT_METASTORE_PARQUET.key -> isConverted) {
+          HiveUtils.CONVERT_METASTORE_ORC.key -> s"$isConverted",
+          HiveUtils.CONVERT_METASTORE_PARQUET.key -> s"$isConverted") {
           withTable(format) {
             sql(s"CREATE TABLE $format (key STRING, value STRING) STORED AS $format")
             sql(s"INSERT INTO TABLE $format SELECT * FROM src")
 
-            val hasHiveStats = !isConverted.toBoolean
+            val hasHiveStats = !isConverted
             checkTableStats(format, hasSizeInBytes = hasHiveStats, expectedRowCounts = None)
 
             sql(s"ANALYZE TABLE $format COMPUTE STATISTICS")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to improve **StatisticsSuite** to test `convertMetastore` configuration properly. Currently, some test logic in `test statistics of LogicalRelation converted from Hive serde tables` depends on the default configuration. New test case is shorter and covers both(true/false) cases explicitly.

This test case was previously modified by SPARK-17410 and SPARK-17284 in Spark 2.3.0.
- https://github.com/apache/spark/commit/a2460be9c30b67b9159fe339d115b84d53cc288a#diff-1c464c86b68c2d0b07e73b7354e74ce7R443

## How was this patch tested?

Pass the Jenkins with the improved test case.