### PR TITLE
[SPARK-22313][PYTHON] Mark/print deprecation warnings as DeprecationWarning for deprecated APIs

### DIFF
--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -175,7 +175,9 @@ class JavaMLWriter(MLWriter):
 
         .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
         """
-        warnings.warn("Deprecated in 2.1 and will be removed in 3.0, use session instead.")
+        warnings.warn(
+            "Deprecated in 2.1 and will be removed in 3.0, use session instead.",
+            DeprecationWarning)
         self._jwrite.context(sqlContext._ssql_ctx)
         return self
 
@@ -256,7 +258,9 @@ class JavaMLReader(MLReader):
 
         .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
         """
-        warnings.warn("Deprecated in 2.1 and will be removed in 3.0, use session instead.")
+        warnings.warn(
+            "Deprecated in 2.1 and will be removed in 3.0, use session instead.",
+            DeprecationWarning)
         self._jread.context(sqlContext._ssql_ctx)
         return self
 

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -311,7 +311,7 @@ class LogisticRegressionWithSGD(object):
         """
         warnings.warn(
             "Deprecated in 2.0.0. Use ml.classification.LogisticRegression or "
-            "LogisticRegressionWithLBFGS.")
+            "LogisticRegressionWithLBFGS.", DeprecationWarning)
 
         def train(rdd, i):
             return callMLlibFunc("trainLogisticRegressionModelWithSGD", rdd, int(iterations),

--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -234,7 +234,7 @@ class MulticlassMetrics(JavaModelWrapper):
         """
         if label is None:
             # note:: Deprecated in 2.0.0. Use accuracy.
-            warnings.warn("Deprecated in 2.0.0. Use accuracy.")
+            warnings.warn("Deprecated in 2.0.0. Use accuracy.", DeprecationWarning)
             return self.call("precision")
         else:
             return self.call("precision", float(label))
@@ -246,7 +246,7 @@ class MulticlassMetrics(JavaModelWrapper):
         """
         if label is None:
             # note:: Deprecated in 2.0.0. Use accuracy.
-            warnings.warn("Deprecated in 2.0.0. Use accuracy.")
+            warnings.warn("Deprecated in 2.0.0. Use accuracy.", DeprecationWarning)
             return self.call("recall")
         else:
             return self.call("recall", float(label))
@@ -259,7 +259,7 @@ class MulticlassMetrics(JavaModelWrapper):
         if beta is None:
             if label is None:
                 # note:: Deprecated in 2.0.0. Use accuracy.
-                warnings.warn("Deprecated in 2.0.0. Use accuracy.")
+                warnings.warn("Deprecated in 2.0.0. Use accuracy.", DeprecationWarning)
                 return self.call("fMeasure")
             else:
                 return self.call("fMeasure", label)

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -278,7 +278,8 @@ class LinearRegressionWithSGD(object):
           A condition which decides iteration termination.
           (default: 0.001)
         """
