### PR TITLE
[WIP][SPARK-22374][SQL][2.2] closeAllForUGI is required after using loginUserFromKeytab

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.common.cli.HiveFileProcessor;
 import org.apache.hadoop.hive.common.cli.IHiveFileProcessor;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -47,6 +48,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.processors.SetProcessor;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.common.util.HiveVersionInfo;
 import org.apache.hive.service.auth.HiveAuthFactory;
 import org.apache.hive.service.cli.FetchOrientation;
@@ -565,6 +567,11 @@ public class HiveSessionImpl implements HiveSession {
       }
       try {
         sessionState.close();
+        if (hiveConf.get("spark.yarn.principal") != null &&
+          hiveConf.get("spark.yarn.keytab") != null) {
+          LOG.info("closeAllForUGI: " + UserGroupInformation.getCurrentUser().hashCode());
+          FileSystem.closeAllForUGI(UserGroupInformation.getCurrentUser());
+        }
       } finally {
         sessionState = null;
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -116,9 +116,11 @@ private[hive] class HiveClientImpl(
         throw new SparkException(s"Keytab file: ${keytabFileName}" +
           " specified in spark.yarn.keytab does not exist")
       } else {
+        logInfo(s"Old UGI(hashcode): ${UserGroupInformation.getCurrentUser.hashCode}")
         logInfo("Attempting to login to Kerberos" +
           s" using principal: ${principalName} and keytab: ${keytabFileName}")
         UserGroupInformation.loginUserFromKeytab(principalName, keytabFileName)
+        logInfo(s"Session UGI(hashcode): ${UserGroupInformation.getCurrentUser.hashCode}")
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a secure cluster, FileSystem.Cache grows indefinitely when we use
1. `spark.yarn.principal` and `spark.yarn.keytab` is used.
2. Spark Thrift Server run with `hive.server2.enable.doAs=false`.

For example, with 6GB (-Xmx6144m) options, `HiveConf` consumes 4GB inside FileSystem.CACHE and OOM occurs. This PR aims to clear up `FileSystem.Cache` by using `closeAllForUGI`.

![2](https://user-images.githubusercontent.com/9700541/32129492-b09f6cbc-bb3c-11e7-8f75-fe027d626816.png)

![3](https://user-images.githubusercontent.com/9700541/32129494-bafa2cce-bb3c-11e7-80f8-5b03e3471109.png)

## How was this patch tested?

N/A