### PR TITLE
[SPARK-22222][CORE][TEST][FOLLOW-UP] Remove redundant and deprecated `Timeouts`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.expressions.codegen
 
 import org.scalatest.{BeforeAndAfterEach, Matchers}
-import org.scalatest.concurrent.TimeLimits
 
 import org.apache.spark.{SparkFunSuite, TestUtils}
 import org.apache.spark.deploy.SparkSubmitSuite
@@ -32,8 +31,7 @@ class BufferHolderSparkSubmitSuite
   extends SparkFunSuite
     with Matchers
     with BeforeAndAfterEach
-    with ResetSystemProperties
-    with TimeLimits {
+    with ResetSystemProperties {
 
   test("SPARK-22222: Buffer holder should be able to allocate memory larger than 1GB") {
     val unusedJar = TestUtils.createJarWithClasses(Seq.empty)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions.codegen
 
 import org.scalatest.{BeforeAndAfterEach, Matchers}
-import org.scalatest.concurrent.Timeouts
+import org.scalatest.concurrent.TimeLimits
 
 import org.apache.spark.{SparkFunSuite, TestUtils}
 import org.apache.spark.deploy.SparkSubmitSuite
@@ -33,7 +33,7 @@ class BufferHolderSparkSubmitSuite
     with Matchers
     with BeforeAndAfterEach
     with ResetSystemProperties
-    with Timeouts {
+    with TimeLimits {
 
   test("SPARK-22222: Buffer holder should be able to allocate memory larger than 1GB") {
     val unusedJar = TestUtils.createJarWithClasses(Seq.empty)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since SPARK-21939, Apache Spark uses `TimeLimits` instead of the deprecated `Timeouts`. This PR fixes the build warning `BufferHolderSparkSubmitSuite.scala` introduced at [SPARK-22222](https://github.com/apache/spark/pull/19460/files#diff-d8cf6e0c229969db94ec8ffc31a9239cR36) by removing the redundant `Timeouts`.
```scala
trait Timeouts in package concurrent is deprecated: Please use org.scalatest.concurrent.TimeLimits instead
[warn]     with Timeouts {
```
## How was this patch tested?

N/A