### PR TITLE
[SPARK-22570][SQL] Avoid to create a lot of global variables by using a local variable with allocation of an object in generated code

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -799,9 +799,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private[this] def castToByteCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = ctx.freshName("wrapper")
-      ctx.addMutableState("UTF8String.IntWrapper", wrapper,
-        s"$wrapper = new UTF8String.IntWrapper();")
+      val wrapper = "intWrapper"
+      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
+        ctx.addMutableState("UTF8String.IntWrapper", wrapper,
+          s"$wrapper = new UTF8String.IntWrapper();")
+      }
       (c, evPrim, evNull) =>
         s"""
           if ($c.toByte($wrapper)) {
@@ -826,9 +828,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       from: DataType,
       ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = ctx.freshName("wrapper")
-      ctx.addMutableState("UTF8String.IntWrapper", wrapper,
-        s"$wrapper = new UTF8String.IntWrapper();")
+      val wrapper = "intWrapper"
+      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
+        ctx.addMutableState("UTF8String.IntWrapper", wrapper,
+          s"$wrapper = new UTF8String.IntWrapper();")
+      }
       (c, evPrim, evNull) =>
         s"""
           if ($c.toShort($wrapper)) {
@@ -851,9 +855,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private[this] def castToIntCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = ctx.freshName("wrapper")
-      ctx.addMutableState("UTF8String.IntWrapper", wrapper,
-        s"$wrapper = new UTF8String.IntWrapper();")
+      val wrapper = "intWrapper"
+      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
+        ctx.addMutableState("UTF8String.IntWrapper", wrapper,
+          s"$wrapper = new UTF8String.IntWrapper();")
+      }
       (c, evPrim, evNull) =>
         s"""
           if ($c.toInt($wrapper)) {
@@ -876,9 +882,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private[this] def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = ctx.freshName("wrapper")
-      ctx.addMutableState("UTF8String.LongWrapper", wrapper,
-        s"$wrapper = new UTF8String.LongWrapper();")
+      val wrapper = "longWrapper"
+      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
+        ctx.addMutableState("UTF8String.LongWrapper", wrapper,
+          s"$wrapper = new UTF8String.LongWrapper();")
+      }
 
       (c, evPrim, evNull) =>
         s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -808,6 +808,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           } else {
             $evNull = true;
           }
+          $wrapper = null;
         """
     case BooleanType =>
       (c, evPrim, evNull) => s"$evPrim = $c ? (byte) 1 : (byte) 0;"
@@ -834,6 +835,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           } else {
             $evNull = true;
           }
+          $wrapper = null;
         """
     case BooleanType =>
       (c, evPrim, evNull) => s"$evPrim = $c ? (short) 1 : (short) 0;"
@@ -858,6 +860,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           } else {
             $evNull = true;
           }
+          $wrapper = null;
         """
     case BooleanType =>
       (c, evPrim, evNull) => s"$evPrim = $c ? 1 : 0;"
@@ -883,6 +886,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           } else {
             $evNull = true;
           }
+          $wrapper = null;
         """
     case BooleanType =>
       (c, evPrim, evNull) => s"$evPrim = $c ? 1L : 0L;"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -799,13 +799,10 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private[this] def castToByteCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = "intWrapper"
-      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
-        ctx.addMutableState("UTF8String.IntWrapper", wrapper,
-          s"$wrapper = new UTF8String.IntWrapper();")
-      }
+      val wrapper = ctx.freshName("intWrapper")
       (c, evPrim, evNull) =>
         s"""
