### PR TITLE
[SPARK-22470][DOC][SQL] functions.hash is also used internally for shuffle and bucketing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2140,6 +2140,8 @@ object functions {
   /**
    * Calculates the hash code of given columns, and returns the result as an int column.
    *
+   * This is the same hash function as used internally by Spark for shuffle and bucketing.
+   *
    * @group misc_funcs
    * @since 2.0.0
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add clarifying documentation to the scaladoc of `functions.hash`

## How was this patch tested?

Existing tests, though this is a docs-only change.