### PR TITLE
[SPARK-22719][SQL]Refactor ConstantPropagation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -141,16 +141,12 @@ object ConstantPropagation extends Rule[LogicalPlan] with PredicateHelper {
     : Expression = {
     val constantsMap = AttributeMap(equalityPredicates.map(_._1))
     val predicates = equalityPredicates.map(_._2).toSet
-    def _replaceConstants(expression: Expression) = expression transform {
-      case a: AttributeReference =>
-        constantsMap.get(a) match {
-          case Some(literal) => literal
-          case None => a
-        }
+    def replaceConstants0(expression: Expression) = expression transform {
+      case a: AttributeReference => constantsMap.getOrElse(a, a)
     }
     condition transform {
-      case e @ EqualTo(_, _) if !predicates.contains(e) => _replaceConstants(e)
-      case e @ EqualNullSafe(_, _) if !predicates.contains(e) => _replaceConstants(e)
+      case e @ EqualTo(_, _) if !predicates.contains(e) => replaceConstants0(e)
+      case e @ EqualNullSafe(_, _) if !predicates.contains(e) => replaceConstants0(e)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current time complexity of ConstantPropagation is O(n^2), which can be slow when the query is complex.
Refactor the implementation with O( n ) time complexity, and some pruning to avoid traversing the whole `Condition`

## How was this patch tested?

Unit test.

Also simple benchmark test in ConstantPropagationSuite
```
  val condition = (1 to 500).map{_ => Rand(0) === Rand(0)}.reduce(And)
  val query = testRelation
    .select(columnA)
    .where(condition)
  val start = System.currentTimeMillis()
  (1 to 40).foreach { _ =>
    Optimize.execute(query.analyze)
  }
  val end = System.currentTimeMillis()
  println(end - start)
```
Run time before changes: 18989ms (474ms per loop)
Run time after changes: 1275 ms (32ms per loop)
