### PR TITLE
[SPARK-19606][MESOS] Support constraints in spark-dispatcher

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -263,7 +263,10 @@ resource offers will be accepted.
 conf.set("spark.mesos.constraints", "os:centos7;us-east-1:false")
 {% endhighlight %}
 
-For example, Let's say `spark.mesos.constraints` is set to `os:centos7;us-east-1:false`, then the resource offers will be checked to see if they meet both these constraints and only then will be accepted to start new executors.
+For example, Let's say `spark.mesos.constraints` is set to `os:centos7;us-east-1:false`, then the resource offers will
+be checked to see if they meet both these constraints and only then will be accepted to start new executors.
+
+To constrain where driver tasks are run, use `spark.mesos.driver.constraints`
 
 # Mesos Docker Support
 
@@ -455,6 +458,13 @@ See the [configuration page](configuration.html) for information on Spark config
       <li>Text constraints are matched with "equality" semantics i.e. value in the constraint must be exactly equal to the resource offer's value.</li>
       <li>In case there is no value present as a part of the constraint any offer with the corresponding attribute will be accepted (without value check).</li>
     </ul>
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.driver.constraints</code></td>
+  <td>(none)</td>
+  <td>
+    Same as <code>spark.mesos.constraints</code> except applied to drivers.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -450,7 +450,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.constraints</code></td>
   <td>(none)</td>
   <td>
-    Attribute based constraints on mesos resource offers. By default, all resource offers will be accepted. Refer to <a href="http://mesos.apache.org/documentation/attributes-resources/">Mesos Attributes & Resources</a> for more information on attributes.
+    Attribute based constraints on mesos resource offers. By default, all resource offers will be accepted. This setting
+    applies only to executors. Refer to <a href="http://mesos.apache.org/documentation/attributes-resources/">Mesos
+    Attributes & Resources</a> for more information on attributes.
     <ul>
       <li>Scalar constraints are matched with "less than equal" semantics i.e. value in the constraint must be less than or equal to the value in the resource offer.</li>
       <li>Range constraints are matched with "contains" semantics i.e. value in the constraint must be within the resource offer's value.</li>
@@ -465,7 +467,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>(none)</td>
   <td>
     Same as <code>spark.mesos.constraints</code> except applied to drivers when launched through the dispatcher. By default,
-    all resource offers will be accepted.
+    all offers with sufficient resources will be accepted.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -464,7 +464,8 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.driver.constraints</code></td>
   <td>(none)</td>
   <td>
-    Same as <code>spark.mesos.constraints</code> except applied to drivers.
+    Same as <code>spark.mesos.constraints</code> except applied to drivers when launched through the dispatcher. By default,
+    all resource offers will be accepted.
   </td>
 </tr>
 <tr>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -122,4 +122,11 @@ package object config {
         "Example: key1:val1,key2:val2")
       .stringConf
       .createOptional
