### PR TITLE
[SPARK-22267][SQL] [WIP] Spark SQL incorrectly reads ORC file when column order is different

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -210,7 +210,7 @@ private[sql] trait SQLTestUtilsBase
    *
    * @todo Probably this method should be moved to a more general place
    */
-  protected def withTempDir(f: File => Unit): Unit = {
+  protected def withTempDir[A](f: File => A): A = {
     val dir = Utils.createTempDir().getCanonicalFile
     try f(dir) finally {
       // wait for all tasks to finish before deleting files


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ticket: [SPARK-22267](https://issues.apache.org/jira/browse/SPARK-22267)

## How was this patch tested?

No change yet, please do not merge - only tests were added to clarify the issue.
