### PR TITLE
[SPARK-22111][MLLIB] OnlineLDAOptimizer should filter out empty documents beforehand

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -415,9 +415,9 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
       docs: RDD[(Long, Vector)],
       lda: LDA): OnlineLDAOptimizer = {
     this.k = lda.getK
-    this.docs = docs.filter(_._2.numNonzeros > 0) // filter out empty documents
+    this.docs = docs
     this.corpusSize = this.docs.count()
-    this.vocabSize = docs.first()._2.size
+    this.vocabSize = this.docs.first()._2.size
     this.alpha = if (lda.getAsymmetricDocConcentration.size == 1) {
       if (lda.getAsymmetricDocConcentration(0) == -1) Vectors.dense(Array.fill(k)(1.0 / k))
       else {
@@ -445,7 +445,8 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
   override private[clustering] def next(): OnlineLDAOptimizer = {
     val batch = docs.sample(withReplacement = sampleWithReplacement, miniBatchFraction,
       randomGenerator.nextLong())
-    submitMiniBatch(batch)
+    val batchNoEmptyDocs = batch.filter(_._2.numNonzeros > 0)
+    submitMiniBatch(batchNoEmptyDocs)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -514,7 +514,7 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
   /**
    * Update lambda based on the batch submitted. batchSize can be different for each iteration.
    */
-  private def updateLambda(stat: BDM[Double], batchSize: Double): Unit = {
+  private def updateLambda(stat: BDM[Double], batchSize: Long): Unit = {
     // weight of the mini-batch.
     val weight = rho()
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -452,7 +452,7 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
    * Submit a subset (like 1%, decide by the miniBatchFraction) of the corpus to the Online LDA
    * model, and it will update the topic distribution adaptively for the terms appearing in the
    * subset.
-   * The methods assumes no empty documents are submitted.
+   * The method assumes no empty documents are submitted.
    */
   private[clustering] def submitMiniBatch(batch: RDD[(Long, Vector)]): OnlineLDAOptimizer = {
     iteration += 1

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -445,7 +445,6 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
   override private[clustering] def next(): OnlineLDAOptimizer = {
     val batch = docs.sample(withReplacement = sampleWithReplacement, miniBatchFraction,
       randomGenerator.nextLong())
-    if (batch.isEmpty()) return this
     submitMiniBatch(batch)
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
@@ -275,6 +275,21 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     }
   }
 
+  test("submit submitMiniBatch method of OnlineLDAOptimizer correctly processes an empty RDD") {
+    val lda = new LDA().setK(2).setOptimizer("online")
+    val corpus = sc.parallelize(tinyCorpus, 2)
+    val optimizer = lda.getOptimizer.asInstanceOf[OnlineLDAOptimizer]
+    val emptyRDD = sc.parallelize(Seq[(Long, Vector)]())
+
+    optimizer.initialize(corpus, lda)
+    val initialLambda = optimizer.getLambda.copy
+    optimizer.submitMiniBatch(emptyRDD)
+    val newLambda = optimizer.getLambda
+
+    assert(initialLambda === newLambda, "Submition of an empty mini-batch " +
+      "changes the state of the optimizer while it should not ")
+  }
+
   test("LocalLDAModel logLikelihood") {
     val ldaModel: LocalLDAModel = toyModel
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The empty documents are filtered out in the `initialize` method and are never included in mini-batches.  `batchSize`, and `nonEmptyDocsN` are now the same thing.

## How was this patch tested?

Existing unit-tests.
