### PR TITLE
[SPARK-22705][SQL] Case, Coalesce, and In use less global variables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -187,8 +187,8 @@ case class CaseWhen(
     val HAS_NONNULL = 0
     // 1 means the condition is met and result is null.
     val HAS_NULL = 1
-    // It is initialized to `-1`, and if it's set to `1` or `0`, We won't go on anymore on the
-    // computation.
+    // It is initialized to `NOT_MATCHED`, and if it's set to `HAS_NULL` or `HAS_NONNULL`,
+    // We won't go on anymore on the computation.
     val resultState = ctx.freshName("caseWhenResultState")
     val tmpResult = ctx.freshName("caseWhenTmpResult")
     ctx.addMutableState(ctx.javaType(dataType), tmpResult)
@@ -269,7 +269,7 @@ case class CaseWhen(
          |do {
          |  $codes
          |} while (false);
-         |// TRUE if any condition is met and the result is not null, or no any condition is met.
+         |// TRUE if any condition is met and the result is null, or no any condition is met.
          |final boolean ${ev.isNull} = ($resultState != $HAS_NONNULL);
          |final ${ctx.javaType(dataType)} ${ev.value} = $tmpResult;
        """.stripMargin)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -88,13 +88,14 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
        """.stripMargin
     }
 
+    val resultType = ctx.javaType(dataType)
     val codes = ctx.splitExpressionsWithCurrentInputs(
       expressions = evals,
       funcName = "coalesce",
-      returnType = ctx.javaType(dataType),
+      returnType = resultType,
       makeSplitFunction = func =>
         s"""
-           |${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
+           |$resultType ${ev.value} = ${ctx.defaultValue(dataType)};
            |do {
            |  $func
            |} while (false);
@@ -113,7 +114,7 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
     ev.copy(code =
       s"""
          |$tmpIsNull = true;
-         |${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
+         |$resultType ${ev.value} = ${ctx.defaultValue(dataType)};
          |do {
          |  $codes
          |} while (false);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -238,7 +238,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
     val valueGen = value.genCode(ctx)
     val listGen = list.map(_.genCode(ctx))
     // inTmpResult has 3 possible values:
-    // -1 means no matches found and there is at least one value in the list evaluated
+    // -1 means no matches found and there is at least one value in the list evaluated to null
     val HAS_NULL = -1
     // 0 means no matches found and all values in the list are not null
     val NOT_MATCHED = 0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -245,6 +245,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
     // The evaluation of variables can be stopped when we find a matching value.
     val listCode = listGen.map(x =>
       s"""
+         |$tmpResult = 0;
          |${x.code}
          |if (${x.isNull}) {
          |  $tmpResult = -1; // isNull = true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ConditionalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ConditionalExpressionSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.types._
 
 class ConditionalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -144,5 +145,11 @@ class ConditionalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper
     assert(caseKeyWhaen.branches ==
       IndexedSeq((Literal(12) === Literal(1), Literal(42)),
         (Literal(12) === Literal(42), Literal(1))))
+  }
+
+  test("SPARK-22705: case when should use less global variables") {
+    val ctx = new CodegenContext()
+    CaseWhen(Seq((Literal.create(false, BooleanType), Literal(1))), Literal(-1)).genCode(ctx)
+    assert(ctx.mutableStates.size == 1)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import java.sql.{Date, Timestamp}
 
 import scala.collection.immutable.HashSet
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.RandomDataGenerator
 import org.apache.spark.sql.catalyst.InternalRow

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -20,11 +20,11 @@ package org.apache.spark.sql.catalyst.expressions
 import java.sql.{Date, Timestamp}
 
 import scala.collection.immutable.HashSet
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.RandomDataGenerator
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExamplePointUDT
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 
@@ -243,6 +243,12 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     val N = 3000
     val sets = (1 to N).map(i => Literal(i.toDouble))
     checkEvaluation(In(Literal(1.0D), sets), true)
+  }
+
+  test("SPARK-22705: In should use less global variables") {
+    val ctx = new CodegenContext()
+    In(Literal(1.0D), Seq(Literal(1.0D), Literal(2.0D))).genCode(ctx)
+    assert(ctx.mutableStates.isEmpty)
   }
 
   test("INSET") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR accomplishes the following two items.

1. Reduce # of global variables from two to one for generated code of `Case` and `Coalesce` and remove global variables for generated code of `In`.
2. Make lifetime of global variable local within an operation
  
Item 1. reduces # of constant pool entries in a Java class. Item 2. ensures that an variable is not passed to arguments in a method split by `CodegenContext.splitExpressions()`, which is addressed by #19865.

## How was this patch tested?

Added new tests into `PredicateSuite`, `NullExpressionsSuite`, and `ConditionalExpressionSuite`.