### PR TITLE
[SPARK-21322][SQL] support histogram in filter cardinality estimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -123,11 +123,11 @@ object EstimationUtils {
    * @return the number of the first bin into which a column values falls.
    */
   def findFirstBinForValue(value: Double, bins: Array[HistogramBin]): Int = {
-    var binId = 0
-    bins.foreach { bin =>
-      if (value > bin.hi) binId += 1
+    var i = 0
+    while ((i < bins.length) && (value > bins(i).hi)) {
+      i +=1
     }
-    binId
+    i
   }
 
   /**
@@ -139,6 +139,12 @@ object EstimationUtils {
    * @return the number of the last bin into which a column values falls.
    */
   def findLastBinForValue(value: Double, bins: Array[HistogramBin]): Int = {
+    var i = bins.length - 1
+    while ((i >= 0) && (value < bins(i).lo)) {
+      i -=1
+    }
+    i
+    /*
     var binId = 0
     for (i <- bins.indices) {
       if (value > bins(i).hi) {
@@ -154,6 +160,7 @@ object EstimationUtils {
       }
     }
     binId
+    */
   }
 
   /**
@@ -172,28 +179,15 @@ object EstimationUtils {
       lowerValue: Double,
       histogram: Histogram): Double = {
     val curBin = histogram.bins(binId)
-    if (binId == 0 && curBin.hi == curBin.lo) {
-      // the Min of the histogram occupies the whole first bin
+    if (curBin.hi == curBin.lo) {
+      // the entire bin is covered in the range
       1.0
-    } else if (binId == 0 && curBin.hi != curBin.lo) {
-      if (higherValue == lowerValue) {
-        // set percentage to 1/NDV
-        1.0 / curBin.ndv.toDouble
-      } else {
-        // Use proration since the range falls inside this bin.
-        (higherValue - lowerValue) / (curBin.hi - curBin.lo)
-      }
+    } else if (higherValue == lowerValue) {
+      // set percentage to 1/NDV
+      1.0 / curBin.ndv.toDouble
     } else {
-      if (curBin.hi == curBin.lo) {
-        // the entire bin is covered in the range
-        1.0
-      } else if (higherValue == lowerValue) {
-        // set percentage to 1/NDV
-        1.0 / curBin.ndv.toDouble
-      } else {
-        // Use proration since the range falls inside this bin.
-        math.min((higherValue - lowerValue) / (curBin.hi - curBin.lo), 1.0)
-      }
+      // Use proration since the range falls inside this bin.
+      math.min((higherValue - lowerValue) / (curBin.hi - curBin.lo), 1.0)
     }
   }
 
@@ -230,7 +224,7 @@ object EstimationUtils {
    * @param higherEnd a given upper bound value of a specified column value range
    * @param lowerEnd a given lower bound value of a specified column value range
    * @param histogram a numeric equi-height histogram
-   * @return the selectivity percentage for column values in [lowerEnd, higherEnd].
+   * @return the number of bins for column values in [lowerEnd, higherEnd].
    */
   def getOccupationBins(
       higherId: Int,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -144,23 +144,6 @@ object EstimationUtils {
       i -=1
     }
     i
-    /*
-    var binId = 0
-    for (i <- bins.indices) {
-      if (value > bins(i).hi) {
-        // increment binId to point to next bin
-        binId += 1
-      }
-      if ((value == bins(i).hi) && (i < bins.length - 1) && (value == bins(i + 1).lo)) {
-        // We assume the above 3 conditions will be evaluated from left to right sequentially.
-        // If the above 3 conditions are evaluated out-of-order, then out-of-bound error may happen.
-        // At that time, we should split the third condition into another if statement.
-        // increment binId since the value appears in this bin and next bin
-        binId += 1
-      }
-    }
-    binId
-    */
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.plans.logical.statsEstimation
 import scala.math.BigDecimal.RoundingMode
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
-import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types.{DecimalType, _}
 
 
@@ -112,6 +112,199 @@ object EstimationUtils {
       case DoubleType => dec.toDouble
       case _: DecimalType => dec
     }
+  }
+
+  /**
+   * Returns the number of the first bin/bucket into which a column values falls for a specified
+   * numeric equi-height histogram.
+   *
+   * @param value a literal value of a column
+   * @param histogram a numeric equi-height histogram
+   * @return the number of the first bin/bucket into which a column values falls.
+   */
+
+  def findFirstBucketForValue(value: Double, histogram: Histogram): Int = {
+    var binId = 0
+    histogram.bins.foreach { bin =>
+      if (value > bin.hi) binId += 1
+    }
+    binId
+  }
+
+  /**
+   * Returns the number of the last bin/bucket into which a column values falls for a specified
+   * numeric equi-height histogram.
+   *
+   * @param value a literal value of a column
+   * @param histogram a numeric equi-height histogram
+   * @return the number of the last bin/bucket into which a column values falls.
+   */
+
+  def findLastBucketForValue(value: Double, histogram: Histogram): Int = {
+    var binId = 0
+    for (i <- 0 until histogram.bins.length) {
+      if (value > histogram.bins(i).hi) {
+        // increment binId to point to next bin
+        binId += 1
+      }
+      if ((value == histogram.bins(i).hi) && (i < histogram.bins.length - 1)) {
+        if (value == histogram.bins(i + 1).lo) {
+          // increment binId since the value appears into this bin and next bin
+          binId += 1
+        }
+      }
+    }
+    binId
+  }
+
+  /**
+   * Returns a percentage of a bin/bucket holding values for column value in the range of
+   * [lowerValue, higherValue]
+   *
+   * @param bucketId a given bin/bucket id in a specified histogram
+   * @param higherValue a given upper bound value of a specified column value range
+   * @param lowerValue a given lower bound value of a specified column value range
+   * @param histogram a numeric equi-height histogram
+   * @return the percentage of a single bin/bucket holding values in [lowerValue, higherValue].
+   */
+
+  private def getOccupation(
+      bucketId: Int,
+      higherValue: Double,
+      lowerValue: Double,
+      histogram: Histogram): Double = {
+    val curBucket = histogram.bins(bucketId)
+    if (bucketId == 0 && curBucket.hi == curBucket.lo) {
+      // the Min of the histogram occupies the whole first bucket
+      1.0
+    } else if (bucketId == 0 && curBucket.hi != curBucket.lo) {
+      if (higherValue == lowerValue) {
+        // in the case curBucket.binNdv == 0, current bucket is occupied by one value, which
+        // is included in the previous bucket
+        1.0 / math.max(curBucket.ndv.toDouble, 1)
+      } else {
+        (higherValue - lowerValue) / (curBucket.hi - curBucket.lo)
+      }
+    } else {
+      if (curBucket.hi == curBucket.lo) {
+        // the entire bucket is covered in the range
+        1.0
+      } else if (higherValue == lowerValue) {
+        // the literal value falls in this bucket
+        1.0 / math.max(curBucket.ndv.toDouble, 1)
+      } else {
+        // Use proration since the range falls inside this bucket.
+        math.min((higherValue - lowerValue) / (curBucket.hi - curBucket.lo), 1.0)
+      }
+    }
+  }
+
+  /**
+   * Returns the number of buckets for column values in [lowerValue, higherValue].
+   * The column value distribution is saved in an equi-height histogram.
+   *
+   * @param higherEnd a given upper bound value of a specified column value range
+   * @param lowerEnd a given lower bound value of a specified column value range
+   * @param histogram a numeric equi-height histogram
+   * @return the selectivity percentage for column values in [lowerValue, higherValue].
+   */
+
+  def getOccupationBuckets(
+      higherEnd: Double,
+      lowerEnd: Double,
+      histogram: Histogram): Double = {
+    // find buckets where current min and max locate
+    val minBucketId = findFirstBucketForValue(lowerEnd, histogram)
+    val maxBucketId = findLastBucketForValue(higherEnd, histogram)
+    assert(minBucketId <= maxBucketId)
+
+    // compute how much current [min, max] occupy the histogram, in the number of buckets
+    getOccupationBuckets(maxBucketId, minBucketId, higherEnd, lowerEnd, histogram)
+  }
+
+  /**
+   * Returns the number of buckets for column values in [lowerValue, higherValue].
+   * This is an overloaded method. The column value distribution is saved in an
+   * equi-height histogram.
+   *
+   * @param higherId id of the high end bucket holding the high end value of a column range
+   * @param lowerId id of the low end bucket holding the low end value of a column range
+   * @param higherEnd a given upper bound value of a specified column value range
+   * @param lowerEnd a given lower bound value of a specified column value range
+   * @param histogram a numeric equi-height histogram
+   * @return the selectivity percentage for column values in [lowerEnd, higherEnd].
+   */
+
+  def getOccupationBuckets(
+      higherId: Int,
+      lowerId: Int,
+      higherEnd: Double,
+      lowerEnd: Double,
+      histogram: Histogram): Double = {
+    if (lowerId == higherId) {
+      getOccupation(lowerId, higherEnd, lowerEnd, histogram)
+    } else {
+      // compute how much lowerEnd/higherEnd occupy its bucket
+      val lowerCurBucket = histogram.bins(lowerId)
+      val lowerPart = getOccupation(lowerId, lowerCurBucket.hi, lowerEnd, histogram)
+
+      // in case higherId > lowerId, higherId must be > 0
+      val higherCurBucket = histogram.bins(higherId)
+      val higherPart = getOccupation(higherId, higherEnd, higherCurBucket.lo,
+        histogram)
+      // the total length is lowerPart + higherPart + buckets between them
+      higherId - lowerId - 1 + lowerPart + higherPart
+    }
+  }
+
+  /**
+   * Returns the number of distinct values, ndv, for column values in [lowerEnd, higherEnd].
+   * The column value distribution is saved in an equi-height histogram.
+   *
+   * @param higherId id of the high end bucket holding the high end value of a column range
+   * @param lowerId id of the low end bucket holding the low end value of a column range
+   * @param higherEnd a given upper bound value of a specified column value range
+   * @param lowerEnd a given lower bound value of a specified column value range
+   * @param histogram a numeric equi-height histogram
+   * @return the number of distinct values, ndv, for column values in [lowerEnd, higherEnd].
+   */
+
+  def getOccupationNdv(
+      higherId: Int,
+      lowerId: Int,
+      higherEnd: Double,
+      lowerEnd: Double,
+      histogram: Histogram)
+    : Long = {
+    val ndv: Double = if (higherEnd == lowerEnd) {
+      1
+    } else if (lowerId == higherId) {
+      getOccupation(lowerId, higherEnd, lowerEnd, histogram) * histogram.bins(lowerId).ndv
+    } else {
+      // compute how much lowerEnd/higherEnd occupy its bucket
+      val minCurBucket = histogram.bins(lowerId)
+      val minPartNdv = getOccupation(lowerId, minCurBucket.hi, lowerEnd, histogram) *
+        minCurBucket.ndv
+
+      // in case higherId > lowerId, higherId must be > 0
+      val maxCurBucket = histogram.bins(higherId)
+      val maxPartNdv = getOccupation(higherId, higherEnd, maxCurBucket.lo, histogram) *
+        maxCurBucket.ndv
+
+      // The total ndv is minPartNdv + maxPartNdv + Ndvs between them.
+      // In order to avoid counting same distinct value twice, we check if the upperBound value
+      // of next bucket is equal to the hi value of the previous bucket.  We bump up
+      // ndv value only if the hi values of two consecutive buckets are different.
+      var middleNdv: Long = 0
+      for (i <- histogram.bins.indices) {
+        val bucket = histogram.bins(i)
+        if (bucket.hi != bucket.lo && i >= lowerId + 1 && i <= higherId - 1) {
+          middleNdv += bucket.ndv
+        }
+      }
+      minPartNdv + maxPartNdv + middleNdv
+    }
+    math.round(ndv)
   }
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -145,11 +145,12 @@ object EstimationUtils {
         // increment binId to point to next bin
         binId += 1
       }
-      if ((value == bins(i).hi) && (i < bins.length - 1)) {
-        if (value == bins(i + 1).lo) {
-          // increment binId since the value appears in this bin and next bin
-          binId += 1
-        }
+      if ((value == bins(i).hi) && (i < bins.length - 1) && (value == bins(i + 1).lo)) {
+        // We assume the above 3 conditions will be evaluated from left to right sequentially.
+        // If the above 3 conditions are evaluated out-of-order, then out-of-bound error may happen.
+        // At that time, we should split the third condition into another if statement.
+        // increment binId since the value appears in this bin and next bin
+        binId += 1
       }
     }
     binId

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -541,10 +541,9 @@ case class FilterEstimation(plan: Filter) extends Logging {
       } else {
         val numericHistogram = colStat.histogram.get
         val datum = EstimationUtils.toDecimal(literal.value, literal.dataType).toDouble
-        val maxDouble = EstimationUtils.toDecimal(colStat.max.get, literal.dataType).toDouble
-        val minDouble = EstimationUtils.toDecimal(colStat.min.get, literal.dataType).toDouble
-        percent = computePercentByEquiHeightHgm(op, numericHistogram, maxDouble, minDouble,
-          datum)
+        val max = EstimationUtils.toDecimal(colStat.max.get, literal.dataType).toDouble
+        val min = EstimationUtils.toDecimal(colStat.min.get, literal.dataType).toDouble
+        percent = computePercentByEquiHeightHgm(op, numericHistogram, max, min, datum)
       }
 
       if (update) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -37,97 +37,70 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   // column cint has values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
   // Hence, distinctCount:10, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
   val attrInt = AttributeReference("cint", IntegerType)()
-  val hgmInt = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
-    HistogramBin(3.0, 4.0, 2), HistogramBin(5.0, 6.0, 2),
-    HistogramBin(7.0, 8.0, 2), HistogramBin(9.0, 10.0, 2)))
   val colStatInt = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
