### PR TITLE
[SPARK-22428][DOC] Add spark application garbage collector configurat…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2346,6 +2346,7 @@ showDF(properties, numRows = 200, truncate = FALSE)
   </tr>
 </table>
 
+
 ### Cluster Managers
 
 Each cluster manager in Spark has additional configuration options. Configurations

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1132,6 +1132,46 @@ Apart from these, the following properties are also available, and may be useful
     to get the replication level of the block to the initial number.
   </td>
 </tr>
+<tr>
+  <td><code>spark.cleaner.periodicGC.interval</code></td>
+  <td>30min</td>
+  <td>
+    Controls how often to trigger a garbage collection.<br><br>
+    This context cleaner triggers cleanups only when weak references are garbage collected.
+    In long-running applications with large driver JVMs, where there is little memory pressure
+    on the driver, this may happen very occasionally or not at all. Not cleaning at all may
+    lead to executors running out of disk space after a while.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.cleaner.referenceTracking</code></td>
+  <td>true</td>
+  <td>
+    Enables or disables context cleaning.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.cleaner.referenceTracking.blocking</code></td>
+  <td>true</td>
+  <td>
+    Controls whether the cleaning thread should block on cleanup tasks (other than shuffle, which is controlled by
+    <code>spark.cleaner.referenceTracking.blocking.shuffle</code> Spark property).
+  </td>
+</tr>
+<tr>
+  <td><code>spark.cleaner.referenceTracking.blocking.shuffle</code></td>
+  <td>false</td>
+  <td>
+    Controls whether the cleaning thread should block on shuffle cleanup tasks.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.cleaner.referenceTracking.cleanCheckpoints</code></td>
+  <td>false</td>
+  <td>
+    Controls whether to clean checkpoint files if the reference is out of scope.
+  </td>
+</tr>
 </table>
 
 ### Execution Behavior
@@ -2303,52 +2343,6 @@ showDF(properties, numRows = 200, truncate = FALSE)
     <td><code>spark.deploy.zookeeper.dir</code></td>
     <td>None</td>
     <td>When `spark.deploy.recoveryMode` is set to ZOOKEEPER, this configuration is used to set the zookeeper directory to store recovery state.</td>
-  </tr>
-</table>
-
-### Spark Application Garbage Collector
-
-<table class="table">
-  <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
-  <tr>
-    <td><code>spark.cleaner.periodicGC.interval</code></td>
-    <td>30min</td>
-    <td>
-      Controls how often to trigger a garbage collection.<br><br>
-      This context cleaner triggers cleanups only when weak references are garbage collected.
-      In long-running applications with large driver JVMs, where there is little memory pressure
-      on the driver, this may happen very occasionally or not at all. Not cleaning at all may
-      lead to executors running out of disk space after a while.
-    </td>
-  </tr>
-  <tr>
-    <td><code>spark.cleaner.referenceTracking</code></td>
-    <td>true</td>
-    <td>
-      Enables or disables context cleaning.
-    </td>
-  </tr>
-  <tr>
-    <td><code>spark.cleaner.referenceTracking.blocking</code></td>
-    <td>true</td>
-    <td>
-      Controls whether the cleaning thread should block on cleanup tasks (other than shuffle, which is controlled by
-      <code>spark.cleaner.referenceTracking.blocking.shuffle</code> Spark property).
-    </td>
-  </tr>
-  <tr>
-    <td><code>spark.cleaner.referenceTracking.blocking.shuffle</code></td>
-    <td>false</td>
-    <td>
-      Controls whether the cleaning thread should block on shuffle cleanup tasks.
-    </td>
-  </tr>
-  <tr>
-    <td><code>spark.cleaner.referenceTracking.cleanCheckpoints</code></td>
-    <td>false</td>
-    <td>
-      Controls whether to clean checkpoint files if the reference is out of scope.
-    </td>
   </tr>
 </table>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2306,6 +2306,50 @@ showDF(properties, numRows = 200, truncate = FALSE)
   </tr>
 </table>
 
+### Spark Application Garbage Collector
+
+<table class="table">
+  <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
+  <tr>
+    <td><code>spark.cleaner.periodicGC.interval</code></td>
+    <td>30min</td>
+    <td>
+      Controls how often to trigger a garbage collection.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spark.cleaner.referenceTracking</code></td>
+    <td>true</td>
+    <td>
+      Controls whether a ContextCleaner should be created when a SparkContext initializes.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spark.cleaner.referenceTracking.blocking</code></td>
+    <td>true</td>
+    <td>
+      Controls whether the cleaning thread should block on cleanup tasks (other than shuffle, which is controlled by
+      spark.cleaner.referenceTracking.blocking.shuffle Spark property).<br><br>
+      It is true as a workaround to <a href="https://issues.apache.org/jira/browse/SPARK-3015">
+      SPARK-3015 Removing broadcast in quick successions causes Akka timeout</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spark.cleaner.referenceTracking.blocking.shuffle</code></td>
+    <td>false</td>
+    <td>
+      Controls whether the cleaning thread should block on shuffle cleanup tasks.<br><br>
+      It is false as a workaround to SPARK-3139 Akka timeouts from ContextCleaner when cleaning shuffles.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spark.cleaner.referenceTracking.cleanCheckpoints</code></td>
+    <td>false</td>
+    <td>
+      Controls whether to clean checkpoint files if the reference is out of scope.
+    </td>
+  </tr>
+</table>
 
 ### Cluster Managers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2314,14 +2314,18 @@ showDF(properties, numRows = 200, truncate = FALSE)
     <td><code>spark.cleaner.periodicGC.interval</code></td>
     <td>30min</td>
     <td>
-      Controls how often to trigger a garbage collection.
+      Controls how often to trigger a garbage collection.<br><br>
+      This context cleaner triggers cleanups only when weak references are garbage collected.
+      In long-running applications with large driver JVMs, where there is little memory pressure
+      on the driver, this may happen very occasionally or not at all. Not cleaning at all may
+      lead to executors running out of disk space after a while.
     </td>
   </tr>
   <tr>
     <td><code>spark.cleaner.referenceTracking</code></td>
     <td>true</td>
     <td>
-      Controls whether a ContextCleaner should be created when a SparkContext initializes.
+      Enables or disables context cleaning.
     </td>
   </tr>
   <tr>
@@ -2329,17 +2333,14 @@ showDF(properties, numRows = 200, truncate = FALSE)
     <td>true</td>
     <td>
       Controls whether the cleaning thread should block on cleanup tasks (other than shuffle, which is controlled by
-      spark.cleaner.referenceTracking.blocking.shuffle Spark property).<br><br>
-      It is true as a workaround to <a href="https://issues.apache.org/jira/browse/SPARK-3015">
-      SPARK-3015 Removing broadcast in quick successions causes Akka timeout</a>.
+      <code>spark.cleaner.referenceTracking.blocking.shuffle</code> Spark property).
     </td>
   </tr>
   <tr>
     <td><code>spark.cleaner.referenceTracking.blocking.shuffle</code></td>
     <td>false</td>
     <td>
-      Controls whether the cleaning thread should block on shuffle cleanup tasks.<br><br>
-      It is false as a workaround to SPARK-3139 Akka timeouts from ContextCleaner when cleaning shuffles.
+      Controls whether the cleaning thread should block on shuffle cleanup tasks.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The spark properties for configuring the ContextCleaner are not documented in the official documentation at https://spark.apache.org/docs/latest/configuration.html#available-properties.

This PR adds the doc.

## How was this patch tested?

Manual.

```
cd docs
jekyll build
open _site/configuration.html
```
