### PR TITLE
[SPARK-22754][DEPLOY] Check whether spark.executor.heartbeatInterval bigger…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -570,7 +570,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
       get("spark.executor.heartbeatInterval", "10s"))
     // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
     // it will almost always cause ExecutorLostFailure.See SPARK-22754.
-    require(executorHeartbeatInterval > executorTimeoutThreshold, "The value of " +
+    require(executorHeartbeatInterval > executorTimeoutThreshold, s"The value of " +
       "spark.network.timeout' must be no less than the value of " +
       "'spark.executor.heartbeatInterval'.")
   }

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -568,9 +568,11 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     val executorTimeoutThreshold = Utils.timeStringAsSeconds(get("spark.network.timeout", "120s"))
     val executorHeartbeatInterval = Utils.timeStringAsSeconds(
       get("spark.executor.heartbeatInterval", "10s"))
-    require(executorHeartbeatInterval > executorTimeoutThreshold, s"The value of" +
-      s"spark.network.timeout' must be no less than the value of" +
-      s" 'spark.executor.heartbeatInterval'.")
+    // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
+    // it will almost always cause ExecutorLostFailure.See SPARK-22754.
+    require(executorHeartbeatInterval > executorTimeoutThreshold, "The value of" +
+      "spark.network.timeout' must be no less than the value of" +
+      "'spark.executor.heartbeatInterval'.")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -568,9 +568,9 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     val executorTimeoutThreshold = Utils.timeStringAsSeconds(get("spark.network.timeout", "120s"))
     val executorHeartbeatInterval = Utils.timeStringAsSeconds(
       get("spark.executor.heartbeatInterval", "10s"))
-    require(executorHeartbeatInterval > executorTimeoutThreshold,
-      s"The value of 'spark.network.timeout' must be no less than the value of" +
-        s" 'spark.executor.heartbeatInterval'.")
+    require(executorHeartbeatInterval > executorTimeoutThreshold, s"The value of" +
+      s"spark.network.timeout' must be no less than the value of" +
+      s" 'spark.executor.heartbeatInterval'.")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -570,8 +570,8 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
     // it will almost always cause ExecutorLostFailure. See SPARK-22754.
     require(executorTimeoutThreshold > executorHeartbeatInterval, "The value of " +
-      s"'spark.network.timeout=${executorTimeoutThreshold}' must be no less than the value of " +
-      s"'spark.executor.heartbeatInterval=${executorHeartbeatInterval}'.")
+      s"spark.network.timeout=${executorTimeoutThreshold}s must be no less than the value of " +
+      s"spark.executor.heartbeatInterval=${executorHeartbeatInterval}s.")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -570,8 +570,8 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
       get("spark.executor.heartbeatInterval", "10s"))
     // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
     // it will almost always cause ExecutorLostFailure.See SPARK-22754.
