### PR TITLE
[SPARK-22450][Core][MLLib][FollowUp] safely register class for mllib - LabeledPoint/VectorWithNorm/TreePoint

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -181,23 +181,24 @@ class KryoSerializer(conf: SparkConf)
 
     // We can't load those class directly in order to avoid unnecessary jar dependencies.
     // We load them safely, ignore it if the class not found.
-    Seq("org.apache.spark.mllib.linalg.Vector",
-      "org.apache.spark.mllib.linalg.DenseVector",
-      "org.apache.spark.mllib.linalg.SparseVector",
-      "org.apache.spark.mllib.linalg.Matrix",
-      "org.apache.spark.mllib.linalg.DenseMatrix",
-      "org.apache.spark.mllib.linalg.SparseMatrix",
-      "org.apache.spark.mllib.regression.LabeledPoint",
+    Seq(
       "org.apache.spark.mllib.clustering.VectorWithNorm",
-      "org.apache.spark.ml.linalg.Vector",
-      "org.apache.spark.ml.linalg.DenseVector",
-      "org.apache.spark.ml.linalg.SparseVector",
-      "org.apache.spark.ml.linalg.Matrix",
-      "org.apache.spark.ml.linalg.DenseMatrix",
-      "org.apache.spark.ml.linalg.SparseMatrix",
+      "org.apache.spark.mllib.linalg.DenseMatrix",
+      "org.apache.spark.mllib.linalg.DenseVector",
+      "org.apache.spark.mllib.linalg.Matrix",
+      "org.apache.spark.mllib.linalg.SparseMatrix",
+      "org.apache.spark.mllib.linalg.SparseVector",
+      "org.apache.spark.mllib.linalg.Vector",
+      "org.apache.spark.mllib.regression.LabeledPoint",
       "org.apache.spark.ml.feature.Instance",
-      "org.apache.spark.ml.feature.OffsetInstance",
       "org.apache.spark.ml.feature.LabeledPoint",
+      "org.apache.spark.ml.feature.OffsetInstance",
+      "org.apache.spark.ml.linalg.DenseMatrix",
+      "org.apache.spark.ml.linalg.DenseVector",
+      "org.apache.spark.ml.linalg.Matrix",
+      "org.apache.spark.ml.linalg.SparseMatrix",
+      "org.apache.spark.ml.linalg.SparseVector",
+      "org.apache.spark.ml.linalg.Vector",
       "org.apache.spark.ml.tree.impl.TreePoint"
     ).foreach { name =>
       try {

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -187,6 +187,7 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.mllib.linalg.Matrix",
       "org.apache.spark.mllib.linalg.DenseMatrix",
       "org.apache.spark.mllib.linalg.SparseMatrix",
+      "org.apache.spark.mllib.regression.LabeledPoint",
       "org.apache.spark.ml.linalg.Vector",
       "org.apache.spark.ml.linalg.DenseVector",
       "org.apache.spark.ml.linalg.SparseVector",
@@ -194,7 +195,8 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.ml.linalg.DenseMatrix",
       "org.apache.spark.ml.linalg.SparseMatrix",
       "org.apache.spark.ml.feature.Instance",
-      "org.apache.spark.ml.feature.OffsetInstance"
+      "org.apache.spark.ml.feature.OffsetInstance",
+      "org.apache.spark.ml.feature.LabeledPoint"
     ).foreach { name =>
       try {
         val clazz = Utils.classForName(name)

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -188,6 +188,7 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.mllib.linalg.DenseMatrix",
       "org.apache.spark.mllib.linalg.SparseMatrix",
       "org.apache.spark.mllib.regression.LabeledPoint",
+      "org.apache.spark.mllib.clustering.VectorWithNorm",
       "org.apache.spark.ml.linalg.Vector",
       "org.apache.spark.ml.linalg.DenseVector",
       "org.apache.spark.ml.linalg.SparseVector",

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -197,8 +197,7 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.ml.feature.Instance",
       "org.apache.spark.ml.feature.OffsetInstance",
       "org.apache.spark.ml.feature.LabeledPoint",
-      "org.apache.spark.ml.tree.impl.TreePoint",
-      "org.apache.spark.ml.tree.impl.BaggedPoint"
+      "org.apache.spark.ml.tree.impl.TreePoint"
     ).foreach { name =>
       try {
         val clazz = Utils.classForName(name)

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -196,7 +196,9 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.ml.linalg.SparseMatrix",
       "org.apache.spark.ml.feature.Instance",
       "org.apache.spark.ml.feature.OffsetInstance",
-      "org.apache.spark.ml.feature.LabeledPoint"
+      "org.apache.spark.ml.feature.LabeledPoint",
+      "org.apache.spark.ml.tree.impl.TreePoint",
+      "org.apache.spark.ml.tree.impl.BaggedPoint"
     ).foreach { name =>
       try {
         val clazz = Utils.classForName(name)

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -182,14 +182,6 @@ class KryoSerializer(conf: SparkConf)
     // We can't load those class directly in order to avoid unnecessary jar dependencies.
     // We load them safely, ignore it if the class not found.
     Seq(
-      "org.apache.spark.mllib.clustering.VectorWithNorm",
-      "org.apache.spark.mllib.linalg.DenseMatrix",
-      "org.apache.spark.mllib.linalg.DenseVector",
-      "org.apache.spark.mllib.linalg.Matrix",
-      "org.apache.spark.mllib.linalg.SparseMatrix",
-      "org.apache.spark.mllib.linalg.SparseVector",
-      "org.apache.spark.mllib.linalg.Vector",
-      "org.apache.spark.mllib.regression.LabeledPoint",
       "org.apache.spark.ml.feature.Instance",
       "org.apache.spark.ml.feature.LabeledPoint",
       "org.apache.spark.ml.feature.OffsetInstance",
@@ -199,7 +191,15 @@ class KryoSerializer(conf: SparkConf)
       "org.apache.spark.ml.linalg.SparseMatrix",
       "org.apache.spark.ml.linalg.SparseVector",
       "org.apache.spark.ml.linalg.Vector",
-      "org.apache.spark.ml.tree.impl.TreePoint"
+      "org.apache.spark.ml.tree.impl.TreePoint",
+      "org.apache.spark.mllib.clustering.VectorWithNorm",
+      "org.apache.spark.mllib.linalg.DenseMatrix",
+      "org.apache.spark.mllib.linalg.DenseVector",
+      "org.apache.spark.mllib.linalg.Matrix",
+      "org.apache.spark.mllib.linalg.SparseMatrix",
+      "org.apache.spark.mllib.linalg.SparseVector",
+      "org.apache.spark.mllib.linalg.Vector",
+      "org.apache.spark.mllib.regression.LabeledPoint"
     ).foreach { name =>
       try {
         val clazz = Utils.classForName(name)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuit.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuit.scala
@@ -28,11 +28,10 @@ class InstanceSuit extends SparkFunSuite{
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
-    val ser = new KryoSerializer(conf)
-    val serInstance = new KryoSerializer(conf).newInstance()
+    val ser = new KryoSerializer(conf).newInstance()
 
     def check[T: ClassTag](t: T) {
-      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
     }
 
     val instance1 = Instance(19.0, 2.0, Vectors.dense(1.0, 7.0))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/InstanceSuite.scala
@@ -17,30 +17,29 @@
 
 package org.apache.spark.ml.feature
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.serializer.KryoSerializer
 
-class InstanceSuit extends SparkFunSuite{
+class InstanceSuite extends SparkFunSuite{
   test("Kryo class register") {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check[T: ClassTag](t: T) {
-      assert(ser.deserialize[T](ser.serialize(t)) === t)
-    }
-
     val instance1 = Instance(19.0, 2.0, Vectors.dense(1.0, 7.0))
     val instance2 = Instance(17.0, 1.0, Vectors.dense(0.0, 5.0).toSparse)
+    Seq(instance1, instance2).foreach { i =>
+      val i2 = ser.deserialize[Instance](ser.serialize(i))
+      assert(i === i2)
+    }
+
     val oInstance1 = OffsetInstance(0.2, 1.0, 2.0, Vectors.dense(0.0, 5.0))
     val oInstance2 = OffsetInstance(0.2, 1.0, 2.0, Vectors.dense(0.0, 5.0).toSparse)
-    check(instance1)
-    check(instance2)
-    check(oInstance1)
-    check(oInstance2)
+    Seq(oInstance1, oInstance2).foreach { o =>
+      val o2 = ser.deserialize[OffsetInstance](ser.serialize(o))
+      assert(o === o2)
+    }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
@@ -15,48 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.spark.mllib.regression
+package org.apache.spark.ml.feature
 
 import scala.reflect.ClassTag
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.ml.feature.{LabeledPoint => NewLabeledPoint}
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.serializer.KryoSerializer
 
-class LabeledPointSuite extends SparkFunSuite {
-
-  test("parse labeled points") {
-    val points = Seq(
-      LabeledPoint(1.0, Vectors.dense(1.0, 0.0)),
-      LabeledPoint(0.0, Vectors.sparse(2, Array(1), Array(-1.0))))
-    points.foreach { p =>
-      assert(p === LabeledPoint.parse(p.toString))
-    }
-  }
-
-  test("parse labeled points with whitespaces") {
-    val point = LabeledPoint.parse("(0.0, [1.0, 2.0])")
-    assert(point === LabeledPoint(0.0, Vectors.dense(1.0, 2.0)))
-  }
-
-  test("parse labeled points with v0.9 format") {
-    val point = LabeledPoint.parse("1.0,1.0 0.0 -2.0")
-    assert(point === LabeledPoint(1.0, Vectors.dense(1.0, 0.0, -2.0)))
-  }
-
-  test("conversions between new ml LabeledPoint and mllib LabeledPoint") {
-    val points: Seq[LabeledPoint] = Seq(
-      LabeledPoint(1.0, Vectors.dense(1.0, 0.0)),
-      LabeledPoint(0.0, Vectors.sparse(2, Array(1), Array(-1.0))))
-
-    val newPoints: Seq[NewLabeledPoint] = points.map(_.asML)
-
-    points.zip(newPoints).foreach { case (p1, p2) =>
-      assert(p1 === LabeledPoint.fromML(p2))
-    }
-  }
-
+class LabeledPointSuite extends SparkFunSuite{
   test("Kryo class register") {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
@@ -28,11 +28,10 @@ class LabeledPointSuite extends SparkFunSuite{
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
-    val ser = new KryoSerializer(conf)
-    val serInstance = new KryoSerializer(conf).newInstance()
+    val ser = new KryoSerializer(conf).newInstance()
 
     def check[T: ClassTag](t: T) {
-      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
     }
 
     val labeled1 = LabeledPoint(1.0, Vectors.dense(Array(1.0, 2.0)))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.feature
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.serializer.KryoSerializer

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/LabeledPointSuite.scala
@@ -23,20 +23,19 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.serializer.KryoSerializer
 
-class LabeledPointSuite extends SparkFunSuite{
+class LabeledPointSuite extends SparkFunSuite {
   test("Kryo class register") {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check[T: ClassTag](t: T) {
-      assert(ser.deserialize[T](ser.serialize(t)) === t)
-    }
-
     val labeled1 = LabeledPoint(1.0, Vectors.dense(Array(1.0, 2.0)))
     val labeled2 = LabeledPoint(1.0, Vectors.sparse(10, Array(5, 7), Array(1.0, 2.0)))
-    check(labeled1)
-    check(labeled2)
+
+    Seq(labeled1, labeled2).foreach { l =>
+      val l2 = ser.deserialize[LabeledPoint](ser.serialize(l))
+      assert(l === l2)
+    }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
@@ -27,14 +27,20 @@ class TreePointSuite extends SparkFunSuite{
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
-    val ser = new KryoSerializer(conf)
-    val serInstance = new KryoSerializer(conf).newInstance()
+    val ser = new KryoSerializer(conf).newInstance()
 
     def check[T: ClassTag](t: T) {
-      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
+    }
+
+    def check2(p: TreePoint): Unit = {
+      val p2 = ser.deserialize[TreePoint](ser.serialize(p))
+      assert(p2.label === p.label)
+      assert(p2.binnedFeatures === p.binnedFeatures)
     }
 
     val point = new TreePoint(1.0, Array(1, 2, 3))
+    check2(point)
     check(point)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.tree.impl
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.KryoSerializer
 
@@ -29,18 +27,13 @@ class TreePointSuite extends SparkFunSuite{
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check[T: ClassTag](t: T) {
-      assert(ser.deserialize[T](ser.serialize(t)) === t)
-    }
-
-    def check2(p: TreePoint): Unit = {
+    def check(p: TreePoint): Unit = {
       val p2 = ser.deserialize[TreePoint](ser.serialize(p))
       assert(p2.label === p.label)
       assert(p2.binnedFeatures === p.binnedFeatures)
     }
 
     val point = new TreePoint(1.0, Array(1, 2, 3))
-    check2(point)
     check(point)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
@@ -20,20 +20,16 @@ package org.apache.spark.ml.tree.impl
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.KryoSerializer
 
-class TreePointSuite extends SparkFunSuite{
+class TreePointSuite extends SparkFunSuite {
   test("Kryo class register") {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check(p: TreePoint): Unit = {
-      val p2 = ser.deserialize[TreePoint](ser.serialize(p))
-      assert(p2.label === p.label)
-      assert(p2.binnedFeatures === p.binnedFeatures)
-    }
-
     val point = new TreePoint(1.0, Array(1, 2, 3))
-    check(point)
+    val point2 = ser.deserialize[TreePoint](ser.serialize(point))
+    assert(point.label === point2.label)
+    assert(point.binnedFeatures === point2.binnedFeatures)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreePointSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.tree.impl
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.serializer.KryoSerializer
+
+class TreePointSuite extends SparkFunSuite{
+  test("Kryo class register") {
+    val conf = new SparkConf(false)
+    conf.set("spark.kryo.registrationRequired", "true")
+
+    val ser = new KryoSerializer(conf)
+    val serInstance = new KryoSerializer(conf).newInstance()
+
+    def check[T: ClassTag](t: T) {
+      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+    }
+
+    val point = new TreePoint(1.0, Array(1, 2, 3))
+    check(point)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -318,16 +318,14 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check(v: VectorWithNorm): Unit = {
+    val vec1 = new VectorWithNorm(Vectors.dense(Array(1.0, 2.0)))
+    val vec2 = new VectorWithNorm(Vectors.sparse(10, Array(5, 8), Array(1.0, 2.0)))
+
+    Seq(vec1, vec2).foreach { v =>
       val v2 = ser.deserialize[VectorWithNorm](ser.serialize(v))
       assert(v2.norm === v.norm)
       assert(v2.vector === v.vector)
     }
-
-    val vec1 = new VectorWithNorm(Vectors.dense(Array(1.0, 2.0)))
-    val vec2 = new VectorWithNorm(Vectors.sparse(10, Array(5, 8), Array(1.0, 2.0)))
-    check(vec1)
-    check(vec2)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.mllib.clustering
 
-import scala.reflect.ClassTag
 import scala.util.Random
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -319,11 +318,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check[T: ClassTag](t: T) {
-      assert(ser.deserialize[T](ser.serialize(t)) === t)
-    }
-
-    def check2(v: VectorWithNorm): Unit = {
+    def check(v: VectorWithNorm): Unit = {
       val v2 = ser.deserialize[VectorWithNorm](ser.serialize(v))
       assert(v2.norm === v.norm)
       assert(v2.vector === v.vector)
@@ -331,8 +326,6 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val vec1 = new VectorWithNorm(Vectors.dense(Array(1.0, 2.0)))
     val vec2 = new VectorWithNorm(Vectors.sparse(10, Array(5, 8), Array(1.0, 2.0)))
-    check2(vec1)
-    check2(vec2)
     check(vec1)
     check(vec2)
   }

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -317,15 +317,22 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
-    val ser = new KryoSerializer(conf)
-    val serInstance = new KryoSerializer(conf).newInstance()
+    val ser = new KryoSerializer(conf).newInstance()
 
     def check[T: ClassTag](t: T) {
-      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
+    }
+
+    def check2(v: VectorWithNorm): Unit = {
+      val v2 = ser.deserialize[VectorWithNorm](ser.serialize(v))
+      assert(v2.norm === v.norm)
+      assert(v2.vector === v.vector)
     }
 
     val vec1 = new VectorWithNorm(Vectors.dense(Array(1.0, 2.0)))
     val vec2 = new VectorWithNorm(Vectors.sparse(10, Array(5, 8), Array(1.0, 2.0)))
+    check2(vec1)
+    check2(vec2)
     check(vec1)
     check(vec2)
   }

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/LabeledPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/LabeledPointSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.mllib.regression
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.ml.feature.{LabeledPoint => NewLabeledPoint}
 import org.apache.spark.mllib.linalg.Vectors
@@ -63,13 +61,12 @@ class LabeledPointSuite extends SparkFunSuite {
 
     val ser = new KryoSerializer(conf).newInstance()
 
-    def check[T: ClassTag](t: T) {
-      assert(ser.deserialize[T](ser.serialize(t)) === t)
-    }
-
     val labeled1 = LabeledPoint(1.0, Vectors.dense(Array(1.0, 2.0)))
     val labeled2 = LabeledPoint(1.0, Vectors.sparse(10, Array(5, 7), Array(1.0, 2.0)))
-    check(labeled1)
-    check(labeled2)
+
+    Seq(labeled1, labeled2).foreach { l =>
+      val l2 = ser.deserialize[LabeledPoint](ser.serialize(l))
+      assert(l === l2)
+    }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/LabeledPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/LabeledPointSuite.scala
@@ -61,11 +61,10 @@ class LabeledPointSuite extends SparkFunSuite {
     val conf = new SparkConf(false)
     conf.set("spark.kryo.registrationRequired", "true")
 
-    val ser = new KryoSerializer(conf)
-    val serInstance = new KryoSerializer(conf).newInstance()
+    val ser = new KryoSerializer(conf).newInstance()
 
     def check[T: ClassTag](t: T) {
-      assert(serInstance.deserialize[T](serInstance.serialize(t)) === t)
+      assert(ser.deserialize[T](ser.serialize(t)) === t)
     }
 
     val labeled1 = LabeledPoint(1.0, Vectors.dense(Array(1.0, 2.0)))


### PR DESCRIPTION
## What changes were proposed in this pull request?
register following classes in Kryo:
`org.apache.spark.mllib.regression.LabeledPoint`
`org.apache.spark.mllib.clustering.VectorWithNorm`
`org.apache.spark.ml.feature.LabeledPoint`
`org.apache.spark.ml.tree.impl.TreePoint`

`org.apache.spark.ml.tree.impl.BaggedPoint` seems also need to be registered, but I don't know how to do it in this safe way.
@WeichenXu123 @cloud-fan 

## How was this patch tested?
added tests
