### PR TITLE
[SPARK-22695][SQL] ScalaUDF should not use global variables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -983,7 +983,6 @@ case class ScalaUDF(
   // scalastyle:on line.size.limit
 
   private val converterClassName = classOf[Any => Any].getName
-  private val expressionClassName = classOf[Expression].getName
   private val scalaUDFClassName = classOf[ScalaUDF].getName
   private val typeConvertersClassName = CatalystTypeConverters.getClass.getName + ".MODULE$"
 
@@ -993,7 +992,7 @@ case class ScalaUDF(
     val expressionIdx = ctx.references.size - 1
     (converterTerm,
       s"$converterClassName $converterTerm = ($converterClassName)$typeConvertersClassName" +
-        s".createToScalaConverter((($expressionClassName)((($scalaUDFClassName)" +
+        s".createToScalaConverter(((Expression)((($scalaUDFClassName)" +
         s"references[$expressionIdx]).getChildren().apply($index))).dataType());")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -999,9 +999,8 @@ case class ScalaUDF(
   override def doGenCode(
       ctx: CodegenContext,
       ev: ExprCode): ExprCode = {
-    val thisClassName = this.getClass.getName
     val scalaUDF = ctx.freshName("scalaUDF")
-    val scalaUDFRef = ctx.addReferenceMinorObj(this, thisClassName)
+    val scalaUDFRef = ctx.addReferenceMinorObj(this, scalaUDFClassName)
 
     // Object to convert the returned value of user-defined functions to Catalyst type
     val catalystConverterTerm = ctx.freshName("catalystConverter")
@@ -1041,7 +1040,7 @@ case class ScalaUDF(
     val callFunc =
       s"""
          |${ctx.boxedType(dataType)} $resultTerm = null;
-         |$thisClassName $scalaUDF = $scalaUDFRef;
+         |$scalaUDFClassName $scalaUDF = $scalaUDFRef;
          |try {
          |  $funcClassName $funcTerm = ($funcClassName)$scalaUDF.userDefinedFunc();
          |  $converterClassName $catalystConverterTerm = ($converterClassName)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import java.util.Locale
 
 import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -47,4 +48,10 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(e2.getMessage.contains("Failed to execute user defined function"))
   }
 
+  test("SPARK-22695: ScalaUDF should not use global variables") {
+    val ctx = new CodegenContext
+    ScalaUDF((s: String) => s + "x", StringType, Literal("a") :: Nil).genCode(ctx)
+    // we have one variable (globalIsNull) introduced by reduceCodeSize
+    assert(ctx.mutableStates.length == 1)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -51,7 +51,6 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("SPARK-22695: ScalaUDF should not use global variables") {
     val ctx = new CodegenContext
     ScalaUDF((s: String) => s + "x", StringType, Literal("a") :: Nil).genCode(ctx)
-    // we have one variable (globalIsNull) introduced by reduceCodeSize
-    assert(ctx.mutableStates.length == 1)
+    assert(ctx.mutableStates.isEmpty)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ScalaUDF is using global variables which are not needed. This can generate some unneeded entries in the constant pool.

The PR replaces the unneeded global variables with local variables.

## How was this patch tested?

added UT
