### PR TITLE
[SPARK-22697][SQL] GenerateMutableProjection should not create unneeded global variables

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -380,4 +380,15 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
         s"Incorrect Evaluation: expressions: $exprAnd, actual: $actualAnd, expected: $expectedAnd")
     }
   }
+
+  test("SPARK-22694: GenerateMutableProjection should not create unneeded global variables") {
+    val mutableProjection = GenerateMutableProjection.generate(
+      EqualTo(Literal(1), Literal(1)) :: Nil)
+    val declaredFields = mutableProjection.getClass.getDeclaredFields
+    // we have always 3 global declared variables at least:
+    // - one for references
+    // - one for mutableRow
+    // - one for this
+    assert(declaredFields.length == 3)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

GenerateMutableProjection is using global variables which are not needed. This can generate many unneeded entries in the constant pool.

The PR removes the unnecessary mutable states and makes them local variables.

## How was this patch tested?

added UT