+          UTF8String.IntWrapper $wrapper = new UTF8String.IntWrapper();
           if ($c.toByte($wrapper)) {
             $evPrim = (byte) $wrapper.value;
           } else {
@@ -828,13 +825,10 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       from: DataType,
       ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = "intWrapper"
-      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
-        ctx.addMutableState("UTF8String.IntWrapper", wrapper,
-          s"$wrapper = new UTF8String.IntWrapper();")
-      }
+      val wrapper = ctx.freshName("intWrapper")
       (c, evPrim, evNull) =>
         s"""
+          UTF8String.IntWrapper $wrapper = new UTF8String.IntWrapper();
           if ($c.toShort($wrapper)) {
             $evPrim = (short) $wrapper.value;
           } else {
@@ -855,13 +849,10 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private[this] def castToIntCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = "intWrapper"
-      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
-        ctx.addMutableState("UTF8String.IntWrapper", wrapper,
-          s"$wrapper = new UTF8String.IntWrapper();")
-      }
+      val wrapper = ctx.freshName("intWrapper")
       (c, evPrim, evNull) =>
         s"""
+          UTF8String.IntWrapper $wrapper = new UTF8String.IntWrapper();
           if ($c.toInt($wrapper)) {
             $evPrim = $wrapper.value;
           } else {
@@ -882,14 +873,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private[this] def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      val wrapper = "longWrapper"
-      if (!ctx.mutableStates.exists(s => s._1 == wrapper)) {
-        ctx.addMutableState("UTF8String.LongWrapper", wrapper,
-          s"$wrapper = new UTF8String.LongWrapper();")
-      }
+      val wrapper = ctx.freshName("longWrapper")
 
       (c, evPrim, evNull) =>
         s"""
+          UTF8String.LongWrapper $wrapper = new UTF8String.LongWrapper();
           if ($c.toLong($wrapper)) {
             $evPrim = $wrapper.value;
           } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -185,23 +185,6 @@ class CodegenContext {
   }
 
   /**
-   * Add a mutable state as a field to the generated class if the name has not been added
-   *
-   * @param javaType Java type of the field.
-   * @param variableName Name of the field.
-   * @param initCode The statement(s) to put into the init() method to initialize this field.
-   *                 If left blank, the field will be default-initialized.
-   */
-  def reuseOrAddMutableState(
-      javaType: String,
-      variableName: String,
-      initCode: String = ""): Unit = {
-    if (!mutableStates.exists(s => s._1 == variableName)) {
-      addMutableState(javaType, variableName, initCode)
-    }
-  }
-
-  /**
    * Add buffer variable which stores data coming from an [[InternalRow]]. This methods guarantees
    * that the variable is safely stored, which is important for (potentially) byte array backed
    * data types like: UTF8String, ArrayData, MapData & InternalRow.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -185,6 +185,23 @@ class CodegenContext {
   }
 
   /**
+   * Add a mutable state as a field to the generated class if the name has not been added
+   *
+   * @param javaType Java type of the field.
+   * @param variableName Name of the field.
+   * @param initCode The statement(s) to put into the init() method to initialize this field.
+   *                 If left blank, the field will be default-initialized.
+   */
+  def reuseOrAddMutableState(
+      javaType: String,
+      variableName: String,
+      initCode: String = ""): Unit = {
+    if (!mutableStates.exists(s => s._1 == variableName)) {
+      addMutableState(javaType, variableName, initCode)
+    }
+  }
+
+  /**
    * Add buffer variable which stores data coming from an [[InternalRow]]. This methods guarantees
    * that the variable is safely stored, which is important for (potentially) byte array backed
    * data types like: UTF8String, ArrayData, MapData & InternalRow.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -87,11 +87,11 @@ private [sql] object GenArrayData {
       elementType: DataType,
       elementsCode: Seq[ExprCode],
       isMapKey: Boolean): (String, Seq[String], String, String) = {
-    val arrayName = "array"
     val arrayDataName = ctx.freshName("arrayData")
     val numElements = elementsCode.length
 
     if (!ctx.isPrimitiveType(elementType)) {
+      val arrayName = "arrayObject"
       val genericArrayClass = classOf[GenericArrayData].getName
       if (!ctx.mutableStates.exists(s => s._1 == arrayName)) {
         ctx.addMutableState("Object[]", arrayName)
@@ -121,6 +121,7 @@ private [sql] object GenArrayData {
        s"final ArrayData $arrayDataName = new $genericArrayClass($arrayName);",
        arrayDataName)
     } else {
+      val arrayName = ctx.freshName("array")
       val unsafeArraySizeInBytes =
         UnsafeArrayData.calculateHeaderPortionInBytes(numElements) +
         ByteArrayMethods.roundNumberOfBytesToNearestWord(elementType.defaultSize * numElements)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -146,7 +146,7 @@ private [sql] object GenArrayData {
 
       (s"""
         byte[] $arrayName = new byte[$unsafeArraySizeInBytes];
-        $arrayDataName = new UnsafeArrayData();
+        UnsafeArrayData $arrayDataName = new UnsafeArrayData();
         Platform.putLong($arrayName, $baseOffset, $numElements);
         $arrayDataName.pointTo($arrayName, $baseOffset, $unsafeArraySizeInBytes);
       """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -113,7 +113,7 @@ private [sql] object GenArrayData {
         funcName = "apply",
         extraArguments = ("Object[]", arrayDataName) :: Nil)
 
-      (s"$arrayName = new Object[$numElements];",
+      (s"Object[] $arrayName = new Object[$numElements];",
        assignmentString,
        s"final ArrayData $arrayDataName = new $genericArrayClass($arrayName);",
        arrayDataName)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -334,10 +334,8 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
     ctx.addMutableState("String", termLastReplacement, s"${termLastReplacement} = null;")
     ctx.addMutableState("UTF8String",
       termLastReplacementInUTF8, s"${termLastReplacementInUTF8} = null;")
-    if (!ctx.mutableStates.exists(s => s._1 == termResult)) {
-      ctx.addMutableState(classNameStringBuffer,
-        termResult, s"${termResult} = new $classNameStringBuffer();")
-    }
+    ctx.reuseOrAddMutableState(classNameStringBuffer,
+      termResult, s"${termResult} = new $classNameStringBuffer();")
 
     val setEvNotNull = if (nullable) {
       s"${ev.isNull} = false;"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -322,7 +322,7 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
     val termLastReplacement = ctx.freshName("lastReplacement")
     val termLastReplacementInUTF8 = ctx.freshName("lastReplacementInUTF8")
 
-    val termResult = ctx.freshName("result")
+    val termResult = "termResult"
 
     val classNamePattern = classOf[Pattern].getCanonicalName
     val classNameStringBuffer = classOf[java.lang.StringBuffer].getCanonicalName
@@ -334,8 +334,10 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
     ctx.addMutableState("String", termLastReplacement, s"${termLastReplacement} = null;")
     ctx.addMutableState("UTF8String",
       termLastReplacementInUTF8, s"${termLastReplacementInUTF8} = null;")
-    ctx.addMutableState(classNameStringBuffer,
-      termResult, s"${termResult} = new $classNameStringBuffer();")
+    if (!ctx.mutableStates.exists(s => s._1 == termResult)) {
+      ctx.addMutableState(classNameStringBuffer,
+        termResult, s"${termResult} = new $classNameStringBuffer();")
+    }
 
     val setEvNotNull = if (nullable) {
       s"${ev.isNull} = false;"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -321,8 +321,7 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
 
     val termLastReplacement = ctx.freshName("lastReplacement")
     val termLastReplacementInUTF8 = ctx.freshName("lastReplacementInUTF8")
-
-    val termResult = "termResult"
+    val termResult = ctx.freshName("termResult")
 
     val classNamePattern = classOf[Pattern].getCanonicalName
     val classNameStringBuffer = classOf[java.lang.StringBuffer].getCanonicalName
@@ -334,8 +333,6 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
     ctx.addMutableState("String", termLastReplacement, s"${termLastReplacement} = null;")
     ctx.addMutableState("UTF8String",
       termLastReplacementInUTF8, s"${termLastReplacementInUTF8} = null;")
-    ctx.reuseOrAddMutableState(classNameStringBuffer,
-      termResult, s"${termResult} = new $classNameStringBuffer();")
 
     val setEvNotNull = if (nullable) {
       s"${ev.isNull} = false;"
@@ -355,7 +352,7 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
         ${termLastReplacementInUTF8} = $rep.clone();
         ${termLastReplacement} = ${termLastReplacementInUTF8}.toString();
       }
-      ${termResult}.delete(0, ${termResult}.length());
+      $classNameStringBuffer ${termResult} = new $classNameStringBuffer();
       java.util.regex.Matcher ${matcher} = ${termPattern}.matcher($subject.toString());
 
       while (${matcher}.find()) {
@@ -363,6 +360,7 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
       }
       ${matcher}.appendTail(${termResult});
       ${ev.value} = UTF8String.fromString(${termResult}.toString());
+      ${termResult} = null;
       $setEvNotNull
     """
     })

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -23,6 +23,7 @@ import java.util.{Calendar, Locale, TimeZone}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.TimeZoneGMT
@@ -846,23 +847,10 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(cast(Literal.create(inputOuter, fromOuter), toOuter), outputOuter)
   }
 
