### PR TITLE
[SPARK-22672][SQL][TEST][FOLLOWUP] Fix to use `spark.conf`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -51,12 +51,12 @@ abstract class OrcTest extends QueryTest with SQLTestUtils with BeforeAndAfterAl
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
-    originalConfORCImplementation = conf.getConf(ORC_IMPLEMENTATION)
-    conf.setConf(ORC_IMPLEMENTATION, orcImp)
+    originalConfORCImplementation = spark.conf.get(ORC_IMPLEMENTATION)
+    spark.conf.set(ORC_IMPLEMENTATION.key, orcImp)
   }
 
   protected override def afterAll(): Unit = {
-    conf.setConf(ORC_IMPLEMENTATION, originalConfORCImplementation)
+    spark.conf.set(ORC_IMPLEMENTATION.key, originalConfORCImplementation)
     super.afterAll()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During https://github.com/apache/spark/pull/19882, `conf` is mistakenly used to switch ORC implementation between `native` and `hive`. To affect `OrcTest` correctly, `spark.conf` should be used.

## How was this patch tested?

Pass the tests.