### PR TITLE
[SPARK-22462][SQL] Make rdd-based actions in Dataset trackable in SQL UI

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2579,10 +2579,8 @@ class Dataset[T] private[sql](
    * @group action
    * @since 1.6.0
    */
-  def foreach(f: T => Unit): Unit = {
-    withNewRDDExecutionId {
-      rdd.foreach(f)
-    }
+  def foreach(f: T => Unit): Unit = withNewRDDExecutionId {
+    rdd.foreach(f)
   }
 
   /**
@@ -2600,10 +2598,8 @@ class Dataset[T] private[sql](
    * @group action
    * @since 1.6.0
    */
-  def foreachPartition(f: Iterator[T] => Unit): Unit = {
-    withNewRDDExecutionId {
-      rdd.foreachPartition(f)
-    }
+  def foreachPartition(f: Iterator[T] => Unit): Unit = withNewRDDExecutionId {
+    rdd.foreachPartition(f)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the few Dataset actions such as `foreach`, currently no SQL metrics are visible in the SQL tab of SparkUI. It is because it binds wrongly to Dataset's `QueryExecution`. As the actions directly evaluate on the RDD which has individual `QueryExecution`, to show correct SQL metrics on UI, we should bind to RDD's `QueryExecution`.

## How was this patch tested?

Manually test. Screenshot is attached in the PR.

