### PR TITLE
[SPARK-22668][SQL] Ensure no global variables in arguments of method split by CodegenContext.splitExpressions()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -801,7 +801,8 @@ class CodegenContext {
    * @param expressions the codes to evaluate expressions.
    * @param funcName the split function name base.
    * @param extraArguments the list of (type, name) of the arguments of the split function,
-   *                       except for the current inputs like `ctx.INPUT_ROW`.
+   *                       except for the current inputs like `ctx.INPUT_ROW`. Name must not be
+   *                       mutable state.
    * @param returnType the return type of the split function.
    * @param makeSplitFunction makes split function body, e.g. add preparation or cleanup.
    * @param foldFunctions folds the split function calls.
@@ -835,7 +836,8 @@ class CodegenContext {
    *
    * @param expressions the codes to evaluate expressions.
    * @param funcName the split function name base.
-   * @param arguments the list of (type, name) of the arguments of the split function.
+   * @param arguments the list of (type, name) of the arguments of the split function. Name must
+   *                  not be mutable state
    * @param returnType the return type of the split function.
    * @param makeSplitFunction makes split function body, e.g. add preparation or cleanup.
    * @param foldFunctions folds the split function calls.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -394,4 +394,23 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
       Map("add" -> Literal(1))).genCode(ctx)
     assert(ctx.mutableStates.isEmpty)
   }
+
+  test("SPARK-22668: ensure no global variables in split method arguments") {
+    val ctx = new CodegenContext
+    ctx.addMutableState(ctx.JAVA_INT, "ij")
+    ctx.addMutableState("int[]", "array")
+    ctx.addMutableState("int[][]", "b")
+
+    assert(ctx.isDeclaredMutableState("ij"))
+    assert(ctx.isDeclaredMutableState("array"))
+    assert(ctx.isDeclaredMutableState("array[1]"))
+    assert(ctx.isDeclaredMutableState("b[]"))
+    assert(ctx.isDeclaredMutableState("b[1][]"))
+
+    assert(!ctx.isDeclaredMutableState("i"))
+    assert(!ctx.isDeclaredMutableState("j"))
+    assert(!ctx.isDeclaredMutableState("ij1"))
+    assert(!ctx.isDeclaredMutableState("arr"))
+    assert(!ctx.isDeclaredMutableState("bb[]"))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR ensures that no global variables in arguments of method split by `CodegenContext.splitExpressions()`. This PR asserts this condition.

If there are a global variables in split method by `CodegenContext.splitExpressions() `, the following problem may occur. When variables in arguments are declared as local variables, to assign a value to the variable, which has been originally declared as a global variable, updates a local variable.

Each code generator has to ensure there is no such a case.

```
class Test {
  int globalInt;

  void splittedFunction(int globalInt) {
    ...
    globalInt = 2;
  }

  void apply() {
    globalInt = 1;
    ...
    splittedFunction(globalInt);
    // globalInt should be 2 here since it is 2 if statements are not split
  }
}
```

## How was this patch tested?

Existing test suites