### PR TITLE
[SPARK-22609][SQL] Reuse CodeGenerator.nullSafeExec when possible

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -179,15 +179,15 @@ case class SortPrefix(child: SortOrder) extends UnaryExpression {
         s"$DoublePrefixCmp.computePrefix($input.toDouble())"
       case _ => "0L"
     }
-
+    val nullSafeCode = ctx.nullSafeExec(child.child.nullable, childCode.isNull) {
+      s"${ev.value} = $prefixCode;"
+    }
     ev.copy(code = childCode.code +
       s"""
-         |long ${ev.value} = 0L;
-         |boolean ${ev.isNull} = ${childCode.isNull};
-         |if (!${childCode.isNull}) {
-         |  ${ev.value} = $prefixCode;
-         |}
-      """.stripMargin)
+        long ${ev.value} = 0L;
+        boolean ${ev.isNull} = ${childCode.isNull};
+        $nullSafeCode
+      """)
   }
 
   override def dataType: DataType = LongType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1133,13 +1133,12 @@ abstract class RoundBase(child: Expression, scale: Expression,
         boolean ${ev.isNull} = true;
         ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};""")
     } else {
+      val nullSafeCode = ctx.nullSafeExec(nullable, ev.isNull)(evaluationCode)
       ev.copy(code = s"""
         ${ce.code}
         boolean ${ev.isNull} = ${ce.isNull};
         ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
-        if (!${ev.isNull}) {
-          $evaluationCode
-        }""")
+        $nullSafeCode""")
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -124,13 +124,14 @@ case class Like(left: Expression, right: Expression) extends StringRegexExpressi
 
         // We don't use nullSafeCodeGen here because we don't want to re-evaluate right again.
         val eval = left.genCode(ctx)
+        val nullSafeCode = ctx.nullSafeExec(nullable, ev.isNull) {
+          s"${ev.value} = $pattern.matcher(${eval.value}.toString()).matches();"
+        }
         ev.copy(code = s"""
           ${eval.code}
           boolean ${ev.isNull} = ${eval.isNull};
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
-          if (!${ev.isNull}) {
-            ${ev.value} = $pattern.matcher(${eval.value}.toString()).matches();
-          }
+          $nullSafeCode
         """)
       } else {
         ev.copy(code = s"""
@@ -199,13 +200,14 @@ case class RLike(left: Expression, right: Expression) extends StringRegexExpress
 
         // We don't use nullSafeCodeGen here because we don't want to re-evaluate right again.
         val eval = left.genCode(ctx)
+        val nullSafeCode = ctx.nullSafeExec(nullable, ev.isNull) {
+          s"${ev.value} = $pattern.matcher(${eval.value}.toString()).find(0);"
+        }
         ev.copy(code = s"""
           ${eval.code}
           boolean ${ev.isNull} = ${eval.isNull};
           ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
-          if (!${ev.isNull}) {
-            ${ev.value} = $pattern.matcher(${eval.value}.toString()).find(0);
-          }
+          $nullSafeCode
         """)
       } else {
         ev.copy(code = s"""


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are several places in the code where `CodeGeneration.nullSafeExec` could be used, but it is not. This makes the generated code containing a lot of useless:
```
if (!false) {
  // some code here
}
```
This PR use `CodeGeneration.nullSafeExec` where it is possible, also for consistency and coherency of the code.

## How was this patch tested?

Existing UTs
