### PR TITLE
[SPARK-22551][SQL] Prevent possible 64kb compile error for common expression types

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -380,4 +380,16 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
         s"Incorrect Evaluation: expressions: $exprAnd, actual: $actualAnd, expected: $expectedAnd")
     }
   }
+
+  test("SPARK-22551: Prevent possible 64kb compile error for common expression types") {
+    val N = 1800
+    var addedExpr: Expression = Literal(1)
+    var expected = 1
+    for (i <- 0 until N) {
+      addedExpr = Add(Literal(i), addedExpr)
+      expected += i
+    }
+
+    checkEvaluation(Add(addedExpr, addedExpr), expected * 2, EmptyRow)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

For common expression types, such as BinaryExpression and TernaryExpression, the combination of generated codes of children can possibly be large. We should put the codes into functions to prevent possible 64kb compile error.

## How was this patch tested?

Added test.