-  test("SPARK-22570: should not create a lot of instance variables") {
-    val N = 30000
-
-    val from1 = new StructType(
-      (1 to N).map(i => StructField(s"s$i", StringType)).toArray)
-    val to1 = new StructType(
-      (1 to N).map(i => StructField(s"i$i", IntegerType)).toArray)
-    val input1 = Row.fromSeq((1 to N).map(i => i.toString))
-    val output1 = Row.fromSeq((1 to N))
-    checkEvaluation(cast(Literal.create(input1, from1), to1), output1)
-
-    val from2 = new StructType(
-      (1 to N).map(i => StructField(s"s$i", StringType)).toArray)
-    val to2 = new StructType(
-      (1 to N).map(i => StructField(s"i$i", LongType)).toArray)
-    val input2 = Row.fromSeq((1 to N).map(i => i.toString))
-    val output2 = Row.fromSeq((1 to N).map(i => i.toLong))
-    checkEvaluation(cast(Literal.create(input2, from2), to2), output2)
+  test("SPARK-22570: Cast should not create a lot of instance variables") {
+    val ctx = new CodegenContext
+    cast("1", IntegerType).genCode(ctx).code
+    cast("2", LongType).genCode(ctx).code
+    assert(ctx.mutableStates.length == 0)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -847,10 +847,10 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(cast(Literal.create(inputOuter, fromOuter), toOuter), outputOuter)
   }
 
-  test("SPARK-22570: Cast should not create a lot of instance variables") {
+  test("SPARK-22570: Cast should not create a lot of global variables") {
     val ctx = new CodegenContext
-    cast("1", IntegerType).genCode(ctx).code
-    cast("2", LongType).genCode(ctx).code
+    cast("1", IntegerType).genCode(ctx)
+    cast("2", LongType).genCode(ctx)
     assert(ctx.mutableStates.length == 0)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -845,4 +845,24 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     val outputOuter = Row.fromSeq((1 to N).map(_ => outputInner))
     checkEvaluation(cast(Literal.create(inputOuter, fromOuter), toOuter), outputOuter)
   }
+
+  test("SPARK-22570: should not create a lot of instance variables") {
+    val N = 30000
+
+    val from1 = new StructType(
+      (1 to N).map(i => StructField(s"s$i", StringType)).toArray)
+    val to1 = new StructType(
+      (1 to N).map(i => StructField(s"i$i", IntegerType)).toArray)
+    val input1 = Row.fromSeq((1 to N).map(i => i.toString))
+    val output1 = Row.fromSeq((1 to N))
+    checkEvaluation(cast(Literal.create(input1, from1), to1), output1)
+
+    val from2 = new StructType(
+      (1 to N).map(i => StructField(s"s$i", StringType)).toArray)
+    val to2 = new StructType(
+      (1 to N).map(i => StructField(s"i$i", LongType)).toArray)
+    val input2 = Row.fromSeq((1 to N).map(i => i.toString))
+    val output2 = Row.fromSeq((1 to N).map(i => i.toLong))
+    checkEvaluation(cast(Literal.create(input2, from2), to2), output2)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeGenerator, CodegenContext}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodegenContext, CodeGenerator}
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
@@ -179,14 +179,12 @@ class RegexpExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(nonNullExpr, "num-num", row1)
   }
 
