### PR TITLE
[SPARK-22446][SQL][ML] Declare StringIndexerModel indexer udf as nondeterministic

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -261,7 +261,7 @@ class StringIndexerModel (
             s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
         }
       }
-    }
+    }.asNondeterministic()
 
     filteredDataset.select(col("*"),
       indexer(dataset($(inputCol)).cast(StringType)).as($(outputCol), metadata))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -97,7 +97,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     // Data transformation.
     val assembleFunc = udf { r: Row =>
       VectorAssembler.assemble(r.toSeq: _*)
-    }
+    }.asNondeterministic()
     val args = $(inputCols).map { c =>
       schema(c).dataType match {
         case DoubleType => dataset(c)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -314,4 +314,21 @@ class StringIndexerSuite
       idx += 1
     }
   }
+
+  test("SPARK-22446: StringIndexerModel's indexer UDF should not apply on filtered data") {
+    val df = List(
+         ("A", "London", "StrA"),
+         ("B", "Bristol", null),
+         ("C", "New York", "StrC")).toDF("ID", "CITY", "CONTENT")
+
+    val dfNoBristol = df.filter($"CONTENT".isNotNull)
+
+    val model = new StringIndexer()
+      .setInputCol("CITY")
+      .setOutputCol("CITYIndexed")
+      .fit(dfNoBristol)
+
+    val dfWithIndex = model.transform(dfNoBristol)
+    assert(dfWithIndex.filter($"CITYIndexed" === 1.0).count == 1)
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -127,7 +127,7 @@ class VectorAssemblerSuite
     testDefaultReadWrite(t)
   }
 
-  test("VectorAssembler's UDF should not apply on filtered data") {
+  test("SPARK-22446: VectorAssembler's UDF should not apply on filtered data") {
     val df = Seq(
       (0, 0.0, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L),
       (0, 1.0, null, "b", null, 20L)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.DefaultReadWriteTest
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, udf}
 
 class VectorAssemblerSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
@@ -125,5 +125,26 @@ class VectorAssemblerSuite
       .setInputCols(Array("myInputCol", "myInputCol2"))
       .setOutputCol("myOutputCol")
     testDefaultReadWrite(t)
+  }
+
+  test("VectorAssembler's UDF should not apply on filtered data") {
+    val df = Seq(
+      (0, 0.0, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L),
+      (0, 1.0, null, "b", null, 20L)
+    ).toDF("id", "x", "y", "name", "z", "n")
+
+    val assembler = new VectorAssembler()
+      .setInputCols(Array("x", "z", "n"))
+      .setOutputCol("features")
+
+    val filteredDF = df.filter($"y".isNotNull)
+
+    val vectorUDF = udf { vector: Vector =>
+      vector.numActives
+    }
+
+    assert(assembler.transform(filteredDF).select("features")
+      .filter(vectorUDF($"features") > 1)
+      .count() == 1)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -75,7 +75,7 @@ abstract class Expression extends TreeNode[Expression] {
    * - it relies on some mutable internal state, or
    * - it relies on some implicit input that is not part of the children expression list.
    * - it has non-deterministic child or children.
-   * - it is an UDF that can cause runtime exception on some specific input.
+   * - it assumes the input satisfies some certain condition via the child operator.
    *
    * An example would be `SparkPartitionID` that relies on the partition id returned by TaskContext.
    * By default leaf expressions are deterministic as Nil.forall(_.deterministic) returns true.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -75,6 +75,7 @@ abstract class Expression extends TreeNode[Expression] {
    * - it relies on some mutable internal state, or
    * - it relies on some implicit input that is not part of the children expression list.
    * - it has non-deterministic child or children.
+   * - it is an UDF that can cause runtime exception on some specific input.
    *
    * An example would be `SparkPartitionID` that relies on the partition id returned by TaskContext.
    * By default leaf expressions are deterministic as Nil.forall(_.deterministic) returns true.


### PR DESCRIPTION
## What changes were proposed in this pull request?

UDFs that can cause runtime exception on invalid data are not safe to pushdown, because its behavior depends on its position in the query plan. Pushdown of it will risk to change its original behavior.

The example reported in the JIRA and taken as test case shows this issue. We should declare UDFs that can cause runtime exception on invalid data as non-determinstic.

This updates the document of `deterministic` property in `Expression` and states clearly an UDF that can cause runtime exception on some specific input, should be declared as non-determinstic.

## How was this patch tested?

Added test. Manually test.