### PR TITLE
[SPARK-22744][CORE] Add a configuration to show the application submi…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -743,6 +743,11 @@ object SparkSubmit extends CommandLineUtils with Logging {
       sparkConf.set("spark.submit.pyFiles", formattedPyFiles)
     }
 
+    // [SPARK-22744]. Add a configuration to show the application submit hostname
+    if (sparkConf.getOption("spark.submit.hostname").isEmpty) {
+      sparkConf.set("spark.submit.hostname", Utils.localHostName)
+    }
+
     (childArgs, childClasspath, sparkConf, childMainClass)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -171,6 +171,27 @@ class SparkSubmitSuite
     appArgs.toString should include ("thequeue")
   }
 
+  test("check the default application submit hostname") {
+    val clArgs = Seq(
+      "--name", "myApp",
+      "--class", "Foo",
+      "userjar.jar")
+    val appArgs = new SparkSubmitArguments(clArgs)
+    val (_, _, conf, _) = prepareSubmitEnvironment(appArgs)
+    conf.get("spark.submit.hostname") should be (Utils.localHostName())
+  }
+
+  test("check the user defined application submit hostname") {
+    val clArgs = Seq(
+      "--name", "myApp",
+      "--class", "Foo",
+      "--conf", "spark.submit.hostname=host1",
+      "userjar.jar")
+    val appArgs = new SparkSubmitArguments(clArgs)
+    val (_, _, conf, _) = prepareSubmitEnvironment(appArgs)
+    conf.get("spark.submit.hostname") should be ("host1")
+  }
+
   test("specify deploy mode through configuration") {
     val clArgs = Seq(
       "--master", "yarn",


### PR DESCRIPTION
…t hostname

## What changes were proposed in this pull request?

In MapReduce, we can get the submit hostname via checking the value of configuration **mapreduce.job.submithostname**. It can help infra team or other people to do support work and debug. Bu in Spark, the information is not included.

Then, I suggest to introduce a new configuration parameter, **spark.submit.hostname**, which will be set automatically by default, but it also allows to set this to an user defined hostname if needed (e.g, using an user node instead of Livy server node).

## How was this patch tested?

unit tests
