### PR TITLE
[SPARK-22467]Added a config to support whether `stdout_stream` and `stderr_stream` output to disk

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/logging/RollingFileAppender.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/RollingFileAppender.scala
@@ -42,7 +42,7 @@ private[spark] class RollingFileAppender(
     val rollingPolicy: RollingPolicy,
     conf: SparkConf,
     bufferSize: Int = RollingFileAppender.DEFAULT_BUFFER_SIZE
-  ) extends FileAppender(inputStream, activeFile, bufferSize) {
+  ) extends FileAppender(inputStream, activeFile, conf, bufferSize) {
 
   import RollingFileAppender._
 

--- a/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
@@ -55,10 +55,21 @@ class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter with Logging {
     // The `header` should not be covered
     val header = "Add header"
     Files.write(header, testFile, StandardCharsets.UTF_8)
-    val appender = new FileAppender(inputStream, testFile)
+    val appender = new FileAppender(inputStream, testFile, new SparkConf())
     inputStream.close()
     appender.awaitTermination()
     assert(Files.toString(testFile, StandardCharsets.UTF_8) === header + testString)
+  }
+
+  test("basic file appender disable") {
+    val testString = (1 to 1000).mkString(", ")
+    val inputStream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8))
+    val sparkConf = new SparkConf()
+    sparkConf.set("spark.executorLog.enabled", "false")
+    val appender = new FileAppender(inputStream, testFile, sparkConf)
+    inputStream.close()
+    appender.awaitTermination()
+    assert(Files.toString(testFile, StandardCharsets.UTF_8) === "")
   }
 
   test("rolling file appender - time-based rolling") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should add a switch to control the `stdout_stream` and `stdout_stream` output to disk.
In my environment,due to disk I/O blocking, the `stdout_stream` output is very slow, so it can not be timely cleaning，and this leads the executor process to be blocked.

## How was this patch tested?
Added a unit test
