### PR TITLE
[SPARK-22527][SQL] Reuse coordinated exchanges if possible

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExecutedCommandExec, ShowTablesCommand}
-import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange, ReuseExchangeWithCoordinator}
 import org.apache.spark.sql.execution.joins.ReorderJoinPredicates
 import org.apache.spark.sql.types.{BinaryType, DateType, DecimalType, TimestampType, _}
 import org.apache.spark.util.Utils
@@ -108,6 +108,7 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
     EnsureRequirements(sparkSession.sessionState.conf),
     CollapseCodegenStages(sparkSession.sessionState.conf),
     ReuseExchange(sparkSession.sessionState.conf),
+    ReuseExchangeWithCoordinator(sparkSession.sessionState.conf),
     ReuseSubquery(sparkSession.sessionState.conf))
 
   protected def stringOrError[A](f: => A): String =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -83,9 +83,9 @@ import org.apache.spark.sql.execution.{ShuffledRowRDD, SparkPlan}
  *  - post-shuffle partition 3: pre-shuffle partition 3 and 4 (size 50 MB)
  */
 class ExchangeCoordinator(
-    numExchanges: Int,
-    advisoryTargetPostShuffleInputSize: Long,
-    minNumPostShufflePartitions: Option[Int] = None)
+    val numExchanges: Int,
+    val advisoryTargetPostShuffleInputSize: Long,
+    val minNumPostShufflePartitions: Option[Int] = None)
   extends Logging {
 
   // The registered Exchange operators.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -47,6 +47,10 @@ case class ShuffleExchangeExec(
   override lazy val metrics = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"))
 
+  private[exchange] def withoutCoordinator(): ShuffleExchangeExec = {
+    ShuffleExchangeExec(newPartitioning, child, None)
+  }
+
   override def nodeName: String = {
     val extraInfo = coordinator match {
       case Some(exchangeCoordinator) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

ShuffleExchange without coordinator can be reused, but coordinated ShuffleExchange can't currently. That is because `Exchange.sameResult` doesn't consider coordinator when deciding if two exchanges produce the same result.

But we can't simply exclude coordinator in `Exchange.sameResult` to fix this. The reason is, the results of coordinated exchanges are dependent with all exchanges coordinated by the same coordinator. Even `Exchange.sameResult` returns true for two exchanges by excluding their coordinator, if they have different exchange siblings, the coordinated shuffle results are different.

For an example query:

```scala
// Assume SQLConf.ADAPTIVE_EXECUTION_ENABLED is enabled.
val query =
  """SELECT name, sum(amount) FROM table1 GROUP BY name
    |UNION ALL SELECT name, sum(amount) FROM table1 GROUP BY name
    |UNION ALL SELECT name, sum(amount) FROM table1 GROUP BY name
    |""".stripMargin
sql(query)
```

The executed plan looks like:

```
Union
:- *HashAggregate(keys=[name#17], functions=[sum(cast(amount#16 as bigint))], output=[name#17, sum(amount)#21L])
:  +- Exchange(coordinator id: 1962297942) hashpartitioning(name#17, 5), coordinator[target post-shuffle partition 
size: 67108864]
:     +- *HashAggregate(keys=[name#17], functions=[partial_sum(cast(amount#16 as bigint))], output=[name#17, sum#28
L])
:        +- *FileScan parquet default.table1[amount#16,name#17] Batched: true, Format: Parquet, Location: InMemoryF
ileIndex[file:/root/repos/spark-1/sql/core/spark-warehouse/table1], PartitionFilters: [], PushedFilters: [], ReadSc
hema: struct<amount:int,name:string>
:- *HashAggregate(keys=[name#17], functions=[sum(cast(amount#16 as bigint))], output=[name#17, sum(amount)#22L])
:  +- Exchange(coordinator id: 1500445863) hashpartitioning(name#17, 5), coordinator[target post-shuffle partition 
size: 67108864]
:     +- *HashAggregate(keys=[name#17], functions=[partial_sum(cast(amount#16 as bigint))], output=[name#17, sum#30
L])
:        +- *FileScan parquet default.table1[amount#16,name#17] Batched: true, Format: Parquet, Location: InMemoryF
ileIndex[file:/root/repos/spark-1/sql/core/spark-warehouse/table1], PartitionFilters: [], PushedFilters: [], ReadSc
hema: struct<amount:int,name:string>
+- *HashAggregate(keys=[name#17], functions=[sum(cast(amount#16 as bigint))], output=[name#17, sum(amount)#23L])
   +- Exchange(coordinator id: 1275650533) hashpartitioning(name#17, 5), coordinator[target post-shuffle partition 
size: 67108864]
      +- *HashAggregate(keys=[name#17], functions=[partial_sum(cast(amount#16 as bigint))], output=[name#17, sum#32
L])
         +- *FileScan parquet default.table1[amount#16,name#17] Batched: true, Format: Parquet, Location: InMemoryF
ileIndex[file:/root/repos/spark-1/sql/core/spark-warehouse/table1], PartitionFilters: [], PushedFilters: [], ReadSc
hema: struct<amount:int,name:string>
```

We should be able to reuse coordinated ShuffleExchange, like:

```
Union
:- *HashAggregate(keys=[name#17], functions=[sum(cast(amount#16 as bigint))], output=[name#17, sum(amount)#21L])
:  +- Exchange(coordinator id: 260303313) hashpartitioning(name#17, 5), coordinator[target post-shuffle partition s
ize: 67108864]
:     +- *HashAggregate(keys=[name#17], functions=[partial_sum(cast(amount#16 as bigint))], output=[name#17, sum#28
L])
:        +- *FileScan parquet default.table1[amount#16,name#17] Batched: true, Format: Parquet, Location: InMemoryF
ileIndex[file:/root/repos/spark-1/sql/core/spark-warehouse/table1], PartitionFilters: [], PushedFilters: [], ReadSc
hema: struct<amount:int,name:string>
:- *HashAggregate(keys=[name#17], functions=[sum(cast(amount#16 as bigint))], output=[name#17, sum(amount)#22L])
:  +- ReusedExchange [name#17, sum#30L], Exchange(coordinator id: 260303313) hashpartitioning(name#17, 5), coordina
tor[target post-shuffle partition size: 67108864]
+- *HashAggregate(keys=[name#17], functions=[sum(cast(amount#16 as bigint))], output=[name#17, sum(amount)#23L])
   +- ReusedExchange [name#17, sum#32L], Exchange(coordinator id: 260303313) hashpartitioning(name#17, 5), coordina
tor[target post-shuffle partition size: 67108864]
```




## How was this patch tested?

Added test.
