### PR TITLE
[SPARK-22566][PYTHON] Better error message for `_merge_type` in Pandas to Spark DF conversion

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -338,7 +338,7 @@ class SparkSession(object):
         if type(first) is dict:
             warnings.warn("inferring schema from dict is deprecated,"
                           "please use pyspark.sql.Row instead")
-        schema = reduce(_merge_type, [_infer_schema(row, names) for row in data])
+        schema = reduce(_merge_type, (_infer_schema(row, names) for row in data))
         if _has_nulltype(schema):
             raise ValueError("Some of types cannot be determined after inferring")
         return schema

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -380,9 +380,14 @@ class SparkSession(object):
         Create an RDD for DataFrame from an existing RDD, returns the RDD and schema.
         """
         if schema is None or isinstance(schema, (list, tuple)):
-            schema = self._inferSchema(rdd, samplingRatio, names=schema)
-            converter = _create_converter(schema)
+            struct = self._inferSchema(rdd, samplingRatio, names=schema)
+            converter = _create_converter(struct)
             rdd = rdd.map(converter)
+            if isinstance(schema, (list, tuple)):
+                for i, name in enumerate(schema):
+                    struct.fields[i].name = name
+                    struct.names[i] = name
+            schema = struct
 
         elif not isinstance(schema, StructType):
             raise TypeError("schema should be StructType or list or None, but got: %s" % schema)
@@ -401,9 +406,14 @@ class SparkSession(object):
             data = list(data)
 
         if schema is None or isinstance(schema, (list, tuple)):
-            schema = self._inferSchemaFromList(data, names=schema)
-            converter = _create_converter(schema)
+            struct = self._inferSchemaFromList(data, names=schema)
+            converter = _create_converter(struct)
             data = map(converter, data)
+            if isinstance(schema, (list, tuple)):
+                for i, name in enumerate(schema):
+                    struct.fields[i].name = name
+                    struct.names[i] = name
+            schema = struct
 
         elif not isinstance(schema, StructType):
             raise TypeError("schema should be StructType or list or None, but got: %s" % schema)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -401,14 +401,9 @@ class SparkSession(object):
             data = list(data)
 
         if schema is None or isinstance(schema, (list, tuple)):
-            struct = self._inferSchemaFromList(data, names=schema)
-            converter = _create_converter(struct)
+            schema = self._inferSchemaFromList(data, names=schema)
+            converter = _create_converter(schema)
             data = map(converter, data)
-            if isinstance(schema, (list, tuple)):
-                for i, name in enumerate(schema):
-                    struct.fields[i].name = name
-                    struct.names[i] = name
-            schema = struct
 
         elif not isinstance(schema, StructType):
             raise TypeError("schema should be StructType or list or None, but got: %s" % schema)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1753,7 +1753,7 @@ class SQLTests(ReusedSQLTestCase):
             StructType([StructField("f1", LongType()), StructField("f2", StringType())]),
             StructType([StructField("f1", LongType()), StructField("f2", StringType())])
         ), StructType([StructField("f1", LongType()), StructField("f2", StringType())]))
-        with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)'):
+        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)'):
             _merge_type(
                 StructType([StructField("f1", LongType()), StructField("f2", StringType())]),
                 StructType([StructField("f1", DoubleType()), StructField("f2", StringType())]))
@@ -1762,7 +1762,7 @@ class SQLTests(ReusedSQLTestCase):
             StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())]),
             StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())])
         ), StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())]))
-        with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)'):
+        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)'):
             _merge_type(
                 StructType([
                     StructField("f1", ArrayType(LongType())),
@@ -1781,7 +1781,7 @@ class SQLTests(ReusedSQLTestCase):
         ), StructType([
             StructField("f1", MapType(StringType(), LongType())),
             StructField("f2", StringType())]))
-        with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)'):
+        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)'):
             _merge_type(
                 StructType([
                     StructField("f1", MapType(StringType(), LongType())),
@@ -1794,7 +1794,7 @@ class SQLTests(ReusedSQLTestCase):
             StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),
             StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))])
         ), StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]))
-        with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)\.arrayElement\.mapKey'):
+        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)\.arrayElement\.mapKey'):
             _merge_type(
                 StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),
                 StructType([StructField("f1", ArrayType(MapType(DoubleType(), LongType())))])

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1729,7 +1729,10 @@ class SQLTests(ReusedSQLTestCase):
 
         self.assertEqual(_merge_type(LongType(), LongType()), LongType())
 
-        self.assertEqual(_merge_type(ArrayType(LongType()), ArrayType(LongType())), ArrayType(LongType()))
+        self.assertEqual(_merge_type(
+            ArrayType(LongType()),
+            ArrayType(LongType())
+        ), ArrayType(LongType()))
         with self.assertRaisesRegexp(TypeError, 'arrayElement'):
             _merge_type(ArrayType(LongType()), ArrayType(DoubleType()))
 
@@ -1761,22 +1764,36 @@ class SQLTests(ReusedSQLTestCase):
         ), StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())]))
         with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)'):
             _merge_type(
-                StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())]),
-                StructType([StructField("f1", ArrayType(DoubleType())), StructField("f2", StringType())]))
+                StructType([
+                    StructField("f1", ArrayType(LongType())),
+                    StructField("f2", StringType())]),
+                StructType([
+                    StructField("f1", ArrayType(DoubleType())),
+                    StructField("f2", StringType())]))
 
         self.assertEqual(_merge_type(
-            StructType([StructField("f1", MapType(StringType(), LongType())), StructField("f2", StringType())]),
-            StructType([StructField("f1", MapType(StringType(), LongType())), StructField("f2", StringType())])
-        ), StructType([StructField("f1", MapType(StringType(), LongType())), StructField("f2", StringType())]))
+            StructType([
+                StructField("f1", MapType(StringType(), LongType())),
+                StructField("f2", StringType())]),
+            StructType([
+                StructField("f1", MapType(StringType(), LongType())),
+                StructField("f2", StringType())])
+        ), StructType([
+            StructField("f1", MapType(StringType(), LongType())),
+            StructField("f2", StringType())]))
         with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)'):
             _merge_type(
-                StructType([StructField("f1", MapType(StringType(), LongType())), StructField("f2", StringType())]),
-                StructType([StructField("f1", MapType(StringType(), DoubleType())), StructField("f2", StringType())]))
+                StructType([
+                    StructField("f1", MapType(StringType(), LongType())),
+                    StructField("f2", StringType())]),
+                StructType([
+                    StructField("f1", MapType(StringType(), DoubleType())),
+                    StructField("f2", StringType())]))
 
         self.assertEqual(_merge_type(
-                StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),
-                StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))])
-            ), StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]))
+            StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),
+            StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))])
+        ), StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]))
         with self.assertRaisesRegexp(TypeError, r'structField\("f1"\)\.arrayElement\.mapKey'):
             _merge_type(
                 StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -847,6 +847,11 @@ class SQLTests(ReusedSQLTestCase):
         result = self.spark.sql("SELECT l[0].a from test2 where d['key'].d = '2'")
         self.assertEqual(1, result.head()[0])
 
+    def test_infer_schema_fails(self):
+        with self.assertRaisesRegexp(TypeError, 'field a'):
+            self.spark.createDataFrame(self.spark.sparkContext.parallelize([[1, 1], ["x", 1]]),
+                                       schema=["a", "b"], samplingRatio=0.99)
+
     def test_infer_nested_schema(self):
         NestedRow = Row("f1", "f2")
         nestedRdd1 = self.sc.parallelize([NestedRow([1, 2], {"row1": 1.0}),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -847,6 +847,10 @@ class SQLTests(ReusedSQLTestCase):
         result = self.spark.sql("SELECT l[0].a from test2 where d['key'].d = '2'")
         self.assertEqual(1, result.head()[0])
 
+    def test_infer_schema_not_enough_names(self):
+        df = self.spark.createDataFrame([["a", "b"]], ["col1"])
+        self.assertEqual(df.columns, ['col1', '_2'])
+
     def test_infer_schema_fails(self):
         with self.assertRaisesRegexp(TypeError, 'field a'):
             self.spark.createDataFrame(self.spark.sparkContext.parallelize([[1, 1], ["x", 1]]),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1733,18 +1733,18 @@ class SQLTests(ReusedSQLTestCase):
             ArrayType(LongType()),
             ArrayType(LongType())
         ), ArrayType(LongType()))
-        with self.assertRaisesRegexp(TypeError, 'arrayElement'):
+        with self.assertRaisesRegexp(TypeError, 'element in array'):
             _merge_type(ArrayType(LongType()), ArrayType(DoubleType()))
 
         self.assertEqual(_merge_type(
             MapType(StringType(), LongType()),
             MapType(StringType(), LongType())
         ), MapType(StringType(), LongType()))
-        with self.assertRaisesRegexp(TypeError, 'mapKey'):
+        with self.assertRaisesRegexp(TypeError, 'key of map'):
             _merge_type(
                 MapType(StringType(), LongType()),
                 MapType(DoubleType(), LongType()))
-        with self.assertRaisesRegexp(TypeError, 'mapValue'):
+        with self.assertRaisesRegexp(TypeError, 'value of map'):
             _merge_type(
                 MapType(StringType(), LongType()),
                 MapType(StringType(), DoubleType()))
@@ -1753,16 +1753,25 @@ class SQLTests(ReusedSQLTestCase):
             StructType([StructField("f1", LongType()), StructField("f2", StringType())]),
             StructType([StructField("f1", LongType()), StructField("f2", StringType())])
         ), StructType([StructField("f1", LongType()), StructField("f2", StringType())]))
-        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)'):
+        with self.assertRaisesRegexp(TypeError, 'field f1'):
             _merge_type(
                 StructType([StructField("f1", LongType()), StructField("f2", StringType())]),
                 StructType([StructField("f1", DoubleType()), StructField("f2", StringType())]))
 
         self.assertEqual(_merge_type(
+            StructType([StructField("f1", StructType([StructField("f2", LongType())]))]),
+            StructType([StructField("f1", StructType([StructField("f2", LongType())]))])
+        ), StructType([StructField("f1", StructType([StructField("f2", LongType())]))]))
+        with self.assertRaisesRegexp(TypeError, 'field f2 in field f1'):
+            _merge_type(
+                StructType([StructField("f1", StructType([StructField("f2", LongType())]))]),
+                StructType([StructField("f1", StructType([StructField("f2", StringType())]))]))
+
+        self.assertEqual(_merge_type(
             StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())]),
             StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())])
         ), StructType([StructField("f1", ArrayType(LongType())), StructField("f2", StringType())]))
-        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)'):
+        with self.assertRaisesRegexp(TypeError, 'element in array field f1'):
             _merge_type(
                 StructType([
                     StructField("f1", ArrayType(LongType())),
@@ -1781,7 +1790,7 @@ class SQLTests(ReusedSQLTestCase):
         ), StructType([
             StructField("f1", MapType(StringType(), LongType())),
             StructField("f2", StringType())]))
-        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)'):
+        with self.assertRaisesRegexp(TypeError, 'value of map field f1'):
             _merge_type(
                 StructType([
                     StructField("f1", MapType(StringType(), LongType())),
@@ -1794,7 +1803,7 @@ class SQLTests(ReusedSQLTestCase):
             StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),
             StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))])
         ), StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]))
-        with self.assertRaisesRegexp(TypeError, 'structField\("f1"\)\.arrayElement\.mapKey'):
+        with self.assertRaisesRegexp(TypeError, 'key of map element in array field f1'):
             _merge_type(
                 StructType([StructField("f1", ArrayType(MapType(StringType(), LongType())))]),
                 StructType([StructField("f1", ArrayType(MapType(DoubleType(), LongType())))])

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -872,6 +872,10 @@ class SQLTests(ReusedSQLTestCase):
         df = self.spark.createDataFrame(rdd)
         self.assertEqual(Row(field1=1, field2=u'row1'), df.first())
 
+    def test_create_dataframe_from_dict_respects_schema(self):
+        df = self.spark.createDataFrame([{'a': 1}], ["b"])
+        self.assertEqual(df.columns, ['b'])
+
     def test_create_dataframe_from_objects(self):
         data = [MyObject(1, "1"), MyObject(2, "2")]
         df = self.spark.createDataFrame(data)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1086,7 +1086,6 @@ def _infer_schema(row, names=None):
             if names is None:
                 names = ['_%d' % i for i in range(1, len(row) + 1)]
             elif len(names) < len(row):
-                names = names[:]
                 names.extend('_%d' % i for i in range(len(names) + 1, len(row) + 1))
             items = zip(names, row)
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1119,7 +1119,7 @@ def _merge_type(a, b, name=None):
         if name is None:
             raise TypeError("Can not merge type %s and %s" % (type(a), type(b)))
         else:
-            raise TypeError("Can not merge type %s and %s in column %s" % (type(a), type(b), name))
+            raise TypeError("Can not merge type %s and %s in field '%s'" % (type(a), type(b), name))
 
     # same type
     if isinstance(a, StructType):
@@ -1133,11 +1133,11 @@ def _merge_type(a, b, name=None):
         return StructType(fields)
 
     elif isinstance(a, ArrayType):
-        return ArrayType(_merge_type(a.elementType, b.elementType), True)
+        return ArrayType(_merge_type(a.elementType, b.elementType, name=name), True)
 
     elif isinstance(a, MapType):
-        return MapType(_merge_type(a.keyType, b.keyType),
-                       _merge_type(a.valueType, b.valueType),
+        return MapType(_merge_type(a.keyType, b.keyType, name=name),
+                       _merge_type(a.valueType, b.valueType, name=name),
                        True)
     else:
         return a

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1134,7 +1134,8 @@ def _merge_type(a, b, path=''):
         return StructType(fields)
 
     elif isinstance(a, ArrayType):
-        return ArrayType(_merge_type(a.elementType, b.elementType, path=path + '.arrayElement'), True)
+        return ArrayType(_merge_type(a.elementType, b.elementType,
+                                     path=path + '.arrayElement'), True)
 
     elif isinstance(a, MapType):
         return MapType(_merge_type(a.keyType, b.keyType, path=path + '.mapKey'),

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1109,12 +1109,6 @@ def _has_nulltype(dt):
         return isinstance(dt, NullType)
 
 
-def _merge_type_path(path, addition):
-    if path:
-        return "%s in %s" % (addition, path)
-    return addition
-
-
 def _merge_type(a, b, name=None):
     if name is None:
         new_msg = lambda msg: msg

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1085,6 +1085,9 @@ def _infer_schema(row, names=None):
         else:
             if names is None:
                 names = ['_%d' % i for i in range(1, len(row) + 1)]
+            elif len(names) < len(row):
+                names = names[:]
+                names.extend('_%d' % i for i in range(len(names) + 1, len(row) + 1))
             items = zip(names, row)
 
     elif hasattr(row, "__dict__"):  # object

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1116,10 +1116,10 @@ def _merge_type(a, b, name=None):
         return a
     elif type(a) is not type(b):
         # TODO: type cast (such as int -> long)
-        if name is not None:
-            raise TypeError("Can not merge type %s and %s in column %s" % (type(a), type(b), name))
-        else:
+        if name is None:
             raise TypeError("Can not merge type %s and %s" % (type(a), type(b)))
+        else:
+            raise TypeError("Can not merge type %s and %s in column %s" % (type(a), type(b), name))
 
     # same type
     if isinstance(a, StructType):


### PR DESCRIPTION
## What changes were proposed in this pull request?

It provides a better error message when doing `spark_session.createDataFrame(pandas_df)` with no schema and an error occurs in the schema inference due to incompatible types.

The Pandas column names are propagated down and the error message mentions which column had the merging error. 

https://issues.apache.org/jira/browse/SPARK-22566

## How was this patch tested?

Manually in the `./bin/pyspark` console, and with new tests: `./python/run-tests`

<img width="873" alt="screen shot 2017-11-21 at 13 29 49" src="https://user-images.githubusercontent.com/3977115/33080121-382274e0-cecf-11e7-808f-057a65bb7b00.png">

I state that the contribution is my original work and that I license the work to the Apache Spark project under the project’s open source license.