+    nullCount = 0, avgLen = 4, maxLen = 4)
 
-  // column cbool has only 2 distinct values in 10 rows
+  // column cbool has only 2 distinct values
   val attrBool = AttributeReference("cbool", BooleanType)()
-  val hgmBool = Histogram(2.0, Array(HistogramBin(0.0, 0.0, 1),
-    HistogramBin(0.0, 0.0, 1), HistogramBin(0.0, 1.0, 2),
-    HistogramBin(1.0, 1.0, 1), HistogramBin(1.0, 1.0, 1)))
   val colStatBool = ColumnStat(distinctCount = 2, min = Some(false), max = Some(true),
-    nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))
+    nullCount = 0, avgLen = 1, maxLen = 1)
 
   // column cdate has 10 values from 2017-01-01 through 2017-01-10.
   val dMin = DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-01"))
   val dMax = DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-10"))
   val attrDate = AttributeReference("cdate", DateType)()
-  val hgmDate = Histogram(2.0, Array(
-    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-01")).toDouble,
-      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-02")).toDouble, 2),
-    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-03")).toDouble,
-      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-04")).toDouble, 2),
-    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-05")).toDouble,
-      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-06")).toDouble, 2),
-    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-07")).toDouble,
-      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-08")).toDouble, 2),
-    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-09")).toDouble,
-      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-10")).toDouble, 2)))
   val colStatDate = ColumnStat(distinctCount = 10, min = Some(dMin), max = Some(dMax),
-    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))
+    nullCount = 0, avgLen = 4, maxLen = 4)
 
   // column cdecimal has 4 values from 0.20 through 0.80 at increment of 0.20.
   val decMin = Decimal("0.200000000000000000")
   val decMax = Decimal("0.800000000000000000")
   val attrDecimal = AttributeReference("cdecimal", DecimalType(18, 18))()
-  val hgmDecimal = Histogram(1.0, Array(
-    HistogramBin(Decimal("0.200000000000000000").toDouble,
-      Decimal("0.200000000000000000").toDouble, 1),
-    HistogramBin(Decimal("0.400000000000000000").toDouble,
-      Decimal("0.400000000000000000").toDouble, 1),
-    HistogramBin(Decimal("0.600000000000000000").toDouble,
-      Decimal("0.600000000000000000").toDouble, 1),
-    HistogramBin(Decimal("0.800000000000000000").toDouble,
-      Decimal("0.800000000000000000").toDouble, 1)))
   val colStatDecimal = ColumnStat(distinctCount = 4, min = Some(decMin), max = Some(decMax),
-    nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDecimal))
+    nullCount = 0, avgLen = 8, maxLen = 8)
 
   // column cdouble has 10 double values: 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
   val attrDouble = AttributeReference("cdouble", DoubleType)()
