### PR TITLE
[SPARK-22727] spark.executor.instances's default value should be 2

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2552,7 +2552,7 @@ private[spark] object Utils extends Logging {
           "please update your configs.")
     }
 
-    if (conf.get(EXECUTOR_INSTANCES).getOrElse(0) < conf.get(DYN_ALLOCATION_MIN_EXECUTORS)) {
+    if (conf.get(EXECUTOR_INSTANCES).getOrElse(2) < conf.get(DYN_ALLOCATION_MIN_EXECUTORS)) {
       logWarning(s"${EXECUTOR_INSTANCES.key} less than " +
         s"${DYN_ALLOCATION_MIN_EXECUTORS.key} is invalid, ignoring its setting, " +
           "please update your configs.")
@@ -2561,7 +2561,7 @@ private[spark] object Utils extends Logging {
     val initialExecutors = Seq(
       conf.get(DYN_ALLOCATION_MIN_EXECUTORS),
       conf.get(DYN_ALLOCATION_INITIAL_EXECUTORS),
-      conf.get(EXECUTOR_INSTANCES).getOrElse(0)).max
+      conf.get(EXECUTOR_INSTANCES).getOrElse(2)).max
 
     logInfo(s"Using initial executors = $initialExecutors, max of " +
       s"${DYN_ALLOCATION_INITIAL_EXECUTORS.key}, ${DYN_ALLOCATION_MIN_EXECUTORS.key} and " +

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManager.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManager.scala
@@ -202,7 +202,7 @@ private[streaming] object ExecutorAllocationManager extends Logging {
   val MAX_EXECUTORS_KEY = "spark.streaming.dynamicAllocation.maxExecutors"
 
   def isDynamicAllocationEnabled(conf: SparkConf): Boolean = {
-    val numExecutor = conf.getInt("spark.executor.instances", 0)
+    val numExecutor = conf.getInt("spark.executor.instances", 2)
     val streamingDynamicAllocationEnabled = conf.getBoolean(ENABLED_KEY, false)
     if (numExecutor != 0 && streamingDynamicAllocationEnabled) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SPARK-22727](https://issues.apache.org/jira/browse/SPARK-22727)
## What changes were proposed in this pull request?

when I run a application on yarn,I don't set the value of spark.executor.instances,so I think it's default value should as same as the running-on-yarn.md said is 2.But the log of driver logs "spark.executor.instances less than spark.dynamicAllocation.minExecutors is invalid, ignoring its setting, please update your configs.",so I know the default value of this configuration isn't 2.So I think we should fix it.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
