### PR TITLE
[SPARK-22409] Introduce function type argument in pandas_udf

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -37,8 +37,8 @@ private[spark] object PythonEvalType {
 
   val SQL_BATCHED_UDF = 100
 
-  val PANDAS_SCALAR_UDF = 200
-  val PANDAS_GROUP_MAP_UDF = 201
+  val SQL_PANDAS_SCALAR_UDF = 200
+  val SQL_PANDAS_GROUP_MAP_UDF = 201
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -39,8 +39,6 @@ private[spark] object PythonEvalType {
 
   val PANDAS_SCALAR_UDF = 200
   val PANDAS_GROUP_MAP_UDF = 201
-  val PANDAS_GROUP_AGGREGATE_UDF = 202
-  val PANDAS_GROUP_FLATMAP_UDF = 203
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -34,9 +34,13 @@ import org.apache.spark.util._
  */
 private[spark] object PythonEvalType {
   val NON_UDF = 0
-  val SQL_BATCHED_UDF = 1
-  val SQL_PANDAS_UDF = 2
-  val SQL_PANDAS_GROUPED_UDF = 3
+
+  val SQL_BATCHED_UDF = 100
+
+  val PANDAS_SCALAR_UDF = 200
+  val PANDAS_GROUP_MAP_UDF = 201
+  val PANDAS_GROUP_AGGREGATE_UDF = 202
+  val PANDAS_GROUP_FLATMAP_UDF = 203
 }
 
 /**

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -68,8 +68,8 @@ class PythonEvalType(object):
 
     SQL_BATCHED_UDF = 100
 
-    PANDAS_SCALAR_UDF = 200
-    PANDAS_GROUP_MAP_UDF = 201
+    SQL_PANDAS_SCALAR_UDF = 200
+    SQL_PANDAS_GROUP_MAP_UDF = 201
 
 
 def portable_hash(x):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -61,6 +61,8 @@ class PythonEvalType(object):
     Evaluation type of python rdd.
 
     These values are internal to PySpark.
+
+    These values should match values in org.apache.spark.api.python.PythonEvalType.
     """
     NON_UDF = 0
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -68,8 +68,6 @@ class PythonEvalType(object):
 
     PANDAS_SCALAR_UDF = 200
     PANDAS_GROUP_MAP_UDF = 201
-    PANDAS_GROUP_AGGREGATE_UDF = 202
-    PANDAS_GROUP_FLATMAP_UDF = 203
 
 
 def portable_hash(x):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -56,6 +56,22 @@ from pyspark.traceback_utils import SCCallSiteSync
 __all__ = ["RDD"]
 
 
+class PythonEvalType(object):
+    """
+    Evaluation type of python rdd.
+
+    These values are internal to PySpark.
+    """
+    NON_UDF = 0
+
+    SQL_BATCHED_UDF = 100
+
+    PANDAS_SCALAR_UDF = 200
+    PANDAS_GROUP_MAP_UDF = 201
+    PANDAS_GROUP_AGGREGATE_UDF = 202
+    PANDAS_GROUP_FLATMAP_UDF = 203
+
+
 def portable_hash(x):
     """
     This function returns consistent hash code for builtin types, especially

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -82,13 +82,6 @@ class SpecialLengths(object):
     START_ARROW_STREAM = -6
 
 
-class PythonEvalType(object):
-    NON_UDF = 0
-    SQL_BATCHED_UDF = 1
-    SQL_PANDAS_UDF = 2
-    SQL_PANDAS_GROUPED_UDF = 3
-
-
 class Serializer(object):
 
     def dump_stream(self, iterator, stream):

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -257,7 +257,7 @@ class Catalog(object):
         [Row(stringLengthInt(test)=4)]
         """
         udf = UserDefinedFunction(f, returnType=returnType, name=name,
-                                  udfType=PythonEvalType.SQL_BATCHED_UDF)
+                                  evalType=PythonEvalType.SQL_BATCHED_UDF)
         self._jsparkSession.udf().registerPython(name, udf._judf)
         return udf._wrapped()
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -19,9 +19,9 @@ import warnings
 from collections import namedtuple
 
 from pyspark import since
-from pyspark.rdd import ignore_unicode_prefix
+from pyspark.rdd import ignore_unicode_prefix, PythonEvalType
 from pyspark.sql.dataframe import DataFrame
-from pyspark.sql.functions import UserDefinedFunction
+from pyspark.sql.udf import UserDefinedFunction
 from pyspark.sql.types import IntegerType, StringType, StructType
 
 
@@ -256,7 +256,8 @@ class Catalog(object):
         >>> spark.sql("SELECT stringLengthInt('test')").collect()
         [Row(stringLengthInt(test)=4)]
         """
-        udf = UserDefinedFunction(f, returnType, name)
+        udf = UserDefinedFunction(f, returnType=returnType, name=name,
+                                  udfType=PythonEvalType.SQL_BATCHED_UDF)
         self._jsparkSession.udf().registerPython(name, udf._judf)
         return udf._wrapped()
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2158,7 +2158,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        ... def normalize(pdf):
        ...     v = pdf.v
        ...     return pdf.assign(v=(v - v.mean()) / v.std())
-       >>> df.groupby('id').apply(normalize).show()  # doctest: +SKIP
+       >>> df.groupby("id").apply(normalize).show()  # doctest: +SKIP
        +---+-------------------+
        | id|                  v|
        +---+-------------------+

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2147,7 +2147,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        A group map UDF defines transformation: A `pandas.DataFrame` -> A `pandas.DataFrame`
        The returnType should be a :class:`StructType` describing the schema of the returned
        `pandas.DataFrame`.
-       The length of the returned `pandas.DataFrame` can arbitrary.
+       The length of the returned `pandas.DataFrame` can be arbitrary.
 
        Group map UDFs are used with :meth:`pyspark.sql.GroupedData.apply`.
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2108,7 +2108,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
 
     :param f: user-defined function. A python function if used as a standalone function
     :param returnType: a :class:`pyspark.sql.types.DataType` object
-    :param functionType: an enum value in :class:`pyspark.sql.functions.PandasUdfType`.
+    :param functionType: an enum value in :class:`pyspark.sql.functions.PandasUDFType`.
                          Default: SCALAR.
 
     The function type of the UDF can be one of the following:
@@ -2122,13 +2122,14 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        Scalar UDFs are used with :meth:`pyspark.sql.DataFrame.withColumn` and
        :meth:`pyspark.sql.DataFrame.select`.
 
+       >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
        >>> from pyspark.sql.types import IntegerType, StringType
        >>> slen = pandas_udf(lambda s: s.str.len(), IntegerType())
-       >>> @pandas_udf(returnType=StringType())
+       >>> @pandas_udf(StringType())
        ... def to_upper(s):
        ...     return s.str.upper()
        ...
-       >>> @pandas_udf(returnType="integer")
+       >>> @pandas_udf("integer", PandasUDFType.SCALAR)
        ... def add_one(x):
        ...     return x + 1
        ...

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2053,9 +2053,9 @@ def map_values(col):
 class PandasUDFType(object):
     """Pandas UDF Types. See :meth:`pyspark.sql.functions.pandas_udf`.
     """
-    SCALAR = PythonEvalType.PANDAS_SCALAR_UDF
+    SCALAR = PythonEvalType.SQL_PANDAS_SCALAR_UDF
 
-    GROUP_MAP = PythonEvalType.PANDAS_GROUP_MAP_UDF
+    GROUP_MAP = PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF
 
 
 @since(1.3)
@@ -2192,7 +2192,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
             eval_type = returnType
         else:
             # @pandas_udf(dataType) or @pandas_udf(returnType=dataType)
-            eval_type = PythonEvalType.PANDAS_SCALAR_UDF
+            eval_type = PythonEvalType.SQL_PANDAS_SCALAR_UDF
 
         return functools.partial(_create_udf, returnType=return_type, evalType=eval_type)
     else:
@@ -2202,7 +2202,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
         if functionType is not None:
             eval_type = functionType
         else:
-            eval_type = PythonEvalType.PANDAS_SCALAR_UDF
+            eval_type = PythonEvalType.SQL_PANDAS_SCALAR_UDF
 
         return _create_udf(f=f, returnType=returnType, evalType=eval_type)
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2050,7 +2050,6 @@ def map_values(col):
 
 # ---------------------------- User Defined Function ----------------------------------
 
-@since(2.3)
 class PandasUDFType(object):
     """Pandas UDF Types. See :meth:`pyspark.sql.functions.pandas_udf`.
     """

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -18,7 +18,6 @@
 """
 A collections of builtin functions
 """
-import enum
 import math
 import sys
 import functools
@@ -2051,8 +2050,8 @@ def map_values(col):
 
 # ---------------------------- User Defined Function ----------------------------------
 
-class PandasUDFType(enum.Enum):
-    """Pandas UDF
+class PandasUDFType(object):
+    """Pandas UDF Types
 
     """
     SCALAR = PythonEvalType.PANDAS_SCALAR_UDF
@@ -2185,10 +2184,10 @@ def pandas_udf(f=None, returnType=None, functionType=None):
         if functionType is not None:
             # @pandas_udf(dataType, functionType=functionType)
             # @pandas_udf(returnType=dataType, functionType=functionType)
-            eval_type = functionType.value
-        elif returnType is not None and isinstance(returnType, PandasUDFType):
+            eval_type = functionType
+        elif returnType is not None and isinstance(returnType, int):
             # @pandas_udf(dataType, functionType)
-            eval_type = returnType.value
+            eval_type = returnType
         else:
             # @pandas_udf(dataType) or @pandas_udf(returnType=dataType)
             eval_type = PythonEvalType.PANDAS_SCALAR_UDF
@@ -2199,7 +2198,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
             raise ValueError("Must specify return type.")
 
         if functionType is not None:
-            eval_type = functionType.value
+            eval_type = functionType
         else:
             eval_type = PythonEvalType.PANDAS_SCALAR_UDF
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -18,6 +18,7 @@
 """
 A collections of builtin functions
 """
+import enum
 import math
 import sys
 import functools
@@ -2049,7 +2050,7 @@ def map_values(col):
 
 # ---------------------------- User Defined Function ----------------------------------
 
-class PandasUdfType(object):
+class PandasUDFType(enum.Enum):
     """
     TODO: Add docs
     """
@@ -2099,10 +2100,10 @@ def udf(f=None, returnType=StringType()):
         # for decorator use it as a returnType
         return_type = f or returnType
         return functools.partial(_create_udf, returnType=return_type,
-                                 udfType=PythonEvalType.SQL_BATCHED_UDF)
+                                 evalType=PythonEvalType.SQL_BATCHED_UDF)
     else:
         return _create_udf(f=f, returnType=returnType,
-                           udfType=PythonEvalType.SQL_BATCHED_UDF)
+                           evalType=PythonEvalType.SQL_BATCHED_UDF)
 
 
 @since(2.3)
@@ -2187,23 +2188,25 @@ def pandas_udf(f=None, returnType=None, functionType=None):
         if functionType is not None:
             # @pandas_udf(dataType, functionType=functionType)
             # @pandas_udf(returnType=dataType, functionType=functionType)
-            udf_type = functionType
-        elif returnType is not None and isinstance(returnType, int):
+            eval_type = functionType.value
+        elif returnType is not None and isinstance(returnType, PandasUDFType):
             # @pandas_udf(dataType, functionType)
-            udf_type = returnType
+            eval_type = returnType.value
         else:
             # @pandas_udf(dataType) or @pandas_udf(returnType=dataType)
-            udf_type = PythonEvalType.PANDAS_SCALAR_UDF
+            eval_type = PythonEvalType.PANDAS_SCALAR_UDF
 
-        return functools.partial(_create_udf, returnType=return_type, udfType=udf_type)
+        return functools.partial(_create_udf, returnType=return_type, evalType=eval_type)
     else:
-
         if returnType is None:
             raise ValueError("Must specify return type.")
 
-        udf_type = functionType or PythonEvalType.PANDAS_SCALAR_UDF
+        if functionType is not None:
+            eval_type = functionType.value
+        else:
+            eval_type = PythonEvalType.PANDAS_SCALAR_UDF
 
-        return _create_udf(f=f, returnType=returnType, udfType=udf_type)
+        return _create_udf(f=f, returnType=returnType, evalType=eval_type)
 
 
 blacklist = ['map', 'since', 'ignore_unicode_prefix']

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2055,7 +2055,6 @@ class PandasUDFType(enum.Enum):
     """Pandas UDF
 
     """
-
     SCALAR = PythonEvalType.PANDAS_SCALAR_UDF
 
     GROUP_MAP = PythonEvalType.PANDAS_GROUP_MAP_UDF

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -35,6 +35,7 @@ from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.types import StringType, DataType
 from pyspark.sql.udf import UserDefinedFunction, _create_udf
 
+
 def _create_function(name, doc=""):
     """ Create a function for aggregator by name"""
     def _(col):
@@ -2051,17 +2052,14 @@ def map_values(col):
 # ---------------------------- User Defined Function ----------------------------------
 
 class PandasUDFType(enum.Enum):
-    """
-    TODO: Add docs
+    """Pandas UDF
+
     """
 
     SCALAR = PythonEvalType.PANDAS_SCALAR_UDF
 
     GROUP_MAP = PythonEvalType.PANDAS_GROUP_MAP_UDF
 
-    GROUP_AGG = PythonEvalType.PANDAS_GROUP_AGGREGATE_UDF
-
-    GROUP_FLATMAP = PythonEvalType.PANDAS_GROUP_FLATMAP_UDF
 
 @since(1.3)
 def udf(f=None, returnType=StringType()):

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -218,7 +218,7 @@ class GroupedData(object):
         >>> df = spark.createDataFrame(
         ...     [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
         ...     ("id", "v"))
-        >>> @pandas_udf(returnType=df.schema, functionType=PandasUDFType.GROUP_MAP)
+        >>> @pandas_udf(returnType="id long, v double", functionType=PandasUDFType.GROUP_MAP)
         ... def normalize(pdf):
         ...     v = pdf.v
         ...     return pdf.assign(v=(v - v.mean()) / v.std())

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -241,9 +241,9 @@ class GroupedData(object):
         if isinstance(udf, Column) or not hasattr(udf, 'func') \
            or udf.evalType != PythonEvalType.PANDAS_GROUP_MAP_UDF:
             raise ValueError("Invalid udf: the udf argument must be a pandas_udf of type "
-                             "`GROUP_MAP`.")
+                             "GROUP_MAP.")
         if not isinstance(udf.returnType, StructType):
-            raise ValueError("Invalid returnType: The returnType of the udf must be a StructType")
+            raise ValueError("Invalid returnType: the returnType of the udf must be a StructType")
 
         df = self._df
         func = udf.func

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -218,11 +218,11 @@ class GroupedData(object):
         >>> df = spark.createDataFrame(
         ...     [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
         ...     ("id", "v"))
-        >>> @pandas_udf(returnType="id long, v double", functionType=PandasUDFType.GROUP_MAP)
+        >>> @pandas_udf("id long, v double", PandasUDFType.GROUP_MAP)
         ... def normalize(pdf):
         ...     v = pdf.v
         ...     return pdf.assign(v=(v - v.mean()) / v.std())
-        >>> df.groupby('id').apply(normalize).show()  # doctest: +SKIP
+        >>> df.groupby("id").apply(normalize).show()  # doctest: +SKIP
         +---+-------------------+
         | id|                  v|
         +---+-------------------+

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -238,7 +238,7 @@ class GroupedData(object):
         """
         # Columns are special because hasattr always return True
         if isinstance(udf, Column) or not hasattr(udf, 'func') \
-           or udf.evalType != PythonEvalType.PANDAS_GROUP_MAP_UDF:
+           or udf.evalType != PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
             raise ValueError("Invalid udf: the udf argument must be a pandas_udf of type "
                              "GROUP_MAP.")
         df = self._df

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -236,43 +236,13 @@ class GroupedData(object):
         .. seealso:: :meth:`pyspark.sql.functions.pandas_udf`
 
         """
-
         # Columns are special because hasattr always return True
         if isinstance(udf, Column) or not hasattr(udf, 'func') \
            or udf.evalType != PythonEvalType.PANDAS_GROUP_MAP_UDF:
             raise ValueError("Invalid udf: the udf argument must be a pandas_udf of type "
                              "GROUP_MAP.")
-        if not isinstance(udf.returnType, StructType):
-            raise ValueError("Invalid returnType: the returnType of the udf must be a StructType")
-
         df = self._df
-        func = udf.func
-        returnType = udf.returnType
-
-        # The python executors expects the function to use pd.Series as input and output
-        # So we to create a wrapper function that turns that to a pd.DataFrame before passing
-        # down to the user function, then turn the result pd.DataFrame back into pd.Series
-        columns = df.columns
-
-        def wrapped(*cols):
-            from pyspark.sql.types import to_arrow_type
-            import pandas as pd
-            result = func(pd.concat(cols, axis=1, keys=columns))
-            if not isinstance(result, pd.DataFrame):
-                raise TypeError("Return type of the user-defined function should be "
-                                "pandas.DataFrame, but is {}".format(type(result)))
-            if not len(result.columns) == len(returnType):
-                raise RuntimeError(
-                    "Number of columns of the returned pandas.DataFrame "
-                    "doesn't match specified schema. "
-                    "Expected: {} Actual: {}".format(len(returnType), len(result.columns)))
-            arrow_return_types = (to_arrow_type(field.dataType) for field in returnType)
-            return [(result[result.columns[i]], arrow_type)
-                    for i, arrow_type in enumerate(arrow_return_types)]
-
-        udf_obj = UserDefinedFunction(
-            wrapped, returnType=returnType, name=udf.__name__, evalType=udf.evalType)
-        udf_column = udf_obj(*[df[col] for col in df.columns])
+        udf_column = udf(*[df[col] for col in df.columns])
         jdf = self._jgd.flatMapGroupsInPandas(udf_column._jc.expr())
         return DataFrame(jdf, self.sql_ctx)
 

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -240,10 +240,10 @@ class GroupedData(object):
         # Columns are special because hasattr always return True
         if isinstance(udf, Column) or not hasattr(udf, 'func') \
            or udf.udfType != PythonEvalType.PANDAS_GROUP_FLATMAP_UDF:
-            raise ValueError('Invalid udf: the udf argument must be a pandas_udf of type '
-                             '`GROUP_FLATMAP`.')
+            raise ValueError("Invalid udf: the udf argument must be a pandas_udf of type "
+                             "`GROUP_FLATMAP`.")
         if not isinstance(udf.returnType, StructType):
-            raise ValueError('Invalid returnType: The returnType of the udf must be a StructType')
+            raise ValueError("Invalid returnType: The returnType of the udf must be a StructType")
 
         df = self._df
         func = udf.func
@@ -259,13 +259,13 @@ class GroupedData(object):
             import pandas as pd
             result = func(pd.concat(cols, axis=1, keys=columns))
             if not isinstance(result, pd.DataFrame):
-                raise TypeError('Return type of the user-defined function should be '
-                                'Pandas.DataFrame, but is {}'.format(type(result)))
+                raise TypeError("Return type of the user-defined function should be "
+                                "pandas.DataFrame, but is {}".format(type(result)))
             if not len(result.columns) == len(returnType):
                 raise RuntimeError(
-                    'Number of columns of the returned Pandas.DataFrame '
-                    'doesn\'t match specified schema. '
-                    'Expected: {} Actual: {}'.format(len(returnType), len(result.columns)))
+                    "Number of columns of the returned pandas.DataFrame "
+                    "doesn't match specified schema. "
+                    "Expected: {} Actual: {}".format(len(returnType), len(result.columns)))
             arrow_return_types = (to_arrow_type(field.dataType) for field in returnType)
             return [(result[result.columns[i]], arrow_type)
                     for i, arrow_type in enumerate(arrow_return_types)]
@@ -283,8 +283,8 @@ def _test():
     import pyspark.sql.group
     globs = pyspark.sql.group.__dict__.copy()
     spark = SparkSession.builder\
-        .master('local[4]')\
-        .appName('sql.group tests')\
+        .master("local[4]")\
+        .appName("sql.group tests")\
         .getOrCreate()
     sc = spark.sparkContext
     globs['sc'] = sc

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3238,14 +3238,18 @@ class PandasUDFTests(ReusedSQLTestCase):
                 @pandas_udf(PandasUDFType.GROUP_MAP)
                 def foo(df):
                     return df
+            with self.assertRaisesRegexp(ValueError, 'return type'):
+                @pandas_udf(returnType=PandasUDFType.GROUP_MAP)
+                def foo(df):
+                    return df
             with self.assertRaisesRegexp(ValueError, 'Invalid returnType'):
                 @pandas_udf(returnType='double', functionType=PandasUDFType.GROUP_MAP)
                 def foo(df):
                     return df
             with self.assertRaisesRegexp(ValueError, 'Invalid function'):
-                @pandas_udf(returnType='id int, v double', functionType=PandasUDFType.GROUP_MAP)
-                def foo(id, v):
-                    return id
+                @pandas_udf(returnType='k int, v double', functionType=PandasUDFType.GROUP_MAP)
+                def foo(k, v):
+                    return k
 
 
 @unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3172,26 +3172,26 @@ class PandasUDFTests(ReusedSQLTestCase):
         from pyspark.sql.functions import pandas_udf, PandasUDFType
 
         udf = pandas_udf(lambda x: x, DoubleType())
-        self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
+        self.assertEqual(udf.returnType, DoubleType())
+        self.assertEqual(udf.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         udf = pandas_udf(lambda x: x, DoubleType(), PandasUDFType.SCALAR)
-        self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
+        self.assertEqual(udf.returnType, DoubleType())
+        self.assertEqual(udf.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         udf = pandas_udf(lambda x: x, 'v double', PandasUDFType.GROUP_MAP)
-        self.assertEquals(udf.returnType, StructType([StructField("v", DoubleType())]))
-        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        self.assertEqual(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         udf = pandas_udf(lambda x: x, 'v double',
                          functionType=PandasUDFType.GROUP_MAP)
-        self.assertEquals(udf.returnType, StructType([StructField("v", DoubleType())]))
-        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        self.assertEqual(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         udf = pandas_udf(lambda x: x, returnType='v double',
                          functionType=PandasUDFType.GROUP_MAP)
-        self.assertEquals(udf.returnType, StructType([StructField("v", DoubleType())]))
-        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        self.assertEqual(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
     def test_pandas_udf_decorator(self):
         from pyspark.rdd import PythonEvalType
@@ -3201,34 +3201,34 @@ class PandasUDFTests(ReusedSQLTestCase):
         @pandas_udf(DoubleType())
         def foo(x):
             return x
-        self.assertEquals(foo.returnType, DoubleType())
-        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
+        self.assertEqual(foo.returnType, DoubleType())
+        self.assertEqual(foo.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         @pandas_udf(returnType=DoubleType())
         def foo(x):
             return x
-        self.assertEquals(foo.returnType, DoubleType())
-        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
+        self.assertEqual(foo.returnType, DoubleType())
+        self.assertEqual(foo.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         schema = StructType([StructField("v", DoubleType())])
 
         @pandas_udf(schema, PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
-        self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
+        self.assertEqual(foo.returnType, schema)
+        self.assertEqual(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         @pandas_udf(schema, functionType=PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
-        self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
+        self.assertEqual(foo.returnType, schema)
+        self.assertEqual(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         @pandas_udf(returnType=schema, functionType=PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
-        self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
+        self.assertEqual(foo.returnType, schema)
+        self.assertEqual(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
     def test_udf_wrong_arg(self):
         from pyspark.sql.functions import pandas_udf, PandasUDFType
@@ -3238,7 +3238,7 @@ class PandasUDFTests(ReusedSQLTestCase):
                 @pandas_udf(PandasUDFType.GROUP_MAP)
                 def foo(df):
                     return df
-            with self.assertRaisesRegexp(ValueError, 'return type'):
+            with self.assertRaisesRegexp(TypeError, 'Invalid returnType'):
                 @pandas_udf(returnType=PandasUDFType.GROUP_MAP)
                 def foo(df):
                     return df
@@ -3558,7 +3558,7 @@ class VectorizedUDFTests(ReusedSQLTestCase):
                 return x
 
             result = df.select(check_records_per_batch(col("id")))
-            self.assertEquals(df.collect(), result.collect())
+            self.assertEqual(df.collect(), result.collect())
         finally:
             if orig_value is None:
                 self.spark.conf.unset("spark.sql.execution.arrow.maxRecordsPerBatch")

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3173,25 +3173,25 @@ class PandasUDFTests(ReusedSQLTestCase):
 
         udf = pandas_udf(lambda x: x, DoubleType())
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         udf = pandas_udf(lambda x: x, DoubleType(), PandasUDFType.SCALAR)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         udf = pandas_udf(lambda x: x, 'v double', PandasUDFType.GROUP_MAP)
         self.assertEquals(udf.returnType, StructType([StructField("v", DoubleType())]))
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         udf = pandas_udf(lambda x: x, 'v double',
                          functionType=PandasUDFType.GROUP_MAP)
         self.assertEquals(udf.returnType, StructType([StructField("v", DoubleType())]))
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         udf = pandas_udf(lambda x: x, returnType='v double',
                          functionType=PandasUDFType.GROUP_MAP)
         self.assertEquals(udf.returnType, StructType([StructField("v", DoubleType())]))
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
     def test_pandas_udf_decorator(self):
         from pyspark.rdd import PythonEvalType
@@ -3202,13 +3202,13 @@ class PandasUDFTests(ReusedSQLTestCase):
         def foo(x):
             return x
         self.assertEquals(foo.returnType, DoubleType())
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         @pandas_udf(returnType=DoubleType())
         def foo(x):
             return x
         self.assertEquals(foo.returnType, DoubleType())
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
 
         schema = StructType([StructField("v", DoubleType())])
 
@@ -3216,19 +3216,19 @@ class PandasUDFTests(ReusedSQLTestCase):
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         @pandas_udf(schema, functionType=PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
         @pandas_udf(returnType=schema, functionType=PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF)
 
     def test_udf_wrong_arg(self):
         from pyspark.sql.functions import pandas_udf, PandasUDFType

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3169,62 +3169,62 @@ class ArrowTests(ReusedSQLTestCase):
 class PandasUDFTests(ReusedSQLTestCase):
     def test_pandas_udf_basic(self):
         from pyspark.rdd import PythonEvalType
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
 
         udf = pandas_udf(lambda x: x, DoubleType())
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.udfType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
 
-        udf = pandas_udf(lambda x: x, DoubleType(), PandasUdfType.GROUP_FLATMAP)
+        udf = pandas_udf(lambda x: x, DoubleType(), PandasUDFType.GROUP_FLATMAP)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.udfType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
 
         udf = pandas_udf(lambda x: x, DoubleType(),
-                         functionType=PandasUdfType.GROUP_FLATMAP)
+                         functionType=PandasUDFType.GROUP_FLATMAP)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.udfType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
 
         udf = pandas_udf(lambda x: x, returnType=DoubleType(),
-                         functionType=PandasUdfType.GROUP_FLATMAP)
+                         functionType=PandasUDFType.GROUP_FLATMAP)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.udfType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
 
     def test_pandas_udf_decorator(self):
         from pyspark.rdd import PythonEvalType
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
         from pyspark.sql.types import StructType, StructField, DoubleType
 
         @pandas_udf(DoubleType())
         def foo(x):
             return x
         self.assertEquals(foo.returnType, DoubleType())
-        self.assertEquals(foo.udfType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
 
         @pandas_udf(returnType=DoubleType())
         def foo(x):
             return x
         self.assertEquals(foo.returnType, DoubleType())
-        self.assertEquals(foo.udfType, PythonEvalType.PANDAS_SCALAR_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
 
         schema = StructType([StructField("v", DoubleType())])
 
-        @pandas_udf(schema, PandasUdfType.GROUP_FLATMAP)
+        @pandas_udf(schema, PandasUDFType.GROUP_FLATMAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.udfType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
 
-        @pandas_udf(schema, functionType=PandasUdfType.GROUP_FLATMAP)
+        @pandas_udf(schema, functionType=PandasUDFType.GROUP_FLATMAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.udfType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
 
-        @pandas_udf(returnType=schema, functionType=PandasUdfType.GROUP_FLATMAP)
+        @pandas_udf(returnType=schema, functionType=PandasUDFType.GROUP_FLATMAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.udfType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
 
 
 @unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3175,19 +3175,19 @@ class PandasUDFTests(ReusedSQLTestCase):
         self.assertEquals(udf.returnType, DoubleType())
         self.assertEquals(udf.evalType, PythonEvalType.PANDAS_SCALAR_UDF)
 
-        udf = pandas_udf(lambda x: x, DoubleType(), PandasUDFType.GROUP_FLATMAP)
+        udf = pandas_udf(lambda x: x, DoubleType(), PandasUDFType.GROUP_MAP)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
 
         udf = pandas_udf(lambda x: x, DoubleType(),
-                         functionType=PandasUDFType.GROUP_FLATMAP)
+                         functionType=PandasUDFType.GROUP_MAP)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
 
         udf = pandas_udf(lambda x: x, returnType=DoubleType(),
-                         functionType=PandasUDFType.GROUP_FLATMAP)
+                         functionType=PandasUDFType.GROUP_MAP)
         self.assertEquals(udf.returnType, DoubleType())
-        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(udf.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
 
     def test_pandas_udf_decorator(self):
         from pyspark.rdd import PythonEvalType
@@ -3208,23 +3208,23 @@ class PandasUDFTests(ReusedSQLTestCase):
 
         schema = StructType([StructField("v", DoubleType())])
 
-        @pandas_udf(schema, PandasUDFType.GROUP_FLATMAP)
+        @pandas_udf(schema, PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
 
-        @pandas_udf(schema, functionType=PandasUDFType.GROUP_FLATMAP)
+        @pandas_udf(schema, functionType=PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
 
-        @pandas_udf(returnType=schema, functionType=PandasUDFType.GROUP_FLATMAP)
+        @pandas_udf(returnType=schema, functionType=PandasUDFType.GROUP_MAP)
         def foo(x):
             return x
         self.assertEquals(foo.returnType, schema)
-        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF)
+        self.assertEquals(foo.evalType, PythonEvalType.PANDAS_GROUP_MAP_UDF)
 
 
 @unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")
@@ -3558,7 +3558,7 @@ class GroupbyApplyTests(ReusedSQLTestCase):
             .withColumn("v", explode(col('vs'))).drop('vs')
 
     def test_simple(self):
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
         df = self.data
 
         foo_udf = pandas_udf(
@@ -3568,7 +3568,7 @@ class GroupbyApplyTests(ReusedSQLTestCase):
                  StructField('v', IntegerType()),
                  StructField('v1', DoubleType()),
                  StructField('v2', LongType())]),
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
 
         result = df.groupby('id').apply(foo_udf).sort('id').toPandas()
@@ -3576,12 +3576,12 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         self.assertFramesEqual(expected, result)
 
     def test_decorator(self):
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
         df = self.data
 
         @pandas_udf(
             'id long, v int, v1 double, v2 long',
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
         def foo(pdf):
             return pdf.assign(v1=pdf.v * pdf.id * 1.0, v2=pdf.v + pdf.id)
@@ -3591,13 +3591,13 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         self.assertFramesEqual(expected, result)
 
     def test_coerce(self):
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
         df = self.data
 
         foo = pandas_udf(
             lambda pdf: pdf,
             'id long, v double',
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
 
         result = df.groupby('id').apply(foo).sort('id').toPandas()
@@ -3606,12 +3606,12 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         self.assertFramesEqual(expected, result)
 
     def test_complex_groupby(self):
-        from pyspark.sql.functions import pandas_udf, col, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, col, PandasUDFType
         df = self.data
 
         @pandas_udf(
             'id long, v int, norm double',
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
         def normalize(pdf):
             v = pdf.v
@@ -3625,12 +3625,12 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         self.assertFramesEqual(expected, result)
 
     def test_empty_groupby(self):
-        from pyspark.sql.functions import pandas_udf, col, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, col, PandasUDFType
         df = self.data
 
         @pandas_udf(
             'id long, v int, norm double',
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
         def normalize(pdf):
             v = pdf.v
@@ -3644,13 +3644,13 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         self.assertFramesEqual(expected, result)
 
     def test_datatype_string(self):
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
         df = self.data
 
         foo_udf = pandas_udf(
             lambda pdf: pdf.assign(v1=pdf.v * pdf.id * 1.0, v2=pdf.v + pdf.id),
             'id long, v int, v1 double, v2 long',
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
 
         result = df.groupby('id').apply(foo_udf).sort('id').toPandas()
@@ -3658,13 +3658,13 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         self.assertFramesEqual(expected, result)
 
     def test_wrong_return_type(self):
-        from pyspark.sql.functions import pandas_udf, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
         df = self.data
 
         foo = pandas_udf(
             lambda pdf: pdf,
             'id long, v string',
-            PandasUdfType.GROUP_FLATMAP
+            PandasUDFType.GROUP_MAP
         )
 
         with QuietTest(self.sc):
@@ -3672,7 +3672,7 @@ class GroupbyApplyTests(ReusedSQLTestCase):
                 df.groupby('id').apply(foo).sort('id').toPandas()
 
     def test_wrong_args(self):
-        from pyspark.sql.functions import udf, pandas_udf, sum, PandasUdfType
+        from pyspark.sql.functions import udf, pandas_udf, sum, PandasUDFType
         df = self.data
 
         with QuietTest(self.sc):
@@ -3693,14 +3693,14 @@ class GroupbyApplyTests(ReusedSQLTestCase):
             with self.assertRaisesRegexp(ValueError, 'Invalid udf'):
                 df.groupby('id').apply(
                     pandas_udf(lambda x, y: x, StructType([StructField("d", DoubleType())]),
-                               PandasUdfType.SCALAR))
+                               PandasUDFType.SCALAR))
 
     def test_unsupported_types(self):
-        from pyspark.sql.functions import pandas_udf, col, PandasUdfType
+        from pyspark.sql.functions import pandas_udf, col, PandasUDFType
         schema = StructType(
             [StructField("id", LongType(), True), StructField("dt", DecimalType(), True)])
         df = self.spark.createDataFrame([(1, None,)], schema=schema)
-        f = pandas_udf(lambda x: x, df.schema, PandasUdfType.GROUP_FLATMAP)
+        f = pandas_udf(lambda x: x, df.schema, PandasUDFType.GROUP_MAP)
         with QuietTest(self.sc):
             with self.assertRaisesRegexp(Exception, 'Unsupported data type'):
                 df.groupby('id').apply(f).collect()

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -33,7 +33,7 @@ def _wrap_function(sc, func, returnType):
 
 
 def _create_udf(f, returnType, evalType):
-    if evalType == PythonEvalType.PANDAS_SCALAR_UDF:
+    if evalType == PythonEvalType.SQL_PANDAS_SCALAR_UDF:
         import inspect
         argspec = inspect.getargspec(f)
         if len(argspec.args) == 0 and argspec.varargs is None:
@@ -42,7 +42,7 @@ def _create_udf(f, returnType, evalType):
                 "Instead, create a 1-arg pandas_udf and ignore the arg in your function."
             )
 
-    elif evalType == PythonEvalType.PANDAS_GROUP_MAP_UDF:
+    elif evalType == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
         import inspect
         argspec = inspect.getargspec(f)
         if len(argspec.args) != 1:
@@ -93,7 +93,7 @@ class UserDefinedFunction(object):
             else:
                 self._returnType_placeholder = _parse_datatype_string(self._returnType)
 
-        if self.evalType == PythonEvalType.PANDAS_GROUP_MAP_UDF \
+        if self.evalType == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF \
                 and not isinstance(self._returnType_placeholder, StructType):
             raise ValueError("Invalid returnType: returnType must be a StructType for "
                              "pandas_udf with function type GROUP_MAP")

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -51,6 +51,7 @@ def _create_udf(f, returnType, evalType):
                 "must take a single arg that is a pandas DataFrame."
             )
 
+    # Set the name of the UserDefinedFunction object to be the name of function f
     udf_obj = UserDefinedFunction(f, returnType=returnType, name=None, evalType=evalType)
     return udf_obj._wrapped()
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -47,7 +47,7 @@ def _create_udf(f, returnType, evalType):
         argspec = inspect.getargspec(f)
         if len(argspec.args) != 1:
             raise ValueError(
-                "Invalid function: pandas_udf with function type GROUP_MAP "
+                "Invalid function: pandas_udfs with function type GROUP_MAP "
                 "must take a single arg that is a pandas DataFrame."
             )
 
@@ -67,17 +67,17 @@ class UserDefinedFunction(object):
                  evalType=PythonEvalType.SQL_BATCHED_UDF):
         if not callable(func):
             raise TypeError(
-                "Not a function or callable (__call__ is not defined): "
+                "Invalid function: not a function or callable (__call__ is not defined): "
                 "{0}".format(type(func)))
 
         if not isinstance(returnType, (DataType, str)):
             raise TypeError(
-                "Invalid returnType. returnType should be DataType or str "
+                "Invalid returnType: returnType should be DataType or str "
                 "but is {}".format(returnType))
 
         if not isinstance(evalType, int):
             raise TypeError(
-                "Invalid evalType. evalType should be an int but is {}".format(evalType))
+                "Invalid evalType: evalType should be an int but is {}".format(evalType))
 
         self.func = func
         self._returnType = returnType

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -70,6 +70,11 @@ class UserDefinedFunction(object):
                 "Not a function or callable (__call__ is not defined): "
                 "{0}".format(type(func)))
 
+        if not isinstance(returnType, (DataType, str)):
+            raise TypeError(
+                "Invalid returnType. returnType should be DataType or str "
+                "but is {}".format(returnType))
+
         if not isinstance(evalType, int):
             raise TypeError(
                 "Invalid evalType. evalType should be an int but is {}".format(evalType))

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -32,8 +32,8 @@ def _wrap_function(sc, func, returnType):
                                   sc.pythonVer, broadcast_vars, sc._javaAccumulator)
 
 
-def _create_udf(f, *, returnType, evalType):
-    if evalType in (PythonEvalType.PANDAS_SCALAR_UDF, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF):
+def _create_udf(f, returnType, evalType):
+    if evalType in (PythonEvalType.PANDAS_SCALAR_UDF, PythonEvalType.PANDAS_GROUP_MAP_UDF):
         import inspect
         argspec = inspect.getargspec(f)
         if len(argspec.args) == 0 and argspec.varargs is None:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -1,0 +1,136 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+User-defined function related classes and functions
+"""
+import functools
+
+from pyspark import SparkContext
+from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType
+from pyspark.sql.column import Column, _to_java_column, _to_seq
+from pyspark.sql.types import StringType, DataType, _parse_datatype_string
+
+
+def _wrap_function(sc, func, returnType):
+    command = (func, returnType)
+    pickled_command, broadcast_vars, env, includes = _prepare_for_python_RDD(sc, command)
+    return sc._jvm.PythonFunction(bytearray(pickled_command), env, includes, sc.pythonExec,
+                                  sc.pythonVer, broadcast_vars, sc._javaAccumulator)
+
+
+def _create_udf(f, *, returnType, udfType):
+    if udfType in (PythonEvalType.PANDAS_SCALAR_UDF, PythonEvalType.PANDAS_GROUP_FLATMAP_UDF):
+        import inspect
+        argspec = inspect.getargspec(f)
+        if len(argspec.args) == 0 and argspec.varargs is None:
+            raise ValueError(
+                "0-arg pandas_udfs are not supported. "
+                "Instead, create a 1-arg pandas_udf and ignore the arg in your function."
+            )
+    udf_obj = UserDefinedFunction(f, returnType=returnType, name=None, udfType=udfType)
+    return udf_obj._wrapped()
+
+
+class UserDefinedFunction(object):
+    """
+    User defined function in Python
+
+    .. versionadded:: 1.3
+    """
+    def __init__(self, func,
+                 returnType=StringType(), name=None,
+                 udfType=PythonEvalType.SQL_BATCHED_UDF):
+        if not callable(func):
+            raise TypeError(
+                "Not a function or callable (__call__ is not defined): "
+                "{0}".format(type(func)))
+
+        self.func = func
+        self._returnType = returnType
+        # Stores UserDefinedPythonFunctions jobj, once initialized
+        self._returnType_placeholder = None
+        self._judf_placeholder = None
+        self._name = name or (
+            func.__name__ if hasattr(func, '__name__')
+            else func.__class__.__name__)
+        self.udfType = udfType
+
+
+    @property
+    def returnType(self):
+        # This makes sure this is called after SparkContext is initialized.
+        # ``_parse_datatype_string`` accesses to JVM for parsing a DDL formatted string.
+        if self._returnType_placeholder is None:
+            if isinstance(self._returnType, DataType):
+                self._returnType_placeholder = self._returnType
+            else:
+                self._returnType_placeholder = _parse_datatype_string(self._returnType)
+        return self._returnType_placeholder
+
+    @property
+    def _judf(self):
+        # It is possible that concurrent access, to newly created UDF,
+        # will initialize multiple UserDefinedPythonFunctions.
+        # This is unlikely, doesn't affect correctness,
+        # and should have a minimal performance impact.
+        if self._judf_placeholder is None:
+            self._judf_placeholder = self._create_judf()
+        return self._judf_placeholder
+
+    def _create_judf(self):
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.builder.getOrCreate()
+        sc = spark.sparkContext
+
+        wrapped_func = _wrap_function(sc, self.func, self.returnType)
+        jdt = spark._jsparkSession.parseDataType(self.returnType.json())
+        judf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonFunction(
+            self._name, wrapped_func, jdt, self.udfType)
+        return judf
+
+    def __call__(self, *cols):
+        judf = self._judf
+        sc = SparkContext._active_spark_context
+        return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))
+
+    def _wrapped(self):
+        """
+        Wrap this udf with a function and attach docstring from func
+        """
+
+        # It is possible for a callable instance without __name__ attribute or/and
+        # __module__ attribute to be wrapped here. For example, functools.partial. In this case,
+        # we should avoid wrapping the attributes from the wrapped function to the wrapper
+        # function. So, we take out these attribute names from the default names to set and
+        # then manually assign it after being wrapped.
+        assignments = tuple(
+            a for a in functools.WRAPPER_ASSIGNMENTS if a != '__name__' and a != '__module__')
+
+        @functools.wraps(self.func, assigned=assignments)
+        def wrapper(*args):
+            return self(*args)
+
+        wrapper.__name__ = self._name
+        wrapper.__module__ = (self.func.__module__ if hasattr(self.func, '__module__')
+                              else self.func.__class__.__module__)
+
+        wrapper.func = self.func
+        wrapper.returnType = self.returnType
+        wrapper.udfType = self.udfType
+
+        return wrapper

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -73,7 +73,6 @@ class UserDefinedFunction(object):
             else func.__class__.__name__)
         self.evalType = evalType
 
-
     @property
     def returnType(self):
         # This makes sure this is called after SparkContext is initialized.

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -122,9 +122,9 @@ def read_single_udf(pickleSer, infile, eval_type):
             row_func = chain(row_func, f)
 
     # the last returnType will be the return type of UDF
-    if eval_type == PythonEvalType.PANDAS_SCALAR_UDF:
+    if eval_type == PythonEvalType.SQL_PANDAS_SCALAR_UDF:
         return arg_offsets, wrap_pandas_scalar_udf(row_func, return_type)
-    elif eval_type == PythonEvalType.PANDAS_GROUP_MAP_UDF:
+    elif eval_type == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
         return arg_offsets, wrap_pandas_group_map_udf(row_func, return_type)
     else:
         return arg_offsets, wrap_udf(row_func, return_type)
@@ -148,8 +148,8 @@ def read_udfs(pickleSer, infile, eval_type):
 
     func = lambda _, it: map(mapper, it)
 
-    if eval_type == PythonEvalType.PANDAS_SCALAR_UDF \
-       or eval_type == PythonEvalType.PANDAS_GROUP_MAP_UDF:
+    if eval_type == PythonEvalType.SQL_PANDAS_SCALAR_UDF \
+       or eval_type == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
         ser = ArrowStreamPandasSerializer()
     else:
         ser = BatchedSerializer(PickleSerializer(), 100)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -104,7 +104,7 @@ def read_single_udf(pickleSer, infile, eval_type):
     # the last returnType will be the return type of UDF
     if eval_type == PythonEvalType.PANDAS_SCALAR_UDF:
         return arg_offsets, wrap_pandas_udf(row_func, return_type)
-    elif eval_type == PythonEvalType.PANDAS_GROUP_FLATMAP_UDF:
+    elif eval_type == PythonEvalType.PANDAS_GROUP_MAP_UDF:
         # a groupby apply udf has already been wrapped under apply()
         return arg_offsets, row_func
     else:
@@ -130,7 +130,7 @@ def read_udfs(pickleSer, infile, eval_type):
     func = lambda _, it: map(mapper, it)
 
     if eval_type == PythonEvalType.PANDAS_SCALAR_UDF \
-       or eval_type == PythonEvalType.PANDAS_GROUP_FLATMAP_UDF:
+       or eval_type == PythonEvalType.PANDAS_GROUP_MAP_UDF:
         ser = ArrowStreamPandasSerializer()
     else:
         ser = BatchedSerializer(PickleSerializer(), 100)

--- a/python/setup.py
+++ b/python/setup.py
@@ -196,7 +196,10 @@ try:
             'pyspark.examples.src.main.python': ['*.py', '*/*.py']},
         scripts=scripts,
         license='http://www.apache.org/licenses/LICENSE-2.0',
-        install_requires=['py4j==0.10.6'],
+        install_requires=[
+            'py4j==0.10.6',
+            'enum34'
+        ],
         setup_requires=['pypandoc'],
         extras_require={
             'ml': ['numpy>=1.7'],

--- a/python/setup.py
+++ b/python/setup.py
@@ -196,10 +196,7 @@ try:
             'pyspark.examples.src.main.python': ['*.py', '*/*.py']},
         scripts=scripts,
         license='http://www.apache.org/licenses/LICENSE-2.0',
-        install_requires=[
-            'py4j==0.10.6',
-            'enum34'
-        ],
+        install_requires=['py4j==0.10.6'],
         setup_requires=['pypandoc'],
         extras_require={
             'ml': ['numpy>=1.7'],

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -450,7 +450,7 @@ class RelationalGroupedDataset protected[sql](
    * workers.
    */
   private[sql] def flatMapGroupsInPandas(expr: PythonUDF): DataFrame = {
-    require(expr.evalType == PythonEvalType.PANDAS_GROUP_MAP_UDF,
+    require(expr.evalType == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF,
       "Must pass a group map udf")
     require(expr.dataType.isInstanceOf[StructType],
       "The returnType of the udf must be a StructType")

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -23,6 +23,7 @@ import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 
 import org.apache.spark.annotation.InterfaceStability
+import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.analysis.{Star, UnresolvedAlias, UnresolvedAttribute, UnresolvedFunction}
 import org.apache.spark.sql.catalyst.expressions._
@@ -30,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
-import org.apache.spark.sql.execution.python.{PythonUDF, PythonUdfType}
+import org.apache.spark.sql.execution.python.{PythonUDF}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{NumericType, StructType}
 
@@ -449,10 +450,10 @@ class RelationalGroupedDataset protected[sql](
    * workers.
    */
   private[sql] def flatMapGroupsInPandas(expr: PythonUDF): DataFrame = {
-    require(expr.pythonUdfType == PythonUdfType.PANDAS_GROUPED_UDF,
-      "Must pass a grouped vectorized python udf")
+    require(expr.pythonUdfType == PythonEvalType.PANDAS_GROUP_FLATMAP_UDF,
+      "Must pass a group flatmap udf")
     require(expr.dataType.isInstanceOf[StructType],
-      "The returnType of the vectorized python udf must be a StructType")
+      "The returnType of the udf must be a StructType")
 
     val groupingNamedExpressions = groupingExprs.map {
       case ne: NamedExpression => ne

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -450,8 +450,8 @@ class RelationalGroupedDataset protected[sql](
    * workers.
    */
   private[sql] def flatMapGroupsInPandas(expr: PythonUDF): DataFrame = {
-    require(expr.evalType == PythonEvalType.PANDAS_GROUP_FLATMAP_UDF,
-      "Must pass a group flatmap udf")
+    require(expr.evalType == PythonEvalType.PANDAS_GROUP_MAP_UDF,
+      "Must pass a group map udf")
     require(expr.dataType.isInstanceOf[StructType],
       "The returnType of the udf must be a StructType")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
-import org.apache.spark.sql.execution.python.{PythonUDF}
+import org.apache.spark.sql.execution.python.PythonUDF
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{NumericType, StructType}
 
@@ -450,7 +450,7 @@ class RelationalGroupedDataset protected[sql](
    * workers.
    */
   private[sql] def flatMapGroupsInPandas(expr: PythonUDF): DataFrame = {
-    require(expr.pythonUdfType == PythonEvalType.PANDAS_GROUP_FLATMAP_UDF,
+    require(expr.evalType == PythonEvalType.PANDAS_GROUP_FLATMAP_UDF,
       "Must pass a group flatmap udf")
     require(expr.dataType.isInstanceOf[StructType],
       "The returnType of the udf must be a StructType")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -81,7 +81,7 @@ case class ArrowEvalPythonExec(udfs: Seq[PythonUDF], output: Seq[Attribute], chi
 
     val columnarBatchIter = new ArrowPythonRunner(
         funcs, bufferSize, reuseWorker,
-        PythonEvalType.PANDAS_SCALAR_UDF, argOffsets, schema, sessionLocalTimeZone)
+        PythonEvalType.SQL_PANDAS_SCALAR_UDF, argOffsets, schema, sessionLocalTimeZone)
       .compute(batchIter, context.partitionId(), context)
 
     new Iterator[InternalRow] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -81,7 +81,7 @@ case class ArrowEvalPythonExec(udfs: Seq[PythonUDF], output: Seq[Attribute], chi
 
     val columnarBatchIter = new ArrowPythonRunner(
         funcs, bufferSize, reuseWorker,
-        PythonEvalType.SQL_PANDAS_UDF, argOffsets, schema, sessionLocalTimeZone)
+        PythonEvalType.PANDAS_SCALAR_UDF, argOffsets, schema, sessionLocalTimeZone)
       .compute(batchIter, context.partitionId(), context)
 
     new Iterator[InternalRow] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -140,7 +140,7 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
         if (validUdfs.nonEmpty) {
           require(validUdfs.forall(udf =>
             udf.evalType == PythonEvalType.SQL_BATCHED_UDF ||
-            udf.evalType == PythonEvalType.PANDAS_SCALAR_UDF
+            udf.evalType == PythonEvalType.SQL_PANDAS_SCALAR_UDF
           ), "Can only extract scalar vectorized udf or sql batch udf")
 
           val resultAttrs = udfs.zipWithIndex.map { case (u, i) =>
@@ -148,7 +148,7 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
           }
 
           val evaluation = validUdfs.partition(
-            _.evalType == PythonEvalType.PANDAS_SCALAR_UDF
+            _.evalType == PythonEvalType.SQL_PANDAS_SCALAR_UDF
           ) match {
             case (vectorizedUdfs, plainUdfs) if plainUdfs.isEmpty =>
               ArrowEvalPythonExec(vectorizedUdfs, child.output ++ resultAttrs, child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.python
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
@@ -137,15 +138,18 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
           udf.references.subsetOf(child.outputSet)
         }
         if (validUdfs.nonEmpty) {
-          if (validUdfs.exists(_.pythonUdfType == PythonUdfType.PANDAS_GROUPED_UDF)) {
-            throw new IllegalArgumentException("Can not use grouped vectorized UDFs")
-          }
+          require(validUdfs.forall(udf =>
+            udf.pythonUdfType == PythonEvalType.SQL_BATCHED_UDF ||
+            udf.pythonUdfType == PythonEvalType.PANDAS_SCALAR_UDF
+          ), "Can only extract scalar vectorized udf or sql batch udf")
 
           val resultAttrs = udfs.zipWithIndex.map { case (u, i) =>
             AttributeReference(s"pythonUDF$i", u.dataType)()
           }
 
-          val evaluation = validUdfs.partition(_.pythonUdfType == PythonUdfType.PANDAS_UDF) match {
+          val evaluation = validUdfs.partition(
+            _.pythonUdfType == PythonEvalType.PANDAS_SCALAR_UDF
+          ) match {
             case (vectorizedUdfs, plainUdfs) if plainUdfs.isEmpty =>
               ArrowEvalPythonExec(vectorizedUdfs, child.output ++ resultAttrs, child)
             case (vectorizedUdfs, plainUdfs) if vectorizedUdfs.isEmpty =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -139,8 +139,8 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
         }
         if (validUdfs.nonEmpty) {
           require(validUdfs.forall(udf =>
-            udf.pythonUdfType == PythonEvalType.SQL_BATCHED_UDF ||
-            udf.pythonUdfType == PythonEvalType.PANDAS_SCALAR_UDF
+            udf.evalType == PythonEvalType.SQL_BATCHED_UDF ||
+            udf.evalType == PythonEvalType.PANDAS_SCALAR_UDF
           ), "Can only extract scalar vectorized udf or sql batch udf")
 
           val resultAttrs = udfs.zipWithIndex.map { case (u, i) =>
@@ -148,7 +148,7 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
           }
 
           val evaluation = validUdfs.partition(
-            _.pythonUdfType == PythonEvalType.PANDAS_SCALAR_UDF
+            _.evalType == PythonEvalType.PANDAS_SCALAR_UDF
           ) match {
             case (vectorizedUdfs, plainUdfs) if plainUdfs.isEmpty =>
               ArrowEvalPythonExec(vectorizedUdfs, child.output ++ resultAttrs, child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -95,7 +95,7 @@ case class FlatMapGroupsInPandasExec(
 
       val columnarBatchIter = new ArrowPythonRunner(
         chainedFunc, bufferSize, reuseWorker,
-        PythonEvalType.PANDAS_GROUP_MAP_UDF, argOffsets, schema, sessionLocalTimeZone)
+        PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF, argOffsets, schema, sessionLocalTimeZone)
           .compute(grouped, context.partitionId(), context)
 
       columnarBatchIter.flatMap(_.rowIterator.asScala).map(UnsafeProjection.create(output, output))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -95,7 +95,7 @@ case class FlatMapGroupsInPandasExec(
 
       val columnarBatchIter = new ArrowPythonRunner(
         chainedFunc, bufferSize, reuseWorker,
-        PythonEvalType.PANDAS_GROUP_FLATMAP_UDF, argOffsets, schema, sessionLocalTimeZone)
+        PythonEvalType.PANDAS_GROUP_MAP_UDF, argOffsets, schema, sessionLocalTimeZone)
           .compute(grouped, context.partitionId(), context)
 
       columnarBatchIter.flatMap(_.rowIterator.asScala).map(UnsafeProjection.create(output, output))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -95,7 +95,7 @@ case class FlatMapGroupsInPandasExec(
 
       val columnarBatchIter = new ArrowPythonRunner(
         chainedFunc, bufferSize, reuseWorker,
-        PythonEvalType.SQL_PANDAS_GROUPED_UDF, argOffsets, schema, sessionLocalTimeZone)
+        PythonEvalType.PANDAS_GROUP_FLATMAP_UDF, argOffsets, schema, sessionLocalTimeZone)
           .compute(grouped, context.partitionId(), context)
 
       columnarBatchIter.flatMap(_.rowIterator.asScala).map(UnsafeProjection.create(output, output))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDF.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDF.scala
@@ -29,7 +29,7 @@ case class PythonUDF(
     func: PythonFunction,
     dataType: DataType,
     children: Seq[Expression],
-    pythonUdfType: Int)
+    evalType: Int)
   extends Expression with Unevaluable with NonSQLExpression with UserDefinedExpression {
 
   override def toString: String = s"$name(${children.mkString(", ")})"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -29,10 +29,10 @@ case class UserDefinedPythonFunction(
     name: String,
     func: PythonFunction,
     dataType: DataType,
-    pythonUdfType: Int) {
+    pythonEvalType: Int) {
 
   def builder(e: Seq[Expression]): PythonUDF = {
-    PythonUDF(name, func, dataType, e, pythonUdfType)
+    PythonUDF(name, func, dataType, e, pythonEvalType)
   }
 
   /** Returns a [[Column]] that will evaluate to calling this UDF with the given input. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -22,15 +22,6 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.DataType
 
-private[spark] object PythonUdfType {
-  // row-at-a-time UDFs
-  val NORMAL_UDF = 0
-  // scalar vectorized UDFs
-  val PANDAS_UDF = 1
-  // grouped vectorized UDFs
-  val PANDAS_GROUPED_UDF = 2
-}
-
 /**
  * A user-defined Python function. This is used by the Python API.
  */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.python
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.api.python.PythonFunction
+import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}
 import org.apache.spark.sql.execution.{FilterExec, InputAdapter, SparkPlanTest, WholeStageCodegenExec}
@@ -109,4 +109,4 @@ class MyDummyPythonUDF extends UserDefinedPythonFunction(
   name = "dummyUDF",
   func = new DummyUDF,
   dataType = BooleanType,
-  pythonUdfType = PythonUdfType.NORMAL_UDF)
+  pythonEvalType = PythonEvalType.SQL_BATCHED_UDF)


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Add a "function type" argument to pandas_udf.
* Add a new public enum class `PandasUdfType` in pyspark.sql.functions
* Refactor udf related code from pyspark.sql.functions to pyspark.sql.udf
* Merge "PythonUdfType" and "PythonEvalType" into a single enum class "PythonEvalType"

Example:
```
from pyspark.sql.functions import pandas_udf, PandasUDFType

@pandas_udf('double', PandasUDFType.SCALAR):
def plus_one(v):
    return v + 1
```

## Design doc
https://docs.google.com/document/d/1KlLaa-xJ3oz28xlEJqXyCAHU3dwFYkFs_ixcUXrJNTc/edit

## How was this patch tested?

Added PandasUDFTests

## TODO:
* [x] Implement proper enum type for `PandasUDFType`
* [x] Update documentation
* [x] Add more tests in PandasUDFTests
