### PR TITLE
[SPARK-22487][SQL][followup] still keep spark.sql.hive.version

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -55,6 +55,7 @@ private[hive] object SparkSQLEnv extends Logging {
       metadataHive.setOut(new PrintStream(System.out, true, "UTF-8"))
       metadataHive.setInfo(new PrintStream(System.err, true, "UTF-8"))
       metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
+      sparkSession.conf.set(HiveUtils.FAKE_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
     }
   }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -77,6 +77,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
     } else {
       sqlContext.newSession()
     }
+    ctx.setConf(HiveUtils.FAKE_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
     if (sessionConf != null && sessionConf.containsKey("use:database")) {
       ctx.sql(s"use ${sessionConf.get("use:database")}")
     }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -155,9 +155,9 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
 
   test("Checks Hive version") {
     withJdbcStatement() { statement =>
-      val resultSet = statement.executeQuery("SET spark.sql.hive.metastore.version")
+      val resultSet = statement.executeQuery("SET spark.sql.hive.version")
       resultSet.next()
-      assert(resultSet.getString(1) === "spark.sql.hive.metastore.version")
+      assert(resultSet.getString(1) === "spark.sql.hive.version")
       assert(resultSet.getString(2) === HiveUtils.builtinHiveVersion)
     }
   }
@@ -521,7 +521,20 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
         conf += resultSet.getString(1) -> resultSet.getString(2)
       }
 
-      assert(conf.get("spark.sql.hive.metastore.version") === Some("1.2.1"))
+      assert(conf.get("spark.sql.hive.version") === Some("1.2.1"))
+    }
+  }
+
+  test("Checks Hive version via SET") {
+    withJdbcStatement() { statement =>
+      val resultSet = statement.executeQuery("SET")
+
+      val conf = mutable.Map.empty[String, String]
+      while (resultSet.next()) {
+        conf += resultSet.getString(1) -> resultSet.getString(2)
+      }
+
+      assert(conf.get("spark.sql.hive.version") === Some("1.2.1"))
     }
   }
 
@@ -708,9 +721,9 @@ class HiveThriftHttpServerSuite extends HiveThriftJdbcTest {
 
   test("Checks Hive version") {
     withJdbcStatement() { statement =>
-      val resultSet = statement.executeQuery("SET spark.sql.hive.metastore.version")
+      val resultSet = statement.executeQuery("SET spark.sql.hive.version")
       resultSet.next()
-      assert(resultSet.getString(1) === "spark.sql.hive.metastore.version")
+      assert(resultSet.getString(1) === "spark.sql.hive.version")
       assert(resultSet.getString(2) === HiveUtils.builtinHiveVersion)
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -66,9 +66,11 @@ private[spark] object HiveUtils extends Logging {
     .stringConf
     .createWithDefault(builtinHiveVersion)
 
-  // A deprecated config which is only used to provide a default value, in case some existing
-  // applications depend on this config, e.g. Spark SQL ODBC driver.
-  val HIVE_EXECUTION_VERSION = buildConf("spark.sql.hive.version")
+  // A fake config which is only here for backward compatibility reasons. This config has no affect
+  // to Spark, just for reporting the builtin Hive version of Spark to existing applications that
+  // already reply on this config.
+  val FAKE_HIVE_VERSION = buildConf("spark.sql.hive.version")
+    .doc(s"deprecated, please use ${HIVE_METASTORE_VERSION.key} to get the Hive version in Spark.")
     .stringConf
     .createWithDefault(builtinHiveVersion)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -66,9 +66,9 @@ private[spark] object HiveUtils extends Logging {
     .stringConf
     .createWithDefault(builtinHiveVersion)
 
-  // A fake config which is only here for backward compatibility reasons. This config has no affect
+  // A fake config which is only here for backward compatibility reasons. This config has no effect
   // to Spark, just for reporting the builtin Hive version of Spark to existing applications that
-  // already reply on this config.
+  // already rely on this config.
   val FAKE_HIVE_VERSION = buildConf("spark.sql.hive.version")
     .doc(s"deprecated, please use ${HIVE_METASTORE_VERSION.key} to get the Hive version in Spark.")
     .stringConf

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -66,6 +66,12 @@ private[spark] object HiveUtils extends Logging {
     .stringConf
     .createWithDefault(builtinHiveVersion)
 
+  // A deprecated config which is only used to provide a default value, in case some existing
+  // applications depend on this config, e.g. Spark SQL ODBC driver.
+  val HIVE_EXECUTION_VERSION = buildConf("spark.sql.hive.version")
+    .stringConf
+    .createWithDefault(builtinHiveVersion)
+
   val HIVE_METASTORE_JARS = buildConf("spark.sql.hive.metastore.jars")
     .doc(s"""
       | Location of the jars that should be used to instantiate the HiveMetastoreClient.


### PR DESCRIPTION
## What changes were proposed in this pull request?

a followup of https://github.com/apache/spark/pull/19712 , adds back the `spark.sql.hive.version`, so that if users try to read this config, they can still get a default value instead of null.

## How was this patch tested?

N/A