### PR TITLE
[MINOR][SQL] Fix a misleading `resultSchema` in ParquetFileFormat

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -342,7 +342,7 @@ class ParquetFileFormat
     // TODO: if you move this into the closure it reverts to the default values.
     // If true, enable using the custom RecordReader for parquet. This only works for
     // a subset of the types (no complex types).
-    val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+    val resultSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
     val enableVectorizedReader: Boolean =
       sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
       resultSchema.forall(_.dataType.isInstanceOf[AtomicType])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Conceptually, `resultSchema` is used for `requiredSchema + partitionSchema`. `partitionSchema` is at the end. This PR fixes a misleading typo in `resultSchema` variable in ParquetFileFormat.

## How was this patch tested?

Pass the existing tests.