### PR TITLE
[SPARK-22594][CORE] Handling spark-submit and master version mismatch

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -199,7 +199,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     } else if (message instanceof RpcFailure) {
       RpcFailure resp = (RpcFailure) message;
       RpcResponseCallback listener = outstandingRpcs.get(resp.requestId);
-      if (listener == null) {
+      if (listener == null && resp.requestId != RpcFailure.EMPTY_REQUEST_ID) {
         logger.warn("Ignoring response for RPC {} from {} ({}) since it is not outstanding",
           resp.requestId, getRemoteAddress(channel), resp.errorString);
       } else {

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/RpcFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/RpcFailure.java
@@ -22,9 +22,10 @@ import io.netty.buffer.ByteBuf;
 
 /** Response to {@link RpcRequest} for a failed RPC. */
 public final class RpcFailure extends AbstractMessage implements ResponseMessage {
+  public static final long EMPTY_REQUEST_ID = Long.MIN_VALUE;
+
   public final long requestId;
   public final String errorString;
-  public static final long EMPTY_REQUEST_ID = Long.MIN_VALUE;
 
   public RpcFailure(long requestId, String errorString) {
     this.requestId = requestId;

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/RpcFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/RpcFailure.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBuf;
 public final class RpcFailure extends AbstractMessage implements ResponseMessage {
   public final long requestId;
   public final String errorString;
+  public static final long EMPTY_REQUEST_ID = Long.MIN_VALUE;
 
   public RpcFailure(long requestId, String errorString) {
     this.requestId = requestId;

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.network.server;
 
+import java.io.InvalidClassException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 
@@ -206,6 +207,11 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
   private void processOneWayMessage(OneWayMessage req) {
     try {
       rpcHandler.receive(reverseClient, req.body().nioByteBuffer());
+    } catch (InvalidClassException ice) {
+        final String msg = "There is probably a version mismatch between client and server: ";
+        respond(new RpcFailure(RpcFailure.EMPTY_REQUEST_ID, msg
+                + Throwables.getStackTraceAsString(ice)));
+        logger.error(msg, ice);
     } catch (Exception e) {
       logger.error("Error while invoking RpcHandler#receive() for one-way message.", e);
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the `InvalidClassException` exception is thrown in the `TransportRequestHandler.processOneWayMessage` (as a consequence of the different `serialVersionUID`s) let's send the connected client a message that there is probably a version mismatch between his spark-submit and the remote spark master she is trying to contact.

## How was this patch tested?
TODO:
- [x] (Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
  ( I've added test in https://github.com/apache/spark/pull/19802/commits/1b0fd3a4dd97c1bcb2aa407da9aea8df493e9f74 )
- [x] Please review http://spark.apache.org/contributing.html before opening a pull request.
