### PR TITLE
[SPARK-22347][PySpark][DOC] Add document to notice users for using udfs with conditional expressions

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2186,8 +2186,9 @@ def udf(f=None, returnType=StringType()):
         it is present in the query.
 
     .. note:: The user-defined functions do not support conditional execution by using them with
-        SQL conditional expressions such `when` or `if`. The functions still apply on all rows no
-        matter the conditions are met or not. If the functions can cause runtime failure on the
+        SQL conditional expressions such as `when` or `if`. The functions still apply on all rows no
+        matter the conditions are met or not. So the output is correct if the functions can be
+        correctly run on all rows without failure. If the functions can cause runtime failure on the
         rows that do not satisfy the conditions, the suggested workaround is to incorporate the
         condition logic into the functions.
 
@@ -2286,8 +2287,9 @@ def pandas_udf(f=None, returnType=StringType()):
     .. note:: The user-defined function must be deterministic.
 
     .. note:: The user-defined functions do not support conditional execution by using them with
-        SQL conditional expressions such `when` or `if`. The functions still apply on all rows no
-        matter the conditions are met or not. If the functions can cause runtime failure on the
+        SQL conditional expressions such as `when` or `if`. The functions still apply on all rows no
+        matter the conditions are met or not. So the output is correct if the functions can be
+        correctly run on all rows without failure. If the functions can cause runtime failure on the
         rows that do not satisfy the conditions, the suggested workaround is to incorporate the
         condition logic into the functions.
     """

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2185,6 +2185,12 @@ def udf(f=None, returnType=StringType()):
         duplicate invocations may be eliminated or the function may even be invoked more times than
         it is present in the query.
 
+    .. note:: The user-defined functions do not support conditional execution by using them with
+        SQL conditional expressions such `when` or `if`. The functions still apply on all rows no
+        matter the conditions are met or not. If the functions can cause runtime failure on the
+        rows that do not satisfy the conditions, the suggested workaround is to incorporate the
+        condition logic into the functions.
+
     :param f: python function if used as a standalone function
     :param returnType: a :class:`pyspark.sql.types.DataType` object
 
@@ -2278,6 +2284,12 @@ def pandas_udf(f=None, returnType=StringType()):
        .. seealso:: :meth:`pyspark.sql.GroupedData.apply`
 
     .. note:: The user-defined function must be deterministic.
+
+    .. note:: The user-defined functions do not support conditional execution by using them with
+        SQL conditional expressions such `when` or `if`. The functions still apply on all rows no
+        matter the conditions are met or not. If the functions can cause runtime failure on the
+        rows that do not satisfy the conditions, the suggested workaround is to incorporate the
+        condition logic into the functions.
     """
     return _create_udf(f, returnType=returnType, pythonUdfType=PythonUdfType.PANDAS_UDF)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Under the current execution mode of Python UDFs, we don't well support Python UDFs as branch values or else value in CaseWhen expression.

Since to fix it might need the change not small (e.g., #19592) and this issue has simpler workaround. We should just notice users in the document about this.

## How was this patch tested?

Only document change.
