### PR TITLE
[SPARK-22397][ML]add multiple columns support to QuantileDiscretizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/QuantileDiscretizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/QuantileDiscretizer.scala
@@ -106,12 +106,11 @@ private[feature] trait QuantileDiscretizerBase extends Params
  * categorical features. The number of bins can be set using the `numBuckets` parameter. It is
  * possible that the number of buckets used will be smaller than this value, for example, if there
  * are too few distinct values of the input to create enough distinct quantiles.
- * Since 2.3.0,
- * `QuantileDiscretizer` can map multiple columns at once by setting the `inputCols` parameter.
- * Note that only one of `inputCol` and `inputCols` parameters can be set. If both of the
- * `inputCol` and `inputCols` parameters are set, an Exception will be thrown. To specify the
- * number of buckets for each column, the `numBucketsArray` parameter can be set, or if the
- * number of buckets should be the same across columns, `numBuckets` can be set as a convenience.
+ * Since 2.3.0, `QuantileDiscretizer` can map multiple columns at once by setting the `inputCols`
+ * parameter. If both of the `inputCol` and `inputCols` parameters are set, an Exception will be
+ * thrown. To specify the number of buckets for each column, the `numBucketsArray` parameter can
+ * be set, or if the number of buckets should be the same across columns, `numBuckets` can be
+ * set as a convenience.
  *
  * NaN handling:
  * null and NaN values will be ignored from the column during `QuantileDiscretizer` fitting. This
