### PR TITLE
[SPARK-22494][SQL] Fix 64KB limit exception with Coalesce and AtleastNNonNulls

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -91,7 +91,7 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
     ev.copy(code = s"""
       ${ev.isNull} = true;
       ${ev.value} = ${ctx.defaultValue(dataType)};
-      ${ctx.splitExpressions(evals, "coalesce", Nil)}""")
+      ${ctx.splitExpressions(ctx.INPUT_ROW, evals)}""")
   }
 }
 
@@ -383,7 +383,7 @@ case class AtLeastNNonNulls(n: Int, children: Seq[Expression]) extends Predicate
       }
     }
 
-    val code = ctx.splitExpressions(evals, "atLeastNNonNull", Nil)
+    val code = ctx.splitExpressions(ctx.INPUT_ROW, evals)
 
     ev.copy(code = s"""
       $nonnull = 0;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -91,7 +91,7 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
     ev.copy(code = s"""
       ${ev.isNull} = true;
       ${ev.value} = ${ctx.defaultValue(dataType)};
-      ${ctx.splitExpressions(ctx.INPUT_ROW, evals)}""")
+      ${ctx.splitExpressions(evals, "coalesce", Nil)}""")
   }
 }
 
@@ -383,7 +383,7 @@ case class AtLeastNNonNulls(n: Int, children: Seq[Expression]) extends Predicate
       }
     }
 
-    val code = ctx.splitExpressions(ctx.INPUT_ROW, evals)
+    val code = ctx.splitExpressions(evals, "atLeastNNonNull", Nil)
 
     ev.copy(code = s"""
       $nonnull = 0;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -72,8 +72,8 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    ctx.addMutableState("boolean", ev.isNull, s"")
-    ctx.addMutableState(ctx.javaType(dataType), ev.value, s"")
+    ctx.addMutableState("boolean", ev.isNull, "")
+    ctx.addMutableState(ctx.javaType(dataType), ev.value, "")
 
     val evals = children.map { e =>
       val eval = e.genCode(ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -382,7 +382,7 @@ case class AtLeastNNonNulls(n: Int, children: Seq[Expression]) extends Predicate
       }
     }
 
-    val code = if (ctx.INPUT_ROW == null || ctx.currentVars == null) {
+    val code = if (ctx.INPUT_ROW == null || ctx.currentVars != null) {
       evals.mkString("\n")
     } else {
       ctx.splitExpressions(evals, "atLeastNNonNull",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -385,7 +385,7 @@ case class AtLeastNNonNulls(n: Int, children: Seq[Expression]) extends Predicate
     val code = if (ctx.INPUT_ROW == null || ctx.currentVars != null) {
       evals.mkString("\n")
     } else {
-      ctx.splitExpressions(evals, "atLeastNNonNull",
+      ctx.splitExpressions(evals, "atLeastNNonNulls",
         ("InternalRow", ctx.INPUT_ROW) :: ("int", nonnull) :: Nil,
         returnType = "int",
         makeSplitFunction = { body =>
@@ -395,7 +395,7 @@ case class AtLeastNNonNulls(n: Int, children: Seq[Expression]) extends Predicate
           """
         },
         foldFunctions = { funcCalls =>
-          funcCalls.map { funcCall => s"$nonnull = $funcCall;" }.mkString("\n")
+          funcCalls.map(funcCall => s"$nonnull = $funcCall;").mkString("\n")
         }
       )
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -392,7 +392,7 @@ case class AtLeastNNonNulls(n: Int, children: Seq[Expression]) extends Predicate
         """
       },
       foldFunctions = { funcCalls =>
-        funcCalls.map { funcCall => s"$nonnull = $funcCall" }.mkString("", ";\n", ";")
+        funcCalls.map { funcCall => s"$nonnull = $funcCall;" }.mkString("\n")
       }
     )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/NullExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/NullExpressionsSuite.scala
@@ -149,4 +149,14 @@ class NullExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(AtLeastNNonNulls(3, nullOnly), true, EmptyRow)
     checkEvaluation(AtLeastNNonNulls(4, nullOnly), false, EmptyRow)
   }
+
+  test("Coalesce should not throw 64kb exception") {
+    val inputs = (1 to 2500).map(x => Literal(s"x_$x"))
+    checkEvaluation(Coalesce(inputs), "x_1")
+  }
+
+  test("AtLeastNNonNulls should not throw 64kb exception") {
+    val inputs = (1 to 4000).map(x => Literal(s"x_$x"))
+    checkEvaluation(AtLeastNNonNulls(1, inputs), true)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Both `Coalesce` and `AtLeastNNonNulls` can cause the 64KB limit exception when used with a lot of arguments and/or complex expressions.
This PR splits their expressions in order to avoid the issue.

## How was this patch tested?

Added UTs
