### PR TITLE
[SPARK-22489][SQL] Shouldn't change broadcast join buildSide if user clearly specified

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1494,18 +1494,20 @@ that these options will be deprecated in future release as more optimizations ar
 
 ## Broadcast Hint for SQL Queries
 
-Broadcast hint is a way for users to manually annotate a query and suggest to the query optimizer the join method. 
-It is very useful when the query optimizer cannot make optimal decision with respect to join methods 
-due to conservativeness or the lack of proper statistics. 
-Spark Broadcast Hint has higher priority than autoBroadcastJoin mechanism, examples:
+The `BROADCAST` hint guides Spark to broadcast each specified table when joining them with another table or view.
+When Spark deciding the join methods, the broadcast hash join (i.e., BHJ) is preferred, 
+even if the statistics is above the configuration `spark.sql.autoBroadcastJoinThreshold`.
+When both sides of a join are specified, Spark broadcasts the one having the lower statistics.
+Note Spark does not guaranttee BHJ is always chosen, since not all cases (e.g. full outer join) 
+support BHJ. When the broadcast nested loop join is selected, we still respect the hint.
 
 <div class="codetabs">
 
 <div data-lang="scala"  markdown="1">
 
 {% highlight scala %}
-val src = sql("SELECT * FROM src")
-broadcast(src).join(recordsDF, Seq("key")).show()
+import org.apache.spark.sql.functions.broadcast
+broadcast(spark.table("src")).join(spark.table("records"), "key").show()
 {% endhighlight %}
 
 </div>
@@ -1513,8 +1515,8 @@ broadcast(src).join(recordsDF, Seq("key")).show()
 <div data-lang="java"  markdown="1">
 
 {% highlight java %}
-Dataset<Row> src = sql("SELECT * FROM src");
-broadcast(src).join(recordsDF, Seq("key")).show();
+import static org.apache.spark.sql.functions.broadcast;
+broadcast(spark.table("src")).join(spark.table("records"), "key").show();
 {% endhighlight %}
 
 </div>
@@ -1522,8 +1524,8 @@ broadcast(src).join(recordsDF, Seq("key")).show();
 <div data-lang="python"  markdown="1">
 
 {% highlight python %}
-src = spark.sql("SELECT * FROM src")
-recordsDF.join(broadcast(src), "key").show()
+from pyspark.sql.functions import broadcast
+broadcast(spark.table("src")).join(spark.table("records"), "key").show()
 {% endhighlight %}
 
 </div>
@@ -1531,8 +1533,9 @@ recordsDF.join(broadcast(src), "key").show()
 <div data-lang="r"  markdown="1">
 
 {% highlight r %}
-src <- sql("SELECT COUNT(*) FROM src")
-showDF(join(broadcast(src), recordsDF, src$key == recordsDF$key)))
+src <- sql("SELECT * FROM src")
+records <- sql("SELECT * FROM records")
+head(join(broadcast(src), records, src$key == records$key))
 {% endhighlight %}
 
 </div>
@@ -1540,12 +1543,12 @@ showDF(join(broadcast(src), recordsDF, src$key == recordsDF$key)))
 <div data-lang="sql"  markdown="1">
 
 {% highlight sql %}
+-- We accept BROADCAST, BROADCASTJOIN and MAPJOIN for broadcast hint
 SELECT /*+ BROADCAST(r) */ * FROM records r JOIN src s ON r.key = s.key
 {% endhighlight %}
 
 </div>
 </div>
-(Note that we accept `BROADCAST`, `BROADCASTJOIN` and `MAPJOIN` for broadcast hint)
 
 # Distributed SQL Engine
 

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1498,7 +1498,7 @@ The `BROADCAST` hint guides Spark to broadcast each specified table when joining
 When Spark deciding the join methods, the broadcast hash join (i.e., BHJ) is preferred, 
 even if the statistics is above the configuration `spark.sql.autoBroadcastJoinThreshold`.
 When both sides of a join are specified, Spark broadcasts the one having the lower statistics.
-Note Spark does not guaranttee BHJ is always chosen, since not all cases (e.g. full outer join) 
+Note Spark does not guarantee BHJ is always chosen, since not all cases (e.g. full outer join) 
 support BHJ. When the broadcast nested loop join is selected, we still respect the hint.
 
 <div class="codetabs">

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1492,6 +1492,19 @@ that these options will be deprecated in future release as more optimizations ar
   </tr>
 </table>
 
+## Broadcast Hint for SQL Queries
+
+Broadcast hint is a way for users to manually annotate a query and suggest to the query optimizer the join method. 
+It is very useful when the query optimizer cannot make optimal decision with respect to join methods 
+due to conservativeness or the lack of proper statistics. The hint syntax looks like the following 
+(Note that we accept `BROADCAST`, `BROADCASTJOIN` and `MAPJOIN` for broadcast hint):
+
+{% highlight sql %}
+
+SELECT /*+ MAPJOIN(t1) */ * FROM t1 JOIN t2 ON t1.key = t2.key
+
+{% endhighlight %}
+
 # Distributed SQL Engine
 
 Spark SQL can also act as a distributed query engine using its JDBC/ODBC or command-line interface.

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1496,14 +1496,56 @@ that these options will be deprecated in future release as more optimizations ar
 
 Broadcast hint is a way for users to manually annotate a query and suggest to the query optimizer the join method. 
 It is very useful when the query optimizer cannot make optimal decision with respect to join methods 
