### PR TITLE
[SPARK-22546][SQL] Supporting for changing column dataType

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/change-column.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/change-column.sql
@@ -6,7 +6,7 @@ DESC test_change;
 ALTER TABLE test_change CHANGE a a1 INT;
 DESC test_change;
 
--- Change column dataType (not supported yet)
+-- Change column dataType
 ALTER TABLE test_change CHANGE a a STRING;
 DESC test_change;
 

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -44,8 +44,7 @@ ALTER TABLE test_change CHANGE a a STRING
 -- !query 4 schema
 struct<>
 -- !query 4 output
-org.apache.spark.sql.AnalysisException
-ALTER TABLE CHANGE COLUMN is not supported for changing column 'a' with type 'IntegerType' to 'a' with type 'StringType';
+
 
 
 -- !query 5
@@ -53,7 +52,7 @@ DESC test_change
 -- !query 5 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 5 output
-a                   	int                 	                    
+a                   	string              	                    
 b                   	string              	                    
 c                   	int
 
@@ -91,7 +90,7 @@ DESC test_change
 -- !query 8 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 8 output
-a                   	int                 	                    
+a                   	string              	                    
 b                   	string              	                    
 c                   	int
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1697,6 +1697,11 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     sql("ALTER TABLE dbx.tab1 CHANGE COLUMN col1 col1 INT COMMENT 'this is col1'")
     assert(getMetadata("col1").getString("key") == "value")
     assert(getMetadata("col1").getString("comment") == "this is col1")
+
+    // Ensure that change column type take effect
+    sql("ALTER TABLE dbx.tab1 CHANGE COLUMN col1 col1 STRING")
+    val column = catalog.getTableMetadata(tableIdent).schema.fields.find(_.name == "col1")
+    assert(column.get.dataType == StringType)
   }
 
   test("drop build-in function") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1698,7 +1698,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     assert(getMetadata("col1").getString("key") == "value")
     assert(getMetadata("col1").getString("comment") == "this is col1")
 
-    // Ensure that change column type take effect
+    // Ensure that changing column type takes effect
     sql("ALTER TABLE dbx.tab1 CHANGE COLUMN col1 col1 STRING")
     val column = catalog.getTableMetadata(tableIdent).schema.fields.find(_.name == "col1")
     assert(column.get.dataType == StringType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1704,8 +1704,19 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     assert(column.get.dataType == StringType)
 
     // Ensure that changing partition column type throw exception
-    intercept[AnalysisException] {
+    var msg = intercept[AnalysisException] {
       sql("ALTER TABLE dbx.tab1 CHANGE COLUMN a a STRING")
+    }
+    assert(msg.getMessage.startsWith(
+      "Can't find column `a` given table data columns"))
+
+    withTable("t") {
+      sql("CREATE TABLE t(s STRUCT<a:INT, b:STRING>) USING PARQUET")
+      msg = intercept[AnalysisException]{
+        sql("ALTER TABLE t CHANGE COLUMN s s INT")
+      }
+      assert(msg.getMessage.startsWith(
+        "ALTER TABLE CHANGE COLUMN is not supported for changing column "))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1702,6 +1702,11 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     sql("ALTER TABLE dbx.tab1 CHANGE COLUMN col1 col1 STRING")
     val column = catalog.getTableMetadata(tableIdent).schema.fields.find(_.name == "col1")
     assert(column.get.dataType == StringType)
+
+    // Ensure that changing partition column type throw exception
+    intercept[AnalysisException] {
+      sql("ALTER TABLE dbx.tab1 CHANGE COLUMN a a STRING")
+    }
   }
 
   test("drop build-in function") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support user to change column dataType in hive table and datasource table, also make sure the new changed data type can work with all data sources.

- [x] DDL support for `ALTER TABLE CHANGE COLUMN`
- [ ] Support in parquet vectorized reader
- [ ] Support in parquet row reader
- [ ] Support in orc  vectorized reader
- [ ] Support in orc  row reader

## How was this patch tested?

Add test case in `DDLSuite.scala` and `SQLQueryTestSuite.scala`