### PR TITLE
[SPARK-22587] Spark job fails if fs.defaultFS and application jar are different url

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1429,8 +1429,8 @@ private object Client extends Logging {
     }
 
     val srcAuthority = srcUri.getAuthority()
-    val detAuthority = dstUri.getAuthority()
-    if (srcAuthority != detAuthority || (srcAuthority != null && !srcAuthority.equalsIgnoreCase(detAuthority))) {
+    val dstAuthority = dstUri.getAuthority()
+    if (srcAuthority != null && !srcAuthority.equalsIgnoreCase(dstAuthority)) {
       return false
     }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1421,7 +1421,7 @@ private object Client extends Logging {
   /**
    * Return whether two URI represent file system are the same
    */
-  private def compareUri(srcUri: URI, dstUri: URI): Boolean = {
+  def compareUri(srcUri: URI, dstUri: URI): Boolean = {
 
     if (srcUri.getScheme() == null || srcUri.getScheme() != dstUri.getScheme()) {
       return false

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1428,6 +1428,12 @@ private object Client extends Logging {
       return false
     }
 
+    val srcAuthority = srcUri.getAuthority()
+    val detAuthority = dstUri.getAuthority()
+    if (srcAuthority != detAuthority || (srcAuthority != null && !srcAuthority.equalsIgnoreCase(detAuthority))) {
+      return false
+    }
+
     var srcHost = srcUri.getHost()
     var dstHost = dstUri.getHost()
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1421,7 +1421,7 @@ private object Client extends Logging {
   /**
    * Return whether two URI represent file system are the same
    */
-  def compareUri(srcUri: URI, dstUri: URI): Boolean = {
+  private[spark] def compareUri(srcUri: URI, dstUri: URI): Boolean = {
 
     if (srcUri.getScheme() == null || srcUri.getScheme() != dstUri.getScheme()) {
       return false

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1419,11 +1419,10 @@ private object Client extends Logging {
   }
 
   /**
-   * Return whether the two file systems are the same.
+   * Return whether two URI represent file system are the same
    */
-  private def compareFs(srcFs: FileSystem, destFs: FileSystem): Boolean = {
-    val srcUri = srcFs.getUri()
-    val dstUri = destFs.getUri()
+  private def compareUri(srcUri: URI, dstUri: URI): Boolean = {
+
     if (srcUri.getScheme() == null || srcUri.getScheme() != dstUri.getScheme()) {
       return false
     }
@@ -1451,6 +1450,17 @@ private object Client extends Logging {
     }
 
     Objects.equal(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
+
+  }
+
+  /**
+   * Return whether the two file systems are the same.
+   */
+  protected def compareFs(srcFs: FileSystem, destFs: FileSystem): Boolean = {
+    val srcUri = srcFs.getUri()
+    val dstUri = destFs.getUri()
+
+    compareUri(srcUri, dstUri)
   }
 
   /**

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -365,8 +365,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
     ("hdfs URI match test", "hdfs:/path1", "hdfs:/path1")
   )
 
-  matching.foreach {
-    t =>
+  matching.foreach { t =>
       test(t._1) {
         assert(Client.compareUri(new URI(t._2), new URI(t._3)),
           s"No match between ${t._2} and ${t._3}")
@@ -384,8 +383,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
     ("hdfs URI unmatch test2", "hdfs://namenode1:8020/path1", "hdfs://namenode1:8080/path2")
   )
 
-  unmatching.foreach {
-    t =>
+  unmatching.foreach { t =>
       test(t._1) {
         assert(!Client.compareUri(new URI(t._2), new URI(t._3)),
           s"match between ${t._2} and ${t._3}")

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -358,11 +358,11 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   private val matching = Seq(
-    ("files", "file:///file1", "file:///file2"),
-    ("files", "file:///c:file1", "file://c:file2"),
-    ("files", "file://host/file1", "file://host/file2"),
-    ("wasb", "wasb://bucket1@user", "wasb://bucket1@user/"),
-    ("hdfs", "hdfs:/path1", "hdfs:/path1")
+    ("files URI match test1", "file:///file1", "file:///file2"),
+    ("files URI match test2", "file:///c:file1", "file://c:file2"),
+    ("files URI match test3", "file://host/file1", "file://host/file2"),
+    ("wasb URI match test", "wasb://bucket1@user", "wasb://bucket1@user/"),
+    ("hdfs URI match test", "hdfs:/path1", "hdfs:/path1")
   )
 
   matching.foreach {
@@ -374,14 +374,14 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   private val unmatching = Seq(
-    ("files", "file:///file1", "file://host/file2"),
-    ("files", "file://host/file1", "file:///file2"),
-    ("files", "file://host/file1", "file://host2/file2"),
-    ("wasb", "wasb://bucket1@user", "wasb://bucket2@user/"),
-    ("wasb", "wasb://bucket1@user", "wasb://bucket1@user2/"),
-    ("s3", "s3a://user@pass:bucket1/", "s3a://user2@pass2:bucket1/"),
-    ("hdfs", "hdfs://namenode1/path1", "hdfs://namenode1:8080/path2"),
-    ("hdfs", "hdfs://namenode1:8020/path1", "hdfs://namenode1:8080/path2")
+    ("files URI unmatch test1", "file:///file1", "file://host/file2"),
+    ("files URI unmatch test2", "file://host/file1", "file:///file2"),
+    ("files URI unmatch test3", "file://host/file1", "file://host2/file2"),
+    ("wasb URI unmatch test1", "wasb://bucket1@user", "wasb://bucket2@user/"),
+    ("wasb URI unmatch test2", "wasb://bucket1@user", "wasb://bucket1@user2/"),
+    ("s3 URI unmatch test", "s3a://user@pass:bucket1/", "s3a://user2@pass2:bucket1/"),
+    ("hdfs URI unmatch test1", "hdfs://namenode1/path1", "hdfs://namenode1:8080/path2"),
+    ("hdfs URI unmatch test2", "hdfs://namenode1:8020/path1", "hdfs://namenode1:8080/path2")
   )
 
   unmatching.foreach {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -357,6 +357,45 @@ class ClientSuite extends SparkFunSuite with Matchers {
     sparkConf.get(SECONDARY_JARS) should be (Some(Seq(new File(jar2.toURI).getName)))
   }
 
+  test("compare URI for filesystems") {
+
+    val matching = Seq(
+      ("files", "file:///file1", "file:///file2"),
+      ("files", "file:///c:file1", "file://c:file2"),
+      ("files", "file://host/file1", "file://host/file2"),
+      ("wasb", "wasb://bucket1@user", "wasb://bucket1@user/"),
+      ("hdfs", "hdfs:/path1", "hdfs:/path1")
+    )
+
+    matching.foreach {
+      t =>
+        test(t._1) {
+          assert(Client.compareUri(new URI(t._2), new URI(t._3)),
+            s"No match between ${t._2} and ${t._3}")
+        }
+    }
+
+    val unmatching = Seq(
+      ("files", "file:///file1", "file://host/file2"),
+      ("files", "file://host/file1", "file:///file2"),
+      ("files", "file://host/file1", "file://host2/file2"),
+      ("wasb", "wasb://bucket1@user", "wasb://bucket2@user/"),
+      ("wasb", "wasb://bucket1@user", "wasb://bucket1@user2/"),
+      ("s3", "s3a://user@pass:bucket1/", "s3a://user2@pass2:bucket1/"),
+      ("hdfs", "hdfs://namenode1/path1", "hdfs://namenode1:8080/path2"),
+      ("hdfs", "hdfs://namenode1:8020/path1", "hdfs://namenode1:8080/path2")
+    )
+
+    unmatching.foreach {
+      t =>
+        test(t._1) {
+          assert(!Client.compareUri(new URI(t._2), new URI(t._3)),
+            s"match between ${t._2} and ${t._3}")
+        }
+    }
+
+  }
+
   object Fixtures {
 
     val knownDefYarnAppCP: Seq[String] =

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -357,43 +357,39 @@ class ClientSuite extends SparkFunSuite with Matchers {
     sparkConf.get(SECONDARY_JARS) should be (Some(Seq(new File(jar2.toURI).getName)))
   }
 
-  test("compare URI for filesystems") {
+  private val matching = Seq(
+    ("files", "file:///file1", "file:///file2"),
+    ("files", "file:///c:file1", "file://c:file2"),
+    ("files", "file://host/file1", "file://host/file2"),
+    ("wasb", "wasb://bucket1@user", "wasb://bucket1@user/"),
+    ("hdfs", "hdfs:/path1", "hdfs:/path1")
+  )
 
-    val matching = Seq(
-      ("files", "file:///file1", "file:///file2"),
-      ("files", "file:///c:file1", "file://c:file2"),
-      ("files", "file://host/file1", "file://host/file2"),
-      ("wasb", "wasb://bucket1@user", "wasb://bucket1@user/"),
-      ("hdfs", "hdfs:/path1", "hdfs:/path1")
-    )
+  matching.foreach {
+    t =>
+      test(t._1) {
+        assert(Client.compareUri(new URI(t._2), new URI(t._3)),
+          s"No match between ${t._2} and ${t._3}")
+      }
+  }
 
-    matching.foreach {
-      t =>
-        test(t._1) {
-          assert(Client.compareUri(new URI(t._2), new URI(t._3)),
-            s"No match between ${t._2} and ${t._3}")
-        }
-    }
+  private val unmatching = Seq(
+    ("files", "file:///file1", "file://host/file2"),
+    ("files", "file://host/file1", "file:///file2"),
+    ("files", "file://host/file1", "file://host2/file2"),
+    ("wasb", "wasb://bucket1@user", "wasb://bucket2@user/"),
+    ("wasb", "wasb://bucket1@user", "wasb://bucket1@user2/"),
+    ("s3", "s3a://user@pass:bucket1/", "s3a://user2@pass2:bucket1/"),
+    ("hdfs", "hdfs://namenode1/path1", "hdfs://namenode1:8080/path2"),
+    ("hdfs", "hdfs://namenode1:8020/path1", "hdfs://namenode1:8080/path2")
+  )
 
-    val unmatching = Seq(
-      ("files", "file:///file1", "file://host/file2"),
-      ("files", "file://host/file1", "file:///file2"),
-      ("files", "file://host/file1", "file://host2/file2"),
-      ("wasb", "wasb://bucket1@user", "wasb://bucket2@user/"),
-      ("wasb", "wasb://bucket1@user", "wasb://bucket1@user2/"),
-      ("s3", "s3a://user@pass:bucket1/", "s3a://user2@pass2:bucket1/"),
-      ("hdfs", "hdfs://namenode1/path1", "hdfs://namenode1:8080/path2"),
-      ("hdfs", "hdfs://namenode1:8020/path1", "hdfs://namenode1:8080/path2")
-    )
-
-    unmatching.foreach {
-      t =>
-        test(t._1) {
-          assert(!Client.compareUri(new URI(t._2), new URI(t._3)),
-            s"match between ${t._2} and ${t._3}")
-        }
-    }
-
+  unmatching.foreach {
+    t =>
+      test(t._1) {
+        assert(!Client.compareUri(new URI(t._2), new URI(t._3)),
+          s"match between ${t._2} and ${t._3}")
+      }
   }
 
   object Fixtures {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two filesystems comparing does not consider the authority of URI. This is specific for 
WASB file storage system, where userInfo is honored to differentiate filesystems.
For example: wasbs://user1@xyz.net, wasbs://user2@xyz.net would consider as two filesystem. 
Therefore, we have to add the authority to compare two filesystem, and  two filesystem with different authority can not be the same FS. 

Please review http://spark.apache.org/contributing.html before opening a pull request.
