### PR TITLE
[SPARK-22411][SQL] Disable the heuristic to calculate max partition size when  dynamic allocation is enabled and use the value specified by the property spark.sql.files.maxPartitionBytes instead

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -424,11 +424,18 @@ case class FileSourceScanExec(
     val defaultMaxSplitBytes =
       fsRelation.sparkSession.sessionState.conf.filesMaxPartitionBytes
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
-    val defaultParallelism = fsRelation.sparkSession.sparkContext.defaultParallelism
-    val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
-    val bytesPerCore = totalBytes / defaultParallelism
 
-    val maxSplitBytes = Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+    val maxSplitBytes =
+      if (Utils.isDynamicAllocationEnabled(fsRelation.sparkSession.sparkContext.getConf)) {
+      defaultMaxSplitBytes
+    } else {
+      val defaultParallelism = fsRelation.sparkSession.sparkContext.defaultParallelism
+      val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
+      val bytesPerCore = totalBytes / defaultParallelism
+      val maxPartitionBytes =
+        Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+      maxPartitionBytes
+    }
     logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
       s"open cost is considered as scanning $openCostInBytes bytes.")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The heuristic to calculate the maxSplitSize in DataSourceScanExec is as follows:
https://github.com/apache/spark/blob/d28d5732ae205771f1f443b15b10e64dcffb5ff0/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala#L431

bytesPerCore is calculated based on the default parallelism. Default parallelism in this case is the number of total cores of all the registered executors for this application. The heuristic works well with static allocation but with dynamic allocation enabled, defaultParallelism is usually one (with default config of min and initial executors as zero) at the time of split calculation. This heuristic was introduced in SPARK-14582.

With dynamic allocation it is confusing to tune the split size with this heuristic. It is better to ignore bytesPerCore and use the values of 'spark.sql.files.maxPartitionBytes' as the max split size.

## How was this patch tested?
Tested manually.
