### PR TITLE
[SPARK-14220] Update Kafka 0.10.x version to 0.10.1.1 to ensure Scala…

### DIFF
--- a/external/kafka-0-10-sql/pom.xml
+++ b/external/kafka-0-10-sql/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>spark-sql-kafka-0-10_2.11</artifactId>
   <properties>
     <sbt.project.name>sql-kafka-0-10</sbt.project.name>
-    <kafka.version>0.10.0.1</kafka.version>
+    <kafka.version>0.10.1.1</kafka.version>
   </properties>
   <packaging>jar</packaging>
   <name>Kafka 0.10 Source for Structured Streaming</name>

--- a/external/kafka-0-10/pom.xml
+++ b/external/kafka-0-10/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>spark-streaming-kafka-0-10_2.11</artifactId>
   <properties>
     <sbt.project.name>streaming-kafka-0-10</sbt.project.name>
-    <kafka.version>0.10.0.1</kafka.version>
+    <kafka.version>0.10.1.1</kafka.version>
   </properties>
   <packaging>jar</packaging>
   <name>Spark Integration for Kafka 0.10</name>


### PR DESCRIPTION
… 2.12 compatibility (earlier versions not available via Maven Central)

## What changes were proposed in this pull request?

Update Kafka 0.10.x version to 0.10.1.1 to ensure Scala 2.12 compatibility (earlier versions not available via Maven Central)

## How was this patch tested?

Change the Scala version using dev/change-scala-version.sh to 2.12 and then build.
Before this change, get resolution errors on kafka_2.12 0.10.0.1 (because it doesn't exist in Maven Central).