+
+  private[spark] val DRIVER_CONSTRAINTS =
+    ConfigBuilder("spark.mesos.driver.constraints")
+      .doc("Attribute based constraints on mesos resource offers. Applied by the dispatcher " +
+        "when launching drivers. Default is to accept all offers with sufficient resources.")
+      .stringConf
+      .createWithDefault("")
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -602,12 +602,14 @@ private[spark] class MesosClusterScheduler(
     for (submission <- candidates) {
       val driverCpu = submission.cores
       val driverMem = submission.mem
-      val constraints = parseConstraintString(submission.conf.get("spark.mesos.driver.constraints", ""))
-      logTrace(s"Finding offer to launch driver with cpu: $driverCpu, mem: $driverMem, constraints: $constraints")
+      val driverConstraints =
+        parseConstraintString(submission.conf.get("spark.mesos.driver.constraints", ""))
+      logTrace(s"Finding offer to launch driver with cpu: $driverCpu, mem: $driverMem, " +
+        s"driverConstraints: $driverConstraints")
       val offerOption = currentOffers.find { offer =>
         getResource(offer.remainingResources, "cpus") >= driverCpu &&
         getResource(offer.remainingResources, "mem") >= driverMem &&
-        matchesAttributeRequirements(constraints, toAttributeMap(offer.attributes))
+        matchesAttributeRequirements(driverConstraints, toAttributeMap(offer.attributes))
       }
       if (offerOption.isEmpty) {
         logDebug(s"Unable to find offer to launch driver id: ${submission.submissionId}, " +

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -556,7 +556,8 @@ private[spark] class MesosClusterScheduler(
 
   private class ResourceOffer(
       val offer: Offer,
-      var remainingResources: JList[Resource]) {
+      var remainingResources: JList[Resource],
+      var attributes: JList[Attribute]) {
     override def toString(): String = {
       s"Offer id: ${offer.getId}, resources: ${remainingResources}"
     }
@@ -601,10 +602,12 @@ private[spark] class MesosClusterScheduler(
     for (submission <- candidates) {
       val driverCpu = submission.cores
       val driverMem = submission.mem
-      logTrace(s"Finding offer to launch driver with cpu: $driverCpu, mem: $driverMem")
+      val constraints = parseConstraintString(submission.conf.get("spark.mesos.driver.constraints", ""))
+      logTrace(s"Finding offer to launch driver with cpu: $driverCpu, mem: $driverMem, constraints: $constraints")
       val offerOption = currentOffers.find { offer =>
         getResource(offer.remainingResources, "cpus") >= driverCpu &&
-        getResource(offer.remainingResources, "mem") >= driverMem
+        getResource(offer.remainingResources, "mem") >= driverMem &&
+        matchesAttributeRequirements(constraints, toAttributeMap(offer.attributes))
       }
       if (offerOption.isEmpty) {
         logDebug(s"Unable to find offer to launch driver id: ${submission.submissionId}, " +
@@ -652,7 +655,7 @@ private[spark] class MesosClusterScheduler(
     val currentTime = new Date()
 
     val currentOffers = offers.asScala.map {
-      offer => new ResourceOffer(offer, offer.getResourcesList)
+      offer => new ResourceOffer(offer, offer.getResourcesList, offer.getAttributesList)
     }.toList
 
     stateLock.synchronized {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -559,7 +559,7 @@ private[spark] class MesosClusterScheduler(
       var remainingResources: JList[Resource],
       var attributes: JList[Attribute]) {
     override def toString(): String = {
-      s"Offer id: ${offer.getId}, resources: ${remainingResources}"
+      s"Offer id: ${offer.getId}, resources: ${remainingResources}, attributes: ${attributes}"
     }
   }
 
@@ -603,7 +603,7 @@ private[spark] class MesosClusterScheduler(
       val driverCpu = submission.cores
       val driverMem = submission.mem
       val driverConstraints =
-        parseConstraintString(submission.conf.get("spark.mesos.driver.constraints", ""))
+        parseConstraintString(submission.conf.get(config.DRIVER_CONSTRAINTS))
       logTrace(s"Finding offer to launch driver with cpu: $driverCpu, mem: $driverMem, " +
         s"driverConstraints: $driverConstraints")
       val offerOption = currentOffers.find { offer =>

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -274,7 +274,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
           command,
           Map("spark.mesos.executor.home" -> "test",
             "spark.app.name" -> "test",
-            "spark.mesos.driver.constraints" -> driverConstraints),
+            config.DRIVER_CONSTRAINTS.key -> driverConstraints),
           "s1",
           new Date()))
       assert(response.success)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -19,8 +19,6 @@ package org.apache.spark.scheduler.cluster.mesos
 
 import java.util.Collections
 
-import org.apache.mesos.protobuf.ByteString
-
 import scala.collection.JavaConverters._
 
 import org.apache.mesos.Protos._
@@ -33,14 +31,6 @@ import org.mockito.Mockito._
 import org.apache.spark.deploy.mesos.config.MesosSecretConfig
 
 object Utils {
-  def createTextAttribute(name: String, value: String): Attribute = {
-    Attribute.newBuilder()
-      .setName(name)
-      .setType(Value.Type.TEXT)
-      .setText(Value.Text.newBuilder().setValue(value))
-      .build()
-  }
-
 
   val TEST_FRAMEWORK_ID = FrameworkID.newBuilder()
     .setValue("test-framework-id")
@@ -53,13 +43,13 @@ object Utils {
     .build()
 
   def createOffer(
-      offerId: String,
-      slaveId: String,
-      mem: Int,
-      cpus: Int,
-      ports: Option[(Long, Long)] = None,
-      gpus: Int = 0,
-      attributes: List[Attribute] = List.empty): Offer = {
+                   offerId: String,
+                   slaveId: String,
+                   mem: Int,
+                   cpus: Int,
+                   ports: Option[(Long, Long)] = None,
+                   gpus: Int = 0,
+                   attributes: List[Attribute] = List.empty): Offer = {
     val builder = Offer.newBuilder()
     builder.addResourcesBuilder()
       .setName("mem")
@@ -74,7 +64,7 @@ object Utils {
         .setName("ports")
         .setType(Value.Type.RANGES)
         .setRanges(Ranges.newBuilder().addRange(MesosRange.newBuilder()
-          .setBegin(resourcePorts._1).setEnd(resourcePorts._2).build()))
+        .setBegin(resourcePorts._1).setEnd(resourcePorts._2).build()))
     }
     if (gpus > 0) {
       builder.addResourcesBuilder()
@@ -84,7 +74,7 @@ object Utils {
     }
     builder.setId(createOfferId(offerId))
       .setFrameworkId(FrameworkID.newBuilder()
-        .setValue("f1"))
+      .setValue("f1"))
       .setSlaveId(SlaveID.newBuilder().setValue(slaveId))
       .setHostname(s"host${slaveId}")
       .addAllAttributes(attributes.asJava)
@@ -137,7 +127,7 @@ object Utils {
       .getVariablesList
       .asScala
     assert(envVars
-      .count(!_.getName.startsWith("SPARK_")) == 2)  // user-defined secret env vars
+      .count(!_.getName.startsWith("SPARK_")) == 2) // user-defined secret env vars
     val variableOne = envVars.filter(_.getName == "SECRET_ENV_KEY").head
     assert(variableOne.getSecret.isInitialized)
     assert(variableOne.getSecret.getType == Secret.Type.REFERENCE)
@@ -166,7 +156,7 @@ object Utils {
       .getVariablesList
       .asScala
     assert(envVars
-      .count(!_.getName.startsWith("SPARK_")) == 2)  // user-defined secret env vars
+      .count(!_.getName.startsWith("SPARK_")) == 2) // user-defined secret env vars
     val variableOne = envVars.filter(_.getName == "USER").head
     assert(variableOne.getSecret.isInitialized)
     assert(variableOne.getSecret.getType == Secret.Type.VALUE)
@@ -224,4 +214,13 @@ object Utils {
     assert(secretVolTwo.getSource.getSecret.getValue.getData ==
       ByteString.copyFrom("password".getBytes))
   }
+
+  def createTextAttribute(name: String, value: String): Attribute = {
+    Attribute.newBuilder()
+      .setName(name)
+      .setType(Value.Type.TEXT)
+      .setText(Value.Text.newBuilder().setValue(value))
+      .build()
+  }
 }
+

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -19,6 +19,8 @@ package org.apache.spark.scheduler.cluster.mesos
 
 import java.util.Collections
 
+import org.apache.mesos.protobuf.ByteString
+
 import scala.collection.JavaConverters._
 
 import org.apache.mesos.Protos._
@@ -31,6 +33,14 @@ import org.mockito.Mockito._
 import org.apache.spark.deploy.mesos.config.MesosSecretConfig
 
 object Utils {
+  def createTextAttribute(name: String, value: String): Attribute = {
+    Attribute.newBuilder()
+      .setName(name)
+      .setType(Value.Type.TEXT)
+      .setText(Value.Text.newBuilder().setValue(value))
+      .build()
+  }
+
 
   val TEST_FRAMEWORK_ID = FrameworkID.newBuilder()
     .setValue("test-framework-id")
@@ -48,7 +58,8 @@ object Utils {
       mem: Int,
       cpus: Int,
       ports: Option[(Long, Long)] = None,
-      gpus: Int = 0): Offer = {
+      gpus: Int = 0,
+      attributes: List[Attribute] = List.empty): Offer = {
     val builder = Offer.newBuilder()
     builder.addResourcesBuilder()
       .setName("mem")
@@ -76,6 +87,7 @@ object Utils {
         .setValue("f1"))
       .setSlaveId(SlaveID.newBuilder().setValue(slaveId))
       .setHostname(s"host${slaveId}")
+      .addAllAttributes(attributes.asJava)
       .build()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A discussed in SPARK-19606, the addition of a new config property named "spark.mesos.constraints.driver" for constraining drivers running on a Mesos cluster

## How was this patch tested?

Corresponding unit test added also tested locally on a Mesos cluster

Please review http://spark.apache.org/contributing.html before opening a pull request.
