### PR TITLE
[SPARKR][SPARK-22344] Set java.io.tmpdir for SparkR tests

### DIFF
--- a/R/pkg/inst/tests/testthat/test_basic.R
+++ b/R/pkg/inst/tests/testthat/test_basic.R
@@ -18,11 +18,8 @@
 context("basic tests for CRAN")
 
 test_that("create DataFrame from list or data.frame", {
-  r_tmp_dir <- tempdir()
-  tmp_arg <- paste("-Djava.io.tmpdir=", r_tmp_dir, sep = "")
   sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE,
-                 sparkConfig = list(spark.driver.extraJavaOptions = tmp_arg,
-                                    spark.executor.extraJavaOptions = tmp_arg))
+                 sparkConfig = sparkRTestConfig)
 
   i <- 4
   df <- createDataFrame(data.frame(dummy = 1:i))
@@ -53,11 +50,8 @@ test_that("create DataFrame from list or data.frame", {
 })
 
 test_that("spark.glm and predict", {
-  r_tmp_dir <- tempdir()
-  tmp_arg <- paste("-Djava.io.tmpdir=", r_tmp_dir, sep = "")
   sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE,
-                 sparkConfig = list(spark.driver.extraJavaOptions = tmp_arg,
-                                    spark.executor.extraJavaOptions = tmp_arg))
+                 sparkConfig = sparkRTestConfig)
 
   training <- suppressWarnings(createDataFrame(iris))
   # gaussian family

--- a/R/pkg/inst/tests/testthat/test_basic.R
+++ b/R/pkg/inst/tests/testthat/test_basic.R
@@ -18,7 +18,11 @@
 context("basic tests for CRAN")
 
 test_that("create DataFrame from list or data.frame", {
-  sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
+  r_tmp_dir <- tempdir()
+  tmp_arg <- paste("-Djava.io.tmpdir=", r_tmp_dir, sep = "")
+  sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE,
+                 sparkConfig = list(spark.driver.extraJavaOptions = tmp_arg,
+                                    spark.executor.extraJavaOptions = tmp_arg))
 
   i <- 4
   df <- createDataFrame(data.frame(dummy = 1:i))
@@ -49,7 +53,11 @@ test_that("create DataFrame from list or data.frame", {
 })
 
 test_that("spark.glm and predict", {
-  sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
+  r_tmp_dir <- tempdir()
+  tmp_arg <- paste("-Djava.io.tmpdir=", r_tmp_dir, sep = "")
+  sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE,
+                 sparkConfig = list(spark.driver.extraJavaOptions = tmp_arg,
+                                    spark.executor.extraJavaOptions = tmp_arg))
 
   training <- suppressWarnings(createDataFrame(iris))
   # gaussian family

--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -38,6 +38,10 @@ sparkRFilesBefore <- list.files(path = sparkRDir, all.files = TRUE)
 sparkRTestMaster <- "local[1]"
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   sparkRTestMaster <- ""
+} else {
+  # Disable hsperfdata on CRAN
+  old_java_opt <- Sys.getenv("_JAVA_OPTIONS")
+  Sys.setenv("_JAVA_OPTIONS"=paste("-XX:-UsePerfData", old_java_opt, sep=" "))
 }
 
 test_package("SparkR")

--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -36,12 +36,17 @@ invisible(lapply(sparkRWhitelistSQLDirs,
 sparkRFilesBefore <- list.files(path = sparkRDir, all.files = TRUE)
 
 sparkRTestMaster <- "local[1]"
+sparkRTestConfig <- list()
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   sparkRTestMaster <- ""
 } else {
   # Disable hsperfdata on CRAN
   old_java_opt <- Sys.getenv("_JAVA_OPTIONS")
-  Sys.setenv("_JAVA_OPTIONS"=paste("-XX:-UsePerfData", old_java_opt, sep=" "))
+  Sys.setenv("_JAVA_OPTIONS" = paste("-XX:-UsePerfData", old_java_opt))
+  tmpDir <- tempdir()
+  tmpArg <- paste0("-Djava.io.tmpdir=", tmpDir)
+  sparkRTestConfig <- list(spark.driver.extraJavaOptions = tmpArg,
+                            spark.executor.extraJavaOptions = tmpArg)
 }
 
 test_package("SparkR")

--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -41,7 +41,7 @@ tmp_arg <- paste("-Djava.io.tmpdir=", r_tmp_dir, sep = "")
 sparkSessionConfig <- list(spark.driver.extraJavaOptions = tmp_arg,
                            spark.executor.extraJavaOptions = tmp_arg)
 old_java_opt <- Sys.getenv("_JAVA_OPTIONS")
-new_java_opt <- Sys.setenv("_JAVA_OPTIONS"=paste("-XX:-UsePerfData", old_java_opt, sep = " "))
+Sys.setenv("_JAVA_OPTIONS" = paste("-XX:-UsePerfData", old_java_opt, sep = " "))
 ```
 
 ## Overview

--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -36,6 +36,12 @@ opts_hooks$set(eval = function(options) {
   }
   options
 })
+r_tmp_dir <- tempdir()
+tmp_arg <- paste("-Djava.io.tmpdir=", r_tmp_dir, sep = "")
+sparkSessionConfig <- list(spark.driver.extraJavaOptions = tmp_arg,
+                           spark.executor.extraJavaOptions = tmp_arg)
+old_java_opt <- Sys.getenv("_JAVA_OPTIONS")
+new_java_opt <- Sys.setenv("_JAVA_OPTIONS"=paste("-XX:-UsePerfData", old_java_opt, sep = " "))
 ```
 
 ## Overview
@@ -57,7 +63,7 @@ We use default settings in which it runs in local mode. It auto downloads Spark 
 
 ```{r, include=FALSE}
 install.spark()
-sparkR.session(master = "local[1]")
+sparkR.session(master = "local[1]", sparkConfig = sparkSessionConfig, enableHiveSupport = FALSE)
 ```
 ```{r, eval=FALSE}
 sparkR.session()


### PR DESCRIPTION
This PR sets the java.io.tmpdir for CRAN checks and also disables the hsperfdata for the JVM when running CRAN checks. Together this prevents files from being left behind in `/tmp`

## How was this patch tested?
Tested manually on a clean EC2 machine