-        warnings.warn("Deprecated in 2.0.0. Use ml.regression.LinearRegression.")
+        warnings.warn(
+            "Deprecated in 2.0.0. Use ml.regression.LinearRegression.", DeprecationWarning)
 
         def train(rdd, i):
             return callMLlibFunc("trainLinearRegressionModelWithSGD", rdd, int(iterations),
@@ -421,7 +422,8 @@ class LassoWithSGD(object):
         """
         warnings.warn(
             "Deprecated in 2.0.0. Use ml.regression.LinearRegression with elasticNetParam = 1.0. "
-            "Note the default regParam is 0.01 for LassoWithSGD, but is 0.0 for LinearRegression.")
+            "Note the default regParam is 0.01 for LassoWithSGD, but is 0.0 for LinearRegression.",
+            DeprecationWarning)
 
         def train(rdd, i):
             return callMLlibFunc("trainLassoModelWithSGD", rdd, int(iterations), float(step),
@@ -566,7 +568,7 @@ class RidgeRegressionWithSGD(object):
         warnings.warn(
             "Deprecated in 2.0.0. Use ml.regression.LinearRegression with elasticNetParam = 0.0. "
             "Note the default regParam is 0.01 for RidgeRegressionWithSGD, but is 0.0 for "
-            "LinearRegression.")
+            "LinearRegression.", DeprecationWarning)
 
         def train(rdd, i):
             return callMLlibFunc("trainRidgeModelWithSGD", rdd, int(iterations), float(step),

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -130,6 +130,8 @@ class DataFrame(object):
 
         .. note:: Deprecated in 2.0, use createOrReplaceTempView instead.
         """
+        warnings.warn(
+            "Deprecated in 2.0, use createOrReplaceTempView instead.", DeprecationWarning)
         self._jdf.createOrReplaceTempView(name)
 
     @since(2.0)
@@ -1308,6 +1310,7 @@ class DataFrame(object):
 
         .. note:: Deprecated in 2.0, use :func:`union` instead.
         """
+        warnings.warn("Deprecated in 2.0, use union instead.", DeprecationWarning)
         return self.union(other)
 
     @since(2.3)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -21,6 +21,7 @@ A collections of builtin functions
 import math
 import sys
 import functools
+import warnings
 
 if sys.version < "3":
     from itertools import imap as map
@@ -42,6 +43,14 @@ def _create_function(name, doc=""):
     _.__name__ = name
     _.__doc__ = doc
     return _
+
+
+def _wrap_deprecated_function(func, message):
+    """ Wrap the deprecated function to print out deprecation warnings"""
+    def _(col):
+        warnings.warn(message, DeprecationWarning)
+        return func(col)
+    return functools.wraps(func)(_)
 
 
 def _create_binary_mathfunction(name, doc=""):
@@ -207,6 +216,12 @@ _window_functions = {
         """returns the relative rank (i.e. percentile) of rows within a window partition.""",
 }
 
+# Wraps deprecated functions (keys) with the messages (values).
+_functions_deprecated = {
+    'toDegrees': 'Deprecated in 2.1, use degrees instead.',
+    'toRadians': 'Deprecated in 2.1, use radians instead.',
+}
+
 for _name, _doc in _functions.items():
     globals()[_name] = since(1.3)(_create_function(_name, _doc))
 for _name, _doc in _functions_1_4.items():
@@ -219,6 +234,8 @@ for _name, _doc in _functions_1_6.items():
     globals()[_name] = since(1.6)(_create_function(_name, _doc))
 for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
+for _name, _message in _functions_deprecated.items():
+    globals()[_name] = _wrap_deprecated_function(globals()[_name], _message)
 del _name, _doc
 
 
@@ -227,6 +244,7 @@ def approxCountDistinct(col, rsd=None):
     """
     .. note:: Deprecated in 2.1, use :func:`approx_count_distinct` instead.
     """
+    warnings.warn("Deprecated in 2.1, use approx_count_distinct instead.", DeprecationWarning)
     return approx_count_distinct(col, rsd)
 
 

--- a/python/pyspark/streaming/flume.py
+++ b/python/pyspark/streaming/flume.py
@@ -56,6 +56,7 @@ class FlumeUtils(object):
 
         .. note:: Deprecated in 2.3.0
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
         helper = FlumeUtils._get_helper(ssc._sc)
         jstream = helper.createStream(ssc._jssc, hostname, port, jlevel, enableDecompression)
@@ -84,6 +85,7 @@ class FlumeUtils(object):
 
         .. note:: Deprecated in 2.3.0
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
         hosts = []
         ports = []

--- a/python/pyspark/streaming/flume.py
+++ b/python/pyspark/streaming/flume.py
@@ -54,9 +54,13 @@ class FlumeUtils(object):
         :param bodyDecoder:  A function used to decode body (default is utf8_decoder)
         :return: A DStream object
 
-        .. note:: Deprecated in 2.3.0. See SPARK-22142.
+        .. note:: Deprecated in 2.3.0. Flume support is deprecated as of Spark 2.3.0.
+            See SPARK-22142.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-22142.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Flume support is deprecated as of Spark 2.3.0. "
+            "See SPARK-22142.",
+            DeprecationWarning)
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
         helper = FlumeUtils._get_helper(ssc._sc)
         jstream = helper.createStream(ssc._jssc, hostname, port, jlevel, enableDecompression)
@@ -83,9 +87,13 @@ class FlumeUtils(object):
         :param bodyDecoder:  A function used to decode body (default is utf8_decoder)
         :return: A DStream object
 
-        .. note:: Deprecated in 2.3.0. See SPARK-22142.
+        .. note:: Deprecated in 2.3.0. Flume support is deprecated as of Spark 2.3.0.
+            See SPARK-22142.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-22142.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Flume support is deprecated as of Spark 2.3.0. "
+            "See SPARK-22142.",
+            DeprecationWarning)
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
         hosts = []
         ports = []

--- a/python/pyspark/streaming/flume.py
+++ b/python/pyspark/streaming/flume.py
@@ -54,9 +54,9 @@ class FlumeUtils(object):
         :param bodyDecoder:  A function used to decode body (default is utf8_decoder)
         :return: A DStream object
 
-        .. note:: Deprecated in 2.3.0
+        .. note:: Deprecated in 2.3.0. See SPARK-22142.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-22142.", DeprecationWarning)
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
         helper = FlumeUtils._get_helper(ssc._sc)
         jstream = helper.createStream(ssc._jssc, hostname, port, jlevel, enableDecompression)
@@ -83,9 +83,9 @@ class FlumeUtils(object):
         :param bodyDecoder:  A function used to decode body (default is utf8_decoder)
         :return: A DStream object
 
-        .. note:: Deprecated in 2.3.0
+        .. note:: Deprecated in 2.3.0. See SPARK-22142.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-22142.", DeprecationWarning)
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
         hosts = []
         ports = []

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -58,9 +58,9 @@ class KafkaUtils(object):
         :param valueDecoder:  A function used to decode value (default is utf8_decoder)
         :return: A DStream object
 
-        .. note:: Deprecated in 2.3.0
+        .. note:: Deprecated in 2.3.0. See SPARK-21893.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         if kafkaParams is None:
             kafkaParams = dict()
         kafkaParams.update({
@@ -108,9 +108,9 @@ class KafkaUtils(object):
         :return: A DStream object
 
         .. note:: Experimental
-        .. note:: Deprecated in 2.3.0
+        .. note:: Deprecated in 2.3.0. See SPARK-21893.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         if fromOffsets is None:
             fromOffsets = dict()
         if not isinstance(topics, list):
@@ -163,9 +163,9 @@ class KafkaUtils(object):
         :return: An RDD object
 
         .. note:: Experimental
-        .. note:: Deprecated in 2.3.0
+        .. note:: Deprecated in 2.3.0. See SPARK-21893.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         if leaders is None:
             leaders = dict()
         if not isinstance(kafkaParams, dict):
@@ -234,7 +234,7 @@ class OffsetRange(object):
     """
     Represents a range of offsets from a single Kafka TopicAndPartition.
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, topic, partition, fromOffset, untilOffset):
@@ -245,7 +245,7 @@ class OffsetRange(object):
         :param fromOffset: Inclusive starting offset.
         :param untilOffset: Exclusive ending offset.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         self.topic = topic
         self.partition = partition
         self.fromOffset = fromOffset