-  val hgmDouble = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
-    HistogramBin(3.0, 4.0, 2), HistogramBin(5.0, 6.0, 2),
-    HistogramBin(7.0, 8.0, 2), HistogramBin(9.0, 10.0, 2)))
   val colStatDouble = ColumnStat(distinctCount = 10, min = Some(1.0), max = Some(10.0),
-    nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDouble))
+    nullCount = 0, avgLen = 8, maxLen = 8)
 
   // column cstring has 10 String values:
   // "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9"
   val attrString = AttributeReference("cstring", StringType)()
   val colStatString = ColumnStat(distinctCount = 10, min = None, max = None,
-    nullCount = 0, avgLen = 2, maxLen = 2, histogram = None)
+    nullCount = 0, avgLen = 2, maxLen = 2)
 
   // column cint2 has values: 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
   // Hence, distinctCount:10, min:7, max:16, nullCount:0, avgLen:4, maxLen:4
   // This column is created to test "cint < cint2
   val attrInt2 = AttributeReference("cint2", IntegerType)()
-  val hgmInt2 = Histogram(2.0, Array(HistogramBin(7.0, 8.0, 2),
-    HistogramBin(9.0, 10.0, 2), HistogramBin(11.0, 12.0, 2),
-    HistogramBin(13.0, 14.0, 2), HistogramBin(15.0, 16.0, 2)))
   val colStatInt2 = ColumnStat(distinctCount = 10, min = Some(7), max = Some(16),
-    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))
+    nullCount = 0, avgLen = 4, maxLen = 4)
 
   // column cint3 has values: 30, 31, 32, 33, 34, 35, 36, 37, 38, 39
   // Hence, distinctCount:10, min:30, max:39, nullCount:0, avgLen:4, maxLen:4
   // This column is created to test "cint = cint3 without overlap at all.
   val attrInt3 = AttributeReference("cint3", IntegerType)()
-  val hgmInt3 = Histogram(2.0, Array(HistogramBin(30.0, 31.0, 2),
-    HistogramBin(32.0, 33.0, 2), HistogramBin(34.0, 35.0, 2),
-    HistogramBin(36.0, 37.0, 2), HistogramBin(38.0, 39.0, 2)))
   val colStatInt3 = ColumnStat(distinctCount = 10, min = Some(30), max = Some(39),
-    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt3))
+    nullCount = 0, avgLen = 4, maxLen = 4)
 
   // column cint4 has values in the range from 1 to 10
   // distinctCount:10, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
   // This column is created to test complete overlap
   val attrInt4 = AttributeReference("cint4", IntegerType)()
-  val hgmInt4 = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
-    HistogramBin(3.0, 4.0, 2), HistogramBin(5.0, 6.0, 2),
-    HistogramBin(7.0, 8.0, 2), HistogramBin(9.0, 10.0, 2)))
   val colStatInt4 = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4))
+    nullCount = 0, avgLen = 4, maxLen = 4)
+
+
+  // Suppose our test table has 10 rows and 6 columns.
+  // column cint has values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 with histogram.
+  // Hence, distinctCount:10, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
+  val attrIntHgm = AttributeReference("cintHgm", IntegerType)()
+  val hgmInt = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
+    HistogramBin(2.0, 4.0, 2), HistogramBin(4.0, 6.0, 2),
+    HistogramBin(6.0, 8.0, 2), HistogramBin(8.0, 10.0, 2)))
+  val colStatIntHgm = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
 
   val attributeMap = AttributeMap(Seq(
     attrInt -> colStatInt,
@@ -138,7 +111,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     attrString -> colStatString,
     attrInt2 -> colStatInt2,
     attrInt3 -> colStatInt3,
-    attrInt4 -> colStatInt4
+    attrInt4 -> colStatInt4,
+    attrIntHgm -> colStatIntHgm
   ))
 
   test("true") {
@@ -196,8 +170,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(And(LessThan(attrInt, Literal(3)), Literal(null, IntegerType)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
-      Seq(attrInt -> colStatInt.copy(distinctCount = 7)),
-      expectedRowCount = 7)
+      Seq(attrInt -> colStatInt.copy(distinctCount = 8)),
+      expectedRowCount = 8)
   }
 
   test("Not(cint < 3 OR null)") {
@@ -212,15 +186,15 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(And(LessThan(attrInt, Literal(3)), Not(Literal(null, IntegerType))))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
-      Seq(attrInt -> colStatInt.copy(distinctCount = 7)),
-      expectedRowCount = 7)
+      Seq(attrInt -> colStatInt.copy(distinctCount = 8)),
+      expectedRowCount = 8)
   }
 
   test("cint = 2") {
     validateEstimatedStats(
       Filter(EqualTo(attrInt, Literal(2)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 1)
   }
 
@@ -228,7 +202,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualNullSafe(attrInt, Literal(2)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 1)
   }
 
@@ -244,7 +218,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, Literal(3)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 3)
   }
 
@@ -260,7 +234,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThanOrEqual(attrInt, Literal(3)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 3)
   }
 
@@ -268,7 +242,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThan(attrInt, Literal(6)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 5, min = Some(6), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 5)
   }
 
@@ -284,7 +258,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThanOrEqual(attrInt, Literal(6)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 5, min = Some(6), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 5)
   }
 
@@ -299,7 +273,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(IsNotNull(attrInt), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 10)
   }
 
@@ -318,7 +292,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(3), max = Some(6),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 4)
   }
 
@@ -342,8 +316,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(Or(LessThanOrEqual(attrInt, Literal(3)), GreaterThan(attrInt, Literal(6))))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
-      Seq(attrInt -> colStatInt.copy(distinctCount = 4)),
-      expectedRowCount = 4)
+      Seq(attrInt -> colStatInt.copy(distinctCount = 5)),
+      expectedRowCount = 5)
   }
 
   test("Not(cint = 3 AND cstring < 'A8')") {
@@ -367,7 +341,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(InSet(attrInt, Set(3, 4, 5)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 3, min = Some(3), max = Some(5),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 3)
   }
 
@@ -382,7 +356,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(InSet(attrBool, Set(true)), childStatsTestPlan(Seq(attrBool), 10L)),
       Seq(attrBool -> ColumnStat(distinctCount = 1, min = Some(true), max = Some(true),
-        nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))),
+        nullCount = 0, avgLen = 1, maxLen = 1)),
       expectedRowCount = 5)
   }
 
@@ -390,16 +364,16 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualTo(attrBool, Literal(true)), childStatsTestPlan(Seq(attrBool), 10L)),
       Seq(attrBool -> ColumnStat(distinctCount = 1, min = Some(true), max = Some(true),
-        nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))),
+        nullCount = 0, avgLen = 1, maxLen = 1)),
       expectedRowCount = 5)
   }
 
   test("cbool > false") {
     validateEstimatedStats(
       Filter(GreaterThan(attrBool, Literal(false)), childStatsTestPlan(Seq(attrBool), 10L)),
-      Seq(attrBool -> ColumnStat(distinctCount = 2, min = Some(false), max = Some(true),
-        nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))),
-      expectedRowCount = 6)
+      Seq(attrBool -> ColumnStat(distinctCount = 1, min = Some(true), max = Some(true),
+        nullCount = 0, avgLen = 1, maxLen = 1)),
+      expectedRowCount = 5)
   }
 
   test("cdate = cast('2017-01-02' AS DATE)") {
@@ -408,7 +382,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(EqualTo(attrDate, Literal(d20170102, DateType)),
         childStatsTestPlan(Seq(attrDate), 10L)),
       Seq(attrDate -> ColumnStat(distinctCount = 1, min = Some(d20170102), max = Some(d20170102),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 1)
   }
 
@@ -418,7 +392,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(LessThan(attrDate, Literal(d20170103, DateType)),
         childStatsTestPlan(Seq(attrDate), 10L)),
       Seq(attrDate -> ColumnStat(distinctCount = 3, min = Some(dMin), max = Some(d20170103),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 3)
   }
 
@@ -431,7 +405,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(In(attrDate, Seq(Literal(d20170103, DateType), Literal(d20170104, DateType),
         Literal(d20170105, DateType))), childStatsTestPlan(Seq(attrDate), 10L)),
       Seq(attrDate -> ColumnStat(distinctCount = 3, min = Some(d20170103), max = Some(d20170105),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 3)
   }
 
@@ -441,7 +415,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(EqualTo(attrDecimal, Literal(dec_0_40)),
         childStatsTestPlan(Seq(attrDecimal), 4L)),
       Seq(attrDecimal -> ColumnStat(distinctCount = 1, min = Some(dec_0_40), max = Some(dec_0_40),
-        nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDecimal))),
+        nullCount = 0, avgLen = 8, maxLen = 8)),
       expectedRowCount = 1)
   }
 
