### PR TITLE
[SPARK-22712][SQL] Use `buildReaderWithPartitionValues` in native OrcFileFormat

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -32,21 +32,13 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 class OrcDeserializer(
     dataSchema: StructType,
-    resultSchema: StructType,
-    requestedColIds: Array[Int],
-    partitionValues: InternalRow) {
+    requiredSchema: StructType,
+    requestedColIds: Array[Int]) {
 
-  // Make a resultRow and initialize the partition column values once.
-  private val resultRow = new SpecificInternalRow(resultSchema.map(_.dataType))
-  private var i = 0
-  private val start = resultSchema.length - partitionValues.numFields
-  while (i < partitionValues.numFields) {
-    resultRow.update(start + i, partitionValues.get(i, resultSchema(start + i).dataType))
-    i += 1
-  }
+  private val resultRow = new SpecificInternalRow(requiredSchema.map(_.dataType))
 
   private val fieldWriters: Array[WritableComparable[_] => Unit] = {
-    resultSchema.zipWithIndex
+    requiredSchema.zipWithIndex
       // The value of missing columns are always null, do not need writers.
       .filterNot { case (_, index) => requestedColIds(index) == -1 }
       .map { case (f, index) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

To support vectorization in native OrcFileFormat later, we need to use `buildReaderWithPartitionValues` instead of `buildReader` like ParquetFileFormat. This PR replaces `buildReader` with `buildReaderWithPartitionValues`.

## How was this patch tested?

Pass the Jenkins with the existing test cases.