-due to conservativeness or the lack of proper statistics. The hint syntax looks like the following 
-(Note that we accept `BROADCAST`, `BROADCASTJOIN` and `MAPJOIN` for broadcast hint):
+due to conservativeness or the lack of proper statistics. 
+Spark Broadcast Hint has higher priority than autoBroadcastJoin mechanism, examples:
+
+<div class="codetabs">
+
+<div data-lang="scala"  markdown="1">
+
+{% highlight scala %}
+val src = sql("SELECT * FROM src")
+broadcast(src).join(recordsDF, Seq("key")).show()
+{% endhighlight %}
+
+</div>
+
+<div data-lang="java"  markdown="1">
+
+{% highlight java %}
+Dataset<Row> src = sql("SELECT * FROM src");
+broadcast(src).join(recordsDF, Seq("key")).show();
+{% endhighlight %}
+
+</div>
+
+<div data-lang="python"  markdown="1">
+
+{% highlight python %}
+src = spark.sql("SELECT * FROM src")
+recordsDF.join(broadcast(src), "key").show()
+{% endhighlight %}
+
+</div>
+
+<div data-lang="r"  markdown="1">
+
+{% highlight r %}
+src <- sql("SELECT COUNT(*) FROM src")
+showDF(join(broadcast(src), recordsDF, src$key == recordsDF$key)))
+{% endhighlight %}
+
+</div>
+
+<div data-lang="sql"  markdown="1">
 
 {% highlight sql %}
-
-SELECT /*+ MAPJOIN(t1) */ * FROM t1 JOIN t2 ON t1.key = t2.key
-
+SELECT /*+ BROADCAST(r) */ * FROM records r JOIN src s ON r.key = s.key
 {% endhighlight %}
+
+</div>
+</div>
+(Note that we accept `BROADCAST`, `BROADCASTJOIN` and `MAPJOIN` for broadcast hint)
 
 # Distributed SQL Engine
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -159,7 +159,6 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       val buildRight = canBuildRight && right.stats.hints.broadcast
       val buildLeft = canBuildLeft && left.stats.hints.broadcast
 
-
       if (buildRight && buildLeft) {
         // Broadcast smaller side base on its estimated physical size
         // if both sides have broadcast hint

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -172,8 +172,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         // for the last default broadcast nested loop join
         smallerSide
       } else {
-        throw new AnalysisException(
-          "Can not decide to use which side for BuildSide for this join")
+        throw new AnalysisException("Can not decide which side to broadcast for this join")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -223,7 +223,11 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
       case logical.Join(left, right, joinType, condition) =>
         val buildSide =
-          if (right.stats.sizeInBytes <= left.stats.sizeInBytes) {
+          if (right.stats.hints.broadcast) {
+            BuildRight
+          } else if (left.stats.hints.broadcast) {
+            BuildLeft
+          } else if (right.stats.sizeInBytes <= left.stats.sizeInBytes) {
             BuildRight
           } else {
             BuildLeft

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -91,11 +91,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
    * predicates can be evaluated by matching join keys. If found,  Join implementations are chosen
    * with the following precedence:
    *
-   * - Broadcast: if one side of the join has an estimated physical size that is smaller than the
-   *     user-configurable [[SQLConf.AUTO_BROADCASTJOIN_THRESHOLD]] threshold
-   *     or if that side has an explicit broadcast hint (e.g. the user applied the
-   *     [[org.apache.spark.sql.functions.broadcast()]] function to a DataFrame or
-   *     a MAPJOIN comment in SQL queries), then that side
+   * - Broadcast: if one side of the join has an explicit broadcast hint (e.g. the user applied the
+   *     [[org.apache.spark.sql.functions.broadcast()]] function to a DataFrame)
+   *     or if that side has an estimated physical size that is smaller than the
+   *     user-configurable [[SQLConf.AUTO_BROADCASTJOIN_THRESHOLD]] threshold, then that side
    *     of the join will be broadcasted and the other side will be streamed, with no shuffling
    *     performed. If both sides of the join are eligible to be broadcasted then the
    * - Shuffle hash join: if the average size of a single partition is small enough to build a hash


### PR DESCRIPTION
## What changes were proposed in this pull request?

How to reproduce:
```scala
import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec

spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value").createTempView("table1")
spark.createDataFrame(Seq((1, "1"), (2, "2"))).toDF("key", "value").createTempView("table2")

val bl = sql("SELECT /*+ MAPJOIN(t1) */ * FROM table1 t1 JOIN table2 t2 ON t1.key = t2.key").queryExecution.executedPlan

println(bl.children.head.asInstanceOf[BroadcastHashJoinExec].buildSide)
```
The result is `BuildRight`, but should be `BuildLeft`. This PR fix this issue.
## How was this patch tested?

unit tests