### PR TITLE
[SPARK-22454][CORE] ExternalShuffleClient.close() should check clientFactory null

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -148,6 +148,9 @@ public class ExternalShuffleClient extends ShuffleClient {
   @Override
   public void close() {
     checkInit();
-    clientFactory.close();
+    if (clientFactory != null) {
+      clientFactory.close();
+      clientFactory = null;
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ExternalShuffleClient.close()` should check `clientFactory` null. otherwise it will throw NPE sometimes:
```
17/11/06 20:08:05 ERROR Utils: Uncaught exception in thread main
java.lang.NullPointerException
	at org.apache.spark.network.shuffle.ExternalShuffleClient.close(ExternalShuffleClient.java:152)
	at org.apache.spark.storage.BlockManager.stop(BlockManager.scala:1407)
	at org.apache.spark.SparkEnv.stop(SparkEnv.scala:89)
	at org.apache.spark.SparkContext$$anonfun$stop$11.apply$mcV$sp(SparkContext.scala:1849)
```

## How was this patch tested?
manual tests