@@ -171,7 +170,8 @@ final class QuantileDiscretizer @Since("1.6.0") (@Since("1.6.0") override val ui
   private[feature] def getInOutCols: (Array[String], Array[String]) = {
     require((isSet(inputCol) && isSet(outputCol) && !isSet(inputCols) && !isSet(outputCols)) ||
       (!isSet(inputCol) && !isSet(outputCol) && isSet(inputCols) && isSet(outputCols)),
-      "Only allow to set either inputCol/outputCol, or inputCols/outputCols"
+      "QuantileDiscretizer only supports setting either inputCol/outputCol or" +
+        "inputCols/outputCols."
     )
 
     if (isSet(inputCol)) {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/QuantileDiscretizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/QuantileDiscretizer.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types.StructType
  * Params for [[QuantileDiscretizer]].
  */
 private[feature] trait QuantileDiscretizerBase extends Params
-  with HasHandleInvalid with HasInputCol with HasInputCols with HasOutputCol with HasOutputCols {
+  with HasHandleInvalid with HasInputCol with HasOutputCol {
 
   /**
    * Number of buckets (quantiles, or categories) into which data points are grouped. Must
@@ -126,7 +126,8 @@ private[feature] trait QuantileDiscretizerBase extends Params
  */
 @Since("1.6.0")
 final class QuantileDiscretizer @Since("1.6.0") (@Since("1.6.0") override val uid: String)
-  extends Estimator[Bucketizer] with QuantileDiscretizerBase with DefaultParamsWritable {
+  extends Estimator[Bucketizer] with QuantileDiscretizerBase with DefaultParamsWritable
+    with HasInputCols with HasOutputCols {
 
   @Since("1.6.0")
   def this() = this(Identifiable.randomUID("quantileDiscretizer"))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
@@ -374,7 +374,7 @@ class QuantileDiscretizerSuite
     }
   }
 
-  test("multiple columns: read/write") {
+  test("Multiple Columns: read/write") {
     val discretizer = new QuantileDiscretizer()
       .setInputCols(Array("input1", "input2"))
       .setOutputCols(Array("result1", "result2"))
@@ -382,16 +382,33 @@ class QuantileDiscretizerSuite
     testDefaultReadWrite(discretizer)
   }
 
-  test("multiple columns: Both inputCol and inputCols are set") {
+  test("Multiple Columns: Both inputCol and inputCols are set") {
+    val spark = this.spark
+    import spark.implicits._
+    val discretizer = new QuantileDiscretizer()
+      .setInputCol("input")
+      .setOutputCol("result")
+      .setNumBuckets(3)
+      .setInputCols(Array("input1", "input2"))
+    val df = sc.parallelize(Array(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+      .map(Tuple1.apply).toDF("input")
+    // When both inputCol and inputCols are set, we throw Exception.
     intercept[IllegalArgumentException] {
-      new QuantileDiscretizer().setInputCol("in").setInputCols(Array("in1", "in2")).getInOutCols
+      discretizer.fit(df)
     }
   }
 
-  test("multiple columns: Mismatched sizes of inputCols / outputCols") {
+  test("Multiple Columns: Mismatched sizes of inputCols / outputCols") {
+    val spark = this.spark
+    import spark.implicits._
+    val discretizer = new QuantileDiscretizer()
+      .setInputCols(Array("input"))
+      .setOutputCols(Array("result1", "result2"))
+      .setNumBuckets(3)
+    val df = sc.parallelize(Array(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+      .map(Tuple1.apply).toDF("input")
     intercept[IllegalArgumentException] {
-      new QuantileDiscretizer().setInputCols(Array("in1", "in2"))
-        .setOutputCols(Array("out1")).getInOutCols
+      discretizer.fit(df)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
@@ -232,9 +232,7 @@ class QuantileDiscretizerSuite
         val dataFrame: DataFrame = validData1.zip(validData2).zip(v).zip(w).map {
           case (((a, b), c), d) => (a, b, c, d)
         }.toSeq.toDF("input1", "input2", "expected1", "expected2")
-        dataFrame.show
         val result = discretizer.fit(dataFrame).transform(dataFrame)
-        result.show
         result.select("result1", "expected1", "result2", "expected2").collect().foreach {
           case Row(x: Double, y: Double, z: Double, w: Double) =>
             assert(x === y && w === z)
@@ -342,8 +340,6 @@ class QuantileDiscretizerSuite
     val spark = this.spark
     import spark.implicits._
 
-    val datasetSize = 20
-    val numBucketsArray: Array[Int] = Array(2, 5, 10)
     val data1 = Array.range(1, 21, 1).map(_.toDouble)
     val data2 = Array.range(1, 40, 2).map(_.toDouble)
     val data3 = Array.range(1, 60, 3).map(_.toDouble)
@@ -386,19 +382,16 @@ class QuantileDiscretizerSuite
     testDefaultReadWrite(discretizer)
   }
 
-  test("Both inputCol and inputCols are set") {
-    val spark = this.spark
-    import spark.implicits._
-    val discretizer = new QuantileDiscretizer()
-      .setInputCol("input")
-      .setOutputCol("result")
-      .setNumBuckets(3)
-      .setInputCols(Array("input1", "input2"))
-    val df = sc.parallelize(Array(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
-      .map(Tuple1.apply).toDF("input")
-    // When both inputCol and inputCols are set, we throw Exception.
-    intercept[Exception] {
-      discretizer.fit(df)
+  test("multiple columns: Both inputCol and inputCols are set") {
+    intercept[IllegalArgumentException] {
+      new QuantileDiscretizer().setInputCol("in").setInputCols(Array("in1", "in2")).getInOutCols
+    }
+  }
+
+  test("multiple columns: Mismatched sizes of inputCols / outputCols") {
+    intercept[IllegalArgumentException] {
+      new QuantileDiscretizer().setInputCols(Array("in1", "in2"))
+        .setOutputCols(Array("out1")).getInOutCols
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
@@ -155,10 +155,7 @@ class QuantileDiscretizerSuite
     val numBuckets = 5
     val data1 = Array.range(1, 100001, 1).map(_.toDouble)
     val data2 = Array.range(1, 200000, 2).map(_.toDouble)
-    val data = (0 until 100000).map { idx =>
-      (data1(idx), data2(idx))
-    }
-    val df: DataFrame = data.toSeq.toDF("input1", "input2")
+    val df = data1.zip(data2).toSeq.toDF("input1", "input2")
 
     val discretizer = new QuantileDiscretizer()
       .setInputCols(Array("input1", "input2"))
@@ -191,10 +188,7 @@ class QuantileDiscretizerSuite
     val expectedNumBucket = 3
     val data1 = Array(1.0, 3.0, 2.0, 1.0, 1.0, 2.0, 3.0, 2.0, 2.0, 2.0, 1.0, 3.0)
     val data2 = Array(1.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 3.0, 2.0, 3.0, 1.0, 2.0)
-    val data = (0 until data1.length).map { idx =>
-      (data1(idx), data2(idx))
-    }
-    val df: DataFrame = data.toSeq.toDF("input1", "input2")
+    val df = data1.zip(data2).toSeq.toDF("input1", "input2")
     val discretizer = new QuantileDiscretizer()
       .setInputCols(Array("input1", "input2"))
       .setOutputCols(Array("result1", "result2"))
@@ -222,7 +216,7 @@ class QuantileDiscretizerSuite
     val data = (0 until validData1.length).map { idx =>
       (validData1(idx), validData2(idx), expectedKeep1(idx), expectedKeep2(idx))
     }
-    val dataFrame: DataFrame = data.toSeq.toDF("input1", "input2", "expected1", "expected2")
+    val dataFrame = data.toSeq.toDF("input1", "input2", "expected1", "expected2")
 
     val discretizer = new QuantileDiscretizer()
       .setInputCols(Array("input1", "input2"))
@@ -263,18 +257,18 @@ class QuantileDiscretizerSuite
     val datasetSize = 20
     val numBucketsArray: Array[Int] = Array(2, 5, 10)
     val data1 = Array.range(1, 21, 1).map(_.toDouble)
-    val expected1 = Array (0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0,
-      5.0, 5.0, 6.0, 6.0, 7.0, 8.0, 8.0, 9.0, 9.0, 9.0)
+    val expected1 = Array (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
     val data2 = Array.range(1, 40, 2).map(_.toDouble)
-    val expected2 = Array (0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0,
-      5.0, 5.0, 6.0, 6.0, 7.0, 8.0, 8.0, 9.0, 9.0, 9.0)
+    val expected2 = Array (0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0,
+      2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0)
     val data3 = Array.range(1, 60, 3).map(_.toDouble)
     val expected3 = Array (0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0,
       5.0, 5.0, 6.0, 6.0, 7.0, 8.0, 8.0, 9.0, 9.0, 9.0)
     val data = (0 until 20).map { idx =>
       (data1(idx), data2(idx), data3(idx), expected1(idx), expected2(idx), expected3(idx))
     }
-    val df: DataFrame =
+    val df =
       data.toSeq.toDF("input1", "input2", "input3", "expected1", "expected2", "expected3")
 
     val discretizer = new QuantileDiscretizer()

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/QuantileDiscretizerSuite.scala
@@ -162,7 +162,6 @@ class QuantileDiscretizerSuite
       .setInputCols(Array("input1", "input2"))
       .setOutputCols(Array("result1", "result2"))
       .setNumBuckets(numBuckets)
-    assert(discretizer.isQuantileDiscretizeMultipleColumns())
     val result = discretizer.fit(df).transform(df)
 
     val relativeError = discretizer.getRelativeError
@@ -194,7 +193,6 @@ class QuantileDiscretizerSuite
       .setInputCols(Array("input1", "input2"))
       .setOutputCols(Array("result1", "result2"))
       .setNumBuckets(numBuckets)
-    assert(discretizer.isQuantileDiscretizeMultipleColumns())
     val result = discretizer.fit(df).transform(df)
     for (i <- 1 to 2) {
       val observedNumBuckets = result.select("result" + i).distinct.count
@@ -220,7 +218,6 @@ class QuantileDiscretizerSuite
       .setInputCols(Array("input1", "input2"))
       .setOutputCols(Array("result1", "result2"))
       .setNumBuckets(numBuckets)
-    assert(discretizer.isQuantileDiscretizeMultipleColumns())
 
     withClue("QuantileDiscretizer with handleInvalid=error should throw exception for NaN values") {
       val dataFrame: DataFrame = validData1.zip(validData2).toSeq.toDF("input1", "input2")
@@ -269,8 +266,6 @@ class QuantileDiscretizerSuite
       .setInputCols(Array("input1", "input2", "input3"))
       .setOutputCols(Array("result1", "result2", "result3"))
       .setNumBucketsArray(numBucketsArray)
-
-    assert(discretizer.isQuantileDiscretizeMultipleColumns())
 
     discretizer.fit(df).transform(df).
       select("result1", "expected1", "result2", "expected2", "result3", "expected3")
@@ -388,18 +383,22 @@ class QuantileDiscretizerSuite
       .setInputCols(Array("input1", "input2"))
       .setOutputCols(Array("result1", "result2"))
       .setNumBucketsArray(Array(5, 10))
-    assert(discretizer.isQuantileDiscretizeMultipleColumns())
     testDefaultReadWrite(discretizer)
   }
 
   test("Both inputCol and inputCols are set") {
+    val spark = this.spark
+    import spark.implicits._
     val discretizer = new QuantileDiscretizer()
       .setInputCol("input")
       .setOutputCol("result")
       .setNumBuckets(3)
       .setInputCols(Array("input1", "input2"))
-
-    // When both are set, we ignore `inputCols` and just map the column specified by `inputCol`.
-    assert(discretizer.isQuantileDiscretizeMultipleColumns() == false)
+    val df = sc.parallelize(Array(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+      .map(Tuple1.apply).toDF("input")
+    // When both inputCol and inputCols are set, we throw Exception.
+    intercept[Exception] {
+      discretizer.fit(df)
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

add multi columns support to  QuantileDiscretizer.
When calculating the splits, we can either merge together all the  probabilities into one array by calculating approxQuantiles on multiple columns at once, or compute approxQuantiles separately  for each column. After doing the performance comparision, we found it’s better to calculating approxQuantiles on multiple columns at once. 

Here is how we measuring the performance time:
```
    var duration = 0.0
    for (i<- 0 until 10) {
      val start = System.nanoTime()
      discretizer.fit(df)
      val end = System.nanoTime()
      duration += (end - start) / 1e9
    }
    println(duration/10)
```
Here is the performance test result: 

|numCols |NumRows  | compute each approxQuantiles separately|compute multiple columns approxQuantiles at one time| 
|--------|----------|--------------------------------|-------------------------------------------|
|10         |60             |0.3623195839                            |0.1626658607                                                |
|10         |6000        |0.7537239841                             |0.3869370046                                               |
|22         |6000        |1.6497598557                             |0.4767903059                                               |
|50         |6000        |3.2268305752                            |0.7217818396                                                |



## How was this patch tested?

add UT in QuantileDiscretizerSuite to test multi columns supports 



