### PR TITLE
[SPARK-22694][SQL] Like and RLike should not use global variables

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
@@ -231,4 +231,15 @@ class RegexpExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(StringSplit(s1, s2), null, row3)
   }
 
+  test("SPARK-22694: Like should not use global variables") {
+    val ctx = new CodegenContext
+    Like(Literal("a"), Literal("a%")).genCode(ctx)
+    assert(ctx.mutableStates.isEmpty)
+  }
+
+  test("SPARK-22694: RLike should not use global variables") {
+    val ctx = new CodegenContext
+    RLike(Literal("a"), Literal("a*")).genCode(ctx)
+    assert(ctx.mutableStates.isEmpty)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Like and RLike are using a global variable which is not needed. This can generate some unneeded entries in the constant pool.

The PR removes the unnecessary mutable states and makes them local variables.

## How was this patch tested?

added UTs
