### PR TITLE
[SPARK-22704][SQL] Least and Greatest use less global variables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -681,7 +681,7 @@ case class Greatest(children: Seq[Expression]) extends Expression {
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val evalChildren = children.map(_.genCode(ctx))
-    val isNull = ctx.freshName("isNull")
+    val isNull = ctx.freshName("greatestTmpIsNull")
     ctx.addMutableState(ctx.JAVA_BOOLEAN, isNull)
     val evals = evalChildren.map(eval =>
       s"""
@@ -697,7 +697,7 @@ case class Greatest(children: Seq[Expression]) extends Expression {
     val resultType = ctx.javaType(dataType)
     val codes = ctx.splitExpressionsWithCurrentInputs(
       expressions = evals,
-      funcName = "least",
+      funcName = "greatest",
       extraArguments = Seq(resultType -> ev.value),
       returnType = resultType,
       makeSplitFunction = body =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -606,13 +606,13 @@ case class Least(children: Seq[Expression]) extends Expression {
     ctx.addMutableState(ctx.JAVA_BOOLEAN, leastTmpIsNull)
     val evals = evalChildren.map(eval =>
       s"""
-        ${eval.code}
-        if (!${eval.isNull} && (${leastTmpIsNull} ||
-          ${ctx.genGreater(dataType, ev.value, eval.value)})) {
-          $leastTmpIsNull = false;
-          ${ev.value} = ${eval.value};
-        }
-      """
+         |${eval.code}
+         |if (!${eval.isNull} && (${leastTmpIsNull} ||
+         |  ${ctx.genGreater(dataType, ev.value, eval.value)})) {
+         |  $leastTmpIsNull = false;
+         |  ${ev.value} = ${eval.value};
+         |}
+      """.stripMargin
     )
 
     val resultType = ctx.javaType(dataType)
@@ -627,11 +627,13 @@ case class Least(children: Seq[Expression]) extends Expression {
           |return ${ev.value};
         """.stripMargin,
       foldFunctions = _.map(funcCall => s"${ev.value} = $funcCall;").mkString("\n"))
-    ev.copy(code = s"""
-      $leastTmpIsNull = true;
-      ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
-      $codes
-      final boolean ${ev.isNull} = $leastTmpIsNull;""")
+    ev.copy(code =
+      s"""
+         |$leastTmpIsNull = true;
+         |${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
+         |$codes
+         |final boolean ${ev.isNull} = $leastTmpIsNull;
+      """.stripMargin)
   }
 }
 
@@ -685,13 +687,13 @@ case class Greatest(children: Seq[Expression]) extends Expression {
     ctx.addMutableState(ctx.JAVA_BOOLEAN, greatestTmpIsNull)
     val evals = evalChildren.map(eval =>
       s"""
-        ${eval.code}
-        if (!${eval.isNull} && (${greatestTmpIsNull} ||
-          ${ctx.genGreater(dataType, eval.value, ev.value)})) {
-          $greatestTmpIsNull = false;
-          ${ev.value} = ${eval.value};
-        }
-      """
+         |${eval.code}
+         |if (!${eval.isNull} && (${greatestTmpIsNull} ||
+         |  ${ctx.genGreater(dataType, eval.value, ev.value)})) {
+         |  $greatestTmpIsNull = false;
+         |  ${ev.value} = ${eval.value};
+         |}
+      """.stripMargin
     )
 
     val resultType = ctx.javaType(dataType)
@@ -706,10 +708,12 @@ case class Greatest(children: Seq[Expression]) extends Expression {
            |return ${ev.value};
         """.stripMargin,
       foldFunctions = _.map(funcCall => s"${ev.value} = $funcCall;").mkString("\n"))
-    ev.copy(code = s"""
-      $greatestTmpIsNull = true;
-      ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
-      $codes
-      final boolean ${ev.isNull} = $greatestTmpIsNull;""")
+    ev.copy(code =
+      s"""
+         |$greatestTmpIsNull = true;
+         |${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
+         |$codes
+         |final boolean ${ev.isNull} = $greatestTmpIsNull;
+      """.stripMargin)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -602,7 +602,7 @@ case class Least(children: Seq[Expression]) extends Expression {
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val evalChildren = children.map(_.genCode(ctx))
-    val isNull = ctx.freshName("isNull")
+    val isNull = ctx.freshName("leastTmpIsNull")
     ctx.addMutableState(ctx.JAVA_BOOLEAN, isNull)
     val evals = evalChildren.map(eval =>
       s"""
@@ -631,7 +631,7 @@ case class Least(children: Seq[Expression]) extends Expression {
       $isNull = true;
       ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
       $codes
-      boolean ${ev.isNull} = $isNull;""")
+      final boolean ${ev.isNull} = $isNull;""")
   }
 }
 
@@ -710,6 +710,6 @@ case class Greatest(children: Seq[Expression]) extends Expression {
       $isNull = true;
       ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
       $codes
-      boolean ${ev.isNull} = $isNull;""")
+      final boolean ${ev.isNull} = $isNull;""")
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -684,7 +684,7 @@ case class Greatest(children: Seq[Expression]) extends Expression {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val evalChildren = children.map(_.genCode(ctx))
     val tmpIsNull = ctx.freshName("greatestTmpIsNull")
-    ctx.addMutableState(ctx.JAVA_BOOLEAN, greatestTmpIsNull)
+    ctx.addMutableState(ctx.JAVA_BOOLEAN, tmpIsNull)
     val evals = evalChildren.map(eval =>
       s"""
          |${eval.code}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -347,7 +347,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
 
   test("SPARK-22704: Least and greatest use less global variables") {
     val ctx1 = new CodegenContext()
-    print(Least(Seq(Literal(1), Literal(1))).genCode(ctx1).code)
+    Least(Seq(Literal(1), Literal(1))).genCode(ctx1)
     assert(ctx1.mutableStates.size == 1)
 
     val ctx2 = new CodegenContext()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR accomplishes the following two items.

1. Reduce # of global variables from two to one
2. Make lifetime of global variable local within an operation
  
Item 1. reduces # of constant pool entries in a Java class. Item 2. ensures that an variable is not passed to arguments in a method split by `CodegenContext.splitExpressions()`, which is addressed by #19865.

## How was this patch tested?

Added new test into `ArithmeticExpressionSuite`