### PR TITLE
SPARK-22345: Fix sort-merge joins with conditions and codegen.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -585,21 +585,26 @@ case class SortMergeJoinExec(
 
     val iterator = ctx.freshName("iterator")
     val numOutput = metricTerm(ctx, "numOutputRows")
+    val joinedRow = ctx.freshName("joined")
     val (beforeLoop, condCheck) = if (condition.isDefined) {
       // Split the code of creating variables based on whether it's used by condition or not.
       val loaded = ctx.freshName("loaded")
       val (leftBefore, leftAfter) = splitVarsByCondition(left.output, leftVars)
       val (rightBefore, rightAfter) = splitVarsByCondition(right.output, rightVars)
       // Generate code for condition
+      // set INPUT_ROW to the joined row because it is the data for the condition
+      ctx.INPUT_ROW = joinedRow
       ctx.currentVars = leftVars ++ rightVars
       val cond = BindReferences.bindReference(condition.get, output).genCode(ctx)
       // evaluate the columns those used by condition before loop
       val before = s"""
            |boolean $loaded = false;
+           |$joinedRow.withLeft($leftRow);
            |$leftBefore
          """.stripMargin
 
       val checking = s"""
+         |$joinedRow.withRight($rightRow);
          |$rightBefore
          |${cond.code}
          |if (${cond.isNull} || !${cond.value}) continue;
@@ -615,6 +620,7 @@ case class SortMergeJoinExec(
     }
 
     s"""
+       |JoinedRow $joinedRow = new JoinedRow();
        |while (findNextInnerJoinRows($leftInput, $rightInput)) {
        |  ${beforeLoop.trim}
        |  scala.collection.Iterator<UnsafeRow> $iterator = $matches.generateIterator();

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -231,28 +231,6 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
   )
 
   testInnerJoin(
-    "inner join without codegen",
-    myUpperCaseData,
-    myLowerCaseData,
-    () => {
-      // test equality with a UDF that will not generate code to exercise CodegenFallback
-      // val udfEquals = org.apache.spark.sql.functions.udf((a: String, b: String) =>
-      //   a != null && a.toLowerCase(Locale.ENGLISH) == b.toLowerCase(Locale.ENGLISH))
-      And(
-        (myUpperCaseData.col("N") === myLowerCaseData.col("n")).expr,
-        EqNoCodegen(
-          org.apache.spark.sql.functions.lower(myUpperCaseData.col("L")).expr,
-          myLowerCaseData.col("l").expr))
-    },
-    Seq(
-      (1, "A", 1, "a"),
-      (2, "B", 2, "b"),
-      (3, "C", 3, "c"),
-      (4, "D", 4, "d")
-    )
-  )
-
-  testInnerJoin(
     "inner join with CodegenFallback filter",
     myUpperCaseData,
     myLowerCaseData,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds a joined row to sort-merge join codegen. That joined row is used to generate code for filter expressions, which may fall back to using the result row. Previously, the right side of the join was used, which is incorrect (the non-codegen implementations use a joined row).

## How was this patch tested?

Current tests.