### PR TITLE
[SPARK-22292][Mesos] Added spark.mem.max support for Mesos

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -196,17 +196,18 @@ configuration variables:
 
 * Executor memory: `spark.executor.memory`
 * Executor cores: `spark.executor.cores`
-* Number of executors: `spark.cores.max`/`spark.executor.cores`
+* Number of executors: min(`spark.cores.max`/`spark.executor.cores`, 
+`spark.mem.max`/(`spark.executor.memory`+`spark.mesos.executor.memoryOverhead`))
 
 Please see the [Spark Configuration](configuration.html) page for
 details and default values.
 
 Executors are brought up eagerly when the application starts, until
-`spark.cores.max` is reached.  If you don't set `spark.cores.max`, the
-Spark application will consume all resources offered to it by Mesos,
-so we of course urge you to set this variable in any sort of
-multi-tenant cluster, including one which runs multiple concurrent
-Spark applications.
+`spark.cores.max` or `spark.mem.max` is reached.  If you set neither
+`spark.cores.max` nor `spark.mem.max`, the Spark application will
+consume all resources offered to it by Mesos, so we of course urge
+you to set this variable in any sort of multi-tenant cluster,
+including one which runs multiple concurrent Spark applications.
 
 The scheduler will start executors round-robin on the offers Mesos
 gives it, but there are no spread guarantees, as Mesos does not
@@ -341,6 +342,13 @@ See the [configuration page](configuration.html) for information on Spark config
     include the cores used to run the Spark tasks. In other words, even if no Spark task
     is being run, each Mesos executor will occupy the number of cores configured here.
     The value can be a floating point number.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mem.max</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    Maximum amount of memory Spark accepts from Mesos launching executor.
   </td>
 </tr>
 <tr>
@@ -619,7 +627,8 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
     Time to consider unused resources refused, serves as a fallback of
     `spark.mesos.rejectOfferDurationForUnmetConstraints`,
-    `spark.mesos.rejectOfferDurationForReachedMaxCores`
+    `spark.mesos.rejectOfferDurationForReachedMaxCores`,
+    `spark.mesos.rejectOfferDurationForReachedMaxMem`
   </td>
 </tr>
 <tr>
@@ -635,6 +644,14 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
     Time to consider unused resources refused when maximum number of cores
     <code>spark.cores.max</code> is reached
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.rejectOfferDurationForReachedMaxMem</code></td>
+  <td><code>spark.mesos.rejectOfferDuration</code></td>
+  <td>
+    Time to consider unused resources refused when maximum amount of memory
+    <code>spark.mem.max</code> is reached
   </td>
 </tr>
 </table>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -203,7 +203,7 @@ details and default values.
 
 Executors are brought up eagerly when the application starts, until
 `spark.cores.max` is reached.  If you don't set `spark.cores.max`, the
-Spark application will reserve all resources offered to it by Mesos,
+Spark application will consume all resources offered to it by Mesos,
 so we of course urge you to set this variable in any sort of
 multi-tenant cluster, including one which runs multiple concurrent
 Spark applications.
@@ -611,6 +611,30 @@ See the [configuration page](configuration.html) for information on Spark config
     it tears down the driver framework by killing all its 
     executors. The default value is zero, meaning no timeout: if the 
     driver disconnects, the master immediately tears down the framework.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.rejectOfferDuration</code></td>
+  <td><code>120s</code></td>
+  <td>
+    Time to consider unused resources refused, serves as a fallback of
+    `spark.mesos.rejectOfferDurationForUnmetConstraints`,
+    `spark.mesos.rejectOfferDurationForReachedMaxCores`
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.rejectOfferDurationForUnmetConstraints</code></td>
+  <td><code>spark.mesos.rejectOfferDuration</code></td>
+  <td>
+    Time to consider unused resources refused with unmet constraints
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.rejectOfferDurationForReachedMaxCores</code></td>
+  <td><code>spark.mesos.rejectOfferDuration</code></td>
+  <td>
+    Time to consider unused resources refused when maximum number of cores
+    <code>spark.cores.max</code> is reached
   </td>
 </tr>
 </table>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -391,6 +391,12 @@ trait MesosSchedulerUtils extends Logging {
       getRejectOfferDurationStr(conf))
   }
 
+  protected def getRejectOfferDurationForReachedMaxMem(conf: SparkConf): Long = {
+    conf.getTimeAsSeconds(
+      "spark.mesos.rejectOfferDurationForReachedMaxMem",
+      getRejectOfferDurationStr(conf))
+  }
+
   /**
    * Checks executor ports if they are within some range of the offered list of ports ranges,
    *

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -158,7 +158,6 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
                    "spark.executor.cores" -> "1"))
 
     val executorMemory = backend.executorMemory(sc)
-
     val maxCores = 10
     offerResources(List(Resources(executorMemory * 3, maxCores)))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To limit the amount of resources a spark job accept from Mesos, currently we can only use `spark.cores.max` to limit in terms of cpu cores.
However, when we have big memory executors, it would consume all the resources.

This PR added `spark.mem.max` option for Mesos

## How was this patch tested?

Added Unit Test
