### PR TITLE
[SPARK-22683][CORE] Add a executorAllocationRatio parameter to throttle the parallelism of the dynamic allocation

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -116,8 +116,12 @@ private[spark] class ExecutorAllocationManager(
   // TODO: The default value of 1 for spark.executor.cores works right now because dynamic
   // allocation is only supported for YARN and the default number of cores per executor in YARN is
   // 1, but it might need to be attained differently for different cluster managers
-  private val tasksPerExecutor =
+  private val taskSlotPerExecutor =
     conf.getInt("spark.executor.cores", 1) / conf.getInt("spark.task.cpus", 1)
+
+  private val tasksPerExecutorSlot = conf.getInt("spark.dynamicAllocation.tasksPerExecutorSlot", 1)
+
+  private val tasksPerExecutor = tasksPerExecutorSlot * taskSlotPerExecutor
 
   validateSettings()
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,7 +26,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{DYN_ALLOCATION_MAX_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS}
+import org.apache.spark.internal.config._
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.scheduler._
 import org.apache.spark.storage.BlockManagerMaster
@@ -124,7 +124,7 @@ private[spark] class ExecutorAllocationManager(
     conf.getInt("spark.executor.cores", 1) / conf.getInt("spark.task.cpus", 1)
 
   private val executorAllocationRatio =
-    conf.getDouble("spark.dynamicAllocation.executorAllocationRatio", 1.0)
+    conf.get(DYN_ALLOCATION_EXECUTOR_ALLOCATION_RATIO)
 
   validateSettings()
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -126,6 +126,10 @@ package object config {
   private[spark] val DYN_ALLOCATION_MAX_EXECUTORS =
     ConfigBuilder("spark.dynamicAllocation.maxExecutors").intConf.createWithDefault(Int.MaxValue)
 
+  private[spark] val DYN_ALLOCATION_EXECUTOR_ALLOCATION_RATIO =
+    ConfigBuilder("spark.dynamicAllocation.executorAllocationRatio")
+      .doubleConf.createWithDefault(1.0)
+
   private[spark] val LOCALITY_WAIT = ConfigBuilder("spark.locality.wait")
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("3s")

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -145,7 +145,7 @@ class ExecutorAllocationManagerSuite
     assert(numExecutorsToAdd(manager) === 1)
   }
 
-  def testParallelismDivisor(cores: Int, divisor: Double, expected: Int): Unit = {
+  def testAllocationRatio(cores: Int, divisor: Double, expected: Int): Unit = {
     val conf = new SparkConf()
       .setMaster("myDummyLocalExternalClusterManager")
       .setAppName("test-executor-allocation-manager")
@@ -153,7 +153,7 @@ class ExecutorAllocationManagerSuite
       .set("spark.dynamicAllocation.testing", "true")
       .set("spark.dynamicAllocation.maxExecutors", "15")
       .set("spark.dynamicAllocation.minExecutors", "3")
-      .set("spark.dynamicAllocation.fullExecutorAllocationDivisor", divisor.toString)
+      .set("spark.dynamicAllocation.executorAllocationRatio", divisor.toString)
       .set("spark.executor.cores", cores.toString)
     val sc = new SparkContext(conf)
     contexts += sc
@@ -166,15 +166,15 @@ class ExecutorAllocationManagerSuite
     sc.stop()
   }
 
-  test("fullExecutorAllocationDivisor is correctly handled") {
-    testParallelismDivisor(1, 2.0, 10)
-    testParallelismDivisor(1, 3.0, 7)
-    testParallelismDivisor(2, 3.0, 4)
-    testParallelismDivisor(1, 2.6, 8)
+  test("executionAllocationRatio is correctly handled") {
+    testAllocationRatio(1, 0.5, 10)
+    testAllocationRatio(1, 1.0/3.0, 7)
+    testAllocationRatio(2, 1.0/3.0, 4)
+    testAllocationRatio(1, 0.385, 8)
 
     // max/min executors capping
-    testParallelismDivisor(1, 1.0, 15) // should be 20 but capped by max
-    testParallelismDivisor(4, 3.0, 3)  // should be 2 but elevated by min
+    testAllocationRatio(1, 1.0, 15) // should be 20 but capped by max
+    testAllocationRatio(4, 1.0/3.0, 3)  // should be 2 but elevated by min
   }
 
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -153,7 +153,7 @@ class ExecutorAllocationManagerSuite
       .set("spark.dynamicAllocation.testing", "true")
       .set("spark.dynamicAllocation.maxExecutors", "15")
       .set("spark.dynamicAllocation.minExecutors", "3")
-      .set("spark.dynamicAllocation.fullParallelismDivisor", divisor.toString)
+      .set("spark.dynamicAllocation.fullExecutorAllocationDivisor", divisor.toString)
       .set("spark.executor.cores", cores.toString)
     val sc = new SparkContext(conf)
     contexts += sc
@@ -166,7 +166,7 @@ class ExecutorAllocationManagerSuite
     sc.stop()
   }
 
-  test("fullParallelismDivisor is correctly handled") {
+  test("fullExecutorAllocationDivisor is correctly handled") {
     testParallelismDivisor(1, 2.0, 10)
     testParallelismDivisor(1, 3.0, 7)
     testParallelismDivisor(2, 3.0, 4)

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -145,7 +145,7 @@ class ExecutorAllocationManagerSuite
     assert(numExecutorsToAdd(manager) === 1)
   }
 
-  def testParallelismDivisor(cores:Int, divisor:Double, expected: Int): Unit = {
+  def testParallelismDivisor(cores: Int, divisor: Double, expected: Int): Unit = {
     val conf = new SparkConf()
       .setMaster("myDummyLocalExternalClusterManager")
       .setAppName("test-executor-allocation-manager")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1753,6 +1753,7 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.dynamicAllocation.minExecutors</code>,
     <code>spark.dynamicAllocation.maxExecutors</code>, and
     <code>spark.dynamicAllocation.initialExecutors</code>
+    <code>spark.dynamicAllocation.tasksPerExecutorSlots</code>
   </td>
 </tr>
 <tr>
@@ -1795,6 +1796,19 @@ Apart from these, the following properties are also available, and may be useful
   <td>0</td>
   <td>
     Lower bound for the number of executors if dynamic allocation is enabled.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.dynamicAllocation.tasksPerSlot</code></td>
+  <td>1</td>
+  <td>
+    Each executor can process a certain number of tasks in parallel (task slots).
+    The number of task slots per executor is: executor.cores / task.cpus.
+    The ExecutorAllocationManager will set a target number of running executors equal to:
+    nbCurrentTask / (taskSlots * tasksPerSlot), with nbCurrentTask being the total number
+    of running and backlogged tasks. With the default value of 1, each available task slot
+    will compute a single task in average, which gives the best latency. With small tasks
+    however, this setting wastes a lot of resources due to executor allocation overhead
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1804,10 +1804,10 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     By default, the dynamic allocation will request enough executors to maximize the 
     parallelism according to the number of tasks to process. While this minimizes the 
-    latency of the job, with small tasks this setting wastes a lot of resources due to
+    latency of the job, with small tasks this setting can waste a lot of resources due to
     executor allocation overhead, as some executor might not even do any work.
     This setting allows to set a divisor that will be used to reduce the number of
-    executors w.r.t. full parallelism
+    executors w.r.t. full parallelism.
     Defaults to 1.0
   </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1802,13 +1802,16 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.dynamicAllocation.fullParallelismDivisor</code></td>
   <td>1</td>
   <td>
-    By default, the dynamic allocation will request enough executors to maximize the 
-    parallelism according to the number of tasks to process. While this minimizes the 
+    By default, the dynamic allocation will request enough executors to maximize the
+    parallelism according to the number of tasks to process. While this minimizes the
     latency of the job, with small tasks this setting can waste a lot of resources due to
     executor allocation overhead, as some executor might not even do any work.
     This setting allows to set a divisor that will be used to reduce the number of
     executors w.r.t. full parallelism.
     Defaults to 1.0
+    The target number of executors computed by the dynamicAllocation can still be overriden
+    by the <code>spark.dynamicAllocation.minExecutors</code> and
+    <code>spark.dynamicAllocation.maxExecutors</code> settings
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1753,7 +1753,7 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.dynamicAllocation.minExecutors</code>,
     <code>spark.dynamicAllocation.maxExecutors</code>, and
     <code>spark.dynamicAllocation.initialExecutors</code>
-    <code>spark.dynamicAllocation.tasksPerExecutorSlots</code>
+    <code>spark.dynamicAllocation.fullParallelismDivisor</code>
   </td>
 </tr>
 <tr>
@@ -1799,16 +1799,16 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.dynamicAllocation.tasksPerSlot</code></td>
+  <td><code>spark.dynamicAllocation.fullParallelismDivisor</code></td>
   <td>1</td>
   <td>
-    Each executor can process a certain number of tasks in parallel (task slots).
-    The number of task slots per executor is: executor.cores / task.cpus.
-    The ExecutorAllocationManager will set a target number of running executors equal to:
-    nbCurrentTask / (taskSlots * tasksPerSlot), with nbCurrentTask being the total number
-    of running and backlogged tasks. With the default value of 1, each available task slot
-    will compute a single task in average, which gives the best latency. With small tasks
-    however, this setting wastes a lot of resources due to executor allocation overhead
+    By default, the dynamic allocation will request enough executors to maximize the 
+    parallelism according to the number of tasks to process. While this minimizes the 
+    latency of the job, with small tasks this setting wastes a lot of resources due to
+    executor allocation overhead, as some executor might not even do any work.
+    This setting allows to set a divisor that will be used to reduce the number of
+    executors w.r.t. full parallelism
+    Defaults to 1.0
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1753,7 +1753,7 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.dynamicAllocation.minExecutors</code>,
     <code>spark.dynamicAllocation.maxExecutors</code>, and
     <code>spark.dynamicAllocation.initialExecutors</code>
-    <code>spark.dynamicAllocation.fullExecutorAllocationDivisor</code>
+    <code>spark.dynamicAllocation.executorAllocationRatio</code>
   </td>
 </tr>
 <tr>
@@ -1799,16 +1799,17 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.dynamicAllocation.fullExecutorAllocationDivisor</code></td>
+  <td><code>spark.dynamicAllocation.executorAllocationRatio</code></td>
   <td>1</td>
   <td>
     By default, the dynamic allocation will request enough executors to maximize the
     parallelism according to the number of tasks to process. While this minimizes the
     latency of the job, with small tasks this setting can waste a lot of resources due to
     executor allocation overhead, as some executor might not even do any work.
-    This setting allows to set a divisor that will be used to reduce the number of
+    This setting allows to set a ratio that will be used to reduce the number of
     executors w.r.t. full parallelism.
-    Defaults to 1.0
+    Defaults to 1.0 to give maximum parallelism.
+    0.5 will divide the target number of executors by 2
     The target number of executors computed by the dynamicAllocation can still be overriden
     by the <code>spark.dynamicAllocation.minExecutors</code> and
     <code>spark.dynamicAllocation.maxExecutors</code> settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1753,7 +1753,7 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.dynamicAllocation.minExecutors</code>,
     <code>spark.dynamicAllocation.maxExecutors</code>, and
     <code>spark.dynamicAllocation.initialExecutors</code>
-    <code>spark.dynamicAllocation.fullParallelismDivisor</code>
+    <code>spark.dynamicAllocation.fullExecutorAllocationDivisor</code>
   </td>
 </tr>
 <tr>
@@ -1799,7 +1799,7 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.dynamicAllocation.fullParallelismDivisor</code></td>
+  <td><code>spark.dynamicAllocation.fullExecutorAllocationDivisor</code></td>
   <td>1</td>
   <td>
     By default, the dynamic allocation will request enough executors to maximize the


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default, the dynamic allocation will request enough executors to maximize the
parallelism according to the number of tasks to process. While this minimizes the
latency of the job, with small tasks this setting can waste a lot of resources due to
executor allocation overhead, as some executor might not even do any work.
This setting allows to set a ratio that will be used to reduce the number of
target executors w.r.t. full parallelism.

The number of executors computed with this setting is still fenced by
`spark.dynamicAllocation.maxExecutors` and `spark.dynamicAllocation.minExecutors` 

## How was this patch tested?
Units tests and runs on various actual workloads on a Yarn Cluster 