### PR TITLE
[SPARK-22456][SQL] Add support for dayofweek function

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -869,6 +869,19 @@ def month(col):
     return Column(sc._jvm.functions.month(_to_java_column(col)))
 
 
+@since(2.2)
+def dayofweek(col):
+    """
+    Extract the day of the week of a given date as integer.
+
+    >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
+    >>> df.select(dayofweek('dt').alias('day')).collect()
+    [Row(day=8)]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.dayofweek(_to_java_column(col)))
+
+
 @since(1.5)
 def dayofmonth(col):
     """

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -876,7 +876,7 @@ def dayofweek(col):
 
     >>> df = spark.createDataFrame([('2015-04-08',)], ['dt'])
     >>> df.select(dayofweek('dt').alias('day')).collect()
-    [Row(day=8)]
+    [Row(day=4)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.dayofweek(_to_java_column(col)))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -869,7 +869,7 @@ def month(col):
     return Column(sc._jvm.functions.month(_to_java_column(col)))
 
 
-@since(2.2)
+@since(2.3)
 def dayofweek(col):
     """
     Extract the day of the week of a given date as integer.

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1714,6 +1714,13 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(first['date'], epoch)
         self.assertEqual(first['lit_date'], epoch)
 
+    def test_dayofweek(self):
+        from pyspark.sql.functions import dayofweek
+        dt = datetime.datetime(2017, 11, 6)
+        df = self.spark.createDataFrame([Row(date=dt)])
+        row = df.select(dayofweek(df.date)).first()
+        self.assertEqual(row[0], 2)
+
     def test_decimal(self):
         from decimal import Decimal
         schema = StructType([StructField("decimal", DecimalType(10, 5))])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -376,7 +376,6 @@ object FunctionRegistry {
     expression[DayOfMonth]("day"),
     expression[DayOfYear]("dayofyear"),
     expression[DayOfMonth]("dayofmonth"),
-    expression[DayOfWeek]("dayofweek"),
     expression[FromUnixTime]("from_unixtime"),
     expression[FromUTCTimestamp]("from_utc_timestamp"),
     expression[Hour]("hour"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -376,6 +376,7 @@ object FunctionRegistry {
     expression[DayOfMonth]("day"),
     expression[DayOfYear]("dayofyear"),
     expression[DayOfMonth]("dayofmonth"),
+    expression[DayOfWeek]("dayofweek"),
     expression[FromUnixTime]("from_unixtime"),
     expression[FromUTCTimestamp]("from_utc_timestamp"),
     expression[Hour]("hour"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2550,6 +2550,13 @@ object functions {
    * @group datetime_funcs
    * @since 1.5.0
    */
+  def dayofweek(e: Column): Column = withExpr { DayOfWeek(e.expr) }
+
+  /**
+   * Extracts the day of the month as an integer from a given date/timestamp/string.
+   * @group datetime_funcs
+   * @since 1.5.0
+   */
   def dayofmonth(e: Column): Column = withExpr { DayOfMonth(e.expr) }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2546,16 +2546,16 @@ object functions {
   def month(e: Column): Column = withExpr { Month(e.expr) }
 
   /**
-   * Extracts the day of the month as an integer from a given date/timestamp/string.
+   * Extracts the day of the week as an integer from a given date/timestamp/string.
    * @group datetime_funcs
-   * @since 1.5.0
+   * @since 2.3.0
    */
   def dayofweek(e: Column): Column = withExpr { DayOfWeek(e.expr) }
 
   /**
    * Extracts the day of the month as an integer from a given date/timestamp/string.
    * @group datetime_funcs
-   * @since 2.3.0
+   * @since 1.5.0
    */
   def dayofmonth(e: Column): Column = withExpr { DayOfMonth(e.expr) }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2555,7 +2555,7 @@ object functions {
   /**
    * Extracts the day of the month as an integer from a given date/timestamp/string.
    * @group datetime_funcs
-   * @since 1.5.0
+   * @since 2.3.0
    */
   def dayofmonth(e: Column): Column = withExpr { DayOfMonth(e.expr) }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds support for a new function called `dayofweek` that returns the day of the week of the given argument as an integer value in the range 1-7, where 1 represents Sunday.

## How was this patch tested?
Unit tests and manual tests.
