### PR TITLE
[SPARK-22305] Write HDFSBackedStateStoreProvider.loadMap non-recursively

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -301,7 +301,9 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
     // Shortcut if the map for this version is already there to avoid a redundant put.
     val currentVersionMap =
       synchronized { loadedMaps.get(version) }.orElse(readSnapshotFile(version))
-    if (currentVersionMap.isDefined) return currentVersionMap.get
+    if (currentVersionMap.isDefined) {
+      return currentVersionMap.get
+    }
 
 
     // Find the most recent map before this version that we can.
@@ -309,7 +311,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
     var lastAvailableVersion = version
     var lastAvailableMap: Option[MapType] = None
     while (lastAvailableMap.isEmpty) {
-      lastAvailableVersion = lastAvailableVersion - 1
+      lastAvailableVersion -= 1
 
       if (lastAvailableVersion <= 0) {
         // Use an empty map for versions 0 or less.
@@ -323,13 +325,13 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
 
     // Load all the deltas from the version after the last available one up to the target version.
     // The last available version is the one with a full snapshot, so it doesn't need deltas.
-    var resultMap = lastAvailableMap.get
+    val resultMap = lastAvailableMap.get
     for (deltaVersion <- lastAvailableVersion + 1 to version) {
       updateFromDeltaFile(deltaVersion, resultMap)
     }
 
     loadedMaps.put(version, resultMap)
-    return resultMap
+    resultMap
   }
 
   private def writeUpdateToDeltaFile(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -324,7 +324,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
 
     // Load all the deltas from the version after the last available one up to the target version.
     // The last available version is the one with a full snapshot, so it doesn't need deltas.
-    val resultMap = lastAvailableMap.get
+    val resultMap = new MapType(lastAvailableMap.get)
     for (deltaVersion <- lastAvailableVersion + 1 to version) {
       updateFromDeltaFile(deltaVersion, resultMap)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -329,7 +329,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
       updateFromDeltaFile(deltaVersion, resultMap)
     }
 
-    loadedMaps.put(version, resultMap)
+    synchronized { loadedMaps.put(version, resultMap) }
     resultMap
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -305,7 +305,6 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
       return currentVersionMap.get
     }
 
-
     // Find the most recent map before this version that we can.
     // [SPARK-22305] This must be done iteratively to avoid stack overflow.
     var lastAvailableVersion = version

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -299,10 +299,14 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   private def loadMap(version: Long): MapType = {
 
     // Shortcut if the map for this version is already there to avoid a redundant put.
-    val currentVersionMap =
-      synchronized { loadedMaps.get(version) }.orElse(readSnapshotFile(version))
-    if (currentVersionMap.isDefined) {
-      return currentVersionMap.get
+    val loadedCurrentVersionMap = synchronized { loadedMaps.get(version) }
+    if (loadedCurrentVersionMap.isDefined) {
+      return loadedCurrentVersionMap.get
+    }
+    val snapshotCurrentVersionMap = readSnapshotFile(version)
+    if (snapshotCurrentVersionMap.isDefined) {
+      synchronized { loadedMaps.put(version, snapshotCurrentVersionMap.get) }
+      return snapshotCurrentVersionMap.get
     }
 
     // Find the most recent map before this version that we can.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -153,23 +153,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(tempFiles.isEmpty)
   }
 
-  test("SPARK-22305: large number of deltas") {
-    val provider = newStoreProvider(opId = Random.nextInt, partition = 0, minDeltasForSnapshot = 5)
-    for (i <- 1 to 10000) {
-      val store = provider.getStore(i - 1)
-      put(store, "a", i)
-      store.commit()
-    }
-
-    // What we're trying to check is the case where we need to load partitions from N all the way
-    // down to 1, since in previous code that would cause a stack overflow. doMaintenance will
-    // generate a snapshot at the current version of 10000, but also evict most of the old versions
-    // from the state store cache. So if we try to get the store a few versions back, we'll dodge
-    // the snapshot and all cached versions.
-    provider.doMaintenance()
-    provider.getStore(9500)
-  }
-
   test("corrupted file handling") {
     val provider = newStoreProvider(opId = Random.nextInt, partition = 0, minDeltasForSnapshot = 5)
     for (i <- 1 to 6) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -153,6 +153,23 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(tempFiles.isEmpty)
   }
 
+  test("SPARK-22305: large number of deltas") {
+    val provider = newStoreProvider(opId = Random.nextInt, partition = 0, minDeltasForSnapshot = 5)
+    for (i <- 1 to 10000) {
+      val store = provider.getStore(i - 1)
+      put(store, "a", i)
+      store.commit()
+    }
+
+    // What we're trying to check is the case where we need to load partitions from N all the way
+    // down to 1, since in previous code that would cause a stack overflow. doMaintenance will
+    // generate a snapshot at the current version of 10000, but also evict most of the old versions
+    // from the state store cache. So if we try to get the store a few versions back, we'll dodge
+    // the snapshot and all cached versions.
+    provider.doMaintenance()
+    provider.getStore(9500)
+  }
+
   test("corrupted file handling") {
     val provider = newStoreProvider(opId = Random.nextInt, partition = 0, minDeltasForSnapshot = 5)
     for (i <- 1 to 6) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Write HDFSBackedStateStoreProvider.loadMap non-recursively. This prevents stack overflow if too many deltas stack up in a low memory environment.

## How was this patch tested?

existing unit tests for functional equivalence, new unit test to check for stack overflow