### PR TITLE
[SPARK-22499][SQL] Fix 64KB JVM bytecode limit problem with least and greatest

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -604,6 +604,8 @@ case class Least(children: Seq[Expression]) extends Expression {
     val evalChildren = children.map(_.genCode(ctx))
     val first = evalChildren(0)
     val rest = evalChildren.drop(1)
+    ctx.addMutableState("boolean", ev.isNull, "")
+    ctx.addMutableState(ctx.javaType(dataType), ev.value, "")
     def updateEval(eval: ExprCode): String = {
       s"""
         ${eval.code}
@@ -614,11 +616,12 @@ case class Least(children: Seq[Expression]) extends Expression {
         }
       """
     }
+    val rests = ctx.splitExpressions(ctx.INPUT_ROW, rest.map(updateEval))
     ev.copy(code = s"""
       ${first.code}
-      boolean ${ev.isNull} = ${first.isNull};
-      ${ctx.javaType(dataType)} ${ev.value} = ${first.value};
-      ${rest.map(updateEval).mkString("\n")}""")
+      ${ev.isNull} = ${first.isNull};
+      ${ev.value} = ${first.value};
+      $rests""")
   }
 }
 
@@ -670,6 +673,8 @@ case class Greatest(children: Seq[Expression]) extends Expression {
     val evalChildren = children.map(_.genCode(ctx))
     val first = evalChildren(0)
     val rest = evalChildren.drop(1)
+    ctx.addMutableState("boolean", ev.isNull, "")
+    ctx.addMutableState(ctx.javaType(dataType), ev.value, "")
     def updateEval(eval: ExprCode): String = {
       s"""
         ${eval.code}
@@ -680,10 +685,11 @@ case class Greatest(children: Seq[Expression]) extends Expression {
         }
       """
     }
+    val rests = ctx.splitExpressions(ctx.INPUT_ROW, rest.map(updateEval))
     ev.copy(code = s"""
       ${first.code}
-      boolean ${ev.isNull} = ${first.isNull};
-      ${ctx.javaType(dataType)} ${ev.value} = ${first.value};
-      ${rest.map(updateEval).mkString("\n")}""")
+      ${ev.isNull} = ${first.isNull};
+      ${ev.value} = ${first.value};
+      $rests""")
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -602,8 +602,6 @@ case class Least(children: Seq[Expression]) extends Expression {
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val evalChildren = children.map(_.genCode(ctx))
-    val first = evalChildren(0)
-    val rest = evalChildren.drop(1)
     ctx.addMutableState("boolean", ev.isNull, "")
     ctx.addMutableState(ctx.javaType(dataType), ev.value, "")
     def updateEval(eval: ExprCode): String = {
@@ -616,12 +614,11 @@ case class Least(children: Seq[Expression]) extends Expression {
         }
       """
     }
-    val rests = ctx.splitExpressions(ctx.INPUT_ROW, rest.map(updateEval))
+    val codes = ctx.splitExpressions(ctx.INPUT_ROW, evalChildren.map(updateEval))
     ev.copy(code = s"""
-      ${first.code}
-      ${ev.isNull} = ${first.isNull};
-      ${ev.value} = ${first.value};
-      $rests""")
+      ${ev.isNull} = true;
+      ${ev.value} = ${ctx.defaultValue(dataType)};
+      $codes""")
   }
 }
 
@@ -671,8 +668,6 @@ case class Greatest(children: Seq[Expression]) extends Expression {
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val evalChildren = children.map(_.genCode(ctx))
-    val first = evalChildren(0)
-    val rest = evalChildren.drop(1)
     ctx.addMutableState("boolean", ev.isNull, "")
     ctx.addMutableState(ctx.javaType(dataType), ev.value, "")
     def updateEval(eval: ExprCode): String = {
@@ -685,11 +680,10 @@ case class Greatest(children: Seq[Expression]) extends Expression {
         }
       """
     }
-    val rests = ctx.splitExpressions(ctx.INPUT_ROW, rest.map(updateEval))
+    val codes = ctx.splitExpressions(ctx.INPUT_ROW, evalChildren.map(updateEval))
     ev.copy(code = s"""
-      ${first.code}
-      ${ev.isNull} = ${first.isNull};
-      ${ev.value} = ${first.value};
-      $rests""")
+      ${ev.isNull} = true;
+      ${ev.value} = ${ctx.defaultValue(dataType)};
+      $codes""")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -334,4 +334,13 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
       checkConsistencyBetweenInterpretedAndCodegen(Greatest, dt, 2)
     }
   }
+
+  test("SPARK-22499: Least and greatest should not generate codes beyond 64KB") {
+    val N = 3000
+    val strings = (1 to N).map(x => "s" * x)
+    val inputsExpr = strings.map(Literal.create(_, StringType))
+
+    checkEvaluation(Least(inputsExpr), "s" * 1, EmptyRow)
+    checkEvaluation(Greatest(inputsExpr), "s" * N, EmptyRow)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes `least` and `greatest` code generation to place generated code for expression for arguments into separated methods if these size could be large.
This PR resolved two cases:

* `least` with a lot of argument
* `greatest` with a lot of argument

## How was this patch tested?

Added a new test case into `ArithmeticExpressionsSuite`
