### PR TITLE
[WEB-UI] Add count in fair scheduler pool page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -113,7 +113,7 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       var content = summary ++
         {
           if (sc.isDefined && isFairScheduler) {
-            <h4>{pools.size} Fair Scheduler Pools</h4> ++ poolTable.toNodeSeq
+            <h4>Fair Scheduler Pools {pools.size}</h4> ++ poolTable.toNodeSeq
           } else {
             Seq.empty[Node]
           }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -113,7 +113,7 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       var content = summary ++
         {
           if (sc.isDefined && isFairScheduler) {
-            <h4>Fair Scheduler Pools {pools.size}</h4> ++ poolTable.toNodeSeq
+            <h4>Fair Scheduler Pools ({pools.size})</h4> ++ poolTable.toNodeSeq
           } else {
             Seq.empty[Node]
           }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -57,7 +57,7 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
 
       var content = <h4>Summary </h4> ++ poolTable.toNodeSeq
       if (shouldShowActiveStages) {
-        content ++= <h4>{activeStages.size} Active Stages</h4> ++ activeStagesTable.toNodeSeq
+        content ++= <h4>Active Stages {activeStages.size}</h4> ++ activeStagesTable.toNodeSeq
       }
 
       UIUtils.headerSparkPage("Fair Scheduler Pool: " + poolName, content, parent)

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -57,7 +57,7 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
 
       var content = <h4>Summary </h4> ++ poolTable.toNodeSeq
       if (shouldShowActiveStages) {
-        content ++= <h4>Active Stages {activeStages.size}</h4> ++ activeStagesTable.toNodeSeq
+        content ++= <h4>Active Stages ({activeStages.size})</h4> ++ activeStagesTable.toNodeSeq
       }
 
       UIUtils.headerSparkPage("Fair Scheduler Pool: " + poolName, content, parent)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add count in fair scheduler pool page. The purpose is to know the statistics clearly.
For specific reasons, please refer to PR of https://github.com/apache/spark/pull/18525

fix before:
![1](https://user-images.githubusercontent.com/26266482/31641589-4b17b970-b318-11e7-97eb-f5a36db428f6.png)

![2](https://user-images.githubusercontent.com/26266482/31641643-97b6345a-b318-11e7-8c20-4b164ade228d.png)

fix after:
![3](https://user-images.githubusercontent.com/26266482/31641688-e6ceacb6-b318-11e7-8204-6a816c581a29.png)

 
![4](https://user-images.githubusercontent.com/26266482/31641766-7310b0c0-b319-11e7-871d-a57f874f1e8b.png)



## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
