### PR TITLE
[SPARK-22291][SQL] Conversion error when transforming array types of uuid, inet and cidr to StingType in PostgreSQL

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.jdbc
 
 import java.sql.Connection
-import java.util.{Properties, UUID}
+import java.util.Properties
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -60,7 +60,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
       "(id integer, tstz TIMESTAMP WITH TIME ZONE, ttz TIME WITH TIME ZONE)")
       .executeUpdate()
     conn.prepareStatement("INSERT INTO ts_with_timezone VALUES " +
-      "(1, TIMESTAMP WITH TIME ZONE '2016-08-12 10:22:31.949271-07', TIME WITH TIME ZONE '17:22:31.949271+00')")
+      "(1, TIMESTAMP WITH TIME ZONE '2016-08-12 10:22:31.949271-07', " +
+      "TIME WITH TIME ZONE '17:22:31.949271+00')")
       .executeUpdate()
 
     conn.prepareStatement("CREATE TABLE arrtypes (c0 uuid[], c1 inet[], c2 cidr[]," +
@@ -145,7 +146,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(schema(1).dataType == ShortType)
   }
 
-  test("SPARK-20557: column type TIMESTAMP with TIME ZONE and TIME with TIME ZONE should be recognized") {
+  test("SPARK-20557: column type TIMESTAMP with TIME ZONE and TIME with TIME ZONE " +
+    "should be recognized") {
     val dfRead = sqlContext.read.jdbc(jdbcUrl, "ts_with_timezone", new Properties)
     val rows = dfRead.collect()
     val types = rows(0).toSeq.map(x => x.getClass.toString)

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -63,12 +63,15 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
       "(1, TIMESTAMP WITH TIME ZONE '2016-08-12 10:22:31.949271-07', TIME WITH TIME ZONE '17:22:31.949271+00')")
       .executeUpdate()
 
-    conn.prepareStatement("CREATE TABLE arrtypes (c0 uuid[], c1 inet[], c2 cidr[])")
+    conn.prepareStatement("CREATE TABLE arrtypes (c0 uuid[], c1 inet[], c2 cidr[]," +
+      "c3 uuid, c4 inet, c5 cidr)")
       .executeUpdate()
     conn.prepareStatement("INSERT INTO arrtypes VALUES (ARRAY" +
       "['7be8aaf8-650e-4dbb-8186-0a749840ecf2','205f9bfc-018c-4452-a605-609c0cfad228']::uuid[]," +
       "ARRAY['172.16.0.41', '172.16.0.42']::inet[]," +
-      "ARRAY['192.168.0.0/24', '10.1.0.0/16']::cidr[])")
+      "ARRAY['192.168.0.0/24', '10.1.0.0/16']::cidr[]," +
+      "'0a532531-cdf1-45e3-963d-5de90b6a30f1'::uuid," +
+      "'172.168.22.1'::inet, '192.168.100.128/25'::cidr)")
       .executeUpdate()
   }
 
@@ -157,5 +160,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
       "205f9bfc-018c-4452-a605-609c0cfad228"))
     assert(rows(0).getSeq(1) == Seq("172.16.0.41", "172.16.0.42"))
     assert(rows(0).getSeq(2) == Seq("192.168.0.0/24", "10.1.0.0/16"))
+    assert(rows(0).getString(3) == "0a532531-cdf1-45e3-963d-5de90b6a30f1")
+    assert(rows(0).getString(4) == "172.168.22.1")
+    assert(rows(0).getString(5) == "192.168.100.128/25")
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -158,7 +158,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(types(2).equals("class java.sql.Timestamp"))
   }
 