@@ -276,7 +276,7 @@ class TopicAndPartition(object):
     """
     Represents a specific topic and partition for Kafka.
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, topic, partition):
@@ -285,7 +285,7 @@ class TopicAndPartition(object):
         :param topic: Kafka topic name.
         :param partition: Kafka partition id.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         self._topic = topic
         self._partition = partition
 
@@ -310,7 +310,7 @@ class Broker(object):
     """
     Represent the host and port info for a Kafka broker.
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, host, port):
@@ -319,7 +319,7 @@ class Broker(object):
         :param host: Broker's hostname.
         :param port: Broker's port.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         self._host = host
         self._port = port
 
@@ -331,11 +331,11 @@ class KafkaRDD(RDD):
     """
     A Python wrapper of KafkaRDD, to provide additional information on normal RDD.
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, jrdd, ctx, jrdd_deserializer):
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         RDD.__init__(self, jrdd, ctx, jrdd_deserializer)
 
     def offsetRanges(self):
@@ -354,11 +354,11 @@ class KafkaDStream(DStream):
     """
     A Python wrapper of KafkaDStream
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, jdstream, ssc, jrdd_deserializer):
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         DStream.__init__(self, jdstream, ssc, jrdd_deserializer)
 
     def foreachRDD(self, func):
@@ -393,11 +393,11 @@ class KafkaTransformedDStream(TransformedDStream):
     """
     Kafka specific wrapper of TransformedDStream to transform on Kafka RDD.
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, prev, func):
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         TransformedDStream.__init__(self, prev, func)
 
     @property
@@ -416,7 +416,7 @@ class KafkaMessageAndMetadata(object):
     """
     Kafka message and metadata information. Including topic, partition, offset and message
 