@@ -451,7 +425,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(LessThan(attrDecimal, Literal(dec_0_60)),
         childStatsTestPlan(Seq(attrDecimal), 4L)),
       Seq(attrDecimal -> ColumnStat(distinctCount = 3, min = Some(decMin), max = Some(dec_0_60),
-        nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDecimal))),
+        nullCount = 0, avgLen = 8, maxLen = 8)),
       expectedRowCount = 3)
   }
 
@@ -459,7 +433,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrDouble, Literal(3.0)), childStatsTestPlan(Seq(attrDouble), 10L)),
       Seq(attrDouble -> ColumnStat(distinctCount = 3, min = Some(1.0), max = Some(3.0),
-        nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDouble))),
+        nullCount = 0, avgLen = 8, maxLen = 8)),
       expectedRowCount = 3)
   }
 
@@ -467,7 +441,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualTo(attrString, Literal("A2")), childStatsTestPlan(Seq(attrString), 10L)),
       Seq(attrString -> ColumnStat(distinctCount = 1, min = None, max = None,
-        nullCount = 0, avgLen = 2, maxLen = 2, histogram = None)),
+        nullCount = 0, avgLen = 2, maxLen = 2)),
       expectedRowCount = 1)
   }
 
@@ -475,7 +449,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrString, Literal("A2")), childStatsTestPlan(Seq(attrString), 10L)),
       Seq(attrString -> ColumnStat(distinctCount = 10, min = None, max = None,
-        nullCount = 0, avgLen = 2, maxLen = 2, histogram = None)),
+        nullCount = 0, avgLen = 2, maxLen = 2)),
       expectedRowCount = 10)
   }
 
@@ -485,7 +459,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     // For example, column has only 2 distinct values 1 and 6.
     // The predicate is: column IN (1, 2, 3, 4, 5).
     val cornerChildColStatInt = ColumnStat(distinctCount = 2, min = Some(1), max = Some(6),
-      nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
+      nullCount = 0, avgLen = 4, maxLen = 4)
     val cornerChildStatsTestplan = StatsTestPlan(
       outputList = Seq(attrInt),
       rowCount = 2L,
@@ -494,20 +468,15 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(InSet(attrInt, Set(1, 2, 3, 4, 5)), cornerChildStatsTestplan),
       Seq(attrInt -> ColumnStat(distinctCount = 2, min = Some(1), max = Some(5),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+        nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 2)
   }
 
-  /* TODO: We should enable this test case after JoinEstimation.scala has supported histogram.
-  This is because there is a dependency here.
   // This is a limitation test. We should remove it after the limitation is removed.
   test("don't estimate IsNull or IsNotNull if the child is a non-leaf node") {
     val attrIntLargerRange = AttributeReference("c1", IntegerType)()
-    val hgmIntLargerRange = Histogram(4.0, Array(HistogramBin(1.0, 4.0, 4),
-      HistogramBin(5.0, 8.0, 4), HistogramBin(9.0, 12.0, 4),
-      HistogramBin(13.0, 16.0, 4), HistogramBin(17.0, 20.0, 4)))
     val colStatIntLargerRange = ColumnStat(distinctCount = 20, min = Some(1), max = Some(20),
-      nullCount = 10, avgLen = 4, maxLen = 4, histogram = Some(hgmIntLargerRange))
+      nullCount = 10, avgLen = 4, maxLen = 4)
     val smallerTable = childStatsTestPlan(Seq(attrInt), 10L)
     val largerTable = StatsTestPlan(
       outputList = Seq(attrIntLargerRange),
@@ -524,16 +493,15 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
         expectedRowCount = 30)
     }
   }
-  */
 
   test("cint = cint2") {
     // partial overlap case
     validateEstimatedStats(
       Filter(EqualTo(attrInt, attrInt2), childStatsTestPlan(Seq(attrInt, attrInt2), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+        nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt2 -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))),
+          nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 4)
   }
 
@@ -542,9 +510,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThan(attrInt, attrInt2), childStatsTestPlan(Seq(attrInt, attrInt2), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+        nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt2 -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))),
+          nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 4)
   }
 
@@ -553,9 +521,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, attrInt2), childStatsTestPlan(Seq(attrInt, attrInt2), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+        nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt2 -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(16),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))),
+          nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 4)
   }
 
@@ -564,9 +532,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualTo(attrInt, attrInt4), childStatsTestPlan(Seq(attrInt, attrInt4), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+        nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt4 -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4))),
+          nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 10)
   }
 
@@ -575,9 +543,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, attrInt4), childStatsTestPlan(Seq(attrInt, attrInt4), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+        nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt4 -> ColumnStat(distinctCount = 4, min = Some(1), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4))),
+          nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 4)
   }
 
@@ -594,9 +562,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, attrInt3), childStatsTestPlan(Seq(attrInt, attrInt3), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+        nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt3 -> ColumnStat(distinctCount = 10, min = Some(30), max = Some(39),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt3))),
+          nullCount = 0, avgLen = 4, maxLen = 4)),
       expectedRowCount = 10)
   }
 
@@ -615,11 +583,117 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(condition, childStatsTestPlan(Seq(attrInt, attrInt4, attrString), 10L)),
       Seq(
         attrInt -> ColumnStat(distinctCount = 5, min = Some(3), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
+          nullCount = 0, avgLen = 4, maxLen = 4),
         attrInt4 -> ColumnStat(distinctCount = 5, min = Some(1), max = Some(6),
-          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4)),
+          nullCount = 0, avgLen = 4, maxLen = 4),
         attrString -> colStatString.copy(distinctCount = 5)),
       expectedRowCount = 5)
