### PR TITLE
[MINOR][doc] The left navigation bar should be fixed with respect to scrolling.

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -195,7 +195,7 @@ a.anchorjs-link:hover { text-decoration: none; }
   margin-top: 0px;
   width: 210px;
   float: left;
-  position: absolute;
+  position: fixed;
 }
 
 .left-menu {


### PR DESCRIPTION

## What changes were proposed in this pull request?
A minor CSS style change to make Left navigation bar stay fixed with respect to scrolling, it improves usability of the docs.

## How was this patch tested?
It was tested on both, firefox and chrome.
### Before
![a2](https://user-images.githubusercontent.com/992952/33004206-6acf9fc0-cde5-11e7-9070-02f26f7899b0.gif)

### After
![a1](https://user-images.githubusercontent.com/992952/33004205-69b27798-cde5-11e7-8002-509b29786b37.gif)