-    .. note:: Deprecated in 2.3.0
+    .. note:: Deprecated in 2.3.0. See SPARK-21893.
     """
 
     def __init__(self, topic, partition, offset, key, message):
@@ -430,7 +430,7 @@ class KafkaMessageAndMetadata(object):
         :param message: actual message payload of this Kafka message, the return data is
                         undecoded bytearray.
         """
-        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
+        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
         self.topic = topic
         self.partition = partition
         self.offset = offset

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import warnings
+
 from py4j.protocol import Py4JJavaError
 
 from pyspark.rdd import RDD
@@ -58,6 +60,7 @@ class KafkaUtils(object):
 
         .. note:: Deprecated in 2.3.0
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         if kafkaParams is None:
             kafkaParams = dict()
         kafkaParams.update({
@@ -107,6 +110,7 @@ class KafkaUtils(object):
         .. note:: Experimental
         .. note:: Deprecated in 2.3.0
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         if fromOffsets is None:
             fromOffsets = dict()
         if not isinstance(topics, list):
@@ -161,6 +165,7 @@ class KafkaUtils(object):
         .. note:: Experimental
         .. note:: Deprecated in 2.3.0
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         if leaders is None:
             leaders = dict()
         if not isinstance(kafkaParams, dict):
@@ -240,6 +245,7 @@ class OffsetRange(object):
         :param fromOffset: Inclusive starting offset.
         :param untilOffset: Exclusive ending offset.
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         self.topic = topic
         self.partition = partition
         self.fromOffset = fromOffset
@@ -279,6 +285,7 @@ class TopicAndPartition(object):
         :param topic: Kafka topic name.
         :param partition: Kafka partition id.
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         self._topic = topic
         self._partition = partition
 
@@ -312,6 +319,7 @@ class Broker(object):
         :param host: Broker's hostname.
         :param port: Broker's port.
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         self._host = host
         self._port = port
 
@@ -327,6 +335,7 @@ class KafkaRDD(RDD):
     """
 
     def __init__(self, jrdd, ctx, jrdd_deserializer):
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         RDD.__init__(self, jrdd, ctx, jrdd_deserializer)
 
     def offsetRanges(self):
@@ -349,6 +358,7 @@ class KafkaDStream(DStream):
     """
 
     def __init__(self, jdstream, ssc, jrdd_deserializer):
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         DStream.__init__(self, jdstream, ssc, jrdd_deserializer)
 
     def foreachRDD(self, func):
@@ -387,6 +397,7 @@ class KafkaTransformedDStream(TransformedDStream):
     """
 
     def __init__(self, prev, func):
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         TransformedDStream.__init__(self, prev, func)
 
     @property
@@ -419,6 +430,7 @@ class KafkaMessageAndMetadata(object):
         :param message: actual message payload of this Kafka message, the return data is
                         undecoded bytearray.
         """
+        warnings.warn("Deprecated in 2.3.0.", DeprecationWarning)
         self.topic = topic
         self.partition = partition
         self.offset = offset

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -58,9 +58,13 @@ class KafkaUtils(object):
         :param valueDecoder:  A function used to decode value (default is utf8_decoder)
         :return: A DStream object
 
-        .. note:: Deprecated in 2.3.0. See SPARK-21893.
+        .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+            See SPARK-21893.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         if kafkaParams is None:
             kafkaParams = dict()
         kafkaParams.update({
@@ -108,9 +112,13 @@ class KafkaUtils(object):
         :return: A DStream object
 
         .. note:: Experimental
-        .. note:: Deprecated in 2.3.0. See SPARK-21893.
+        .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+            See SPARK-21893.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         if fromOffsets is None:
             fromOffsets = dict()
         if not isinstance(topics, list):
@@ -163,9 +171,13 @@ class KafkaUtils(object):
         :return: An RDD object
 
         .. note:: Experimental
-        .. note:: Deprecated in 2.3.0. See SPARK-21893.
+        .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+            See SPARK-21893.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         if leaders is None:
             leaders = dict()
         if not isinstance(kafkaParams, dict):
@@ -234,7 +246,8 @@ class OffsetRange(object):
     """
     Represents a range of offsets from a single Kafka TopicAndPartition.
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, topic, partition, fromOffset, untilOffset):
@@ -245,7 +258,10 @@ class OffsetRange(object):
         :param fromOffset: Inclusive starting offset.
         :param untilOffset: Exclusive ending offset.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         self.topic = topic
         self.partition = partition
         self.fromOffset = fromOffset
@@ -276,7 +292,8 @@ class TopicAndPartition(object):
     """
     Represents a specific topic and partition for Kafka.
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, topic, partition):
@@ -285,7 +302,10 @@ class TopicAndPartition(object):
         :param topic: Kafka topic name.
         :param partition: Kafka partition id.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         self._topic = topic
         self._partition = partition
 
@@ -310,7 +330,8 @@ class Broker(object):
     """
     Represent the host and port info for a Kafka broker.
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, host, port):
@@ -319,7 +340,10 @@ class Broker(object):
         :param host: Broker's hostname.
         :param port: Broker's port.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         self._host = host
         self._port = port
 
@@ -331,11 +355,15 @@ class KafkaRDD(RDD):
     """
     A Python wrapper of KafkaRDD, to provide additional information on normal RDD.
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, jrdd, ctx, jrdd_deserializer):
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         RDD.__init__(self, jrdd, ctx, jrdd_deserializer)
 
     def offsetRanges(self):
@@ -354,11 +382,15 @@ class KafkaDStream(DStream):
     """
     A Python wrapper of KafkaDStream
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, jdstream, ssc, jrdd_deserializer):
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         DStream.__init__(self, jdstream, ssc, jrdd_deserializer)
 
     def foreachRDD(self, func):
@@ -393,11 +425,15 @@ class KafkaTransformedDStream(TransformedDStream):
     """
     Kafka specific wrapper of TransformedDStream to transform on Kafka RDD.
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, prev, func):
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         TransformedDStream.__init__(self, prev, func)
 
     @property
@@ -416,7 +452,8 @@ class KafkaMessageAndMetadata(object):
     """
     Kafka message and metadata information. Including topic, partition, offset and message
 
-    .. note:: Deprecated in 2.3.0. See SPARK-21893.
+    .. note:: Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0.
+        See SPARK-21893.
     """
 
     def __init__(self, topic, partition, offset, key, message):
@@ -430,7 +467,10 @@ class KafkaMessageAndMetadata(object):
         :param message: actual message payload of this Kafka message, the return data is
                         undecoded bytearray.
         """
-        warnings.warn("Deprecated in 2.3.0. See SPARK-21893.", DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 2.3.0. Kafka 0.8 support is deprecated as of Spark 2.3.0. "
+            "See SPARK-21893.",
+            DeprecationWarning)
         self.topic = topic
         self.partition = partition
         self.offset = offset


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to mark the existing warnings as `DeprecationWarning` and print out warnings for deprecated functions.

This could be actually useful for Spark app developers. I use (old) PyCharm and this IDE can detect this specific `DeprecationWarning` in some cases:

**Before**

<img src="https://user-images.githubusercontent.com/6477701/31762664-df68d9f8-b4f6-11e7-8773-f0468f70a2cc.png" height="45" />

**After**

<img src="https://user-images.githubusercontent.com/6477701/31762662-de4d6868-b4f6-11e7-98dc-3c8446a0c28a.png" height="70" />

For console usage, `DeprecationWarning` is usually disabled (see https://docs.python.org/2/library/warnings.html#warning-categories and https://docs.python.org/3/library/warnings.html#warning-categories):

```
>>> import warnings
>>> filter(lambda f: f[2] == DeprecationWarning, warnings.filters)
[('ignore', <_sre.SRE_Pattern object at 0x10ba58c00>, <type 'exceptions.DeprecationWarning'>, <_sre.SRE_Pattern object at 0x10bb04138>, 0), ('ignore', None, <type 'exceptions.DeprecationWarning'>, None, 0)]
```

so, it won't actually mess up the terminal much unless it is intended.

If this is intendedly enabled, it'd should as below:

```
>>> import warnings
>>> warnings.simplefilter('always', DeprecationWarning)
>>>
>>> from pyspark.sql import functions
>>> functions.approxCountDistinct("a")
.../spark/python/pyspark/sql/functions.py:232: DeprecationWarning: Deprecated in 2.1, use approx_count_distinct instead.
  "Deprecated in 2.1, use approx_count_distinct instead.", DeprecationWarning)
...
```

These instances were found by:

```
cd python/pyspark
grep -r "Deprecated" .
grep -r "deprecated" .
grep -r "deprecate" .
```

## How was this patch tested?

Manually tested.