### PR TITLE
Added more information to Imputer

### DIFF
--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -1373,7 +1373,9 @@ for more details on the API.
 The `Imputer` transformer completes missing values in a dataset, either using the mean or the 
 median of the columns in which the missing values are located. The input columns should be of
 `DoubleType` or `FloatType`. Currently `Imputer` does not support categorical features and possibly
-creates incorrect values for columns containing categorical features.
+creates incorrect values for columns containing categorical features. Imputer can impute custom values 
+other than 'NaN' by `.setMissingValue(custom_value)`. For example, `.setMissingValue(0)` will impute 
+all occurrences of (0).
 
 **Note** all `null` values in the input columns are treated as missing, and so are also imputed.
 


### PR DESCRIPTION
Often times we want to impute custom values other than 'NaN'. My addition helps people locate this function without reading the API.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
