### PR TITLE
[SPARK-22673][SQL] InMemoryRelation should utilize existing stats whenever possible

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1073,7 +1073,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.memory.offHeap.size</code></td>
   <td>0</td>
   <td>
-    The absolute amount of memory in bytes which can be used for off-heap allocation.
+    The absolute amount of memory (in terms by bytes) which can be used for off-heap allocation.
     This setting has no impact on heap memory usage, so if your executors' total memory consumption must fit within some hard limit then be sure to shrink your JVM heap size accordingly.
     This must be set to a positive value when <code>spark.memory.offHeap.enabled=true</code>.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1073,7 +1073,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.memory.offHeap.size</code></td>
   <td>0</td>
   <td>
-    The absolute amount of memory (in terms by bytes) which can be used for off-heap allocation.
+    The absolute amount of memory in bytes which can be used for off-heap allocation.
     This setting has no impact on heap memory usage, so if your executors' total memory consumption must fit within some hard limit then be sure to shrink your JVM heap size accordingly.
     This must be set to a positive value when <code>spark.memory.offHeap.enabled=true</code>.
   </td>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -80,14 +80,6 @@ class CacheManager extends Logging {
     cachedData.isEmpty
   }
 
-  private def extractStatsOfPlanForCache(plan: LogicalPlan): Option[Statistics] = {
-    if (plan.stats.rowCount.isDefined) {
-      Some(plan.stats)
-    } else {
-      None
-    }
-  }
-
   /**
    * Caches the data produced by the logical representation of the given [[Dataset]].
    * Unlike `RDD.cache()`, the default storage level is set to be `MEMORY_AND_DISK` because
@@ -107,7 +99,7 @@ class CacheManager extends Logging {
         sparkSession.sessionState.conf.columnBatchSize, storageLevel,
         sparkSession.sessionState.executePlan(planToCache).executedPlan,
         tableName,
-        extractStatsOfPlanForCache(planToCache))
+        planToCache.stats)
       cachedData.add(CachedData(planToCache, inMemoryRelation))
     }
   }
@@ -156,7 +148,7 @@ class CacheManager extends Logging {
           storageLevel = cd.cachedRepresentation.storageLevel,
           child = spark.sessionState.executePlan(cd.plan).executedPlan,
           tableName = cd.cachedRepresentation.tableName,
-          statsOfPlanToCache = extractStatsOfPlanForCache(cd.plan))
+          statsOfPlanToCache = cd.plan.stats)
         needToRecache += cd.copy(cachedRepresentation = newCache)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -81,7 +81,7 @@ class CacheManager extends Logging {
   }
 
   private def extractStatsOfPlanForCache(plan: LogicalPlan): Option[Statistics] = {
-    if (plan.conf.cboEnabled && plan.stats.rowCount.isDefined) {
+    if (plan.stats.rowCount.isDefined) {
       Some(plan.stats)
     } else {
       None
@@ -156,7 +156,7 @@ class CacheManager extends Logging {
           storageLevel = cd.cachedRepresentation.storageLevel,
           child = spark.sessionState.executePlan(cd.plan).executedPlan,
           tableName = cd.cachedRepresentation.tableName,
-          stats = extractStatsOfPlanForCache(cd.plan))
+          statsOfPlanToCache = extractStatsOfPlanForCache(cd.plan))
         needToRecache += cd.copy(cachedRepresentation = newCache)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.{FileSystem, Path}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -38,9 +38,9 @@ object InMemoryRelation {
       storageLevel: StorageLevel,
       child: SparkPlan,
       tableName: Option[String],
-      stats: Option[Statistics]): InMemoryRelation =
+      statsOfPlanToCache: Option[Statistics]): InMemoryRelation =
     new InMemoryRelation(child.output, useCompression, batchSize, storageLevel, child, tableName)(
-      statsOfPlanToCache = stats)
+      statsOfPlanToCache = statsOfPlanToCache)
 }
 
 
@@ -73,7 +73,10 @@ case class InMemoryRelation(
   @transient val partitionStatistics = new PartitionStatistics(output)
 
   override def computeStats(): Statistics = {
+    // scalastyle:off
     if (batchStats.value == 0L) {
+      // Underlying columnar RDD hasn't been materialized, use the stats from the plan to cache when
+      // applicable
       statsOfPlanToCache.getOrElse(Statistics(sizeInBytes =
         child.sqlContext.conf.defaultSizeInBytes))
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -74,7 +74,7 @@ case class InMemoryRelation(
   override def computeStats(): Statistics = {
     if (batchStats.value == 0L) {
       children.filter(_.isInstanceOf[LogicalRelation]) match {
-        case Seq(c @ LogicalRelation(_, _, _, _), _) if SQLConf.CBO_ENABLED =>
+        case Seq(c @ LogicalRelation(_, _, _, _), _) if c.conf.cboEnabled =>
           val stats = c.computeStats()
           if (stats.rowCount.isDefined) {
             stats

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -79,7 +79,7 @@ case class InMemoryRelation(
     }
   }
 
-  private var inheritedStats: Option[Statistics] = _
+  private var inheritedStats: Option[Statistics] = None
 
   private[execution] def setStatsFromCachedPlan(planToCache: LogicalPlan): Unit = {
     require(planToCache.conf.cboEnabled, "you cannot use the stats of cached plan in" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -73,7 +73,6 @@ case class InMemoryRelation(
   @transient val partitionStatistics = new PartitionStatistics(output)
 
   override def computeStats(): Statistics = {
-    // scalastyle:off
     if (batchStats.value == 0L) {
       // Underlying columnar RDD hasn't been materialized, use the stats from the plan to cache when
       // applicable

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -38,7 +38,7 @@ object InMemoryRelation {
       storageLevel: StorageLevel,
       child: SparkPlan,
       tableName: Option[String],
-      stats: Option[Statistics]): InMemoryRelation =
+      stats: Option[Statistics] = None): InMemoryRelation =
     new InMemoryRelation(child.output, useCompression, batchSize, storageLevel, child, tableName)(
       statsOfPlanToCache = stats)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -144,7 +144,7 @@ case class InMemoryRelation(
   def withOutput(newOutput: Seq[Attribute]): InMemoryRelation = {
     InMemoryRelation(
       newOutput, useCompression, batchSize, storageLevel, child, tableName)(
-        _cachedColumnBuffers, batchStats)
+        _cachedColumnBuffers, batchStats, statsOfPlanToCache)
   }
 
   override def newInstance(): this.type = {
@@ -156,11 +156,12 @@ case class InMemoryRelation(
       child,
       tableName)(
         _cachedColumnBuffers,
-        batchStats).asInstanceOf[this.type]
+        batchStats,
+        statsOfPlanToCache).asInstanceOf[this.type]
   }
 
   def cachedColumnBuffers: RDD[CachedBatch] = _cachedColumnBuffers
 
   override protected def otherCopyArgs: Seq[AnyRef] =
-    Seq(_cachedColumnBuffers, batchStats)
+    Seq(_cachedColumnBuffers, batchStats, statsOfPlanToCache)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -38,7 +38,7 @@ object InMemoryRelation {
       storageLevel: StorageLevel,
       child: SparkPlan,
       tableName: Option[String],
-      stats: Option[Statistics] = None): InMemoryRelation =
+      stats: Option[Statistics]): InMemoryRelation =
     new InMemoryRelation(child.output, useCompression, batchSize, storageLevel, child, tableName)(
       statsOfPlanToCache = stats)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -488,32 +488,40 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-22673: InMemoryRelation should utilize existing stats of the plan to be cached") {
     withSQLConf("spark.sql.cbo.enabled" -> "true") {
-      val workDir = s"${Utils.createTempDir()}/table1"
-      val data = Seq(100, 200, 300, 400).toDF("count")
-      data.write.parquet(workDir)
-      val dfFromFile = spark.read.parquet(workDir).cache()
-      val inMemoryRelation = dfFromFile.queryExecution.optimizedPlan.collect {
-        case plan: InMemoryRelation => plan
-      }.head
-      // InMemoryRelation's stats is file size before the underlying RDD is materialized
-      assert(inMemoryRelation.computeStats().sizeInBytes === 740)
+      withTempDir { workDir =>
+        withTable("table1") {
+          val workDirPath = workDir.getAbsolutePath + "/table1"
+          val data = Seq(100, 200, 300, 400).toDF("count")
+          data.write.parquet(workDirPath)
+          val dfFromFile = spark.read.parquet(workDirPath).cache()
+          val inMemoryRelation = dfFromFile.queryExecution.optimizedPlan.collect {
+            case plan: InMemoryRelation => plan
+          }.head
+          // InMemoryRelation's stats is file size before the underlying RDD is materialized
+          assert(inMemoryRelation.computeStats().sizeInBytes === 740)
 
-      // InMemoryRelation's stats is updated after materializing RDD
-      dfFromFile.collect()
-      assert(inMemoryRelation.computeStats().sizeInBytes === 16)
+          // InMemoryRelation's stats is updated after materializing RDD
+          dfFromFile.collect()
+          assert(inMemoryRelation.computeStats().sizeInBytes === 16)
 
-      // test of catalog table
-      val dfFromTable = spark.catalog.createTable("table1", workDir).cache()
-      val inMemoryRelation2 = dfFromTable.queryExecution.optimizedPlan.
-        collect { case plan: InMemoryRelation => plan }.head
+          // test of catalog table
+          val dfFromTable = spark.catalog.createTable("table1", workDirPath).cache()
+          val inMemoryRelation2 = dfFromTable.queryExecution.optimizedPlan.
+            collect { case plan: InMemoryRelation => plan }.head
 
-      // Even CBO enabled, InMemoryRelation's stats keeps as the file size before table's stats
-      // is calculated
-      assert(inMemoryRelation2.computeStats().sizeInBytes === 740)
+          // Even CBO enabled, InMemoryRelation's stats keeps as the file size before table's stats
+          // is calculated
+          assert(inMemoryRelation2.computeStats().sizeInBytes === 740)
 
-      // InMemoryRelation's stats should be updated after calculating stats of the table
-      spark.sql("ANALYZE TABLE table1 COMPUTE STATISTICS")
-      assert(inMemoryRelation2.computeStats().sizeInBytes === 16)
+          // InMemoryRelation's stats should be updated after calculating stats of the table
+          // clear cache to simulate a fresh environment
+          dfFromTable.unpersist(blocking = true)
+          spark.sql("ANALYZE TABLE table1 COMPUTE STATISTICS")
+          val inMemoryRelation3 = spark.read.table("table1").cache().queryExecution.optimizedPlan.
+            collect { case plan: InMemoryRelation => plan }.head
+          assert(inMemoryRelation3.computeStats().sizeInBytes === 48)
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.execution.columnar
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, QueryTest, Row, SparkSession}
+import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, In}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.{FilterExec, LocalTableScanExec, WholeStageCodegenExec}
@@ -30,6 +31,7 @@ import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.test.SQLTestData._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.util.Utils
 
 class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -478,6 +480,34 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
         }
         assert(execPlan.executeCollectPublic().length == 0)
       }
+    }
+  }
+
+  test("SPARK-22673: InMemoryRelation should utilize existing stats whenever possible") {
+    withSQLConf("spark.sql.cbo.enabled" -> "true") {
+      // scalastyle:off
+      val workDir = s"${Utils.createTempDir()}/table1"
+      val data = Seq(100, 200, 300, 400).toDF("count")
+      data.write.parquet(workDir)
+      val dfFromFile = spark.read.parquet(workDir).cache()
+      val inMemoryRelation = dfFromFile.queryExecution.optimizedPlan.collect {
+        case plan: InMemoryRelation => plan
+      }.head
+      // InMemoryRelation's stats is Long.MaxValue before the underlying RDD is materialized
+      assert(inMemoryRelation.computeStats().sizeInBytes === Long.MaxValue)
+      // InMemoryRelation's stats is updated after materializing RDD
+      dfFromFile.collect()
+      assert(inMemoryRelation.computeStats().sizeInBytes === 16)
+      // test of catalog table
+      val dfFromTable = spark.catalog.createTable("table1", workDir).cache()
+      val inMemoryRelation2 = dfFromTable.queryExecution.optimizedPlan.
+        collect { case plan: InMemoryRelation => plan }.head
+      // Even CBO enabled, InMemoryRelation's stats keeps as the default one before table's stats
+      // is calculated
+      assert(inMemoryRelation2.computeStats().sizeInBytes === Long.MaxValue)
+      // InMemoryRelation's stats should be updated after calculating stats of the table
+      spark.sql("ANALYZE TABLE table1 COMPUTE STATISTICS")
+      assert(inMemoryRelation2.computeStats().sizeInBytes === 16)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -488,9 +488,9 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-22673: InMemoryRelation should utilize existing stats of the plan to be cached") {
     withSQLConf("spark.sql.cbo.enabled" -> "true") {
-      withTempDir { workDir =>
+      withTempPath { workDir =>
         withTable("table1") {
-          val workDirPath = workDir.getAbsolutePath + "/table1"
+          val workDirPath = workDir.getAbsolutePath
           val data = Seq(100, 200, 300, 400).toDF("count")
           data.write.parquet(workDirPath)
           val dfFromFile = spark.read.parquet(workDirPath).cache()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.execution.columnar
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row, SparkSession}
-import org.apache.spark.sql.catalyst.catalog._
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, In}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.{FilterExec, LocalTableScanExec, WholeStageCodegenExec}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -506,7 +506,7 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
       // Even CBO enabled, InMemoryRelation's stats keeps as the default one before table's stats
       // is calculated
       assert(inMemoryRelation2.computeStats().sizeInBytes === Long.MaxValue)
-      
+
       // InMemoryRelation's stats should be updated after calculating stats of the table
       spark.sql("ANALYZE TABLE table1 COMPUTE STATISTICS")
       assert(inMemoryRelation2.computeStats().sizeInBytes === 16)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current implementation of InMemoryRelation always uses the most expensive execution plan when writing cache
With CBO enabled, we can actually have a more exact estimation of the underlying table size...

## How was this patch tested?

existing test
