### PR TITLE
[SPARK-22287][MESOS] SPARK_DAEMON_MEMORY not honored by MesosClusterD…

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
@@ -81,6 +81,7 @@ class SparkClassCommandBuilder extends AbstractCommandBuilder {
       case "org.apache.spark.deploy.mesos.MesosClusterDispatcher":
         javaOptsKeys.add("SPARK_DAEMON_JAVA_OPTS");
         extraClassPath = getenv("SPARK_DAEMON_CLASSPATH");
+        memKey = "SPARK_DAEMON_MEMORY";
         break;
       case "org.apache.spark.deploy.ExternalShuffleService":
       case "org.apache.spark.deploy.mesos.MesosExternalShuffleService":


### PR DESCRIPTION
…ispatcher

## What changes were proposed in this pull request?

Allow JVM max heap size to be controlled for MesosClusterDispatcher via SPARK_DAEMON_MEMORY environment variable.

## How was this patch tested?

Tested on local Mesos cluster
