### PR TITLE
[SPARK-22485][BUILD] Use `exclude[Problem]` instead `excludePackage` in MiMa

### DIFF
--- a/project/MimaBuild.scala
+++ b/project/MimaBuild.scala
@@ -44,7 +44,7 @@ object MimaBuild {
 
   // Exclude a single class
   def excludeClass(className: String) = Seq(
-      excludePackage(className),
+      ProblemFilters.exclude[Problem](className + ".*"),
       ProblemFilters.exclude[MissingClassProblem](className),
       ProblemFilters.exclude[MissingTypesProblem](className)
     )
@@ -56,7 +56,7 @@ object MimaBuild {
 
   // Exclude a Spark package, that is in the package org.apache.spark
   def excludeSparkPackage(packageName: String) = {
-    excludePackage("org.apache.spark." + packageName)
+    ProblemFilters.exclude[Problem]("org.apache.spark." + packageName + ".*")
   }
 
   def ignoredABIProblems(base: File, currentSparkVersion: String) = {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -240,17 +240,17 @@ object MimaExcludes {
   // Exclude rules for 2.0.x
   lazy val v20excludes = {
     Seq(
-      excludePackage("org.apache.spark.rpc"),
-      excludePackage("org.spark-project.jetty"),
-      excludePackage("org.spark_project.jetty"),
-      excludePackage("org.apache.spark.internal"),
-      excludePackage("org.apache.spark.unused"),
-      excludePackage("org.apache.spark.unsafe"),
-      excludePackage("org.apache.spark.memory"),
-      excludePackage("org.apache.spark.util.collection.unsafe"),
-      excludePackage("org.apache.spark.sql.catalyst"),
-      excludePackage("org.apache.spark.sql.execution"),
-      excludePackage("org.apache.spark.sql.internal"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.rpc.*"),
+      ProblemFilters.exclude[Problem]("org.spark-project.jetty.*"),
+      ProblemFilters.exclude[Problem]("org.spark_project.jetty.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.internal.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.unused.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.unsafe.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.memory.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.util.collection.unsafe.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.catalyst.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.execution.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.internal.*"),
       ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.mllib.feature.PCAModel.this"),
       ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.status.api.v1.StageData.this"),
       ProblemFilters.exclude[MissingMethodProblem](


### PR DESCRIPTION
## What changes were proposed in this pull request?

`excludePackage` is deprecated like the [following](https://github.com/lightbend/migration-manager/blob/master/core/src/main/scala/com/typesafe/tools/mima/core/Filters.scala#L33-L36) and shows deprecation warnings now. This PR uses `exclude[Problem](packageName + ".*")` instead.

```scala
@deprecated("Replace with ProblemFilters.exclude[Problem](\"my.package.*\")", "0.1.15")
def excludePackage(packageName: String): ProblemFilter = {
  exclude[Problem](packageName + ".*")
}
```

## How was this patch tested?

Pass the Jenkins MiMa.