### PR TITLE
[WIP][SPARK-22339] [CORE] [NETWORK-SHUFFLE] Push epoch updates to executors on fetch failure to avoid fetch retries for missing executors

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockFetchingListener.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockFetchingListener.java
@@ -33,4 +33,13 @@ public interface BlockFetchingListener extends EventListener {
    * Called at least once per block upon failures.
    */
   void onBlockFetchFailure(String blockId, Throwable exception);
+
+  boolean shouldRetry(Throwable t);
+
+  abstract class Base implements BlockFetchingListener {
+    @Override
+    public boolean shouldRetry(Throwable t) {
+      return true;
+    }
+  }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
@@ -190,7 +190,7 @@ public class SaslIntegrationSuite {
       AtomicReference<Throwable> exception = new AtomicReference<>();
 
       CountDownLatch blockFetchLatch = new CountDownLatch(1);
-      BlockFetchingListener listener = new BlockFetchingListener() {
+      BlockFetchingListener listener = new BlockFetchingListener.Base() {
         @Override
         public void onBlockFetchSuccess(String blockId, ManagedBuffer data) {
           blockFetchLatch.countDown();

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -136,7 +136,7 @@ public class ExternalShuffleIntegrationSuite {
     ExternalShuffleClient client = new ExternalShuffleClient(clientConf, null, false, 5000);
     client.init(APP_ID);
     client.fetchBlocks(TestUtils.getLocalHost(), port, execId, blockIds,
-      new BlockFetchingListener() {
+      new BlockFetchingListener.Base() {
         @Override
         public void onBlockFetchSuccess(String blockId, ManagedBuffer data) {
           synchronized (this) {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -304,6 +304,8 @@ class SparkContext(config: SparkConf) extends Logging {
     _dagScheduler = ds
   }
 
+  private[spark] def heartbeatReceiverRef: RpcEndpointRef = _heartbeatReceiver
+
   /**
    * A unique identifier for the Spark application.
    * Its format depends on the scheduler implementation.

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -123,6 +123,12 @@ private[spark] class CoarseGrainedExecutorBackend(
           executor.stop()
         }
       }.start()
+
+    case UpdateEpoch(newEpoch) =>
+      env.mapOutputTracker match {
+        case env: MapOutputTrackerWorker => env.updateEpoch(newEpoch)
+        case _ =>
+      }
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -748,6 +748,10 @@ private[spark] class Executor(
         logInfo("Told to re-register on heartbeat")
         env.blockManager.reregister()
       }
+      response.updatedEpoch.foreach { epoch =>
+        logInfo(s"Told to update MapOutputTracker epoch to ${epoch}")
+        env.mapOutputTracker.updateEpoch(epoch)
+      }
       heartbeatFailures = 0
     } catch {
       case NonFatal(e) =>

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -750,7 +750,7 @@ private[spark] class Executor(
       }
       response.updatedEpoch.foreach { epoch =>
         logInfo(s"Told to update MapOutputTracker epoch to ${epoch}")
-        env.mapOutputTracker.updateEpoch(epoch)
+        env.mapOutputTracker.asInstanceOf[MapOutputTrackerWorker].updateEpoch(epoch)
       }
       heartbeatFailures = 0
     } catch {

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -96,7 +96,7 @@ abstract class BlockTransferService extends ShuffleClient with Closeable with Lo
     // A monitor for the thread to wait on.
     val result = Promise[ManagedBuffer]()
     fetchBlocks(host, port, execId, Array(blockId),
-      new BlockFetchingListener {
+      new BlockFetchingListener.Base {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           result.failure(exception)
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1461,6 +1461,7 @@ class DAGScheduler(
             mapOutputTracker.removeOutputsOnExecutor(execId)
         }
         sc.heartbeatReceiverRef.ask[Boolean](UpdatedEpoch(mapOutputTracker.getEpoch))
+        taskScheduler.updateEpoch(mapOutputTracker.getEpoch)
         clearCacheLocs()
 
       } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1460,6 +1460,7 @@ class DAGScheduler(
             logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
             mapOutputTracker.removeOutputsOnExecutor(execId)
         }
+        sc.heartbeatReceiverRef.ask[Boolean](UpdatedEpoch(mapOutputTracker.getEpoch))
         clearCacheLocs()
 
       } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
@@ -69,4 +69,5 @@ private[spark] trait SchedulerBackend {
    */
   def getDriverLogUrls: Option[Map[String, String]] = None
 
+  def updateEpoch(newEpoch: Long): Unit = {}
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -101,4 +101,5 @@ private[spark] trait TaskScheduler {
    */
   def applicationAttemptId(): Option[String]
 
+  def updateEpoch(newEpoch: Long): Unit = {}
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -689,6 +689,10 @@ private[spark] class TaskSchedulerImpl(
     }
   }
 
+  override def updateEpoch(newEpoch: Long): Unit = {
+    backend.updateEpoch(newEpoch)
+  }
+
 }
 
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -119,4 +119,5 @@ private[spark] object CoarseGrainedClusterMessages {
   // Used internally by executors to shut themselves down.
   case object Shutdown extends CoarseGrainedClusterMessage
 
+  case class UpdateEpoch(newEpoch: Long) extends CoarseGrainedClusterMessage
 }

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
@@ -157,7 +157,7 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
     val promise = Promise[ManagedBuffer]()
 
     self.fetchBlocks(from.hostName, from.port, execId, Array(blockId.toString),
-      new BlockFetchingListener {
+      new BlockFetchingListener.Base {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           promise.failure(exception)
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a task finishes with error due to a fetch error, then DAGScheduler unregisters the shuffle blocks hosted by the serving executor (or even all the executors in the failing host, with external shuffle and spark.files.fetchFailure.unRegisterOutputOnHost enabled) in the shuffle block directory stored by MapOutputTracker, that then increments its epoch as a result. This event is only signaled to the other executors when a new task with a new epoch starts in each executor. This means that other executors reading from the failed executors will retry fetching shuffle blocks from them, even though the driver already knows those executors are lost and those blocks are now unavailable at those locations. This impacts job runtime, specially for long shuffles and executor failures at the end of a stage, when the only pending tasks are shuffle reads.
This could be improved by pushing the epoch update to the executors without having to wait for a new task. In the attached patch I sketch a possible solution that sends the updated epoch from the driver to the executors by piggybacking on the executor heartbeat response. ShuffleBlockFetcherIterator, RetryingBlockFetcher and BlockFetchingListener are modified so blocks locations are checked on each fetch retry. This doesn't introduce additional traffic, as MapOutputTrackerWorker.mapStatuses is shared by all tasks running on the same Executor, and the lookup of the new shuffle blocks directory was going to happen anyway when the new epoch is detected during the start of the next task.
I would like to know the opinion of the community on this approach.

## How was this patch tested?
Unit tests, tests in Yarn cluster