-  test("SPARK-22570: should not create a lot of instance variables") {
-    val N = 16000
-    val expr = RegExpReplace(Literal("100"), Literal("(\\d+)"), Literal("num"))
+  test("SPARK-22570: RegExpReplace should not create a lot of global variables") {
     val ctx = new CodegenContext
-    (1 to N).map(_ => expr.genCode(ctx).code)
+    RegExpReplace(Literal("100"), Literal("(\\d+)"), Literal("num")).genCode(ctx)
     // four global variables (lastRegex, pattern, lastReplacement, and lastReplacementInUTF8)
     // are always required
-    assert(ctx.mutableStates.length == 4 * N)
+    assert(ctx.mutableStates.length == 4)
   }
 
   test("RegexExtract") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodegenContext, CodeGenerator}
-import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.types.StringType
 
 /**
  * Unit tests for regular expression (regexp) related SQL expressions.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -165,9 +165,9 @@ class ComplexTypesSuite extends PlanTest{
     comparePlans(Optimizer execute query, expected)
   }
 
-  test("SPARK-22570: should not create a lot of instance variables") {
+  test("SPARK-22570: CreateArray should not create a lot of global variables") {
     val ctx = new CodegenContext
-    (1 to 60000).map(i => CreateArray(Seq(Literal(s"$i"))).genCode(ctx).code)
+    CreateArray(Seq(Literal(1))).genCode(ctx).code
     assert(ctx.mutableStates.length == 0)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodegenContext, CodeGenerator}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Range}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
@@ -167,7 +167,7 @@ class ComplexTypesSuite extends PlanTest{
 
   test("SPARK-22570: CreateArray should not create a lot of global variables") {
     val ctx = new CodegenContext
-    CreateArray(Seq(Literal(1))).genCode(ctx).code
+    CreateArray(Seq(Literal(1))).genCode(ctx)
     assert(ctx.mutableStates.length == 0)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -167,24 +167,8 @@ class ComplexTypesSuite extends PlanTest{
 
   test("SPARK-22570: should not create a lot of instance variables") {
     val ctx = new CodegenContext
-    val codes = (1 to 60000).map(i => CreateArray(Seq(Literal(s"$i"))).genCode(ctx).code)
-    val eval = ctx.splitExpressions(ctx.INPUT_ROW, codes)
-    val codeBody = s"""
-      public ComplexTypesTest generate(Object[] references) {
-        return new ComplexTypesTest(references);
-      }
-      class ComplexTypesTest {
-        Object[] references;
-        ${ctx.declareMutableStates()}
-        public ComplexTypesTest(Object[] references) {
-          ${ctx.initMutableStates()}
-        }
-        public void apply(InternalRow ${ctx.INPUT_ROW}) {
-          ${eval}
-        }
-       ${ctx.declareAddedFunctions()}
-     }"""
-    CodeGenerator.compile(new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+    (1 to 60000).map(i => CreateArray(Seq(Literal(s"$i"))).genCode(ctx).code)
+    assert(ctx.mutableStates.length == 0)
   }
 
   test("simplify map ops") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeGenerator, CodegenContext}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodegenContext, CodeGenerator}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Range}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR reduces # of global variables in generated code by replacing a global variable with a local variable with an allocation of an object every time. When a lot of global variables were generated, the generated code may meet 64K constant pool limit.  
This PR reduces # of generated global variables in the following three operations:
* `Cast` with String to primitive byte/short/int/long
* `RegExpReplace`
* `CreateArray`

I intentionally leave [this part](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala#L595-L603). This is because this variable keeps a class that is dynamically generated. In other word, it is not possible to reuse one class.

## How was this patch tested?

Added test cases