### PR TITLE
[SPARK-22671][SQL] Make SortMergeJoin shuffle read less data when wholeStageCodegen is off

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -144,6 +144,7 @@ public final class UnsafeExternalRowSorter {
 
   public Iterator<UnsafeRow> sort(Iterator<UnsafeRow> inputIterator) throws IOException {
     final UnsafeSorterIterator[] sortedIterator = new UnsafeSorterIterator[1];
+    sortedIterator[0] = sorter.getSortedIterator();
     return new AbstractIterator<UnsafeRow>() {
       // inputIterator == null means the rows has been inserted
       boolean inserted = inputIterator == null;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -141,11 +141,6 @@ public final class UnsafeExternalRowSorter {
   public Iterator<UnsafeRow> sort(Iterator<UnsafeRow> inputIterator) throws IOException {
     try {
       final UnsafeSorterIterator sortedIterator = sorter.getSortedIterator();
-      if (!sortedIterator.hasNext()) {
-        // Since we won't ever call next() on an empty iterator, we need to clean up resources
-        // here in order to prevent memory leaks.
-        cleanupResources();
-      }
       return new AbstractIterator<UnsafeRow>() {
         boolean alreadyCalculated = false;
         private final int numFields = schema.length();
@@ -188,8 +183,11 @@ public final class UnsafeExternalRowSorter {
         }
       };
     } catch (IOException e) {
-      cleanupResources();
       throw e;
+    } finally {
+      // Since we won't ever call next() on an empty iterator, we need to clean up resources
+      // here in order to prevent memory leaks.
+      cleanupResources();
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -146,7 +146,7 @@ public final class UnsafeExternalRowSorter {
     final UnsafeSorterIterator[] sortedIterator = new UnsafeSorterIterator[1];
     sortedIterator[0] = sorter.getSortedIterator();
     return new AbstractIterator<UnsafeRow>() {
-      // inputIterator == null means the rows has been inserted
+      // inputIterator is null means the rows has already been inserted
       boolean inserted = inputIterator == null;
       private final int numFields = schema.length();
       private UnsafeRow row = new UnsafeRow(numFields);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -142,65 +142,64 @@ public final class UnsafeExternalRowSorter {
     return sort(null);
   }
 
-  public Iterator<UnsafeRow> sort(Iterator<UnsafeRow> inputIterator)
-    throws IOException {
-    try {
-      final UnsafeSorterIterator sortedIterator = sorter.getSortedIterator();
-      return new AbstractIterator<UnsafeRow>() {
-        // inputIterator == null means the rows has been inserted
-        boolean inserted = inputIterator == null;
-        private final int numFields = schema.length();
-        private UnsafeRow row = new UnsafeRow(numFields);
+  public Iterator<UnsafeRow> sort(Iterator<UnsafeRow> inputIterator) throws IOException {
+    final UnsafeSorterIterator[] sortedIterator = new UnsafeSorterIterator[1];
+    return new AbstractIterator<UnsafeRow>() {
+      // inputIterator == null means the rows has been inserted
+      boolean inserted = inputIterator == null;
+      private final int numFields = schema.length();
+      private UnsafeRow row = new UnsafeRow(numFields);
 
-        @Override
-        public boolean hasNext() {
-          try {
-            if (!inserted) {
-              while (inputIterator.hasNext()) {
-                insertRow(inputIterator.next());
-              }
-              inserted = true;
-              if (!sortedIterator.hasNext()) {
-                // Since we won't ever call next() on an empty iterator, we need to clean up resources
-                // here in order to prevent memory leaks.
-                cleanupResources();
-              }
+      @Override
+      public boolean hasNext() {
+        try {
+          if (!inserted) {
+            while (inputIterator.hasNext()) {
+              insertRow(inputIterator.next());
             }
-          } catch (IOException e) {
-            return false;
-          }
-          return sortedIterator.hasNext();
-        }
-
-        @Override
-        public UnsafeRow next() {
-          try {
-            sortedIterator.loadNext();
-            row.pointTo(
-              sortedIterator.getBaseObject(),
-              sortedIterator.getBaseOffset(),
-              sortedIterator.getRecordLength());
-            if (!hasNext()) {
-              UnsafeRow copy = row.copy(); // so that we don't have dangling pointers to freed page
-              row = null; // so that we don't keep references to the base object
+            sortedIterator[0] = sorter.getSortedIterator();
+            inserted = true;
+            if (!sortedIterator[0].hasNext()) {
+              // Since we won't ever call next() on an empty iterator, we need to clean up resources
+              // here in order to prevent memory leaks.
               cleanupResources();
-              return copy;
-            } else {
-              return row;
             }
-          } catch (IOException e) {
-            cleanupResources();
-            // Scala iterators don't declare any checked exceptions, so we need to use this hack
-            // to re-throw the exception:
-            Platform.throwException(e);
           }
-          throw new RuntimeException("Exception should have been re-thrown in next()");
+        } catch (IOException e) {
+          cleanupResources();
+          // Scala iterators don't declare any checked exceptions, so we need to use this hack
+          // to re-throw the exception:
+          Platform.throwException(e);
         }
-      };
-    } catch (IOException e) {
-      cleanupResources();
-      throw e;
-    }
+        return sortedIterator[0].hasNext();
+      }
+
+      @Override
+      public UnsafeRow next() {
+        UnsafeSorterIterator sortedIter = sortedIterator[0];
+        try {
+          sortedIter.loadNext();
+          row.pointTo(
+            sortedIter.getBaseObject(),
+            sortedIter.getBaseOffset(),
+            sortedIter.getRecordLength());
+          if (!hasNext()) {
+            UnsafeRow copy = row.copy(); // so that we don't have dangling pointers to freed page
+            row = null; // so that we don't keep references to the base object
+            cleanupResources();
+            return copy;
+          } else {
+            return row;
+          }
+        } catch (IOException e) {
+          cleanupResources();
+          // Scala iterators don't declare any checked exceptions, so we need to use this hack
+          // to re-throw the exception:
+          Platform.throwException(e);
+        }
+        throw new RuntimeException("Exception should have been re-thrown in next()");
+      }
+    };
   }
 
   private static final class RowComparator extends RecordComparator {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -105,7 +105,7 @@ case class SortExec(
       // Remember spill data size of this task before execute this operator so that we can
       // figure out how many bytes we spilled for this operator.
       val spillSizeBefore = metrics.memoryBytesSpilled
-      val sortedIterator = sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
+      val sortedIterator = sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]], false)
       sortTime += sorter.getSortTimeNanos / 1000000
       peakMemory += sorter.getPeakMemoryUsage
       spillSize += metrics.memoryBytesSpilled - spillSizeBefore

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -105,7 +105,7 @@ case class SortExec(
       // Remember spill data size of this task before execute this operator so that we can
       // figure out how many bytes we spilled for this operator.
       val spillSizeBefore = metrics.memoryBytesSpilled
-      val sortedIterator = sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]], false)
+      val sortedIterator = sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
       sortTime += sorter.getSortTimeNanos / 1000000
       peakMemory += sorter.getPeakMemoryUsage
       spillSize += metrics.memoryBytesSpilled - spillSizeBefore

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -675,7 +675,7 @@ private[joins] class SortMergeJoinScanner(
     new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold)
 
   // Initialization (note: do _not_ want to advance streamed here).
-  private lazy val advancedResult = advancedBufferedToRowWithNullFreeJoinKey()
+  private lazy val advancedBufferedIterRes = advancedBufferedToRowWithNullFreeJoinKey()
 
   // --- Public methods ---------------------------------------------------------------------------
 
@@ -700,13 +700,14 @@ private[joins] class SortMergeJoinScanner(
       bufferedMatches.clear()
       false
     } else {
-      advancedResult
+      advancedBufferedIterRes
       if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
-        // The new streamed row has the same join key as the previous row, so return the same matches.
+        // The new streamed row has the same join key as the previous row, so return the same
+        // matches.
         true
       } else if (bufferedRow == null) {
-        // The streamed row's join key does not match the current batch of buffered rows and there are
-        // no more rows to read from the buffered iterator, so there can be no more matches.
+        // The streamed row's join key does not match the current batch of buffered rows and there
+        // are no more rows to read from the buffered iterator, so there can be no more matches.
         matchJoinKey = null
         bufferedMatches.clear()
         false
@@ -729,8 +730,8 @@ private[joins] class SortMergeJoinScanner(
           bufferedMatches.clear()
           false
         } else {
-          // The streamed row's join key matches the current buffered row's join, so walk through the
-          // buffered iterator to buffer the rest of the matching rows.
+          // The streamed row's join key matches the current buffered row's join, so walk through
+          // the buffered iterator to buffer the rest of the matching rows.
           assert(comp == 0)
           bufferMatchingRows()
           true
@@ -753,7 +754,7 @@ private[joins] class SortMergeJoinScanner(
       bufferedMatches.clear()
       false
     } else {
-      advancedResult
+      advancedBufferedIterRes
       if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
         // Matches the current group, so do nothing.
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -700,14 +700,14 @@ private[joins] class SortMergeJoinScanner(
       matchJoinKey = null
       bufferedMatches.clear()
       false
+    } else if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
+      // The new streamed row has the same join key as the previous row, so return the same
+      // matches.
+      true
     } else {
       // To make sure vars like bufferedRow is set
       advancedBufferedIterRes
-      if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
-        // The new streamed row has the same join key as the previous row, so return the same
-        // matches.
-        true
-      } else if (bufferedRow == null) {
+      if (bufferedRow == null) {
         // The streamed row's join key does not match the current batch of buffered rows and there
         // are no more rows to read from the buffered iterator, so there can be no more matches.
         matchJoinKey = null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -674,7 +674,8 @@ private[joins] class SortMergeJoinScanner(
   private[this] val bufferedMatches =
     new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold)
 
-  // Initialization (note: do _not_ want to advance streamed here).
+  // Initialization (note: do _not_ want to advance streamed here). This is made lazy to prevent
+  // unnecessary trigger of calculation.
   private lazy val advancedBufferedIterRes = advancedBufferedToRowWithNullFreeJoinKey()
 
   // --- Public methods ---------------------------------------------------------------------------
@@ -700,6 +701,7 @@ private[joins] class SortMergeJoinScanner(
       bufferedMatches.clear()
       false
     } else {
+      // To make sure vars like bufferedRow is set
       advancedBufferedIterRes
       if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
         // The new streamed row has the same join key as the previous row, so return the same
@@ -754,6 +756,7 @@ private[joins] class SortMergeJoinScanner(
       bufferedMatches.clear()
       false
     } else {
+      // To make sure vars like bufferedRow is set
       advancedBufferedIterRes
       if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
         // Matches the current group, so do nothing.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -675,7 +675,7 @@ private[joins] class SortMergeJoinScanner(
     new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold)
 
   // Initialization (note: do _not_ want to advance streamed here).
-  advancedBufferedToRowWithNullFreeJoinKey()
+  private lazy val advancedResult = advancedBufferedToRowWithNullFreeJoinKey()
 
   // --- Public methods ---------------------------------------------------------------------------
 
@@ -699,39 +699,42 @@ private[joins] class SortMergeJoinScanner(
       matchJoinKey = null
       bufferedMatches.clear()
       false
-    } else if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
-      // The new streamed row has the same join key as the previous row, so return the same matches.
-      true
-    } else if (bufferedRow == null) {
-      // The streamed row's join key does not match the current batch of buffered rows and there are
-      // no more rows to read from the buffered iterator, so there can be no more matches.
-      matchJoinKey = null
-      bufferedMatches.clear()
-      false
     } else {
-      // Advance both the streamed and buffered iterators to find the next pair of matching rows.
-      var comp = keyOrdering.compare(streamedRowKey, bufferedRowKey)
-      do {
-        if (streamedRowKey.anyNull) {
-          advancedStreamed()
-        } else {
-          assert(!bufferedRowKey.anyNull)
-          comp = keyOrdering.compare(streamedRowKey, bufferedRowKey)
-          if (comp > 0) advancedBufferedToRowWithNullFreeJoinKey()
-          else if (comp < 0) advancedStreamed()
-        }
-      } while (streamedRow != null && bufferedRow != null && comp != 0)
-      if (streamedRow == null || bufferedRow == null) {
-        // We have either hit the end of one of the iterators, so there can be no more matches.
+      advancedResult
+      if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
+        // The new streamed row has the same join key as the previous row, so return the same matches.
+        true
+      } else if (bufferedRow == null) {
+        // The streamed row's join key does not match the current batch of buffered rows and there are
+        // no more rows to read from the buffered iterator, so there can be no more matches.
         matchJoinKey = null
         bufferedMatches.clear()
         false
       } else {
-        // The streamed row's join key matches the current buffered row's join, so walk through the
-        // buffered iterator to buffer the rest of the matching rows.
-        assert(comp == 0)
-        bufferMatchingRows()
-        true
+        // Advance both the streamed and buffered iterators to find the next pair of matching rows.
+        var comp = keyOrdering.compare(streamedRowKey, bufferedRowKey)
+        do {
+          if (streamedRowKey.anyNull) {
+            advancedStreamed()
+          } else {
+            assert(!bufferedRowKey.anyNull)
+            comp = keyOrdering.compare(streamedRowKey, bufferedRowKey)
+            if (comp > 0) advancedBufferedToRowWithNullFreeJoinKey()
+            else if (comp < 0) advancedStreamed()
+          }
+        } while (streamedRow != null && bufferedRow != null && comp != 0)
+        if (streamedRow == null || bufferedRow == null) {
+          // We have either hit the end of one of the iterators, so there can be no more matches.
+          matchJoinKey = null
+          bufferedMatches.clear()
+          false
+        } else {
+          // The streamed row's join key matches the current buffered row's join, so walk through the
+          // buffered iterator to buffer the rest of the matching rows.
+          assert(comp == 0)
+          bufferMatchingRows()
+          true
+        }
       }
     }
   }
@@ -750,6 +753,7 @@ private[joins] class SortMergeJoinScanner(
       bufferedMatches.clear()
       false
     } else {
+      advancedResult
       if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
         // Matches the current group, so do nothing.
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SortMergeJoin(with wholeStageCodegen), an optimization already exists: if the left table of a partition is empty then there is no need to read the right table of this corresponding partition. This benefits the case in which many partitions of left table is empty and the right table is big.

While in the code path without wholeStageCodegen, this optimization doesn't happen. This is mainly due to the lack of optimization in codegen-SortMergeJoin & the lack of support in `SortExec`, which doesn't do lazy evaluation. UI of TPC-DS q37 when wholeStageCodegen is off:
<img width="908" alt="off_wholestage_before" src="https://user-images.githubusercontent.com/7685352/33493586-8311ac58-d6fb-11e7-816c-7a0fb2065345.PNG">

When the switch is on: 
<img width="935" alt="wholestage_on" src="https://user-images.githubusercontent.com/7685352/33937845-fddfd9a8-e03f-11e7-829e-8b211ee8bb60.PNG">

This PR lazy evaluates sort, and only trigger the right table read after reading the left table and find it's not empty.

After this PR, with wholeStageCodegen off:
<img width="938" alt="wholestage_off" src="https://user-images.githubusercontent.com/7685352/33937825-f0bd9ff8-e03f-11e7-847a-118661b7d435.PNG">

## How was this patch tested?

Existed test suites.

