### PR TITLE
[SPARK-22508][SQL] Fix 64KB JVM bytecode limit problem with GenerateUnsafeRowJoiner.create()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeRowJoiner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeRowJoiner.scala
@@ -95,11 +95,11 @@ object GenerateUnsafeRowJoiner extends CodeGenerator[(StructType, StructType), U
       s"$putLong(buf, ${offset + i * 8}, $bits);\n"
     }
 
-    val functions = mutable.ArrayBuffer.empty[String]
-    val args = "java.lang.Object obj1, long offset1, java.lang.Object obj2, long offset2"
-    val copyBitsets = ctx.splitExpressions(copyBitset, "copyBitsetFunc",
-      ("java.lang.Object", "obj1") :: ("long", "offset1") ::
-      ("java.lang.Object", "obj2") :: ("long", "offset2") :: Nil)
+    val copyBitsets = ctx.splitExpressions(
+      expressions = copyBitset,
+      funcName = "copyBitsetFunc",
+      arguments = ("java.lang.Object", "obj1") :: ("long", "offset1") ::
+                  ("java.lang.Object", "obj2") :: ("long", "offset2") :: Nil)
 
     // --------------------- copy fixed length portion from row 1 ----------------------- //
     var cursor = offset + outputBitsetWords * 8
@@ -160,14 +160,14 @@ object GenerateUnsafeRowJoiner extends CodeGenerator[(StructType, StructType), U
             s"(${(outputBitsetWords - bitset2Words + schema1.size) * 8}L + numBytesVariableRow1)"
           }
         val cursor = offset + outputBitsetWords * 8 + i * 8
-        s"""
-           |$putLong(buf, $cursor, $getLong(buf, $cursor) + ($shift << 32));
-         """.stripMargin
+        s"$putLong(buf, $cursor, $getLong(buf, $cursor) + ($shift << 32));\n"
       }
     }
 
-    val updateOffsets = ctx.splitExpressions(updateOffset, "copyBitsetFunc",
-      ("long", "numBytesVariableRow1") :: Nil)
+    val updateOffsets = ctx.splitExpressions(
+      expressions = updateOffset,
+      funcName = "copyBitsetFunc",
+      arguments = ("long", "numBytesVariableRow1") :: Nil)
 
     // ------------------------ Finally, put everything together  --------------------------- //
     val codeBody = s"""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeRowJoinerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeRowJoinerSuite.scala
@@ -66,6 +66,11 @@ class GenerateUnsafeRowJoinerSuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-22508: GenerateUnsafeRowJoiner.create should not generate codes beyond 64KB") {
+    val N = 3000
+    testConcatOnce(N, N, variable)
+  }
+
   private def testConcat(numFields1: Int, numFields2: Int, candidateTypes: Seq[DataType]): Unit = {
     for (i <- 0 until 10) {
       testConcatOnce(numFields1, numFields2, candidateTypes)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes `GenerateUnsafeRowJoiner.create()` code generation to place generated code for statements to operate bitmap and offset into separated methods if these size could be large.

## How was this patch tested?

Added a new test case into `GenerateUnsafeRowJoinerSuite`
