### PR TITLE
[SPARK-22606][Streaming]Add threadId to the CachedKafkaConsumer key

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
@@ -193,6 +193,8 @@ private[spark] class KafkaRDD[K, V](
     logInfo(s"Computing topic ${part.topic}, partition ${part.partition} " +
       s"offsets ${part.fromOffset} -> ${part.untilOffset}")
 
+    val threadId = Thread.currentThread().getId
+
     val groupId = kafkaParams.get(ConsumerConfig.GROUP_ID_CONFIG).asInstanceOf[String]
 
     context.addTaskCompletionListener{ context => closeIfNeeded() }
@@ -201,9 +203,9 @@ private[spark] class KafkaRDD[K, V](
       CachedKafkaConsumer.init(cacheInitialCapacity, cacheMaxCapacity, cacheLoadFactor)
       if (context.attemptNumber >= 1) {
         // just in case the prior attempt failures were cache related
-        CachedKafkaConsumer.remove(groupId, part.topic, part.partition)
+        CachedKafkaConsumer.remove(groupId, part.topic, part.partition, threadId)
       }
-      CachedKafkaConsumer.get[K, V](groupId, part.topic, part.partition, kafkaParams)
+      CachedKafkaConsumer.get[K, V](groupId, part.topic, part.partition, threadId, kafkaParams)
     } else {
       CachedKafkaConsumer.getUncached[K, V](groupId, part.topic, part.partition, kafkaParams)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the value of param 'spark.streaming.concurrentJobs' is more than one, and the value of param 'spark.executor.cores' is more than one, there may be two or more tasks in one executor will use the same kafka consumer at the same time, then it will throw an exception: "KafkaConsumer is not safe for multi-threaded access";
for example:
spark.streaming.concurrentJobs=2
spark.executor.cores=2
spark.cores.max=2
if there is only one topic with one partition('topic1',0) to consume, there will be two jobs to run at the same time, and they will use the same cacheKey('groupid','topic1',0) to get the CachedKafkaConsumer from the cache list of' private var cache: ju.LinkedHashMap[CacheKey, CachedKafkaConsumer[_, _]]' , then it will get the same CachedKafkaConsumer.

this PR add threadId  to the CachedKafkaConsumer key to prevent two thread using a consumer at the same time.



## How was this patch tested?
existing ut test
