### PR TITLE
[SPARK-22243][DStream]spark.yarn.jars should reload from config when checkpoint recovery

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -53,6 +53,7 @@ class Checkpoint(ssc: StreamingContext, val checkpointTime: Time)
       "spark.driver.host",
       "spark.driver.port",
       "spark.master",
+      "spark.yarn.jars",
       "spark.yarn.keytab",
       "spark.yarn.principal",
       "spark.yarn.credentials.file",


### PR DESCRIPTION
## What changes were proposed in this pull request?
the previous [PR](https://github.com/apache/spark/pull/19469) is deleted by mistake.
the solution is straight forward. 
adding  "spark.yarn.jars" to propertiesToReload so this property will load from config. 

## How was this patch tested?

manual tests