### PR TITLE
[SPARK-22464] [SQL] No pushdown for Hive metastore partition predicates containing null-safe equality

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -592,8 +592,13 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     }
   }
 
-  /** An extractor that matches all binary comparison operators except null-safe equality. */
-  object OperatorsInPartitionFilters {
+
+  /**
+   * An extractor that matches all binary comparison operators except null-safe equality.
+   *
+   * null-safe equality is not supported by Hive metastore partition predicate pushdown
+   */
+  object OperatorsInMetastorePartitionFPD {
     def unapply(e: BinaryComparison): Option[(Expression, Expression)] = e match {
       case _: EqualNullSafe => None
       case _ => Some((e.left, e.right))
@@ -608,14 +613,14 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       .map(col => col.getName).toSet
 
     filters.collect {
-      case op @ OperatorsInPartitionFilters(a: Attribute, Literal(v, _: IntegralType)) =>
+      case op @ OperatorsInMetastorePartitionFPD(a: Attribute, Literal(v, _: IntegralType)) =>
         s"${a.name} ${op.symbol} $v"
-      case op @ OperatorsInPartitionFilters(Literal(v, _: IntegralType), a: Attribute) =>
+      case op @ OperatorsInMetastorePartitionFPD(Literal(v, _: IntegralType), a: Attribute) =>
         s"$v ${op.symbol} ${a.name}"
-      case op @ OperatorsInPartitionFilters(a: Attribute, Literal(v, _: StringType))
+      case op @ OperatorsInMetastorePartitionFPD(a: Attribute, Literal(v, _: StringType))
         if !varcharKeys.contains(a.name) =>
         s"""${a.name} ${op.symbol} ${quoteStringLiteral(v.toString)}"""
-      case op @ OperatorsInPartitionFilters(Literal(v, _: StringType), a: Attribute)
+      case op @ OperatorsInMetastorePartitionFPD(Literal(v, _: StringType), a: Attribute)
         if !varcharKeys.contains(a.name) =>
         s"""${quoteStringLiteral(v.toString)} ${op.symbol} ${a.name}"""
     }.mkString(" and ")
@@ -674,10 +679,10 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       case InSet(a: Attribute, ExtractableValues(values))
           if !varcharKeys.contains(a.name) && values.nonEmpty =>
         convertInToOr(a, values)
-      case op @ OperatorsInPartitionFilters(a: Attribute, ExtractableLiteral(value))
+      case op @ OperatorsInMetastorePartitionFPD(a: Attribute, ExtractableLiteral(value))
           if !varcharKeys.contains(a.name) =>
         s"${a.name} ${op.symbol} $value"
-      case op @ OperatorsInPartitionFilters(ExtractableLiteral(value), a: Attribute)
+      case op @ OperatorsInMetastorePartitionFPD(ExtractableLiteral(value), a: Attribute)
           if !varcharKeys.contains(a.name) =>
         s"$value ${op.symbol} ${a.name}"
       case And(expr1, expr2)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -592,6 +592,14 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     }
   }
 
+  /** An extractor that matches all binary comparison operators except null-safe equality. */
+  object OperatorsInPartitionFilters {
+    def unapply(e: BinaryComparison): Option[(Expression, Expression)] = e match {
+      case _: EqualNullSafe => None
+      case _ => Some((e.left, e.right))
+    }
+  }
+
   private def convertBasicFilters(table: Table, filters: Seq[Expression]): String = {
     // hive varchar is treated as catalyst string, but hive varchar can't be pushed down.
     lazy val varcharKeys = table.getPartitionKeys.asScala
@@ -600,14 +608,14 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       .map(col => col.getName).toSet
 
     filters.collect {
-      case op @ BinaryComparison(a: Attribute, Literal(v, _: IntegralType)) =>
+      case op @ OperatorsInPartitionFilters(a: Attribute, Literal(v, _: IntegralType)) =>
         s"${a.name} ${op.symbol} $v"
-      case op @ BinaryComparison(Literal(v, _: IntegralType), a: Attribute) =>
+      case op @ OperatorsInPartitionFilters(Literal(v, _: IntegralType), a: Attribute) =>
         s"$v ${op.symbol} ${a.name}"
-      case op @ BinaryComparison(a: Attribute, Literal(v, _: StringType))
+      case op @ OperatorsInPartitionFilters(a: Attribute, Literal(v, _: StringType))
         if !varcharKeys.contains(a.name) =>
         s"""${a.name} ${op.symbol} ${quoteStringLiteral(v.toString)}"""
-      case op @ BinaryComparison(Literal(v, _: StringType), a: Attribute)
+      case op @ OperatorsInPartitionFilters(Literal(v, _: StringType), a: Attribute)
         if !varcharKeys.contains(a.name) =>
         s"""${quoteStringLiteral(v.toString)} ${op.symbol} ${a.name}"""
     }.mkString(" and ")
@@ -666,16 +674,16 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       case InSet(a: Attribute, ExtractableValues(values))
           if !varcharKeys.contains(a.name) && values.nonEmpty =>
         convertInToOr(a, values)
-      case op @ BinaryComparison(a: Attribute, ExtractableLiteral(value))
+      case op @ OperatorsInPartitionFilters(a: Attribute, ExtractableLiteral(value))
           if !varcharKeys.contains(a.name) =>
         s"${a.name} ${op.symbol} $value"
-      case op @ BinaryComparison(ExtractableLiteral(value), a: Attribute)
+      case op @ OperatorsInPartitionFilters(ExtractableLiteral(value), a: Attribute)
           if !varcharKeys.contains(a.name) =>
         s"$value ${op.symbol} ${a.name}"
-      case op @ And(expr1, expr2)
+      case And(expr1, expr2)
           if convert.isDefinedAt(expr1) || convert.isDefinedAt(expr2) =>
         (convert.lift(expr1) ++ convert.lift(expr2)).mkString("(", " and ", ")")
-      case op @ Or(expr1, expr2)
+      case Or(expr1, expr2)
           if convert.isDefinedAt(expr1) && convert.isDefinedAt(expr2) =>
         s"(${convert(expr1)} or ${convert(expr2)})"
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -78,6 +78,15 @@ class HiveClientSuite(version: String)
     assert(filteredPartitions.size == testPartitionCount)
   }
 
+  test("getPartitionsByFilter: ds<=>20170101") {
+    // Should return all partitions where <=> is not supported
+    testMetastorePartitionFiltering(
+      "ds<=>20170101",
+      20170101 to 20170103,
+      0 to 23,
+      "aa" :: "ab" :: "ba" :: "bb" :: Nil)
+  }
+
   test("getPartitionsByFilter: ds=20170101") {
     testMetastorePartitionFiltering(
       "ds=20170101",


### PR DESCRIPTION
## What changes were proposed in this pull request?
`<=>` is not supported by Hive metastore partition predicate pushdown. We should not push down it to Hive metastore when they are be using in partition predicates.

## How was this patch tested?
Added a test case