### PR TITLE
[SPARK-22405][SQL] Add new alter table and alter database related ExternalCatalogEvent

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -157,9 +157,9 @@ abstract class ExternalCatalog
   final def alterTable(tableDefinition: CatalogTable): Unit = {
     val db = tableDefinition.database
     val name = tableDefinition.identifier.table
-    postToAll(AlterTablePreEvent(db, name))
+    postToAll(AlterTablePreEvent(db, name, AlterTableKind.Table))
     doAlterTable(tableDefinition)
-    postToAll(AlterTableEvent(db, name))
+    postToAll(AlterTableEvent(db, name, AlterTableKind.Table))
   }
 
   protected def doAlterTable(tableDefinition: CatalogTable): Unit
@@ -174,15 +174,21 @@ abstract class ExternalCatalog
    * @param newDataSchema Updated data schema to be used for the table.
    */
   final def alterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit = {
-    postToAll(AlterTableDataSchemaPreEvent(db, table))
+    postToAll(AlterTablePreEvent(db, table, AlterTableKind.DataSchema))
     doAlterTableDataSchema(db, table, newDataSchema)
-    postToAll(AlterTableDataSchemaEvent(db, table))
+    postToAll(AlterTableEvent(db, table, AlterTableKind.DataSchema))
   }
 
   protected def doAlterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit
 
   /** Alter the statistics of a table. If `stats` is None, then remove all existing statistics. */
-  def alterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit
+  final def alterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit = {
+    postToAll(AlterTablePreEvent(db, table, AlterTableKind.Stats))
+    doAlterTableStats(db, table, stats)
+    postToAll(AlterTableEvent(db, table, AlterTableKind.Stats))
+  }
+
+  protected def doAlterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit
 
   def getTable(db: String, table: String): CatalogTable
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -174,9 +174,9 @@ abstract class ExternalCatalog
    * @param newDataSchema Updated data schema to be used for the table.
    */
   final def alterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit = {
-    postToAll(AlterTableSchemaPreEvent(db, table))
+    postToAll(AlterTableDataSchemaPreEvent(db, table))
     doAlterTableDataSchema(db, table, newDataSchema)
-    postToAll(AlterTableSchemaEvent(db, table))
+    postToAll(AlterTableDataSchemaEvent(db, table))
   }
 
   protected def doAlterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -157,9 +157,9 @@ abstract class ExternalCatalog
   final def alterTable(tableDefinition: CatalogTable): Unit = {
     val db = tableDefinition.database
     val name = tableDefinition.identifier.table
-    postToAll(AlterTablePreEvent(db, name, AlterTableKind.Table))
+    postToAll(AlterTablePreEvent(db, name, AlterTableKind.TABLE))
     doAlterTable(tableDefinition)
-    postToAll(AlterTableEvent(db, name, AlterTableKind.Table))
+    postToAll(AlterTableEvent(db, name, AlterTableKind.TABLE))
   }
 
   protected def doAlterTable(tableDefinition: CatalogTable): Unit
@@ -174,18 +174,18 @@ abstract class ExternalCatalog
    * @param newDataSchema Updated data schema to be used for the table.
    */
   final def alterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit = {
-    postToAll(AlterTablePreEvent(db, table, AlterTableKind.DataSchema))
+    postToAll(AlterTablePreEvent(db, table, AlterTableKind.DATASCHEMA))
     doAlterTableDataSchema(db, table, newDataSchema)
-    postToAll(AlterTableEvent(db, table, AlterTableKind.DataSchema))
+    postToAll(AlterTableEvent(db, table, AlterTableKind.DATASCHEMA))
   }
 
   protected def doAlterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit
 
   /** Alter the statistics of a table. If `stats` is None, then remove all existing statistics. */
   final def alterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit = {
-    postToAll(AlterTablePreEvent(db, table, AlterTableKind.Stats))
+    postToAll(AlterTablePreEvent(db, table, AlterTableKind.STATS))
     doAlterTableStats(db, table, stats)
-    postToAll(AlterTableEvent(db, table, AlterTableKind.Stats))
+    postToAll(AlterTableEvent(db, table, AlterTableKind.STATS))
   }
 
   protected def doAlterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -173,13 +173,13 @@ abstract class ExternalCatalog
    * @param table Name of table to alter schema for
    * @param newDataSchema Updated data schema to be used for the table.
    */
