### PR TITLE
[SPARK-22347][SQL][PySpark] Support optionally running PythonUDFs in conditional expressions

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -35,8 +35,9 @@ import org.apache.spark.util._
 private[spark] object PythonEvalType {
   val NON_UDF = 0
   val SQL_BATCHED_UDF = 1
-  val SQL_PANDAS_UDF = 2
-  val SQL_PANDAS_GROUPED_UDF = 3
+  val SQL_BATCHED_OPT_UDF = 2
+  val SQL_PANDAS_UDF = 3
+  val SQL_PANDAS_GROUPED_UDF = 4
 }
 
 /**

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -85,8 +85,9 @@ class SpecialLengths(object):
 class PythonEvalType(object):
     NON_UDF = 0
     SQL_BATCHED_UDF = 1
-    SQL_PANDAS_UDF = 2
-    SQL_PANDAS_GROUPED_UDF = 3
+    SQL_BATCHED_OPT_UDF = 2
+    SQL_PANDAS_UDF = 3
+    SQL_PANDAS_GROUPED_UDF = 4
 
 
 class Serializer(object):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -105,8 +105,14 @@ def read_single_udf(pickleSer, infile, eval_type):
     elif eval_type == PythonEvalType.SQL_PANDAS_GROUPED_UDF:
         # a groupby apply udf has already been wrapped under apply()
         return arg_offsets, row_func
-    else:
+    elif eval_type == PythonEvalType.SQL_BATCHED_UDF:
         return arg_offsets, wrap_udf(row_func, return_type)
+    elif eval_type == PythonEvalType.SQL_BATCHED_OPT_UDF:
+        udf = wrap_udf(row_func, return_type)
+        opt_udf = lambda *a: udf(*a[:-1]) if a[-1] is True else None
+        return arg_offsets, opt_udf
+    else:
+        raise Exception(("Unknown python evaluation type: %d") % (eval_type))
 
 
 def read_udfs(pickleSer, infile, eval_type):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchOptEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchOptEvalPythonExec.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.api.python.PythonEvalType
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.DataType
+
+/**
+ * A physical plan that evaluates a [[PythonUDF]]. Different to [[BatchEvalPythonExec]], this plan
+ * overrides the way to compute argument offsets and adds conditional expressions into the end of
+ * the offsets of the udf, if any. On Python side, the udf can be optionally run depending on the
+ * evaluated values of conditional expressions.
+ */
+case class BatchOptEvalPythonExec(
+      udfs: Seq[PythonUDF],
+      output: Seq[Attribute],
+      child: SparkPlan,
+      udfConditionsMap: Map[PythonUDF, Seq[Expression]])
+  extends BatchEvalPythonExecBase(udfs, output, child) {
+
+  protected override val evalType: Int = PythonEvalType.SQL_BATCHED_OPT_UDF
+
+  protected override def computeArgOffsets(
+      inputs: Seq[Seq[Expression]],
+      allInputs: ArrayBuffer[Expression],
+      dataTypes: ArrayBuffer[DataType]): Array[Array[Int]] = {
+    inputs.zipWithIndex.map { case (input, idx) =>
+      var funcArgs = input.map(mapExpressionIntoFuncInputs(_, allInputs, dataTypes)).toArray
+      udfConditionsMap.get(udfs(idx)).foreach { conditions =>
+        conditions.reduceOption(Or).foreach { cond =>
+          val condArgOffset = mapExpressionIntoFuncInputs(cond, allInputs, dataTypes)
+          funcArgs = funcArgs :+ condArgOffset
+        }
+      }
+      funcArgs
+    }.toArray
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Under the current execution mode of Python UDFs, we don't well support Python UDFs as branch values or else value in CaseWhen expression. The execution of batch Python UDFs evaluates the UDFs in an operator at all rows. It breaks the semantics of the conditional expressions and causes failures under some cases:

```python
from pyspark.sql import Row
from pyspark.sql.functions import col, udf, when
from pyspark.sql.types import IntegerType

df = sc.parallelize([Row(x=5), Row(x=0)]).toDF()
f = udf(lambda value: 10 // int(value), IntegerType())
whenExpr1 = when((col('x') > 0), f(col('x')))
df.select(whenExpr1).collect() ## Raise a division by zero error
```

Even from performance perspective, to evaluate all Python UDFs used in conditional expressions can be waste of computing, if only small portion of rows satisfies the conditions.

The patch fixes the issue by adding an extra argument for Python UDFs used with conditional expressions. The argument takes the evaluated value of conditions. In Python side, we can optionally run Python UDFs based on the condition value.

Question: How about vectorized Python UDFs?

Seems it doesn't make much sense to do similar with vectorized UDFs. Vectoroized UDFs process input as batch of rows, instead of single row at one time. We can't simply optionally run vectorized UDFs only on valid rows. But as pandas Series can be more resistant to such error and evaluate to `inf` for shown case, it should be less serious than batch UDFs. As vectorized Python UDFs are not in releases, maybe we can consider to disable using it with conditional expression and don't worry breaking compatibility.

## How was this patch tested?

Added python tests.
