### PR TITLE
[SPARK-22396] [SQL] Better Error Message for InsertIntoDir using Hive format without enabling Hive Support

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -404,6 +404,9 @@ object HiveOnlyCheck extends (LogicalPlan => Unit) {
     plan.foreach {
       case CreateTable(tableDesc, _, _) if DDLUtils.isHiveTable(tableDesc) =>
         throw new AnalysisException("Hive support is required to CREATE Hive TABLE (AS SELECT)")
+      case i: InsertIntoDir if DDLUtils.isHiveTable(i.provider) =>
+        throw new AnalysisException(
+          "Hive support is required to INSERT OVERWRITE DIRECTORY with the Hive format")
       case _ => // OK
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -408,6 +408,22 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
     }
   }
 
+  test("Insert overwrite directory using Hive serde without turning on Hive support") {
+    withTempDir { dir =>
+      val path = dir.toURI.getPath
+      val e = intercept[AnalysisException] {
+        sql(
+          s"""
+             |INSERT OVERWRITE LOCAL DIRECTORY '$path'
+             |STORED AS orc
+             |SELECT 1, 2
+           """.stripMargin)
+      }.getMessage
+      assert(e.contains(
+        "Hive support is required to INSERT OVERWRITE DIRECTORY with the Hive format"))
+    }
+  }
+
   test("insert overwrite directory to data source not providing FileFormat") {
     withTempDir { dir =>
       val path = dir.toURI.getPath


### PR DESCRIPTION
## What changes were proposed in this pull request?
When Hive support is not on, users can hit unresolved plan node when trying to call `INSERT OVERWRITE DIRECTORY` using Hive format.
```
"unresolved operator 'InsertIntoDir true, Storage(Location: /private/var/folders/vx/j0ydl5rn0gd9mgrh1pljnw900000gn/T/spark-b4227606-9311-46a8-8c02-56355bf0e2bc, Serde Library: org.apache.hadoop.hive.ql.io.orc.OrcSerde, InputFormat: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, OutputFormat: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat), hive, true;;
```

This PR is to issue a better error message.
## How was this patch tested?
Added a test case.