### PR TITLE
[SPARK-22343][core] Add support for publishing Spark metrics into Prometheus

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -172,6 +172,15 @@
 # Unit of the polling period for the Slf4jSink
 #*.sink.slf4j.unit=minutes
 
+# Enable Prometheus for all instances by class name
+#*.sink.prometheus.class=org.apache.spark.metrics.sink.PrometheusSink
+
+#Prometheus host
+#*.sink.prometheus.pushgateway-address-protocol=<prometheus pushgateway protocol> - defaults to http
+#*.sink.prometheus.pushgateway-address=<prometheus pushgateway address> - defaults to 127.0.0.1:9091
+#*.sink.prometheus.unit=< unit> - defaults to seconds (TimeUnit.SECONDS)
+#*.sink.prometheus.period=<period> - defaults to 10
+
 # Enable JvmSource for instance master, worker, driver and executor
 #master.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -178,6 +178,7 @@
 #Prometheus host
 #*.sink.prometheus.pushgateway-address-protocol=<prometheus pushgateway protocol> - defaults to http
 #*.sink.prometheus.pushgateway-address=<prometheus pushgateway address> - defaults to 127.0.0.1:9091
+#*.sink.prometheus.pushgateway-enable-timestamp=<enable/disable timestamp> - defaults to false
 #*.sink.prometheus.unit=< unit> - defaults to seconds (TimeUnit.SECONDS)
 #*.sink.prometheus.period=<period> - defaults to 10
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -267,6 +267,18 @@
       <artifactId>metrics-graphite</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_dropwizard</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_pushgateway</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -445,7 +457,7 @@
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
-           <configuration>
+            <configuration>
               <outputDirectory>${project.build.directory}</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>false</overWriteSnapshots>
