### PR TITLE
[SPARK-22756] [Build] [SparkR] Run SparkR tests if hive_thriftserver module has code changes

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -111,7 +111,7 @@ def determine_modules_to_test(changed_modules):
     >>> x = [x.name for x in determine_modules_to_test([modules.sql])]
     >>> x # doctest: +NORMALIZE_WHITESPACE
     ['sql', 'hive', 'mllib', 'sql-kafka-0-10', 'examples', 'hive-thriftserver',
-     'pyspark-sql', 'repl', 'sparkr', 'pyspark-mllib', 'pyspark-ml']
+     'pyspark-sql', 'repl', 'pyspark-mllib', 'sparkr', 'pyspark-ml']
     """
     modules_to_test = set()
     for module in changed_modules:

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -481,7 +481,7 @@ pyspark_ml = Module(
 
 sparkr = Module(
     name="sparkr",
-    dependencies=[hive, mllib],
+    dependencies=[hive, mllib, hive_thriftserver],
     source_file_regexes=[
         "R/",
     ],


### PR DESCRIPTION
## What changes were proposed in this pull request?
The recent PR change in `hive_thriftserver` caused the test failure in CRAN requirements. To some extends, `SparkR` module also depends on `hive_thriftserver` module which could output some log files, so we should run `SparkR` tests if the `hive_thriftserver` module has code changes.

## How was this patch tested?
N/A