### PR TITLE
[SPARK-22667][ML][WIP] Fix model-specific optimization support for ML tuning: Python API

### DIFF
--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -71,6 +71,22 @@ class Estimator(Params):
             raise ValueError("Params must be either a param map or a list/tuple of param maps, "
                              "but got %s." % type(params))
 
+    @since("2.3.0")
+    def parallelFit(self, dataset, paramMaps, threadPool, modelCallback):
+        """
+        Parallelly fits models to the input dataset with a list of param maps.
+
+        :param dataset: input dataset, which is an instance of :py:class:`pyspark.sql.DataFrame`
+        :param paramMaps: a list of param maps
+        :param threadPool: a thread pool used to run parallel fitting
+        :param modelCallback: fitted model with corresponding param map index will be passed to
+                              the callback function.
+        """
+        def singleTrain(paramMapIndex):
+            model = self.fit(dataset, paramMaps[paramMapIndex])
+            modelCallback(model, paramMapIndex)
+        threadPool.map(singleTrain, range(len(paramMaps)))
+
 
 @inherit_doc
 class Transformer(Params):

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -262,7 +262,6 @@ class CrossValidator(Estimator, ValidatorParams, HasParallelism, MLReadable, MLW
         randCol = self.uid + "_rand"
         df = dataset.select("*", rand(seed).alias(randCol))
         metrics = [0.0] * numModels
-
         pool = ThreadPool(processes=min(self.getParallelism(), numModels))
 
         for i in range(nFolds):
@@ -273,9 +272,11 @@ class CrossValidator(Estimator, ValidatorParams, HasParallelism, MLReadable, MLW
             train = df.filter(~condition).cache()
 
             currentFoldMetrics = [0.0] * numModels
+
             def modelCallback(model, paramMapIndex):
                 metric = eva.evaluate(model.transform(validation, epm[paramMapIndex]))
                 currentFoldMetrics[paramMapIndex] = metric
+
             est.parallelFit(train, epm, pool, modelCallback)
 
             for j in range(numModels):
@@ -420,7 +421,7 @@ class CrossValidatorModel(Model, ValidatorParams, MLReadable, MLWritable):
         avgMetrics = _java2py(sc, java_stage.avgMetrics())
         estimator, epms, evaluator = super(CrossValidatorModel, cls)._from_java_impl(java_stage)
 
-        py_stage = cls(bestModel = bestModel, avgMetrics = avgMetrics).setEstimator(estimator)
+        py_stage = cls(bestModel=bestModel, avgMetrics=avgMetrics).setEstimator(estimator)
         py_stage = py_stage.setEstimatorParamMaps(epms).setEvaluator(evaluator)
 
         py_stage._resetUid(java_stage.uid())
@@ -683,8 +684,8 @@ class TrainValidationSplitModel(Model, ValidatorParams, MLReadable, MLWritable):
         estimator, epms, evaluator = super(TrainValidationSplitModel,
                                            cls)._from_java_impl(java_stage)
         # Create a new instance of this stage.
-        py_stage = cls(bestModel = bestModel, validationMetrics = validationMetrics)\
-            .setEstimator(estimator)
+        py_stage = cls(bestModel=bestModel,
+                       validationMetrics=validationMetrics).setEstimator(estimator)
         py_stage = py_stage.setEstimatorParamMaps(epms).setEvaluator(evaluator)
 
         py_stage._resetUid(java_stage.uid())


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is python api for #19350 

Python CrossValidator/TrainValidationSplit:
With base Estimator implemented in Scala/Java
→ Convert base Estimator to Scala/Java object, and call the JVM fit()
With base Estimator implemented in Python
→ Python needs the same machinery for multi-model fitting and parallelism as Scala.  We can call directly into it. New API added:
```
class Estimator:
  def parallelFit(self, dataset, paramMaps, threadPool, modelCallback):
```

Doc [link](https://docs.google.com/document/d/1xw5M4sp1e0eQie75yIt-r6-GTuD5vpFf_I6v-AFBM3M/edit)

**Note** This PR also fix the `# TODO: persist average/validation metrics as well` in CV/TVS. Because the testsuite need to check consistency of `avgMetrics/validationMetrics` so this need to be fixed.
If this need backport to old spark version, I can split it to a separate PR.

## How was this patch tested?

Existing UT already covers each code paths which need test.
