### PR TITLE
[SPARK-22591][SQL] GenerateOrdering shouldn't change CodegenContext.INPUT_ROW

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -72,6 +72,7 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
    * Generates the code for ordering based on the given order.
    */
   def genComparisons(ctx: CodegenContext, ordering: Seq[SortOrder]): String = {
+    val oldInputRow = ctx.INPUT_ROW
     val comparisons = ordering.map { order =>
       val oldCurrentVars = ctx.currentVars
       ctx.INPUT_ROW = "i"
@@ -149,10 +150,12 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
       })
     // make sure INPUT_ROW is declared even if splitExpressions
     // returns an inlined block
-    s"""
+    val finalCode = s"""
        |InternalRow ${ctx.INPUT_ROW} = null;
        |$code
      """.stripMargin
+    ctx.INPUT_ROW = oldInputRow
+    finalCode
   }
 
   protected def create(ordering: Seq[SortOrder]): BaseOrdering = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -149,16 +149,14 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
           """
         }.mkString
       })
-    // make sure INPUT_ROW is declared even if splitExpressions
-    // returns an inlined block
-    val finalCode = s"""
-       |InternalRow ${ctx.INPUT_ROW} = null;
-       |$code
-     """.stripMargin
-    // Restore original currentVars and INPUT_ROW.
     ctx.currentVars = oldCurrentVars
     ctx.INPUT_ROW = oldInputRow
-    finalCode
+    // make sure INPUT_ROW is declared even if splitExpressions
+    // returns an inlined block
+    s"""
+       |InternalRow $inputRow = null;
+       |$code
+     """.stripMargin
   }
 
   protected def create(ordering: Seq[SortOrder]): BaseOrdering = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -73,13 +73,14 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
    */
   def genComparisons(ctx: CodegenContext, ordering: Seq[SortOrder]): String = {
     val oldInputRow = ctx.INPUT_ROW
+    val oldCurrentVars = ctx.currentVars
+    val inputRow = "i"
+    ctx.INPUT_ROW = inputRow
+    // to use INPUT_ROW we must make sure currentVars is null
+    ctx.currentVars = null
+
     val comparisons = ordering.map { order =>
-      val oldCurrentVars = ctx.currentVars
-      ctx.INPUT_ROW = "i"
-      // to use INPUT_ROW we must make sure currentVars is null
-      ctx.currentVars = null
       val eval = order.child.genCode(ctx)
-      ctx.currentVars = oldCurrentVars
       val asc = order.isAscending
       val isNullA = ctx.freshName("isNullA")
       val primitiveA = ctx.freshName("primitiveA")
@@ -154,6 +155,8 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
        |InternalRow ${ctx.INPUT_ROW} = null;
        |$code
      """.stripMargin
+    // Restore original currentVars and INPUT_ROW.
+    ctx.currentVars = oldCurrentVars
     ctx.INPUT_ROW = oldInputRow
     finalCode
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.{GenerateOrdering, LazilyGeneratedOrdering}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, GenerateOrdering, LazilyGeneratedOrdering}
 import org.apache.spark.sql.types._
 
 class OrderingSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -155,5 +155,14 @@ class OrderingSuite extends SparkFunSuite with ExpressionEvalHelper {
       assert(rowOrdering.compare(rowB1, rowB2) < 0)
       assert(genOrdering.compare(rowB1, rowB2) < 0)
     }
+  }
+
+  test("SPARK-22591: GenerateOrdering shouldn't change ctx.INPUT_ROW") {
+    val ctx = new CodegenContext()
+    ctx.INPUT_ROW = null
+
+    val schema = new StructType().add("field", FloatType, nullable = true)
+    GenerateOrdering.genComparisons(ctx, schema)
+    assert(ctx.INPUT_ROW == null)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I played with codegen in developing another PR, I found the value of `CodegenContext.INPUT_ROW` is not reliable. Under wholestage codegen, it is assigned to null first and then suddenly changed to `i`. 

The reason is `GenerateOrdering` changes `CodegenContext.INPUT_ROW` but doesn't restore it back.

## How was this patch tested?

Added test.

