### PR TITLE
[SPARK-22597][SQL] Add spark-sql cmd script for Windows users

### DIFF
--- a/bin/find-spark-home.cmd
+++ b/bin/find-spark-home.cmd
@@ -32,7 +32,7 @@ if not "x%PYSPARK_PYTHON%"=="x" (
 )
 
 rem If there is python installed, trying to use the root dir as SPARK_HOME
-where %PYTHON_RUNNER% > nul 2>$1
+where %PYTHON_RUNNER% > nul 2>&1
 if %ERRORLEVEL% neq 0 (
   if not exist %PYTHON_RUNNER% (
     if "x%SPARK_HOME%"=="x" (

--- a/bin/spark-sql.cmd
+++ b/bin/spark-sql.cmd
@@ -17,11 +17,9 @@ rem See the License for the specific language governing permissions and
 rem limitations under the License.
 rem
 
-rem Figure out where the Spark framework is installed
-call "%~dp0find-spark-home.cmd"
-
-set _SPARK_CMD_USAGE=Usage: .\bin\run-example [options] example-class [example args]
+rem This is the entry point for running SparkSQL. To avoid polluting the
+rem environment, it just launches a new cmd to do the real work.
 
 rem The outermost quotes are used to prevent Windows command line parse error
 rem when there are some quotes in parameters, see SPARK-21877.
-cmd /V /E /C ""%~dp0spark-submit.cmd" run-example %*"
+cmd /V /E /C ""%~dp0spark-sql2.cmd" %*"

--- a/bin/spark-sql2.cmd
+++ b/bin/spark-sql2.cmd
@@ -20,8 +20,6 @@ rem
 rem Figure out where the Spark framework is installed
 call "%~dp0find-spark-home.cmd"
 
-set _SPARK_CMD_USAGE=Usage: .\bin\run-example [options] example-class [example args]
+set _SPARK_CMD_USAGE=Usage: .\bin\spark-sql [options] [cli option]
 
-rem The outermost quotes are used to prevent Windows command line parse error
-rem when there are some quotes in parameters, see SPARK-21877.
-cmd /V /E /C ""%~dp0spark-submit.cmd" run-example %*"
+call "%SPARK_HOME%\bin\spark-submit2.cmd" --class org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver %*

--- a/bin/sparkR2.cmd
+++ b/bin/sparkR2.cmd
@@ -21,6 +21,5 @@ rem Figure out where the Spark framework is installed
 call "%~dp0find-spark-home.cmd"
 
 call "%SPARK_HOME%\bin\load-spark-env.cmd"
-
-
+set _SPARK_CMD_USAGE=Usage: .\bin\sparkR [options]
 call "%SPARK_HOME%\bin\spark-submit2.cmd" sparkr-shell-main %*


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add cmd scripts so that Windows users can also run `spark-sql` script.

## How was this patch tested?

Manually tested on Windows.

**Before**

```cmd
C:\...\spark>.\bin\spark-sql
'.\bin\spark-sql' is not recognized as an internal or external command,
operable program or batch file.

C:\...\spark>.\bin\spark-sql.cmd
'.\bin\spark-sql.cmd' is not recognized as an internal or external command,
operable program or batch file.
```

**After**

```cmd
C:\...\spark>.\bin\spark-sql
...
spark-sql> SELECT 'Hello World !!';
...
Hello World !!
```