### PR TITLE
[SPARK-22537][core] Aggregation of map output statistics on driver faces single point bottleneck

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -522,8 +522,8 @@ private[spark] class MapOutputTrackerMaster(
           }
         }
       } else {
+        val threadPool = ThreadUtils.newDaemonFixedThreadPool(parallelism, "map-output-aggregate")
         try {
-          val threadPool = ThreadUtils.newDaemonFixedThreadPool(parallelism, "map-output-aggregate")
           implicit val executionContext = ExecutionContext.fromExecutor(threadPool)
           val mapStatusSubmitTasks = equallyDivide(totalSizes.length, parallelism).map {
             reduceIds => Future {
@@ -534,7 +534,7 @@ private[spark] class MapOutputTrackerMaster(
           }
           ThreadUtils.awaitResult(Future.sequence(mapStatusSubmitTasks), Duration.Inf)
         } finally {
-          threadpool.shutdown()
+          threadPool.shutdown()
         }
       }
       new MapOutputStatistics(dep.shuffleId, totalSizes)

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -514,7 +514,7 @@ private[spark] class MapOutputTrackerMaster(
         SHUFFLE_MAP_OUTPUT_PARALLEL_AGGREGATION_THRESHOLD)
       val parallelism = math.min(
         Runtime.getRuntime.availableProcessors(),
-        statuses.length * totalSizes.length / parallelAggThreshold + 1)
+        statuses.length.toLong * totalSizes.length / parallelAggThreshold + 1).toInt
       if (parallelism <= 1) {
         for (s <- statuses) {
           for (i <- 0 until totalSizes.length) {

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Map}
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
+
 import org.apache.spark.broadcast.{Broadcast, BroadcastManager}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -496,14 +496,14 @@ private[spark] class MapOutputTrackerMaster(
     shuffleStatuses(dep.shuffleId).withMapStatuses { statuses =>
       val totalSizes = new Array[Long](dep.partitioner.numPartitions)
       if (statuses.length * totalSizes.length <=
-        conf.get(SHUFFLE_MAP_OUTPUT_STATISTICS_MULTITHREAD_THRESHOLD)) {
+        conf.get(SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLEL_AGGREGATION_THRESHOLD)) {
         for (s <- statuses) {
           for (i <- 0 until totalSizes.length) {
             totalSizes(i) += s.getSizeForBlock(i)
           }
         }
       } else {
-        val parallelism = conf.getInt("spark.adaptive.map.statistics.cores", 8)
+        val parallelism = conf.get(SHUFFLE_MAP_OUTPUT_STATISTICS_CORES)
         val threadPool = ThreadUtils.newDaemonFixedThreadPool(parallelism, "map-output-statistics")
         val executionContext = ExecutionContext.fromExecutor(threadPool)
         val mapStatusSubmitTasks = equallyDivide(totalSizes.length, parallelism).map {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -490,8 +490,15 @@ package object config {
     ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelAggregationThreshold")
       .internal()
       .doc("Multi-thread is used when the number of mappers * shuffle partitions exceeds this " +
-        "threshold")
+        "threshold.")
       .intConf
-      .createWithDefault(100000000)
+      .createWithDefault(10000000)
+
+  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_CORES =
+    ConfigBuilder("spark.shuffle.mapOutputStatistics.cores")
+      .internal()
+      .doc("The cores will be used during map output statistics parallel aggregation.")
+      .intConf
+      .createWithDefault(8)
 
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -489,7 +489,7 @@ package object config {
   private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLEL_AGGREGATION_THRESHOLD =
     ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelAggregationThreshold")
       .internal()
-      .doc("Multi-thread is used when the number of mappers * shuffle patterns exceeds this " +
+      .doc("Multi-thread is used when the number of mappers * shuffle partitions exceeds this " +
         "threshold")
       .intConf
       .createWithDefault(100000000)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -485,4 +485,13 @@ package object config {
         "array in the sorter.")
       .intConf
       .createWithDefault(Integer.MAX_VALUE)
+
+  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_MULTITHREAD_THRESHOLD =
+    ConfigBuilder("spark.shuffle.mapOutputStatisticsMultithreadThreshold")
+      .internal()
+      .doc("Multi-thread is used when the number of mappers * shuffle patterns exceeds this " +
+        "threshold")
+      .intConf
+      .createWithDefault(100000000)
+
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -489,13 +489,13 @@ package object config {
   private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLEL_AGGREGATION_THRESHOLD =
     ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelAggregationThreshold")
       .internal()
-      .doc("Multi-thread is used when the number of mappers * shuffle partitions exceeds this " +
-        "threshold.")
+      .doc("Multi-thread is used when the number of mappers * shuffle partitions is greater than " +
+        "or equal to this threshold.")
       .intConf
       .createWithDefault(10000000)
 
-  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_CORES =
-    ConfigBuilder("spark.shuffle.mapOutputStatistics.cores")
+  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLELISM =
+    ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelism")
       .internal()
       .doc("The cores will be used during map output statistics parallel aggregation.")
       .intConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -486,19 +486,12 @@ package object config {
       .intConf
       .createWithDefault(Integer.MAX_VALUE)
 
-  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLEL_AGGREGATION_THRESHOLD =
-    ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelAggregationThreshold")
+  private[spark] val SHUFFLE_MAP_OUTPUT_PARALLEL_AGGREGATION_THRESHOLD =
+    ConfigBuilder("spark.shuffle.mapOutput.parallelAggregationThreshold")
       .internal()
       .doc("Multi-thread is used when the number of mappers * shuffle partitions is greater than " +
         "or equal to this threshold.")
       .intConf
       .createWithDefault(10000000)
-
-  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLELISM =
-    ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelism")
-      .internal()
-      .doc("The cores will be used during map output statistics parallel aggregation.")
-      .intConf
-      .createWithDefault(8)
 
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -486,8 +486,8 @@ package object config {
       .intConf
       .createWithDefault(Integer.MAX_VALUE)
 
-  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_MULTITHREAD_THRESHOLD =
-    ConfigBuilder("spark.shuffle.mapOutputStatisticsMultithreadThreshold")
+  private[spark] val SHUFFLE_MAP_OUTPUT_STATISTICS_PARALLEL_AGGREGATION_THRESHOLD =
+    ConfigBuilder("spark.shuffle.mapOutputStatistics.parallelAggregationThreshold")
       .internal()
       .doc("Multi-thread is used when the number of mappers * shuffle patterns exceeds this " +
         "threshold")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -490,8 +490,10 @@ package object config {
     ConfigBuilder("spark.shuffle.mapOutput.parallelAggregationThreshold")
       .internal()
       .doc("Multi-thread is used when the number of mappers * shuffle partitions is greater than " +
-        "or equal to this threshold.")
+        "or equal to this threshold. Note that the actual parallelism is calculated by number of " +
+        "mappers * shuffle partitions / this threshold + 1, so this threshold should be positive.")
       .intConf
+      .checkValue(v => v > 0, "The threshold should be positive.")
       .createWithDefault(10000000)
 
 }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -275,4 +275,27 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     }
   }
 
+  test("equally divide map statistics tasks") {
+    val func = newTrackerMaster().equallyDivide _
+    val cases = Seq((0, 5), (4, 5), (15, 5), (16, 5), (17, 5), (18, 5), (19, 5), (20, 5))
+    val expects = Seq(
+      Seq(0, 0, 0, 0, 0),
+      Seq(1, 1, 1, 1, 0),
+      Seq(3, 3, 3, 3, 3),
+      Seq(3, 3, 3, 3, 4),
+      Seq(3, 3, 3, 4, 4),
+      Seq(3, 3, 4, 4, 4),
+      Seq(3, 4, 4, 4, 4),
+      Seq(4, 4, 4, 4, 4))
+    cases.zip(expects).foreach { case ((num, divisor), expect) =>
+      val answer = func(num, divisor).toSeq
+      var wholeSplit = (0 until num)
+      answer.zip(expect).foreach { case (split, expectSplitLength) =>
+        val (currentSplit, rest) = wholeSplit.splitAt(expectSplitLength)
+        assert(currentSplit.toSet == split.toSet)
+        wholeSplit = rest
+      }
+    }
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -282,10 +282,10 @@ class MapOutputTrackerSuite extends SparkFunSuite {
       Seq(0, 0, 0, 0, 0),
       Seq(1, 1, 1, 1, 0),
       Seq(3, 3, 3, 3, 3),
-      Seq(3, 3, 3, 3, 4),
-      Seq(3, 3, 3, 4, 4),
-      Seq(3, 3, 4, 4, 4),
-      Seq(3, 4, 4, 4, 4),
+      Seq(4, 3, 3, 3, 3),
+      Seq(4, 4, 3, 3, 3),
+      Seq(4, 4, 4, 3, 3),
+      Seq(4, 4, 4, 4, 3),
       Seq(4, 4, 4, 4, 4))
     cases.zip(expects).foreach { case ((num, divisor), expect) =>
       val answer = func(num, divisor).toSeq


### PR DESCRIPTION
## What changes were proposed in this pull request?

In adaptive execution, the map output statistics of all mappers will be aggregated after previous stage is successfully executed. Driver takes the aggregation job while it will get slow when the number of `mapper * shuffle partitions` is large, since it only uses single thread to compute. This PR uses multi-thread to deal with this single point bottleneck.

## How was this patch tested?

Test cases are in `MapOutputTrackerSuite.scala`
