### PR TITLE
[SPARK-22479][SQL][BRANCH-2.2] Exclude credentials from SaveintoDataSourceCommand.simpleString

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -247,7 +247,7 @@ package object config {
         "a property key or value, the value is redacted from the environment UI and various logs " +
         "like YARN and event logs.")
       .regexConf
-      .createWithDefault("(?i)secret|password".r)
+      .createWithDefault("(?i)secret|password|url|user|username".r)
 
   private[spark] val STRING_REDACTION_PATTERN =
     ConfigBuilder("spark.redaction.string.regex")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.sql.{Dataset, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.util.Utils
 
 /**
  * Saves the results of `query` in to a data source.
@@ -48,5 +50,10 @@ case class SaveIntoDataSourceCommand(
       options = options).write(mode, Dataset.ofRows(sparkSession, query))
 
     Seq.empty[Row]
+  }
+
+  override def simpleString: String = {
+    val redacted = Utils.redact(SparkEnv.get.conf, options.toSeq).toMap
+    s"SaveIntoDataSourceCommand ${dataSource}, ${redacted}, ${mode}"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -54,6 +54,6 @@ case class SaveIntoDataSourceCommand(
 
   override def simpleString: String = {
     val redacted = Utils.redact(SparkEnv.get.conf, options.toSeq).toMap
-    s"SaveIntoDataSourceCommand ${dataSource}, ${redacted}, ${mode}"
+    s"SaveIntoDataSourceCommand ${provider}, ${partitionColumns}, ${redacted}, ${mode}"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.test.SharedSQLContext
+
+class SaveIntoDataSourceCommandSuite extends SharedSQLContext {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set("spark.redaction.regex", "(?i)password|url")
+
+  test("simpleString is redacted") {
+    val URL = "connection.url"
+    val PASS = "123"
+    val DRIVER = "mydriver"
+
+    val dataSource = DataSource(
+      sparkSession = spark,
+      className = "jdbc",
+      partitionColumns = Nil,
+      options = Map("password" -> PASS, "url" -> URL, "driver" -> DRIVER))
+
+    val logicalPlanString = dataSource
+      .planForWriting(SaveMode.ErrorIfExists, spark.range(1).logicalPlan)
+      .treeString(true)
+
+    assert(!logicalPlanString.contains(URL))
+    assert(!logicalPlanString.contains(PASS))
+    assert(logicalPlanString.contains(DRIVER))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -31,18 +31,15 @@ class SaveIntoDataSourceCommandSuite extends SharedSQLContext {
     val PASS = "123"
     val DRIVER = "mydriver"
 
-    val dataSource = DataSource(
-      sparkSession = spark,
-      className = "jdbc",
-      partitionColumns = Nil,
-      options = Map("password" -> PASS, "url" -> URL, "driver" -> DRIVER))
+    val simpleString = SaveIntoDataSourceCommand(
+      spark.range(1).logicalPlan,
+      "jdbc",
+      Nil,
+      Map("password" -> PASS, "url" -> URL, "driver" -> DRIVER),
+      SaveMode.ErrorIfExists).treeString(true)
 
-    val logicalPlanString = dataSource
-      .planForWriting(SaveMode.ErrorIfExists, spark.range(1).logicalPlan)
-      .treeString(true)
-
-    assert(!logicalPlanString.contains(URL))
-    assert(!logicalPlanString.contains(PASS))
-    assert(logicalPlanString.contains(DRIVER))
+    assert(!simpleString.contains(URL))
+    assert(!simpleString.contains(PASS))
+    assert(simpleString.contains(DRIVER))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not include jdbc properties which may contain credentials in logging a logical plan with `SaveIntoDataSourceCommand` in it.

## How was this patch tested?
new tests
