### PR TITLE
[SPARK-22548][SQL] Incorrect nested AND expression pushed down to JDBC data source

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -497,7 +497,10 @@ object DataSourceStrategy {
         Some(sources.IsNotNull(a.name))
 
       case expressions.And(left, right) =>
-        (translateFilter(left) ++ translateFilter(right)).reduceOption(sources.And)
+        for {
+          leftFilter <- translateFilter(left)
+          rightFilter <- translateFilter(right)
+        } yield sources.And(leftFilter, rightFilter)
 
       case expressions.Or(left, right) =>
         for {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -497,7 +497,7 @@ object DataSourceStrategy {
         Some(sources.IsNotNull(a.name))
 
       case expressions.And(left, right) =>
-        // See SPARK-12218 and PR 10362 for detailed discussion
+        // See SPARK-12218 for detailed discussion
         // It is not safe to just convert one side if we do not understand the
         // other side. Here is an example used to explain the reason.
         // Let's say we have (a = 2 AND trim(b) = 'blah') OR (c > 0)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -497,6 +497,7 @@ object DataSourceStrategy {
         Some(sources.IsNotNull(a.name))
 
       case expressions.And(left, right) =>
+        // See SPARK-12218 and PR 10362 for detailed discussion
         for {
           leftFilter <- translateFilter(left)
           rightFilter <- translateFilter(right)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -498,6 +498,14 @@ object DataSourceStrategy {
 
       case expressions.And(left, right) =>
         // See SPARK-12218 and PR 10362 for detailed discussion
+        // It is not safe to just convert one side if we do not understand the
+        // other side. Here is an example used to explain the reason.
+        // Let's say we have (a = 2 AND trim(b) = 'blah') OR (c > 0)
+        // and we do not understand how to convert trim(b) = 'blah'.
+        // If we only convert a = 2, we will end up with
+        // (a = 2) OR (c > 0), which will generate wrong results.
+        // Pushing one leg of AND down is only safe to do at the top level.
+        // You can see ParquetFilters' createFilter for more details.
         for {
           leftFilter <- translateFilter(left)
           rightFilter <- translateFilter(right)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.{sources, QueryTest}
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.types._
+
+
+class DataSourceStrategySuite extends QueryTest with SharedSQLContext {
+
+  test("translate simple expression") {
+    val attrInt = AttributeReference("cint", IntegerType)()
+    val attrStr = AttributeReference("cstr", StringType)()
+
+    assertResult(Some(sources.EqualTo("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.EqualTo(attrInt, Literal(1)))
+    }
+    assertResult(Some(sources.EqualTo("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.EqualTo(Literal(1), attrInt))
+    }
+
+    assertResult(Some(sources.EqualNullSafe("cstr", null))) {
+      DataSourceStrategy.translateFilter(
+        expressions.EqualNullSafe(attrStr, Literal(null)))
+    }
+    assertResult(Some(sources.EqualNullSafe("cstr", null))) {
+      DataSourceStrategy.translateFilter(
+        expressions.EqualNullSafe(Literal(null), attrStr))
+    }
+
+    assertResult(Some(sources.GreaterThan("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.GreaterThan(attrInt, Literal(1)))
+    }
+    assertResult(Some(sources.GreaterThan("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.LessThan(Literal(1), attrInt))
+    }
+
+    assertResult(Some(sources.LessThan("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.LessThan(attrInt, Literal(1)))
+    }
+    assertResult(Some(sources.LessThan("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.GreaterThan(Literal(1), attrInt))
+    }
+
+    assertResult(Some(sources.GreaterThanOrEqual("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.GreaterThanOrEqual(attrInt, Literal(1)))
+    }
+    assertResult(Some(sources.GreaterThanOrEqual("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.LessThanOrEqual(Literal(1), attrInt))
+    }
+
+    assertResult(Some(sources.LessThanOrEqual("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.LessThanOrEqual(attrInt, Literal(1)))
+    }
+    assertResult(Some(sources.LessThanOrEqual("cint", 1))) {
+      DataSourceStrategy.translateFilter(
+        expressions.GreaterThanOrEqual(Literal(1), attrInt))
+    }
+
+    assertResult(Some(sources.In("cint", Array(1, 2, 3)))) {
+      DataSourceStrategy.translateFilter(
+        expressions.InSet(attrInt, Set(1, 2, 3)))
+    }
+
+    assertResult(Some(sources.In("cint", Array(1, 2, 3)))) {
+      DataSourceStrategy.translateFilter(
+        expressions.In(attrInt, Seq(Literal(1), Literal(2), Literal(3))))
+    }
+
+    assertResult(Some(sources.IsNull("cint"))) {
+      DataSourceStrategy.translateFilter(
+        expressions.IsNull(attrInt))
+    }
+    assertResult(Some(sources.IsNotNull("cint"))) {
+      DataSourceStrategy.translateFilter(
+        expressions.IsNotNull(attrInt))
+    }
+
+    assertResult(Some(sources.And(
+      sources.GreaterThan("cint", 1),
+      sources.LessThan("cint", 10)))) {
+      DataSourceStrategy.translateFilter(expressions.And(
+        expressions.GreaterThan(attrInt, Literal(1)),
+        expressions.LessThan(attrInt, Literal(10))
+      ))
+    }
+
+    assertResult(Some(sources.Or(
+      sources.GreaterThanOrEqual("cint", 8),
+      sources.LessThanOrEqual("cint", 2)))) {
+      DataSourceStrategy.translateFilter(expressions.Or(
+        expressions.GreaterThanOrEqual(attrInt, Literal(8)),
+        expressions.LessThanOrEqual(attrInt, Literal(2))
+      ))
+    }
+
+    assertResult(Some(sources.Not(
+      sources.GreaterThanOrEqual("cint", 8)))) {
+      DataSourceStrategy.translateFilter(
+        expressions.Not(expressions.GreaterThanOrEqual(attrInt, Literal(8))
+        ))
+    }
+
+    assertResult(Some(sources.StringStartsWith("cstr", "a"))) {
+      DataSourceStrategy.translateFilter(
+        expressions.StartsWith(attrStr, Literal("a")
+        ))
+    }
+
+    assertResult(Some(sources.StringEndsWith("cstr", "a"))) {
+      DataSourceStrategy.translateFilter(
+        expressions.EndsWith(attrStr, Literal("a")
+        ))
+    }
+
+    assertResult(Some(sources.StringContains("cstr", "a"))) {
+      DataSourceStrategy.translateFilter(
+        expressions.Contains(attrStr, Literal("a")
+        ))
+    }
+  }
+
+  test("translate complex expression") {
+    val attrInt = AttributeReference("cint", IntegerType)()
+
+    assertResult(None) {
+      DataSourceStrategy.translateFilter(
+        expressions.LessThanOrEqual(
+          expressions.Subtract(expressions.Abs(attrInt), Literal(2)), Literal(1)))
+    }
+
+    assertResult(Some(sources.Or(
+      sources.And(
+        sources.GreaterThan("cint", 1),
+        sources.LessThan("cint", 10)),
+      sources.And(
+        sources.GreaterThan("cint", 50),
+        sources.LessThan("cint", 100))))) {
+      DataSourceStrategy.translateFilter(expressions.Or(
+        expressions.And(
+          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.LessThan(attrInt, Literal(10))
+        ),
+        expressions.And(
+          expressions.GreaterThan(attrInt, Literal(50)),
+          expressions.LessThan(attrInt, Literal(100))
+        )
+      ))
+    }
+    // SPARK-22548 Incorrect nested AND expression pushed down to JDBC data source
+    assertResult(None) {
+      DataSourceStrategy.translateFilter(expressions.Or(
+        expressions.And(
+          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.LessThan(
+            expressions.Abs(attrInt),
+            Literal(10))
+        ),
+        expressions.And(
+          expressions.GreaterThan(attrInt, Literal(50)),
+          expressions.LessThan(attrInt, Literal(100))
+        )
+      ))
+    }
+    assertResult(None) {
+      DataSourceStrategy.translateFilter(
+        expressions.Not(expressions.And(
+          expressions.Or(
+            expressions.LessThanOrEqual(attrInt, Literal(1)),
+            expressions.GreaterThanOrEqual(
+              expressions.Abs(attrInt),
+              Literal(10))
+          ),
+          expressions.Or(
+            expressions.LessThanOrEqual(attrInt, Literal(50)),
+            expressions.GreaterThanOrEqual(attrInt, Literal(100))
+          )
+        )))
+    }
+
+    assertResult(Some(sources.Or(
+      sources.Or(
+        sources.EqualTo("cint", 1),
+        sources.EqualTo("cint", 10)),
+      sources.Or(
+        sources.GreaterThan("cint", 0),
+        sources.LessThan("cint", -10))))) {
+      DataSourceStrategy.translateFilter(expressions.Or(
+        expressions.Or(
+          expressions.EqualTo(attrInt, Literal(1)),
+          expressions.EqualTo(attrInt, Literal(10))
+        ),
+        expressions.Or(
+          expressions.GreaterThan(attrInt, Literal(0)),
+          expressions.LessThan(attrInt, Literal(-10))
+        )
+      ))
+    }
+    assertResult(None) {
+      DataSourceStrategy.translateFilter(expressions.Or(
+        expressions.Or(
+          expressions.EqualTo(attrInt, Literal(1)),
+          expressions.EqualTo(
+            expressions.Abs(attrInt),
+            Literal(10))
+        ),
+        expressions.Or(
+          expressions.GreaterThan(attrInt, Literal(0)),
+          expressions.LessThan(attrInt, Literal(-10))
+        )
+      ))
+    }
+
+    assertResult(Some(sources.And(
+      sources.And(
+        sources.GreaterThan("cint", 1),
+        sources.LessThan("cint", 10)),
+      sources.And(
+        sources.EqualTo("cint", 6),
+        sources.IsNotNull("cint"))))) {
+      DataSourceStrategy.translateFilter(expressions.And(
+        expressions.And(
+          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.LessThan(attrInt, Literal(10))
+        ),
+        expressions.And(
+          expressions.EqualTo(attrInt, Literal(6)),
+          expressions.IsNotNull(attrInt)
+        )
+      ))
+    }
+    assertResult(None) {
+      DataSourceStrategy.translateFilter(expressions.And(
+        expressions.And(
+          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.LessThan(attrInt, Literal(10))
+        ),
+        expressions.And(
+          expressions.EqualTo(expressions.Abs(attrInt),
+            Literal(6)),
+          expressions.IsNotNull(attrInt)
+        )
+      ))
+    }
+
+    assertResult(Some(sources.And(
+      sources.Or(
+        sources.GreaterThan("cint", 1),
+        sources.LessThan("cint", 10)),
+      sources.Or(
+        sources.EqualTo("cint", 6),
+        sources.IsNotNull("cint"))))) {
+      DataSourceStrategy.translateFilter(expressions.And(
+        expressions.Or(
+          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.LessThan(attrInt, Literal(10))
+        ),
+        expressions.Or(
+          expressions.EqualTo(attrInt, Literal(6)),
+          expressions.IsNotNull(attrInt)
+        )
+      ))
+    }
+    assertResult(None) {
+      DataSourceStrategy.translateFilter(expressions.And(
+        expressions.Or(
+          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.LessThan(attrInt, Literal(10))
+        ),
+        expressions.Or(
+          expressions.EqualTo(expressions.Abs(attrInt),
+            Literal(6)),
+          expressions.IsNotNull(attrInt)
+        )
+      ))
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -17,27 +17,27 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types._
 
 
 class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
 
   test("translate simple expression") {
-    val attrInt = AttributeReference("cint", IntegerType)()
-    val attrStr = AttributeReference("cstr", StringType)()
+    val attrInt = 'cint.int
+    val attrStr = 'cstr.string
 
     assertResult(Some(sources.EqualTo("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.EqualTo(attrInt, Literal(1)))
+        expressions.EqualTo(attrInt, 1))
     }
     assertResult(Some(sources.EqualTo("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.EqualTo(Literal(1), attrInt))
+        expressions.EqualTo(1, attrInt))
     }
 
     assertResult(Some(sources.EqualNullSafe("cstr", null))) {
@@ -51,38 +51,38 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
 
     assertResult(Some(sources.GreaterThan("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.GreaterThan(attrInt, Literal(1)))
+        expressions.GreaterThan(attrInt, 1))
     }
     assertResult(Some(sources.GreaterThan("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.LessThan(Literal(1), attrInt))
+        expressions.LessThan(1, attrInt))
     }
 
     assertResult(Some(sources.LessThan("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.LessThan(attrInt, Literal(1)))
+        expressions.LessThan(attrInt, 1))
     }
     assertResult(Some(sources.LessThan("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.GreaterThan(Literal(1), attrInt))
+        expressions.GreaterThan(1, attrInt))
     }
 
     assertResult(Some(sources.GreaterThanOrEqual("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.GreaterThanOrEqual(attrInt, Literal(1)))
+        expressions.GreaterThanOrEqual(attrInt, 1))
     }
     assertResult(Some(sources.GreaterThanOrEqual("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.LessThanOrEqual(Literal(1), attrInt))
+        expressions.LessThanOrEqual(1, attrInt))
     }
 
     assertResult(Some(sources.LessThanOrEqual("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.LessThanOrEqual(attrInt, Literal(1)))
+        expressions.LessThanOrEqual(attrInt, 1))
     }
     assertResult(Some(sources.LessThanOrEqual("cint", 1))) {
       DataSourceStrategy.translateFilter(
-        expressions.GreaterThanOrEqual(Literal(1), attrInt))
+        expressions.GreaterThanOrEqual(1, attrInt))
     }
 
     assertResult(Some(sources.In("cint", Array(1, 2, 3)))) {
@@ -92,7 +92,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
 
     assertResult(Some(sources.In("cint", Array(1, 2, 3)))) {
       DataSourceStrategy.translateFilter(
-        expressions.In(attrInt, Seq(Literal(1), Literal(2), Literal(3))))
+        expressions.In(attrInt, Seq(1, 2, 3)))
     }
 
     assertResult(Some(sources.IsNull("cint"))) {
@@ -108,8 +108,8 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
       sources.GreaterThan("cint", 1),
       sources.LessThan("cint", 10)))) {
       DataSourceStrategy.translateFilter(expressions.And(
-        expressions.GreaterThan(attrInt, Literal(1)),
-        expressions.LessThan(attrInt, Literal(10))
+        expressions.GreaterThan(attrInt, 1),
+        expressions.LessThan(attrInt, 10)
       ))
     }
 
@@ -117,44 +117,44 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
       sources.GreaterThanOrEqual("cint", 8),
       sources.LessThanOrEqual("cint", 2)))) {
       DataSourceStrategy.translateFilter(expressions.Or(
-        expressions.GreaterThanOrEqual(attrInt, Literal(8)),
-        expressions.LessThanOrEqual(attrInt, Literal(2))
+        expressions.GreaterThanOrEqual(attrInt, 8),
+        expressions.LessThanOrEqual(attrInt, 2)
       ))
     }
 
     assertResult(Some(sources.Not(
       sources.GreaterThanOrEqual("cint", 8)))) {
       DataSourceStrategy.translateFilter(
-        expressions.Not(expressions.GreaterThanOrEqual(attrInt, Literal(8))
+        expressions.Not(expressions.GreaterThanOrEqual(attrInt, 8)
         ))
     }
 
     assertResult(Some(sources.StringStartsWith("cstr", "a"))) {
       DataSourceStrategy.translateFilter(
-        expressions.StartsWith(attrStr, Literal("a")
+        expressions.StartsWith(attrStr, "a"
         ))
     }
 
     assertResult(Some(sources.StringEndsWith("cstr", "a"))) {
       DataSourceStrategy.translateFilter(
-        expressions.EndsWith(attrStr, Literal("a")
+        expressions.EndsWith(attrStr, "a"
         ))
     }
 
     assertResult(Some(sources.StringContains("cstr", "a"))) {
       DataSourceStrategy.translateFilter(
-        expressions.Contains(attrStr, Literal("a")
+        expressions.Contains(attrStr, "a"
         ))
     }
   }
 
   test("translate complex expression") {
-    val attrInt = AttributeReference("cint", IntegerType)()
+    val attrInt = 'cint.int
 
     assertResult(None) {
       DataSourceStrategy.translateFilter(
         expressions.LessThanOrEqual(
-          expressions.Subtract(expressions.Abs(attrInt), Literal(2)), Literal(1)))
+          expressions.Subtract(expressions.Abs(attrInt), 2), 1))
     }
 
     assertResult(Some(sources.Or(
@@ -166,12 +166,12 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         sources.LessThan("cint", 100))))) {
       DataSourceStrategy.translateFilter(expressions.Or(
         expressions.And(
-          expressions.GreaterThan(attrInt, Literal(1)),
-          expressions.LessThan(attrInt, Literal(10))
+          expressions.GreaterThan(attrInt, 1),
+          expressions.LessThan(attrInt, 10)
         ),
         expressions.And(
-          expressions.GreaterThan(attrInt, Literal(50)),
-          expressions.LessThan(attrInt, Literal(100))
+          expressions.GreaterThan(attrInt, 50),
+          expressions.LessThan(attrInt, 100)
         )
       ))
     }
@@ -179,14 +179,13 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.Or(
         expressions.And(
-          expressions.GreaterThan(attrInt, Literal(1)),
+          expressions.GreaterThan(attrInt, 1),
           expressions.LessThan(
-            expressions.Abs(attrInt),
-            Literal(10))
+            expressions.Abs(attrInt), 10)
         ),
         expressions.And(
-          expressions.GreaterThan(attrInt, Literal(50)),
-          expressions.LessThan(attrInt, Literal(100))
+          expressions.GreaterThan(attrInt, 50),
+          expressions.LessThan(attrInt, 100)
         )
       ))
     }
@@ -194,14 +193,14 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
       DataSourceStrategy.translateFilter(
         expressions.Not(expressions.And(
           expressions.Or(
-            expressions.LessThanOrEqual(attrInt, Literal(1)),
+            expressions.LessThanOrEqual(attrInt, 1),
             expressions.GreaterThanOrEqual(
               expressions.Abs(attrInt),
-              Literal(10))
+              10)
           ),
           expressions.Or(
-            expressions.LessThanOrEqual(attrInt, Literal(50)),
-            expressions.GreaterThanOrEqual(attrInt, Literal(100))
+            expressions.LessThanOrEqual(attrInt, 50),
+            expressions.GreaterThanOrEqual(attrInt, 100)
           )
         )))
     }
@@ -215,26 +214,25 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         sources.LessThan("cint", -10))))) {
       DataSourceStrategy.translateFilter(expressions.Or(
         expressions.Or(
-          expressions.EqualTo(attrInt, Literal(1)),
-          expressions.EqualTo(attrInt, Literal(10))
+          expressions.EqualTo(attrInt, 1),
+          expressions.EqualTo(attrInt, 10)
         ),
         expressions.Or(
-          expressions.GreaterThan(attrInt, Literal(0)),
-          expressions.LessThan(attrInt, Literal(-10))
+          expressions.GreaterThan(attrInt, 0),
+          expressions.LessThan(attrInt, -10)
         )
       ))
     }
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.Or(
         expressions.Or(
-          expressions.EqualTo(attrInt, Literal(1)),
+          expressions.EqualTo(attrInt, 1),
           expressions.EqualTo(
-            expressions.Abs(attrInt),
-            Literal(10))
+            expressions.Abs(attrInt), 10)
         ),
         expressions.Or(
-          expressions.GreaterThan(attrInt, Literal(0)),
-          expressions.LessThan(attrInt, Literal(-10))
+          expressions.GreaterThan(attrInt, 0),
+          expressions.LessThan(attrInt, -10)
         )
       ))
     }
@@ -248,11 +246,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         sources.IsNotNull("cint"))))) {
       DataSourceStrategy.translateFilter(expressions.And(
         expressions.And(
-          expressions.GreaterThan(attrInt, Literal(1)),
-          expressions.LessThan(attrInt, Literal(10))
+          expressions.GreaterThan(attrInt, 1),
+          expressions.LessThan(attrInt, 10)
         ),
         expressions.And(
-          expressions.EqualTo(attrInt, Literal(6)),
+          expressions.EqualTo(attrInt, 6),
           expressions.IsNotNull(attrInt)
         )
       ))
@@ -260,12 +258,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.And(
         expressions.And(
-          expressions.GreaterThan(attrInt, Literal(1)),
-          expressions.LessThan(attrInt, Literal(10))
+          expressions.GreaterThan(attrInt, 1),
+          expressions.LessThan(attrInt, 10)
         ),
         expressions.And(
-          expressions.EqualTo(expressions.Abs(attrInt),
-            Literal(6)),
+          expressions.EqualTo(expressions.Abs(attrInt), 6),
           expressions.IsNotNull(attrInt)
         )
       ))
@@ -280,11 +277,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         sources.IsNotNull("cint"))))) {
       DataSourceStrategy.translateFilter(expressions.And(
         expressions.Or(
-          expressions.GreaterThan(attrInt, Literal(1)),
-          expressions.LessThan(attrInt, Literal(10))
+          expressions.GreaterThan(attrInt, 1),
+          expressions.LessThan(attrInt, 10)
         ),
         expressions.Or(
-          expressions.EqualTo(attrInt, Literal(6)),
+          expressions.EqualTo(attrInt, 6),
           expressions.IsNotNull(attrInt)
         )
       ))
@@ -292,12 +289,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.And(
         expressions.Or(
-          expressions.GreaterThan(attrInt, Literal(1)),
-          expressions.LessThan(attrInt, Literal(10))
+          expressions.GreaterThan(attrInt, 1),
+          expressions.LessThan(attrInt, 10)
         ),
         expressions.Or(
-          expressions.EqualTo(expressions.Abs(attrInt),
-            Literal(6)),
+          expressions.EqualTo(expressions.Abs(attrInt), 6),
           expressions.IsNotNull(attrInt)
         )
       ))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -150,7 +150,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
 
   test("translate complex expression") {
     val attrInt = 'cint.int
-
+    // Functions such as 'Abs' are not supported
     assertResult(None) {
       DataSourceStrategy.translateFilter(
         expressions.LessThanOrEqual(
@@ -176,6 +176,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
       ))
     }
     // SPARK-22548 Incorrect nested AND expression pushed down to JDBC data source
+    // Functions such as 'Abs' are not supported
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.Or(
         expressions.And(
@@ -189,6 +190,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         )
       ))
     }
+    // Functions such as 'Abs' are not supported
     assertResult(None) {
       DataSourceStrategy.translateFilter(
         expressions.Not(expressions.And(
@@ -223,6 +225,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         )
       ))
     }
+    // Functions such as 'Abs' are not supported
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.Or(
         expressions.Or(
@@ -255,6 +258,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         )
       ))
     }
+    // Functions such as 'Abs' are not supported
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.And(
         expressions.And(
@@ -286,6 +290,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
         )
       ))
     }
+    // Functions such as 'Abs' are not supported
     assertResult(None) {
       DataSourceStrategy.translateFilter(expressions.And(
         expressions.Or(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -85,7 +85,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
   test("translate complex expression") {
     val attrInt = 'cint.int
 
-    // ABS(cint) - 2 = 1
+    // ABS(cint) - 2 <= 1
     testTranslateFilter(LessThanOrEqual(
       // Expressions are not supported
       // Functions such as 'Abs' are not supported

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -17,14 +17,15 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.{sources, QueryTest}
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.sources
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 
 
-class DataSourceStrategySuite extends QueryTest with SharedSQLContext {
+class DataSourceStrategySuite extends PlanTest with SharedSQLContext {
 
   test("translate simple expression") {
     val attrInt = AttributeReference("cint", IntegerType)()

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -294,16 +294,13 @@ class JDBCSuite extends SparkFunSuite
 
     // This is a test to reflect discussion in SPARK-12218.
     // The older versions of spark have this kind of bugs in parquet data source.
-    val df1 = sql("SELECT * FROM foobar WHERE NOT (THEID != 2 AND NAME != 'mary')")
-    val df2 = sql("SELECT * FROM foobar WHERE NOT (THEID != 2) OR NOT (NAME != 'mary')")
-
+    val df1 = sql("SELECT * FROM foobar WHERE NOT (THEID != 2) OR NOT (NAME != 'mary')")
     assert(df1.collect.toSet === Set(Row("mary", 2)))
-    assert(df2.collect.toSet === Set(Row("mary", 2)))
 
     // SPARK-22548: Incorrect nested AND expression pushed down to JDBC data source
-    val df3 = sql("SELECT * FROM foobar " +
+    val df2 = sql("SELECT * FROM foobar " +
       "WHERE (THEID > 0 AND TRIM(NAME) = 'mary') OR (NAME = 'fred')")
-    assert(df3.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df2.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
 
     def checkNotPushdown(df: DataFrame): DataFrame = {
       val parentPlan = df.queryExecution.executedPlan

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -296,8 +296,33 @@ class JDBCSuite extends SparkFunSuite
     // The older versions of spark have this kind of bugs in parquet data source.
     val df1 = sql("SELECT * FROM foobar WHERE NOT (THEID != 2 AND NAME != 'mary')")
     val df2 = sql("SELECT * FROM foobar WHERE NOT (THEID != 2) OR NOT (NAME != 'mary')")
+    val df3 = sql("SELECT * FROM foobar WHERE (THEID > 0 AND NAME = 'mary') OR (NAME = 'fred')")
+    val df4 = sql("SELECT * FROM foobar " +
+      "WHERE (THEID > 0 AND TRIM(NAME) = 'mary') OR (NAME = 'fred')")
+    val df5 = sql("SELECT * FROM foobar " +
+      "WHERE THEID > 0 AND TRIM(NAME) = 'mary' AND LENGTH(NAME) > 3")
+    val df6 = sql("SELECT * FROM foobar " +
+      "WHERE THEID < 0 OR NAME = 'mary' OR NAME = 'fred'")
+    val df7 = sql("SELECT * FROM foobar " +
+      "WHERE THEID < 0 OR TRIM(NAME) = 'mary' OR NAME = 'fred'")
+    val df8 = sql("SELECT * FROM foobar " +
+      "WHERE NOT((THEID < 0 OR NAME != 'mary') AND (THEID != 1 OR NAME != 'fred'))")
+    val df9 = sql("SELECT * FROM foobar " +
+      "WHERE NOT((THEID < 0 OR NAME != 'mary') AND (THEID != 1 OR TRIM(NAME) != 'fred'))")
+    val df10 = sql("SELECT * FROM foobar " +
+      "WHERE (NOT(THEID < 0 OR TRIM(NAME) != 'mary')) OR (THEID = 1 AND NAME = 'fred')")
+
     assert(df1.collect.toSet === Set(Row("mary", 2)))
     assert(df2.collect.toSet === Set(Row("mary", 2)))
+    assert(df3.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df4.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df5.collect.toSet === Set(Row("mary", 2)))
+    assert(df6.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df7.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df8.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df9.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+    assert(df10.collect.toSet === Set(Row("fred", 1), Row("mary", 2)))
+
 
     def checkNotPushdown(df: DataFrame): DataFrame = {
       val parentPlan = df.queryExecution.executedPlan


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let’s say I have a nested AND expression shown below and p2 can not be pushed down, 

(p1 AND p2) OR p3

In current Spark code, during data source filter translation, (p1 AND p2) is returned as p1 only and p2 is simply lost. This issue occurs with JDBC data source and is similar to [SPARK-12218](https://github.com/apache/spark/pull/10362) for Parquet. When we have AND nested below another expression, we should either push both legs or nothing. 

Note that:
- The current Spark code will always split conjunctive predicate before it determines if a predicate can be pushed down or not
- If I have (p1 AND p2) AND p3, it will be split into p1, p2, p3. There won't be nested AND expression.
- The current Spark code logic for OR is OK. It either pushes both legs or nothing.

The same translation method is also called by Data Source V2. 

## How was this patch tested?

Added new unit test cases to JDBCSuite

@gatorsmile 
