### PR TITLE
[SPARK-22500][SQL] Fix 64KB JVM bytecode limit problem with cast

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1041,8 +1041,10 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
        """
     }
     val fieldsEvalCodes = if (ctx.INPUT_ROW != null && ctx.currentVars == null) {
-      ctx.splitExpressions(fieldsEvalCode, "castStruct",
-        ("InternalRow", tmpRow) :: (rowClass, result) :: Nil)
+      ctx.splitExpressions(
+        expressions = fieldsEvalCode,
+        funcName = "castStruct",
+        arguments = ("InternalRow", tmpRow) :: (rowClass, result) :: Nil)
     } else {
       fieldsEvalCode.mkString("\n")
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1049,8 +1049,8 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
     (c, evPrim, evNull) =>
       s"""
-        $rowClass $result = new $rowClass(${fieldsCasts.length});
-        InternalRow $tmpRow = $c;
+        final $rowClass $result = new $rowClass(${fieldsCasts.length});
+        final InternalRow $tmpRow = $c;
         $fieldsEvalCodes
         $evPrim = $result;
       """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1042,7 +1042,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     }
     val fieldsEvalCodes = if (ctx.INPUT_ROW != null && ctx.currentVars == null) {
       ctx.splitExpressions(fieldsEvalCode, "castStruct",
-        ("InternalRow", ctx.INPUT_ROW) :: (rowClass, result) :: ("InternalRow", tmpRow) :: Nil)
+        ("InternalRow", tmpRow) :: (rowClass, result) :: Nil)
     } else {
       fieldsEvalCode.mkString("\n")
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -827,4 +827,17 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     checkEvaluation(cast(Literal.create(input, from), to), input)
   }
+
+  test("SPARK-22500: cast for struct should not generate codes beyond 64KB") {
+    val N = 1000
+    val from = new StructType(
+      (1 to N).map(i => StructField(s"s$i", StringType)).toArray)
+    val to = new StructType(
+      (1 to N).map(i => StructField(s"i$i", IntegerType)).toArray)
+
+    val input = Row.fromSeq((1 to N).map(i => i.toString))
+    val output = Row.fromSeq((1 to N))
+
+    checkEvaluation(cast(Literal.create(input, from), to), output)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -829,47 +829,20 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-22500: cast for struct should not generate codes beyond 64KB") {
-    val N = 1000
-    val M = 250
-
-    val from1 = new StructType(
-      (1 to N).map(i => StructField(s"s$i", StringType)).toArray)
-    val to1 = new StructType(
-      (1 to N).map(i => StructField(s"i$i", IntegerType)).toArray)
-    val input1 = Row.fromSeq((1 to N).map(i => i.toString))
-    val output1 = Row.fromSeq((1 to N))
-    checkEvaluation(cast(Literal.create(input1, from1), to1), output1)
-
-    val from2 = new StructType(
-      (1 to N).map(i => StructField(s"a$i", ArrayType(StringType, containsNull = false))).toArray)
-    val to2 = new StructType(
-      (1 to N).map(i => StructField(s"i$i", ArrayType(IntegerType, containsNull = true))).toArray)
-    val input2 = Row.fromSeq((1 to N).map(_ => Seq("456", "true", "78.9")))
-    val output2 = Row.fromSeq((1 to N).map(_ => Seq(456, null, 78)))
-    checkEvaluation(cast(Literal.create(input2, from2), to2), output2)
-
-    val from3 = new StructType(
-      (1 to N).map(i => StructField(s"s$i",
-        StructType(Seq(StructField("l$i", IntegerType, nullable = true))))).toArray)
-    val to3 = new StructType(
-      (1 to N).map(i => StructField(s"s$i",
-        StructType(Seq(StructField("l$i", LongType, nullable = true))))).toArray)
-    val input3 = Row.fromSeq((1 to N).map(i => Row(i)))
-    val output3 = Row.fromSeq((1 to N).map(i => Row(i.toLong)))
-    checkEvaluation(cast(Literal.create(input3, from3), to3), output3)
+    val N = 250
 
     val fromInner = new StructType(
-      (1 to M).map(i => StructField(s"s$i", DoubleType)).toArray)
+      (1 to N).map(i => StructField(s"s$i", DoubleType)).toArray)
     val toInner = new StructType(
-      (1 to M).map(i => StructField(s"i$i", IntegerType)).toArray)
-    val inputInner = Row.fromSeq((1 to M).map(i => i + 0.5))
-    val outputInner = Row.fromSeq((1 to M))
+      (1 to N).map(i => StructField(s"i$i", IntegerType)).toArray)
+    val inputInner = Row.fromSeq((1 to N).map(i => i + 0.5))
+    val outputInner = Row.fromSeq((1 to N))
     val fromOuter = new StructType(
-      (1 to M).map(i => StructField(s"s$i", fromInner)).toArray)
+      (1 to N).map(i => StructField(s"s$i", fromInner)).toArray)
     val toOuter = new StructType(
-      (1 to M).map(i => StructField(s"s$i", toInner)).toArray)
-    val inputOuter = Row.fromSeq((1 to M).map(_ => inputInner))
-    val outputOuter = Row.fromSeq((1 to M).map(_ => outputInner))
+      (1 to N).map(i => StructField(s"s$i", toInner)).toArray)
+    val inputOuter = Row.fromSeq((1 to N).map(_ => inputInner))
+    val outputOuter = Row.fromSeq((1 to N).map(_ => outputInner))
     checkEvaluation(cast(Literal.create(inputOuter, fromOuter), toOuter), outputOuter)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes `cast` code generation to place generated code for expression for fields of a structure into separated methods if these size could be large.

## How was this patch tested?

Added new test cases into `CastSuite`
