### PR TITLE
[SPARK-22760][CORE][YARN] Lost executor of RPC disassociated, and occurs exception: Could not find CoarseGrainedScheduler or it has been stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -217,7 +217,10 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
       case StopExecutors =>
         logInfo("Asking each executor to shut down")
-        for ((_, executorData) <- executorDataMap) {
+        for ((executorId, executorData) <- executorDataMap) {
+          synchronized {
+            executorsPendingToRemove(executorId) = false
+          }
           executorData.executorEndpoint.send(StopExecutor)
         }
         context.reply(true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the number of executors is big, and YarnSchedulerBackend.stopped=False after YarnSchedulerBackend.stop() is running, some executor is stoped, and YarnSchedulerBackend.onDisconnected() will be called, then the problem is exists. So i change the code, when removing executor, add this executorId to executorsPendingToRemove, So the YarnSchedulerBackend.onDisconnected() will not send message to executor


Please review http://spark.apache.org/contributing.html before opening a pull request.
