### PR TITLE
[SPARK-22520][SQL][followup] remove outer if for case when codegen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -197,28 +197,24 @@ case class CaseWhen(
       val cond = condExpr.genCode(ctx)
       val res = valueExpr.genCode(ctx)
       s"""
-        if(!$conditionMet) {
-          ${cond.code}
-          if (!${cond.isNull} && ${cond.value}) {
-            ${res.code}
-            ${ev.isNull} = ${res.isNull};
-            ${ev.value} = ${res.value};
-            $conditionMet = true;
-            continue;
-          }
-        }
-      """
+         |${cond.code}
+         |if (!${cond.isNull} && ${cond.value}) {
+         |  ${res.code}
+         |  ${ev.isNull} = ${res.isNull};
+         |  ${ev.value} = ${res.value};
+         |  $conditionMet = true;
+         |  continue;
+         |}
+       """.stripMargin
     }
 
     val elseCode = elseValue.map { elseExpr =>
       val res = elseExpr.genCode(ctx)
       s"""
-        if(!$conditionMet) {
-          ${res.code}
-          ${ev.isNull} = ${res.isNull};
-          ${ev.value} = ${res.value};
-        }
-      """
+         |${res.code}
+         |${ev.isNull} = ${res.isNull};
+         |${ev.value} = ${res.value};
+       """.stripMargin
     }
 
     val allConditions = cases ++ elseCode


### PR DESCRIPTION
## What changes were proposed in this pull request?

a minor cleanup for https://github.com/apache/spark/pull/19752 . Remove the outer if as the code is inside `do while`

## How was this patch tested?

existing tests