### PR TITLE
[SPARK-22524][SQL] Subquery shows reused on UI SQL tab even if it's not reused

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -623,6 +623,8 @@ object CoalesceExec {
  */
 case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
 
+  override def doCanonicalize = child.canonicalized
+
   override lazy val metrics = Map(
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
     "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -623,7 +623,7 @@ object CoalesceExec {
  */
 case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
 
-  override def doCanonicalize = child.canonicalized
+  override def doCanonicalize(): SparkPlan = child.canonicalized
 
   override lazy val metrics = Map(
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

After manually disabling `reuseSubquery` rule, the subqueries won't be reused. But on the SQL graph, there is only one subquery node and it looks like subquery is reused.

`SparkPlanGraph` compares different `SparkPlanInfo`s by comparing their `simpleString`, which requires us to design `simpleString` well. While `SubqueryExec`'s `simpleString` depends only on the `exprId`, so we need to add extra index to its name.

I test on TPC-DS q23b.

Before my PR, the UI graph when manually disable `reuseSubquery`:
![subquery_seems_reused](https://user-images.githubusercontent.com/7685352/32837412-72fd36d0-ca48-11e7-8e91-c1d44e4d1ebf.png)

With my PR, the UI graph when manually disable `reuseSubquery`:
![subquery_not_used](https://user-images.githubusercontent.com/7685352/32837451-9618f4ec-ca48-11e7-9ddd-810953d65904.png)

## How was this patch tested?

UI change. Please see the graph.
