### PR TITLE
[SPARK-22664] The logs about "Connected to Zookeeper" in ReliableKafkaReceiver.scala are in wrong position

### DIFF
--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
@@ -115,12 +115,12 @@ class ReliableKafkaReceiver[
 
     assert(!consumerConfig.autoCommitEnable)
 
-    logInfo(s"Connecting to Zookeeper: ${consumerConfig.zkConnect}")
     consumerConnector = Consumer.create(consumerConfig)
-    logInfo(s"Connected to Zookeeper: ${consumerConfig.zkConnect}")
 
+    logInfo(s"Connecting to Zookeeper: ${consumerConfig.zkConnect}")
     zkClient = new ZkClient(consumerConfig.zkConnect, consumerConfig.zkSessionTimeoutMs,
       consumerConfig.zkConnectionTimeoutMs, ZKStringSerializer)
+    logInfo(s"Connected to Zookeeper: ${consumerConfig.zkConnect}")
 
     messageHandlerThreadPool = ThreadUtils.newDaemonFixedThreadPool(
       topics.values.sum, "KafkaMessageHandler")

--- a/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
+++ b/external/kafka-0-8/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
@@ -115,9 +115,9 @@ class ReliableKafkaReceiver[
 
     assert(!consumerConfig.autoCommitEnable)
 
+    logInfo(s"Connecting to Zookeeper: ${consumerConfig.zkConnect}")
     consumerConnector = Consumer.create(consumerConfig)
 
-    logInfo(s"Connecting to Zookeeper: ${consumerConfig.zkConnect}")
     zkClient = new ZkClient(consumerConfig.zkConnect, consumerConfig.zkSessionTimeoutMs,
       consumerConfig.zkConnectionTimeoutMs, ZKStringSerializer)
     logInfo(s"Connected to Zookeeper: ${consumerConfig.zkConnect}")


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-22664](https://issues.apache.org/jira/browse/SPARK-22664)
The logs about "Connecting to Zookeeper" and "Connected to Zookeeper" in ReliableKafkaReceiver.scala should be printed when new a zkClient() in line 122.