### PR TITLE
[SPARK-22725][SQL] Add failing test for select with a splatted stream

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2228,4 +2228,12 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df, Row(0, 10) :: Nil)
     assert(df.queryExecution.executedPlan.isInstanceOf[WholeStageCodegenExec])
   }
+
+  test("SPARK-ABC123: support select with a splatted stream") {
+    val df = spark.createDataFrame(sparkContext.emptyRDD[Row], StructType(List("bar", "foo").map {
+      StructField(_, StringType, false)
+    }))
+    val allColumns = Stream(df.col("bar"), col("foo"))
+    val result = df.select(allColumns : _*)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2229,11 +2229,19 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.queryExecution.executedPlan.isInstanceOf[WholeStageCodegenExec])
   }
 
-  test("SPARK-ABC123: support select with a splatted stream") {
+  test("SPARK-22725: select of a Stream") {
     val df = spark.createDataFrame(sparkContext.emptyRDD[Row], StructType(List("bar", "foo").map {
       StructField(_, StringType, false)
     }))
     val allColumns = Stream(df.col("bar"), col("foo"))
+    val result = df.select(allColumns : _*)
+  }
+
+  test("SPARK-22725: select with a List") {
+    val df = spark.createDataFrame(sparkContext.emptyRDD[Row], StructType(List("bar", "foo").map {
+      StructField(_, StringType, false)
+    }))
+    val allColumns = Seq(df.col("bar"), col("foo"))
     val result = df.select(allColumns : _*)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add additional test.  I plan to file an issue in SPARK Jira soon detailing this change.  It seems like there is an assumption in `.select` about some behavior that's not guaranteed by `Seq` but does exist in a `List`, because replacing `Stream` with `Seq` in the test causes it to pass.  Possibly this is due to Seq#map being lazy whereas List#map is eager.

## How was this patch tested?

Additional test.