### PR TITLE
[SPARK-22443][SQL]add implementation of quoteIdentifier, getTableExistsQuery and getSchemaQuery in AggregatedDialect

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -43,15 +43,15 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
   }
 
   override def quoteIdentifier(colName: String): String = {
-    dialects.map(_.quoteIdentifier(colName)).head
+    dialects.head.quoteIdentifier(colName)
   }
 
   override def getTableExistsQuery(table: String): String = {
-    dialects.map(_.getTableExistsQuery(table)).head
+    dialects.head.getTableExistsQuery(table)
   }
 
   override def getSchemaQuery(table: String): String = {
-    dialects.map(_.getSchemaQuery(table)).head
+    dialects.head.getSchemaQuery(table)
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -42,6 +42,18 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
     dialects.flatMap(_.getJDBCType(dt)).headOption
   }
 
+  override def quoteIdentifier(colName: String): String = {
+    dialects.map(_.quoteIdentifier(colName)).head
+  }
+
+  override def getTableExistsQuery(table: String): String = {
+    dialects.map(_.getTableExistsQuery(table)).head
+  }
+
+  override def getSchemaQuery(table: String): String = {
+    dialects.map(_.getSchemaQuery(table)).head
+  }
+
   override def isCascadingTruncateTable(): Option[Boolean] = {
     // If any dialect claims cascading truncate, this dialect is also cascading truncate.
     // Otherwise, if any dialect has unknown cascading truncate, this dialect is also unknown.

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -740,6 +740,15 @@ class JDBCSuite extends SparkFunSuite
         } else {
           None
         }
+      override def quoteIdentifier(colName: String): String = {
+        s"My $colName quoteIdentifier"
+      }
+      override def getTableExistsQuery(table: String): String = {
+        s"My $table Table"
+      }
+      override def getSchemaQuery(table: String): String = {
+        s"My $table Schema"
+      }
       override def isCascadingTruncateTable(): Option[Boolean] = Some(true)
     }, testH2Dialect))
     assert(agg.canHandle("jdbc:h2:xxx"))
@@ -747,6 +756,9 @@ class JDBCSuite extends SparkFunSuite
     assert(agg.getCatalystType(0, "", 1, null) === Some(LongType))
     assert(agg.getCatalystType(1, "", 1, null) === Some(StringType))
     assert(agg.isCascadingTruncateTable() === Some(true))
+    assert(agg.quoteIdentifier ("Dummy") === "My Dummy quoteIdentifier")
+    assert(agg.getTableExistsQuery ("Dummy") === "My Dummy Table")
+    assert(agg.getSchemaQuery ("Dummy") === "My Dummy Schema")
   }
 
   test("Aggregated dialects: isCascadingTruncateTable") {


### PR DESCRIPTION
…

## What changes were proposed in this pull request?

override JDBCDialects methods quoteIdentifier, getTableExistsQuery and getSchemaQuery in AggregatedDialect

## How was this patch tested?

Test the new implementation in JDBCSuite test("Aggregated dialects")


