### PR TITLE
[SPARK-22335][SQL] Clarify union behavior on Dataset of typed objects in the document

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1751,30 +1751,26 @@ class Dataset[T] private[sql](
    * This is equivalent to `UNION ALL` in SQL. To do a SQL-style set union (that does
    * deduplication of elements), use this function followed by a [[distinct]].
    *
-   * Also as standard in SQL, this function resolves columns by position (not by name).
+   * Also as standard in SQL, this function resolves columns by position (not by name):
+   *
+   * {{{
+   *   val df1 = Seq((1, 2, 3)).toDF("col0", "col1", "col2")
+   *   val df2 = Seq((4, 5, 6)).toDF("col1", "col2", "col0")
+   *   df1.union(df2).show
+   *
+   *   // output:
+   *   // +----+----+----+
+   *   // |col0|col1|col2|
+   *   // +----+----+----+
+   *   // |   1|   2|   3|
+   *   // |   4|   5|   6|
+   *   // +----+----+----+
+   * }}}
    *
    * Notice that the column positions in the schema aren't necessarily matched with the
    * fields in the strongly typed objects in a Dataset. This function resolves columns
-   * by their positions in the schema, not the fields in the strongly typed objects, as
-   * this Scala example shows (using Scala case class for example, it is also applicable
-   * to the strongly-typed JVM objects):
-   *
-   * {{{
-   *   case class Test(a: String, b: String)
-   *   val ds1 = Seq(("a", "b")).toDF("a", "b").as[Test] // ds1's schema: [a: String, b: String]
-   *   val ds2 = Seq(("b", "a")).toDF("b", "a").as[Test] // ds2's schema: [b: String, a: String]
-   *   ds1.union(ds2).show
-   *
-   *   // output:
-   *   // +---+---+
-   *   // |  a|  b|
-   *   // +---+---+
-   *   // |  a|  b|
-   *   // |  b|  a|
-   *   // +---+---+
-   * }}}
-   *
-   * Use [[unionByName]] to resolve columns by field name in the typed objects.
+   * by their positions in the schema, not the fields in the strongly typed objects. Use
+   * [[unionByName]] to resolve columns by field name in the typed objects.
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1755,10 +1755,10 @@ class Dataset[T] private[sql](
    *
    * Notice that the column positions in the schema aren't necessarily matched with the
    * fields in the typed objects in a Dataset. This function resolves columns by their positions
-   * in the schema, not the fields in the typed objects:
+   * in the schema, not the fields in the typed objects, as this Scala example shows:
    *
    * {{{
-   *   case class Test(a : String, b : String)
+   *   case class Test(a: String, b: String)
    *   val ds1 = Seq(("a", "b")).toDF("a", "b").as[Test] // ds1's schema: [a: String, b: String]
    *   val ds2 = Seq(("b", "a")).toDF("b", "a").as[Test] // ds2's schema: [b: String, a: String]
    *   ds1.union(ds2).show

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1753,6 +1753,27 @@ class Dataset[T] private[sql](
    *
    * Also as standard in SQL, this function resolves columns by position (not by name).
    *
+   * Notice that the column positions in the schema aren't necessarily matched with the
+   * fields in the typed objects in a Dataset. This function resolves columns by their positions
+   * in the schema, not the fields in the typed objects:
+   *
+   * {{{
+   *   case class Test(a : String, b : String)
+   *   val ds1 = Seq(("a", "b")).toDF("a", "b").as[Test] // ds1's schema: [a: String, b: String]
+   *   val ds2 = Seq(("b", "a")).toDF("b", "a").as[Test] // ds2's schema: [b: String, a: String]
+   *   ds1.union(ds2).show
+   *
+   *   // output:
+   *   // +---+---+
+   *   // |  a|  b|
+   *   // +---+---+
+   *   // |  a|  b|
+   *   // |  b|  a|
+   *   // +---+---+
+   * }}}
+   *
+   * Use [[unionByName]] to resolve columns by field name in the typed objects.
+   *
    * @group typedrel
    * @since 2.0.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1754,8 +1754,10 @@ class Dataset[T] private[sql](
    * Also as standard in SQL, this function resolves columns by position (not by name).
    *
    * Notice that the column positions in the schema aren't necessarily matched with the
-   * fields in the typed objects in a Dataset. This function resolves columns by their positions
-   * in the schema, not the fields in the typed objects, as this Scala example shows:
+   * fields in the strongly typed objects in a Dataset. This function resolves columns
+   * by their positions in the schema, not the fields in the strongly typed objects, as
+   * this Scala example shows (using Scala case class for example, it is also applicable
+   * to the strongly-typed JVM objects):
    *
    * {{{
    *   case class Test(a: String, b: String)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seems that end users can be confused by the union's behavior on Dataset of typed objects. We can clarity it more in the document of `union` function.

## How was this patch tested?

Only document change.