### PR TITLE
[SPARK-22014][SQL]  removed TypeCheckFailure: slide duration <= windowDuration

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -82,10 +82,6 @@ case class TimeWindow(
       if (startTime < 0) {
         return TypeCheckFailure(s"The start time ($startTime) must be greater than or equal to 0.")
       }
-      if (slideDuration > windowDuration) {
-        return TypeCheckFailure(s"The slide duration ($slideDuration) must be less than or equal" +
-          s" to the windowDuration ($windowDuration).")
-      }
       if (startTime >= slideDuration) {
         return TypeCheckFailure(s"The start time ($startTime) must be less than the " +
           s"slideDuration ($slideDuration).")


### PR DESCRIPTION
It is possible to create sampling windows in Spark Streaming, where the duration of the window is smaller than the slide, but it throws a TypeCheckFailure in Spark SQL.

I think there should be no difference (duration and slide) in a "Spark Streaming window" and a "Spark SQL window" function.

@brkyvz 