-  test("SPARK-22291: Postgresql UUID[] to Cassandra: Conversion Error") {
+  test("SPARK-22291: PostgreSQL UUID[] to StringType: Conversion Error") {
     val df = sqlContext.read.jdbc(jdbcUrl, "st_with_array", new Properties)
     val rows = df.collect()
     assert(rows(0).getString(0) == "0a532531-cdf1-45e3-963d-5de90b6a30f1")

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -158,7 +158,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(types(2).equals("class java.sql.Timestamp"))
   }
 
-  test("SPARK-22291: PostgreSQL UUID[] to StringType: Conversion Error") {
+  test("SPARK-22291: Conversion error when transforming array types of " +
+    "uuid, inet and cidr to StingType in PostgreSQL") {
     val df = sqlContext.read.jdbc(jdbcUrl, "st_with_array", new Properties)
     val rows = df.collect()
     assert(rows(0).getString(0) == "0a532531-cdf1-45e3-963d-5de90b6a30f1")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -456,17 +456,10 @@ object JdbcUtils extends Logging {
 
         case StringType =>
           (array: Object) =>
-            array match {
-              case _: Array[java.lang.String] =>
-                array.asInstanceOf[Array[java.lang.String]]
-                  .map(UTF8String.fromString)
-              case _: Array[java.util.UUID] =>
-                array.asInstanceOf[Array[java.util.UUID]]
-                  .map(uuid => UTF8String.fromString(uuid.toString))
-              case _ =>
-                array.asInstanceOf[Array[java.lang.Object]]
-                  .map(obj => UTF8String.fromString(obj.toString))
-            }
+            // some underling types are not String such as uuid, inet, cidr, etc.
+            array.asInstanceOf[Array[java.lang.Object]]
+              .map(obj => UTF8String.fromString(
+                if (obj == null) null else obj.toString))
 
         case DateType =>
           (array: Object) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -456,8 +456,14 @@ object JdbcUtils extends Logging {
 
         case StringType =>
           (array: Object) =>
-            array.asInstanceOf[Array[java.lang.String]]
-              .map(UTF8String.fromString)
+            array match {
+              case _: Array[java.util.UUID] =>
+                array.asInstanceOf[Array[java.util.UUID]]
+                  .map(uuid => UTF8String.fromString(uuid.toString))
+              case _ =>
+                array.asInstanceOf[Array[java.lang.String]]
+                  .map(UTF8String.fromString)
+            }
 
         case DateType =>
           (array: Object) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -458,8 +458,7 @@ object JdbcUtils extends Logging {
           (array: Object) =>
             // some underling types are not String such as uuid, inet, cidr, etc.
             array.asInstanceOf[Array[java.lang.Object]]
-              .map(obj => UTF8String.fromString(
-                if (obj == null) null else obj.toString))
+              .map(obj => if (obj == null) null else UTF8String.fromString(obj.toString))
 
         case DateType =>
           (array: Object) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -457,12 +457,15 @@ object JdbcUtils extends Logging {
         case StringType =>
           (array: Object) =>
             array match {
+              case _: Array[java.lang.String] =>
+                array.asInstanceOf[Array[java.lang.String]]
+                  .map(UTF8String.fromString)
               case _: Array[java.util.UUID] =>
                 array.asInstanceOf[Array[java.util.UUID]]
                   .map(uuid => UTF8String.fromString(uuid.toString))
               case _ =>
-                array.asInstanceOf[Array[java.lang.String]]
-                  .map(UTF8String.fromString)
+                array.asInstanceOf[Array[java.lang.Object]]
+                  .map(obj => UTF8String.fromString(obj.toString))
             }
 
         case DateType =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the conversion error when reads data from a PostgreSQL table that contains columns of `uuid[]`, `inet[]` and `cidr[]` data types. 

For example, create a table with the uuid[] data type, and insert the test data.
```SQL
CREATE TABLE users
(
    id smallint NOT NULL,
    name character varying(50),
    user_ids uuid[],
    PRIMARY KEY (id)
)

INSERT INTO users ("id", "name","user_ids") 
VALUES (1, 'foo', ARRAY
    ['7be8aaf8-650e-4dbb-8186-0a749840ecf2'
    ,'205f9bfc-018c-4452-a605-609c0cfad228']::UUID[]
)
```
Then it will throw the following exceptions when trying to load the data.
```
java.lang.ClassCastException: [Ljava.util.UUID; cannot be cast to [Ljava.lang.String;
    at org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$$anonfun$14.apply(JdbcUtils.scala:459)
    at org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$$anonfun$14.apply(JdbcUtils.scala:458)
...
```


## How was this patch tested?

Added test in `PostgresIntegrationSuite`.