### PR TITLE
[SPARK-22450][Core][Mllib]safely register class for mllib

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -180,12 +180,21 @@ class KryoSerializer(conf: SparkConf)
 
     // We can't load those class directly in order to avoid unnecessary jar dependencies.
     // We load them safely, ignore it if the class not found.
-    safeClassLoader("org.apache.spark.mllib.linalg.Vector").foreach(kryo.register(_))
-    safeClassLoader("org.apache.spark.mllib.linalg.DenseVector").foreach(kryo.register(_))
-    safeClassLoader("org.apache.spark.mllib.linalg.SparseVector").foreach(kryo.register(_))
-    safeClassLoader("org.apache.spark.mllib.linalg.Matrix").foreach(kryo.register(_))
-    safeClassLoader("org.apache.spark.mllib.linalg.DenseMatrix").foreach(kryo.register(_))
-    safeClassLoader("org.apache.spark.mllib.linalg.SparseMatrix").foreach(kryo.register(_))
+    Seq("org.apache.spark.mllib.linalg.Vector",
+      "org.apache.spark.mllib.linalg.DenseVector",
+      "org.apache.spark.mllib.linalg.SparseVector",
+      "org.apache.spark.mllib.linalg.Matrix",
+      "org.apache.spark.mllib.linalg.DenseMatrix",
+      "org.apache.spark.mllib.linalg.SparseMatrix",
+      "org.apache.spark.ml.linalg.Vector",
+      "org.apache.spark.ml.linalg.DenseVector",
+      "org.apache.spark.ml.linalg.SparseVector",
+      "org.apache.spark.ml.linalg.Matrix",
+      "org.apache.spark.ml.linalg.DenseMatrix",
+      "org.apache.spark.ml.linalg.SparseMatrix",
+      "org.apache.spark.ml.feature.Instance",
+      "org.apache.spark.ml.feature.OffsetInstance"
+    ).flatMap(safeClassLoader(_)).foreach(kryo.register(_))
 
     kryo.setClassLoader(classLoader)
     kryo

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -25,7 +25,7 @@ import javax.annotation.Nullable
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
-import scala.util.Try
+import scala.util.control.NonFatal
 
 import com.esotericsoftware.kryo.{Kryo, KryoException, Serializer => KryoClassSerializer}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
@@ -195,9 +195,12 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.ml.linalg.SparseMatrix",
       "org.apache.spark.ml.feature.Instance",
       "org.apache.spark.ml.feature.OffsetInstance"