-  final def alterTableSchema(db: String, table: String, newDataSchema: StructType): Unit = {
+  final def alterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit = {
     postToAll(AlterTableSchemaPreEvent(db, table))
-    doAlterTableSchema(db, table, newDataSchema)
+    doAlterTableDataSchema(db, table, newDataSchema)
     postToAll(AlterTableSchemaEvent(db, table))
   }
 
-  protected def doAlterTableSchema(db: String, table: String, newDataSchema: StructType): Unit
+  protected def doAlterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit
 
   /** Alter the statistics of a table. If `stats` is None, then remove all existing statistics. */
   def alterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -87,7 +87,14 @@ abstract class ExternalCatalog
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
    */
-  def alterDatabase(dbDefinition: CatalogDatabase): Unit
+  final def alterDatabase(dbDefinition: CatalogDatabase): Unit = {
+    val db = dbDefinition.name
+    postToAll(AlterDatabasePreEvent(db))
+    doAlterDatabase(dbDefinition)
+    postToAll(AlterDatabaseEvent(db))
+  }
+
+  protected def doAlterDatabase(dbDefinition: CatalogDatabase): Unit
 
   def getDatabase(db: String): CatalogDatabase
 
@@ -147,7 +154,15 @@ abstract class ExternalCatalog
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
    */
-  def alterTable(tableDefinition: CatalogTable): Unit
+  final def alterTable(tableDefinition: CatalogTable): Unit = {
+    val db = tableDefinition.database
+    val name = tableDefinition.identifier.table
+    postToAll(AlterTablePreEvent(db, name))
+    doAlterTable(tableDefinition)
+    postToAll(AlterTableEvent(db, name))
+  }
+
+  protected def doAlterTable(tableDefinition: CatalogTable): Unit
 
   /**
    * Alter the data schema of a table identified by the provided database and table name. The new
@@ -158,7 +173,13 @@ abstract class ExternalCatalog
    * @param table Name of table to alter schema for
    * @param newDataSchema Updated data schema to be used for the table.
    */
-  def alterTableDataSchema(db: String, table: String, newDataSchema: StructType): Unit
+  final def alterTableSchema(db: String, table: String, newDataSchema: StructType): Unit = {
+    postToAll(AlterTableSchemaPreEvent(db, table))
+    doAlterTableSchema(db, table, newDataSchema)
+    postToAll(AlterTableSchemaEvent(db, table))
+  }
+
+  protected def doAlterTableSchema(db: String, table: String, newDataSchema: StructType): Unit
 
   /** Alter the statistics of a table. If `stats` is None, then remove all existing statistics. */
   def alterTableStats(db: String, table: String, stats: Option[CatalogStatistics]): Unit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -152,7 +152,7 @@ class InMemoryCatalog(
     }
   }
 