@@ -510,5 +522,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.metrics.prometheus.client.exporter;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+/**
+ * Export metrics via the Prometheus Pushgateway.
+ * <p>
+ * The Prometheus Pushgateway exists to allow ephemeral and
+ * batch jobs to expose their metrics to Prometheus.
+ * Since these kinds of jobs may not exist long enough to be scraped,
+ * they can instead push their metrics to a Pushgateway.
+ * This class allows pushing the contents of a {@link CollectorRegistry} to
+ * a Pushgateway.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   void executeBatchJob() throws Exception {
+ *     CollectorRegistry registry = new CollectorRegistry();
+ *     Gauge duration = Gauge.build()
+ *         .name("my_batch_job_duration_seconds")
+ *         .help("Duration of my batch job in seconds.")
+ *         .register(registry);
+ *     Gauge.Timer durationTimer = duration.startTimer();
+ *     try {
+ *       // Your code here.
+ *
+ *       // This is only added to the registry after success,
+ *       // so that a previous success in the Pushgateway isn't overwritten on failure.
+ *       Gauge lastSuccess = Gauge.build()
+ *           .name("my_batch_job_last_success")
+ *           .help("Last time my batch job succeeded, in unixtime.")
+ *           .register(registry);
+ *       lastSuccess.setToCurrentTime();
+ *     } finally {
+ *       durationTimer.setDuration();
+ *       PushGatewayWithTimestamp pg = new PushGatewayWithTimestamp("127.0.0.1:9091");
+ *       pg.pushAdd(registry, "my_batch_job");
+ *     }
+ *   }
+ * }
+ * </pre>
+ * <p>
+ * See <a href="https://github.com/prometheus/pushgateway">
+ *     https://github.com/prometheus/pushgateway</a>
+ */
+public class PushGatewayWithTimestamp {
+
+    private static final Logger logger = LoggerFactory.getLogger(PushGatewayWithTimestamp.class);
+    private final String address;
+    private static final int SECONDS_PER_MILLISECOND = 1000;
+    /**
+     * Construct a Pushgateway, with the given address.
+     * <p>
+     * @param address  host:port or ip:port of the Pushgateway.
+     */
+    public PushGatewayWithTimestamp(String address) {
+        this.address = address;
+    }
+
+    /**
+     * Pushes all metrics in a registry,
+     * replacing all those with the same job and no grouping key.
+     * <p>
+     * This uses the PUT HTTP method.
+     */
+    public void push(CollectorRegistry registry, String job) throws IOException {
+        doRequest(registry, job, null, "PUT", null);
+    }
+
+    /**
+     * Pushes all metrics in a Collector,
+     * replacing all those with the same job and no grouping key.
+     * <p>
+     * This is useful for pushing a single Gauge.
+     * <p>
+     * This uses the PUT HTTP method.
+     */
+    public void push(Collector collector, String job) throws IOException {
+        CollectorRegistry registry = new CollectorRegistry();
+        collector.register(registry);
+        push(registry, job);
+    }
+
+    /**
+     * Pushes all metrics in a registry,
+     * replacing all those with the same job and grouping key.
+     * <p>
+     * This uses the PUT HTTP method.
+     */
+    public void push(CollectorRegistry registry,
+                     String job, Map<String, String> groupingKey) throws IOException {
+        doRequest(registry, job, groupingKey, "PUT", null);
+    }
+
+    /**
+     * Pushes all metrics in a Collector, replacing all those with the same job and grouping key.
+     * <p>
+     * This is useful for pushing a single Gauge.
+     * <p>
+     * This uses the PUT HTTP method.
+     */
+    public void push(Collector collector,
+                     String job, Map<String, String> groupingKey) throws IOException {
+        CollectorRegistry registry = new CollectorRegistry();
+        collector.register(registry);
+        push(registry, job, groupingKey);
+    }
+
+    /**
+     * Pushes all metrics in a registry,
+     * replacing only previously pushed metrics of the same name and job and no grouping key.
+     * <p>
+     * This uses the POST HTTP method.
+     */
+    public void pushAdd(CollectorRegistry registry,
+                        String job, String timestamp) throws IOException {
+        doRequest(registry, job, null, "POST", timestamp);
+    }
+
+    /**
+     * Pushes all metrics in a Collector,
+     * replacing only previously pushed metrics of the same name and job and no grouping key.
+     * <p>
+     * This is useful for pushing a single Gauge.
+     * <p>
+     * This uses the POST HTTP method.
+     */
+    public void pushAdd(Collector collector, String job) throws IOException {
+        CollectorRegistry registry = new CollectorRegistry();
+        collector.register(registry);
+        pushAdd(registry, job, "");
+    }
+
+    /**
+     * Pushes all metrics in a registry,
+     * replacing only previously pushed metrics of the same name, job and grouping key.
+     * <p>
+     * This uses the POST HTTP method.
+     */
+    public void pushAdd(CollectorRegistry registry,String job,
+                        Map<String, String> groupingKey, String timestamp) throws IOException {
+        doRequest(registry, job, groupingKey, "POST", timestamp);
+    }
+
+    /**
+     * Pushes all metrics in a Collector,
+     * replacing only previously pushed metrics of the same name, job and grouping key.
+     * <p>
+     * This is useful for pushing a single Gauge.
+     * <p>
+     * This uses the POST HTTP method.
+     */
+    public void pushAdd(Collector collector, String job,
+                        Map<String, String> groupingKey) throws IOException {
+        CollectorRegistry registry = new CollectorRegistry();
+        collector.register(registry);
+        pushAdd(registry, job, groupingKey, null);
+    }
+
+
+    /**
+     * Deletes metrics from the Pushgateway.
+     * <p>
+     * Deletes metrics with no grouping key and the provided job.
+     * This uses the DELETE HTTP method.
+     */
+    public void delete(String job) throws IOException {
+        doRequest(null, job, null, "DELETE", null);
+    }
+
+    /**
+     * Deletes metrics from the Pushgateway.
+     * <p>
+     * Deletes metrics with the provided job and grouping key.
+     * This uses the DELETE HTTP method.
+     */
+    public void delete(String job, Map<String, String> groupingKey) throws IOException {
+        doRequest(null, job, groupingKey, "DELETE", null);
+    }
+
+
+    /**
+     * Pushes all metrics in a registry, replacing all those with the same job and instance.
+     * <p>
+     * This uses the PUT HTTP method.
+     * @deprecated use {@link #push(CollectorRegistry, String, Map)}
+     */
+    @Deprecated
+    public void push(CollectorRegistry registry, String job, String instance) throws IOException {
+        push(registry, job, Collections.singletonMap("instance", instance));
+    }
+
+    /**
+     * Pushes all metrics in a Collector, replacing all those with the same job and instance.
+     * <p>
+     * This is useful for pushing a single Gauge.
+     * <p>
+     * This uses the PUT HTTP method.
+     * @deprecated use {@link #push(Collector, String, Map)}
+     */
+    @Deprecated
+    public void push(Collector collector, String job, String instance) throws IOException {
+        push(collector, job, Collections.singletonMap("instance", instance));
+    }
+
+    /**
+     * Pushes all metrics in a Collector,
+     * replacing only previously pushed metrics of the same name.
+     * <p>
+     * This is useful for pushing a single Gauge.
+     * <p>
+     * This uses the POST HTTP method.
+     * @deprecated use {@link #pushAdd(Collector, String, Map)}
+     */
+    @Deprecated
+    public void pushAdd(Collector collector, String job, String instance) throws IOException {
+        pushAdd(collector, job, Collections.singletonMap("instance", instance));
+    }
+
+    /**
+     * Deletes metrics from the Pushgateway.
+     * <p>
+     * This uses the DELETE HTTP method.
+     * @deprecated use {@link #delete(String, Map)}
+     */
+    @Deprecated
+    public void delete(String job, String instance) throws IOException {
+        delete(job, Collections.singletonMap("instance", instance));
+    }
+
+    void doRequest(CollectorRegistry registry, String job, Map<String,
+            String> groupingKey, String method, String timestamp) throws IOException {
+        String url = address + "/metrics/job/" + URLEncoder.encode(job, "UTF-8");
+        if (groupingKey != null) {
+            for (Map.Entry<String, String> entry: groupingKey.entrySet()) {
+                url += "/" + entry.getKey() + "/" + URLEncoder.encode(entry.getValue(), "UTF-8");
+            }
+        }
+
+        logger.info("Sending metrics data to '{}'", url);
+
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setRequestProperty("Content-Type", TextFormatWithTimestamp.CONTENT_TYPE_004);
+        if (!method.equals("DELETE")) {
+            connection.setDoOutput(true);
+        }
+        connection.setRequestMethod(method);
+
+        connection.setConnectTimeout(10 * SECONDS_PER_MILLISECOND);
+        connection.setReadTimeout(10 * SECONDS_PER_MILLISECOND);
+        connection.connect();
+
+        try {
+            if (!method.equals("DELETE")) {
+                BufferedWriter writer =
+                        new BufferedWriter(
+                                new OutputStreamWriter(connection.getOutputStream(), "UTF-8"));
+                TextFormatWithTimestamp.write004(writer,
+                                                registry.metricFamilySamples(), timestamp);
+                writer.flush();
+                writer.close();
+            }
+
+            int response = connection.getResponseCode();
+            if (response != HttpURLConnection.HTTP_ACCEPTED) {
+                throw new IOException("Response code from " + url + " was " + response);
+            }
+        } catch (Exception ex) {
+            logger.error("Sending metrics failed due to: ", ex);
+        }
+
+        finally {
+            connection.disconnect();
+        }
+    }
+
+    /**
+     * Returns a grouping key with the instance label set to the machine's IP address.
+     * <p>
+     * This is a convenience function, and should only be used where you want to
+     * push per-instance metrics rather than cluster/job level metrics.
+     */
+    public static Map<String, String> instanceIPGroupingKey() throws UnknownHostException {
+        Map<String, String> groupingKey = new HashMap<String, String>();
+        groupingKey.put("instance", InetAddress.getLocalHost().getHostAddress());
+        return groupingKey;
+    }
+
+}
+

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -23,7 +23,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -228,9 +228,10 @@ public class PushGatewayWithTimestamp {
 
         connection.setConnectTimeout(10 * SECONDS_PER_MILLISECOND);
         connection.setReadTimeout(10 * SECONDS_PER_MILLISECOND);
-        connection.connect();
 
         try {
+            connection.connect();
+
             if (!method.equals("DELETE")) {
                 BufferedWriter writer =
                         new BufferedWriter(

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -209,7 +209,7 @@ public class PushGatewayWithTimestamp {
     }
 
 
-    void doRequest(CollectorRegistry registry, String job, Map<String,
+    private void doRequest(CollectorRegistry registry, String job, Map<String,
             String> groupingKey, String method, String timestamp) throws IOException {
         String url = address + "/metrics/job/" + URLEncoder.encode(job, "UTF-8");
         if (groupingKey != null) {
@@ -249,7 +249,6 @@ public class PushGatewayWithTimestamp {
         } catch (Exception ex) {
             logger.error("Sending metrics failed due to: ", ex);
         }
-
         finally {
             connection.disconnect();
         }

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/PushGatewayWithTimestamp.java
@@ -209,55 +209,6 @@ public class PushGatewayWithTimestamp {
     }
 
 
-    /**
-     * Pushes all metrics in a registry, replacing all those with the same job and instance.
-     * <p>
-     * This uses the PUT HTTP method.
-     * @deprecated use {@link #push(CollectorRegistry, String, Map)}
-     */
-    @Deprecated
-    public void push(CollectorRegistry registry, String job, String instance) throws IOException {
-        push(registry, job, Collections.singletonMap("instance", instance));
-    }
-
-    /**
-     * Pushes all metrics in a Collector, replacing all those with the same job and instance.
-     * <p>
-     * This is useful for pushing a single Gauge.
-     * <p>
-     * This uses the PUT HTTP method.
-     * @deprecated use {@link #push(Collector, String, Map)}
-     */
-    @Deprecated
-    public void push(Collector collector, String job, String instance) throws IOException {
-        push(collector, job, Collections.singletonMap("instance", instance));
-    }
-
-    /**
-     * Pushes all metrics in a Collector,
-     * replacing only previously pushed metrics of the same name.
-     * <p>
-     * This is useful for pushing a single Gauge.
-     * <p>
-     * This uses the POST HTTP method.
-     * @deprecated use {@link #pushAdd(Collector, String, Map)}
-     */
-    @Deprecated
-    public void pushAdd(Collector collector, String job, String instance) throws IOException {
-        pushAdd(collector, job, Collections.singletonMap("instance", instance));
-    }
-
-    /**
-     * Deletes metrics from the Pushgateway.
-     * <p>
-     * This uses the DELETE HTTP method.
-     * @deprecated use {@link #delete(String, Map)}
-     */
-    @Deprecated
-    public void delete(String job, String instance) throws IOException {
-        delete(job, Collections.singletonMap("instance", instance));
-    }
-
     void doRequest(CollectorRegistry registry, String job, Map<String,
             String> groupingKey, String method, String timestamp) throws IOException {
         String url = address + "/metrics/job/" + URLEncoder.encode(job, "UTF-8");

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestamp.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.metrics.prometheus.client.exporter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Enumeration;
+
+import io.prometheus.client.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TextFormatWithTimestamp {
+    private static final Logger logger = LoggerFactory.getLogger(TextFormatWithTimestamp.class);
+
+    /**
+     * Content-type for text version 0.0.4.
+     */
+    public static final String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
+
+    private static StringBuilder jsonMessageLogBuilder = new StringBuilder();
+
+    public static void write004(Writer writer,
+                                Enumeration<Collector.MetricFamilySamples> mfs)throws IOException {
+        write004(writer, mfs, null);
+    }
+
+    /**
+     * Write out the text version 0.0.4 of the given MetricFamilySamples.
+     */
+    public static void write004(Writer writer,Enumeration<Collector.MetricFamilySamples> mfs,
+                                String timestamp) throws IOException {
+    /* See http://prometheus.io/docs/instrumenting/exposition_formats/
+     * for the output format specification. */
+    while(mfs.hasMoreElements()) {
+        Collector.MetricFamilySamples metricFamilySamples = mfs.nextElement();
+
+        logger.debug("Metrics data");
+        logger.debug(metricFamilySamples.toString());
+        logger.debug("Logging metrics as a json format:");
+
+
+        writer.write("# HELP ");
+        appendToJsonMessageLogBuilder("# HELP ");
+        writer.write(metricFamilySamples.name);
+        appendToJsonMessageLogBuilder(metricFamilySamples.name);
+        writer.write(' ');
+        appendToJsonMessageLogBuilder(' ');
+        writeEscapedHelp(writer, metricFamilySamples.help);
+        writer.write('\n');
+        appendToJsonMessageLogBuilder('\n');
+
+        writer.write("# TYPE ");
+        appendToJsonMessageLogBuilder("# TYPE ");
+        writer.write(metricFamilySamples.name);
+        appendToJsonMessageLogBuilder(metricFamilySamples.name);
+        writer.write(' ');
+        appendToJsonMessageLogBuilder(' ');
+        writer.write(typeString(metricFamilySamples.type));
+        appendToJsonMessageLogBuilder(typeString(metricFamilySamples.type));
+        writer.write('\n');
+        appendToJsonMessageLogBuilder('\n');
+
+        for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
+            writer.write(sample.name);
+            appendToJsonMessageLogBuilder(sample.name);
+            if (sample.labelNames.size() > 0) {
+                writer.write('{');
+                appendToJsonMessageLogBuilder('{');
+                for (int i = 0; i < sample.labelNames.size(); ++i) {
+                    writer.write(sample.labelNames.get(i));
+                    appendToJsonMessageLogBuilder(sample.labelNames.get(i));
+                    writer.write("=\"");
+                    appendToJsonMessageLogBuilder("=\"");
+                    writeEscapedLabelValue(writer, sample.labelValues.get(i));
+                    writer.write("\",");
+                    appendToJsonMessageLogBuilder("\",");
+                }
+                writer.write('}');
+                appendToJsonMessageLogBuilder('}');
+            }
+            writer.write(' ');
+            appendToJsonMessageLogBuilder(' ');
+            writer.write(Collector.doubleToGoString(sample.value));
+            appendToJsonMessageLogBuilder(Collector.doubleToGoString(sample.value));
+            if(timestamp != null && !timestamp.isEmpty()) {
+                writer.write(" " + timestamp);
+                appendToJsonMessageLogBuilder(" " + timestamp);
+            }
+            writer.write('\n');
+            appendToJsonMessageLogBuilder('\n');
+        }
+        logger.debug("JSON: "+ jsonMessageLogBuilder);
+        }
+    }
+
+    private static void writeEscapedHelp(Writer writer, String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+
+                    writer.append("\\\\");
+                    appendToJsonMessageLogBuilder("\\\\");
+                    break;
+                case '\n':
+                    writer.append("\\n");
+                    appendToJsonMessageLogBuilder("\\n");
+                    break;
+                default:
+                    writer.append(c);
+                    appendToJsonMessageLogBuilder(c);
+            }
+        }
+    }
+
+    private static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+                    writer.append("\\\\");
+                    appendToJsonMessageLogBuilder("\\\\");
+                    break;
+                case '\"':
+                    writer.append("\\\"");
+                    appendToJsonMessageLogBuilder("\\\"");
+                    break;
+                case '\n':
+                    writer.append("\\n");
+                    appendToJsonMessageLogBuilder("\\n");
+                    break;
+                default:
+                    writer.append(c);
+                    appendToJsonMessageLogBuilder(c);
+            }
+        }
+    }
+
+    private static String typeString(Collector.Type t) {
+        switch (t) {
+            case GAUGE:
+                return "gauge";
+            case COUNTER:
+                return "counter";
+            case SUMMARY:
+                return "summary";
+            case HISTOGRAM:
+                return "histogram";
+            default:
+                return "untyped";
+        }
+    }
+
+    private static void appendToJsonMessageLogBuilder(String msg) {
+        if (logger.isDebugEnabled()) {
+            jsonMessageLogBuilder.append(msg);
+        }
+    }
+
+    private static void appendToJsonMessageLogBuilder(char c) {
+        if (logger.isDebugEnabled()) {
+            jsonMessageLogBuilder.append(c);
+        }
+    }
+}
+

--- a/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestamp.java
+++ b/core/src/main/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestamp.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Writing {@link Collector.MetricFamilySamples}
- * into the format expected by Prometheus {@see http://prometheus.io/docs/instrumenting/exposition_formats/}
+ * into the format expected by Prometheus
+ * {@see http://prometheus.io/docs/instrumenting/exposition_formats/}
  */
 public class TextFormatWithTimestamp {
     private static final Logger logger = LoggerFactory.getLogger(TextFormatWithTimestamp.class);
@@ -60,7 +61,8 @@ public class TextFormatWithTimestamp {
      * Converts the given {@link Collector.MetricFamilySamples} collection into text version 0.0.4
      * according to {@see http://prometheus.io/docs/instrumenting/exposition_formats/}
      */
-    protected static String buildTextFormat(Enumeration<Collector.MetricFamilySamples> mfs, String timestamp) {
+    protected static String buildTextFormat(Enumeration<Collector.MetricFamilySamples> mfs,
+                                            String timestamp) {
         StringBuilder textFormatBuilder = new StringBuilder();
 
         for (Collector.MetricFamilySamples metricFamilySamples : Collections.list(mfs)) {
@@ -84,7 +86,8 @@ public class TextFormatWithTimestamp {
         appendEscapedHelp(sb, help);
     }
 
-    private static void appendType(StringBuilder sb, String metricsFamilyName, Collector.Type type) {
+    private static void appendType(StringBuilder sb, String metricsFamilyName, Collector.Type
+            type) {
         sb.append('\n');
         sb.append("# TYPE ").append(metricsFamilyName).append(' ');
         sb.append(typeString(type));
@@ -104,7 +107,8 @@ public class TextFormatWithTimestamp {
         sb.append('}');
     }
 
-    private static void appendMetricSample(StringBuilder sb, Collector.MetricFamilySamples.Sample sample) {
+    private static void appendMetricSample(StringBuilder sb, Collector.MetricFamilySamples.Sample
+            sample) {
         sb.append(sample.name);
         if (sample.labelNames.size() > 0) {
             appendLabels(sb, sample.labelNames, sample.labelValues);

--- a/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusSink.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusSink.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.metrics.sink
+
+import java.net.URI
+import java.util
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+import com.codahale.metrics._
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.dropwizard.DropwizardExports
+
+import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkEnv}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.METRICS_NAMESPACE
+import org.apache.spark.metrics.MetricsSystem
+import org.apache.spark.metrics.prometheus.client.exporter.PushGatewayWithTimestamp
+
+
+private[spark] class PrometheusSink(
+                                     val property: Properties,
+                                     val registry: MetricRegistry,
+                                     securityMgr: SecurityManager)
+  extends Sink with Logging {
+
+  protected class Reporter(registry: MetricRegistry)
+    extends ScheduledReporter(
+      registry,
+      "prometheus-reporter",
+      MetricFilter.ALL,
+      TimeUnit.SECONDS,
+      TimeUnit.MILLISECONDS) {
+
+    val defaultSparkConf: SparkConf = new SparkConf(true)
+
+    override def report(
+                         gauges: util.SortedMap[String, Gauge[_]],
+                         counters: util.SortedMap[String, Counter],
+                         histograms: util.SortedMap[String, Histogram],
+                         meters: util.SortedMap[String, Meter],
+                         timers: util.SortedMap[String, Timer]): Unit = {
+
+      // SparkEnv may become available only after metrics sink creation thus retrieving
+      // SparkConf from spark env here and not during the creation/initialisation of PrometheusSink.
+      val sparkConf: SparkConf = Option(SparkEnv.get).map(_.conf).getOrElse(defaultSparkConf)
+
+      val metricsNamespace: Option[String] = sparkConf.get(METRICS_NAMESPACE)
+      val sparkAppId: Option[String] = sparkConf.getOption("spark.app.id")
+      val executorId: Option[String] = sparkConf.getOption("spark.executor.id")
+
+      logInfo(s"metricsNamespace=$metricsNamespace, sparkAppId=$sparkAppId, " +
+        s"executorId=$executorId")
+
+      val role: String = (sparkAppId, executorId) match {
+        case (Some(_), Some(SparkContext.DRIVER_IDENTIFIER)) => "driver"
+        case (Some(_), Some(_)) => "executor"
+        case _ => "shuffle"
+      }
+
+      val job: String = role match {
+        case "driver" => metricsNamespace.getOrElse(sparkAppId.get)
+        case "executor" => metricsNamespace.getOrElse(sparkAppId.get)
+        case _ => metricsNamespace.getOrElse("shuffle")
+      }
+      logInfo(s"role=$role, job=$job")
+
+      val groupingKey: Map[String, String] = (role, executorId) match {
+        case ("driver", _) => Map("role" -> role)
+        case ("executor", Some(id)) => Map ("role" -> role, "number" -> id)
+        case _ => Map("role" -> role)
+      }
+
+
+      pushGateway.pushAdd(pushRegistry, job, groupingKey.asJava,
+        s"${System.currentTimeMillis}")
+
+    }
+
+  }
+
+  val DEFAULT_PUSH_PERIOD: Int = 10
+  val DEFAULT_PUSH_PERIOD_UNIT: TimeUnit = TimeUnit.SECONDS
+  val DEFAULT_PUSHGATEWAY_ADDRESS: String = "127.0.0.1:9091"
+  val DEFAULT_PUSHGATEWAY_ADDRESS_PROTOCOL: String = "http"
+
+  val KEY_PUSH_PERIOD = "period"
+  val KEY_PUSH_PERIOD_UNIT = "unit"
+  val KEY_PUSHGATEWAY_ADDRESS = "pushgateway-address"
+  val KEY_PUSHGATEWAY_ADDRESS_PROTOCOL = "pushgateway-address-protocol"
+
+
+  val pollPeriod: Int =
+    Option(property.getProperty(KEY_PUSH_PERIOD))
+      .map(_.toInt)
+      .getOrElse(DEFAULT_PUSH_PERIOD)
+
+  val pollUnit: TimeUnit =
+    Option(property.getProperty(KEY_PUSH_PERIOD_UNIT))
+      .map { s => TimeUnit.valueOf(s.toUpperCase) }
+      .getOrElse(DEFAULT_PUSH_PERIOD_UNIT)
+
+  val pushGatewayAddress =
+    Option(property.getProperty(KEY_PUSHGATEWAY_ADDRESS))
+      .getOrElse(DEFAULT_PUSHGATEWAY_ADDRESS)
+
+  val pushGatewayAddressProtocol =
+    Option(property.getProperty(KEY_PUSHGATEWAY_ADDRESS_PROTOCOL))
+      .getOrElse(DEFAULT_PUSHGATEWAY_ADDRESS_PROTOCOL)
+
+  // validate pushgateway host:port
+  Try(new URI(s"$pushGatewayAddressProtocol://$pushGatewayAddress")).get
+
+  MetricsSystem.checkMinimalPollingPeriod(pollUnit, pollPeriod)
+
+  logInfo("Initializing Prometheus Sink...")
+  logInfo(s"Metrics polling period -> $pollPeriod $pollUnit")
+  logInfo(s"$KEY_PUSHGATEWAY_ADDRESS -> $pushGatewayAddress")
+  logInfo(s"$KEY_PUSHGATEWAY_ADDRESS_PROTOCOL -> $pushGatewayAddressProtocol")
+
+  val pushRegistry: CollectorRegistry = new CollectorRegistry()
+  val sparkMetricExports: DropwizardExports = new DropwizardExports(registry)
+  val pushGateway: PushGatewayWithTimestamp =
+    new PushGatewayWithTimestamp(s"$pushGatewayAddressProtocol://$pushGatewayAddress")
+
+  val reporter = new Reporter(registry)
+
+  override def start(): Unit = {
+    sparkMetricExports.register(pushRegistry)
+
+    reporter.start(pollPeriod, pollUnit)
+  }
+
+  override def stop(): Unit = {
+    reporter.stop()
+    pushRegistry.unregister(sparkMetricExports)
+  }
+
+  override def report(): Unit = {
+    reporter.report()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusSink.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusSink.scala
@@ -89,12 +89,10 @@ private[spark] class PrometheusSink(
         case _ => Map("role" -> role)
       }
 
-
       pushGateway.pushAdd(pushRegistry, job, groupingKey.asJava,
         s"${System.currentTimeMillis}")
 
     }
-
   }
 
   val DEFAULT_PUSH_PERIOD: Int = 10
@@ -145,7 +143,6 @@ private[spark] class PrometheusSink(
 
   override def start(): Unit = {
     sparkMetricExports.register(pushRegistry)
-
     reporter.start(pollPeriod, pollUnit)
   }
 

--- a/core/src/test/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestampSuite.java
+++ b/core/src/test/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestampSuite.java
@@ -117,4 +117,46 @@ public class TextFormatWithTimestampSuite {
 
     }
 
+    @Test
+    public void buildTextFormatWithNoMetricsTimestamp() {
+        // Given
+        List<Collector.MetricFamilySamples> mfs = Lists.newArrayList(
+                new Collector.MetricFamilySamples(
+                        "Metric_Family_1",
+                        Collector.Type.GAUGE,
+                        "help1",
+                        Lists.newArrayList(
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Sample1",
+                                        Lists.newArrayList("label1", "label2"),
+                                        Lists.newArrayList("1", "value1"),
+                                        1.0
+                                ),
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Sample2",
+                                        Lists.newArrayList("label1", "label2"),
+                                        Lists.newArrayList("2", "value2"),
+                                        2.0
+                                )
+                        )
+                )
+        );
+
+        String expected = String.join("\n",
+                "# HELP Metric_Family_1 help1",
+                "# TYPE Metric_Family_1 gauge",
+                "Sample1{label1=\"1\",label2=\"value1\"} 1.0",
+                "Sample2{label1=\"2\",label2=\"value2\"} 2.0",
+                ""
+        );
+
+        // When
+        String actual = TextFormatWithTimestamp.buildTextFormat(Collections.enumeration(mfs),
+                null);
+
+        // Then
+        Assert.assertEquals(expected, actual);
+
+    }
+
 }

--- a/core/src/test/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestampSuite.java
+++ b/core/src/test/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestampSuite.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.metrics.prometheus.client.exporter;
+
+
+import com.google.common.collect.Lists;
+import io.prometheus.client.Collector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class TextFormatWithTimestampSuite {
+
+    @Test
+    public void buildTextFormat() {
+        // Given
+        List<Collector.MetricFamilySamples> mfs = Lists.newArrayList(
+                new Collector.MetricFamilySamples(
+                        "Metric_Family_1",
+                        Collector.Type.GAUGE,
+                        "help1",
+                        Lists.newArrayList(
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Sample1",
+                                        Lists.newArrayList("label1", "label2"),
+                                        Lists.newArrayList("1", "value1"),
+                                        1.0
+                                ),
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Sample2",
+                                        Lists.newArrayList("label1", "label2"),
+                                        Lists.newArrayList("2", "value2"),
+                                        2.0
+                                )
+                        )
+                ),
+                new Collector.MetricFamilySamples(
+                        "Metric_Family_2",
+                        Collector.Type.COUNTER,
+                        "help2",
+                        Lists.newArrayList(
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Count1",
+                                        Lists.newArrayList("label1"),
+                                        Lists.newArrayList("1"),
+                                        5
+                                ),
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Sum",
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        9
+                                )
+                        )
+                ),
+                new Collector.MetricFamilySamples(
+                        "Metric_Family_3",
+                        Collector.Type.COUNTER,
+                        "multiline\nhelp\\escaped",
+                        Lists.newArrayList(
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Count1",
+                                        Lists.newArrayList("label1"),
+                                        Lists.newArrayList("1\\2\n"),
+                                        5
+                                ),
+                                new Collector.MetricFamilySamples.Sample(
+                                        "Sum",
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        9
+                                )
+                        )
+                )
+
+        );
+
+        String timeStamp = String.valueOf(System.currentTimeMillis());
+
+
+        String expected = String.join("\n",
+                "# HELP Metric_Family_1 help1",
+                "# TYPE Metric_Family_1 gauge",
+                "Sample1{label1=\"1\",label2=\"value1\"} 1.0 " + timeStamp,
+                "Sample2{label1=\"2\",label2=\"value2\"} 2.0 " + timeStamp,
+                "# HELP Metric_Family_2 help2",
+                "# TYPE Metric_Family_2 counter",
+                "Count1{label1=\"1\"} 5.0 " + timeStamp,
+                "Sum 9.0 " + timeStamp,
+                "# HELP Metric_Family_3 multiline\\nhelp\\\\escaped",
+                "# TYPE Metric_Family_3 counter",
+                "Count1{label1=\"1\\\\2\\n\"} 5.0 " + timeStamp,
+                "Sum 9.0 " + timeStamp,
+                ""
+        );
+
+        // When
+        String actual = TextFormatWithTimestamp.buildTextFormat(Collections.enumeration(mfs), timeStamp);
+
+        // Then
+        Assert.assertEquals(expected, actual);
+
+    }
+
+}

--- a/core/src/test/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestampSuite.java
+++ b/core/src/test/java/org/apache/spark/metrics/prometheus/client/exporter/TextFormatWithTimestampSuite.java
@@ -109,7 +109,8 @@ public class TextFormatWithTimestampSuite {
         );
 
         // When
-        String actual = TextFormatWithTimestamp.buildTextFormat(Collections.enumeration(mfs), timeStamp);
+        String actual = TextFormatWithTimestamp.buildTextFormat(Collections.enumeration(mfs),
+                timeStamp);
 
         // Then
         Assert.assertEquals(expected, actual);

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -171,6 +171,10 @@ scala-reflect-2.11.8.jar
 scala-xml_2.11-1.0.5.jar
 scalap-2.11.8.jar
 shapeless_2.11-2.3.2.jar
+simpleclient-0.0.23.jar
+simpleclient_common-0.0.23.jar
+simpleclient_dropwizard-0.0.23.jar
+simpleclient_pushgateway-0.0.23.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -172,6 +172,10 @@ scala-reflect-2.11.8.jar
 scala-xml_2.11-1.0.5.jar
 scalap-2.11.8.jar
 shapeless_2.11-2.3.2.jar
+simpleclient-0.0.23.jar
+simpleclient_common-0.0.23.jar
+simpleclient_dropwizard-0.0.23.jar
+simpleclient_pushgateway-0.0.23.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <ivy.version>2.4.0</ivy.version>
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>3.1.5</codahale.metrics.version>
+    <prometheus.version>0.0.23</prometheus.version>
     <avro.version>1.7.7</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <jets3t.version>0.9.3</jets3t.version>
@@ -616,6 +617,21 @@
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-graphite</artifactId>
         <version>${codahale.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient</artifactId>
+        <version>${prometheus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_dropwizard</artifactId>
+        <version>${prometheus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_pushgateway</artifactId>
+        <version>${prometheus.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -1372,9 +1388,9 @@
       <dependency>
         <groupId>${hive.group}</groupId>
         <artifactId>hive-exec</artifactId>
-<!--
-        <classifier>core</classifier>
--->
+        <!--
+                <classifier>core</classifier>
+        -->
         <version>${hive.version}</version>
         <scope>${hive.deps.scope}</scope>
         <exclusions>
@@ -2305,7 +2321,7 @@
             <execution>
               <id>default-cli</id>
               <goals>
-                 <goal>build-classpath</goal>
+                <goal>build-classpath</goal>
               </goals>
               <configuration>
                 <!-- This includes dependencies with 'runtime' and 'compile' scopes;


### PR DESCRIPTION
## What changes were proposed in this pull request?

_Originally this PR was submitted to the Spark on K8S fork [here](https://github.com/apache-spark-on-k8s/spark/pull/531) but has been advised to resend it upstream by @erikerlandson and @foxish. K8S specific items were removed from the PR and been reworked for the Apache version._

Publishing Spark metrics into Prometheus - as highlighted in the [JIRA](https://issues.apache.org/jira/browse/SPARK-22343). Implemented a metrics sink that publishes Spark metrics into Prometheus via [Prometheus Pushgateway](https://prometheus.io/docs/instrumenting/pushing/). Metrics data published by Spark is based on [Dropwizard](http://metrics.dropwizard.io/). The format of Spark metrics is not supported natively by Prometheus thus these are converted using [DropwizardExports](https://prometheus.io/client_java/io/prometheus/client/dropwizard/DropwizardExports.html) prior pushing metrics to the pushgateway.

Also the default Prometheus pushgateway client API implementation does not support metrics timestamp thus the client API has been ehanced to enrich metrics  data with timestamp. 

## How was this patch tested?

This PR is not affecting the existing code base and not altering the functionality. Nevertheless, I have executed all `unit and integration` tests. Also this setup has been deployed and been monitored via Prometheus (Prometheus 1.7.1 + Pushgateway 0.3.1). 

`Manual` testing through deploying a Spark cluster, Prometheus server, Pushgateway and ran SparkPi.