-    ).map(name => Try(Utils.classForName(name))).foreach { t =>
-      if (t.isSuccess) {
-        kryo.register(t.get)
+    ).foreach { name =>
+      try {
+        val clazz = Utils.classForName(name)
+        kryo.register(clazz)
+      } catch {
+        case NonFatal(_) => // do nothing
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -108,16 +108,25 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     check(Array(Array("1", "2"), Array("1", "2", "3", "4")))
   }
 
-  test("safely register class for mllib") {
+  test("safely register class for mllib/ml") {
     val conf = new SparkConf(false)
     val ser = new KryoSerializer(conf)
 
-    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.Vector").isEmpty)
-    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.DenseVector").isEmpty)
-    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.SparseVector").isEmpty)
-    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.Matrix").isEmpty)
-    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.DenseMatrix").isEmpty)
-    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.SparseMatrix").isEmpty)
+    Seq("org.apache.spark.mllib.linalg.Vector",
+      "org.apache.spark.mllib.linalg.DenseVector",
+      "org.apache.spark.mllib.linalg.SparseVector",
+      "org.apache.spark.mllib.linalg.Matrix",
+      "org.apache.spark.mllib.linalg.DenseMatrix",
+      "org.apache.spark.mllib.linalg.SparseMatrix",
+      "org.apache.spark.ml.linalg.Vector",
+      "org.apache.spark.ml.linalg.DenseVector",
+      "org.apache.spark.ml.linalg.SparseVector",
+      "org.apache.spark.ml.linalg.Matrix",
+      "org.apache.spark.ml.linalg.DenseMatrix",
+      "org.apache.spark.ml.linalg.SparseMatrix",
+      "org.apache.spark.ml.feature.Instance",
+      "org.apache.spark.ml.feature.OffsetInstance"
+    ).map(ser.safeClassLoader(_)).foreach(_.isEmpty)
   }
 
   test("pairs") {

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -108,6 +108,18 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     check(Array(Array("1", "2"), Array("1", "2", "3", "4")))
   }
 
+  test("safely register class for mllib") {
+    val conf = new SparkConf(false)
+    val ser = new KryoSerializer(conf)
+
+    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.Vector").isEmpty)
+    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.DenseVector").isEmpty)
+    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.SparseVector").isEmpty)
+    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.Matrix").isEmpty)
+    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.DenseMatrix").isEmpty)
+    assert(ser.safeClassLoader("org.apache.spark.mllib.linalg.SparseMatrix").isEmpty)
+  }
+
   test("pairs") {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -108,27 +108,6 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     check(Array(Array("1", "2"), Array("1", "2", "3", "4")))
   }
 
-  test("safely register class for mllib/ml") {
-    val conf = new SparkConf(false)
-    val ser = new KryoSerializer(conf)
-
-    Seq("org.apache.spark.mllib.linalg.Vector",
-      "org.apache.spark.mllib.linalg.DenseVector",
-      "org.apache.spark.mllib.linalg.SparseVector",
-      "org.apache.spark.mllib.linalg.Matrix",
-      "org.apache.spark.mllib.linalg.DenseMatrix",
-      "org.apache.spark.mllib.linalg.SparseMatrix",
-      "org.apache.spark.ml.linalg.Vector",
-      "org.apache.spark.ml.linalg.DenseVector",
-      "org.apache.spark.ml.linalg.SparseVector",
-      "org.apache.spark.ml.linalg.Matrix",
-      "org.apache.spark.ml.linalg.DenseMatrix",
-      "org.apache.spark.ml.linalg.SparseMatrix",
-      "org.apache.spark.ml.feature.Instance",
-      "org.apache.spark.ml.feature.OffsetInstance"
-    ).foreach(!Utils.classIsLoadable(_))
-  }
-
   test("pairs") {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -126,7 +126,7 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
       "org.apache.spark.ml.linalg.SparseMatrix",
       "org.apache.spark.ml.feature.Instance",
       "org.apache.spark.ml.feature.OffsetInstance"
-    ).map(ser.safeClassLoader(_)).foreach(_.isEmpty)
+    ).foreach(!Utils.classIsLoadable(_))
   }
 
   test("pairs") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuit.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuit.scala
@@ -35,11 +35,6 @@ class InstanceSuit extends SparkFunSuite{
       assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
     }
 
-    assert(ser.safeClassLoader("org.apache.spark.ml.linalg.Vector").isDefined)
-    assert(ser.safeClassLoader("org.apache.spark.ml.linalg.DenseVector").isDefined)
-    assert(ser.safeClassLoader("org.apache.spark.ml.linalg.SparseVector").isDefined)
-    assert(ser.safeClassLoader("org.apache.spark.ml.feature.Instance").isDefined)
-    assert(ser.safeClassLoader("org.apache.spark.ml.feature.OffsetInstance").isDefined)
     val instance1 = Instance(19.0, 2.0, Vectors.dense(1.0, 7.0))
     val instance2 = Instance(17.0, 1.0, Vectors.dense(0.0, 5.0).toSparse)
     val oInstance1 = OffsetInstance(0.2, 1.0, 2.0, Vectors.dense(0.0, 5.0))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuit.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuit.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.serializer.KryoSerializer
+
+class InstanceSuit extends SparkFunSuite{
+  test("Kryo class register") {
+    val conf = new SparkConf(false)
+    conf.set("spark.kryo.registrationRequired", "true")
+
+    val ser = new KryoSerializer(conf)
+    val serInstance = new KryoSerializer(conf).newInstance()
+
+    def check[T: ClassTag](t: T) {
+      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+    }
+
+    assert(ser.safeClassLoader("org.apache.spark.ml.linalg.Vector").isDefined)
+    assert(ser.safeClassLoader("org.apache.spark.ml.linalg.DenseVector").isDefined)
+    assert(ser.safeClassLoader("org.apache.spark.ml.linalg.SparseVector").isDefined)
+    assert(ser.safeClassLoader("org.apache.spark.ml.feature.Instance").isDefined)
+    assert(ser.safeClassLoader("org.apache.spark.ml.feature.OffsetInstance").isDefined)
+    val instance1 = Instance(19.0, 2.0, Vectors.dense(1.0, 7.0))
+    val instance2 = Instance(17.0, 1.0, Vectors.dense(0.0, 5.0).toSparse)
+    val oInstance1 = OffsetInstance(0.2, 1.0, 2.0, Vectors.dense(0.0, 5.0))
+    val oInstance2 = OffsetInstance(0.2, 1.0, 2.0, Vectors.dense(0.0, 5.0).toSparse)
+    check(instance1)
+    check(instance2)
+    check(oInstance1)
+    check(oInstance2)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -31,8 +31,6 @@ import org.apache.spark.ml.{linalg => newlinalg}
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.serializer.KryoSerializer
 
-
-
 class MatricesSuite extends SparkFunSuite {
   test("kryo class register") {
     val conf = new SparkConf(false)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -20,16 +20,44 @@ package org.apache.spark.mllib.linalg
 import java.util.Random
 
 import scala.collection.mutable.{Map => MutableMap}
+import scala.reflect.ClassTag
 
 import breeze.linalg.{CSCMatrix, Matrix => BM}
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar._
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.ml.{linalg => newlinalg}
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.serializer.KryoSerializer
+
+
 
 class MatricesSuite extends SparkFunSuite {
+  test("kryo class register") {
+    val conf = new SparkConf(false)
+    conf.set("spark.kryo.registrationRequired", "true")
+
+    val ser = new KryoSerializer(conf).newInstance()
+
+    def check[T: ClassTag](t: T) {
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
+    }
+
+    val m = 3
+    val n = 2
+    val denseValues = Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0)
+    val denseMat = Matrices.dense(m, n, denseValues).asInstanceOf[DenseMatrix]
+
+    val sparseValues = Array(1.0, 2.0, 4.0, 5.0)
+    val colPtrs = Array(0, 2, 4)
+    val rowIndices = Array(1, 2, 1, 2)
+    val sparseMat =
+      Matrices.sparse(m, n, colPtrs, rowIndices, sparseValues).asInstanceOf[SparseMatrix]
+    check(denseMat)
+    check(sparseMat)
+  }
+
   test("dense matrix construction") {
     val m = 3
     val n = 2

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -29,8 +29,6 @@ import org.apache.spark.ml.{linalg => newlinalg}
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.serializer.KryoSerializer
 
-
-
 class VectorsSuite extends SparkFunSuite with Logging {
 
   val arr = Array(0.1, 0.0, 0.3, 0.4)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -17,15 +17,19 @@
 
 package org.apache.spark.mllib.linalg
 
+import scala.reflect.ClassTag
 import scala.util.Random
 
 import breeze.linalg.{squaredDistance => breezeSquaredDistance, DenseMatrix => BDM}
 import org.json4s.jackson.JsonMethods.{parse => parseJson}
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{linalg => newlinalg}
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.serializer.KryoSerializer
+
+
 
 class VectorsSuite extends SparkFunSuite with Logging {
 
@@ -33,6 +37,21 @@ class VectorsSuite extends SparkFunSuite with Logging {
   val n = 4
   val indices = Array(0, 2, 3)
   val values = Array(0.1, 0.3, 0.4)
+
+  test("kryo class register") {
+    val conf = new SparkConf(false)
+    conf.set("spark.kryo.registrationRequired", "true")
+
+    val ser = new KryoSerializer(conf).newInstance()
+    def check[T: ClassTag](t: T) {
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
+    }
+
+    val desVec = Vectors.dense(arr).asInstanceOf[DenseVector]
+    val sparVec = Vectors.sparse(n, indices, values).asInstanceOf[SparseVector]
+    check(desVec)
+    check(sparVec)
+  }
 
   test("dense vector construction with varargs") {
     val vec = Vectors.dense(arr).asInstanceOf[DenseVector]


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are still some algorithms based on mllib, such as KMeans. For now, many mllib common class (such as: Vector, DenseVector, SparseVector, Matrix, DenseMatrix, SparseMatrix) are not registered in Kryo. So there are some performance issues for those object serialization or deserialization.
Previously dicussed: https://github.com/apache/spark/pull/19586

## How was this patch tested?

New test case.