-  override def alterDatabase(dbDefinition: CatalogDatabase): Unit = synchronized {
+  override def doAlterDatabase(dbDefinition: CatalogDatabase): Unit = synchronized {
     requireDbExists(dbDefinition.name)
     catalog(dbDefinition.name).db = dbDefinition
   }
@@ -294,7 +294,7 @@ class InMemoryCatalog(
     catalog(db).tables.remove(oldName)
   }
 
-  override def alterTable(tableDefinition: CatalogTable): Unit = synchronized {
+  override def doAlterTable(tableDefinition: CatalogTable): Unit = synchronized {
     assert(tableDefinition.identifier.database.isDefined)
     val db = tableDefinition.identifier.database.get
     requireTableExists(db, tableDefinition.identifier.table)
@@ -303,7 +303,7 @@ class InMemoryCatalog(
     catalog(db).tables(tableDefinition.identifier.table).table = newTableDefinition
   }
 
-  override def alterTableDataSchema(
+  override def doAlterTableSchema(
       db: String,
       table: String,
       newDataSchema: StructType): Unit = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -313,7 +313,7 @@ class InMemoryCatalog(
     catalog(db).tables(table).table = origTable.copy(schema = newSchema)
   }
 
-  override def alterTableStats(
+  override def doAlterTableStats(
       db: String,
       table: String,
       stats: Option[CatalogStatistics]): Unit = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -303,7 +303,7 @@ class InMemoryCatalog(
     catalog(db).tables(tableDefinition.identifier.table).table = newTableDefinition
   }
 
-  override def doAlterTableSchema(
+  override def doAlterTableDataSchema(
       db: String,
       table: String,
       newDataSchema: StructType): Unit = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -120,11 +120,13 @@ case class RenameTableEvent(
   extends TableEvent
 
 /**
- * Enumeration to indicate which part of table is altered. If a plain alterTable API is called, then
+ * String to indicate which part of table is altered. If a plain alterTable API is called, then
  * type will generally be Table.
  */
 object AlterTableKind extends Enumeration {
-  val Table, DataSchema, Stats = Value
+  val TABLE = "table"
+  val DATASCHEMA = "dataSchema"
+  val STATS = "stats"
 }
 
 /**
@@ -133,7 +135,7 @@ object AlterTableKind extends Enumeration {
 case class AlterTablePreEvent(
     database: String,
     name: String,
-    kind: AlterTableKind.Value) extends TableEvent
+    kind: String) extends TableEvent
 
 /**
  * Event fired after a table is altered.
@@ -141,7 +143,7 @@ case class AlterTablePreEvent(
 case class AlterTableEvent(
     database: String,
     name: String,
-    kind: AlterTableKind.Value) extends TableEvent
+    kind: String) extends TableEvent
 
 /**
  * Event fired when a function is created, dropped, altered or renamed.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -17,8 +17,6 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.scheduler.SparkListenerEvent
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.types.StructType
 
 /**
  * Event emitted by the external catalog when it is modified. Events are either fired before or
@@ -132,14 +130,14 @@ case class AlterTablePreEvent(database: String, name: String) extends TableEvent
 case class AlterTableEvent(database: String, name: String) extends TableEvent
 
 /**
- * Event fired before table schema is altered.
+ * Event fired before table data schema is altered.
  */
-case class AlterTableSchemaPreEvent(database: String, name: String) extends TableEvent
+case class AlterTableDataSchemaPreEvent(database: String, name: String) extends TableEvent
 
 /**
- * Event fired after table schema is altered.
+ * Event fired after table data schema is altered.
  */
-case class AlterTableSchemaEvent(database: String, name: String) extends TableEvent
+case class AlterTableDataSchemaEvent(database: String, name: String) extends TableEvent
 
 /**
  * Event fired when a function is created, dropped, altered or renamed.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.scheduler.SparkListenerEvent
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.types.StructType
 
 /**
  * Event emitted by the external catalog when it is modified. Events are either fired before or
@@ -60,6 +62,16 @@ case class DropDatabasePreEvent(database: String) extends DatabaseEvent
  * Event fired after a database has been dropped.
  */
 case class DropDatabaseEvent(database: String) extends DatabaseEvent
+
+/**
+ * Event fired before a database is altered.
+ */
+case class AlterDatabasePreEvent(database: String) extends DatabaseEvent
+
+/**
+ * Event fired after a database is altered.
+ */
+case class AlterDatabaseEvent(database: String) extends DatabaseEvent
 
 /**
  * Event fired when a table is created, dropped or renamed.
@@ -110,7 +122,27 @@ case class RenameTableEvent(
   extends TableEvent
 
 /**
- * Event fired when a function is created, dropped or renamed.
+ * Event fired before a table is altered.
+ */
+case class AlterTablePreEvent(database: String, name: String) extends TableEvent
+
+/**
+ * Event fired after a table is altered.
+ */
+case class AlterTableEvent(database: String, name: String) extends TableEvent
+
+/**
+ * Event fired before table schema is altered.
+ */
+case class AlterTableSchemaPreEvent(database: String, name: String) extends TableEvent
+
+/**
+ * Event fired after table schema is altered.
+ */
+case class AlterTableSchemaEvent(database: String, name: String) extends TableEvent
+
+/**
+ * Event fired when a function is created, dropped, altered or renamed.
  */
 trait FunctionEvent extends DatabaseEvent {
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -120,24 +120,28 @@ case class RenameTableEvent(
   extends TableEvent
 
 /**
+ * Enumeration to indicate which part of table is altered. If a plain alterTable API is called, then
+ * type will generally be Table.
+ */
+object AlterTableKind extends Enumeration {
+  val Table, DataSchema, Stats = Value
+}
+
+/**
  * Event fired before a table is altered.
  */
-case class AlterTablePreEvent(database: String, name: String) extends TableEvent
+case class AlterTablePreEvent(
+    database: String,
+    name: String,
+    kind: AlterTableKind.Value) extends TableEvent
 
 /**
  * Event fired after a table is altered.
  */
-case class AlterTableEvent(database: String, name: String) extends TableEvent
-
-/**
- * Event fired before table data schema is altered.
- */
-case class AlterTableDataSchemaPreEvent(database: String, name: String) extends TableEvent
-
-/**
- * Event fired after table data schema is altered.
- */
-case class AlterTableDataSchemaEvent(database: String, name: String) extends TableEvent
+case class AlterTableEvent(
+    database: String,
+    name: String,
+    kind: AlterTableKind.Value) extends TableEvent
 
 /**
  * Event fired when a function is created, dropped, altered or renamed.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
@@ -109,8 +109,6 @@ class ExternalCatalogEventSuite extends SparkFunSuite {
       tableType = CatalogTableType.MANAGED,
       storage = storage,
       schema = new StructType().add("id", "long"))
-    val tableDefWithSparkVersion =
-      tableDefinition.copy(createVersion = org.apache.spark.SPARK_VERSION)
 
     catalog.createDatabase(dbDefinition, ignoreIfExists = false)
     checkEvents(CreateDatabasePreEvent("db5") :: CreateDatabaseEvent("db5") :: Nil)
@@ -134,8 +132,8 @@ class ExternalCatalogEventSuite extends SparkFunSuite {
     // ALTER schema
     val newSchema = new StructType().add("id", "long", nullable = false)
     catalog.alterTableDataSchema("db5", "tbl1", newSchema)
-    checkEvents(
-      AlterTableSchemaPreEvent("db5", "tbl1") :: AlterTableSchemaEvent("db5", "tbl1") :: Nil)
+    checkEvents(AlterTableDataSchemaPreEvent("db5", "tbl1") ::
+      AlterTableDataSchemaEvent("db5", "tbl1") :: Nil)
 
     // RENAME
     catalog.renameTable("db5", "tbl1", "tbl2")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
@@ -127,19 +127,19 @@ class ExternalCatalogEventSuite extends SparkFunSuite {
     // ALTER
     val newTableDefinition = tableDefinition.copy(tableType = CatalogTableType.EXTERNAL)
     catalog.alterTable(newTableDefinition)
-    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.Table) ::
-      AlterTableEvent("db5", "tbl1", AlterTableKind.Table) :: Nil)
+    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.TABLE) ::
+      AlterTableEvent("db5", "tbl1", AlterTableKind.TABLE) :: Nil)
 
     // ALTER schema
     val newSchema = new StructType().add("id", "long", nullable = false)
     catalog.alterTableDataSchema("db5", "tbl1", newSchema)
-    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.DataSchema) ::
-      AlterTableEvent("db5", "tbl1", AlterTableKind.DataSchema) :: Nil)
+    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.DATASCHEMA) ::
+      AlterTableEvent("db5", "tbl1", AlterTableKind.DATASCHEMA) :: Nil)
 
     // ALTER stats
     catalog.alterTableStats("db5", "tbl1", None)
-    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.Stats) ::
-      AlterTableEvent("db5", "tbl1", AlterTableKind.Stats) :: Nil)
+    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.STATS) ::
+      AlterTableEvent("db5", "tbl1", AlterTableKind.STATS) :: Nil)
 
     // RENAME
     catalog.renameTable("db5", "tbl1", "tbl2")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
@@ -127,13 +127,19 @@ class ExternalCatalogEventSuite extends SparkFunSuite {
     // ALTER
     val newTableDefinition = tableDefinition.copy(tableType = CatalogTableType.EXTERNAL)
     catalog.alterTable(newTableDefinition)
-    checkEvents(AlterTablePreEvent("db5", "tbl1") :: AlterTableEvent("db5", "tbl1") :: Nil)
+    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.Table) ::
+      AlterTableEvent("db5", "tbl1", AlterTableKind.Table) :: Nil)
 
     // ALTER schema
     val newSchema = new StructType().add("id", "long", nullable = false)
     catalog.alterTableDataSchema("db5", "tbl1", newSchema)
-    checkEvents(AlterTableDataSchemaPreEvent("db5", "tbl1") ::
-      AlterTableDataSchemaEvent("db5", "tbl1") :: Nil)
+    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.DataSchema) ::
+      AlterTableEvent("db5", "tbl1", AlterTableKind.DataSchema) :: Nil)
+
+    // ALTER stats
+    catalog.alterTableStats("db5", "tbl1", None)
+    checkEvents(AlterTablePreEvent("db5", "tbl1", AlterTableKind.Stats) ::
+      AlterTableEvent("db5", "tbl1", AlterTableKind.Stats) :: Nil)
 
     // RENAME
     catalog.renameTable("db5", "tbl1", "tbl2")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogEventSuite.scala
@@ -133,7 +133,7 @@ class ExternalCatalogEventSuite extends SparkFunSuite {
 
     // ALTER schema
     val newSchema = new StructType().add("id", "long", nullable = false)
-    catalog.alterTableSchema("db5", "tbl1", newSchema)
+    catalog.alterTableDataSchema("db5", "tbl1", newSchema)
     checkEvents(
       AlterTableSchemaPreEvent("db5", "tbl1") :: AlterTableSchemaEvent("db5", "tbl1") :: Nil)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -177,7 +177,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
    *
    * Note: As of now, this only supports altering database properties!
    */
-  override def alterDatabase(dbDefinition: CatalogDatabase): Unit = withClient {
+  override def doAlterDatabase(dbDefinition: CatalogDatabase): Unit = withClient {
     val existingDb = getDatabase(dbDefinition.name)
     if (existingDb.properties == dbDefinition.properties) {
       logWarning(s"Request to alter database ${dbDefinition.name} is a no-op because " +
@@ -540,7 +540,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
    * Note: As of now, this doesn't support altering table schema, partition column names and bucket
    * specification. We will ignore them even if users do specify different values for these fields.
    */
-  override def alterTable(tableDefinition: CatalogTable): Unit = withClient {
+  override def doAlterTable(tableDefinition: CatalogTable): Unit = withClient {
     assert(tableDefinition.identifier.database.isDefined)
     val db = tableDefinition.identifier.database.get
     requireTableExists(db, tableDefinition.identifier.table)
@@ -619,8 +619,10 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
   }
 
-  override def alterTableDataSchema(
-      db: String, table: String, newDataSchema: StructType): Unit = withClient {
+  override def doAlterTableSchema(
+      db: String,
+      table: String,
+      newDataSchema: StructType): Unit = withClient {
     requireTableExists(db, table)
     val oldTable = getTable(db, table)
     verifyDataSchema(oldTable.identifier, oldTable.tableType, newDataSchema)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -619,7 +619,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
   }
 
-  override def doAlterTableSchema(
+  override def doAlterTableDataSchema(
       db: String,
       table: String,
       newDataSchema: StructType): Unit = withClient {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -619,6 +619,11 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
   }
 
+  /**
+   * Alter the data schema of a table identified by the provided database and table name. The new
+   * data schema should not have conflict column names with the existing partition columns, and
+   * should still contain all the existing data columns.
+   */
   override def doAlterTableDataSchema(
       db: String,
       table: String,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -655,7 +655,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
   }
 
-  override def alterTableStats(
+  /** Alter the statistics of a table. If `stats` is None, then remove all existing statistics. */
+  override def doAlterTableStats(
       db: String,
       table: String,
       stats: Option[CatalogStatistics]): Unit = withClient {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We're building a data lineage tool in which we need to monitor the metadata changes in ExternalCatalog, current ExternalCatalog already provides several useful events like "CreateDatabaseEvent" for custom SparkListener to use. But still there's some event missing, like alter database event and alter table event. So here propose to and new ExternalCatalogEvent.

## How was this patch tested?

Enrich the current UT and tested on local cluster.

CC @hvanhovell please let me know your comments about current proposal, thanks.