-    require(executorHeartbeatInterval > executorTimeoutThreshold, "The value of" +
-      "spark.network.timeout' must be no less than the value of" +
+    require(executorHeartbeatInterval > executorTimeoutThreshold, "The value of " +
+      "spark.network.timeout' must be no less than the value of " +
       "'spark.executor.heartbeatInterval'.")
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -565,12 +565,11 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     require(!encryptionEnabled || get(NETWORK_AUTH_ENABLED),
       s"${NETWORK_AUTH_ENABLED.key} must be enabled when enabling encryption.")
 
-    val executorTimeoutThreshold = Utils.timeStringAsSeconds(get("spark.network.timeout", "120s"))
-    val executorHeartbeatInterval = Utils.timeStringAsSeconds(
-      get("spark.executor.heartbeatInterval", "10s"))
+    val executorTimeoutThreshold = getTimeAsSeconds("spark.network.timeout", "120s")
+    val executorHeartbeatInterval = getTimeAsSeconds("spark.executor.heartbeatInterval", "10s")
     // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
-    // it will almost always cause ExecutorLostFailure.See SPARK-22754.
-    require(executorHeartbeatInterval > executorTimeoutThreshold, s"The value of " +
+    // it will almost always cause ExecutorLostFailure. See SPARK-22754.
+    require(executorTimeoutThreshold > executorHeartbeatInterval, s"The value of " +
       "spark.network.timeout' must be no less than the value of " +
       "'spark.executor.heartbeatInterval'.")
   }

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -569,9 +569,9 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     val executorHeartbeatInterval = getTimeAsSeconds("spark.executor.heartbeatInterval", "10s")
     // If spark.executor.heartbeatInterval bigger than spark.network.timeout,
     // it will almost always cause ExecutorLostFailure. See SPARK-22754.
-    require(executorTimeoutThreshold > executorHeartbeatInterval, s"The value of " +
-      "spark.network.timeout' must be no less than the value of " +
-      "'spark.executor.heartbeatInterval'.")
+    require(executorTimeoutThreshold > executorHeartbeatInterval, "The value of " +
+      s"'spark.network.timeout=${executorTimeoutThreshold}' must be no less than the value of " +
+      s"'spark.executor.heartbeatInterval=${executorHeartbeatInterval}'.")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -568,14 +568,9 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     val executorTimeoutThreshold = Utils.timeStringAsSeconds(get("spark.network.timeout", "120s"))
     val executorHeartbeatInterval = Utils.timeStringAsSeconds(
       get("spark.executor.heartbeatInterval", "10s"))
-    if (executorHeartbeatInterval > executorTimeoutThreshold) {
-      // Fail-fast see SPARK-22754
-      throw new SparkException(
-        s"""|The heartbeat arguments is incorrect,please do not setting your own arguments
-            | including  spark.network.timeout, spark.executor.heartbeatInterval
-            | check your command remove them and try again.
-            |""".stripMargin.replaceAll("\n", " "))
-    }
+    require(executorHeartbeatInterval > executorTimeoutThreshold,
+      s"The value of 'spark.network.timeout' must be no less than the value of" +
+        s" 'spark.executor.heartbeatInterval'.")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -291,6 +291,18 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (proxyUser != null && principal != null) {
       SparkSubmit.printErrorAndExit("Only one of --proxy-user or --principal can be provided.")
     }
+
+    val executorTimeoutThreshold = Utils.timeStringAsSeconds(
+      sparkProperties.getOrElse("spark.network.timeout", "120s"))
+    val executorHeartbeatInterval = Utils.timeStringAsSeconds(
+      sparkProperties.getOrElse("spark.executor.heartbeatInterval", "10s"))
+    if (executorHeartbeatInterval > executorTimeoutThreshold) {
+      SparkSubmit.printErrorAndExit(
+        s"""|The heartbeat arguments is incorrect,please do not setting your own arguments
+            | including  spark.network.timeout, spark.executor.heartbeatInterval
+            | check your command remove them and try again.
+            |""".stripMargin.replaceAll("\n", " "))
+    }
   }
 
   private def validateKillArguments(): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -291,18 +291,6 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (proxyUser != null && principal != null) {
       SparkSubmit.printErrorAndExit("Only one of --proxy-user or --principal can be provided.")
     }
-
-    val executorTimeoutThreshold = Utils.timeStringAsSeconds(
-      sparkProperties.getOrElse("spark.network.timeout", "120s"))
-    val executorHeartbeatInterval = Utils.timeStringAsSeconds(
-      sparkProperties.getOrElse("spark.executor.heartbeatInterval", "10s"))
-    if (executorHeartbeatInterval > executorTimeoutThreshold) {
-      SparkSubmit.printErrorAndExit(
-        s"""|The heartbeat arguments is incorrect,please do not setting your own arguments
-            | including  spark.network.timeout, spark.executor.heartbeatInterval
-            | check your command remove them and try again.
-            |""".stripMargin.replaceAll("\n", " "))
-    }
   }
 
   private def validateKillArguments(): Unit = {

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -329,6 +329,16 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
     conf.validateSettings()
   }
 
+  test("spark.network.timeout should bigger than spark.executor.heartbeatInterval") {
+    val conf = new SparkConf()
+    conf.validateSettings()
+
+    conf.set("spark.network.timeout", "5s")
+    intercept[IllegalArgumentException] {
+      conf.validateSettings()
+    }
+  }
+
 }
 
 class Class1 {}


### PR DESCRIPTION
… than spark.network.timeout or not

## What changes were proposed in this pull request?

If spark.executor.heartbeatInterval bigger than spark.network.timeout,it will almost always cause exception below.
`Job aborted due to stage failure: Task 4763 in stage 3.0 failed 4 times, most recent failure: Lost task 4763.3 in stage 3.0 (TID 22383, executor id: 4761, host: xxx): ExecutorLostFailure (executor 4761 exited caused by one of the running tasks) Reason: Executor heartbeat timed out after 154022 ms`
Since many users do not get that point.He will set spark.executor.heartbeatInterval incorrectly.
This patch check this case when submit applications.

## How was this patch tested?
Test in cluster
