### PR TITLE
[SPARK-22700][ML] Bucketizer.transform incorrectly drops row containing NaN

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -109,15 +109,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
           s"The feature value is not correct after bucketing.  Expected $y but found $x")
     }
 
-    test("Bucket should only drop NaN in input columns, with handleInvalid=skip") {
-      val df = spark.createDataFrame(Seq((2.3, 3.0), (Double.NaN, 3.0), (6.7, Double.NaN)
-      )).toDF("a", "b")
-      val splits = Array(Double.NegativeInfinity, 3.0, Double.PositiveInfinity)
-      val bucketizer = new Bucketizer().setInputCol("a").setOutputCol("x").setSplits(splits)
-      bucketizer.setHandleInvalid("skip")
-      assert(bucketizer.transform(df).count() == 2)
-    }
-
     bucketizer.setHandleInvalid("skip")
     val skipResults: Array[Double] = bucketizer.transform(dataFrame)
       .select("result").as[Double].collect()
@@ -130,6 +121,15 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
         bucketizer.transform(dataFrame).collect()
       }
     }
+  }
+
+  test("Bucketizer should only drop NaN in input columns, with handleInvalid=skip") {
+    val df = spark.createDataFrame(Seq((2.3, 3.0), (Double.NaN, 3.0), (6.7, Double.NaN)))
+      .toDF("a", "b")
+    val splits = Array(Double.NegativeInfinity, 3.0, Double.PositiveInfinity)
+    val bucketizer = new Bucketizer().setInputCol("a").setOutputCol("x").setSplits(splits)
+    bucketizer.setHandleInvalid("skip")
+    assert(bucketizer.transform(df).count() == 2)
   }
 
   test("Bucket continuous features, with NaN splits") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -109,6 +109,15 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
           s"The feature value is not correct after bucketing.  Expected $y but found $x")
     }
 
+    test("Bucket should only drop NaN in input columns, with handleInvalid=skip") {
+      val df = spark.createDataFrame(Seq((2.3, 3.0), (Double.NaN, 3.0), (6.7, Double.NaN)
+      )).toDF("a", "b")
+      val splits = Array(Double.NegativeInfinity, 3.0, Double.PositiveInfinity)
+      val bucketizer = new Bucketizer().setInputCol("a").setOutputCol("x").setSplits(splits)
+      bucketizer.setHandleInvalid("skip")
+      assert(bucketizer.transform(df).count() == 2)
+    }
+
     bucketizer.setHandleInvalid("skip")
     val skipResults: Array[Double] = bucketizer.transform(dataFrame)
       .select("result").as[Double].collect()


### PR DESCRIPTION
## What changes were proposed in this pull request?
only drops the rows containing NaN in the input columns

## How was this patch tested?
existing tests and added tests