+  }
+
+  // The following test cases have histogram information collected for the test column
+  test("Not(cintHgm < 3 AND null)") {
+    val condition = Not(And(LessThan(attrIntHgm, Literal(3)), Literal(null, IntegerType)))
+    validateEstimatedStats(
+      Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 7)),
+      expectedRowCount = 7)
+  }
+
+  test("cintHgm = 2") {
+    validateEstimatedStats(
+      Filter(EqualTo(attrIntHgm, Literal(2)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 1)
+  }
+
+  test("cintHgm = 0") {
+    // This is an out-of-range case since 0 is outside the range [min, max]
+    validateEstimatedStats(
+      Filter(EqualTo(attrIntHgm, Literal(0)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintHgm < 3") {
+    validateEstimatedStats(
+      Filter(LessThan(attrIntHgm, Literal(3)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 3)
+  }
+
+  test("cintHgm < 0") {
+    // This is a corner case since literal 0 is smaller than min.
+    validateEstimatedStats(
+      Filter(LessThan(attrIntHgm, Literal(0)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintHgm <= 3") {
+    validateEstimatedStats(
+      Filter(LessThanOrEqual(attrIntHgm, Literal(3)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 3)
+  }
+
+  test("cintHgm > 6") {
+    validateEstimatedStats(
+      Filter(GreaterThan(attrIntHgm, Literal(6)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 4, min = Some(6), max = Some(10),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 4)
+  }
+
+  test("cintHgm > 10") {
+    // This is a corner case since max value is 10.
+    validateEstimatedStats(
+      Filter(GreaterThan(attrIntHgm, Literal(10)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintHgm >= 6") {
+    validateEstimatedStats(
+      Filter(GreaterThanOrEqual(attrIntHgm, Literal(6)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 5, min = Some(6), max = Some(10),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 5)
+  }
+
+  test("cintHgm IS NULL") {
+    validateEstimatedStats(
+      Filter(IsNull(attrIntHgm), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintHgm IS NOT NULL") {
+    validateEstimatedStats(
+      Filter(IsNotNull(attrIntHgm), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 10)
+  }
+
+  test("cintHgm > 3 AND cintHgm <= 6") {
+    val condition = And(GreaterThan(attrIntHgm,
+      Literal(3)), LessThanOrEqual(attrIntHgm, Literal(6)))
+    validateEstimatedStats(
+      Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 4, min = Some(3), max = Some(6),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
+      expectedRowCount = 4)
+  }
+
+  test("cintHgm = 3 OR cintHgm = 6") {
+    val condition = Or(EqualTo(attrIntHgm, Literal(3)), EqualTo(attrIntHgm, Literal(6)))
+    validateEstimatedStats(
+      Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 2)),
+      expectedRowCount = 2)
   }
 
   private def childStatsTestPlan(outList: Seq[Attribute], tableRowCount: BigInt): StatsTestPlan = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -22,7 +22,7 @@ import java.sql.Date
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.LeftOuter
-import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Filter, Join, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
@@ -37,59 +37,97 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   // column cint has values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
   // Hence, distinctCount:10, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
   val attrInt = AttributeReference("cint", IntegerType)()
+  val hgmInt = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
+    HistogramBin(3.0, 4.0, 2), HistogramBin(5.0, 6.0, 2),
+    HistogramBin(7.0, 8.0, 2), HistogramBin(9.0, 10.0, 2)))
   val colStatInt = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-    nullCount = 0, avgLen = 4, maxLen = 4)
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
 
-  // column cbool has only 2 distinct values
+  // column cbool has only 2 distinct values in 10 rows
   val attrBool = AttributeReference("cbool", BooleanType)()
+  val hgmBool = Histogram(2.0, Array(HistogramBin(0.0, 0.0, 1),
+    HistogramBin(0.0, 0.0, 1), HistogramBin(0.0, 1.0, 2),
+    HistogramBin(1.0, 1.0, 1), HistogramBin(1.0, 1.0, 1)))
   val colStatBool = ColumnStat(distinctCount = 2, min = Some(false), max = Some(true),
-    nullCount = 0, avgLen = 1, maxLen = 1)
+    nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))
 
   // column cdate has 10 values from 2017-01-01 through 2017-01-10.
   val dMin = DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-01"))
   val dMax = DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-10"))
   val attrDate = AttributeReference("cdate", DateType)()
+  val hgmDate = Histogram(2.0, Array(
+    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-01")).toDouble,
+      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-02")).toDouble, 2),
+    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-03")).toDouble,
+      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-04")).toDouble, 2),
+    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-05")).toDouble,
+      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-06")).toDouble, 2),
+    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-07")).toDouble,
+      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-08")).toDouble, 2),
+    HistogramBin(DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-09")).toDouble,
+      DateTimeUtils.fromJavaDate(Date.valueOf("2017-01-10")).toDouble, 2)))
   val colStatDate = ColumnStat(distinctCount = 10, min = Some(dMin), max = Some(dMax),
-    nullCount = 0, avgLen = 4, maxLen = 4)
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))
 
   // column cdecimal has 4 values from 0.20 through 0.80 at increment of 0.20.
   val decMin = Decimal("0.200000000000000000")
   val decMax = Decimal("0.800000000000000000")
   val attrDecimal = AttributeReference("cdecimal", DecimalType(18, 18))()
+  val hgmDecimal = Histogram(1.0, Array(
+    HistogramBin(Decimal("0.200000000000000000").toDouble,
+      Decimal("0.200000000000000000").toDouble, 1),
+    HistogramBin(Decimal("0.400000000000000000").toDouble,
+      Decimal("0.400000000000000000").toDouble, 1),
+    HistogramBin(Decimal("0.600000000000000000").toDouble,
+      Decimal("0.600000000000000000").toDouble, 1),
+    HistogramBin(Decimal("0.800000000000000000").toDouble,
+      Decimal("0.800000000000000000").toDouble, 1)))
   val colStatDecimal = ColumnStat(distinctCount = 4, min = Some(decMin), max = Some(decMax),
-    nullCount = 0, avgLen = 8, maxLen = 8)
+    nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDecimal))
 
   // column cdouble has 10 double values: 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
   val attrDouble = AttributeReference("cdouble", DoubleType)()
+  val hgmDouble = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
+    HistogramBin(3.0, 4.0, 2), HistogramBin(5.0, 6.0, 2),
+    HistogramBin(7.0, 8.0, 2), HistogramBin(9.0, 10.0, 2)))
   val colStatDouble = ColumnStat(distinctCount = 10, min = Some(1.0), max = Some(10.0),
-    nullCount = 0, avgLen = 8, maxLen = 8)
+    nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDouble))
 
   // column cstring has 10 String values:
   // "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9"
   val attrString = AttributeReference("cstring", StringType)()
   val colStatString = ColumnStat(distinctCount = 10, min = None, max = None,
-    nullCount = 0, avgLen = 2, maxLen = 2)
+    nullCount = 0, avgLen = 2, maxLen = 2, histogram = None)
 
   // column cint2 has values: 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
   // Hence, distinctCount:10, min:7, max:16, nullCount:0, avgLen:4, maxLen:4
   // This column is created to test "cint < cint2
   val attrInt2 = AttributeReference("cint2", IntegerType)()
+  val hgmInt2 = Histogram(2.0, Array(HistogramBin(7.0, 8.0, 2),
+    HistogramBin(9.0, 10.0, 2), HistogramBin(11.0, 12.0, 2),
+    HistogramBin(13.0, 14.0, 2), HistogramBin(15.0, 16.0, 2)))
   val colStatInt2 = ColumnStat(distinctCount = 10, min = Some(7), max = Some(16),
-    nullCount = 0, avgLen = 4, maxLen = 4)
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))
 
   // column cint3 has values: 30, 31, 32, 33, 34, 35, 36, 37, 38, 39
   // Hence, distinctCount:10, min:30, max:39, nullCount:0, avgLen:4, maxLen:4
   // This column is created to test "cint = cint3 without overlap at all.
   val attrInt3 = AttributeReference("cint3", IntegerType)()
+  val hgmInt3 = Histogram(2.0, Array(HistogramBin(30.0, 31.0, 2),
+    HistogramBin(32.0, 33.0, 2), HistogramBin(34.0, 35.0, 2),
+    HistogramBin(36.0, 37.0, 2), HistogramBin(38.0, 39.0, 2)))
   val colStatInt3 = ColumnStat(distinctCount = 10, min = Some(30), max = Some(39),
-    nullCount = 0, avgLen = 4, maxLen = 4)
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt3))
 
   // column cint4 has values in the range from 1 to 10
   // distinctCount:10, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
   // This column is created to test complete overlap
   val attrInt4 = AttributeReference("cint4", IntegerType)()
+  val hgmInt4 = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
+    HistogramBin(3.0, 4.0, 2), HistogramBin(5.0, 6.0, 2),
+    HistogramBin(7.0, 8.0, 2), HistogramBin(9.0, 10.0, 2)))
   val colStatInt4 = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-    nullCount = 0, avgLen = 4, maxLen = 4)
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4))
 
   val attributeMap = AttributeMap(Seq(
     attrInt -> colStatInt,
@@ -158,8 +196,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(And(LessThan(attrInt, Literal(3)), Literal(null, IntegerType)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
-      Seq(attrInt -> colStatInt.copy(distinctCount = 8)),
-      expectedRowCount = 8)
+      Seq(attrInt -> colStatInt.copy(distinctCount = 7)),
+      expectedRowCount = 7)
   }
 
   test("Not(cint < 3 OR null)") {
@@ -174,15 +212,15 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(And(LessThan(attrInt, Literal(3)), Not(Literal(null, IntegerType))))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
-      Seq(attrInt -> colStatInt.copy(distinctCount = 8)),
-      expectedRowCount = 8)
+      Seq(attrInt -> colStatInt.copy(distinctCount = 7)),
+      expectedRowCount = 7)
   }
 
   test("cint = 2") {
     validateEstimatedStats(
       Filter(EqualTo(attrInt, Literal(2)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 1)
   }
 
@@ -190,7 +228,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualNullSafe(attrInt, Literal(2)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 1)
   }
 
@@ -206,7 +244,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, Literal(3)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 3)
   }
 
