### PR TITLE
[SPARK-22463][YARN][SQL][Hive]add hadoop/hive/hbase/etc configuration files in SPARK_CONF_DIR to distribute archive

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -688,16 +688,16 @@ private[spark] class Client(
     val hadoopConfFiles = new HashMap[String, File]()
 
     // SPARK_CONF_DIR shows up in the classpath before HADOOP_CONF_DIR/YARN_CONF_DIR
-    val localConfDir = System.getProperty("SPARK_CONF_DIR",
-      System.getProperty("SPARK_HOME") + File.separator + "conf")
-    val dir = new File(localConfDir)
-    if (dir.isDirectory) {
-      val files = dir.listFiles(new FileFilter {
-        override def accept(pathname: File): Boolean = {
-          pathname.isFile && pathname.getName.endsWith(".xml")
-        }
-      })
-      files.foreach { f => hadoopConfFiles(f.getName) = f }
+    sys.env.get("SPARK_CONF_DIR").foreach { localConfDir =>
+      val dir = new File(localConfDir)
+      if (dir.isDirectory) {
+        val files = dir.listFiles(new FileFilter {
+          override def accept(pathname: File): Boolean = {
+            pathname.isFile && pathname.getName.endsWith(".xml")
+          }
+        })
+        files.foreach { f => hadoopConfFiles(f.getName) = f }
+      }
     }
 
     Seq("HADOOP_CONF_DIR", "YARN_CONF_DIR").foreach { envKey =>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.io.{File, FileOutputStream, IOException, OutputStreamWriter}
+import java.io.{FileSystem => _, _}
 import java.net.{InetAddress, UnknownHostException, URI}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
@@ -702,6 +702,18 @@ private[spark] class Client(
             }
           }
         }
+      }
+    }
+
+    sys.env.get("SPARK_CONF_DIR").foreach { path =>
+      val dir = new File(path)
+      if (dir.isDirectory) {
+        val files = dir.listFiles(new FileFilter {
+          override def accept(pathname: File): Boolean = {
+            pathname.isFile && pathname.getName.endsWith("xml")
+          }
+        })
+        files.foreach { f => hadoopConfFiles(f.getName) = f }
       }
     }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -694,13 +694,12 @@ private[spark] class Client(
     if (dir.isDirectory) {
       val files = dir.listFiles(new FileFilter {
         override def accept(pathname: File): Boolean = {
-          pathname.isFile && pathname.getName.endsWith("xml")
+          pathname.isFile && pathname.getName.endsWith(".xml")
         }
       })
       files.foreach { f => hadoopConfFiles(f.getName) = f }
     }
 
-    // Ensure HADOOP_CONF_DIR/YARN_CONF_DIR not overriding existing files
     Seq("HADOOP_CONF_DIR", "YARN_CONF_DIR").foreach { envKey =>
       sys.env.get(envKey).foreach { path =>
         val dir = new File(path)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -705,17 +705,17 @@ private[spark] class Client(
       }
     }
 
-    sys.env.get("SPARK_CONF_DIR").foreach { path =>
-      val dir = new File(path)
-      if (dir.isDirectory) {
-        val files = dir.listFiles(new FileFilter {
-          override def accept(pathname: File): Boolean = {
-            pathname.isFile && pathname.getName.endsWith("xml")
-          }
-        })
-        files.foreach { f => hadoopConfFiles(f.getName) = f }
-      }
+    val confDir = sys.env.getOrElse("SPARK_CONF_DIR", sys.env("SPARK_HOME") + "/conf")
+    val dir = new File(confDir)
+    if (dir.isDirectory) {
+      val files = dir.listFiles(new FileFilter {
+        override def accept(pathname: File): Boolean = {
+          pathname.isFile && pathname.getName.endsWith("xml")
+        }
+      })
+      files.foreach { f => hadoopConfFiles(f.getName) = f }
     }
+
 
     val confArchive = File.createTempFile(LOCALIZED_CONF_DIR, ".zip",
       new File(Utils.getLocalDir(sparkConf)))

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -705,7 +705,8 @@ private[spark] class Client(
       }
     }
 
-    val confDir = sys.env.getOrElse("SPARK_CONF_DIR", sys.env("SPARK_HOME") + "/conf")
+    val confDir =
+      sys.env.getOrElse("SPARK_CONF_DIR", sys.env("SPARK_HOME") + File.separator + "conf")
     val dir = new File(confDir)
     if (dir.isDirectory) {
       val files = dir.listFiles(new FileFilter {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When I ran self contained sql apps, such as
```scala
import org.apache.spark.sql.SparkSession

object ShowHiveTables {
  def main(args: Array[String]): Unit = {
    val spark = SparkSession
      .builder()
      .appName("Show Hive Tables")
      .enableHiveSupport()
      .getOrCreate()
    spark.sql("show tables").show()
    spark.stop()
  }
}
```
with **yarn cluster** mode and `hive-site.xml` correctly within `$SPARK_HOME/conf`,they failed to connect the right hive metestore for not seeing hive-site.xml in AM/Driver's classpath.

Although submitting them with `--files/--jars local/path/to/hive-site.xml` or puting it to `$HADOOP_CONF_DIR/YARN_CONF_DIR` can make these apps works well in cluster mode as client mode, according to the official doc, see @ http://spark.apache.org/docs/latest/sql-programming-guide.html#hive-tables
> Configuration of Hive is done by placing your hive-site.xml, core-site.xml (for security configuration), and hdfs-site.xml (for HDFS configuration) file in conf/.

We may respect these configuration files too or modify the doc for hive-tables in cluster mode.
## How was this patch tested?

cc @cloud-fan @gatorsmile 
