### PR TITLE
[MINOR][CORE] Improved statistical shuffle write time

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -188,8 +188,8 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
 
     // This file needs to opened in append mode in order to work around a Linux kernel bug that
     // affects transferTo; see SPARK-3948 for more details.
-    final FileChannel out = FileChannel.open(outputFile.toPath(), WRITE, APPEND, CREATE);
     final long writeStartTime = System.nanoTime();
+    final FileChannel out = FileChannel.open(outputFile.toPath(), WRITE, APPEND, CREATE);
     boolean threwException = true;
     try {
       for (int i = 0; i < numPartitions; i++) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Creating the file to write to and creating a disk writer both involve interacting with the disk, and can take a long time when we open or close many files, so should be included in the shuffle write time.

so we call mergeSpillsWithTransferTo, only contains the write file the time, but did not included in the shuffle write time when open and close many merges spill files .

## How was this patch tested?

existed test cases.
