### PR TITLE
[SPARK-22298][WEB-UI] url encode APP id before generating rest endpoint for /allexecutors

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -181,8 +181,8 @@ $(document).ready(function () {
     executorsSummary = $("#active-executors");
 
     getStandAloneppId(function (appId) {
-
-        var endPoint = createRESTEndPoint(appId);
+        var encodedAppId = encodeURIComponent(appId);
+        var endPoint = createRESTEndPoint(encodedAppId);
         $.getJSON(endPoint, function (response, status, jqXHR) {
             var summary = [];
             var allExecCnt = 0;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark Executor Page will return a blank list when the application id contains a forward slash. You can see the /allexecutors api failing with a 404. This can be fixed trivially by url encoding the appId before making the call to `/api/v1/applications/<appId>/allexecutors` in executorspage.js.

## How was this patch tested?
<img width="1035" alt="screen shot 2017-10-17 at 2 50 11 pm" src="https://user-images.githubusercontent.com/1855262/31683573-595e4be2-b34b-11e7-9974-3886fcf766fe.png">
<img width="1347" alt="screen shot 2017-10-17 at 2 57 36 pm" src="https://user-images.githubusercontent.com/1855262/31683659-90b0eae6-b34b-11e7-9018-5b271de9db28.png">

