### PR TITLE
[SPARK-22211][SQL][FOLLOWUP] Fix bad merge for tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -111,8 +111,8 @@ class LimitPushdownSuite extends PlanTest {
 
   test("full outer join where neither side is limited and both sides have same statistics") {
     assert(x.stats(conf).sizeInBytes === y.stats(conf).sizeInBytes)
-    val originalQuery = x.join(y, FullOuter).limit(1)
-    val optimized = Optimize.execute(originalQuery.analyze)
+    val originalQuery = x.join(y, FullOuter).limit(1).analyze
+    val optimized = Optimize.execute(originalQuery)
     // No pushdown for FULL OUTER JOINS.
     comparePlans(optimized, originalQuery)
   }
@@ -120,8 +120,8 @@ class LimitPushdownSuite extends PlanTest {
   test("full outer join where neither side is limited and left side has larger statistics") {
     val xBig = testRelation.copy(data = Seq.fill(2)(null)).subquery('x)
     assert(xBig.stats(conf).sizeInBytes > y.stats(conf).sizeInBytes)
-    val originalQuery = xBig.join(y, FullOuter).limit(1)
-    val optimized = Optimize.execute(originalQuery.analyze)
+    val originalQuery = xBig.join(y, FullOuter).limit(1).analyze
+    val optimized = Optimize.execute(originalQuery)
     // No pushdown for FULL OUTER JOINS.
     comparePlans(optimized, originalQuery)
   }
@@ -129,8 +129,8 @@ class LimitPushdownSuite extends PlanTest {
   test("full outer join where neither side is limited and right side has larger statistics") {
     val yBig = testRelation.copy(data = Seq.fill(2)(null)).subquery('y)
     assert(x.stats(conf).sizeInBytes < yBig.stats(conf).sizeInBytes)
-    val originalQuery = x.join(yBig, FullOuter).limit(1)
-    val optimized = Optimize.execute(originalQuery.analyze)
+    val originalQuery = x.join(yBig, FullOuter).limit(1).analyze
+    val optimized = Optimize.execute(originalQuery)
     // No pushdown for FULL OUTER JOINS.
     comparePlans(optimized, originalQuery)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The merge of SPARK-22211 to branch-2.2 dropped a couple of important lines that made sure the tests that compared plans did so with both plans having been analyzed. Fix by reintroducing the correct analysis statements.

## How was this patch tested?

Re-ran LimitPushdownSuite. All tests passed.