@@ -222,7 +260,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThanOrEqual(attrInt, Literal(3)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 3)
   }
 
@@ -230,7 +268,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThan(attrInt, Literal(6)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 5, min = Some(6), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 5)
   }
 
@@ -246,7 +284,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThanOrEqual(attrInt, Literal(6)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 5, min = Some(6), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 5)
   }
 
@@ -261,7 +299,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(IsNotNull(attrInt), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 10)
   }
 
@@ -280,7 +318,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(3), max = Some(6),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 4)
   }
 
@@ -304,8 +342,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(Or(LessThanOrEqual(attrInt, Literal(3)), GreaterThan(attrInt, Literal(6))))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrInt), 10L)),
-      Seq(attrInt -> colStatInt.copy(distinctCount = 5)),
-      expectedRowCount = 5)
+      Seq(attrInt -> colStatInt.copy(distinctCount = 4)),
+      expectedRowCount = 4)
   }
 
   test("Not(cint = 3 AND cstring < 'A8')") {
@@ -329,7 +367,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(InSet(attrInt, Set(3, 4, 5)), childStatsTestPlan(Seq(attrInt), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 3, min = Some(3), max = Some(5),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 3)
   }
 
@@ -344,7 +382,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(InSet(attrBool, Set(true)), childStatsTestPlan(Seq(attrBool), 10L)),
       Seq(attrBool -> ColumnStat(distinctCount = 1, min = Some(true), max = Some(true),
-        nullCount = 0, avgLen = 1, maxLen = 1)),
+        nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))),
       expectedRowCount = 5)
   }
 
@@ -352,16 +390,16 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualTo(attrBool, Literal(true)), childStatsTestPlan(Seq(attrBool), 10L)),
       Seq(attrBool -> ColumnStat(distinctCount = 1, min = Some(true), max = Some(true),
-        nullCount = 0, avgLen = 1, maxLen = 1)),
+        nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))),
       expectedRowCount = 5)
   }
 
   test("cbool > false") {
     validateEstimatedStats(
       Filter(GreaterThan(attrBool, Literal(false)), childStatsTestPlan(Seq(attrBool), 10L)),
-      Seq(attrBool -> ColumnStat(distinctCount = 1, min = Some(true), max = Some(true),
-        nullCount = 0, avgLen = 1, maxLen = 1)),
-      expectedRowCount = 5)
+      Seq(attrBool -> ColumnStat(distinctCount = 2, min = Some(false), max = Some(true),
+        nullCount = 0, avgLen = 1, maxLen = 1, histogram = Some(hgmBool))),
+      expectedRowCount = 6)
   }
 
   test("cdate = cast('2017-01-02' AS DATE)") {
@@ -370,7 +408,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(EqualTo(attrDate, Literal(d20170102, DateType)),
         childStatsTestPlan(Seq(attrDate), 10L)),
       Seq(attrDate -> ColumnStat(distinctCount = 1, min = Some(d20170102), max = Some(d20170102),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))),
       expectedRowCount = 1)
   }
 
@@ -380,7 +418,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(LessThan(attrDate, Literal(d20170103, DateType)),
         childStatsTestPlan(Seq(attrDate), 10L)),
       Seq(attrDate -> ColumnStat(distinctCount = 3, min = Some(dMin), max = Some(d20170103),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))),
       expectedRowCount = 3)
   }
 
@@ -393,7 +431,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(In(attrDate, Seq(Literal(d20170103, DateType), Literal(d20170104, DateType),
         Literal(d20170105, DateType))), childStatsTestPlan(Seq(attrDate), 10L)),
       Seq(attrDate -> ColumnStat(distinctCount = 3, min = Some(d20170103), max = Some(d20170105),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmDate))),
       expectedRowCount = 3)
   }
 
@@ -403,7 +441,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(EqualTo(attrDecimal, Literal(dec_0_40)),
         childStatsTestPlan(Seq(attrDecimal), 4L)),
       Seq(attrDecimal -> ColumnStat(distinctCount = 1, min = Some(dec_0_40), max = Some(dec_0_40),
-        nullCount = 0, avgLen = 8, maxLen = 8)),
+        nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDecimal))),
       expectedRowCount = 1)
   }
 
@@ -413,7 +451,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(LessThan(attrDecimal, Literal(dec_0_60)),
         childStatsTestPlan(Seq(attrDecimal), 4L)),
       Seq(attrDecimal -> ColumnStat(distinctCount = 3, min = Some(decMin), max = Some(dec_0_60),
-        nullCount = 0, avgLen = 8, maxLen = 8)),
+        nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDecimal))),
       expectedRowCount = 3)
   }
 
@@ -421,7 +459,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrDouble, Literal(3.0)), childStatsTestPlan(Seq(attrDouble), 10L)),
       Seq(attrDouble -> ColumnStat(distinctCount = 3, min = Some(1.0), max = Some(3.0),
-        nullCount = 0, avgLen = 8, maxLen = 8)),
+        nullCount = 0, avgLen = 8, maxLen = 8, histogram = Some(hgmDouble))),
       expectedRowCount = 3)
   }
 
@@ -429,7 +467,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualTo(attrString, Literal("A2")), childStatsTestPlan(Seq(attrString), 10L)),
       Seq(attrString -> ColumnStat(distinctCount = 1, min = None, max = None,
-        nullCount = 0, avgLen = 2, maxLen = 2)),
+        nullCount = 0, avgLen = 2, maxLen = 2, histogram = None)),
       expectedRowCount = 1)
   }
 
@@ -437,7 +475,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrString, Literal("A2")), childStatsTestPlan(Seq(attrString), 10L)),
       Seq(attrString -> ColumnStat(distinctCount = 10, min = None, max = None,
-        nullCount = 0, avgLen = 2, maxLen = 2)),
+        nullCount = 0, avgLen = 2, maxLen = 2, histogram = None)),
       expectedRowCount = 10)
   }
 
@@ -447,7 +485,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     // For example, column has only 2 distinct values 1 and 6.
     // The predicate is: column IN (1, 2, 3, 4, 5).
     val cornerChildColStatInt = ColumnStat(distinctCount = 2, min = Some(1), max = Some(6),
-      nullCount = 0, avgLen = 4, maxLen = 4)
+      nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
     val cornerChildStatsTestplan = StatsTestPlan(
       outputList = Seq(attrInt),
       rowCount = 2L,
@@ -456,15 +494,20 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(InSet(attrInt, Set(1, 2, 3, 4, 5)), cornerChildStatsTestplan),
       Seq(attrInt -> ColumnStat(distinctCount = 2, min = Some(1), max = Some(5),
-        nullCount = 0, avgLen = 4, maxLen = 4)),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 2)
   }
 
+  /* TODO: We should enable this test case after JoinEstimation.scala has supported histogram.
+  This is because there is a dependency here.
   // This is a limitation test. We should remove it after the limitation is removed.
   test("don't estimate IsNull or IsNotNull if the child is a non-leaf node") {
     val attrIntLargerRange = AttributeReference("c1", IntegerType)()
+    val hgmIntLargerRange = Histogram(4.0, Array(HistogramBin(1.0, 4.0, 4),
+      HistogramBin(5.0, 8.0, 4), HistogramBin(9.0, 12.0, 4),
+      HistogramBin(13.0, 16.0, 4), HistogramBin(17.0, 20.0, 4)))
     val colStatIntLargerRange = ColumnStat(distinctCount = 20, min = Some(1), max = Some(20),
-      nullCount = 10, avgLen = 4, maxLen = 4)
+      nullCount = 10, avgLen = 4, maxLen = 4, histogram = Some(hgmIntLargerRange))
     val smallerTable = childStatsTestPlan(Seq(attrInt), 10L)
     val largerTable = StatsTestPlan(
       outputList = Seq(attrIntLargerRange),
@@ -481,15 +524,16 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
         expectedRowCount = 30)
     }
   }
+  */
 
   test("cint = cint2") {
     // partial overlap case
     validateEstimatedStats(
       Filter(EqualTo(attrInt, attrInt2), childStatsTestPlan(Seq(attrInt, attrInt2), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt2 -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4)),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))),
       expectedRowCount = 4)
   }
 
