### PR TITLE
[SPARK-22642][SQL] the createdTempDir will not be deleted if an exception occurs, should delete it with try-finally.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -102,7 +102,8 @@ case class InsertIntoHiveTable(
       }
 
       // All partition column names in the format of "<column name 1>/<column name 2>/..."
-      val partitionColumns = fileSinkConf.getTableInfo.getProperties.getProperty("partition_columns")
+      val partitionColumns = fileSinkConf.getTableInfo.getProperties.
+        getProperty("partition_columns")
       val partitionColumnNames = Option(partitionColumns).map(_.split("/")).getOrElse(Array.empty)
 
       // By this time, the partition map must match the table's partition columns
@@ -148,8 +149,8 @@ case class InsertIntoHiveTable(
             hadoopConf.get(enforceSortingConfig, "true").toBoolean) {
             throw new AnalysisException(message)
           } else {
-            logWarning(message + s" Inserting data anyways since both $enforceBucketingConfig and " +
-              s"$enforceSortingConfig are set to false.")
+            logWarning(message + s" Inserting data anyways since both $enforceBucketingConfig and "
+              + s"$enforceSortingConfig are set to false.")
           }
         case _ => // do nothing since table has no bucketing
       }
@@ -239,9 +240,9 @@ case class InsertIntoHiveTable(
 
       CommandUtils.updateTableStats(sparkSession, table)
 
-      // It would be nice to just return the childRdd unchanged so insert operations could be chained,
-      // however for now we return an empty list to simplify compatibility checks with hive, which
-      // does not return anything for insert operations.
+      // It would be nice to just return the childRdd unchanged so insert operations could be
+      // chained, however for now we return an empty list to simplify compatibility checks with
+      // hive, which does not return anything for insert operations.
       // TODO: implement hive compatibility as rules.
       Seq.empty[Row]
     } finally {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -77,175 +77,177 @@ case class InsertIntoHiveTable(
     val externalCatalog = sparkSession.sharedState.externalCatalog
     val hadoopConf = sparkSession.sessionState.newHadoopConf()
 
-    val hiveQlTable = HiveClientImpl.toHiveTable(table)
-    // Have to pass the TableDesc object to RDD.mapPartitions and then instantiate new serializer
-    // instances within the closure, since Serializer is not serializable while TableDesc is.
-    val tableDesc = new TableDesc(
-      hiveQlTable.getInputFormatClass,
-      // The class of table should be org.apache.hadoop.hive.ql.metadata.Table because
-      // getOutputFormatClass will use HiveFileFormatUtils.getOutputFormatSubstitute to
-      // substitute some output formats, e.g. substituting SequenceFileOutputFormat to
-      // HiveSequenceFileOutputFormat.
-      hiveQlTable.getOutputFormatClass,
-      hiveQlTable.getMetadata
-    )
-    val tableLocation = hiveQlTable.getDataLocation
-    val tmpLocation = getExternalTmpPath(sparkSession, hadoopConf, tableLocation)
-    val fileSinkConf = new FileSinkDesc(tmpLocation.toString, tableDesc, false)
+    try {
+      val hiveQlTable = HiveClientImpl.toHiveTable(table)
+      // Have to pass the TableDesc object to RDD.mapPartitions and then instantiate new serializer
+      // instances within the closure, since Serializer is not serializable while TableDesc is.
+      val tableDesc = new TableDesc(
+        hiveQlTable.getInputFormatClass,
+        // The class of table should be org.apache.hadoop.hive.ql.metadata.Table because
+        // getOutputFormatClass will use HiveFileFormatUtils.getOutputFormatSubstitute to
+        // substitute some output formats, e.g. substituting SequenceFileOutputFormat to
+        // HiveSequenceFileOutputFormat.
+        hiveQlTable.getOutputFormatClass,
+        hiveQlTable.getMetadata
+      )
+      val tableLocation = hiveQlTable.getDataLocation
+      val tmpLocation = getExternalTmpPath(sparkSession, hadoopConf, tableLocation)
+      val fileSinkConf = new FileSinkDesc(tmpLocation.toString, tableDesc, false)
 
-    val numDynamicPartitions = partition.values.count(_.isEmpty)
-    val numStaticPartitions = partition.values.count(_.nonEmpty)
-    val partitionSpec = partition.map {
-      case (key, Some(value)) => key -> value
-      case (key, None) => key -> ""
-    }
-
-    // All partition column names in the format of "<column name 1>/<column name 2>/..."
-    val partitionColumns = fileSinkConf.getTableInfo.getProperties.getProperty("partition_columns")
-    val partitionColumnNames = Option(partitionColumns).map(_.split("/")).getOrElse(Array.empty)
-
-    // By this time, the partition map must match the table's partition columns
-    if (partitionColumnNames.toSet != partition.keySet) {
-      throw new SparkException(
-        s"""Requested partitioning does not match the ${table.identifier.table} table:
-           |Requested partitions: ${partition.keys.mkString(",")}
-           |Table partitions: ${table.partitionColumnNames.mkString(",")}""".stripMargin)
-    }
-
-    // Validate partition spec if there exist any dynamic partitions
-    if (numDynamicPartitions > 0) {
-      // Report error if dynamic partitioning is not enabled
-      if (!hadoopConf.get("hive.exec.dynamic.partition", "true").toBoolean) {
-        throw new SparkException(ErrorMsg.DYNAMIC_PARTITION_DISABLED.getMsg)
+      val numDynamicPartitions = partition.values.count(_.isEmpty)
+      val numStaticPartitions = partition.values.count(_.nonEmpty)
+      val partitionSpec = partition.map {
+        case (key, Some(value)) => key -> value
+        case (key, None) => key -> ""
       }
 
-      // Report error if dynamic partition strict mode is on but no static partition is found
-      if (numStaticPartitions == 0 &&
-        hadoopConf.get("hive.exec.dynamic.partition.mode", "strict").equalsIgnoreCase("strict")) {
-        throw new SparkException(ErrorMsg.DYNAMIC_PARTITION_STRICT_MODE.getMsg)
+      // All partition column names in the format of "<column name 1>/<column name 2>/..."
+      val partitionColumns = fileSinkConf.getTableInfo.getProperties.getProperty("partition_columns")
+      val partitionColumnNames = Option(partitionColumns).map(_.split("/")).getOrElse(Array.empty)
+
+      // By this time, the partition map must match the table's partition columns
+      if (partitionColumnNames.toSet != partition.keySet) {
+        throw new SparkException(
+          s"""Requested partitioning does not match the ${table.identifier.table} table:
+             |Requested partitions: ${partition.keys.mkString(",")}
+             |Table partitions: ${table.partitionColumnNames.mkString(",")}""".stripMargin)
       }
 
-      // Report error if any static partition appears after a dynamic partition
-      val isDynamic = partitionColumnNames.map(partitionSpec(_).isEmpty)
-      if (isDynamic.init.zip(isDynamic.tail).contains((true, false))) {
-        throw new AnalysisException(ErrorMsg.PARTITION_DYN_STA_ORDER.getMsg)
-      }
-    }
-
-    table.bucketSpec match {
-      case Some(bucketSpec) =>
-        // Writes to bucketed hive tables are allowed only if user does not care about maintaining
-        // table's bucketing ie. both "hive.enforce.bucketing" and "hive.enforce.sorting" are
-        // set to false
-        val enforceBucketingConfig = "hive.enforce.bucketing"
-        val enforceSortingConfig = "hive.enforce.sorting"
-
-        val message = s"Output Hive table ${table.identifier} is bucketed but Spark" +
-          "currently does NOT populate bucketed output which is compatible with Hive."
-
-        if (hadoopConf.get(enforceBucketingConfig, "true").toBoolean ||
-          hadoopConf.get(enforceSortingConfig, "true").toBoolean) {
-          throw new AnalysisException(message)
-        } else {
-          logWarning(message + s" Inserting data anyways since both $enforceBucketingConfig and " +
-            s"$enforceSortingConfig are set to false.")
-        }
-      case _ => // do nothing since table has no bucketing
-    }
-
-    val partitionAttributes = partitionColumnNames.takeRight(numDynamicPartitions).map { name =>
-      query.resolve(name :: Nil, sparkSession.sessionState.analyzer.resolver).getOrElse {
-        throw new AnalysisException(
-          s"Unable to resolve $name given [${query.output.map(_.name).mkString(", ")}]")
-      }.asInstanceOf[Attribute]
-    }
-
-    saveAsHiveFile(
-      sparkSession = sparkSession,
-      queryExecution = Dataset.ofRows(sparkSession, query).queryExecution,
-      hadoopConf = hadoopConf,
-      fileSinkConf = fileSinkConf,
-      outputLocation = tmpLocation.toString,
-      partitionAttributes = partitionAttributes)
-
-    if (partition.nonEmpty) {
+      // Validate partition spec if there exist any dynamic partitions
       if (numDynamicPartitions > 0) {
-        externalCatalog.loadDynamicPartitions(
-          db = table.database,
-          table = table.identifier.table,
-          tmpLocation.toString,
-          partitionSpec,
-          overwrite,
-          numDynamicPartitions)
-      } else {
-        // scalastyle:off
-        // ifNotExists is only valid with static partition, refer to
-        // https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries
-        // scalastyle:on
-        val oldPart =
+        // Report error if dynamic partitioning is not enabled
+        if (!hadoopConf.get("hive.exec.dynamic.partition", "true").toBoolean) {
+          throw new SparkException(ErrorMsg.DYNAMIC_PARTITION_DISABLED.getMsg)
+        }
+
+        // Report error if dynamic partition strict mode is on but no static partition is found
+        if (numStaticPartitions == 0 &&
+          hadoopConf.get("hive.exec.dynamic.partition.mode", "strict").equalsIgnoreCase("strict")) {
+          throw new SparkException(ErrorMsg.DYNAMIC_PARTITION_STRICT_MODE.getMsg)
+        }
+
+        // Report error if any static partition appears after a dynamic partition
+        val isDynamic = partitionColumnNames.map(partitionSpec(_).isEmpty)
+        if (isDynamic.init.zip(isDynamic.tail).contains((true, false))) {
+          throw new AnalysisException(ErrorMsg.PARTITION_DYN_STA_ORDER.getMsg)
+        }
+      }
+
+      table.bucketSpec match {
+        case Some(bucketSpec) =>
+          // Writes to bucketed hive tables are allowed only if user does not care about maintaining
+          // table's bucketing ie. both "hive.enforce.bucketing" and "hive.enforce.sorting" are
+          // set to false
+          val enforceBucketingConfig = "hive.enforce.bucketing"
+          val enforceSortingConfig = "hive.enforce.sorting"
+
+          val message = s"Output Hive table ${table.identifier} is bucketed but Spark" +
+            "currently does NOT populate bucketed output which is compatible with Hive."
+
+          if (hadoopConf.get(enforceBucketingConfig, "true").toBoolean ||
+            hadoopConf.get(enforceSortingConfig, "true").toBoolean) {
+            throw new AnalysisException(message)
+          } else {
+            logWarning(message + s" Inserting data anyways since both $enforceBucketingConfig and " +
+              s"$enforceSortingConfig are set to false.")
+          }
+        case _ => // do nothing since table has no bucketing
+      }
+
+      val partitionAttributes = partitionColumnNames.takeRight(numDynamicPartitions).map { name =>
+        query.resolve(name :: Nil, sparkSession.sessionState.analyzer.resolver).getOrElse {
+          throw new AnalysisException(
+            s"Unable to resolve $name given [${query.output.map(_.name).mkString(", ")}]")
+        }.asInstanceOf[Attribute]
+      }
+
+      saveAsHiveFile(
+        sparkSession = sparkSession,
+        queryExecution = Dataset.ofRows(sparkSession, query).queryExecution,
+        hadoopConf = hadoopConf,
+        fileSinkConf = fileSinkConf,
+        outputLocation = tmpLocation.toString,
+        partitionAttributes = partitionAttributes)
+
+      if (partition.nonEmpty) {
+        if (numDynamicPartitions > 0) {
+          externalCatalog.loadDynamicPartitions(
+            db = table.database,
+            table = table.identifier.table,
+            tmpLocation.toString,
+            partitionSpec,
+            overwrite,
+            numDynamicPartitions)
+        } else {
+          // scalastyle:off
+          // ifNotExists is only valid with static partition, refer to
+          // https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries
+          // scalastyle:on
+          val oldPart =
           externalCatalog.getPartitionOption(
             table.database,
             table.identifier.table,
             partitionSpec)
 
-        var doHiveOverwrite = overwrite
+          var doHiveOverwrite = overwrite
 
-        if (oldPart.isEmpty || !ifPartitionNotExists) {
-          // SPARK-18107: Insert overwrite runs much slower than hive-client.
-          // Newer Hive largely improves insert overwrite performance. As Spark uses older Hive
-          // version and we may not want to catch up new Hive version every time. We delete the
-          // Hive partition first and then load data file into the Hive partition.
-          if (oldPart.nonEmpty && overwrite) {
-            oldPart.get.storage.locationUri.foreach { uri =>
-              val partitionPath = new Path(uri)
-              val fs = partitionPath.getFileSystem(hadoopConf)
-              if (fs.exists(partitionPath)) {
-                if (!fs.delete(partitionPath, true)) {
-                  throw new RuntimeException(
-                    "Cannot remove partition directory '" + partitionPath.toString)
+          if (oldPart.isEmpty || !ifPartitionNotExists) {
+            // SPARK-18107: Insert overwrite runs much slower than hive-client.
+            // Newer Hive largely improves insert overwrite performance. As Spark uses older Hive
+            // version and we may not want to catch up new Hive version every time. We delete the
+            // Hive partition first and then load data file into the Hive partition.
+            if (oldPart.nonEmpty && overwrite) {
+              oldPart.get.storage.locationUri.foreach { uri =>
+                val partitionPath = new Path(uri)
+                val fs = partitionPath.getFileSystem(hadoopConf)
+                if (fs.exists(partitionPath)) {
+                  if (!fs.delete(partitionPath, true)) {
+                    throw new RuntimeException(
+                      "Cannot remove partition directory '" + partitionPath.toString)
+                  }
+                  // Don't let Hive do overwrite operation since it is slower.
+                  doHiveOverwrite = false
                 }
-                // Don't let Hive do overwrite operation since it is slower.
-                doHiveOverwrite = false
               }
             }
+
+            // inheritTableSpecs is set to true. It should be set to false for an IMPORT query
+            // which is currently considered as a Hive native command.
+            val inheritTableSpecs = true
+            externalCatalog.loadPartition(
+              table.database,
+              table.identifier.table,
+              tmpLocation.toString,
+              partitionSpec,
+              isOverwrite = doHiveOverwrite,
+              inheritTableSpecs = inheritTableSpecs,
+              isSrcLocal = false)
           }
-
-          // inheritTableSpecs is set to true. It should be set to false for an IMPORT query
-          // which is currently considered as a Hive native command.
-          val inheritTableSpecs = true
-          externalCatalog.loadPartition(
-            table.database,
-            table.identifier.table,
-            tmpLocation.toString,
-            partitionSpec,
-            isOverwrite = doHiveOverwrite,
-            inheritTableSpecs = inheritTableSpecs,
-            isSrcLocal = false)
         }
+      } else {
+        externalCatalog.loadTable(
+          table.database,
+          table.identifier.table,
+          tmpLocation.toString, // TODO: URI
+          overwrite,
+          isSrcLocal = false)
       }
-    } else {
-      externalCatalog.loadTable(
-        table.database,
-        table.identifier.table,
-        tmpLocation.toString, // TODO: URI
-        overwrite,
-        isSrcLocal = false)
+
+      // un-cache this table.
+      sparkSession.catalog.uncacheTable(table.identifier.quotedString)
+      sparkSession.sessionState.catalog.refreshTable(table.identifier)
+
+      CommandUtils.updateTableStats(sparkSession, table)
+
+      // It would be nice to just return the childRdd unchanged so insert operations could be chained,
+      // however for now we return an empty list to simplify compatibility checks with hive, which
+      // does not return anything for insert operations.
+      // TODO: implement hive compatibility as rules.
+      Seq.empty[Row]
+    } finally {
+      // Attempt to delete the staging directory and the inclusive files. If failed, the files are
+      // expected to be dropped at the normal termination of VM since deleteOnExit is used.
+      deleteExternalTmpPath(hadoopConf)
     }
-
-    // Attempt to delete the staging directory and the inclusive files. If failed, the files are
-    // expected to be dropped at the normal termination of VM since deleteOnExit is used.
-    deleteExternalTmpPath(hadoopConf)
-
-    // un-cache this table.
-    sparkSession.catalog.uncacheTable(table.identifier.quotedString)
-    sparkSession.sessionState.catalog.refreshTable(table.identifier)
-
-    CommandUtils.updateTableStats(sparkSession, table)
-
-    // It would be nice to just return the childRdd unchanged so insert operations could be chained,
-    // however for now we return an empty list to simplify compatibility checks with hive, which
-    // does not return anything for insert operations.
-    // TODO: implement hive compatibility as rules.
-    Seq.empty[Row]
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We found staging directories will not be dropped sometimes in our production environment.
The createdTempDir will not be deleted if an exception occurs, we should delete createdTempDir with try-finally.

This PR is follow-up SPARK-18703.

## How was this patch tested?

exist tests

