### PR TITLE
[SPARK-20101][SQL][FOLLOW-UP] use correct config name "spark.sql.columnVector.offheap.enabled"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -141,7 +141,7 @@ object SQLConf {
       .createWithDefault(true)
 
   val COLUMN_VECTOR_OFFHEAP_ENABLED =
-    buildConf("spark.sql.columnVector.offheap.enable")
+    buildConf("spark.sql.columnVector.offheap.enabled")
       .internal()
       .doc("When true, use OffHeapColumnVector in ColumnarBatch.")
       .booleanConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses [the spelling miss](https://github.com/apache/spark/pull/17436#discussion_r152189670) of the config name `spark.sql.columnVector.offheap.enabled`.  
We should use `spark.sql.columnVector.offheap.enabled`.

## How was this patch tested?

Existing tests