@@ -498,9 +542,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThan(attrInt, attrInt2), childStatsTestPlan(Seq(attrInt, attrInt2), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt2 -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4)),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))),
       expectedRowCount = 4)
   }
 
@@ -509,9 +553,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, attrInt2), childStatsTestPlan(Seq(attrInt, attrInt2), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt2 -> ColumnStat(distinctCount = 4, min = Some(7), max = Some(16),
-          nullCount = 0, avgLen = 4, maxLen = 4)),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt2))),
       expectedRowCount = 4)
   }
 
@@ -520,9 +564,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(EqualTo(attrInt, attrInt4), childStatsTestPlan(Seq(attrInt, attrInt4), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt4 -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4)),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4))),
       expectedRowCount = 10)
   }
 
@@ -531,9 +575,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, attrInt4), childStatsTestPlan(Seq(attrInt, attrInt4), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 4, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt4 -> ColumnStat(distinctCount = 4, min = Some(1), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4)),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4))),
       expectedRowCount = 4)
   }
 
@@ -550,9 +594,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(LessThan(attrInt, attrInt3), childStatsTestPlan(Seq(attrInt, attrInt3), 10L)),
       Seq(attrInt -> ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt3 -> ColumnStat(distinctCount = 10, min = Some(30), max = Some(39),
-          nullCount = 0, avgLen = 4, maxLen = 4)),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt3))),
       expectedRowCount = 10)
   }
 
@@ -571,9 +615,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(condition, childStatsTestPlan(Seq(attrInt, attrInt4, attrString), 10L)),
       Seq(
         attrInt -> ColumnStat(distinctCount = 5, min = Some(3), max = Some(10),
-          nullCount = 0, avgLen = 4, maxLen = 4),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt)),
         attrInt4 -> ColumnStat(distinctCount = 5, min = Some(1), max = Some(6),
-          nullCount = 0, avgLen = 4, maxLen = 4),
+          nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt4)),
         attrString -> colStatString.copy(distinctCount = 5)),
       expectedRowCount = 5)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -604,7 +604,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(EqualTo(attrIntHgm, Literal(5)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
       Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(5), max = Some(5),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 4)
+      expectedRowCount = 3)
   }
 
   test("cintHgm = 0") {
@@ -661,21 +661,6 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Seq(attrIntHgm -> ColumnStat(distinctCount = 3, min = Some(6), max = Some(10),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 4)
-  }
-
-  test("cintHgm IS NULL") {
-    validateEstimatedStats(
-      Filter(IsNull(attrIntHgm), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Nil,
-      expectedRowCount = 0)
-  }
-
-  test("cintHgm IS NOT NULL") {
-    validateEstimatedStats(
-      Filter(IsNotNull(attrIntHgm), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 6, min = Some(1), max = Some(10),
-        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 10)
   }
 
   test("cintHgm > 3 AND cintHgm <= 6") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -101,14 +101,14 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   val colStatIntHgm = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
     nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
 
-  // column cintSkewHgm has values: 1, 4, 4, 5, 5, 5, 6, 6, 7, 10 with histogram.
+  // column cintSkewHgm has values: 1, 4, 4, 5, 5, 5, 5, 6, 6, 10 with histogram.
   // Note that cintSkewHgm has a skewed distribution with histogram information built.
-  // distinctCount:6, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
+  // distinctCount:5, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
   val attrIntSkewHgm = AttributeReference("cintSkewHgm", IntegerType)()
   val hgmIntSkew = Histogram(2.0, Array(HistogramBin(1.0, 4.0, 2),
     HistogramBin(4.0, 5.0, 2), HistogramBin(5.0, 5.0, 1),
-    HistogramBin(5.0, 6.0, 1), HistogramBin(6.0, 10.0, 2)))
-  val colStatIntSkewHgm = ColumnStat(distinctCount = 6, min = Some(1), max = Some(10),
+    HistogramBin(5.0, 6.0, 2), HistogramBin(6.0, 10.0, 2)))
+  val colStatIntSkewHgm = ColumnStat(distinctCount = 5, min = Some(1), max = Some(10),
     nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))
 
   val attributeMap = AttributeMap(Seq(
@@ -610,10 +610,10 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 7)
   }
 
-  test("cintHgm = 2") {
+  test("cintHgm = 5") {
     validateEstimatedStats(
-      Filter(EqualTo(attrIntHgm, Literal(2)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
+      Filter(EqualTo(attrIntHgm, Literal(5)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(5), max = Some(5),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
       expectedRowCount = 1)
   }
@@ -688,8 +688,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Or(EqualTo(attrIntHgm, Literal(3)), EqualTo(attrIntHgm, Literal(6)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 2)),
-      expectedRowCount = 2)
+      Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 3)),
+      expectedRowCount = 3)
   }
 
   // The following test cases have histogram information collected for the test column with
@@ -698,7 +698,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     val condition = Not(And(LessThan(attrIntSkewHgm, Literal(3)), Literal(null, IntegerType)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
-      Seq(attrIntSkewHgm -> colStatIntSkewHgm.copy(distinctCount = 6)),
+      Seq(attrIntSkewHgm -> colStatIntSkewHgm.copy(distinctCount = 5)),
       expectedRowCount = 9)
   }
 
@@ -707,7 +707,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Filter(EqualTo(attrIntSkewHgm, Literal(5)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
       Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 1, min = Some(5), max = Some(5),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
-      expectedRowCount = 3)
+      expectedRowCount = 4)
   }
 
   test("cintSkewHgm = 0") {
@@ -746,7 +746,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   test("cintSkewHgm > 6") {
     validateEstimatedStats(
       Filter(GreaterThan(attrIntSkewHgm, Literal(6)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
-      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 2, min = Some(6), max = Some(10),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 1, min = Some(6), max = Some(10),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
       expectedRowCount = 2)
   }
@@ -764,9 +764,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(GreaterThanOrEqual(attrIntSkewHgm, Literal(6)),
         childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
-      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 3, min = Some(6), max = Some(10),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 2, min = Some(6), max = Some(10),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
-      expectedRowCount = 4)
+      expectedRowCount = 3)
   }
 
   test("cintSkewHgm > 3 AND cintSkewHgm <= 6") {
@@ -774,7 +774,7 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Literal(3)), LessThanOrEqual(attrIntSkewHgm, Literal(6)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
-      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 5, min = Some(3), max = Some(6),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 4, min = Some(3), max = Some(6),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
       expectedRowCount = 8)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -91,16 +91,25 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   val colStatInt4 = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
     nullCount = 0, avgLen = 4, maxLen = 4)
 
-
-  // column cintHgm has values: 1, 4, 4, 5, 5, 5, 6, 6, 7, 10 with histogram.
-  // Note that cintHgm has a skewed distribution.
-  // distinctCount:6, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
+  // column cintHgm has values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 with histogram.
+  // Note that cintHgm has an even distribution with histogram information built.
+  // Hence, distinctCount:10, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
   val attrIntHgm = AttributeReference("cintHgm", IntegerType)()
