### PR TITLE
[SPARK-22665][SQL] Avoid repartitioning with empty list of expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -839,7 +839,7 @@ case class RepartitionByExpression(
 
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
   require(partitionExpressions.nonEmpty, s"${getClass.getSimpleName} requires a non empty set of " +
-    s"partitioning expressions.")
+    "partitioning expressions.")
 
   val partitioning: Partitioning = {
     val (sortOrder, nonSortOrder) = partitionExpressions.partition(_.isInstanceOf[SortOrder])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -838,6 +838,8 @@ case class RepartitionByExpression(
     numPartitions: Int) extends RepartitionOperation {
 
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
+  require(partitionExpressions.nonEmpty, s"${getClass.getSimpleName} requires a non empty set of " +
+    s"partitioning expressions.")
 
   val partitioning: Partitioning = {
     val (sortOrder, nonSortOrder) = partitionExpressions.partition(_.isInstanceOf[SortOrder])
@@ -847,13 +849,15 @@ case class RepartitionByExpression(
         "`SortOrder`, which means `RangePartitioning`, or none of them are `SortOrder`, which " +
         "means `HashPartitioning`. In this case we have:" +
       s"""
-         |SortOrder: ${sortOrder}
-         |NonSortOrder: ${nonSortOrder}
+         |SortOrder: $sortOrder
+         |NonSortOrder: $nonSortOrder
        """.stripMargin)
 
     if (sortOrder.nonEmpty) {
       RangePartitioning(sortOrder.map(_.asInstanceOf[SortOrder]), numPartitions)
     } else {
+      // nonSortOrder cannot be empty here since we are requiring that `partitionExpressions` is
+      // not empty
       HashPartitioning(nonSortOrder, numPartitions)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.{Cross, Inner}
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning,
+  RangePartitioning, RoundRobinPartitioning}
 import org.apache.spark.sql.types._
 
 
@@ -529,6 +530,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       exprs = SortOrder(Literal(10), Ascending))
     checkPartitioning[RangePartitioning](numPartitions = 10,
       exprs = SortOrder('a.attr, Ascending), SortOrder('b.attr, Descending))
+
+    checkPartitioning[RoundRobinPartitioning](numPartitions = 10, exprs = Seq.empty: _*)
 
     intercept[IllegalArgumentException] {
       checkPartitioning(numPartitions = 0, exprs = Literal(20))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1426,13 +1426,6 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       assert(e.getCause.isInstanceOf[NullPointerException])
     }
   }
-
-  test("SPARK-22665: repartitioning by empty set of expressions should not be allowed") {
-    val e = intercept[IllegalArgumentException] {
-      spark.range(10).repartition(10, Seq.empty: _*)
-    }
-    assert(e.getMessage.contains("non empty set of partitioning expressions"))
-  }
 }
 
 case class SingleData(id: Int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1426,6 +1426,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       assert(e.getCause.isInstanceOf[NullPointerException])
     }
   }
+
+  test("SPARK-22665: repartitioning by empty set of expressions should not be allowed") {
+    val e = intercept[IllegalArgumentException] {
+      spark.range(10).repartition(10, Seq.empty: _*)
+    }
+    assert(e.getMessage.contains("non empty set of partitioning expressions"))
+  }
 }
 
 case class SingleData(id: Int)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Repartitioning by empty set of expressions is currently possible, even though it is a case which is not handled properly. Indeed, in `HashExpression` there is a check to avoid to run it on an empty set, but this check is not performed while repartitioning.
Thus, the PR adds a check to avoid this wrong situation.

## How was this patch tested?

added UT