### PR TITLE
[SPARK-22328][Core] ClosureCleaner should not miss referenced superclass fields

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -129,10 +129,12 @@ private[spark] object ClosureCleaner extends Logging {
     val clone = instantiateClass(outerClass, parent)
 
     var currentClass = outerClass
-    do {
+    assert(currentClass != null, "The outer class can't be null.")
+
+    while (currentClass != null) {
       setAccessedFields(currentClass, clone, obj, accessedFields)
       currentClass = currentClass.getSuperclass()
-    } while (currentClass != null)
+    }
 
     clone
   }
@@ -437,11 +439,13 @@ private[util] class FieldAccessFinder(
               visitedMethods += m
 
               var currentClass = cl
-              do {
+              assert(currentClass != null, "The outer class can't be null.")
+
+              while (currentClass != null) {
                 ClosureCleaner.getClassReader(currentClass).accept(
                   new FieldAccessFinder(fields, findTransitively, Some(m), visitedMethods), 0)
                 currentClass = currentClass.getSuperclass()
-              } while (currentClass != null)
+              }
             }
           }
         }

--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -97,10 +97,12 @@ private[spark] object ClosureCleaner extends Logging {
       outerClasses: Seq[Class[_]]): Unit = {
     for (cls <- outerClasses) {
       var currentClass = cls
-      do {
+      assert(currentClass != null, "The outer class can't be null.")
+
+      while (currentClass != null) {
         accessedFields(currentClass) = Set.empty[String]
         currentClass = currentClass.getSuperclass()
-      } while (currentClass != null)
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -152,6 +152,30 @@ class ClosureCleanerSuite extends SparkFunSuite {
       assert(rdd.collect() === Seq((111, 222, "aaa", "bbb", 1.0d, 2.0d)))
     }
   }
+
+  test("SPARK-22328: multiple outer classes have the same parent class") {
+    val concreteObject = new TestAbstractClass2 {
+
+      val innerObject = new TestAbstractClass2 {
+        override val n1 = 222
+        override val s1 = "bbb"
+      }
+
+      val innerObject2 = new TestAbstractClass2 {
+        override val n1 = 444
+        val n3 = 333
+        val s3 = "ccc"
+        val d3 = 3.0d
+
+        def getData: Int => (Int, Int, String, String, Double, Double, Int, String) =
+          _ => (n1, n3, s1, s3, d1, d3, innerObject.n1, innerObject.s1)
+      }
+    }
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val rdd = sc.parallelize(1 to 1).map(concreteObject.innerObject2.getData)
+      assert(rdd.collect() === Seq((444, 333, "aaa", "ccc", 1.0d, 3.0d, 222, "bbb")))
+    }
+  }
 }
 
 // A non-serializable class we create in closures to make sure that we aren't


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the given closure uses some fields defined in super class, `ClosureCleaner` can't figure them and don't set it properly. Those fields will be in null values.

## How was this patch tested?

Added test.