### PR TITLE
[SPARK-15474][SQL] Write and read back non-emtpy schema with empty dataframe

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -17,12 +17,18 @@
 
 package org.apache.spark.sql.execution.datasources.orc
 
-import org.apache.orc.TypeDescription
+import java.io._
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.orc.{OrcFile, TypeDescription}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.types.StructType
 
-private[sql] object OrcFileFormat {
+private[sql] object OrcFileFormat extends Logging {
   private def checkFieldName(name: String): Unit = {
     try {
       TypeDescription.fromString(s"struct<$name:int>")
@@ -38,5 +44,33 @@ private[sql] object OrcFileFormat {
   def checkFieldNames(schema: StructType): StructType = {
     schema.fieldNames.foreach(checkFieldName)
     schema
+  }
+
+  def getSchemaString(schema: StructType): String = {
+    schema.fields.map(f => s"${f.name}:${f.dataType.catalogString}").mkString("struct<", ",", ">")
+  }
+
+  private def readSchema(file: Path, conf: Configuration, fs: FileSystem) = {
+    try {
+      val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
+      val reader = OrcFile.createReader(file, readerOptions)
+      val schema = reader.getSchema
+      if (schema.getFieldNames.size == 0) {
+        None
+      } else {
+        Some(schema)
+      }
+    } catch {
+      case _: IOException => None
+    }
+  }
+
+  def readSchema(sparkSession: SparkSession, files: Seq[FileStatus]): Option[StructType] = {
+    val conf = sparkSession.sparkContext.hadoopConfiguration
+    val fs = FileSystem.get(conf)
+    files.map(_.getPath).flatMap(readSchema(_, conf, fs)).headOption.map { schema =>
+      logDebug(s"Reading schema from file $files, got Hive schema string: $schema")
+      CatalystSqlParser.parseDataType(schema.toString).asInstanceOf[StructType]
+    }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.io.{NullWritable, Writable}
 import org.apache.hadoop.mapred.{JobConf, OutputFormat => MapRedOutputFormat, RecordWriter, Reporter}
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat, FileSplit}
-import org.apache.orc.OrcConf.COMPRESS
+import org.apache.orc.OrcConf.{COMPRESS, MAPRED_OUTPUT_SCHEMA}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.SparkSession
@@ -58,10 +58,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    OrcFileOperator.readSchema(
-      files.map(_.getPath.toString),
-      Some(sparkSession.sessionState.newHadoopConf())
-    )
+    org.apache.spark.sql.execution.datasources.orc.OrcFileFormat.readSchema(sparkSession, files)
   }
 
   override def prepareWrite(
@@ -72,6 +69,10 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
     val orcOptions = new OrcOptions(options, sparkSession.sessionState.conf)
 
     val configuration = job.getConfiguration
+
+    configuration.set(
+      MAPRED_OUTPUT_SCHEMA.getAttribute,
+      org.apache.spark.sql.execution.datasources.orc.OrcFileFormat.getSchemaString(dataSchema))
 
     configuration.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
     configuration match {
@@ -252,6 +253,12 @@ private[orc] class OrcOutputWriter(
   override def close(): Unit = {
     if (recordWriterInstantiated) {
       recordWriter.close(Reporter.NULL)
+    } else {
+      // SPARK-15474 Write empty orc file with correct schema
+      val conf = context.getConfiguration()
+      val writer = org.apache.orc.OrcFile.createWriter(
+        new Path(path), org.apache.orc.mapred.OrcOutputFormat.buildOptions(conf))
+      new org.apache.orc.mapreduce.OrcMapreduceRecordWriter(writer).close(context)
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2153,4 +2153,18 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       }
     }
   }
+
+  Seq("orc", "parquet").foreach { format =>
+    test(s"SPARK-15474 Write and read back non-emtpy schema with empty dataframe - $format") {
+      withTempPath { file =>
+        val path = file.getCanonicalPath
+        val emptyDf = Seq((true, 1, "str")).toDF.limit(0)
+        emptyDf.write.format(format).save(path)
+
+        val df = spark.read.format(format).load(path)
+        assert(df.schema.sameType(emptyDf.schema))
+        checkAnswer(df, emptyDf)
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously, ORC file format cannot write a correct schema in case of empty dataframe. Instead, it creates an empty ORC file with **empty** schema, `struct<>`. So, Spark users cannot write and read back ORC files with non-empty schema and no rows. This PR uses new Apache ORC 1.4.1 to create an empty ORC file with a correct schema. Also, this PR uses ORC 1.4.1 to infer schema always.

**BEFORE**
```scala
scala> val emptyDf = Seq((true, 1, "str")).toDF("a", "b", "c").limit(0)
scala> emptyDf.write.format("orc").mode("overwrite").save("/tmp/empty")
scala> spark.read.format("orc").load("/tmp/empty").printSchema
org.apache.spark.sql.AnalysisException: Unable to infer schema for ORC. It must be specified manually.;
```

**AFTER**
```scala
scala> spark.read.format("orc").load("/tmp/empty").printSchema
root
 |-- a: boolean (nullable = true)
 |-- b: integer (nullable = true)
 |-- c: string (nullable = true)
```

## How was this patch tested?

Pass the Jenkins with newly added test cases.