### PR TITLE
[SPARK-22277][ML]fix the bug of ChiSqSelector on preparing the output column

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
@@ -148,10 +148,12 @@ class AttributeGroup private (
 
   /** Converts to ML metadata with some existing metadata. */
   def toMetadata(existingMetadata: Metadata): Metadata = {
-    new MetadataBuilder()
+    val bldr = new MetadataBuilder()
       .withMetadata(existingMetadata)
-      .putMetadata(AttributeKeys.ML_ATTR, toMetadataImpl)
-      .build()
+    if(attributes.isDefined || numAttributes.isDefined) {
+        bldr.putMetadata(AttributeKeys.ML_ATTR, toMetadataImpl)
+    }
+    bldr.build()
   }
 
   /** Converts to ML metadata */

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -291,9 +291,13 @@ final class ChiSqSelectorModel private[ml] (
     val featureAttributes: Array[Attribute] = if (origAttrGroup.attributes.nonEmpty) {
       origAttrGroup.attributes.get.zipWithIndex.filter(x => selector.contains(x._2)).map(_._1)
     } else {
-      Array.fill[Attribute](selector.size)(NominalAttribute.defaultAttr)
+      null
     }
-    val newAttributeGroup = new AttributeGroup($(outputCol), featureAttributes)
+    val newAttributeGroup = if (featureAttributes != null) {
+      new AttributeGroup($(outputCol), featureAttributes)
+    } else {
+      new AttributeGroup($(outputCol))
+    }
     newAttributeGroup.toStructField()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To prepare the output columns when use ChiSqSelector,  the master method adds some additional feature attribute, this is not necessary, and sometimes cause error. 
The right logic is: if there is some feature attributes, we should copy them, if there is no feature attributes, we should not add it.

`    val featureAttributes: Array[Attribute] = if (origAttrGroup.attributes.nonEmpty) {
      origAttrGroup.attributes.get.zipWithIndex.filter(x => selector.contains(x._2)).map(_._1)
    } else {
      Array.fill[Attribute](selector.size)(NominalAttribute.defaultAttr)
    }
    val newAttributeGroup = new AttributeGroup($(outputCol), featureAttributes)` 

## How was this patch tested?
The existing UT.  