-  val hgmInt = Histogram(2.0, Array(HistogramBin(1.0, 4.0, 2),
+  val hgmInt = Histogram(2.0, Array(HistogramBin(1.0, 2.0, 2),
+    HistogramBin(2.0, 4.0, 2), HistogramBin(4.0, 6.0, 2),
+    HistogramBin(6.0, 8.0, 2), HistogramBin(8.0, 10.0, 2)))
+  val colStatIntHgm = ColumnStat(distinctCount = 10, min = Some(1), max = Some(10),
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
+
+  // column cintSkewHgm has values: 1, 4, 4, 5, 5, 5, 6, 6, 7, 10 with histogram.
+  // Note that cintSkewHgm has a skewed distribution with histogram information built.
+  // distinctCount:6, min:1, max:10, nullCount:0, avgLen:4, maxLen:4
+  val attrIntSkewHgm = AttributeReference("cintSkewHgm", IntegerType)()
+  val hgmIntSkew = Histogram(2.0, Array(HistogramBin(1.0, 4.0, 2),
     HistogramBin(4.0, 5.0, 2), HistogramBin(5.0, 5.0, 1),
     HistogramBin(5.0, 6.0, 1), HistogramBin(6.0, 10.0, 2)))
-  val colStatIntHgm = ColumnStat(distinctCount = 6, min = Some(1), max = Some(10),
-    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))
+  val colStatIntSkewHgm = ColumnStat(distinctCount = 6, min = Some(1), max = Some(10),
+    nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))
 
   val attributeMap = AttributeMap(Seq(
     attrInt -> colStatInt,
@@ -112,7 +121,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     attrInt2 -> colStatInt2,
     attrInt3 -> colStatInt3,
     attrInt4 -> colStatInt4,
-    attrIntHgm -> colStatIntHgm
+    attrIntHgm -> colStatIntHgm,
+    attrIntSkewHgm -> colStatIntSkewHgm
   ))
 
   test("true") {
@@ -590,21 +600,22 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 5)
   }
 
-  // The following test cases have histogram information collected for the test column
+  // The following test cases have histogram information collected for the test column with
+  // an even distribution
   test("Not(cintHgm < 3 AND null)") {
     val condition = Not(And(LessThan(attrIntHgm, Literal(3)), Literal(null, IntegerType)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 6)),
-      expectedRowCount = 9)
+      Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 7)),
+      expectedRowCount = 7)
   }
 
-  test("cintHgm = 5") {
+  test("cintHgm = 2") {
     validateEstimatedStats(
-      Filter(EqualTo(attrIntHgm, Literal(5)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(5), max = Some(5),
+      Filter(EqualTo(attrIntHgm, Literal(2)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(2), max = Some(2),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 3)
+      expectedRowCount = 1)
   }
 
   test("cintHgm = 0") {
@@ -618,9 +629,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   test("cintHgm < 3") {
     validateEstimatedStats(
       Filter(LessThan(attrIntHgm, Literal(3)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(1), max = Some(3),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 2)
+      expectedRowCount = 3)
   }
 
   test("cintHgm < 0") {
@@ -634,17 +645,17 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   test("cintHgm <= 3") {
     validateEstimatedStats(
       Filter(LessThanOrEqual(attrIntHgm, Literal(3)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 1, min = Some(1), max = Some(3),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 3, min = Some(1), max = Some(3),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 2)
+      expectedRowCount = 3)
   }
 
   test("cintHgm > 6") {
     validateEstimatedStats(
       Filter(GreaterThan(attrIntHgm, Literal(6)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 2, min = Some(6), max = Some(10),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 4, min = Some(6), max = Some(10),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 2)
+      expectedRowCount = 4)
   }
 
   test("cintHgm > 10") {
@@ -658,9 +669,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   test("cintHgm >= 6") {
     validateEstimatedStats(
       Filter(GreaterThanOrEqual(attrIntHgm, Literal(6)), childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 3, min = Some(6), max = Some(10),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 5, min = Some(6), max = Some(10),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 4)
+      expectedRowCount = 5)
   }
 
   test("cintHgm > 3 AND cintHgm <= 6") {
@@ -668,9 +679,9 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       Literal(3)), LessThanOrEqual(attrIntHgm, Literal(6)))
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
-      Seq(attrIntHgm -> ColumnStat(distinctCount = 5, min = Some(3), max = Some(6),
+      Seq(attrIntHgm -> ColumnStat(distinctCount = 4, min = Some(3), max = Some(6),
         nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmInt))),
-      expectedRowCount = 8)
+      expectedRowCount = 4)
   }
 
   test("cintHgm = 3 OR cintHgm = 6") {
@@ -678,6 +689,101 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     validateEstimatedStats(
       Filter(condition, childStatsTestPlan(Seq(attrIntHgm), 10L)),
       Seq(attrIntHgm -> colStatIntHgm.copy(distinctCount = 2)),
+      expectedRowCount = 2)
+  }
+
+  // The following test cases have histogram information collected for the test column with
+  // a skewed distribution.
+  test("Not(cintSkewHgm < 3 AND null)") {
+    val condition = Not(And(LessThan(attrIntSkewHgm, Literal(3)), Literal(null, IntegerType)))
+    validateEstimatedStats(
+      Filter(condition, childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> colStatIntSkewHgm.copy(distinctCount = 6)),
+      expectedRowCount = 9)
+  }
+
+  test("cintSkewHgm = 5") {
+    validateEstimatedStats(
+      Filter(EqualTo(attrIntSkewHgm, Literal(5)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 1, min = Some(5), max = Some(5),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
+      expectedRowCount = 3)
+  }
+
+  test("cintSkewHgm = 0") {
+    // This is an out-of-range case since 0 is outside the range [min, max]
+    validateEstimatedStats(
+      Filter(EqualTo(attrIntSkewHgm, Literal(0)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintSkewHgm < 3") {
+    validateEstimatedStats(
+      Filter(LessThan(attrIntSkewHgm, Literal(3)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 1, min = Some(1), max = Some(3),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
+      expectedRowCount = 2)
+  }
+
+  test("cintSkewHgm < 0") {
+    // This is a corner case since literal 0 is smaller than min.
+    validateEstimatedStats(
+      Filter(LessThan(attrIntSkewHgm, Literal(0)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintSkewHgm <= 3") {
+    validateEstimatedStats(
+      Filter(LessThanOrEqual(attrIntSkewHgm, Literal(3)),
+        childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 1, min = Some(1), max = Some(3),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
+      expectedRowCount = 2)
+  }
+
+  test("cintSkewHgm > 6") {
+    validateEstimatedStats(
+      Filter(GreaterThan(attrIntSkewHgm, Literal(6)), childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 2, min = Some(6), max = Some(10),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
+      expectedRowCount = 2)
+  }
+
+  test("cintSkewHgm > 10") {
+    // This is a corner case since max value is 10.
+    validateEstimatedStats(
+      Filter(GreaterThan(attrIntSkewHgm, Literal(10)),
+        childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Nil,
+      expectedRowCount = 0)
+  }
+
+  test("cintSkewHgm >= 6") {
+    validateEstimatedStats(
+      Filter(GreaterThanOrEqual(attrIntSkewHgm, Literal(6)),
+        childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 3, min = Some(6), max = Some(10),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
+      expectedRowCount = 4)
+  }
+
+  test("cintSkewHgm > 3 AND cintSkewHgm <= 6") {
+    val condition = And(GreaterThan(attrIntSkewHgm,
+      Literal(3)), LessThanOrEqual(attrIntSkewHgm, Literal(6)))
+    validateEstimatedStats(
+      Filter(condition, childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> ColumnStat(distinctCount = 5, min = Some(3), max = Some(6),
+        nullCount = 0, avgLen = 4, maxLen = 4, histogram = Some(hgmIntSkew))),
+      expectedRowCount = 8)
+  }
+
+  test("cintSkewHgm = 3 OR cintSkewHgm = 6") {
+    val condition = Or(EqualTo(attrIntSkewHgm, Literal(3)), EqualTo(attrIntSkewHgm, Literal(6)))
+    validateEstimatedStats(
+      Filter(condition, childStatsTestPlan(Seq(attrIntSkewHgm), 10L)),
+      Seq(attrIntSkewHgm -> colStatIntSkewHgm.copy(distinctCount = 2)),
       expectedRowCount = 3)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Histogram is effective in dealing with skewed distribution. After we generate histogram information for column statistics, we need to adjust filter estimation based on histogram data structure.

## How was this patch tested?

We revised all the unit test cases by including histogram data structure.

Please review http://spark.apache.org/contributing.html before opening a pull request.
