### PR TITLE
[SPARK-22581][SQL] Catalog api does not allow to specify partitioning columns with create(external)table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalog
 
 import scala.collection.JavaConverters._
-
 import org.apache.spark.annotation.{Experimental, InterfaceStability}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset}
 import org.apache.spark.sql.types.StructType
@@ -411,7 +410,29 @@ abstract class Catalog {
       tableName: String,
       source: String,
       schema: StructType,
-      options: Map[String, String]): DataFrame
+      options: Map[String, String]): DataFrame = {
+    createTable(tableName, source, schema, options, Nil)
+  }
+
+  /**
+    * :: Experimental ::
+    * (Scala-specific)
+    * Create a table based on the dataset in a data source, a schema, a set of options and a set of partition columns.
+    * Then, returns the corresponding DataFrame.
+    *
+    * @param tableName is either a qualified or unqualified name that designates a table.
+    *                  If no database identifier is provided, it refers to a table in
+    *                  the current database.
+    * @since ???
+    */
+  @Experimental
+  @InterfaceStability.Evolving
+  def createTable(
+    tableName: String,
+    source: String,
+    schema: StructType,
+    options: Map[String, String],
+    partitionColumnNames : Seq[String]): DataFrame
 
   /**
    * Drops the local temporary view with the given view name in the catalog.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -335,7 +335,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       source: String,
       schema: StructType,
       options: Map[String, String]): DataFrame = {
-    createTable(tableName, source, schema, options, Nil, None)
+    createTable(tableName, source, schema, options, Nil)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.internal
 
 import java.io.File
 
-import org.scalatest.BeforeAndAfterEach
-
+import org.scalatest.{BeforeAndAfterEach, Tag}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalog.{Column, Database, Function, Table}
@@ -519,7 +518,7 @@ class CatalogSuite
     }
   }
 
-  test("createTable with partition columns") {
+  test("createTable with partition columns", Tag("go")) {
     withTable("t") {
       withTempDir { dir =>
         spark.catalog.createTable(
@@ -537,9 +536,6 @@ class CatalogSuite
         assert(1 == columns.filter("name == 'year' and isPartition = true").count())
 
         sql("DROP TABLE t")
-        // the table path and data files are still there after DROP TABLE, if custom table path is
-        // specified.
-        assert(dir.exists() && dir.listFiles().nonEmpty)
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enhance Catalog api such that partition columns can be specified on createTable method

## How was this patch tested?

Added a test to verify that the created table indeed has added a partition column
