### PR TITLE
[SPARK-22539][SQL] Add second order for rangepartitioner since partition nu…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -202,20 +202,15 @@ class LazilyGeneratedOrdering(
 
   @transient
   private[this] var generatedOrdering = {
-    var generatedOrdering = GenerateOrdering.generate(ordering)
-    if (!secondOrdering.isEmpty) {
-      secondOrdering.foreach { order =>
-        try {
-          GenerateOrdering.generate(Seq(order))
-          ordering ++ Seq(order)
-        } catch {
-          // Ignore exception caused by second ordering
-          case _: IllegalArgumentException =>
-        }
+    GenerateOrdering.generate(ordering ++ secondOrdering.filter( order => {
+      try {
+        GenerateOrdering.generate(Seq(order))
+        true
+      } catch {
+        // Ignore exception caused by second ordering
+        case _: IllegalArgumentException => false
       }
-      generatedOrdering = GenerateOrdering.generate(ordering)
-    }
-    generatedOrdering
+    }))
   }
 
   def compare(a: InternalRow, b: InternalRow): Int = {


### PR DESCRIPTION
…mber may be small if the specified key is skewed

## What changes were proposed in this pull request?

The rangepartitioner generated from shuffle exchange may cause partiton skew if sort key is skewed.
This patch add second order for rangepartitioner to avoid this situation.
This is an improvement from real case.

Before:
![before_second](https://user-images.githubusercontent.com/26762018/33472100-9a2a4788-d6ab-11e7-881c-2f0a6233ad80.png)

After:
![after_second](https://user-images.githubusercontent.com/26762018/33472099-99fae0ce-d6ab-11e7-9fd4-6ac74274a80e.png)

## How was this patch tested?

Manually test.
