### PR TITLE
[SPARK-22490][DOC] Add PySpark doc for SparkSession.builder

### DIFF
--- a/python/docs/pyspark.sql.rst
+++ b/python/docs/pyspark.sql.rst
@@ -8,6 +8,8 @@ Module Context
     :members:
     :undoc-members:
     :exclude-members: builder
+.. We need `exclude-members` to prevent default description generations
+   as a workaround for old Sphinx (< 1.6.6).
 
 pyspark.sql.types module
 ------------------------

--- a/python/docs/pyspark.sql.rst
+++ b/python/docs/pyspark.sql.rst
@@ -7,6 +7,7 @@ Module Context
 .. automodule:: pyspark.sql
     :members:
     :undoc-members:
+    :exclude-members: builder
 
 pyspark.sql.types module
 ------------------------

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -72,6 +72,9 @@ class SparkSession(object):
     ...     .appName("Word Count") \\
     ...     .config("spark.some.config.option", "some-value") \\
     ...     .getOrCreate()
+
+    .. autoattribute:: builder
+       :annotation:
     """
 
     class Builder(object):
@@ -182,6 +185,7 @@ class SparkSession(object):
                     session.sparkContext._conf.set(key, value)
                 return session
 
+    #: class variable for :class:`Builder` shared by all :class:`SparkSession` instances
     builder = Builder()
 
     _instantiatedSession = None

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -186,7 +186,7 @@ class SparkSession(object):
                 return session
 
     builder = Builder()
-    """A class attribute having a :class:`Builder` for constructing :class:`SparkSession` instances"""
+    """A class attribute having a :class:`Builder` to construct :class:`SparkSession` instances"""
 
     _instantiatedSession = None
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -185,8 +185,8 @@ class SparkSession(object):
                     session.sparkContext._conf.set(key, value)
                 return session
 
-    #: class variable for :class:`Builder` shared by all :class:`SparkSession` instances
     builder = Builder()
+    """A class attribute having a :class:`Builder` for constructing :class:`SparkSession` instances"""
 
     _instantiatedSession = None
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In PySpark API Document, [SparkSession.build](http://spark.apache.org/docs/2.2.0/api/python/pyspark.sql.html) is not documented and shows default value description.
```
SparkSession.builder = <pyspark.sql.session.Builder object ...
```

This PR adds the doc.

![screen](https://user-images.githubusercontent.com/9700541/32705514-1bdcafaa-c7ca-11e7-88bf-05566fea42de.png)

The following is the diff of the generated result.

```
$ diff old.html new.html
95a96,101
> <dl class="attribute">
> <dt id="pyspark.sql.SparkSession.builder">
> <code class="descname">builder</code><a class="headerlink" href="#pyspark.sql.SparkSession.builder" title="Permalink to this definition">¶</a></dt>
> <dd><p>A class attribute having a <a class="reference internal" href="#pyspark.sql.SparkSession.Builder" title="pyspark.sql.SparkSession.Builder"><code class="xref py py-class docutils literal"><span class="pre">Builder</span></code></a> to construct <a class="reference internal" href="#pyspark.sql.SparkSession" title="pyspark.sql.SparkSession"><code class="xref py py-class docutils literal"><span class="pre">SparkSession</span></code></a> instances</p>
> </dd></dl>
>
212,216d217
< <dt id="pyspark.sql.SparkSession.builder">
< <code class="descname">builder</code><em class="property"> = &lt;pyspark.sql.session.SparkSession.Builder object&gt;</em><a class="headerlink" href="#pyspark.sql.SparkSession.builder" title="Permalink to this definition">¶</a></dt>
< <dd></dd></dl>
<
< <dl class="attribute">
```

## How was this patch tested?

Manual.

```
cd python/docs
make html
open _build/html/pyspark.sql.html
```