### PR TITLE
[SPARK-22334][SQL] Check table size from filesystem in case the size in metastore is wrong.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -187,6 +187,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val VERIFY_STATS_FROM_HDFS_WHEN_BROADCASTJOIN =
+    buildConf("spark.sql.statistics.verifyStatsFromHdfsWhenBroadcastJoin")
+    .doc("If table size in metastore is below spark.sql.autoBroadcastJoinThreshold, check the " +
+      "size on Hdfs and set table size to be the bigger one. This is for defense and help avoid" +
+      " OOM caused by broadcast join. It's useful when metastore failed to update the stats of" +
+      " table previously.")
+    .booleanConf
+    .createWithDefault(false)
+
   val DEFAULT_SIZE_IN_BYTES = buildConf("spark.sql.defaultSizeInBytes")
     .internal()
     .doc("The default table size used in query planning. By default, it is set to Long.MaxValue " +
@@ -1103,6 +1112,9 @@ class SQLConf extends Serializable with Logging {
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
 
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
+
+  def verifyStatsFromHdfsWhenBroadcastJoin: Boolean =
+    getConf(VERIFY_STATS_FROM_HDFS_WHEN_BROADCASTJOIN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -187,12 +187,12 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val VERIFY_STATS_FROM_HDFS_WHEN_BROADCASTJOIN =
-    buildConf("spark.sql.statistics.verifyStatsFromHdfsWhenBroadcastJoin")
-    .doc("If table size in metastore is below spark.sql.autoBroadcastJoinThreshold, check the " +
-      "size on Hdfs and set table size to be the bigger one. This is for defense and help avoid" +
-      " OOM caused by broadcast join. It's useful when metastore failed to update the stats of" +
-      " table previously.")
+  val VERIFY_STATS_FROM_FILESYSTEM_WHEN_BROADCASTJOIN =
+    buildConf("spark.sql.statistics.verifyStatsFromFileSystemWhenBroadcastJoin")
+    .doc("If table size in metastore is below spark.sql.autoBroadcastJoinThreshold, check the" +
+      " real size on file system and set table size to be the bigger one. This is for defense" +
+      " and help avoid OOM caused by broadcast join. It's useful when metastore failed to" +
+      " update the stats of table previously.")
     .booleanConf
     .createWithDefault(false)
 
@@ -1113,8 +1113,8 @@ class SQLConf extends Serializable with Logging {
 
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
 
-  def verifyStatsFromHdfsWhenBroadcastJoin: Boolean =
-    getConf(VERIFY_STATS_FROM_HDFS_WHEN_BROADCASTJOIN)
+  def verifyStatsFromFileSystemWhenBroadcastJoin: Boolean =
+    getConf(VERIFY_STATS_FROM_FILESYSTEM_WHEN_BROADCASTJOIN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -187,8 +187,8 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val VERIFY_STATS_FROM_FILESYSTEM_WHEN_BROADCASTJOIN =
-    buildConf("spark.sql.statistics.verifyStatsFromFileSystemWhenBroadcastJoin")
+  val VERIFY_STATS_FROM_FILESYSTEM_WHEN_JOIN =
+    buildConf("spark.sql.statistics.verifyStatsFromFileSystemWhenJoin")
     .doc("If table size in metastore is below spark.sql.autoBroadcastJoinThreshold, check the" +
       " real size on file system and set table size to be the bigger one. This is for defense" +
       " and help avoid OOM caused by broadcast join. It's useful when metastore failed to" +
@@ -1113,8 +1113,8 @@ class SQLConf extends Serializable with Logging {
 
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
 
-  def verifyStatsFromFileSystemWhenBroadcastJoin: Boolean =
-    getConf(VERIFY_STATS_FROM_FILESYSTEM_WHEN_BROADCASTJOIN)
+  def verifyStatsFromFileSystemWhenJoin: Boolean =
+    getConf(VERIFY_STATS_FROM_FILESYSTEM_WHEN_JOIN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -130,7 +130,7 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
 
     case relation: HiveTableRelation
         if DDLUtils.isHiveTable(relation.tableMeta) && relation.tableMeta.stats.nonEmpty &&
-          session.sessionState.conf.verifyStatsFromHdfsWhenBroadcastJoin &&
+          session.sessionState.conf.verifyStatsFromFileSystemWhenBroadcastJoin &&
           relation.tableMeta.stats.get.sizeInBytes <
             session.sessionState.conf.autoBroadcastJoinThreshold =>
       val table = relation.tableMeta

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -80,7 +80,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
   }
 
   test("Check Hdfs for stats of small table.") {
-    withSQLConf(SQLConf.VERIFY_STATS_FROM_HDFS_WHEN_BROADCASTJOIN.key -> "true") {
+    withSQLConf(SQLConf.VERIFY_STATS_FROM_FILESYSTEM_WHEN_BROADCASTJOIN.key -> "true") {
       withTable("csv_table") {
         withTempDir { tempDir =>
           // EXTERNAL OpenCSVSerde table pointing to LOCATION


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we use table properties('totalSize') to judge if to use broadcast join. Table properties are from metastore. However they can be wrong. Hive sometimes fails to update table properties after producing data successfully(e,g, NameNode timeout from https://github.com/apache/hive/blob/branch-1.2/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreUtils.java#L180). If 'totalSize' in table properties is much smaller than its real size on filesystem(e.g. HDFS), Spark can launch broadcast join by mistake and suffer OOM.
Could we add a defense config and check the size from filesystem(e.g. HDFS) when 'totalSize' is below `spark.sql.autoBroadcastJoinThreshold`

## How was this patch tested?

Tests added