### PR TITLE
[SPARK-22394] [SQL] Remove redundant synchronization for metastore access

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -89,10 +89,12 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   /**
-   * Run some code involving `client` in a [[synchronized]] block and wrap certain
-   * exceptions thrown in the process in [[AnalysisException]].
+   * Run some code involving `client` and wrap certain exceptions thrown in the process in
+   * [[AnalysisException]]. Thread-safety is guaranteed here because methods in the `client`
+   * ([[org.apache.spark.sql.hive.client.HiveClientImpl]]) are already synchronized through
+   * `clientLoader` in the `retryLocked` method.
    */
-  private def withClient[T](body: => T): T = synchronized {
+  private def withClient[T](body: => T): T = {
     try {
       body
     } catch {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before Spark 2.x, synchronization for metastore access was protected at [line229 in ClientWrapper](https://github.com/apache/spark/blob/branch-1.6/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala#L229) (now it's at [line203 in HiveClientWrapper ](https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L203)). 

After Spark 2.x, `HiveExternalCatalog` was introduced by [SPARK-13080](https://github.com/apache/spark/pull/11293), where an extra level of synchronization was added at [line95](https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala#L95). That is, now we have two levels of synchronization: one is `HiveExternalCatalog` and the other is `IsolatedClientLoader` in `HiveClientImpl`.

But since both `HiveExternalCatalog` and `IsolatedClientLoader` are shared among all spark sessions, the extra level of synchronization in `HiveExternalCatalog` is redundant, thus can be removed.

## How was this patch tested?

Manual test and existing tests.